### PR TITLE
Add an Azure Blob Storage driver

### DIFF
--- a/docs/file-storage.md
+++ b/docs/file-storage.md
@@ -101,35 +101,7 @@ interface ReadResult {
 
 An unsatisfiable range throws `RangeNotSatisfiableError`, and a missing object throws `FileNotFoundError`. Both extend `RequestBreakerError`, so they turn into a `416` and a `404` on their own.
 
-### Writing a custom driver
-
-Extend `FileStorageDriver` and implement `fetch`, `put` and `list`. `read()` and `size()` already have working defaults, so an existing driver keeps compiling and gains range support for free — but the default `read()` buffers the whole object to serve a range, which saves no bandwidth from the backend.
-
-Override `read()` whenever the backend can range natively. Report the *authoritative* total, which most backends hand back in their own `Content-Range` on a ranged read — that is what keeps a range down to a single round trip:
-
-```typescript
-import { parseContentRange, resolveRange, toRangeHeaderValue } from "gemi/services";
-
-async read({ name, range }) {
-  const res = await backend.get(name, range ? toRangeHeaderValue(range) : undefined);
-  const cr = parseContentRange(res.headers["content-range"]);
-  return {
-    body: res.stream,
-    start: cr?.start ?? 0,
-    end: cr?.end ?? (res.size - 1),
-    total: cr?.total ?? res.size,
-    partial: Boolean(cr),
-    type: res.contentType,
-  };
-}
-```
-
-Two things to get right:
-
-- `partial` says whether *you* applied the range, and cannot be derived from the offsets: `bytes=0-` over a whole object is a `206` whose window spans the entire file. A driver that ignored the range must report `false`, or the response will carry a `Content-Range` that does not describe the body it sent.
-- Backends without a native suffix range (`bytes=-N`) need one size lookup first. Use `resolveRange(range, total)` to turn it into absolute offsets, and throw `RangeNotSatisfiableError(total)` when it returns `null`.
-
-Prefer returning a `Blob` over a `ReadableStream` when the backend gives you a sized handle: Bun drops an explicitly set `Content-Length` and falls back to chunked encoding for any stream body, but keeps it for a sized blob.
+See [Writing a custom driver](#writing-a-custom-driver) for how a driver implements `read()`.
 
 ### `list(folder)`
 
@@ -154,7 +126,7 @@ if ((meta.width ?? 0) > 4096) {
 
 ## Drivers
 
-The active driver is set on your app's `FileStorageServiceProvider`. gemi ships two drivers; the default is `FileSystemDriver`.
+The active driver is set on your app's `FileStorageServiceProvider`. gemi ships three drivers; the default is `FileSystemDriver`.
 
 ### `FileSystemDriver` (local disk)
 
@@ -197,11 +169,56 @@ export default class extends FileStorageServiceProvider {
 
 The bucket comes from `params.bucket` when provided, otherwise from `process.env.BUCKET_NAME`. See [Configuration](./configuration.md) for where to define these environment variables.
 
-> **Note:** Both drivers fall back to `process.env.BUCKET_NAME` as the default bucket. For `put`, the S3 driver derives `contentType` from the blob/file when the body is a `Blob`/`File`.
+> **Note:** All drivers fall back to `process.env.BUCKET_NAME` as the default bucket. For `put`, the S3 driver derives `contentType` from the blob/file when the body is a `Blob`/`File`.
+
+### `AzureBlobDriver` (Azure Blob Storage)
+
+`@azure/storage-blob` is an **optional peer dependency** — install it only if you use this driver:
+
+```bash
+bun add @azure/storage-blob
+```
+
+```typescript
+// app/kernel/providers/FileStorageServiceProvider.ts
+import { FileStorageServiceProvider, AzureBlobDriver } from "gemi/services";
+
+export default class extends FileStorageServiceProvider {
+  driver = new AzureBlobDriver({
+    // defaults to process.env.AZURE_STORAGE_CONNECTION_STRING
+    connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
+    container: process.env.BUCKET_NAME,
+  });
+}
+```
+
+The SDK is loaded lazily on first use, so importing `gemi/services` costs nothing when the driver is unused. Using it without the package installed throws an error telling you to install it.
+
+Instead of a connection string you can pass an account `url` (optionally carrying a SAS token) with a `credential`, or hand over a fully built client — useful for a custom credential chain, retry policy or proxy. With `serviceClient` the driver never imports the SDK at all:
+
+```typescript
+import { BlobServiceClient } from "@azure/storage-blob";
+import { DefaultAzureCredential } from "@azure/identity";
+
+new AzureBlobDriver({
+  url: "https://myaccount.blob.core.windows.net",
+  credential: new DefaultAzureCredential(),
+});
+
+// or fully pre-built
+new AzureBlobDriver({
+  serviceClient: BlobServiceClient.fromConnectionString(conn),
+  container: "media",
+});
+```
+
+The container comes from `params.bucket`, then the `container` config, then `process.env.BUCKET_NAME`. `list(folder)` returns a `string[]` of blob names under the prefix.
+
+**On range requests:** Azure's `download(offset, count)` takes an absolute offset and has no suffix form, so the driver handles the two cases differently. `bytes=S-E` and `bytes=S-` — everything a media player actually sends — go straight to the download and read the authoritative total back off Azure's own `Content-Range`, costing no extra round trip. A suffix range (`bytes=-N`) needs one `getProperties()` first to resolve it into absolute offsets.
 
 ### Writing a custom driver
 
-Any storage backend works by subclassing `FileStorageDriver` (exported from `gemi/services`) and implementing `put`, `fetch`, and `list`:
+Subclass `FileStorageDriver` (exported from `gemi/services`) and implement `put`, `fetch` and `list`:
 
 ```typescript
 import {
@@ -222,6 +239,34 @@ class MyDriver extends FileStorageDriver {
   }
 }
 ```
+
+`read()` and `size()` already have working defaults, so a driver that implements only the three methods above still compiles and gains range support — but the default `read()` buffers the whole object to serve a range, which saves no bandwidth from the backend.
+
+Override `read()` whenever the backend can range natively. Report the *authoritative* total, which most backends hand back in their own `Content-Range` on a ranged read — that is what keeps a range down to a single round trip:
+
+```typescript
+import { parseContentRange, resolveRange, toRangeHeaderValue } from "gemi/services";
+
+async read({ name, range }) {
+  const res = await backend.get(name, range ? toRangeHeaderValue(range) : undefined);
+  const cr = parseContentRange(res.headers["content-range"]);
+  return {
+    body: res.stream,
+    start: cr?.start ?? 0,
+    end: cr?.end ?? (res.size - 1),
+    total: cr?.total ?? res.size,
+    partial: Boolean(cr),
+    type: res.contentType,
+  };
+}
+```
+
+Two things to get right:
+
+- `partial` says whether *you* applied the range, and cannot be derived from the offsets: `bytes=0-` over a whole object is a `206` whose window spans the entire file. A driver that ignored the range must report `false`, or the response will carry a `Content-Range` that does not describe the body it sent.
+- Backends without a native suffix range (`bytes=-N`) need one size lookup first — see `AzureBlobDriver` for a worked example. Use `resolveRange(range, total)` to turn it into absolute offsets, and throw `RangeNotSatisfiableError(total)` when it returns `null`.
+
+Prefer returning a `Blob` over a `ReadableStream` when the backend gives you a sized handle: Bun drops an explicitly set `Content-Length` and falls back to chunked encoding for any stream body, but keeps it for a sized blob.
 
 ## Image optimization
 

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -37,7 +37,7 @@
     "lint": "oxlint",
     "build": "NODE_ENV=production bun run build:core && bun run build:bin && bun run build:types && bun run build:client && bun run build:plugin && bun run build:client-types",
     "build:core": "bun ./scripts/build.ts",
-    "build:bin": "bun build --outdir=./dist/bin --target=bun --external=vite --external=react-dom --external=react/jsx-runtime --external=bun --external=sharp --sourcemap ./bin/gemi.ts && bun ./scripts/prepare-bin.ts",
+    "build:bin": "bun build --outdir=./dist/bin --target=bun --external=vite --external=react-dom --external=react/jsx-runtime --external=bun --external=sharp --external=@azure/storage-blob --sourcemap ./bin/gemi.ts && bun ./scripts/prepare-bin.ts",
     "build:client": "vite build -c vite.client.config.mts",
     "build:plugin": "vite build -c vite.plugin.config.mts",
     "build:types": "tsc",
@@ -80,9 +80,15 @@
     "vitest": "^4.0.0"
   },
   "peerDependencies": {
+    "@azure/storage-blob": "^12.28.0",
     "react": ">=19",
     "react-dom": ">=19",
     "sharp": "^0.34.2",
     "vite": "^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@azure/storage-blob": {
+      "optional": true
+    }
   }
 }

--- a/packages/gemi/scripts/build.ts
+++ b/packages/gemi/scripts/build.ts
@@ -29,6 +29,8 @@ const result = await Bun.build({
     "bun",
     "jsx-email",
     "sharp",
+    // Optional peer: only present when an app uses AzureBlobDriver.
+    "@azure/storage-blob",
   ],
   target: "bun",
   format: "esm",

--- a/packages/gemi/services/file-storage/drivers/AzureBlobDriver.test.ts
+++ b/packages/gemi/services/file-storage/drivers/AzureBlobDriver.test.ts
@@ -1,0 +1,380 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import {
+  FileNotFoundError,
+  RangeNotSatisfiableError,
+} from "../../../http/errors";
+import { parseRangeHeader } from "../../../http/range";
+import { AzureBlobDriver } from "./AzureBlobDriver";
+
+type Downloaded = { offset?: number; count?: number };
+
+/**
+ * A stand-in for `@azure/storage-blob`, so these tests never need the optional
+ * peer dependency installed.
+ */
+function fakeAzure(
+  options: {
+    download?: (offset?: number, count?: number) => any;
+    properties?: any;
+    blobs?: string[];
+  } = {},
+) {
+  const calls: {
+    downloads: Downloaded[];
+    getProperties: number;
+    uploads: any[];
+    containers: string[];
+    blobs: string[];
+  } = {
+    downloads: [],
+    getProperties: 0,
+    uploads: [],
+    containers: [],
+    blobs: [],
+  };
+
+  const blobClient = {
+    async download(offset?: number, count?: number) {
+      calls.downloads.push({ offset, count });
+      const result = options.download?.(offset, count);
+      if (result instanceof Error) throw result;
+      return (
+        result ?? {
+          readableStreamBody: undefined,
+          blobBody: Promise.resolve(new Blob(["0123456789"])),
+          contentLength: 10,
+          contentType: "video/mp4",
+          etag: '"tag"',
+          lastModified: new Date("2026-01-02T03:04:05Z"),
+        }
+      );
+    },
+    async getProperties() {
+      calls.getProperties += 1;
+      const result = options.properties;
+      if (result instanceof Error) throw result;
+      return result ?? { contentLength: 12345, contentType: "video/mp4" };
+    },
+    async uploadData(data: any, opts: any) {
+      calls.uploads.push({ data, opts });
+    },
+    async delete() {},
+  };
+
+  const serviceClient = {
+    getContainerClient(name: string) {
+      calls.containers.push(name);
+      return {
+        getBlockBlobClient(blobName: string) {
+          calls.blobs.push(blobName);
+          return blobClient;
+        },
+        async *listBlobsFlat({ prefix }: { prefix?: string } = {}) {
+          for (const name of options.blobs ?? []) {
+            if (!prefix || name.startsWith(prefix)) yield { name };
+          }
+        },
+      };
+    },
+  };
+
+  return { serviceClient, calls };
+}
+
+function driverWith(options: Parameters<typeof fakeAzure>[0] = {}) {
+  const { serviceClient, calls } = fakeAzure(options);
+  const driver = new AzureBlobDriver({
+    serviceClient: serviceClient as any,
+    container: "media",
+  });
+  return { driver, calls };
+}
+
+describe("AzureBlobDriver.read()", () => {
+  beforeEach(() => {
+    delete process.env.BUCKET_NAME;
+  });
+
+  test("downloads the whole blob when no range is asked for", async () => {
+    const { driver, calls } = driverWith();
+
+    const result = await driver.read("clip.mp4");
+
+    expect(calls.downloads).toEqual([{ offset: undefined, count: undefined }]);
+    expect(calls.getProperties).toBe(0);
+    expect(result).toMatchObject({ partial: false, total: 10, type: "video/mp4" });
+  });
+
+  test("maps an offset range onto download(offset, count)", async () => {
+    const { driver, calls } = driverWith({
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x".repeat(100)])),
+        contentRange: "bytes 100-199/12345",
+        contentLength: 100,
+        contentType: "video/mp4",
+      }),
+    });
+
+    const result = await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=100-199"),
+    });
+
+    expect(calls.downloads).toEqual([{ offset: 100, count: 100 }]);
+    // The total came off Content-Range, so no size lookup was needed.
+    expect(calls.getProperties).toBe(0);
+    expect(result).toMatchObject({
+      start: 100,
+      end: 199,
+      total: 12345,
+      partial: true,
+    });
+  });
+
+  test("maps an open ended range onto an offset with no count", async () => {
+    const { driver, calls } = driverWith({
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x"])),
+        contentRange: "bytes 5000-12344/12345",
+        contentType: "video/mp4",
+      }),
+    });
+
+    await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=5000-"),
+    });
+
+    expect(calls.downloads).toEqual([{ offset: 5000, count: undefined }]);
+    expect(calls.getProperties).toBe(0);
+  });
+
+  test("resolves a suffix range against the size, since Azure has no suffix support", async () => {
+    const { driver, calls } = driverWith({
+      properties: { contentLength: 12345, contentType: "video/mp4" },
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x".repeat(500)])),
+        contentRange: "bytes 11845-12344/12345",
+        contentType: "video/mp4",
+      }),
+    });
+
+    const result = await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=-500"),
+    });
+
+    // One getProperties, then an absolute window — the documented cost of a
+    // suffix range on a backend without native support.
+    expect(calls.getProperties).toBe(1);
+    expect(calls.downloads).toEqual([{ offset: 11845, count: 500 }]);
+    expect(result).toMatchObject({ start: 11845, end: 12344, total: 12345 });
+  });
+
+  test("clamps a suffix longer than the blob to the whole blob", async () => {
+    const { driver, calls } = driverWith({
+      properties: { contentLength: 100 },
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x".repeat(100)])),
+        contentRange: "bytes 0-99/100",
+      }),
+    });
+
+    await driver.read({ name: "clip.mp4", range: parseRangeHeader("bytes=-500") });
+
+    expect(calls.downloads).toEqual([{ offset: 0, count: 100 }]);
+  });
+
+  test("rejects a suffix range over an empty blob without downloading", async () => {
+    const { driver, calls } = driverWith({ properties: { contentLength: 0 } });
+
+    await expect(
+      driver.read({ name: "empty.bin", range: parseRangeHeader("bytes=-10") }),
+    ).rejects.toBeInstanceOf(RangeNotSatisfiableError);
+    expect(calls.downloads).toEqual([]);
+  });
+
+  test("turns an InvalidRange into RangeNotSatisfiableError carrying the size", async () => {
+    const { driver } = driverWith({
+      download: () =>
+        Object.assign(new Error("InvalidRange"), {
+          statusCode: 416,
+          details: { errorCode: "InvalidRange" },
+        }),
+      properties: { contentLength: 12345 },
+    });
+
+    await expect(
+      driver.read({ name: "clip.mp4", range: parseRangeHeader("bytes=99999-") }),
+    ).rejects.toMatchObject({ name: "RangeNotSatisfiableError", total: 12345 });
+  });
+
+  test("turns a BlobNotFound into FileNotFoundError", async () => {
+    const { driver } = driverWith({
+      download: () =>
+        Object.assign(new Error("BlobNotFound"), {
+          statusCode: 404,
+          details: { errorCode: "BlobNotFound" },
+        }),
+    });
+
+    await expect(driver.read("missing.mp4")).rejects.toBeInstanceOf(
+      FileNotFoundError,
+    );
+  });
+
+  test("rethrows an unrelated error", async () => {
+    const { driver } = driverWith({
+      download: () =>
+        Object.assign(new Error("boom"), { statusCode: 403 }),
+    });
+
+    await expect(driver.read("clip.mp4")).rejects.toThrow("boom");
+  });
+
+  test("reports partial: false when Azure returned no Content-Range", async () => {
+    const { driver } = driverWith({
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["0123456789"])),
+        contentLength: 10,
+        contentType: "video/mp4",
+      }),
+    });
+
+    const result = await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=0-4"),
+    });
+
+    expect(result.partial).toBe(false);
+  });
+});
+
+describe("AzureBlobDriver container selection", () => {
+  beforeEach(() => {
+    delete process.env.BUCKET_NAME;
+  });
+
+  test("uses the configured container by default", async () => {
+    const { driver, calls } = driverWith();
+    await driver.read("clip.mp4");
+    expect(calls.containers).toEqual(["media"]);
+    expect(calls.blobs).toEqual(["clip.mp4"]);
+  });
+
+  test("lets `bucket` override the container per call", async () => {
+    const { driver, calls } = driverWith();
+    await driver.read({ name: "clip.mp4", bucket: "private" });
+    expect(calls.containers).toEqual(["private"]);
+  });
+
+  test("falls back to BUCKET_NAME", async () => {
+    process.env.BUCKET_NAME = "from-env";
+    const { serviceClient, calls } = fakeAzure();
+    const driver = new AzureBlobDriver({ serviceClient: serviceClient as any });
+
+    await driver.read("clip.mp4");
+
+    expect(calls.containers).toEqual(["from-env"]);
+  });
+
+  test("throws a clear error when no container is configured", async () => {
+    const { serviceClient } = fakeAzure();
+    const driver = new AzureBlobDriver({ serviceClient: serviceClient as any });
+
+    await expect(driver.read("clip.mp4")).rejects.toThrow(/container name/);
+  });
+
+  test("throws when the object name is missing", async () => {
+    const { driver } = driverWith();
+    await expect(driver.read({ name: "" })).rejects.toThrow(
+      "Object name has to be specified",
+    );
+  });
+});
+
+describe("AzureBlobDriver.put()", () => {
+  beforeEach(() => {
+    delete process.env.BUCKET_NAME;
+  });
+
+  test("keeps an explicitly passed contentType", async () => {
+    // S3Driver drops this today; do not repeat that here.
+    const { driver, calls } = driverWith();
+
+    await driver.put({
+      name: "a.bin",
+      body: new Blob(["x"], { type: "application/octet-stream" }),
+      contentType: "image/png",
+    });
+
+    expect(calls.uploads[0].opts.blobHTTPHeaders.blobContentType).toBe(
+      "image/png",
+    );
+  });
+
+  test("falls back to the blob's own type", async () => {
+    const { driver, calls } = driverWith();
+
+    await driver.put({ name: "a.png", body: new Blob(["x"], { type: "image/png" }) });
+
+    expect(calls.uploads[0].opts.blobHTTPHeaders.blobContentType).toBe(
+      "image/png",
+    );
+  });
+
+  // Name generation uses Bun.randomUUIDv7(), like the sibling drivers.
+  test.skipIf(typeof Bun === "undefined")(
+    "generates a name for a bare Blob and returns it",
+    async () => {
+      const { driver } = driverWith();
+
+      const name = await driver.put(new Blob(["x"], { type: "image/png" }));
+
+      expect(name).toMatch(/\.png$/);
+    },
+  );
+});
+
+describe("AzureBlobDriver.list()", () => {
+  test("returns blob names under a prefix", async () => {
+    const { driver } = driverWith({
+      blobs: ["photos/a.png", "photos/b.png", "videos/c.mp4"],
+    });
+
+    expect(await driver.list("photos/")).toEqual([
+      "photos/a.png",
+      "photos/b.png",
+    ]);
+  });
+});
+
+describe("AzureBlobDriver.fetch()", () => {
+  test("still returns a full Response for the legacy path", async () => {
+    const { driver, calls } = driverWith();
+
+    const res = await driver.fetch("clip.mp4");
+
+    expect(res.headers.get("Content-Type")).toBe("video/mp4");
+    expect(res.headers.get("Content-Length")).toBe("10");
+    expect(res.headers.get("ETag")).toBe('"tag"');
+    // No range travels through fetch().
+    expect(calls.downloads).toEqual([{ offset: undefined, count: undefined }]);
+  });
+});
+
+describe("AzureBlobDriver without the SDK", () => {
+  test("explains how to install the optional peer dependency", async () => {
+    const driver = new AzureBlobDriver({
+      container: "media",
+      connectionString: "UseDevelopmentStorage=true",
+    });
+
+    // @azure/storage-blob is not installed in this workspace, so the lazy
+    // import fails and the driver must say why.
+    await expect(driver.read("clip.mp4")).rejects.toThrow(
+      /@azure\/storage-blob/,
+    );
+  });
+});

