### PR TITLE
Fix blank prod pages for views using React.lazy (React #306)

### DIFF
--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemi",
-  "version": "0.41.3",
+  "version": "0.41.4",
   "private": false,
   "license": "MIT",
   "author": "Enes Tufekci <enes@gemijs.dev>",

--- a/packages/gemi/vite/index.ts
+++ b/packages/gemi/vite/index.ts
@@ -29,6 +29,20 @@ const gemi = async (): Promise<PluginOption[]> => {
             sourcemap: true,
             rollupOptions: {
               input: Array.from(JSON.parse(process.env.GEMI_INPUT ?? "[]")),
+              // Each view is a build entry, but the app never imports them
+              // statically — the client router pulls them in via `import.meta.glob`
+              // (a runtime dynamic import). Rolldown's default entry-signature
+              // handling therefore sees a view's `export default` as unused and
+              // tree-shakes it. For a plain view the component is hoisted into the
+              // shared bundle so it still renders, but a view with a module-scope
+              // `lazy(() => import(...))` keeps its own chunk alive as a side
+              // effect while the "unused" default export is dropped — leaving a
+              // hollow chunk whose default is `undefined`. Hydration then renders
+              // `<undefined/>` → React #306 and the whole page unmounts to blank.
+              // `"strict"` forces every entry to preserve its exact exports (a
+              // facade chunk is emitted if needed), so every view keeps its
+              // default regardless of how the router loads it.
+              preserveEntrySignatures: "strict",
               // For the SSR build, externalize `gemi` (a linked package) and all
               // its subpaths. Otherwise the bundler compiles its own copy of
               // gemi's module-level singletons (`RouteStateContext`,


### PR DESCRIPTION
## Bug

In production builds, any page using `React.lazy` renders a blank white page (React error #306 on hydration). Works in dev, breaks only in prod. Not app code — reproduces with a trivial one-line lazy component.

## Root cause

Each view is a Rollup/Rolldown build entry, but the app never imports views statically — the client router pulls them in via `import.meta.glob` (a runtime dynamic import). With no `preserveEntrySignatures` set, Rolldown treats a view's `export default` as unused.

For a plain view the component is hoisted into the shared bundle so it still renders. But a view with a module-scope `lazy(() => import(...))` keeps its own chunk alive as a side effect while the "unused" default export is tree-shaken — leaving a hollow chunk whose default is `undefined`. Hydration renders `<undefined/>` → React #306 → the whole tree unmounts.

## Fix

`preserveEntrySignatures: "strict"` on `build.rollupOptions`, forcing every view entry to preserve its exact exports.

Vite 8 spreads user `rollupOptions` *after* its own default (`ssr ? "allow-extension" : false`), so the value takes effect; `build.rollupOptions` is typed as the full `RolldownOptions`.

## Verification

Against `templates/saas-starter` with a minimal module-scope `lazy` view (rebuilding `dist/bin/gemi.js` — the CLI bundles the plugin from source, so `build:plugin` alone isn't enough to see the change):

- before: the emitted chunk ends in the `lazy(...)` side-effect call with **no `export` at all**
- after: it ends in `export{u as default}`

Plain views (Home, About, Dashboard, SignIn) still export default; chunk count unchanged at 26; `tsc` clean; client and SSR builds green.

Also bumps the version to 0.41.4 so the release workflow publishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eu5sYKyd3FgEgCE8X1mdcs