### PR TITLE
Exclude test files from build output

### DIFF
--- a/packages/gemi/bin/createRollupInput.ts
+++ b/packages/gemi/bin/createRollupInput.ts
@@ -25,6 +25,9 @@ export default async function (appDir: string): Promise<string[]> {
     if (segments.includes("components")) continue; // **/components/**
     if (segments.includes("assets")) continue; // **/assets/**
     if (file === "RootLayout.tsx") continue; // ./views/RootLayout.tsx
+    // Test files are not views — keep them out of the build so they never
+    // become a Vite entry (and never emit a compiled chunk into `dist`).
+    if (/\.(test|spec)\.tsx$/.test(file)) continue; // **/*.{test,spec}.tsx
 
     entries.add(`/app/views/${file}`);
   }

--- a/packages/gemi/tsconfig.browser.json
+++ b/packages/gemi/tsconfig.browser.json
@@ -24,5 +24,13 @@
     "types": ["vite/client", "bun"],
     "outDir": "dist"
   },
-  "include": ["client"]
+  "include": ["client"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ]
 }

--- a/packages/gemi/tsconfig.json
+++ b/packages/gemi/tsconfig.json
@@ -18,5 +18,12 @@
     "i18n",
     "server"
   ],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ]
 }

--- a/templates/saas-starter/app/http/controllers/HomeController.test.ts
+++ b/templates/saas-starter/app/http/controllers/HomeController.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "vitest";
+import { HomeController } from "./HomeController";
+
+test("HomeController.index returns the greeting message", async () => {
+  const controller = new HomeController();
+  const result = await controller.index();
+  expect(result).toEqual({ message: "Hello from HomeController 1" });
+});

--- a/templates/saas-starter/app/views/components/ui/button.test.tsx
+++ b/templates/saas-starter/app/views/components/ui/button.test.tsx
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Button } from "./button";
+
+test("Button renders its children", () => {
+  const html = renderToStaticMarkup(<Button>Click me</Button>);
+  expect(html).toContain("Click me");
+  expect(html).toContain("<button");
+});
+
+test("Button applies the destructive variant classes", () => {
+  const html = renderToStaticMarkup(
+    <Button variant="destructive">Delete</Button>,
+  );
+  expect(html).toContain("bg-destructive");
+});

--- a/templates/saas-starter/vitest.config.ts
+++ b/templates/saas-starter/vitest.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirror the `@/app/*` path alias from tsconfig.json so tests can import
+      // app modules the same way app code does.
+      "@/app": resolve(__dirname, "app"),
+    },
+  },
+});


### PR DESCRIPTION
Fixes #19.

## Problem

Test files were ending up in build output through two separate paths:

1. **`gemi build` (user apps).** The Vite client/SSR entry list is derived from an `app/views/**/*.tsx` glob in `bin/createRollupInput.ts`. Any `*.test.tsx` under `views` became a Vite entry point, emitting a compiled chunk into both `dist/client` and `dist/server`. Reproduced with a `app/views/Home.test.tsx` in the template → a 446 KB `dist/client/assets/Home.test-*.js` chunk plus `dist/server/Home.test.mjs`.
2. **The framework's own `tsc` declaration build** (`build:types` / `build:client-types`) emitted `.d.ts` for every `*.test.ts(x)` in the included source directories (e.g. `dist/services/router/*.test.d.ts`).

The Bun server build (`app/server.ts` entrypoint, `packages: "external"`) never leaked server-side `.test.ts` files, since unimported files are not bundled.

## Fix

- `bin/createRollupInput.ts`: skip `**/*.{test,spec}.tsx` so test files never become a Vite entry / dist chunk.
- `tsconfig.json` + `tsconfig.browser.json`: exclude `*.test.*` / `*.spec.*` so declaration builds stop emitting test `.d.ts`.

## Tests / verification

Added example tests to the `saas-starter` template (a component test and a server-side controller test) plus a `vitest.config.ts` mapping the `@/app` alias. These double as a regression check:

- `bunx vitest run` in the template: 3 tests pass.
- `gemi build` in the template: succeeds, and `find dist -regex '.*\.\(test\|spec\)\..*'` returns nothing.
- Both framework type builds emit no test declarations into `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)