### PR TITLE
Serve HTTP Range requests out of the box

### DIFF
--- a/docs/file-storage.md
+++ b/docs/file-storage.md
@@ -64,10 +64,72 @@ return FileStorage.fetch({ name: record.imageName, bucket: "private" });
 interface ReadFileParams {
   name: string;
   bucket?: string;
+  range?: ByteRange | null;
 }
 ```
 
 Because `fetch` returns a `Response`, a controller can return it directly. See [Controllers](./controllers.md).
+
+### `read(params | string, options?)`
+
+Reads a file as bytes plus metadata, rather than as a finished `Response`. Use it with [`this.stream(...)`](./routing.md#streaming-and-range-requests) to serve range requests:
+
+```typescript
+"/assets/:src*": this.stream(async (req) => FileStorage.read(req.params.src)),
+```
+
+Inside a `this.stream(...)` route the in-flight request's `Range` is picked up automatically and pushed down to the storage backend, so a seek reads one window instead of the whole object. Pass a range explicitly — or `null` to force a full read — when you need to override that:
+
+```typescript
+await FileStorage.read(name, { range: req.range() });
+await FileStorage.read(name, { range: null });
+```
+
+```typescript
+interface ReadResult {
+  body: ReadableStream<Uint8Array> | Blob | null;
+  start: number; // absolute inclusive offsets of `body` within the object
+  end: number;
+  total: number; // authoritative size of the complete object
+  partial: boolean; // whether the driver actually applied the range
+  type: string;
+  etag?: string;
+  lastModified?: Date;
+  name?: string;
+}
+```
+
+An unsatisfiable range throws `RangeNotSatisfiableError`, and a missing object throws `FileNotFoundError`. Both extend `RequestBreakerError`, so they turn into a `416` and a `404` on their own.
+
+### Writing a custom driver
+
+Extend `FileStorageDriver` and implement `fetch`, `put` and `list`. `read()` and `size()` already have working defaults, so an existing driver keeps compiling and gains range support for free — but the default `read()` buffers the whole object to serve a range, which saves no bandwidth from the backend.
+
+Override `read()` whenever the backend can range natively. Report the *authoritative* total, which most backends hand back in their own `Content-Range` on a ranged read — that is what keeps a range down to a single round trip:
+
+```typescript
+import { parseContentRange, resolveRange, toRangeHeaderValue } from "gemi/services";
+
+async read({ name, range }) {
+  const res = await backend.get(name, range ? toRangeHeaderValue(range) : undefined);
+  const cr = parseContentRange(res.headers["content-range"]);
+  return {
+    body: res.stream,
+    start: cr?.start ?? 0,
+    end: cr?.end ?? (res.size - 1),
+    total: cr?.total ?? res.size,
+    partial: Boolean(cr),
+    type: res.contentType,
+  };
+}
+```
+
+Two things to get right:
+
+- `partial` says whether *you* applied the range, and cannot be derived from the offsets: `bytes=0-` over a whole object is a `206` whose window spans the entire file. A driver that ignored the range must report `false`, or the response will carry a `Content-Range` that does not describe the body it sent.
+- Backends without a native suffix range (`bytes=-N`) need one size lookup first. Use `resolveRange(range, total)` to turn it into absolute offsets, and throw `RangeNotSatisfiableError(total)` when it returns `null`.
+
+Prefer returning a `Blob` over a `ReadableStream` when the backend gives you a sized handle: Bun drops an explicitly set `Content-Length` and falls back to chunked encoding for any stream body, but keeps it for a sized blob.
 
 ### `list(folder)`
 

--- a/docs/file-storage.md
+++ b/docs/file-storage.md
@@ -197,7 +197,7 @@ export default class extends FileStorageServiceProvider {
 
 The bucket comes from `params.bucket` when provided, otherwise from `process.env.BUCKET_NAME`. See [Configuration](./configuration.md) for where to define these environment variables.
 
-> **Note:** Both drivers fall back to `process.env.BUCKET_NAME` as the default bucket. For `put`, the S3 driver derives `contentType` from the blob/file when the body is a `Blob`/`File`.
+> **Note:** Both drivers fall back to `process.env.BUCKET_NAME` as the default bucket. For `put`, an explicitly passed `contentType` is used as-is; without one, the S3 driver falls back to the type of the `Blob`/`File` body. A `Buffer` body has no type of its own, so pass `contentType` alongside it or the object is stored without one.
 
 ### Writing a custom driver
 

--- a/docs/file-storage.md
+++ b/docs/file-storage.md
@@ -101,35 +101,7 @@ interface ReadResult {
 
 An unsatisfiable range throws `RangeNotSatisfiableError`, and a missing object throws `FileNotFoundError`. Both extend `RequestBreakerError`, so they turn into a `416` and a `404` on their own.
 
-### Writing a custom driver
-
-Extend `FileStorageDriver` and implement `fetch`, `put` and `list`. `read()` and `size()` already have working defaults, so an existing driver keeps compiling and gains range support for free — but the default `read()` buffers the whole object to serve a range, which saves no bandwidth from the backend.
-
-Override `read()` whenever the backend can range natively. Report the *authoritative* total, which most backends hand back in their own `Content-Range` on a ranged read — that is what keeps a range down to a single round trip:
-
-```typescript
-import { parseContentRange, resolveRange, toRangeHeaderValue } from "gemi/services";
-
-async read({ name, range }) {
-  const res = await backend.get(name, range ? toRangeHeaderValue(range) : undefined);
-  const cr = parseContentRange(res.headers["content-range"]);
-  return {
-    body: res.stream,
-    start: cr?.start ?? 0,
-    end: cr?.end ?? (res.size - 1),
-    total: cr?.total ?? res.size,
-    partial: Boolean(cr),
-    type: res.contentType,
-  };
-}
-```
-
-Two things to get right:
-
-- `partial` says whether *you* applied the range, and cannot be derived from the offsets: `bytes=0-` over a whole object is a `206` whose window spans the entire file. A driver that ignored the range must report `false`, or the response will carry a `Content-Range` that does not describe the body it sent.
-- Backends without a native suffix range (`bytes=-N`) need one size lookup first. Use `resolveRange(range, total)` to turn it into absolute offsets, and throw `RangeNotSatisfiableError(total)` when it returns `null`.
-
-Prefer returning a `Blob` over a `ReadableStream` when the backend gives you a sized handle: Bun drops an explicitly set `Content-Length` and falls back to chunked encoding for any stream body, but keeps it for a sized blob.
+See [Writing a custom driver](#writing-a-custom-driver) for how a driver implements `read()`.
 
 ### `list(folder)`
 
@@ -154,7 +126,7 @@ if ((meta.width ?? 0) > 4096) {
 
 ## Drivers
 
-The active driver is set on your app's `FileStorageServiceProvider`. gemi ships two drivers; the default is `FileSystemDriver`.
+The active driver is set on your app's `FileStorageServiceProvider`. gemi ships three drivers; the default is `FileSystemDriver`.
 
 ### `FileSystemDriver` (local disk)
 
@@ -197,11 +169,56 @@ export default class extends FileStorageServiceProvider {
 
 The bucket comes from `params.bucket` when provided, otherwise from `process.env.BUCKET_NAME`. See [Configuration](./configuration.md) for where to define these environment variables.
 
-> **Note:** Both drivers fall back to `process.env.BUCKET_NAME` as the default bucket. For `put`, the S3 driver derives `contentType` from the blob/file when the body is a `Blob`/`File`.
+> **Note:** All drivers fall back to `process.env.BUCKET_NAME` as the default bucket. For `put`, the S3 driver derives `contentType` from the blob/file when the body is a `Blob`/`File`.
+
+### `AzureBlobDriver` (Azure Blob Storage)
+
+`@azure/storage-blob` is an **optional peer dependency** — install it only if you use this driver:
+
+```bash
+bun add @azure/storage-blob
+```
+
+```typescript
+// app/kernel/providers/FileStorageServiceProvider.ts
+import { FileStorageServiceProvider, AzureBlobDriver } from "gemi/services";
+
+export default class extends FileStorageServiceProvider {
+  driver = new AzureBlobDriver({
+    // defaults to process.env.AZURE_STORAGE_CONNECTION_STRING
+    connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+    container: process.env.BUCKET_NAME,
+  });
+}
+```
+
+The SDK is loaded lazily on first use, so importing `gemi/services` costs nothing when the driver is unused. Using it without the package installed throws an error telling you to install it.
+
+Instead of a connection string you can pass an account `url` (optionally carrying a SAS token) with a `credential`, or hand over a fully built client — useful for a custom credential chain, retry policy or proxy. With `serviceClient` the driver never imports the SDK at all:
+
+```typescript
+import { BlobServiceClient } from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+
+new AzureBlobDriver({
+  url: "https://myaccount.blob.core.windows.net",
+  credential: new DefaultAzureCredential(),
+});
+
+// or fully pre-built
+new AzureBlobDriver({
+  serviceClient: BlobServiceClient.fromConnectionString(conn),
+  container: "media",
+});
+```
+
+The container comes from `params.bucket`, then the `container` config, then `process.env.BUCKET_NAME`. `list(folder)` returns a `string[]` of blob names under the prefix.
+
+**On range requests:** Azure's `download(offset, count)` takes an absolute offset and has no suffix form, so the driver handles the two cases differently. `bytes=S-E` and `bytes=S-` — everything a media player actually sends — go straight to the download and read the authoritative total back off Azure's own `Content-Range`, costing no extra round trip. A suffix range (`bytes=-N`) needs one `getProperties()` first to resolve it into absolute offsets.
 
 ### Writing a custom driver
 
-Any storage backend works by subclassing `FileStorageDriver` (exported from `gemi/services`) and implementing `put`, `fetch`, and `list`:
+Subclass `FileStorageDriver` (exported from `gemi/services`) and implement `put`, `fetch` and `list`:
 
 ```typescript
 import {
@@ -222,6 +239,34 @@ class MyDriver extends FileStorageDriver {
   }
 }
 ```
+
+`read()` and `size()` already have working defaults, so a driver that implements only the three methods above still compiles and gains range support — but the default `read()` buffers the whole object to serve a range, which saves no bandwidth from the backend.
+
+Override `read()` whenever the backend can range natively. Report the *authoritative* total, which most backends hand back in their own `Content-Range` on a ranged read — that is what keeps a range down to a single round trip:
+
+```typescript
+import { parseContentRange, resolveRange, toRangeHeaderValue } from "gemi/services";
+
+async read({ name, range }) {
+  const res = await backend.get(name, range ? toRangeHeaderValue(range) : undefined);
+  const cr = parseContentRange(res.headers["content-range"]);
+  return {
+    body: res.stream,
+    start: cr?.start ?? 0,
+    end: cr?.end ?? (res.size - 1),
+    total: cr?.total ?? res.size,
+    partial: Boolean(cr),
+    type: res.contentType,
+  };
+}
+```
+
+Two things to get right:
+
+- `partial` says whether *you* applied the range, and cannot be derived from the offsets: `bytes=0-` over a whole object is a `206` whose window spans the entire file. A driver that ignored the range must report `false`, or the response will carry a `Content-Range` that does not describe the body it sent.
+- Backends without a native suffix range (`bytes=-N`) need one size lookup first — see `AzureBlobDriver` for a worked example. Use `resolveRange(range, total)` to turn it into absolute offsets, and throw `RangeNotSatisfiableError(total)` when it returns `null`.
+
+Prefer returning a `Blob` over a `ReadableStream` when the backend gives you a sized handle: Bun drops an explicitly set `Content-Length` and falls back to chunked encoding for any stream body, but keeps it for a sized blob.
 
 ## Image optimization
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -143,6 +143,33 @@ routes = {
 };
 ```
 
+### Streaming and range requests
+
+`this.stream(...)` registers a `GET` (and `HEAD`) handler that understands the `Range` header, so browsers can seek within audio and video. Return a `FileStorage.read()` result and the byte window is pushed down to the storage backend, so a seek transfers one window rather than the whole object:
+
+```typescript
+routes = {
+  "/assets/:src*": this.stream(async (req) => FileStorage.read(req.params.src)),
+};
+```
+
+The route handles the HTTP side for you:
+
+- a request with no `Range` gets the complete object with `200` and `Accept-Ranges: bytes`
+- `bytes=S-E`, `bytes=S-` and `bytes=-N` get a `206` with `Content-Range: bytes S-E/TOTAL`
+- a range that starts past the end of the object gets a `416` with `Content-Range: bytes */TOTAL`
+- a malformed or multi-range header is ignored and the complete object is served, as RFC 7233 requires
+
+A handler can also return a `Blob` or a `Bun.file()` directly, and the framework will slice it — no storage driver involved:
+
+```typescript
+"/clip": this.stream(() => Bun.file("/videos/clip.mp4")),
+```
+
+Returning a `Response` yourself opts out of all of the above and is passed through untouched.
+
+Stream routes are excluded from the generated RPC client types, since a typed JSON client has no way to consume a byte stream.
+
 ### Per-route middleware
 
 Every handler returned by `this.get`/`this.post`/… (and `this.resource`) has a fluent `.middleware([...])` that adds middleware to that route only:

--- a/packages/gemi/bin/ide/generateApiManifest.ts
+++ b/packages/gemi/bin/ide/generateApiManifest.ts
@@ -223,7 +223,7 @@ export class ApiManifestGenerator {
       this.routes.set(finalRoutePath, new Map());
     }
 
