### PR TITLE
Database layer on Bun's SQL client, with dialect inferred from DATABASE_URL

### DIFF
--- a/packages/gemi/database/DatabaseManager.ts
+++ b/packages/gemi/database/DatabaseManager.ts
@@ -1,0 +1,45 @@
+import { SQL } from "bun";
+import type { DatabaseConfig } from "./config";
+import { MissingDatabaseUrlError, inferDialect, type Dialect } from "./dialect";
+
+// Wraps Bun's `SQL` client. Bun ships one client that speaks SQLite, Postgres,
+// MySQL and MariaDB, so gemi does not need a driver per database — it needs to
+// know *which* one is in use, which is what `dialect` carries.
+//
+// Like `RedisManager`, this is safe to build eagerly: Bun's client connects on
+// the first query, not at construction. It is still bound as a lazy singleton,
+// so an app that never touches the database never resolves it and never has to
+// have DATABASE_URL set.
+export class DatabaseManager {
+  static token = "database";
+
+  public readonly sql: SQL;
+  public readonly dialect: Dialect;
+  public readonly url: string;
+
+  constructor(public config: DatabaseConfig = {}) {
+    const url = config.url;
+    if (!url) {
+      throw new MissingDatabaseUrlError();
+    }
+
+    this.url = url;
+    // An explicit `dialect` wins, for URLs whose protocol we can't read (a
+    // pooler on a custom scheme). Otherwise infer, which throws rather than
+    // guessing — see the note in dialect.ts.
+    this.dialect = config.dialect ?? inferDialect(url);
+    this.sql = config.options
+      ? new SQL(url, config.options as any)
+      : new SQL(url);
+  }
+
+  // Escape hatch matching Bun's own API, so `db.query` reads like `sql` does in
+  // Bun's docs: db.query`select * from users where id = ${id}`
+  get query(): SQL {
+    return this.sql;
+  }
+
+  async close(): Promise<void> {
+    await this.sql.close();
+  }
+}

--- a/packages/gemi/database/DatabaseServiceProvider.ts
+++ b/packages/gemi/database/DatabaseServiceProvider.ts
@@ -1,0 +1,19 @@
+import { ServiceProvider } from "../support/ServiceProvider";
+import { withDefaults } from "../support/withDefaults";
+import { databaseConfigDefaults, type DatabaseConfig } from "./config";
+import { DatabaseManager } from "./DatabaseManager";
+
+export class DatabaseServiceProvider extends ServiceProvider {
+  register() {
+    this.app.singleton(
+      DatabaseManager,
+      () =>
+        new DatabaseManager(
+          withDefaults(
+            databaseConfigDefaults(),
+            this.app.config.get<DatabaseConfig>("database", {}),
+          ),
+        ),
+    );
+  }
+}

--- a/packages/gemi/database/config.ts
+++ b/packages/gemi/database/config.ts
@@ -1,0 +1,35 @@
+import type { SQL } from "bun";
+import type { Dialect } from "./dialect";
+
+// Config key: `database`.
+export interface DatabaseConfig {
+  // Connection string. Defaults to the `DATABASE_URL` environment variable.
+  // The dialect is inferred from it — `postgres://`, `mysql://`, `mariadb://`,
+  // `sqlite://`, `file:`, or a SQLite path like `./dev.db` or `:memory:`.
+  url?: string;
+
+  // Override the inferred dialect. Only needed when the URL doesn't carry a
+  // recognisable protocol — a proxy or connection pooler fronting Postgres on a
+  // custom scheme, say. Wrong values here produce SQL that fails at runtime
+  // against a database that connected fine, so leave it unset unless inference
+  // actually gets it wrong.
+  dialect?: Dialect;
+
+  // Options passed straight through to Bun's `SQL` client (pool size, timeouts,
+  // TLS, ...). See https://bun.sh/docs/api/sql.
+  options?: Record<string, unknown>;
+}
+
+export function defineDatabaseConfig(config: DatabaseConfig): DatabaseConfig {
+  return config;
+}
+
+export function databaseConfigDefaults(): DatabaseConfig {
+  return {
+    url: process.env.DATABASE_URL,
+    dialect: undefined,
+    options: undefined,
+  };
+}
+
+export type { SQL };

