### PR TITLE
Fix gemi dev serving prebuilt client (resolve NODE_ENV at runtime)

### DIFF
--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemi",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "private": false,
   "license": "MIT",
   "author": "Enes Tufekci <enes@gemijs.dev>",

--- a/packages/gemi/scripts/build.ts
+++ b/packages/gemi/scripts/build.ts
@@ -35,6 +35,18 @@ const result = await Bun.build({
   minify: true,
   splitting: true,
   sourcemap: "external",
+  // The framework build runs under `NODE_ENV=production` (so Bun emits the
+  // production JSX transform — see the `build` script). But Bun's bundler also
+  // constant-folds every literal `process.env.NODE_ENV` to that build-time
+  // value and dead-code-eliminates the losing branch. That baked `"production"`
+  // into the *published* bundle for every runtime check — most visibly
+  // `Server.start`, whose `NODE_ENV === "production"` switch had its whole dev
+  // branch (Vite dev server / HMR in `httpDev`) deleted, so `gemi dev` silently
+  // ran `httpProd` and served the prebuilt `dist/client` with no rebuild/HMR.
+  // Redirect the read to `Bun.env.NODE_ENV` (which Bun does NOT fold) so mode is
+  // resolved at RUNTIME — the same published artifact then serves dev and prod
+  // correctly. JSX selection is unaffected (it follows the env var, not this).
+  define: { "process.env.NODE_ENV": "Bun.env.NODE_ENV" },
 });
 
 if (!result.success) {


### PR DESCRIPTION
## Summary

Fixes #15 — `gemi dev` served the prebuilt `dist/client` with no rebuild/HMR, and a stale `dist/` silently served stale bundles.

## Root cause

The published framework bundle had its **dev/prod switch decided at build time**, not runtime.

The core build (`scripts/build.ts`) runs under `NODE_ENV=production` (required so Bun emits the production JSX transform). But Bun's bundler *also* constant-folds every literal `process.env.NODE_ENV` to the build-time value and dead-code-eliminates the losing branch. So `Server.start`'s switch:

```js
if (process.env.NODE_ENV === "production") { await import("./httpProd.js") … }
else { await import("./httpDev.js") … }   // Vite dev server + HMR
```

shipped in the published package as **`httpProd` only** — the entire `httpDev` (Vite dev server / `createServer` / HMR) branch was deleted. Confirmed by building as publish does and inspecting `dist/server/index.js`: only `httpProd` survived and there was **no `createServer` anywhere in `dist/`** (matching the report).

Because the branch was already gone, `gemi dev` setting `NODE_ENV=development` at runtime had no effect — it ran `httpProd`, which serves the last `gemi build`'s `dist/client`. The same folding also baked `production` into every other framework runtime check (secure cookies in `ViewRouterServiceContainer`, `QueueServiceContainer`, `auth/*`).

## Fix

One line in the core `Bun.build`:

```js
define: { "process.env.NODE_ENV": "Bun.env.NODE_ENV" },
```

`Bun.env.NODE_ENV` is a runtime lookup Bun does **not** fold (and doesn't contain the replaced token, so no recursion), so mode is resolved at **runtime**. The JSX transform is unaffected — it follows the build-time env var, not this `define`.

## Verification

Against a fresh `NODE_ENV=production` build (as `build:publish` runs):

- `Server.start` now compiles to `if (Bun.env.NODE_ENV === "production") { httpProd } else { httpDev }` — a real runtime branch.
- **Both** handler chunks ship; the `httpDev` chunk retains `createServer` / `middlewareMode` / `ssrLoadModule`.
- JSX transform stays production (no `jsxDEV` / `jsx-dev-runtime` in `dist/`).
- A prod-built module returns `DEV` under `NODE_ENV=development` and `PROD` under `NODE_ENV=production` (isolated cross-env run).
- Full `bun run build` chain succeeds. Pre-existing test failures on `main` are unrelated (verified identical on a clean tree; this change only touches the build script, which tests don't import).

> Note: a corrected release (version bump + republish) is needed for the fix to reach npm consumers, since the bug is in the built artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)