--- a/packages/gemi/services/file-storage/drivers/AzureBlobDriver.ts
+++ b/packages/gemi/services/file-storage/drivers/AzureBlobDriver.ts
@@ -1,0 +1,317 @@
+import { Buffer } from "node:buffer";
+import { Readable } from "node:stream";
+
+import {
+  FileNotFoundError,
+  RangeNotSatisfiableError,
+} from "../../../http/errors";
+import { parseContentRange, resolveRange } from "../../../http/range";
+import { FileStorageDriver } from "./FileStorageDriver";
+import type { PutFileParams, ReadFileParams, ReadResult } from "./types";
+
+/**
+ * The slice of `@azure/storage-blob` this driver uses. Declared structurally so
+ * the package stays an optional peer dependency: nothing here imports its types.
+ */
+interface BlobClientLike {
+  download(
+    offset?: number,
+    count?: number,
+  ): Promise<{
+    readableStreamBody?: NodeJS.ReadableStream;
+    blobBody?: Promise<Blob>;
+    contentLength?: number;
+    contentType?: string;
+    contentRange?: string;
+    etag?: string;
+    lastModified?: Date;
+  }>;
+  getProperties(): Promise<{
+    contentLength?: number;
+    contentType?: string;
+    etag?: string;
+    lastModified?: Date;
+  }>;
+  uploadData(
+    data: Buffer | Blob,
+    options?: { blobHTTPHeaders?: { blobContentType?: string } },
+  ): Promise<unknown>;
+  delete(): Promise<unknown>;
+}
+
+interface ContainerClientLike {
+  getBlockBlobClient(name: string): BlobClientLike;
+  listBlobsFlat(options?: { prefix?: string }): AsyncIterable<{ name: string }>;
+}
+
+interface BlobServiceClientLike {
+  getContainerClient(name: string): ContainerClientLike;
+}
+
+export interface AzureBlobDriverConfig {
+  /** Defaults to `process.env.AZURE_STORAGE_CONNECTION_STRING`. */
+  connectionString?: string;
+  /** Account URL, e.g. `https://acct.blob.core.windows.net`, optionally carrying a SAS token. */
+  url?: string;
+  /** A `StorageSharedKeyCredential` or any `TokenCredential`, used with `url`. */
+  credential?: unknown;
+  /** Default container. Falls back to `process.env.BUCKET_NAME`. */
+  container?: string;
+  /**
+   * A pre-built `BlobServiceClient`. Supply this to configure retries, proxies
+   * or a custom credential chain yourself — the driver then never imports the
+   * SDK.
+   */
+  serviceClient?: BlobServiceClientLike;
+}
+
+function isNotFound(err: any) {
+  return (
+    err?.statusCode === 404 ||
+    err?.details?.errorCode === "BlobNotFound" ||
+    err?.code === "BlobNotFound"
+  );
+}
+
+function isInvalidRange(err: any) {
+  return (
+    err?.statusCode === 416 ||
+    err?.details?.errorCode === "InvalidRange" ||
+    err?.code === "InvalidRange"
+  );
+}
+
+/**
+ * Azure Blob Storage.
+ *
+ * `@azure/storage-blob` is an optional peer dependency, loaded on first use, so
+ * apps that do not use Azure never install it.
+ */
+export class AzureBlobDriver extends FileStorageDriver {
+  private serviceClientPromise: Promise<BlobServiceClientLike> | null = null;
+
+  constructor(private config: AzureBlobDriverConfig = {}) {
+    super();
+  }
+
+  private async serviceClient(): Promise<BlobServiceClientLike> {
+    if (this.config.serviceClient) {
+      return this.config.serviceClient;
+    }
+
+    // Memoized so concurrent requests share one client, and one import.
+    this.serviceClientPromise ??= (async () => {
+      let sdk: any;
+      try {
+        // @ts-ignore - optional peer dependency, absent unless the app installs it
+        sdk = await import("@azure/storage-blob");
+      } catch {
+        throw new Error(
+          "AzureBlobDriver requires the '@azure/storage-blob' package. Install it with `bun add @azure/storage-blob`, or pass a pre-built `serviceClient`.",
+        );
+      }
+
+      const connectionString =
+        this.config.connectionString ??
+        process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+      if (this.config.url) {
+        return new sdk.BlobServiceClient(this.config.url, this.config.credential);
+      }
+      if (connectionString) {
+        return sdk.BlobServiceClient.fromConnectionString(connectionString);
+      }
+      throw new Error(
+        "AzureBlobDriver needs a connection string (AZURE_STORAGE_CONNECTION_STRING), a `url`, or a `serviceClient`.",
+      );
+    })();
+
+    return this.serviceClientPromise;
+  }
+
+  private async blob(name: string, container?: string) {
+    if (!name) {
+      throw new Error("Object name has to be specified");
+    }
+    const containerName =
+      container ?? this.config.container ?? process.env.BUCKET_NAME;
+    if (!containerName) {
+      throw new Error(
+        "AzureBlobDriver needs a container name, from `bucket`, the `container` config, or BUCKET_NAME.",
+      );
+    }
+    const service = await this.serviceClient();
+    return service.getContainerClient(containerName).getBlockBlobClient(name);
+  }
+
+  async put(params: PutFileParams | Blob) {
+    let body: Blob | File | Buffer;
+    let contentType: string | undefined;
+    let name: string;
+    let container: string | undefined;
+
+    if (params instanceof Blob) {
+      body = params;
+      name = `${Bun.randomUUIDv7()}.${params.type.split("/")[1].split(";")[0]}`;
+      contentType = params.type;
+    } else {
+      body = params.body;
+      name = params.name;
+      container = params.bucket;
+      // An explicit contentType wins; otherwise fall back to the blob's own.
+      contentType =
+        params.contentType ??
+        (body instanceof Blob || body instanceof File ? body.type : undefined);
+    }
+
+    const data =
+      body instanceof Buffer
+        ? body
+        : Buffer.from(await (body as Blob).arrayBuffer());
+
+    const blob = await this.blob(name, container);
+    await blob.uploadData(data, {
+      blobHTTPHeaders: contentType ? { blobContentType: contentType } : undefined,
+    });
+
+    return name;
+  }
+
+  async list(folder: string) {
+    const containerName = this.config.container ?? process.env.BUCKET_NAME;
+    const service = await this.serviceClient();
+    const container = service.getContainerClient(containerName!);
+
+    const names: string[] = [];
+    for await (const blob of container.listBlobsFlat({ prefix: folder })) {
+      names.push(blob.name);
+    }
+    return names;
+  }
+
+  async fetch(params: ReadFileParams | string) {
+    const result = await this.read(
+      typeof params === "string"
+        ? { name: params }
+        : { name: params.name, bucket: params.bucket },
+    );
+
+    return new Response(result.body as BodyInit, {
+      headers: {
+        "Content-Type": result.type,
+        "Content-Length": String(result.total),
+        "Cache-Control": "private, max-age=12000, must-revalidate",
+        "Last-Modified": result.lastModified?.toUTCString() ?? "",
+        ETag: result.etag ?? "",
+      },
+    });
+  }
+
+  async read(input: ReadFileParams | string): Promise<ReadResult> {
+    const params = typeof input === "string" ? { name: input } : input;
+    const { name, bucket, range = null } = params;
+
+    const blob = await this.blob(name, bucket);
+
+    // Azure has no suffix range: `download()` takes an absolute offset, so
+    // `bytes=-N` has to be resolved against the size first. This is the one
+    // shape that costs a second round trip; `bytes=S-` and `bytes=S-E` go
+    // straight to the download and read the total back off its Content-Range.
+    let offset: number | undefined;
+    let count: number | undefined;
+
+    if (range?.kind === "suffix") {
+      const total = await this.size({ name, bucket });
+      const resolved = resolveRange(range, total);
+      if (!resolved) {
+        throw new RangeNotSatisfiableError(total);
+      }
+      offset = resolved.start;
+      count = resolved.length;
+    } else if (range) {
+      offset = range.start;
+      count = range.end === null ? undefined : range.end - range.start + 1;
+    }
+
+    let result: Awaited<ReturnType<BlobClientLike["download"]>>;
+    try {
+      result = await blob.download(offset, count);
+    } catch (err: any) {
+      if (isInvalidRange(err)) {
+        throw new RangeNotSatisfiableError(await this.size({ name, bucket }));
+      }
+      if (isNotFound(err)) {
+        throw new FileNotFoundError(name);
+      }
+      throw err;
+    }
+
+    // Azure reports the authoritative total in Content-Range on a ranged read.
+    const contentRange = parseContentRange(result.contentRange);
+    const partial = Boolean(contentRange);
+    const total = contentRange?.total ?? result.contentLength ?? 0;
+
+    return {
+      body: await toBody(result),
+      start: contentRange?.start ?? 0,
+      end: contentRange?.end ?? total - 1,
+      total,
+      partial,
+      type: result.contentType ?? "application/octet-stream",
+      etag: result.etag || undefined,
+      lastModified: result.lastModified,
+      name,
+    };
+  }
+
+  async size(params: ReadFileParams | string) {
+    const name = typeof params === "string" ? params : params.name;
+    const bucket = typeof params === "string" ? undefined : params.bucket;
+
+    const blob = await this.blob(name, bucket);
+    try {
+      const properties = await blob.getProperties();
+      return properties.contentLength ?? 0;
+    } catch (err: any) {
+      if (isNotFound(err)) {
+        throw new FileNotFoundError(name);
+      }
+      throw err;
+    }
+  }
+
+  async delete(params: ReadFileParams | string) {
+    const name = typeof params === "string" ? params : params.name;
+    const bucket = typeof params === "string" ? undefined : params.bucket;
+
+    const blob = await this.blob(name, bucket);
+    try {
+      await blob.delete();
+    } catch (err: any) {
+      if (isNotFound(err)) {
+        throw new FileNotFoundError(name);
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Azure hands back a Node stream under Bun and a `Blob` in the browser bundle.
+ * A Blob is returned as-is rather than as a stream: Bun keeps an explicit
+ * Content-Length for a sized body but falls back to chunked for a stream.
+ */
+async function toBody(result: {
+  readableStreamBody?: NodeJS.ReadableStream;
+  blobBody?: Promise<Blob>;
+}): Promise<ReadResult["body"]> {
+  if (result.blobBody) {
+    return await result.blobBody;
+  }
+  if (result.readableStreamBody) {
+    return Readable.toWeb(
+      result.readableStreamBody as Readable,
+    ) as unknown as ReadableStream<Uint8Array>;
+  }
+  return null;
+}

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -2,6 +2,10 @@
 export { FileStorageServiceProvider } from "./file-storage/FileStorageServiceProvider";
 export { FileSystemDriver } from "./file-storage/drivers/FileSystemDriver";
 export { S3Driver } from "./file-storage/drivers/S3Driver";
+export {
+  AzureBlobDriver,
+  type AzureBlobDriverConfig,
+} from "./file-storage/drivers/AzureBlobDriver";
 export type {
   ByteRange,
   FileMetadata,


### PR DESCRIPTION
Adds `AzureBlobDriver`, implementing the full `FileStorageDriver` contract including `read()` — so a `this.stream()` route over Azure serves range requests and video seek works.

> **Stacked on #36** (`feat/range-requests`), which introduces `read()`, `ReadResult` and `resolveRange`. Review/merge that first; the diff below is against it, not `main`.

```typescript
// app/kernel/providers/FileStorageServiceProvider.ts
import { FileStorageServiceProvider, AzureBlobDriver } from "gemi/services";

export default class extends FileStorageServiceProvider {
  driver = new AzureBlobDriver({ container: process.env.BUCKET_NAME });
}
```

## Optional peer dependency

`@azure/storage-blob` is declared as an optional `peerDependency` and loaded with a dynamic `import()` on first use. Importing `gemi/services` and constructing the driver both stay free — only *using* it needs the package, and it says so if missing:

```
AzureBlobDriver requires the '@azure/storage-blob' package. Install it with
`bun add @azure/storage-blob`, or pass a pre-built `serviceClient`.
```

Externalized in `scripts/build.ts` and in the `build:bin` script (alongside `sharp`, the existing precedent) so the bundler leaves the dynamic import alone. Confirmed in the built output — `import("@azure/storage-blob")` survives in `dist/` rather than being inlined.

## Azure has no suffix range

This is the case the `ReadResult` contract was designed around. Azure's `download(offset, count)` takes an *absolute* offset with no suffix form, so the driver splits the two:

- **`bytes=S-E` and `bytes=S-`** — everything a media player actually sends — go straight to the download and read the authoritative total back off Azure's own `Content-Range`. No extra round trip.
- **`bytes=-N`** needs one `getProperties()` first to resolve it into absolute offsets via `resolveRange()`.

Verified against a fake client that counts calls:

| requests | `getProperties` calls |
|---|---|
| 5 offset ranges | 0 |
| 1 full download | 0 |
| 3 suffix ranges | 3 |

## Configuration

A connection string (defaulting to `AZURE_STORAGE_CONNECTION_STRING`), an account `url` plus `credential`, or a pre-built `serviceClient`:

```typescript
new AzureBlobDriver({ connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING });

new AzureBlobDriver({
  url: "https://myaccount.blob.core.windows.net",
  credential: new DefaultAzureCredential(),
});

// custom credential chain / retry policy / proxy — the driver never imports the SDK
new AzureBlobDriver({ serviceClient: BlobServiceClient.fromConnectionString(conn) });
```

`serviceClient` is also what the tests inject, which is why the suite needs nothing installed. The container resolves from `params.bucket`, then the `container` config, then `BUCKET_NAME` — matching the other drivers. `list(folder)` returns a `string[]` of blob names, like `FileSystemDriver`.

The SDK types are referenced structurally rather than imported, so nothing in the package depends on `@azure/storage-blob` being present to typecheck.

## One deliberate divergence from S3Driver

`put()` keeps an explicitly passed `contentType`:

```typescript
contentType =
  params.contentType ??
  (body instanceof Blob || body instanceof File ? body.type : undefined);
```

`S3Driver` unconditionally overwrites it with the blob's own type ([`S3Driver.ts:44-45`](https://github.com/nstfkc/gemi/blob/main/packages/gemi/services/file-storage/drivers/S3Driver.ts#L44-L45)), discarding what the caller asked for. There's a test pinning the correct behaviour here so the two don't silently converge on the wrong one. I left `S3Driver` alone — it's a separate, behaviour-changing fix.

## Verified

End to end through a real `App` and a real `this.stream()` route, with the driver pointed at a fake `BlobServiceClient` that mimics Azure's actual semantics (absolute-offset `download`, no suffix support, `Content-Range` on ranged reads, `InvalidRange`/`BlobNotFound` errors), against a 453,730-byte fixture:

- no-`Range` GET returns exactly 453,730 bytes; full download byte-identical to the fixture
- a four-point window sweep plus the suffix case, all byte-identical to `dd` at the same offsets
- `bytes=-50` → `206 bytes 453680-453729/453730`; open tail and over-long end both clamp correctly
- `bytes=999999-` → `416 bytes */453730`, `Cache-Control: no-store`, empty body
- an empty blob with any range → `416 bytes */0`
- multi-range ignored into a full 200; a missing blob 404s
- `HEAD` returns headers with a 0-byte body

Plus a runtime check that importing `gemi/services` and constructing the driver both succeed with `@azure/storage-blob` absent, and that an injected `serviceClient` bypasses the SDK entirely.

21 unit tests (one skipped off-Bun, since name generation uses `Bun.randomUUIDv7()` like the sibling drivers). Typecheck clean. The repo's pre-existing failure set is unchanged — same 10 files before and after.

## Also in here

Folds together the two `### Writing a custom driver` sections in `docs/file-storage.md`, which #36 left duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