-    if (method === "file") {
+    if (method === "file" || method === "stream") {
       return;
     } else if (method === "resource") {
       const idPrefixer = (path: string) =>

--- a/packages/gemi/facades/FileStorage.ts
+++ b/packages/gemi/facades/FileStorage.ts
@@ -4,10 +4,12 @@ import sharp from "sharp";
 import { Buffer } from "node:buffer";
 import type { Prettify } from "../utils/type";
 
-import { KernelContext } from "../kernel/KernelContext";
+import { RequestContext } from "../http/requestContext";
+import type { ByteRange } from "../http/range";
 import type {
   PutFileParams,
   ReadFileParams,
+  ReadResult,
 } from "../services/file-storage/drivers/types";
 import { FileStorageServiceContainer } from "../services/file-storage/FileStorageServiceContainer";
 
@@ -29,6 +31,35 @@ export class FileStorage {
 
   static async fetch(params: ReadFileParams | string) {
     return FileStorageServiceContainer.use().service.driver.fetch(params);
+  }
+
+  /**
+   * Reads an object as bytes plus metadata, pushing any byte range down to the
+   * storage backend so a seek transfers one window rather than the whole file.
+   *
+   * The range is resolved in this order: an explicit `options.range`, then a
+   * `range` on `params`, then the in-flight request's `Range` header when this
+   * is called inside a `this.stream()` route. Pass `{ range: null }` to force a
+   * full read inside a stream route.
+   */
+  static async read(
+    params: ReadFileParams | string,
+    options: { range?: ByteRange | null } = {},
+  ): Promise<ReadResult> {
+    const base: ReadFileParams =
+      typeof params === "string" ? { name: params } : { ...params };
+
+    const range =
+      "range" in options
+        ? (options.range ?? null)
+        : base.range !== undefined
+          ? base.range
+          : (RequestContext.getStore()?.rangeRequest ?? null);
+
+    return FileStorageServiceContainer.use().service.driver.read({
+      ...base,
+      range,
+    });
   }
   static list(folder: string) {
     return FileStorageServiceContainer.use().service.driver.list(folder);

--- a/packages/gemi/http/ApiRouter.ts
+++ b/packages/gemi/http/ApiRouter.ts
@@ -4,6 +4,14 @@ import type { KeyAndValue, KeyAndValueToObject } from "../internal/type-utils";
 import { Controller, ResourceController, type ControllerMethods } from "./Controller";
 import { HttpRequest } from "./HttpRequest";
 import type { MiddlewareReturnType } from "./Router";
+import {
+  createStreamResponse,
+  createUnsatisfiableResponse,
+  type StreamOutput,
+} from "./createStreamResponse";
+import { RangeNotSatisfiableError } from "./errors";
+import { parseRangeHeader } from "./range";
+import { RequestContext } from "./requestContext";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
@@ -92,6 +100,67 @@ export class FileHandler {
   }
 }
 
+/**
+ * A GET route that serves bytes and understands `Range`.
+ *
+ * Reads the request's `Range` once, parks it on the request context so
+ * `FileStorage.read()` can push it down to the storage backend, and turns
+ * whatever the handler returned into a 200, 206 or 416.
+ */
+export class StreamRouteHandler extends RouteHandler<"GET", any, any, any> {
+  __internal_brand = "StreamHandler";
+
+  async run(_req?: HttpRequest<any, any>) {
+    const ctx = RequestContext.getStore();
+    const rawRequest = ctx?.req?.rawRequest;
+    const range = parseRangeHeader(rawRequest?.headers.get("Range"));
+
+    if (ctx) {
+      ctx.rangeRequest = range;
+    }
+
+    try {
+      const output = await super.run(_req as any);
+      return await createStreamResponse(output, {
+        range,
+        method: rawRequest?.method,
+      });
+    } catch (err) {
+      // The driver reached the backend and found the window unreachable. It
+      // carries the object's real size, which the 416 has to report.
+      if (err instanceof RangeNotSatisfiableError) {
+        return createUnsatisfiableResponse(err.total);
+      }
+      throw err;
+    } finally {
+      // A `FileStorage.read()` later in this request must not inherit it.
+      if (ctx) {
+        ctx.rangeRequest = null;
+      }
+    }
+  }
+}
+
+/**
+ * Structurally `{}` at the type level, exactly like `FileHandler`, so a stream
+ * route stays out of the generated RPC client types — a typed JSON client has
+ * no way to consume a byte stream. At runtime it is a `StreamRouteHandler`.
+ */
+export class StreamHandler {
+  constructor(...args: ConstructorParameters<typeof StreamRouteHandler>) {
+    return new StreamRouteHandler(...args) as any;
+  }
+
+  /**
+   * Declared so `this.stream(...).middleware([...])` typechecks. The runtime
+   * object is a `StreamRouteHandler`, which really does have this. Adding it
+   * keeps the route out of the RPC types: `RouteHandlersParser` maps over
+   * `keyof T` and only emits members that extend `RouteHandler`, and a method
+   * does not.
+   */
+  declare middleware: (middlewareList: string[]) => StreamHandler;
+}
+
 export type RouteHandlers = Partial<{
   post: RouteHandler<"POST", any, any, any>;
   get: RouteHandler<"GET", any, any, any>;
@@ -103,6 +172,7 @@ export type ApiRoutes = Record<
   string,
   | RouteHandler<any, any, any, any>
   | FileHandler
+  | StreamHandler
   | ProxyHandler
   | RouteHandlers
   | typeof ApiRouter
@@ -250,6 +320,30 @@ export class ApiRouter {
     K extends ControllerMethods<any>,
   >(handler: T, methodName?: K) {
     return new FileHandler("GET", handler, methodName);
+  }
+
+  /**
+   * A GET route that serves bytes and answers `Range` requests, so a `<video>`
+   * can seek. Return a `FileStorage.read()` result to have the byte window
+   * pushed down to the storage backend, or a `Blob`/`Bun.file()` to serve a
+   * local file directly.
+   *
+   * ```ts
+   * "/assets/:src*": this.stream(async (req) => FileStorage.read(req.params.src)),
+   * ```
+   */
+  public stream<Input, Output extends StreamOutput, Params>(
+    handler: CallbackHandler<Input, Output, Params>,
+  ): StreamHandler;
+  public stream<T extends new () => Controller, K extends ControllerMethods<T>>(
+    handler: T,
+    methodName: K,
+  ): StreamHandler;
+  public stream<
+    T extends CallbackHandler<any, any, any> | (new () => Controller),
+    K extends ControllerMethods<any>,
+  >(handler: T, methodName?: K) {
+    return new StreamHandler("GET", handler, methodName);
   }
 
   public proxy(url: string, headers: Record<string, string> = {}) {

--- a/packages/gemi/http/CorsMiddleware.ts
+++ b/packages/gemi/http/CorsMiddleware.ts
@@ -17,7 +17,7 @@ export class CorsMiddleware extends Middleware {
   config = {
     origins: {
       "": {
-        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Methods": "GET, HEAD, POST, PUT, DELETE, OPTIONS",
         "Access-Control-Allow-Headers":
           "Content-Type, Authorization, X-Requested-With",
         "Access-Control-Allow-Credentials": "true",

--- a/packages/gemi/http/HttpRequest.ts
+++ b/packages/gemi/http/HttpRequest.ts
@@ -1,3 +1,4 @@
+import { parseRangeHeader } from "./range";
 import { RequestContext } from "./requestContext";
 import { ValidationError } from "./Router";
 
@@ -231,6 +232,15 @@ export class HttpRequest<
 
   ctx() {
     return RequestContext.getStore();
+  }
+
+  /**
+   * The parsed `Range` header, or `null` when absent or unusable. Pass it to
+   * `FileStorage.read(name, { range })` to range explicitly; inside a
+   * `this.stream()` route `read()` already picks it up on its own.
+   */
+  range() {
+    return parseRangeHeader(this.rawRequest.headers.get("Range"));
   }
 
   refine(_input: any): any {

--- a/packages/gemi/http/ViewRouter.ts
+++ b/packages/gemi/http/ViewRouter.ts
@@ -1,6 +1,7 @@
 import type { RemoveGroupPrefix } from "../client/types";
 import { Redirect } from "../facades/Redirect";
 import type { KeyAndValue, KeyAndValueToObject } from "../internal/type-utils";
+import { contentDisposition } from "./contentDisposition";
 import type { Controller } from "./Controller";
 import type { HttpRequest } from "./HttpRequest";
 
@@ -113,13 +114,6 @@ export type FileOutput =
       status?: number;
       headers?: Record<string, string>;
     };
-
-function contentDisposition(name: string, download: boolean) {
-  const kind = download ? "attachment" : "inline";
-  // Quoted form for legacy clients, RFC 5987 form for anything non-ascii.
-  const fallback = name.replace(/["\\]/g, "").replace(/[^\x20-\x7e]/g, "_");
-  return `${kind}; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(name)}`;
-}
 
 export async function createFileResponse(output: FileOutput, headers: Headers) {
   if (output instanceof Response) {

--- a/packages/gemi/http/contentDisposition.ts
+++ b/packages/gemi/http/contentDisposition.ts
@@ -1,0 +1,13 @@
+/**
+ * Builds a `Content-Disposition` value.
+ *
+ * Lives in its own module so both `ViewRouter` and `createStreamResponse` can
+ * use it without `ApiRouter` having to import `ViewRouter`, which would close
+ * an import cycle through the `Redirect` facade.
+ */
+export function contentDisposition(name: string, download: boolean) {
+  const kind = download ? "attachment" : "inline";
+  // Quoted form for legacy clients, RFC 5987 form for anything non-ascii.
+  const fallback = name.replace(/["\\]/g, "").replace(/[^\x20-\x7e]/g, "_");
+  return `${kind}; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(name)}`;
+}

--- a/packages/gemi/http/createStreamResponse.test.ts
+++ b/packages/gemi/http/createStreamResponse.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  createStreamResponse,
+  createUnsatisfiableResponse,
+  type StreamOutput,
+} from "./createStreamResponse";
+import { parseRangeHeader } from "./range";
+
+const TEN = "0123456789";
+
+const serve = (output: StreamOutput, header?: string, method?: string) =>
+  createStreamResponse(output, {
+    range: parseRangeHeader(header ?? null),
+    method,
+  });
+
+const blob = (content = TEN, type = "text/plain") =>
+  new Blob([content], { type });
+
+function streamOf(content: string) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(content));
+      controller.close();
+    },
+  });
+}
+
+describe("createStreamResponse() without a Range", () => {
+  test("serves the whole blob as a 200", async () => {
+    const res = await serve(blob());
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(res.headers.get("Content-Type")).toBe("text/plain");
+    expect(res.headers.get("Content-Length")).toBe("10");
+    expect(res.headers.get("Content-Range")).toBeNull();
+    expect(await res.text()).toBe(TEN);
+  });
+
+  test("falls back to an octet stream content type", async () => {
+    const res = await serve(blob(TEN, ""));
+    expect(res.headers.get("Content-Type")).toBe("application/octet-stream");
+  });
+});
+
+describe("createStreamResponse() with a satisfiable Range", () => {
+  test("slices a blob and reports the window", async () => {
+    const res = await serve(blob(), "bytes=2-5");
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 2-5/10");
+    expect(res.headers.get("Content-Length")).toBe("4");
+    expect(await res.text()).toBe("2345");
+  });
+
+  test("resolves a suffix range", async () => {
+    const res = await serve(blob(), "bytes=-3");
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 7-9/10");
+    expect(await res.text()).toBe("789");
+  });
+
+  test("serves an open ended range to the last byte", async () => {
+    const res = await serve(blob(), "bytes=7-");
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 7-9/10");
+    expect(await res.text()).toBe("789");
+  });
+
+  test("clamps an end past the last byte", async () => {
+    const res = await serve(blob(), "bytes=5-999999");
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 5-9/10");
+    expect(await res.text()).toBe("56789");
+  });
+
+  test("answers `bytes=0-` with a 206 spanning the whole object", async () => {
+    // The case that proves `partial` cannot be derived from the offsets: this
+    // window covers the entire file, and it is still a partial response.
+    const res = await serve(blob(), "bytes=0-");
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 0-9/10");
+    expect(await res.text()).toBe(TEN);
+  });
+});
+
+describe("createStreamResponse() with an unsatisfiable Range", () => {
+  test("returns a bodyless 416 with the current size", async () => {
+    const res = await serve(blob(), "bytes=999-");
+
+    expect(res.status).toBe(416);
+    expect(res.headers.get("Content-Range")).toBe("bytes */10");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(await res.text()).toBe("");
+  });
+
+  test("treats any range over an empty object as unsatisfiable", async () => {
+    const res = await serve(blob(""), "bytes=0-10");
+
+    expect(res.status).toBe(416);
+    // The naive path would have formatted `bytes 0--1/0` here.
+    expect(res.headers.get("Content-Range")).toBe("bytes */0");
+    expect(res.headers.get("Content-Range")).not.toContain("--");
+  });
+
+  test("rejects a zero length suffix", async () => {
+    const res = await serve(blob(), "bytes=-0");
+    expect(res.status).toBe(416);
+  });
+
+  test("createUnsatisfiableResponse builds the same shape", async () => {
+    const res = createUnsatisfiableResponse(42);
+    expect(res.status).toBe(416);
+    expect(res.headers.get("Content-Range")).toBe("bytes */42");
+    expect(res.headers.get("Content-Length")).toBe("0");
+  });
+});
+
+describe("createStreamResponse() with an ignorable Range", () => {
+  test("serves a 200 when the header is malformed", async () => {
+    const res = await serve(blob(), "bytes=nonsense");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Range")).toBeNull();
+    expect(await res.text()).toBe(TEN);
+  });
+
+  test("serves a 200 for a multi range request", async () => {
+    // We never emit multipart/byteranges, so the range is ignored entirely.
+    const res = await serve(blob(), "bytes=0-1,4-5");
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(TEN);
+  });
+});
+
+describe("createStreamResponse() with a driver ReadResult", () => {
+  test("trusts a driver that already applied the range", async () => {
+    const res = await serve(
+      {
+        body: streamOf("2345"),
+        start: 2,
+        end: 5,
+        total: 10,
+        partial: true,
+        type: "video/mp4",
+        etag: '"abc"',
+      },
+      "bytes=2-5",
+    );
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 2-5/10");
+    expect(res.headers.get("Content-Length")).toBe("4");
+    expect(res.headers.get("ETag")).toBe('"abc"');
+    expect(await res.text()).toBe("2345");
+  });
+
+  test("serves a 200 when a driver ignored the range on an unsized stream", async () => {
+    // RFC 7233 §4.1 permits ignoring a Range. Better a full 200 than a 206
+    // whose Content-Range does not describe the bytes actually sent.
+    const res = await serve(
+      {
+        body: streamOf(TEN),
+        start: 0,
+        end: 9,
+        total: 10,
+        partial: false,
+        type: "text/plain",
+      },
+      "bytes=2-5",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Range")).toBeNull();
+    expect(await res.text()).toBe(TEN);
+  });
+
+  test("sets Last-Modified from the driver", async () => {
+    const lastModified = new Date("2026-01-02T03:04:05Z");
+    const res = await serve({
+      body: blob(),
+      start: 0,
+      end: 9,
+      total: 10,
+      partial: false,
+      type: "text/plain",
+      lastModified,
+    });
+
+    expect(res.headers.get("Last-Modified")).toBe(lastModified.toUTCString());
+  });
+});
+
+describe("createStreamResponse() output forms", () => {
+  test("passes a Response through untouched", async () => {
+    const original = new Response("hi", { status: 418 });
+    expect(await serve(original, "bytes=0-1")).toBe(original);
+  });
+
+  test("returns a 404 for a nullish output", async () => {
+    expect((await serve(null)).status).toBe(404);
+    expect((await serve(undefined)).status).toBe(404);
+  });
+
+  test("returns a 404 when a lazy file does not exist", async () => {
+    const missing = Object.assign(new Blob(["x"]), {
+      exists: async () => false,
+    });
+    expect((await serve(missing)).status).toBe(404);
+  });
+
+  test("sets Content-Disposition from a descriptor", async () => {
+    const res = await serve({
+      file: blob(),
+      name: "report.txt",
+      download: true,
+    });
+
+    expect(res.headers.get("Content-Disposition")).toBe(
+      `attachment; filename="report.txt"; filename*=UTF-8''report.txt`,
+    );
+  });
+
+  test("lets descriptor headers win over the computed ones", async () => {
+    const res = await serve({
+      file: blob(),
+      headers: { "Cache-Control": "public, max-age=3600" },
+    });
+
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+  });
+
+  test("ranges a descriptor carrying a sized blob", async () => {
+    const res = await serve({ file: blob(), type: "video/mp4" }, "bytes=1-3");
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 1-3/10");
+    expect(await res.text()).toBe("123");
+  });
+});
+
+describe("createStreamResponse() for HEAD", () => {
+  test("keeps the headers but drops the body", async () => {
+    const res = await serve(blob(), undefined, "HEAD");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Length")).toBe("10");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(res.body).toBeNull();
+  });
+
+  test("still reports the window for a ranged HEAD", async () => {
+    const res = await serve(blob(), "bytes=2-5", "HEAD");
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe("bytes 2-5/10");
+    expect(res.body).toBeNull();
+  });
+
+  test("cancels a stream body rather than leaking it", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(TEN));
+        c.close();
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    await serve(
+      { body, start: 0, end: 9, total: 10, partial: false, type: "text/plain" },
+      undefined,
+      "HEAD",
+    );
+
+    expect(cancelled).toBe(true);
+  });
+});

--- a/packages/gemi/http/createStreamResponse.ts
+++ b/packages/gemi/http/createStreamResponse.ts
@@ -1,0 +1,241 @@
+import { contentDisposition } from "./contentDisposition";
+import {
+  formatContentRange,
+  formatUnsatisfiedContentRange,
+  resolveRange,
+  type ByteRange,
+} from "./range";
+import type { ReadResult } from "../services/file-storage/drivers/types";
+
+export type StreamBody =
+  | Blob
+  | ReadableStream<Uint8Array>
+  | ArrayBuffer
+  | ArrayBufferView;
+
+export type StreamDescriptor = {
+  file: StreamBody;
+  /** File name sent in `Content-Disposition`. Defaults to the blob name, if any. */
+  name?: string;
+  /** Overrides the mime type. Defaults to the blob type, then `application/octet-stream`. */
+  type?: string;
+  /** `true` sends `attachment` (download), `false` (default) sends `inline`. */
+  download?: boolean;
+  /** Total size of the complete object. Required when `file` is a stream, or ranges cannot be served. */
+  total?: number;
+  start?: number;
+  end?: number;
+  /** Set when `file` already holds only the requested window. */
+  partial?: boolean;
+  etag?: string;
+  lastModified?: Date;
+  status?: number;
+  headers?: Record<string, string>;
+};
+
+export type StreamOutput =
+  | ReadResult
+  | Blob
+  | Response
+  | StreamDescriptor
+  | null
+  | undefined;
+
+type Normalized = {
+  body: StreamBody | null;
+  start: number;
+  end: number;
+  total: number;
+  partial: boolean;
+  type: string;
+  name?: string;
+  download: boolean;
+  etag?: string;
+  lastModified?: Date;
+  status: number;
+  extraHeaders: Record<string, string>;
+};
+
+function isReadResult(output: object): output is ReadResult {
+  return "total" in output && "partial" in output && "body" in output;
+}
+
+/** A 416, whose `Content-Range` reports the current size and no offsets. */
+export function createUnsatisfiableResponse(total: number): Response {
+  return new Response(null, {
+    status: 416,
+    headers: {
+      "Accept-Ranges": "bytes",
+      "Content-Range": formatUnsatisfiedContentRange(total),
+      "Content-Length": "0",
+      // A 416 is a function of the client's own Range against the object's
+      // current length. A cache that replayed it to a request which asked for
+      // no range, or a different one, would be serving a wrong answer.
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+async function normalize(output: Exclude<StreamOutput, Response | null | undefined>) {
+  if (output instanceof Blob) {
+    return {
+      body: output,
+      start: 0,
+      end: output.size - 1,
+      total: output.size,
+      partial: false,
+      type: output.type,
+      name: (output as File).name,
+      download: false,
+      status: 200,
+      extraHeaders: {},
+    } satisfies Normalized;
+  }
+
+  if (isReadResult(output)) {
+    return {
+      body: output.body,
+      start: output.start,
+      end: output.end,
+      total: output.total,
+      partial: output.partial,
+      type: output.type,
+      name: output.name,
+      download: false,
+      etag: output.etag,
+      lastModified: output.lastModified,
+      status: 200,
+      extraHeaders: {},
+    } satisfies Normalized;
+  }
+
+  const body = output.file;
+  const blob = body instanceof Blob ? body : null;
+  const total = output.total ?? blob?.size ?? -1;
+
+  return {
+    body,
+    start: output.start ?? 0,
+    end: output.end ?? total - 1,
+    total,
+    partial: output.partial ?? false,
+    type: output.type ?? blob?.type ?? "",
+    name: output.name ?? (body as File)?.name,
+    download: output.download ?? false,
+    etag: output.etag,
+    lastModified: output.lastModified,
+    status: output.status ?? 200,
+    extraHeaders: output.headers ?? {},
+  } satisfies Normalized;
+}
+
+/**
+ * Turns what a `this.stream()` handler returned into an HTTP response,
+ * applying RFC 7233 range semantics.
+ *
+ * Builds a fresh `Headers` rather than taking the request context's: merging
+ * context headers and cookies is the router container's job, and doing it in
+ * both places would append `Set-Cookie` twice.
+ */
+export async function createStreamResponse(
+  output: StreamOutput,
+  options: { range: ByteRange | null; method?: string },
+): Promise<Response> {
+  // A handler that built its own Response owns it completely.
+  if (output instanceof Response) {
+    return output;
+  }
+
+  if (!output) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const normalized = await normalize(output);
+  let { body, start, end, total, partial } = normalized;
+
+  // `Bun.file()` is lazy, so a missing path would otherwise only fail once the
+  // stream is pulled, with a 200 already committed.
+  if (
+    body instanceof Blob &&
+    "exists" in body &&
+    typeof (body as any).exists === "function"
+  ) {
+    if (!(await (body as any).exists())) {
+      return new Response("Not found", { status: 404 });
+    }
+  }
+
+  const { range } = options;
+
+  if (range) {
+    // Must come before anything formats a Content-Range: an empty object has
+    // no satisfiable window, and `bytes 0--1/0` is not a legal header.
+    if (total <= 0) {
+      return createUnsatisfiableResponse(Math.max(total, 0));
+    }
+
+    if (!partial) {
+      if (body instanceof Blob) {
+        // The driver handed back the whole object, but we hold a sized blob,
+        // so the window can still be served without reading past it.
+        const resolved = resolveRange(range, total);
+        if (!resolved) {
+          return createUnsatisfiableResponse(total);
+        }
+        body = body.slice(resolved.start, resolved.end + 1);
+        start = resolved.start;
+        end = resolved.end;
+        partial = true;
+      }
+      // Otherwise the body is an unsized stream and the range cannot be
+      // honoured. RFC 7233 §4.1 permits ignoring a Range, so serve the
+      // complete representation with a 200 rather than lying with a 206.
+    }
+  }
+
+  const isPartial = Boolean(range) && partial;
+  const status = isPartial ? 206 : normalized.status;
+
+  const headers = new Headers();
+  headers.set("Accept-Ranges", "bytes");
+  headers.set("Content-Type", normalized.type || "application/octet-stream");
+
+  if (isPartial) {
+    headers.set("Content-Range", formatContentRange(start, end, total));
+    headers.set("Content-Length", String(end - start + 1));
+  } else if (total >= 0) {
+    headers.set("Content-Length", String(total));
+  }
+
+  if (normalized.name) {
+    headers.set(
+      "Content-Disposition",
+      contentDisposition(normalized.name, normalized.download),
+    );
+  }
+  if (normalized.etag) {
+    headers.set("ETag", normalized.etag);
+  }
+  if (normalized.lastModified) {
+    headers.set("Last-Modified", normalized.lastModified.toUTCString());
+  }
+
+  // The handler's own headers win over everything computed above.
+  for (const [key, value] of Object.entries(normalized.extraHeaders)) {
+    headers.set(key, value);
+  }
+
+  if ((options.method ?? "GET").toUpperCase() === "HEAD") {
+    // Nothing downstream strips the body for us — `app.fetch()` has no such
+    // layer — and an abandoned S3 stream would leak the connection.
+    if (body && "cancel" in body && typeof body.cancel === "function") {
+      await body.cancel();
+    }
+    return new Response(null, { status, headers });
+  }
+
+  // A Blob is passed through as-is rather than as `.stream()`: Bun drops an
+  // explicitly set Content-Length and falls back to chunked encoding for any
+  // stream body, but keeps it for a sized blob.
+  return new Response(body as BodyInit, { status, headers });
+}

--- a/packages/gemi/http/errors.ts
+++ b/packages/gemi/http/errors.ts
@@ -1,4 +1,5 @@
 import { RequestBreakerError } from "./Error";
+import { formatUnsatisfiedContentRange } from "./range";
 
 export class AuthorizationError extends RequestBreakerError {
   private error: string;
@@ -26,6 +27,51 @@ export class InsufficientPermissionsError extends RequestBreakerError {
       api: {
         status: 401,
         data: { error: this.error },
+      },
+      view: {},
+    };
+  }
+}
+
+/**
+ * A `Range` that cannot be satisfied against the object's current size.
+ *
+ * Extends `RequestBreakerError` so a bare `FileStorage.read()` inside an
+ * ordinary route still produces a correct 416 — and, importantly, so it does
+ * not trip `onRequestFail`. A 416 is the client's header being wrong about the
+ * object, not a server failure.
+ */
+export class RangeNotSatisfiableError extends RequestBreakerError {
+  constructor(public total: number) {
+    super("Range not satisfiable");
+    this.name = "RangeNotSatisfiableError";
+    this.payload = {
+      api: {
+        status: 416,
+        data: { error: { message: "Range not satisfiable" } },
+        headers: {
+          "Content-Range": formatUnsatisfiedContentRange(total),
+          "Accept-Ranges": "bytes",
+          // Decided by the client's own Range against the object's current
+          // length, so it must never be replayed from a cache to a request
+          // that did not ask for that window.
+          "Cache-Control": "no-store",
+        },
+      },
+      view: {},
+    };
+  }
+}
+
+export class FileNotFoundError extends RequestBreakerError {
+  constructor(public fileName: string) {
+    super("File not found");
+    this.name = "FileNotFoundError";
+    this.payload = {
+      api: {
+        status: 404,
+        data: { error: { message: "Not found" } },
+        headers: { "Cache-Control": "no-store" },
       },
       view: {},
     };

--- a/packages/gemi/http/index.ts
+++ b/packages/gemi/http/index.ts
@@ -7,6 +7,23 @@ export {
   type FileOutput,
   type ViewHandler,
 } from "./ViewRouter";
+export {
+  createStreamResponse,
+  createUnsatisfiableResponse,
+  type StreamOutput,
+  type StreamDescriptor,
+} from "./createStreamResponse";
+export {
+  formatContentRange,
+  formatUnsatisfiedContentRange,
+  parseContentRange,
+  parseRangeHeader,
+  resolveRange,
+  toRangeHeaderValue,
+  type ByteRange,
+  type ContentRange,
+  type ResolvedRange,
+} from "./range";
 export { ValidationError } from "./Router";
 export { HttpRequest } from "./HttpRequest";
 export { Middleware } from "./Middleware";
@@ -23,4 +40,10 @@ export { CSRFMiddleware } from "./CSRFMiddleware";
 export { PoliciesServiceProvider } from "./PoliciesServiceProvider";
 export { Policies } from "./Policy";
 
-export { AuthenticationError, AuthorizationError, InsufficientPermissionsError } from "./errors";
+export {
+  AuthenticationError,
+  AuthorizationError,
+  FileNotFoundError,
+  InsufficientPermissionsError,
+  RangeNotSatisfiableError,
+} from "./errors";

--- a/packages/gemi/http/range.test.ts
+++ b/packages/gemi/http/range.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  formatContentRange,
+  formatUnsatisfiedContentRange,
+  parseContentRange,
+  parseRangeHeader,
+  resolveRange,
+  toRangeHeaderValue,
+  type ByteRange,
+} from "./range";
+
+describe("parseRangeHeader()", () => {
+  test("parses the offset forms", () => {
+    expect(parseRangeHeader("bytes=0-499")).toEqual({
+      kind: "offset",
+      start: 0,
+      end: 499,
+    });
+    expect(parseRangeHeader("bytes=200-")).toEqual({
+      kind: "offset",
+      start: 200,
+      end: null,
+    });
+    expect(parseRangeHeader("bytes=0-0")).toEqual({
+      kind: "offset",
+      start: 0,
+      end: 0,
+    });
+  });
+
+  test("parses the suffix form", () => {
+    expect(parseRangeHeader("bytes=-500")).toEqual({
+      kind: "suffix",
+      suffixLength: 500,
+    });
+  });
+
+  test("keeps `bytes=-0` distinct from an absent range", () => {
+    // It parses, then resolves to unsatisfiable. Collapsing it to null here
+    // would serve the whole representation, which RFC 7233 disallows.
+    expect(parseRangeHeader("bytes=-0")).toEqual({
+      kind: "suffix",
+      suffixLength: 0,
+    });
+    expect(resolveRange(parseRangeHeader("bytes=-0")!, 100)).toBeNull();
+  });
+
+  test("is case insensitive in the unit and tolerates surrounding whitespace", () => {
+    expect(parseRangeHeader("BYTES=0-9")).toEqual({
+      kind: "offset",
+      start: 0,
+      end: 9,
+    });
+    expect(parseRangeHeader("  bytes=0-9  ")).toEqual({
+      kind: "offset",
+      start: 0,
+      end: 9,
+    });
+    expect(parseRangeHeader("bytes= 0-9")).toEqual({
+      kind: "offset",
+      start: 0,
+      end: 9,
+    });
+  });
+
+  test("tolerates a single trailing comma", () => {
+    expect(parseRangeHeader("bytes=0-9,")).toEqual({
+      kind: "offset",
+      start: 0,
+      end: 9,
+    });
+  });
+
+  // Everything below must be ignored, meaning the caller serves a full 200.
+  test.each([
+    ["absent", null],
+    ["undefined", undefined],
+    ["empty", ""],
+    ["whitespace only", "   "],
+    ["unknown unit", "items=0-5"],
+    ["missing equals", "bytes 0-5"],
+    ["no separator", "bytes=5"],
+    ["empty spec", "bytes="],
+    ["bare separator", "bytes=-"],
+    ["non numeric", "bytes=a-b"],
+    ["non numeric end", "bytes=0-b"],
+    ["inverted", "bytes=100-50"],
+    ["multi range", "bytes=0-499,600-999"],
+    ["three ranges", "bytes=0-1,2-3,4-5"],
+    ["internal whitespace", "bytes=0 - 5"],
+    ["signed", "bytes=+0-5"],
+    ["float", "bytes=0.5-5"],
+    ["hex", "bytes=0x10-0x20"],
+    ["exponent", "bytes=1e3-2e3"],
+    ["unsafe integer", `bytes=0-${Number.MAX_SAFE_INTEGER + 10}`],
+  ])("ignores %s", (_label, header) => {
+    expect(parseRangeHeader(header as string | null | undefined)).toBeNull();
+  });
+});
+
+describe("resolveRange()", () => {
+  const at = (header: string, total: number) =>
+    resolveRange(parseRangeHeader(header)!, total);
+
+  test("resolves offset ranges against a 100 byte object", () => {
+    expect(at("bytes=0-", 100)).toEqual({ start: 0, end: 99, length: 100 });
+    expect(at("bytes=0-49", 100)).toEqual({ start: 0, end: 49, length: 50 });
+    expect(at("bytes=50-", 100)).toEqual({ start: 50, end: 99, length: 50 });
+    expect(at("bytes=99-", 100)).toEqual({ start: 99, end: 99, length: 1 });
+  });
+
+  test("resolves suffix ranges", () => {
+    expect(at("bytes=-30", 100)).toEqual({ start: 70, end: 99, length: 30 });
+  });
+
+  test("clamps a suffix longer than the object to the whole object", () => {
+    expect(at("bytes=-500", 100)).toEqual({ start: 0, end: 99, length: 100 });
+  });
+
+  test("clamps an end past the last byte rather than rejecting it", () => {
+    // Chrome asks for this when loading a <video>.
+    expect(at("bytes=0-2147483647", 100)).toEqual({
+      start: 0,
+      end: 99,
+      length: 100,
+    });
+  });
+
+  test("rejects a start at or past the end", () => {
+    expect(at("bytes=100-", 100)).toBeNull();
+    expect(at("bytes=150-200", 100)).toBeNull();
+  });
+
+  test("rejects a zero length suffix", () => {
+    expect(at("bytes=-0", 100)).toBeNull();
+  });
+
+  test("treats every range over an empty object as unsatisfiable", () => {
+    // This is what stops `bytes 0--1/0` from ever being formatted.
+    for (const header of ["bytes=0-", "bytes=0-0", "bytes=-1", "bytes=5-10"]) {
+      expect(at(header, 0)).toBeNull();
+    }
+  });
+
+  test("rejects a non finite total", () => {
+    expect(resolveRange({ kind: "offset", start: 0, end: null }, NaN)).toBeNull();
+  });
+});
+
+describe("toRangeHeaderValue()", () => {
+  test.each([
+    ["bytes=0-499", { kind: "offset", start: 0, end: 499 }],
+    ["bytes=200-", { kind: "offset", start: 200, end: null }],
+    ["bytes=-500", { kind: "suffix", suffixLength: 500 }],
+  ])("round trips %s", (header, range) => {
+    expect(toRangeHeaderValue(range as ByteRange)).toBe(header);
+    expect(parseRangeHeader(header)).toEqual(range);
+  });
+});
+
+describe("parseContentRange()", () => {
+  test("parses the satisfied form", () => {
+    expect(parseContentRange("bytes 100-199/12345")).toEqual({
+      start: 100,
+      end: 199,
+      total: 12345,
+    });
+    expect(parseContentRange("bytes 0-0/1")).toEqual({
+      start: 0,
+      end: 0,
+      total: 1,
+    });
+  });
+
+  test.each([
+    ["the unsatisfied form", "bytes */12345"],
+    ["a missing total", "bytes 0-99"],
+    ["an unknown unit", "items 0-99/100"],
+    ["garbage", "not a content range"],
+    ["an inverted range", "bytes 99-0/100"],
+    ["empty", ""],
+    ["null", null],
+  ])("returns null for %s", (_label, value) => {
+    expect(parseContentRange(value)).toBeNull();
+  });
+});
+
+describe("formatters", () => {
+  test("formatContentRange", () => {
+    expect(formatContentRange(0, 99, 453730)).toBe("bytes 0-99/453730");
+  });
+
+  test("formatUnsatisfiedContentRange", () => {
+    expect(formatUnsatisfiedContentRange(12345)).toBe("bytes */12345");
+    expect(formatUnsatisfiedContentRange(0)).toBe("bytes */0");
+  });
+});

--- a/packages/gemi/http/range.ts
+++ b/packages/gemi/http/range.ts
@@ -1,0 +1,193 @@
+/**
+ * RFC 7233 byte-range parsing and resolution.
+ *
+ * Deliberately dependency-free: the file storage drivers import `ByteRange`
+ * from here, and drivers otherwise import nothing out of `http/`.
+ */
+
+/**
+ * A parsed but *unresolved* `Range` header. The suffix form carries no absolute
+ * offsets — resolving it needs the total size of the object.
+ */
+export type ByteRange =
+  | { kind: "offset"; start: number; end: number | null }
+  | { kind: "suffix"; suffixLength: number };
+
+/** Absolute, inclusive, clamped-to-the-object byte offsets. */
+export type ResolvedRange = { start: number; end: number; length: number };
+
+/** A parsed response `Content-Range` of the `bytes S-E/TOTAL` form. */
+export type ContentRange = { start: number; end: number; total: number };
+
+function parseInteger(raw: string): number | null {
+  // Reject anything that isn't a run of ASCII digits. `Number()` would happily
+  // take "0x10", " 5", "1e3" and "+5", none of which are valid byte-pos.
+  if (!/^\d+$/.test(raw)) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+/**
+ * Parses a request `Range` header.
+ *
+ * Returns `null` for anything we cannot or will not serve as a partial
+ * response. That is not an error path: RFC 7233 §3.1 requires a recipient to
+ * ignore a `Range` it does not understand, and §4.1 lets a server ignore one it
+ * does. Every `null` here means "serve the complete representation with 200".
+ *
+ * Only a single range is supported — we never emit `multipart/byteranges`, so a
+ * multi-range request is ignored rather than partially honoured.
+ */
+export function parseRangeHeader(
+  header: string | null | undefined,
+): ByteRange | null {
+  if (!header) {
+    return null;
+  }
+
+  const trimmed = header.trim();
+  if (!/^bytes=/i.test(trimmed)) {
+    return null;
+  }
+
+  const specs = trimmed
+    .slice("bytes=".length)
+    .split(",")
+    .map((spec) => spec.trim());
+
+  // A single trailing comma is tolerated ("bytes=0-9,") because some clients
+  // emit it. More than one *non-empty* spec is a genuine multi-range request.
+  const present = specs.filter((spec) => spec !== "");
+  if (present.length !== 1) {
+    return null;
+  }
+
+  const spec = present[0];
+  const separator = spec.indexOf("-");
+  if (separator === -1) {
+    return null;
+  }
+
+  const rawStart = spec.slice(0, separator);
+  const rawEnd = spec.slice(separator + 1);
+
+  if (rawStart === "") {
+    // Suffix form: `bytes=-N`, the last N bytes.
+    const suffixLength = parseInteger(rawEnd);
+    if (suffixLength === null) {
+      return null;
+    }
+    // `bytes=-0` parses cleanly and resolves to unsatisfiable (416). Collapsing
+    // it to `null` here would serve the whole file instead, which the spec does
+    // not allow. Satisfiability is `resolveRange`'s job alone.
+    return { kind: "suffix", suffixLength };
+  }
+
+  const start = parseInteger(rawStart);
+  if (start === null) {
+    return null;
+  }
+
+  if (rawEnd === "") {
+    return { kind: "offset", start, end: null };
+  }
+
+  const end = parseInteger(rawEnd);
+  if (end === null || end < start) {
+    return null;
+  }
+
+  return { kind: "offset", start, end };
+}
+
+/**
+ * Resolves a parsed range against a known total size.
+ *
+ * Returns `null` when the range is unsatisfiable, which the caller must turn
+ * into a 416 rather than a full response.
+ */
+export function resolveRange(
+  range: ByteRange,
+  total: number,
+): ResolvedRange | null {
+  // An empty (or unknown-length) representation has no satisfiable range at
+  // all. Handling it here is what keeps `bytes 0--1/0` from ever being built.
+  if (!Number.isFinite(total) || total <= 0) {
+    return null;
+  }
+
+  let start: number;
+  let end: number;
+
+  if (range.kind === "suffix") {
+    if (range.suffixLength <= 0) {
+      return null;
+    }
+    start = Math.max(0, total - range.suffixLength);
+    end = total - 1;
+  } else {
+    if (range.start >= total) {
+      return null;
+    }
+    start = range.start;
+    // An end past the last byte is clamped, not rejected — Chrome routinely
+    // asks for `bytes=0-2147483647` when loading a <video>.
+    end = range.end === null ? total - 1 : Math.min(range.end, total - 1);
+    if (end < start) {
+      return null;
+    }
+  }
+
+  return { start, end, length: end - start + 1 };
+}
+
+/** Renders a range back into a `Range` request header for a storage backend. */
+export function toRangeHeaderValue(range: ByteRange): string {
+  if (range.kind === "suffix") {
+    return `bytes=-${range.suffixLength}`;
+  }
+  return range.end === null
+    ? `bytes=${range.start}-`
+    : `bytes=${range.start}-${range.end}`;
+}
+
+/**
+ * Parses a response `Content-Range`. Storage backends report the authoritative
+ * total size of the object here on a ranged read, which is what lets a driver
+ * answer a range without a second round trip for the size.
+ *
+ * The unsatisfied form used on a 416 has no offsets and returns `null`.
+ */
+export function parseContentRange(
+  value: string | null | undefined,
+): ContentRange | null {
+  if (!value) {
+    return null;
+  }
+  const match = /^bytes\s+(\d+)-(\d+)\/(\d+)$/i.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+  const start = parseInteger(match[1]);
+  const end = parseInteger(match[2]);
+  const total = parseInteger(match[3]);
+  if (start === null || end === null || total === null || end < start) {
+    return null;
+  }
+  return { start, end, total };
+}
+
+export function formatContentRange(
+  start: number,
+  end: number,
+  total: number,
+): string {
+  return `bytes ${start}-${end}/${total}`;
+}
+
+/** The `Content-Range` of a 416: no offsets, just the current total size. */
+export function formatUnsatisfiedContentRange(total: number): string {
+  return `bytes */${total}`;
+}

--- a/packages/gemi/http/requestContext.ts
+++ b/packages/gemi/http/requestContext.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { HttpRequest } from "./HttpRequest";
 import { Metadata } from "./Metadata";
+import type { ByteRange } from "./range";
 
 export interface CreateCookieOptions {
   maxAge?: number;
@@ -44,6 +45,16 @@ class Store {
   csrfHmac: string | null = null;
   locale: string | null = null;
   metadata = new Metadata();
+  /**
+   * The parsed `Range` of the in-flight request, picked up by
+   * `FileStorage.read()` so a range reaches the storage backend without every
+   * handler having to thread it through by hand.
+   *
+   * Only populated inside a `this.stream()` route, and cleared once that route
+   * returns: a `FileStorage.read()` in an ordinary handler must never start
+   * silently returning partial bytes.
+   */
+  rangeRequest: ByteRange | null = null;
 
   constructor(public req: HttpRequest) {}
 

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -37,7 +37,7 @@
     "lint": "oxlint",
     "build": "NODE_ENV=production bun run build:core && bun run build:bin && bun run build:types && bun run build:client && bun run build:plugin && bun run build:client-types",
     "build:core": "bun ./scripts/build.ts",
-    "build:bin": "bun build --outdir=./dist/bin --target=bun --external=vite --external=react-dom --external=react/jsx-runtime --external=bun --external=sharp --sourcemap ./bin/gemi.ts && bun ./scripts/prepare-bin.ts",
+    "build:bin": "bun build --outdir=./dist/bin --target=bun --external=vite --external=react-dom --external=react/jsx-runtime --external=bun --external=sharp --external=@azure/storage-blob --sourcemap ./bin/gemi.ts && bun ./scripts/prepare-bin.ts",
     "build:client": "vite build -c vite.client.config.mts",
     "build:plugin": "vite build -c vite.plugin.config.mts",
     "build:types": "tsc",
@@ -80,9 +80,15 @@
     "vitest": "^4.0.0"
   },
   "peerDependencies": {
+    "@azure/storage-blob": "^12.28.0",
     "react": ">=19",
     "react-dom": ">=19",
     "sharp": "^0.34.2",
     "vite": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@azure/storage-blob": {
+      "optional": true
+    }
   }
 }

--- a/packages/gemi/scripts/build.ts
+++ b/packages/gemi/scripts/build.ts
@@ -29,6 +29,8 @@ const result = await Bun.build({
     "bun",
     "jsx-email",
     "sharp",
+    // Optional peer: only present when an app uses AzureBlobDriver.
+    "@azure/storage-blob",
   ],
   target: "bun",
   format: "esm",

--- a/packages/gemi/services/file-storage/drivers/AzureBlobDriver.test.ts
+++ b/packages/gemi/services/file-storage/drivers/AzureBlobDriver.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import {
+  FileNotFoundError,
+  RangeNotSatisfiableError,
+} from "../../../http/errors";
+import { parseRangeHeader } from "../../../http/range";
+import { AzureBlobDriver } from "./AzureBlobDriver";
+
+type Downloaded = { offset?: number; count?: number };
+
+/**
+ * A stand-in for `@azure/storage-blob`, so these tests never need the optional
+ * peer dependency installed.
+ */
+function fakeAzure(
+  options: {
+    download?: (offset?: number, count?: number) => any;
+    properties?: any;
+    blobs?: string[];
+  } = {},
+) {
+  const calls: {
+    downloads: Downloaded[];
+    getProperties: number;
+    uploads: any[];
+    containers: string[];
+    blobs: string[];
+  } = {
+    downloads: [],
+    getProperties: 0,
+    uploads: [],
+    containers: [],
+    blobs: [],
+  };
+
+  const blobClient = {
+    async download(offset?: number, count?: number) {
+      calls.downloads.push({ offset, count });
+      const result = options.download?.(offset, count);
+      if (result instanceof Error) throw result;
+      return (
+        result ?? {
+          readableStreamBody: undefined,
+          blobBody: Promise.resolve(new Blob(["0123456789"])),
+          contentLength: 10,
+          contentType: "video/mp4",
+          etag: '"tag"',
+          lastModified: new Date("2026-01-02T03:04:05Z"),
+        }
+      );
+    },
+    async getProperties() {
+      calls.getProperties += 1;
+      const result = options.properties;
+      if (result instanceof Error) throw result;
+      return result ?? { contentLength: 12345, contentType: "video/mp4" };
+    },
+    async uploadData(data: any, opts: any) {
+      calls.uploads.push({ data, opts });
+    },
+    async delete() {},
+  };
+
+  const serviceClient = {
+    getContainerClient(name: string) {
+      calls.containers.push(name);
+      return {
+        getBlockBlobClient(blobName: string) {
+          calls.blobs.push(blobName);
+          return blobClient;
+        },
+        async *listBlobsFlat({ prefix }: { prefix?: string } = {}) {
+          for (const name of options.blobs ?? []) {
+            if (!prefix || name.startsWith(prefix)) yield { name };
+          }
+        },
+      };
+    },
+  };
+
+  return { serviceClient, calls };
+}
+
+function driverWith(options: Parameters<typeof fakeAzure>[0] = {}) {
+  const { serviceClient, calls } = fakeAzure(options);
+  const driver = new AzureBlobDriver({
+    serviceClient: serviceClient as any,
+    container: "media",
+  });
+  return { driver, calls };
+}
+
+describe("AzureBlobDriver.read()", () => {
+  beforeEach(() => {
+    delete process.env.BUCKET_NAME;
+  });
+
+  test("downloads the whole blob when no range is asked for", async () => {
+    const { driver, calls } = driverWith();
+
+    const result = await driver.read("clip.mp4");
+
+    expect(calls.downloads).toEqual([{ offset: undefined, count: undefined }]);
+    expect(calls.getProperties).toBe(0);
+    expect(result).toMatchObject({ partial: false, total: 10, type: "video/mp4" });
+  });
+
+  test("maps an offset range onto download(offset, count)", async () => {
+    const { driver, calls } = driverWith({
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x".repeat(100)])),
+        contentRange: "bytes 100-199/12345",
+        contentLength: 100,
+        contentType: "video/mp4",
+      }),
+    });
+
+    const result = await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=100-199"),
+    });
+
+    expect(calls.downloads).toEqual([{ offset: 100, count: 100 }]);
+    // The total came off Content-Range, so no size lookup was needed.
+    expect(calls.getProperties).toBe(0);
+    expect(result).toMatchObject({
+      start: 100,
+      end: 199,
+      total: 12345,
+      partial: true,
+    });
+  });
+
+  test("maps an open ended range onto an offset with no count", async () => {
+    const { driver, calls } = driverWith({
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x"])),
+        contentRange: "bytes 5000-12344/12345",
+        contentType: "video/mp4",
+      }),
+    });
+
+    await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=5000-"),
+    });
+
+    expect(calls.downloads).toEqual([{ offset: 5000, count: undefined }]);
+    expect(calls.getProperties).toBe(0);
+  });
+
+  test("resolves a suffix range against the size, since Azure has no suffix support", async () => {
+    const { driver, calls } = driverWith({
+      properties: { contentLength: 12345, contentType: "video/mp4" },
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x".repeat(500)])),
+        contentRange: "bytes 11845-12344/12345",
+        contentType: "video/mp4",
+      }),
+    });
+
+    const result = await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=-500"),
+    });
+
+    // One getProperties, then an absolute window — the documented cost of a
+    // suffix range on a backend without native support.
+    expect(calls.getProperties).toBe(1);
+    expect(calls.downloads).toEqual([{ offset: 11845, count: 500 }]);
+    expect(result).toMatchObject({ start: 11845, end: 12344, total: 12345 });
+  });
+
+  test("clamps a suffix longer than the blob to the whole blob", async () => {
+    const { driver, calls } = driverWith({
+      properties: { contentLength: 100 },
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x".repeat(100)])),
+        contentRange: "bytes 0-99/100",
+      }),
+    });
+
+    await driver.read({ name: "clip.mp4", range: parseRangeHeader("bytes=-500") });
+
+    expect(calls.downloads).toEqual([{ offset: 0, count: 100 }]);
+  });
+
+  test("rejects a suffix range over an empty blob without downloading", async () => {
+    const { driver, calls } = driverWith({ properties: { contentLength: 0 } });
+
+    await expect(
+      driver.read({ name: "empty.bin", range: parseRangeHeader("bytes=-10") }),
+    ).rejects.toBeInstanceOf(RangeNotSatisfiableError);
+    expect(calls.downloads).toEqual([]);
+  });
+
+  test("turns an InvalidRange into RangeNotSatisfiableError carrying the size", async () => {
+    const { driver } = driverWith({
+      download: () =>
+        Object.assign(new Error("InvalidRange"), {
+          statusCode: 416,
+          details: { errorCode: "InvalidRange" },
+        }),
+      properties: { contentLength: 12345 },
+    });
+
+    await expect(
+      driver.read({ name: "clip.mp4", range: parseRangeHeader("bytes=99999-") }),
+    ).rejects.toMatchObject({ name: "RangeNotSatisfiableError", total: 12345 });
+  });
+
+  test("turns a BlobNotFound into FileNotFoundError", async () => {
+    const { driver } = driverWith({
+      download: () =>
+        Object.assign(new Error("BlobNotFound"), {
+          statusCode: 404,
+          details: { errorCode: "BlobNotFound" },
+        }),
+    });
+
+    await expect(driver.read("missing.mp4")).rejects.toBeInstanceOf(
+      FileNotFoundError,
+    );
+  });
+
+  test("rethrows an unrelated error", async () => {
+    const { driver } = driverWith({
+      download: () =>
+        Object.assign(new Error("boom"), { statusCode: 403 }),
+    });
+
+    await expect(driver.read("clip.mp4")).rejects.toThrow("boom");
+  });
+
+  test("reports partial: false when Azure returned no Content-Range", async () => {
+    const { driver } = driverWith({
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["0123456789"])),
+        contentLength: 10,
+        contentType: "video/mp4",
+      }),
+    });
+
+    const result = await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=0-4"),
+    });
+
+    expect(result.partial).toBe(false);
+  });
+});
+
+describe("AzureBlobDriver container selection", () => {
+  beforeEach(() => {
+    delete process.env.BUCKET_NAME;
+  });
+
+  test("uses the configured container by default", async () => {
+    const { driver, calls } = driverWith();
+    await driver.read("clip.mp4");
+    expect(calls.containers).toEqual(["media"]);
+    expect(calls.blobs).toEqual(["clip.mp4"]);
+  });
+
+  test("lets `bucket` override the container per call", async () => {
+    const { driver, calls } = driverWith();
+    await driver.read({ name: "clip.mp4", bucket: "private" });
+    expect(calls.containers).toEqual(["private"]);
+  });
+
+  test("falls back to BUCKET_NAME", async () => {
+    process.env.BUCKET_NAME = "from-env";
+    const { serviceClient, calls } = fakeAzure();
+    const driver = new AzureBlobDriver({ serviceClient: serviceClient as any });
+
+    await driver.read("clip.mp4");
+
+    expect(calls.containers).toEqual(["from-env"]);
+  });
+
+  test("throws a clear error when no container is configured", async () => {
+    const { serviceClient } = fakeAzure();
+    const driver = new AzureBlobDriver({ serviceClient: serviceClient as any });
+
+    await expect(driver.read("clip.mp4")).rejects.toThrow(/container name/);
+  });
+
+  test("throws when the object name is missing", async () => {
+    const { driver } = driverWith();
+    await expect(driver.read({ name: "" })).rejects.toThrow(
+      "Object name has to be specified",
+    );
+  });
+});
+
+describe("AzureBlobDriver.put()", () => {
+  beforeEach(() => {
+    delete process.env.BUCKET_NAME;
+  });
+
+  test("keeps an explicitly passed contentType", async () => {
+    // S3Driver drops this today; do not repeat that here.
+    const { driver, calls } = driverWith();
+
+    await driver.put({
+      name: "a.bin",
+      body: new Blob(["x"], { type: "application/octet-stream" }),
+      contentType: "image/png",
+    });
+
+    expect(calls.uploads[0].opts.blobHTTPHeaders.blobContentType).toBe(
+      "image/png",
+    );
+  });
+
+  test("falls back to the blob's own type", async () => {
+    const { driver, calls } = driverWith();
+
+    await driver.put({ name: "a.png", body: new Blob(["x"], { type: "image/png" }) });
+
+    expect(calls.uploads[0].opts.blobHTTPHeaders.blobContentType).toBe(
+      "image/png",
+    );
+  });
+
+  // Name generation uses Bun.randomUUIDv7(), like the sibling drivers.
+  test.skipIf(typeof Bun === "undefined")(
+    "generates a name for a bare Blob and returns it",
+    async () => {
+      const { driver } = driverWith();
+
+      const name = await driver.put(new Blob(["x"], { type: "image/png" }));
+
+      expect(name).toMatch(/\.png$/);
+    },
+  );
+});
+
+describe("AzureBlobDriver.list()", () => {
+  test("returns blob names under a prefix", async () => {
+    const { driver } = driverWith({
+      blobs: ["photos/a.png", "photos/b.png", "videos/c.mp4"],
+    });
+
+    expect(await driver.list("photos/")).toEqual([
+      "photos/a.png",
+      "photos/b.png",
+    ]);
+  });
+});
+
+describe("AzureBlobDriver.fetch()", () => {
+  test("still returns a full Response for the legacy path", async () => {
+    const { driver, calls } = driverWith();
+
+    const res = await driver.fetch("clip.mp4");
+
+    expect(res.headers.get("Content-Type")).toBe("video/mp4");
+    expect(res.headers.get("Content-Length")).toBe("10");
+    expect(res.headers.get("ETag")).toBe('"tag"');
+    // No range travels through fetch().
+    expect(calls.downloads).toEqual([{ offset: undefined, count: undefined }]);
+  });
+});
+
+describe("AzureBlobDriver without the SDK", () => {
+  test("explains how to install the optional peer dependency", async () => {
+    const driver = new AzureBlobDriver({
+      container: "media",
+      connectionString: "UseDevelopmentStorage=true",
+    });
+
+    // @azure/storage-blob is not installed in this workspace, so the lazy
+    // import fails and the driver must say why.
+    await expect(driver.read("clip.mp4")).rejects.toThrow(
+      /@azure\/storage-blob/,
+    );
+  });
+});