--- a/packages/gemi/database/dialect.test.ts
+++ b/packages/gemi/database/dialect.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  UnknownDatabaseUrlError,
+  inferDialect,
+  isMysqlFamily,
+  isSqlite,
+} from "./dialect";
+
+describe("inferDialect()", () => {
+  test.each([
+    ["postgres://user:pass@localhost:5432/app", "postgres"],
+    ["postgresql://user:pass@localhost:5432/app", "postgres"],
+    ["mysql://user:pass@localhost:3306/app", "mysql"],
+    ["mariadb://user:pass@localhost:3306/app", "mariadb"],
+    ["sqlite://./dev.db", "sqlite"],
+    ["sqlite://:memory:", "sqlite"],
+    ["file:./dev.db", "sqlite"],
+  ])("reads the protocol of %s", (url, expected) => {
+    expect(inferDialect(url)).toBe(expected);
+  });
+
+  test("is case insensitive about the protocol", () => {
+    expect(inferDialect("POSTGRES://localhost/app")).toBe("postgres");
+  });
+
+  test("ignores surrounding whitespace", () => {
+    expect(inferDialect("  postgres://localhost/app\n")).toBe("postgres");
+  });
+
+  test.each([":memory:", "./dev.db", "../data/app.sqlite", "/tmp/app.sqlite3"])(
+    "treats the bare SQLite path %s as sqlite",
+    (path) => {
+      expect(inferDialect(path)).toBe("sqlite");
+    },
+  );
+
+  // The failure this guards against: Bun's `new SQL(url)` defaults to postgres,
+  // so an unrecognised URL connects "successfully" and then fails on the first
+  // query with a dialect error. Refusing to guess surfaces it at boot instead.
+  test.each(["", "   ", "redis://localhost:6379", "nonsense", "http://x.dev"])(
+    "refuses to guess for %s",
+    (url) => {
+      expect(() => inferDialect(url)).toThrow(UnknownDatabaseUrlError);
+    },
+  );
+
+  test("names the offending url in the error", () => {
+    expect(() => inferDialect("redis://localhost")).toThrow(
+      /redis:\/\/localhost/,
+    );
+  });
+});
+
+describe("dialect predicates", () => {
+  test("isSqlite", () => {
+    expect(isSqlite("sqlite")).toBe(true);
+    expect(isSqlite("postgres")).toBe(false);
+  });
+
+  // MariaDB is wire-compatible with MySQL, so query generation collapses them.
+  test("isMysqlFamily covers mariadb", () => {
+    expect(isMysqlFamily("mysql")).toBe(true);
+    expect(isMysqlFamily("mariadb")).toBe(true);
+    expect(isMysqlFamily("postgres")).toBe(false);
+    expect(isMysqlFamily("sqlite")).toBe(false);
+  });
+});

