### PR TITLE
Fix mutate(fn): replace instead of merge, and stop no-op'ing on unresolved queries

### DIFF
--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -94,19 +94,31 @@ const { data } = useQuery("/feed", {}, {
 
 ### Optimistic updates with `mutate`
 
-The `mutate` returned by `useQuery` updates the cached value in place:
+The `mutate` returned by `useQuery` has two forms:
 
 ```tsx
 const { data, mutate } = useQuery("/todos");
 
-// Merge/append into the current data
-mutate((todos) => [{ id: "tmp", title: "New" }]);
+// 1. Optimistically REPLACE the cached data with what the callback returns,
+//    then refetch from the server in the background.
+mutate((todos) => [...todos, { id: "tmp", title: "New" }]); // append an item
+mutate((todos) => todos.filter((t) => t.id !== id));        // remove an item
+mutate((todos) => todos.map((t) => (t.id === id ? next : t))); // update an item
 
-// Or refetch by calling with no args
+// 2. Refetch from the server (no optimistic update) by calling with no args.
 mutate();
 ```
 
-For objects, the returned partial is shallow-merged; for arrays, it is appended.
+The callback's return value **replaces** the cached value — it is not merged or
+appended, so you return the full next value (spread the existing data yourself when
+you want to keep it). It must keep the same shape as the current data: return an
+object when the data is an object, an array when it's an array. After the optimistic
+write, `mutate` always refetches so the cache reconciles with the server.
+
+`mutate(fn)` on a query whose data hasn't loaded yet (including a `lazy` query) has
+nothing to update optimistically, so it falls through to a refetch rather than doing
+nothing.
+
 To update a query from **outside** the component that owns it, use `useMutate`.
 
 ## Reusing endpoints on the server: the `Query` facade
@@ -232,7 +244,7 @@ mutate({ path: "/todos" }, (todos) => [newTodo]);
 ```
 
 The signature is `mutate({ path, params?, search? }, fn?)`, with the same
-merge/append semantics as `useQuery`'s `mutate`.
+replace-then-refetch semantics as `useQuery`'s `mutate`.
 
 ## Type safety
 

--- a/packages/gemi/client/QueryResource.ts
+++ b/packages/gemi/client/QueryResource.ts
@@ -80,6 +80,10 @@ export class QueryResource {
     const store = this.store.getValue();
     const state = store.get(variantKey);
     if (!state || !state.data) {
+      // Nothing is cached yet to update optimistically — e.g. a lazy query, or
+      // one that hasn't resolved. Fall through to a refetch so `mutate(fn)` is
+      // not a silent no-op (it still means "go get the latest data").
+      this.resolveVariant(variantKey, false, false);
       return;
     }
     const data = fn(state.data);

--- a/packages/gemi/client/useMutate.ts
+++ b/packages/gemi/client/useMutate.ts
@@ -29,8 +29,8 @@ export function useMutate() {
       search?: Record<string, any>;
     },
     fn?:
-      | ((data: NestedPrettify<Data<T>>) => Partial<NestedPrettify<Data<T>>>)
-      | Partial<NestedPrettify<Data<T>>>,
+      | ((data: NestedPrettify<Data<T>>) => NestedPrettify<Data<T>>)
+      | NestedPrettify<Data<T>>,
   ) {
     const { path, params = {}, search = {} } = options ?? {};
     const normalPath = applyParams(path, params);
@@ -41,18 +41,20 @@ export function useMutate() {
     return resource.mutate.call(resource, variantKey, (data: any) => {
       if (data === undefined || data === null) {
         console.warn("Mutate function called before the query.");
-        return;
+        return data;
       }
 
       if (!fn) {
         return data;
       }
 
+      // The callback's return value *replaces* the cached data. The type checks
+      // below only ensure the shape matches; they do not merge or append.
       const updatedData = typeof fn === "function" ? fn(data) : fn;
 
       if (isPlainObject(data)) {
         if (isPlainObject(updatedData)) {
-          return { ...data, ...updatedData };
+          return updatedData;
         }
         throw new Error(
           "Mutate function must return an object when the current data is an object.",
@@ -61,7 +63,7 @@ export function useMutate() {
 
       if (Array.isArray(data)) {
         if (Array.isArray(updatedData)) {
-          return [...data, ...updatedData];
+          return updatedData;
         }
         throw new Error(
           "Mutate function must return an array when the current data is an array.",

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -239,8 +239,8 @@ export function useQuery<T extends keyof GetRPC>(
     resource.refetch(variantKey);
   }, [resource, variantKey]);
 
-  function mutate(fn?: Partial<NestedPrettify<Data<T>>>): void;
-  function mutate(fn?: (data: NestedPrettify<Data<T>>) => Partial<NestedPrettify<Data<T>>>): void;
+  function mutate(fn?: NestedPrettify<Data<T>>): void;
+  function mutate(fn?: (data: NestedPrettify<Data<T>>) => NestedPrettify<Data<T>>): void;
   function mutate(fn?: any) {
     if (!fn) {
       fetchedRef.current = true;
@@ -250,14 +250,17 @@ export function useQuery<T extends keyof GetRPC>(
     return resource.mutate(variantKey, (data: any) => {
       if (data === undefined || data === null) {
         console.warn("Mutate function called before the query.");
-        return;
+        return data;
       }
 
+      // The callback's return value *replaces* the cached data. The type checks
+      // below only ensure the shape matches so a stray value can't corrupt the
+      // cache; they do not merge or append.
       const updatedData = typeof fn === "function" ? fn(data) : fn;
 
       if (isPlainObject(data)) {
         if (isPlainObject(updatedData)) {
-          return { ...data, ...updatedData };
+          return updatedData;
         }
         throw new Error(
           "Mutate function must return an object when the current data is an object.",
@@ -266,7 +269,7 @@ export function useQuery<T extends keyof GetRPC>(
 
       if (Array.isArray(data)) {
         if (Array.isArray(updatedData)) {
-          return [...data, ...updatedData];
+          return updatedData;
         }
         throw new Error("Mutate function must return an array when the current data is an array.");
       }


### PR DESCRIPTION
Fixes #20.

`useQuery(...).mutate(fn)` (and `useMutate`'s equivalent) had two undocumented footguns that made call sites silently wrong in opposite directions.

## Behavior 1 — merge/append instead of replace

The callback's return value was folded back into the cache rather than replacing it: objects were shallow-spread and **arrays were appended**. This meant:

- `mutate((x) => x)` on a loaded array → `[...data, ...data]` (every row rendered twice)
- `mutate((list) => [...list, item])` → duplicated every existing row
- Optimistic delete/update via `filter`/`map` was **impossible** — the returned array was appended, so removals stayed and survivors duplicated

**Fix:** the callback's return value now **replaces** the cached data. The type checks are kept only to guard the shape (object stays object, array stays array). Spread the existing data yourself when you want to keep it:

```tsx
mutate((todos) => [...todos, newItem]);          // append
mutate((todos) => todos.filter((t) => t.id !== id)); // delete
mutate((todos) => todos.map((t) => t.id === id ? next : t)); // update
```

## Behavior 2 — silent no-op on unresolved / lazy queries

`QueryResource#mutate` returned early when nothing was cached (`!state || !state.data`), so `mutate(fn)` on a `lazy` query — which never populates the cache on mount — did nothing: no cache write **and no request**. A poll firing `mutate((x) => x)` on a lazy query never reached the server.

**Fix:** when there's nothing to update optimistically, fall through to a refetch, so `mutate(fn)` still means "go get the latest data".

## Also

- Updated the `mutate` type signatures (dropped `Partial<...>`, since the callback now returns the full next value) in both `useQuery` and `useMutate`.
- Documented both forms of `mutate` and the replace-then-refetch semantics in `docs/data-fetching.md`.

## Changed files

- `packages/gemi/client/QueryResource.ts` — fall through to refetch instead of no-op
- `packages/gemi/client/useQuery.ts` — replace instead of merge/append; type signature
- `packages/gemi/client/useMutate.ts` — same replace fix; type signature
- `docs/data-fetching.md` — document the two forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)