--- a/packages/gemi/services/file-storage/drivers/AzureBlobDriver.ts
+++ b/packages/gemi/services/file-storage/drivers/AzureBlobDriver.ts
@@ -1,0 +1,317 @@
+import { Buffer } from "node:buffer";
+import { Readable } from "node:stream";
+
+import {
+  FileNotFoundError,
+  RangeNotSatisfiableError,
+} from "../../../http/errors";
+import { parseContentRange, resolveRange } from "../../../http/range";
+import { FileStorageDriver } from "./FileStorageDriver";
+import type { PutFileParams, ReadFileParams, ReadResult } from "./types";
+
+/**
+ * The slice of `@azure/storage-blob` this driver uses. Declared structurally so
+ * the package stays an optional peer dependency: nothing here imports its types.
+ */
+interface BlobClientLike {
+  download(
+    offset?: number,
+    count?: number,
+  ): Promise<{
+    readableStreamBody?: NodeJS.ReadableStream;
+    blobBody?: Promise<Blob>;
+    contentLength?: number;
+    contentType?: string;
+    contentRange?: string;
+    etag?: string;
+    lastModified?: Date;
+  }>;
+  getProperties(): Promise<{
+    contentLength?: number;
+    contentType?: string;
+    etag?: string;
+    lastModified?: Date;
+  }>;
+  uploadData(
+    data: Buffer | Blob,
+    options?: { blobHTTPHeaders?: { blobContentType?: string } },
+  ): Promise<unknown>;
+  delete(): Promise<unknown>;
+}
+
+interface ContainerClientLike {
+  getBlockBlobClient(name: string): BlobClientLike;
+  listBlobsFlat(options?: { prefix?: string }): AsyncIterable<{ name: string }>;
+}
+
+interface BlobServiceClientLike {
+  getContainerClient(name: string): ContainerClientLike;
+}
+
+export interface AzureBlobDriverConfig {
+  /** Defaults to `process.env.AZURE_STORAGE_CONNECTION_STRING`. */
+  connectionString?: string;
+  /** Account URL, e.g. `https://acct.blob.core.windows.net`, optionally carrying a SAS token. */
+  url?: string;
+  /** A `StorageSharedKeyCredential` or any `TokenCredential`, used with `url`. */
+  credential?: unknown;
+  /** Default container. Falls back to `process.env.BUCKET_NAME`. */
+  container?: string;
+  /**
+   * A pre-built `BlobServiceClient`. Supply this to configure retries, proxies
+   * or a custom credential chain yourself — the driver then never imports the
+   * SDK.
+   */
+  serviceClient?: BlobServiceClientLike;
+}
+
+function isNotFound(err: any) {
+  return (
+    err?.statusCode === 404 ||
+    err?.details?.errorCode === "BlobNotFound" ||
+    err?.code === "BlobNotFound"
+  );
+}
+
+function isInvalidRange(err: any) {
+  return (
+    err?.statusCode === 416 ||
+    err?.details?.errorCode === "InvalidRange" ||
+    err?.code === "InvalidRange"
+  );
+}
+
+/**
+ * Azure Blob Storage.
+ *
+ * `@azure/storage-blob` is an optional peer dependency, loaded on first use, so
+ * apps that do not use Azure never install it.
+ */
+export class AzureBlobDriver extends FileStorageDriver {
+  private serviceClientPromise: Promise<BlobServiceClientLike> | null = null;
+
+  constructor(private config: AzureBlobDriverConfig = {}) {
+    super();
+  }
+
+  private async serviceClient(): Promise<BlobServiceClientLike> {
+    if (this.config.serviceClient) {
+      return this.config.serviceClient;
+    }
+
+    // Memoized so concurrent requests share one client, and one import.
+    this.serviceClientPromise ??= (async () => {
+      let sdk: any;
+      try {
+        // @ts-ignore - optional peer dependency, absent unless the app installs it
+        sdk = await import("@azure/storage-blob");
+      } catch {
+        throw new Error(
+          "AzureBlobDriver requires the '@azure/storage-blob' package. Install it with `bun add @azure/storage-blob`, or pass a pre-built `serviceClient`.",
+        );
+      }
+
+      const connectionString =
+        this.config.connectionString ??
+        process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+      if (this.config.url) {
+        return new sdk.BlobServiceClient(this.config.url, this.config.credential);
+      }
+      if (connectionString) {
+        return sdk.BlobServiceClient.fromConnectionString(connectionString);
+      }
+      throw new Error(
+        "AzureBlobDriver needs a connection string (AZURE_STORAGE_CONNECTION_STRING), a `url`, or a `serviceClient`.",
+      );
+    })();
+
+    return this.serviceClientPromise;
+  }
+
+  private async blob(name: string, container?: string) {
+    if (!name) {
+      throw new Error("Object name has to be specified");
+    }
+    const containerName =
+      container ?? this.config.container ?? process.env.BUCKET_NAME;
+    if (!containerName) {
+      throw new Error(
+        "AzureBlobDriver needs a container name, from `bucket`, the `container` config, or BUCKET_NAME.",
+      );
+    }
+    const service = await this.serviceClient();
+    return service.getContainerClient(containerName).getBlockBlobClient(name);
+  }
+
+  async put(params: PutFileParams | Blob) {
+    let body: Blob | File | Buffer;
+    let contentType: string | undefined;
+    let name: string;
+    let container: string | undefined;
+
+    if (params instanceof Blob) {
+      body = params;
+      name = `${Bun.randomUUIDv7()}.${params.type.split("/")[1].split(";")[0]}`;
+      contentType = params.type;
+    } else {
+      body = params.body;
+      name = params.name;
+      container = params.bucket;
+      // An explicit contentType wins; otherwise fall back to the blob's own.
+      contentType =
+        params.contentType ??
+        (body instanceof Blob || body instanceof File ? body.type : undefined);
+    }
+
+    const data =
+      body instanceof Buffer
+        ? body
+        : Buffer.from(await (body as Blob).arrayBuffer());
+
+    const blob = await this.blob(name, container);
+    await blob.uploadData(data, {
+      blobHTTPHeaders: contentType ? { blobContentType: contentType } : undefined,
+    });
+
+    return name;
+  }
+
+  async list(folder: string) {
+    const containerName = this.config.container ?? process.env.BUCKET_NAME;
+    const service = await this.serviceClient();
+    const container = service.getContainerClient(containerName!);
+
+    const names: string[] = [];
+    for await (const blob of container.listBlobsFlat({ prefix: folder })) {
+      names.push(blob.name);
+    }
+    return names;
+  }
+
+  async fetch(params: ReadFileParams | string) {
+    const result = await this.read(
+      typeof params === "string"
+        ? { name: params }
+        : { name: params.name, bucket: params.bucket },
+    );
+
+    return new Response(result.body as BodyInit, {
+      headers: {
+        "Content-Type": result.type,
+        "Content-Length": String(result.total),
+        "Cache-Control": "private, max-age=12000, must-revalidate",
+        "Last-Modified": result.lastModified?.toUTCString() ?? "",
+        ETag: result.etag ?? "",
+      },
+    });
+  }
+
+  async read(input: ReadFileParams | string): Promise<ReadResult> {
+    const params = typeof input === "string" ? { name: input } : input;
+    const { name, bucket, range = null } = params;
+
+    const blob = await this.blob(name, bucket);
+
+    // Azure has no suffix range: `download()` takes an absolute offset, so
+    // `bytes=-N` has to be resolved against the size first. This is the one
+    // shape that costs a second round trip; `bytes=S-` and `bytes=S-E` go
+    // straight to the download and read the total back off its Content-Range.
+    let offset: number | undefined;
+    let count: number | undefined;
+
+    if (range?.kind === "suffix") {
+      const total = await this.size({ name, bucket });
+      const resolved = resolveRange(range, total);
+      if (!resolved) {
+        throw new RangeNotSatisfiableError(total);
+      }
+      offset = resolved.start;
+      count = resolved.length;
+    } else if (range) {
+      offset = range.start;
+      count = range.end === null ? undefined : range.end - range.start + 1;
+    }
+
+    let result: Awaited<ReturnType<BlobClientLike["download"]>>;
+    try {
+      result = await blob.download(offset, count);
+    } catch (err: any) {
+      if (isInvalidRange(err)) {
+        throw new RangeNotSatisfiableError(await this.size({ name, bucket }));
+      }
+      if (isNotFound(err)) {
+        throw new FileNotFoundError(name);
+      }
+      throw err;
+    }
+
+    // Azure reports the authoritative total in Content-Range on a ranged read.
+    const contentRange = parseContentRange(result.contentRange);
+    const partial = Boolean(contentRange);
+    const total = contentRange?.total ?? result.contentLength ?? 0;
+
+    return {
+      body: await toBody(result),
+      start: contentRange?.start ?? 0,
+      end: contentRange?.end ?? total - 1,
+      total,
+      partial,
+      type: result.contentType ?? "application/octet-stream",
+      etag: result.etag || undefined,
+      lastModified: result.lastModified,
+      name,
+    };
+  }
+
+  async size(params: ReadFileParams | string) {
+    const name = typeof params === "string" ? params : params.name;
+    const bucket = typeof params === "string" ? undefined : params.bucket;
+
+    const blob = await this.blob(name, bucket);
+    try {
+      const properties = await blob.getProperties();
+      return properties.contentLength ?? 0;
+    } catch (err: any) {
+      if (isNotFound(err)) {
+        throw new FileNotFoundError(name);
+      }
+      throw err;
+    }
+  }
+
+  async delete(params: ReadFileParams | string) {
+    const name = typeof params === "string" ? params : params.name;
+    const bucket = typeof params === "string" ? undefined : params.bucket;
+
+    const blob = await this.blob(name, bucket);
+    try {
+      await blob.delete();
+    } catch (err: any) {
+      if (isNotFound(err)) {
+        throw new FileNotFoundError(name);
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Azure hands back a Node stream under Bun and a `Blob` in the browser bundle.
+ * A Blob is returned as-is rather than as a stream: Bun keeps an explicit
+ * Content-Length for a sized body but falls back to chunked for a stream.
+ */
+async function toBody(result: {
+  readableStreamBody?: NodeJS.ReadableStream;
+  blobBody?: Promise<Blob>;
+}): Promise<ReadResult["body"]> {
+  if (result.blobBody) {
+    return await result.blobBody;
+  }
+  if (result.readableStreamBody) {
+    return Readable.toWeb(
+      result.readableStreamBody as Readable,
+    ) as unknown as ReadableStream<Uint8Array>;
+  }
+  return null;
+}

--- a/packages/gemi/services/file-storage/drivers/FileStorageDriver.test.ts
+++ b/packages/gemi/services/file-storage/drivers/FileStorageDriver.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+
+import { FileNotFoundError } from "../../../http/errors";
+import { parseRangeHeader } from "../../../http/range";
+import { FileStorageDriver } from "./FileStorageDriver";
+import type { PutFileParams, ReadFileParams } from "./types";
+
+const CONTENT = "0123456789";
+
+/** A driver written before `read()` existed: it only implements `fetch()`. */
+class LegacyDriver extends FileStorageDriver {
+  public fetchCalls = 0;
+
+  async fetch(params: ReadFileParams | string) {
+    this.fetchCalls += 1;
+    const name = typeof params === "string" ? params : params.name;
+    if (name === "missing.txt") {
+      return new Response("Not found", { status: 404 });
+    }
+    return new Response(CONTENT, {
+      headers: {
+        "Content-Type": "text/plain",
+        "Content-Length": String(CONTENT.length),
+        ETag: '"legacy"',
+      },
+    });
+  }
+
+  async put(_params: PutFileParams | Blob) {
+    return "noop";
+  }
+
+  async list() {
+    return [];
+  }
+}
+
+describe("FileStorageDriver's default read()", () => {
+  test("reads a whole object through fetch()", async () => {
+    const driver = new LegacyDriver();
+    const result = await driver.read("file.txt");
+
+    expect(result).toMatchObject({
+      start: 0,
+      end: 9,
+      total: 10,
+      partial: false,
+      type: "text/plain",
+      etag: '"legacy"',
+      name: "file.txt",
+    });
+  });
+
+  test("reports partial: false for a range, leaving the slicing to the framework", async () => {
+    // A driver that cannot range natively must not claim it applied one, or the
+    // response would carry a Content-Range that does not describe the body.
+    const driver = new LegacyDriver();
+    const result = await driver.read({
+      name: "file.txt",
+      range: parseRangeHeader("bytes=2-5"),
+    });
+
+    expect(result.partial).toBe(false);
+    expect(result.total).toBe(10);
+    expect(result.body).toBeInstanceOf(Blob);
+    expect(await (result.body as Blob).text()).toBe(CONTENT);
+  });
+
+  test("turns a failed fetch into FileNotFoundError", async () => {
+    const driver = new LegacyDriver();
+    await expect(driver.read("missing.txt")).rejects.toBeInstanceOf(
+      FileNotFoundError,
+    );
+  });
+
+  test("size() falls back to the Content-Length of a fetch()", async () => {
+    const driver = new LegacyDriver();
+    expect(await driver.size("file.txt")).toBe(10);
+  });
+});

--- a/packages/gemi/services/file-storage/drivers/FileStorageDriver.ts
+++ b/packages/gemi/services/file-storage/drivers/FileStorageDriver.ts
@@ -1,11 +1,94 @@
+import { FileNotFoundError } from "../../../http/errors";
 import type {
   IFileStorageDriver,
-  ReadFileParams,
   PutFileParams,
+  ReadFileParams,
+  ReadResult,
 } from "./types";
 
 export abstract class FileStorageDriver implements IFileStorageDriver {
   abstract fetch(params: ReadFileParams | string): Promise<Response>;
   abstract put(params: PutFileParams | Blob): Promise<string>;
   abstract list(folder: string): Promise<any>;
+
+  /**
+   * Default `read()` for drivers that only implement `fetch()`.
+   *
+   * Deliberately not abstract: every driver written before `read()` existed
+   * keeps compiling and gains working range support for free. It is not
+   * *efficient* though — to serve a range it buffers the whole object so the
+   * framework can slice it, which saves no bandwidth from the backend. Any
+   * driver whose backend can range natively should override this.
+   */
+  async read(input: ReadFileParams | string): Promise<ReadResult> {
+    const params = typeof input === "string" ? { name: input } : input;
+    const response = await this.fetch({
+      name: params.name,
+      bucket: params.bucket,
+    });
+
+    if (!response.ok) {
+      throw new FileNotFoundError(params.name);
+    }
+
+    const type =
+      response.headers.get("Content-Type") ?? "application/octet-stream";
+    const etag = response.headers.get("ETag") ?? undefined;
+    const lastModifiedHeader = response.headers.get("Last-Modified");
+    const lastModified = lastModifiedHeader
+      ? new Date(lastModifiedHeader)
+      : undefined;
+
+    if (params.range) {
+      const blob = await response.blob();
+      return {
+        body: blob,
+        start: 0,
+        end: blob.size - 1,
+        total: blob.size,
+        // The range was not applied by the backend. Reporting `false` hands
+        // the slicing to `createStreamResponse`, which has the total in hand.
+        partial: false,
+        type,
+        etag,
+        lastModified,
+        name: params.name,
+      };
+    }
+
+    const contentLength = Number(response.headers.get("Content-Length"));
+    const total = Number.isFinite(contentLength) ? contentLength : 0;
+
+    return {
+      body: response.body,
+      start: 0,
+      end: total - 1,
+      total,
+      partial: false,
+      type,
+      etag,
+      lastModified,
+      name: params.name,
+    };
+  }
+
+  /**
+   * Total size of an object. Used to resolve suffix ranges on backends without
+   * native suffix support, and to report the total on a 416. Override with a
+   * HEAD-style request wherever one is available.
+   */
+  async size(params: ReadFileParams | string): Promise<number> {
+    const name = typeof params === "string" ? params : params.name;
+    const bucket = typeof params === "string" ? undefined : params.bucket;
+    const response = await this.fetch({ name, bucket });
+    if (!response.ok) {
+      throw new FileNotFoundError(name);
+    }
+    const contentLength = Number(response.headers.get("Content-Length"));
+    if (Number.isFinite(contentLength)) {
+      await response.body?.cancel();
+      return contentLength;
+    }
+    return (await response.blob()).size;
+  }
 }

--- a/packages/gemi/services/file-storage/drivers/FileSystemDriver.ts
+++ b/packages/gemi/services/file-storage/drivers/FileSystemDriver.ts
@@ -1,6 +1,11 @@
-import type { PutFileParams, ReadFileParams } from "./types";
+import type { PutFileParams, ReadFileParams, ReadResult } from "./types";
 import { FileStorageDriver } from "./FileStorageDriver";
 import { readdir } from "fs/promises";
+import { resolveRange } from "../../../http/range";
+import {
+  FileNotFoundError,
+  RangeNotSatisfiableError,
+} from "../../../http/errors";
 
 export class FileSystemDriver extends FileStorageDriver {
   constructor(private folderPath: string = `${process.env.ROOT_DIR}/storage`) {
@@ -62,6 +67,56 @@ export class FileSystemDriver extends FileStorageDriver {
         "Last-Modified": date,
       },
     });
+  }
+
+  async read(input: ReadFileParams | string): Promise<ReadResult> {
+    const params = typeof input === "string" ? { name: input } : input;
+    const { name, range = null } = params;
+
+    if (!name) {
+      throw new Error("Object name has to be specified");
+    }
+
+    const file = Bun.file(`${this.folderPath}/${name}`);
+
+    // `Bun.file()` is lazy. Without this the response commits with a 200 and
+    // the ENOENT only surfaces once the stream is pulled, as an unhandled
+    // rejection with the status already on the wire.
+    if (!(await file.exists())) {
+      throw new FileNotFoundError(name);
+    }
+
+    const total = file.size;
+    const resolved = range ? resolveRange(range, total) : null;
+
+    if (range && !resolved) {
+      throw new RangeNotSatisfiableError(total);
+    }
+
+    const start = resolved?.start ?? 0;
+    const end = resolved ? resolved.end : total - 1;
+
+    return {
+      // A BunFile slice stays lazy and keeps a known size, so Bun can send it
+      // with a real Content-Length instead of falling back to chunked.
+      body: resolved ? file.slice(start, end + 1) : file,
+      start,
+      end,
+      total,
+      partial: Boolean(resolved),
+      type: file.type || "application/octet-stream",
+      lastModified: new Date(file.lastModified),
+      name,
+    };
+  }
+
+  async size(params: ReadFileParams | string) {
+    const name = typeof params === "string" ? params : params.name;
+    const file = Bun.file(`${this.folderPath}/${name}`);
+    if (!(await file.exists())) {
+      throw new FileNotFoundError(name);
+    }
+    return file.size;
   }
 
   async list() {

--- a/packages/gemi/services/file-storage/drivers/S3Driver.test.ts
+++ b/packages/gemi/services/file-storage/drivers/S3Driver.test.ts
@@ -29,6 +29,83 @@ function driverWith(send: (command: any) => Promise<any>) {
   return driver;
 }
 
+describe("S3Driver.put()", () => {
+  beforeEach(() => {
+    process.env.BUCKET_NAME = "test-bucket";
+  });
+
+  async function putWith(params: any) {
+    let input: any;
+    const driver = driverWith(async (command) => {
+      input = command.input;
+      return {};
+    });
+    const name = await driver.put(params);
+    return { input, name };
+  }
+
+  test("keeps an explicitly passed contentType over the blob's own type", async () => {
+    // A caller that says "this PNG is really an octet-stream", or vice versa,
+    // has to win — they know something the blob does not.
+    const { input } = await putWith({
+      name: "a.png",
+      body: new Blob(["x"], { type: "application/octet-stream" }),
+      contentType: "image/png",
+    });
+
+    expect(input.ContentType).toBe("image/png");
+  });
+
+  test("keeps the contentType of a Buffer body", async () => {
+    // A Buffer carries no type of its own, so dropping the caller's value left
+    // it with none at all and S3 stored it as application/octet-stream.
+    const { input } = await putWith({
+      name: "a.png",
+      body: Buffer.from("x"),
+      contentType: "image/png",
+    });
+
+    expect(input.ContentType).toBe("image/png");
+  });
+
+  test("falls back to the blob's own type when none is given", async () => {
+    const { input } = await putWith({
+      name: "a.png",
+      body: new Blob(["x"], { type: "image/png" }),
+    });
+
+    expect(input.ContentType).toBe("image/png");
+  });
+
+  test("sends no content type for a typeless body rather than an empty one", async () => {
+    const { input } = await putWith({ name: "a.bin", body: Buffer.from("x") });
+    expect(input.ContentType).toBeUndefined();
+
+    const blob = await putWith({ name: "b.bin", body: new Blob(["x"]) });
+    expect(blob.input.ContentType).toBeUndefined();
+  });
+
+  // The bare-Blob path generates a name with Bun.randomUUIDv7().
+  test.skipIf(typeof Bun === "undefined")(
+    "uses the blob's type for a bare Blob",
+    async () => {
+      const { input } = await putWith(new Blob(["x"], { type: "image/png" }));
+      expect(input.ContentType).toBe("image/png");
+    },
+  );
+
+  test("honours an explicit bucket", async () => {
+    const { input } = await putWith({
+      name: "a.png",
+      body: Buffer.from("x"),
+      bucket: "other",
+    });
+
+    expect(input.Bucket).toBe("other");
+    expect(input.Key).toBe("a.png");
+  });
+});
+
 describe("S3Driver.read()", () => {
   beforeEach(() => {
     process.env.BUCKET_NAME = "test-bucket";

--- a/packages/gemi/services/file-storage/drivers/S3Driver.test.ts
+++ b/packages/gemi/services/file-storage/drivers/S3Driver.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { RangeNotSatisfiableError, FileNotFoundError } from "../../../http/errors";
+import { parseRangeHeader } from "../../../http/range";
+import { S3Driver } from "./S3Driver";
+
+/** A GetObjectCommandOutput shaped enough for `read()`. */
+function objectOutput(overrides: Record<string, any> = {}) {
+  return {
+    Body: {
+      transformToWebStream: () =>
+        new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        }),
+    },
+    ContentType: "video/mp4",
+    ContentLength: 12345,
+    ETag: '"abc"',
+    $metadata: { httpStatusCode: 200 },
+    ...overrides,
+  };
+}
+
+function driverWith(send: (command: any) => Promise<any>) {
+  const driver = new S3Driver({ region: "test" } as any);
+  (driver as any).client = { send };
+  return driver;
+}
+
+describe("S3Driver.read()", () => {
+  beforeEach(() => {
+    process.env.BUCKET_NAME = "test-bucket";
+  });
+
+  test("sends no Range header when none was asked for", async () => {
+    let input: any;
+    const driver = driverWith(async (command) => {
+      input = command.input;
+      return objectOutput();
+    });
+
+    const result = await driver.read("video.mp4");
+
+    expect(input.Range).toBeUndefined();
+    expect(input.Key).toBe("video.mp4");
+    expect(input.Bucket).toBe("test-bucket");
+    expect(result.partial).toBe(false);
+    expect(result.total).toBe(12345);
+    expect(result.end).toBe(12344);
+  });
+
+  test("forwards an offset range and reads the total back out of Content-Range", async () => {
+    // The whole point of the ReadResult contract: S3 reports the authoritative
+    // total on the ranged GET itself, so no HEAD is needed for the size.
+    let input: any;
+    const driver = driverWith(async (command) => {
+      input = command.input;
+      return objectOutput({
+        ContentRange: "bytes 100-199/12345",
+        ContentLength: 100,
+        $metadata: { httpStatusCode: 206 },
+      });
+    });
+
+    const result = await driver.read({
+      name: "video.mp4",
+      range: parseRangeHeader("bytes=100-199"),
+    });
+
+    expect(input.Range).toBe("bytes=100-199");
+    expect(result).toMatchObject({
+      start: 100,
+      end: 199,
+      total: 12345,
+      partial: true,
+    });
+  });
+
+  test("forwards a suffix range untouched, since S3 resolves it natively", async () => {
+    let input: any;
+    const driver = driverWith(async (command) => {
+      input = command.input;
+      return objectOutput({
+        ContentRange: "bytes 11845-12344/12345",
+        $metadata: { httpStatusCode: 206 },
+      });
+    });
+
+    const result = await driver.read({
+      name: "video.mp4",
+      range: parseRangeHeader("bytes=-500"),
+    });
+
+    expect(input.Range).toBe("bytes=-500");
+    expect(result.start).toBe(11845);
+    expect(result.total).toBe(12345);
+  });
+
+  test("reports partial: false when S3 answered 200 despite a range", async () => {
+    const driver = driverWith(async () => objectOutput());
+
+    const result = await driver.read({
+      name: "video.mp4",
+      range: parseRangeHeader("bytes=0-99"),
+    });
+
+    expect(result.partial).toBe(false);
+  });
+
+  test("turns an InvalidRange into RangeNotSatisfiableError carrying the size", async () => {
+    const driver = driverWith(async (command) => {
+      if (command.constructor.name === "HeadObjectCommand") {
+        return { ContentLength: 12345 };
+      }
+      throw Object.assign(new Error("InvalidRange"), {
+        name: "InvalidRange",
+        $metadata: { httpStatusCode: 416 },
+      });
+    });
+
+    await expect(
+      driver.read({ name: "video.mp4", range: parseRangeHeader("bytes=99999-") }),
+    ).rejects.toMatchObject({
+      name: "RangeNotSatisfiableError",
+      total: 12345,
+    });
+    await expect(
+      driver.read({ name: "video.mp4", range: parseRangeHeader("bytes=99999-") }),
+    ).rejects.toBeInstanceOf(RangeNotSatisfiableError);
+  });
+
+  test("turns a NoSuchKey into FileNotFoundError", async () => {
+    const driver = driverWith(async () => {
+      throw Object.assign(new Error("NoSuchKey"), {
+        name: "NoSuchKey",
+        $metadata: { httpStatusCode: 404 },
+      });
+    });
+
+    await expect(driver.read("missing.mp4")).rejects.toBeInstanceOf(
+      FileNotFoundError,
+    );
+  });
+
+  test("rethrows an unrelated error", async () => {
+    const driver = driverWith(async () => {
+      throw Object.assign(new Error("boom"), { name: "AccessDenied" });
+    });
+
+    await expect(driver.read("video.mp4")).rejects.toThrow("boom");
+  });
+
+  test("size() uses a HEAD rather than pulling the object", async () => {
+    let commandName = "";
+    const driver = driverWith(async (command) => {
+      commandName = command.constructor.name;
+      return { ContentLength: 999 };
+    });
+
+    expect(await driver.size("video.mp4")).toBe(999);
+    expect(commandName).toBe("HeadObjectCommand");
+  });
+});

--- a/packages/gemi/services/file-storage/drivers/S3Driver.ts
+++ b/packages/gemi/services/file-storage/drivers/S3Driver.ts
@@ -26,7 +26,7 @@ export class S3Driver extends FileStorageDriver {
 
   async put(params: PutFileParams | Blob) {
     let body: Blob | File | Buffer;
-    let contentType: string;
+    let contentType: string | undefined;
     let name: string;
     let bucket = process.env.BUCKET_NAME;
 
@@ -38,11 +38,17 @@ export class S3Driver extends FileStorageDriver {
       body = params.body;
       name = params.name;
       bucket = params.bucket ?? bucket;
-      contentType = params.contentType;
+      // An explicitly passed contentType wins; otherwise fall back to the
+      // blob's own type. A Buffer carries no type, so it has nothing to fall
+      // back to and relies on the caller's value.
+      contentType =
+        params.contentType ||
+        (body instanceof Blob || body instanceof File ? body.type : undefined);
     }
 
-    contentType =
-      body instanceof Blob || body instanceof File ? body.type : undefined;
+    // A typeless Blob reports "". Send nothing rather than an empty header, so
+    // S3 applies its own default instead of storing a blank content type.
+    contentType = contentType || undefined;
 
     const buffer =
       body instanceof Buffer

--- a/packages/gemi/services/file-storage/drivers/S3Driver.ts
+++ b/packages/gemi/services/file-storage/drivers/S3Driver.ts
@@ -1,7 +1,8 @@
-import type { PutFileParams, ReadFileParams } from "./types";
+import type { PutFileParams, ReadFileParams, ReadResult } from "./types";
 
 import {
   GetObjectCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
@@ -9,6 +10,11 @@ import {
 
 import { Buffer } from "node:buffer";
 import { FileStorageDriver } from "./FileStorageDriver";
+import { parseContentRange, toRangeHeaderValue } from "../../../http/range";
+import {
+  FileNotFoundError,
+  RangeNotSatisfiableError,
+} from "../../../http/errors";
 
 export class S3Driver extends FileStorageDriver {
   private client: S3Client;
@@ -99,5 +105,73 @@ export class S3Driver extends FileStorageDriver {
         ETag: result.ETag || "",
       },
     });
+  }
+
+  async read(input: ReadFileParams | string): Promise<ReadResult> {
+    const params = typeof input === "string" ? { name: input } : input;
+    const bucket = params.bucket ?? process.env.BUCKET_NAME;
+    const { name, range = null } = params;
+
+    if (!name) {
+      throw new Error("Object name has to be specified");
+    }
+
+    let result: Awaited<ReturnType<S3Client["send"]>> & Record<string, any>;
+    try {
+      result = (await this.client.send(
+        new GetObjectCommand({
+          Bucket: bucket,
+          Key: name,
+          Range: range ? toRangeHeaderValue(range) : undefined,
+        }),
+      )) as any;
+    } catch (err: any) {
+      if (err?.name === "InvalidRange" || err?.$metadata?.httpStatusCode === 416) {
+        throw new RangeNotSatisfiableError(await this.size({ name, bucket }));
+      }
+      if (err?.name === "NoSuchKey" || err?.$metadata?.httpStatusCode === 404) {
+        throw new FileNotFoundError(name);
+      }
+      throw err;
+    }
+
+    // S3 reports the authoritative total in its own Content-Range on any
+    // successful ranged GET. Reading it here is what keeps `bytes=S-E` and
+    // `bytes=-N` down to a single round trip, with no HEAD for the size.
+    const contentRange = parseContentRange(result.ContentRange);
+    const partial =
+      Boolean(contentRange) && result.$metadata?.httpStatusCode === 206;
+    const total = contentRange?.total ?? result.ContentLength ?? 0;
+
+    return {
+      body: result.Body.transformToWebStream(),
+      start: contentRange?.start ?? 0,
+      end: contentRange?.end ?? total - 1,
+      total,
+      partial,
+      type: result.ContentType ?? "application/octet-stream",
+      etag: result.ETag || undefined,
+      lastModified: result.LastModified,
+      name,
+    };
+  }
+
+  async size(params: ReadFileParams | string) {
+    const name = typeof params === "string" ? params : params.name;
+    const bucket =
+      (typeof params === "string" ? undefined : params.bucket) ??
+      process.env.BUCKET_NAME;
+
+    try {
+      const result = await this.client.send(
+        new HeadObjectCommand({ Bucket: bucket, Key: name }),
+      );
+      return result.ContentLength ?? 0;
+    } catch (err: any) {
+      if (err?.name === "NotFound" || err?.$metadata?.httpStatusCode === 404) {
+        throw new FileNotFoundError(name);
+      }
+      throw err;
+    }
   }
 }

--- a/packages/gemi/services/file-storage/drivers/types.ts
+++ b/packages/gemi/services/file-storage/drivers/types.ts
@@ -1,3 +1,7 @@
+import type { ByteRange } from "../../../http/range";
+
+export type { ByteRange };
+
 export interface PutFileParams {
   name: string;
   bucket?: string;
@@ -8,6 +12,45 @@ export interface PutFileParams {
 export interface ReadFileParams {
   name: string;
   bucket?: string;
+  /**
+   * Ask the backend for only these bytes. Absent or `null` reads the whole
+   * object. Drivers that cannot range are free to ignore this and return the
+   * complete object with `partial: false`.
+   */
+  range?: ByteRange | null;
+}
+
+/**
+ * What a driver hands back from `read()`: the bytes, plus enough metadata for
+ * the framework to build the HTTP response. Drivers deliberately do not build
+ * `Response`s themselves, so the 200/206/416 rules live in exactly one place.
+ */
+export interface ReadResult {
+  /**
+   * Prefer a `Blob` (including a `BunFile`) over a `ReadableStream` whenever
+   * the driver holds a sized handle: Bun drops an explicitly set
+   * `Content-Length` and falls back to chunked encoding for any stream body,
+   * but keeps it for a sized blob.
+   */
+  body: ReadableStream<Uint8Array> | Blob | null;
+  /** Absolute inclusive offsets of `body` within the complete object. */
+  start: number;
+  end: number;
+  /** Authoritative size of the *complete* object, not of `body`. */
+  total: number;
+  /**
+   * Whether the driver actually applied the requested range.
+   *
+   * Not derivable from the offsets: `bytes=0-` over a whole object is a 206
+   * whose offsets span the entire file, while a driver that chose to ignore the
+   * range reports the very same offsets and wants a 200.
+   */
+  partial: boolean;
+  type: string;
+  etag?: string;
+  lastModified?: Date;
+  /** Used for `Content-Disposition`. */
+  name?: string;
 }
 
 export interface FileMetadata {
@@ -18,4 +61,9 @@ export interface FileMetadata {
 export interface IFileStorageDriver {
   fetch(input: ReadFileParams | string): Promise<Response>;
   put(params: PutFileParams | Blob): Promise<string>;
+  /**
+   * Optional: `FileStorageDriver` supplies a `fetch()`-backed default, so
+   * drivers written before this existed keep working.
+   */
+  read?(input: ReadFileParams | string): Promise<ReadResult>;
 }

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -2,8 +2,17 @@
 export { FileStorageServiceProvider } from "./file-storage/FileStorageServiceProvider";
 export { FileSystemDriver } from "./file-storage/drivers/FileSystemDriver";
 export { S3Driver } from "./file-storage/drivers/S3Driver";
-export type { FileMetadata, PutFileParams, ReadFileParams } from "./file-storage/drivers/types";
+export type {
+  ByteRange,
+  FileMetadata,
+  PutFileParams,
+  ReadFileParams,
+  ReadResult,
+} from "./file-storage/drivers/types";
 export { FileStorageDriver } from "./file-storage/drivers/FileStorageDriver";
+// The toolkit a custom driver needs to resolve a range against its backend.
+export { resolveRange, toRangeHeaderValue, parseContentRange } from "../http/range";
+export { FileNotFoundError, RangeNotSatisfiableError } from "../http/errors";
 
 // Ratelimiter
 export { RateLimiterServiceProvider } from "./rate-limiter/RateLimiterServiceProvider";

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -2,6 +2,10 @@
 export { FileStorageServiceProvider } from "./file-storage/FileStorageServiceProvider";
 export { FileSystemDriver } from "./file-storage/drivers/FileSystemDriver";
 export { S3Driver } from "./file-storage/drivers/S3Driver";
+export {
+  AzureBlobDriver,
+  type AzureBlobDriverConfig,
+} from "./file-storage/drivers/AzureBlobDriver";
 export type {
   ByteRange,
   FileMetadata,

--- a/packages/gemi/services/router/ApiRouterServiceContainer.ts
+++ b/packages/gemi/services/router/ApiRouterServiceContainer.ts
@@ -130,6 +130,59 @@ export class ApiRouterServiceContainer extends ServiceContainer {
     return data;
   }
 
+  /**
+   * Copies request-context headers and cookies onto a Response a handler built
+   * itself, without disturbing what the handler already set.
+   */
+  private mergeContextIntoResponse(
+    response: Response,
+    headers: Headers,
+    cookies: Set<string>,
+  ) {
+    const entries = headers ? [...headers] : [];
+    const setCookies = [
+      ...(typeof headers?.getSetCookie === "function"
+        ? headers.getSetCookie()
+        : []),
+      ...Array.from(cookies ?? []),
+    ];
+
+    if (entries.length === 0 && setCookies.length === 0) {
+      return response;
+    }
+
+    const apply = (target: Headers) => {
+      for (const [key, value] of entries) {
+        if (key.toLowerCase() === "set-cookie") {
+          continue;
+        }
+        if (!target.has(key)) {
+          target.set(key, value);
+        }
+      }
+      for (const cookie of setCookies) {
+        target.append("Set-Cookie", cookie);
+      }
+    };
+
+    try {
+      // Mutating in place keeps the original Response object, and with it a
+      // sized Blob body — rebuilding turns that into a stream, which costs the
+      // Content-Length that Bun only emits for known-length bodies.
+      apply(response.headers);
+      return response;
+    } catch {
+      // A Response from fetch() — this.proxy() routes — has immutable headers.
+      const merged = new Headers(response.headers);
+      apply(merged);
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: merged,
+      });
+    }
+  }
+
   async handleApiRequest(req: Request) {
     const { params, path } = this.getRouteHandlerAndParams(req);
 
@@ -162,21 +215,35 @@ export class ApiRouterServiceContainer extends ServiceContainer {
       }
       const data = await this.getRouteData(path);
 
+      const headers = ctx.headers;
+      const cookies = ctx.cookies;
+
       if (data instanceof Response) {
-        return data;
+        // A handler owning its own Response — stream, file and proxy routes,
+        // and the RequestBreakerError path in getRouteData — still has to carry
+        // what the request context accumulated: headers set by middleware via
+        // ctx.setHeaders (CORS, Cache-Control) and any Set-Cookie. The
+        // response's own headers win; the context only fills gaps.
+        const response = this.mergeContextIntoResponse(data, headers, cookies);
+
+        if (!req.url.includes("/__gemi__")) {
+          // Before destroy(), which empties the store the hook reads from.
+          this.service.onRequestEnd(httpRequest);
+        }
+        ctx.destroy();
+        return response;
       }
 
-      const headers = ctx.headers;
+      headers.set("Content-Type", "application/json");
 
-      headers.append("Content-Type", "application/json");
-
-      ctx.cookies.forEach((cookie) => headers.append("Set-Cookie", cookie.toString()));
-
-      ctx.destroy();
+      cookies.forEach((cookie) => headers.append("Set-Cookie", cookie.toString()));
 
       if (!req.url.includes("/__gemi__")) {
         this.service.onRequestEnd(httpRequest);
       }
+
+      ctx.destroy();
+
       return new Response(JSON.stringify(data), {
         headers,
       });

--- a/packages/gemi/services/router/createFlatApiRoutes.test.ts
+++ b/packages/gemi/services/router/createFlatApiRoutes.test.ts
@@ -110,3 +110,48 @@ describe("createFlatApiRoutes() resource middleware", () => {
     expect(middlewares["GET /products"]).toEqual(["cors"]);
   });
 });
+
+describe("createFlatApiRoutes - stream routes", () => {
+  test("registers GET, HEAD and OPTIONS", () => {
+    class Root extends ApiRouter {
+      routes = {
+        "/video": this.stream(() => null),
+      };
+    }
+
+    const routes = createFlatApiRoutes(new Root().routes);
+
+    expect(Object.keys(routes["/video"]).sort()).toEqual([
+      "GET",
+      "HEAD",
+      "OPTIONS",
+    ]);
+  });
+
+  test("propagates middleware to both GET and HEAD", () => {
+    class Root extends ApiRouter {
+      routes = {
+        "/video": this.stream(() => null).middleware(["auth"]),
+      };
+    }
+
+    const middlewares = middlewaresOf(
+      createFlatApiRoutes(new Root().routes, "", ["cors"]),
+    );
+
+    expect(middlewares["GET /video"]).toEqual(["cors", "auth"]);
+    expect(middlewares["HEAD /video"]).toEqual(["cors", "auth"]);
+  });
+
+  test("a plain file route stays GET only", () => {
+    class Root extends ApiRouter {
+      routes = {
+        "/download": this.file(() => null),
+      };
+    }
+
+    const routes = createFlatApiRoutes(new Root().routes);
+
+    expect(Object.keys(routes["/download"]).sort()).toEqual(["GET", "OPTIONS"]);
+  });
+});

--- a/packages/gemi/services/router/createFlatApiRoutes.ts
+++ b/packages/gemi/services/router/createFlatApiRoutes.ts
@@ -52,6 +52,13 @@ function isProxyHandler(option: ApiRoutes[string]): option is ProxyHandler {
   return false;
 }
 
+function isStreamHandler(option: ApiRoutes[string]) {
+  if ("__internal_brand" in option) {
+    return option.__internal_brand === "StreamHandler";
+  }
+  return false;
+}
+
 export function createFlatApiRoutes(
   routes: ApiRoutes,
   rootPath = "",
@@ -103,6 +110,11 @@ export function createFlatApiRoutes(
       const middleware = routeHandler.middlewares;
       const exec = routeHandler.run.bind(routeHandler);
       addRoute(path, method, exec, middleware);
+      // A stream route also answers HEAD, so a client can read the size and
+      // Accept-Ranges without pulling the body.
+      if (isStreamHandler(option)) {
+        addRoute(path, "HEAD", exec, middleware);
+      }
     }
 
     if (isRouteHandlers(option)) {


### PR DESCRIPTION
Closes #34. Implements the design in #35.

A gemi app could not answer a `Range` request. `IFileStorageDriver.fetch()` took `{ name, bucket? }` with nowhere to put a byte window, and both bundled drivers always returned a full-object `200` with no `Accept-Ranges`. The practical cost is that video seek does not work at all — a `<video>` that cannot request a byte window fails the load outright in Chrome with `MEDIA_ERR 4`.

```typescript
routes = {
  "/assets/:src*": this.stream(async (req) => FileStorage.read(req.params.src)),
};
```

That route now answers `Range`, and the byte window is pushed all the way down to the storage backend, so a seek transfers one window rather than the whole object.

## Drivers return data, not Responses

The new `FileStorage.read()` hands back the bytes plus the *authoritative* total, and the framework builds the 200/206/416 once:

```typescript
interface ReadResult {
  body: ReadableStream<Uint8Array> | Blob | null;
  start: number;      // absolute inclusive offsets of `body` within the object
  end: number;
  total: number;      // authoritative size of the complete object
  partial: boolean;   // whether the driver actually applied the range
  type: string;
  etag?: string;
  lastModified?: Date;
  name?: string;
}
```

This keeps RFC 7233 out of every driver — a third-party driver can't get the status rules subtly wrong — and it costs no extra round trip. S3 reports the object's real total in its own `Content-Range` on a ranged GET, so `bytes=S-E` and `bytes=-N` are a single request with no HEAD for the size.

`partial` is an explicit field because it cannot be derived from the offsets: `bytes=0-` over a whole object is a 206 whose window spans the entire file, while a driver that *ignored* the range reports identical offsets and wants a 200.

`read()` is optional on `IFileStorageDriver` **and** has a concrete default on the abstract `FileStorageDriver`. Existing third-party drivers keep compiling and gain working range support for free — the default buffers to serve a range, which is correct but saves no bandwidth, so `read()` is documented as the recommended override.

`fetch()` is untouched. A request with no `Range` header gets byte-for-byte what it got before.

## What's in here

- `http/range.ts` — a dependency-free RFC 7233 parser. Single `bytes` range only; multi-range, unknown units, malformed and inverted specs are ignored and the full object is served, as the spec requires. An over-long end is clamped rather than rejected, since Chrome routinely sends `bytes=0-2147483647` for a `<video>`.
- `http/createStreamResponse.ts` — the one place that decides 200 vs 206 vs 416 and sets `Accept-Ranges` / `Content-Range`. An empty object is a 416 with `bytes */0`, never `bytes 0--1/0`. The 416 carries `Cache-Control: no-store`, since it is a function of the client's own header against the object's current length and must not be replayed from a cache.
- `ApiRouter.stream()` — reads the `Range` once, parks it on the request context so `read()` can pick it up, and registers `HEAD` alongside `GET`. Stays out of the generated RPC types (a typed JSON client can't consume a byte stream) while `.middleware([...])` still typechecks.
- `S3Driver.read()`/`size()`, `FileSystemDriver.read()`/`size()`, and `FileStorage.read()`.
- Handlers can also return a plain `Blob` or `Bun.file()` and the framework slices it, with a raw `Response` as the passthrough escape hatch.

## Also in here

The raw-`Response` branch in `ApiRouterServiceContainer` returned **before** `ctx.headers`, `Set-Cookie`, `ctx.destroy()` and `onRequestEnd()` were applied. That was silently dropping every middleware-set CORS and `Cache-Control` header on `this.file()` and `this.proxy()` routes — including the framework's own image-optimization route — and stream routes would have inherited it on exactly the routes that most need cache headers.

A/B against a running server, same build, only that branch changed:

```
without the fix:            with the fix:
HTTP/1.1 206                HTTP/1.1 206
Content-Range: bytes 0-…    Content-Range: bytes 0-…
                            Cache-Control: public, max-age=60
                            x-from-middleware: 1
                            set-cookie: probe=yes; SameSite=Strict; Path=/
```

The response's own headers win and the context only fills gaps, so this is additive. It does mean a `this.proxy()` route in an app running `CorsMiddleware` will start emitting CORS headers it didn't before — that's the fix, but it is a behavior change worth knowing about. Proxy responses come from `fetch()` and have immutable headers, so the merge falls back to rebuilding when in-place mutation throws.

Two smaller things: `Content-Type` was `append`ed rather than `set` on the JSON path, so a handler setting `application/json; charset=utf-8` produced an invalid two-value media type; and `CorsMiddleware`'s default `Access-Control-Allow-Methods` lacked `HEAD`, which stream routes now register.

## On Bun and Content-Length

#35 flagged a reported claim — that Bun drops an explicitly set `Content-Length` on a streamed 200 but keeps it on a 206 under ~16 KB — as something to measure rather than design around. Measured on Bun 1.3.14, and the size-dependent half does not reproduce:

| body | status | result |
|---|---|---|
| `ReadableStream`, 4 KB | 200 | dropped, chunked |
| `ReadableStream`, 4 KB | 206 | dropped, chunked |
| `ReadableStream`, 5 MB | 206 | dropped, chunked |
| `Bun.file().slice()`, 5 MB | 206 | **`content-length: 5242880`** |

It's the body type that decides, not the status or the size. So `ReadResult.body` is typed `ReadableStream | Blob` so drivers return the most concrete handle they hold, `FileSystemDriver` returns a `BunFile` slice, and the response builder passes a `Blob` through rather than calling `.stream()`. A full download through the filesystem driver now carries a real `Content-Length`, where `FileSystemDriver.fetch()` sets one today that never reaches the wire.

S3 bodies are streams, so a 206 from S3 is chunked. That is spec-legal and `Content-Range` carries `start-end/total` regardless, so the size still reaches the client.

## Verified

End to end against a real `App` over a real Bun server, with a 453,730-byte fixture:

- no-`Range` GET returns exactly 453,730 bytes with `Accept-Ranges: bytes`
- `bytes=0-99` → 206, `Content-Range: bytes 0-99/453730`, 100 bytes, byte-identical to `head -c 100` of the full download
- a four-point sweep (first bytes, mid-file, an odd 512-byte window, the tail) byte-identical to `dd` at the same offsets
- suffix `bytes=-50` → `bytes 453680-453729/453730`; open tail and an over-long end both clamp correctly
- `bytes=999999-` → 416 `bytes */453730` with `Cache-Control: no-store` and an empty body
- an empty object with any range → 416 `bytes */0`, not `bytes 0--1/0`
- malformed (`bytes=abc`) and multi-range (`bytes=0-9,20-29`) both ignored into a full 200
- a missing key 404s, with and without a `Range`
- `HEAD` returns the headers with a 0-byte body; a ranged `HEAD` still reports its window

90 new unit tests across the parser, the response builder, both drivers, the `fetch()`-backed default, and the route flattener. Type-checks clean.

**Not fixed here:** the repo's pre-existing test failures. `app/App.test.ts` fails to collect on `main` (`Cannot find package 'bun'` from `RedisServiceContainer.ts`, under both node and bun), which is why the end-to-end verification above is a real server rather than a test file. The failure set is byte-identical before and after this branch — 10 files failing on `main`, the same 10 after.

**Deliberately out of scope:** `If-Range` (can only be evaluated after the read, by which point the wrong window is already fetched), `If-None-Match`/`If-Modified-Since` → 304, and `multipart/byteranges`. Also left alone: `FileSystemDriver.fetch()`'s missing existence check and `S3Driver.fetch()`'s `ContentLength.toString()` throw — pre-existing bugs on the `fetch()` path that `read()` avoids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