--- a/packages/gemi/database/dialect.ts
+++ b/packages/gemi/database/dialect.ts
@@ -1,0 +1,99 @@
+// The SQL dialects Bun's `SQL` client can talk to. Bun infers the *connection*
+// from the URL protocol on its own, but it does not tell us which dialect it
+// picked — and gemi needs to know, because the SQL it generates differs per
+// dialect (`RETURNING` support, upsert syntax, autoincrement, boolean and
+// timestamp types). So we infer it a second time, here, for query generation.
+export type Dialect = "sqlite" | "postgres" | "mysql" | "mariadb";
+
+export class UnknownDatabaseUrlError extends Error {
+  constructor(url: string) {
+    super(
+      `Could not infer a database dialect from "${url}". Expected a URL ` +
+        `starting with postgres://, postgresql://, mysql://, mariadb://, ` +
+        `sqlite://, or file: — or a SQLite path such as ./dev.db or :memory:.`,
+    );
+    this.name = "UnknownDatabaseUrlError";
+  }
+}
+
+export class MissingDatabaseUrlError extends Error {
+  constructor() {
+    super(
+      "No database URL configured. Set the DATABASE_URL environment variable, " +
+        "or set `url` in app/config/database.ts.",
+    );
+    this.name = "MissingDatabaseUrlError";
+  }
+}
+
+const PROTOCOLS: Record<string, Dialect> = {
+  "postgres:": "postgres",
+  "postgresql:": "postgres",
+  "mysql:": "mysql",
+  "mariadb:": "mariadb",
+  "sqlite:": "sqlite",
+  "file:": "sqlite",
+};
+
+const SQLITE_FILE_EXTENSIONS = [".db", ".sqlite", ".sqlite3"];
+
+// Infer the dialect from a connection string. Accepts every form Bun's `SQL`
+// accepts, including the bare SQLite paths (`./dev.db`, `:memory:`) that have no
+// protocol at all.
+//
+// Note this deliberately does NOT default to postgres the way `new SQL(...)`
+// does. Guessing the dialect wrong means generating SQL that fails at runtime
+// against a database that connected fine, which is a far more confusing failure
+// than refusing to guess.
+export function inferDialect(url: string): Dialect {
+  const trimmed = url.trim();
+
+  if (trimmed === "") {
+    throw new UnknownDatabaseUrlError(url);
+  }
+
+  // `:memory:` is SQLite's in-memory database. It looks like a protocol to
+  // `new URL()` but isn't one, so it has to be checked before parsing.
+  if (trimmed === ":memory:") {
+    return "sqlite";
+  }
+
+  const separator = trimmed.indexOf(":");
+  if (separator !== -1) {
+    const protocol = trimmed.slice(0, separator + 1).toLowerCase();
+    const dialect = PROTOCOLS[protocol];
+    if (dialect) {
+      return dialect;
+    }
+  }
+
+  // No recognised protocol. Bun treats a bare path as a SQLite file, so we do
+  // too — but only when it actually looks like one, rather than treating every
+  // unrecognised string as SQLite.
+  if (looksLikeSqlitePath(trimmed)) {
+    return "sqlite";
+  }
+
+  throw new UnknownDatabaseUrlError(url);
+}
+
+function looksLikeSqlitePath(value: string): boolean {
+  if (value.startsWith("./") || value.startsWith("../") || value.startsWith("/")) {
+    return true;
+  }
+  const lower = value.toLowerCase();
+  return SQLITE_FILE_EXTENSIONS.some((extension) => lower.endsWith(extension));
+}
+
+// True when the dialect stores a SQLite database, i.e. a local file rather than
+// a networked server. Callers use this to decide whether `db:setup` should
+// create a file, and which DDL flavour to emit.
+export function isSqlite(dialect: Dialect): boolean {
+  return dialect === "sqlite";
+}
+
+// MariaDB is wire-compatible with MySQL and takes the same SQL in everything
+// gemi generates, so query builders collapse the two.
+export function isMysqlFamily(dialect: Dialect): boolean {
+  return dialect === "mysql" || dialect === "mariadb";
+}

--- a/packages/gemi/database/index.ts
+++ b/packages/gemi/database/index.ts
@@ -1,0 +1,15 @@
+export { DatabaseManager } from "./DatabaseManager";
+export { DatabaseServiceProvider } from "./DatabaseServiceProvider";
+export {
+  defineDatabaseConfig,
+  databaseConfigDefaults,
+  type DatabaseConfig,
+} from "./config";
+export {
+  inferDialect,
+  isSqlite,
+  isMysqlFamily,
+  UnknownDatabaseUrlError,
+  MissingDatabaseUrlError,
+  type Dialect,
+} from "./dialect";

