### PR TITLE
Fix gemi/client bundling react-dom's CJS (#17)

### DIFF
--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemi",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "private": false,
   "license": "MIT",
   "author": "Enes Tufekci <enes@gemijs.dev>",

--- a/packages/gemi/vite.client.config.mts
+++ b/packages/gemi/vite.client.config.mts
@@ -11,7 +11,22 @@ export default defineConfig({
     minify: false,
     outDir: "dist/client",
     rollupOptions: {
-      external: ["react", "react-dom", "react/jsx-runtime", "gemi", "sharp"],
+      // React & friends are peer deps the consuming app provides — they must
+      // stay external so the app's single copy is used. A plain string array is
+      // exact-match, which silently missed subpaths: `react-dom/client`
+      // (`hydrateRoot`/`createRoot` in client/init.tsx) and `scheduler` fell
+      // through and got bundled as react-dom's CJS build, leaving `require("react")`
+      // shims in dist/client/index.js. Those throw under Vite's dev optimizeDeps
+      // ("Calling require for react") so hydration never runs in `gemi dev`.
+      // Match the whole react/react-dom family (any subpath) plus scheduler. See #17.
+      external: (id) =>
+        id === "react" ||
+        id === "react-dom" ||
+        id === "scheduler" ||
+        id.startsWith("react/") ||
+        id.startsWith("react-dom/") ||
+        id === "gemi" ||
+        id === "sharp",
     },
     sourcemap: true,
   },


### PR DESCRIPTION
## Problem (#17)

`gemi`'s published `dist/client/index.js` inlines a CJS copy of react-dom, leaving `require("react")` / `require("react-dom")` shims in the bundle.

- **Prod (`gemi build`)**: rolldown re-resolves those requires, so the prod bundle is clean — this hid the bug.
- **Dev (`gemi dev`, v0.41.1+)**: Vite 8's `optimizeDeps` pre-bundles `gemi/client` on its own and leaves the requires as the rolldown `__require` shim, which throws `"Calling require for react"` in the browser. Hydration never runs → SSR renders but client-side navigation is dead.

Only surfaced on 0.41.1 because that release restored the live Vite dev server; on 0.41.0 dev served the prebuilt `dist/`, so `optimizeDeps` never ran.

## Root cause

`vite.client.config.mts` listed `["react", "react-dom", ...]` as Rollup externals. A **string** external is exact-match, so it never covered the `react-dom/client` subpath (`hydrateRoot`/`createRoot` in `client/init.tsx`) or `scheduler`. Those got bundled as react-dom's CJS build.

## Fix

Replace the string array with a predicate that externalizes the whole `react` / `react-dom` family (any subpath) plus `scheduler` — they're peer deps the consuming app provides, so they must stay external in both build and dev.

## Verification

Rebuilt `dist/client/index.js`:
- `1,384 kB → 98 kB` (react-dom no longer inlined)
- **0** `require()` shims
- `react`, `react-dom`, `react-dom/client`, `react/jsx-runtime` all emit as plain ESM imports

Version bumped to **0.41.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)