### PR TITLE
Keep request-param imports alive when imported type-only

### DIFF
--- a/packages/gemi/bun/customRequestParser.ts
+++ b/packages/gemi/bun/customRequestParser.ts
@@ -2,6 +2,10 @@ import { parse, print } from "recast";
 import { builders } from "ast-types";
 
 export async function customRequestParser(original: string) {
+  // Every identifier we turn from a type annotation into a `new X()` default
+  // value. Their imports have to survive as value imports.
+  const promotedToValue = new Set<string>();
+
   function isExportedControllerClassDeclaration(body: any) {
     return (
       (body.type === "ExportNamedDeclaration" ||
@@ -66,6 +70,7 @@ export async function customRequestParser(original: string) {
         const right = builders.newExpression(builders.identifier(reqName), []);
         const _node = builders.assignmentPattern(left, right);
         node.params[0] = _node;
+        promotedToValue.add(reqName);
       }
     }
   }
@@ -118,7 +123,44 @@ export async function customRequestParser(original: string) {
             );
             const _node = builders.assignmentPattern(left, right);
             arg.params[0] = _node;
+            promotedToValue.add(reqName);
           }
+        }
+      }
+    }
+  }
+
+  // A param annotated as `req: HttpRequest` becomes `req = new HttpRequest()`,
+  // so a type-only import of it would be stripped by the transpiler and leave a
+  // dangling reference. Turn those imports into value imports.
+  function promoteTypeOnlyImports(body: any[]) {
+    for (const node of body) {
+      if (node?.type !== "ImportDeclaration") {
+        continue;
+      }
+
+      const specifiers = node.specifiers ?? [];
+      const isNeeded = (specifier: any) =>
+        promotedToValue.has(specifier.local?.name ?? specifier.imported?.name);
+
+      if (node.importKind === "type") {
+        if (!specifiers.some(isNeeded)) {
+          continue;
+        }
+        // `import type { A, B }` -> `import { A, type B }`, keeping the
+        // untouched specifiers type-only.
+        node.importKind = "value";
+        for (const specifier of specifiers) {
+          if (!isNeeded(specifier)) {
+            specifier.importKind = "type";
+          }
+        }
+        continue;
+      }
+
+      for (const specifier of specifiers) {
+        if (specifier.importKind === "type" && isNeeded(specifier)) {
+          specifier.importKind = "value";
         }
       }
     }
@@ -153,5 +195,7 @@ export async function customRequestParser(original: string) {
       continue;
     }
   }
-  return print(orgFile).code.replace("type HttpRequest", "HttpRequest");
+  promoteTypeOnlyImports(orgFile.program.body);
+
+  return print(orgFile).code;
 }

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemi",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "private": false,
   "license": "MIT",
   "author": "Enes Tufekci <enes@gemijs.dev>",


### PR DESCRIPTION
## Problem

The Bun plugin rewrites annotated handler params so handlers can be called with no args:

```ts
async store(req: HttpRequest<{ html: File }>)  →  async store(req = new HttpRequest())
```

That turns `HttpRequest` from a *type* reference into a *value* reference. To compensate, `customRequestParser` ended with a blunt string patch:

```ts
return print(orgFile).code.replace("type HttpRequest", "HttpRequest");
```

That only matches the inline-specifier form `import { type HttpRequest, ... }`. It does **not** match `import type { HttpRequest } from "gemi/http"` (the text there is `type { HttpRequest`), so the import stays type-only, Bun strips it, and the emitted code references a free `HttpRequest`:

```
ReferenceError: HttpRequest is not defined
  at getRouteData (gemi/services/router/ApiRouterServiceContainer.ts:112:19)
```

Two more holes in the same line: `String.replace` with a string pattern only patches the **first** occurrence, so a file with two type-only request imports breaks; and it is hardcoded to `HttpRequest`, so a custom request class hits the same thing.

## Fix

Handle it at the AST level. Record every identifier promoted to a `new X()` default, then walk the import declarations and clear the type-ness for exactly those specifiers:

- inline form → flip `importKind` on the specifier
- `import type { ... }` → flip `importKind` on the declaration, marking the remaining specifiers inline-`type` so a mixed import keeps its type-only members type-only

## Verification

Ran the real `customRequestParser` over each shape:

| input | output |
| --- | --- |
| `import type { HttpRequest }` | `import { HttpRequest }`, param rewritten |
| `import { Controller, type HttpRequest }` | `import { Controller, HttpRequest }` |
| two separate type-only request imports | both promoted |
| `import type { HttpRequest, SomeType }` | `import { HttpRequest, type SomeType }` |
| already a value import | unchanged |
| unrelated `import type { Foo }` | stays type-only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)