--- a/packages/gemi/facades/DB.ts
+++ b/packages/gemi/facades/DB.ts
@@ -1,0 +1,40 @@
+import type { SQL } from "bun";
+import { DatabaseManager } from "../database/DatabaseManager";
+import type { Dialect } from "../database/dialect";
+import { Facade } from "./Facade";
+
+// Access to the app's database connection. Bun's `SQL` client is a tagged
+// template, so queries read the same here as they do in Bun's own docs:
+//
+//   const users = await DB.sql`select * from users where id = ${id}`
+//
+// Values interpolated into the template are bound as parameters, not
+// concatenated into the SQL string — `${id}` is a placeholder, so this is not a
+// SQL injection risk.
+export class DB extends Facade {
+  static getFacadeAccessor() {
+    return DatabaseManager;
+  }
+
+  // The Bun `SQL` client. Tagged-template queries go through here.
+  static get sql(): SQL {
+    return this.getFacadeRoot().sql;
+  }
+
+  // Which database is in use, inferred from the connection URL. Read this when
+  // generating SQL that differs across databases (upserts, `RETURNING`,
+  // autoincrement, boolean and timestamp types).
+  static get dialect(): Dialect {
+    return this.getFacadeRoot().dialect;
+  }
+
+  // Runs the callback inside a transaction, committing when it resolves and
+  // rolling back if it throws.
+  static transaction<T>(fn: (tx: SQL) => Promise<T>): Promise<T> {
+    return this.sql.begin(fn as any) as Promise<T>;
+  }
+
+  static close(): Promise<void> {
+    return this.getFacadeRoot().close();
+  }
+}

--- a/packages/gemi/facades/index.ts
+++ b/packages/gemi/facades/index.ts
@@ -10,3 +10,4 @@ export { Log } from "./Log";
 export { Meta } from "./Meta";
 export { Cookie } from "./Cookie";
 export { Redis } from "./Redis";
+export { DB } from "./DB";

--- a/packages/gemi/kernel/providers.ts
+++ b/packages/gemi/kernel/providers.ts
@@ -1,5 +1,6 @@
 import type { ServiceProviderConstructor } from "../foundation/Application";
 import { AuthServiceProvider } from "../auth/AuthServiceProvider";
+import { DatabaseServiceProvider } from "../database/DatabaseServiceProvider";
 import { TranslationServiceProvider } from "../i18n/TranslationServiceProvider";
 import { ScheduleServiceProvider } from "../services/cron/ScheduleServiceProvider";
 import { MailServiceProvider } from "../services/email/MailServiceProvider";
