### PR TITLE
Fix unhandled ENOENT when serving a missing static asset

### DIFF
--- a/packages/gemi/server/httpProd.ts
+++ b/packages/gemi/server/httpProd.ts
@@ -93,6 +93,16 @@ export async function httpProd(app: App, instrumentation: Instrumentation) {
           },
         );
       }
+
+      // `Bun.file(path).stream()` is lazy — a missing file only throws ENOENT
+      // once the body is streamed, which is *after* this handler has returned,
+      // so the `try/catch` below can't catch it (it surfaces as an unhandled
+      // rejection with the response already committed as 200). Bail out to a
+      // clean 404 before we ever build the streaming Response.
+      if (!doesExist) {
+        return new Response("Not found", { status: 404 });
+      }
+
       try {
         const file = Bun.file(distPath);
 


### PR DESCRIPTION
## Summary

Fixes #11 — a request for a non-existent static asset (e.g. `/GeistMonoVF.ttf`) returned a broken `200` and threw an **unhandled ENOENT promise rejection** instead of a clean `404`.

## Cause

In `packages/gemi/server/httpProd.ts` the static-asset branch already computed `doesExist`, but only used it to short-circuit missing `.js` requests (cache-bust reload script). Any other missing asset fell through to:

```js
return new Response(Bun.file(distPath).stream(), { /* … */ });
```

`Bun.file(path).stream()` is **lazy** — the file isn't opened until the body streams to the client, which is *after* the handler has returned a committed `200` (with a bogus `Content-Length` from `file.size`). The `ENOENT` then surfaces on the body stream, outside the `try/catch`, as an unhandled rejection that floods `gemi dev` output.

## Fix

Return a clean `404` when the asset doesn't exist, before building the streaming `Response`. The existing `.js` reload branch is preserved, and the `try/catch` still guards synchronous throws.

## Notes

- The dev server (`httpDev.ts`) serves static assets via Vite's middleware, which handles missing files itself — the buggy pattern only lives in this shared prod handler.
- Lint passes (`oxlint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)