@@ -15,8 +16,8 @@ import { RedisServiceProvider } from "../services/redis/RedisServiceProvider";
 import { RouteServiceProvider } from "../services/router/RouteServiceProvider";
 
 /**
- * The providers every gemi app boots with, in registration order. Fourteen
- * providers for fifteen services — `RouteServiceProvider` owns both the api and
+ * The providers every gemi app boots with, in registration order. Fifteen
+ * providers for sixteen services — `RouteServiceProvider` owns both the api and
  * the view dispatcher, the way Laravel's does.
  *
  * Order only matters for `boot()`; `register()` binds factories and resolves
@@ -25,6 +26,7 @@ import { RouteServiceProvider } from "../services/router/RouteServiceProvider";
 export const frameworkProviders: ServiceProviderConstructor[] = [
   KernelIdServiceProvider,
   MiddlewareServiceProvider,
+  DatabaseServiceProvider,
   RouteServiceProvider,
   AuthServiceProvider,
   MailServiceProvider,

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -32,6 +32,7 @@
     "./config": "./config/index.ts",
     "./container": "./container/index.ts",
     "./foundation": "./foundation/index.ts",
+    "./database": "./database/index.ts",
     "./support": "./support/index.ts",
     "./bun/preload": "./bun/preload.ts",
     "./bun/plugin": "./bun/plugin.ts"

--- a/packages/gemi/scripts/build.ts
+++ b/packages/gemi/scripts/build.ts
@@ -22,6 +22,7 @@ const result = await Bun.build({
     "./container/index.ts",
     "./foundation/index.ts",
     "./support/index.ts",
+    "./database/index.ts",
   ],
   outdir: "./dist",
   external: [

--- a/packages/gemi/tsconfig.json
+++ b/packages/gemi/tsconfig.json
@@ -20,6 +20,7 @@
     "container",
     "foundation",
     "support",
+    "database",
     "bin/migrate"
   ],
   "exclude": [

--- a/templates/saas-starter/app/config/database.ts
+++ b/templates/saas-starter/app/config/database.ts
@@ -1,0 +1,12 @@
+import { defineDatabaseConfig } from "gemi/database";
+
+export default defineDatabaseConfig({
+  // Connection string. The dialect is inferred from it — postgres://,
+  // mysql://, mariadb://, sqlite://, file:, or a SQLite path like ./dev.db.
+  url: process.env.DATABASE_URL,
+
+  // Set this only if the URL's protocol can't be read (a pooler on a custom
+  // scheme). Inference throws rather than guessing, so you'll know if you
+  // need it.
+  // dialect: "postgres",
+});

--- a/templates/saas-starter/app/kernel/Kernel.ts
+++ b/templates/saas-starter/app/kernel/Kernel.ts
@@ -1,6 +1,7 @@
 import { Kernel } from "gemi/kernel";
 
 import auth from "../config/auth";
+import database from "../config/database";
 import filesystem from "../config/filesystem";
 import log from "../config/log";
 import mail from "../config/mail";
@@ -16,6 +17,7 @@ import AppServiceProvider from "../providers/AppServiceProvider";
 export default class extends Kernel {
   config = {
     auth,
+    database,
     filesystem,
     log,
     mail,


### PR DESCRIPTION
> **Stacked on #30.** Base is `refactor/laravel-container-architecture`, not `main` — this builds on the config/provider/facade machinery from that PR. Review #30 first; this diff is 14 files.

First step toward deprecating `packages/gemi/auth/adapters` in favour of Bun's built-in database client.

## The part that isn't obvious

Bun ships **one** client that speaks SQLite, Postgres, MySQL and MariaDB, so gemi doesn't need a driver per database — and `new SQL(url)` already infers the *connection* from the URL protocol. That part is nearly free.

What Bun does **not** do is tell you which dialect it picked, and it **defaults to postgres when it can't tell**. So an unrecognised URL connects cleanly and then fails on the first query with a confusing dialect error, well away from the actual mistake.

So gemi infers the dialect a second time, independently, and `inferDialect()` **throws rather than guessing**. This is needed regardless of connection: `RETURNING`, upsert syntax, autoincrement, and boolean/timestamp types all differ per dialect, and the 22-method `IAuthenticationAdapter` uses all of them.

## What's here

| File | |
|---|---|
| `database/dialect.ts` | Inference over every URL form Bun accepts, including bare SQLite paths (`./dev.db`, `:memory:`). `isSqlite`/`isMysqlFamily` — MariaDB is wire-compatible with MySQL, so query generation collapses the two. |
| `database/DatabaseManager.ts` | `static token = "database"`; exposes `sql`, `dialect`, `url`. Bound as a **lazy singleton**, so an app that never queries never has to set `DATABASE_URL`. |
| `database/config.ts` | `defineDatabaseConfig`, `url` defaulting to `DATABASE_URL`, plus a `dialect` override for URLs behind a pooler on a custom scheme. |
| `database/DatabaseServiceProvider.ts` | Registered in `frameworkProviders` (now 15 providers / 16 services). |
| `facades/DB.ts` | `DB.sql`, `DB.dialect`, `DB.transaction()`. |
| `templates/saas-starter/app/config/database.ts` | |

```ts
const users = await DB.sql`select * from users where email = ${email}`
```

## Verification

Run against a **real SQLite database**, not just typechecked: schema creation, insert, parameterised select, and confirmed that interpolated values bind as parameters — an injection attempt inserted a literal string rather than dropping the table.

- 21 unit tests on dialect inference, including that it refuses to guess for `redis://`, `http://`, empty, and nonsense URLs.
- `bun run build:types` green.
- Full suite: same 7 pre-existing failures as `main`; passing tests 45 → 66.

## Next, not in this PR

- `SqlUserProvider` implementing the existing `IAuthenticationAdapter` with dialect-aware SQL.
- `gemi db:setup` to create the 8 auth tables (versioned migrations deferred by decision).

Together those are what let `auth/adapters/prisma.ts` be deprecated. Keeping the interface as the contract means Prisma keeps working as a custom provider throughout — the same shape Laravel uses, where `UserProvider` is a contract with `Eloquent` and `Database` implementations shipped.

**Worth deciding before that lands:** `gemi migrate` is currently the upgrade codemod from #30. Versioned migrations are deferred, but every Laravel user will expect `migrate` to mean schema. Renaming the codemod to `gemi upgrade` is free now and a breaking change once 0.43 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PD1svYQLSDL7duJagM5Hqu
