### PR TITLE
Stop S3Driver.put() discarding the caller's contentType

### DIFF
--- a/docs/file-storage.md
+++ b/docs/file-storage.md
@@ -197,7 +197,7 @@ export default class extends FileStorageServiceProvider {
 
 The bucket comes from `params.bucket` when provided, otherwise from `process.env.BUCKET_NAME`. See [Configuration](./configuration.md) for where to define these environment variables.
 
-> **Note:** Both drivers fall back to `process.env.BUCKET_NAME` as the default bucket. For `put`, the S3 driver derives `contentType` from the blob/file when the body is a `Blob`/`File`.
+> **Note:** Both drivers fall back to `process.env.BUCKET_NAME` as the default bucket. For `put`, an explicitly passed `contentType` is used as-is; without one, the S3 driver falls back to the type of the `Blob`/`File` body. A `Buffer` body has no type of its own, so pass `contentType` alongside it or the object is stored without one.
 
 ### Writing a custom driver
 

--- a/packages/gemi/services/file-storage/drivers/S3Driver.test.ts
+++ b/packages/gemi/services/file-storage/drivers/S3Driver.test.ts
@@ -29,6 +29,83 @@ function driverWith(send: (command: any) => Promise<any>) {
   return driver;
 }
 
+describe("S3Driver.put()", () => {
+  beforeEach(() => {
+    process.env.BUCKET_NAME = "test-bucket";
+  });
+
+  async function putWith(params: any) {
+    let input: any;
+    const driver = driverWith(async (command) => {
+      input = command.input;
+      return {};
+    });
+    const name = await driver.put(params);
+    return { input, name };
+  }
+
+  test("keeps an explicitly passed contentType over the blob's own type", async () => {
+    // A caller that says "this PNG is really an octet-stream", or vice versa,
+    // has to win — they know something the blob does not.
+    const { input } = await putWith({
+      name: "a.png",
+      body: new Blob(["x"], { type: "application/octet-stream" }),
+      contentType: "image/png",
+    });
+
+    expect(input.ContentType).toBe("image/png");
+  });
+
+  test("keeps the contentType of a Buffer body", async () => {
+    // A Buffer carries no type of its own, so dropping the caller's value left
+    // it with none at all and S3 stored it as application/octet-stream.
+    const { input } = await putWith({
+      name: "a.png",
+      body: Buffer.from("x"),
+      contentType: "image/png",
+    });
+
+    expect(input.ContentType).toBe("image/png");
+  });
+
+  test("falls back to the blob's own type when none is given", async () => {
+    const { input } = await putWith({
+      name: "a.png",
+      body: new Blob(["x"], { type: "image/png" }),
+    });
+
+    expect(input.ContentType).toBe("image/png");
+  });
+
+  test("sends no content type for a typeless body rather than an empty one", async () => {
+    const { input } = await putWith({ name: "a.bin", body: Buffer.from("x") });
+    expect(input.ContentType).toBeUndefined();
+
+    const blob = await putWith({ name: "b.bin", body: new Blob(["x"]) });
+    expect(blob.input.ContentType).toBeUndefined();
+  });
+
+  // The bare-Blob path generates a name with Bun.randomUUIDv7().
+  test.skipIf(typeof Bun === "undefined")(
+    "uses the blob's type for a bare Blob",
+    async () => {
+      const { input } = await putWith(new Blob(["x"], { type: "image/png" }));
+      expect(input.ContentType).toBe("image/png");
+    },
+  );
+
+  test("honours an explicit bucket", async () => {
+    const { input } = await putWith({
+      name: "a.png",
+      body: Buffer.from("x"),
+      bucket: "other",
+    });
+
+    expect(input.Bucket).toBe("other");
+    expect(input.Key).toBe("a.png");
+  });
+});
+
 describe("S3Driver.read()", () => {
   beforeEach(() => {
     process.env.BUCKET_NAME = "test-bucket";

--- a/packages/gemi/services/file-storage/drivers/S3Driver.ts
+++ b/packages/gemi/services/file-storage/drivers/S3Driver.ts
@@ -26,7 +26,7 @@ export class S3Driver extends FileStorageDriver {
 
   async put(params: PutFileParams | Blob) {
     let body: Blob | File | Buffer;
-    let contentType: string;
+    let contentType: string | undefined;
     let name: string;
     let bucket = process.env.BUCKET_NAME;
 
@@ -38,11 +38,17 @@ export class S3Driver extends FileStorageDriver {
       body = params.body;
       name = params.name;
       bucket = params.bucket ?? bucket;
-      contentType = params.contentType;
+      // An explicitly passed contentType wins; otherwise fall back to the
+      // blob's own type. A Buffer carries no type, so it has nothing to fall
+      // back to and relies on the caller's value.
+      contentType =
+        params.contentType ||
+        (body instanceof Blob || body instanceof File ? body.type : undefined);
     }
 
-    contentType =
-      body instanceof Blob || body instanceof File ? body.type : undefined;
+    // A typeless Blob reports "". Send nothing rather than an empty header, so
+    // S3 applies its own default instead of storing a blank content type.
+    contentType = contentType || undefined;
 
     const buffer =
       body instanceof Buffer


### PR DESCRIPTION
`S3Driver.put()` computed a `contentType` from its arguments and then immediately threw it away:

```typescript
contentType = params.contentType;
// ...
contentType =
  body instanceof Blob || body instanceof File ? body.type : undefined;
```

`params.contentType` could never reach S3. Two consequences, the second worse than the first:

- **With a `Blob`/`File` body**, an explicit `contentType` was replaced by the blob's own type. A caller correcting a mistyped upload was silently ignored.
- **With a `Buffer` body** there was nothing to fall back to, so `contentType` became `undefined` *every time*. A Buffer upload could not carry a content type at all, and S3 stored it as `application/octet-stream` — which is why an image written from a Buffer comes back with the wrong type and browsers download it instead of rendering it.

An explicit `contentType` now wins, falling back to the blob's own type:

```typescript
contentType =
  params.contentType ||
  (body instanceof Blob || body instanceof File ? body.type : undefined);
```

A typeless body (a `Buffer`, or a `Blob` whose `type` is `""`) now sends no content type rather than an empty one, so S3 applies its own default instead of storing a blank.

## Verified

Three tests pin the behaviour, and **all three fail against the previous implementation**:

```
=== against the unfixed S3Driver:
  × keeps an explicitly passed contentType over the blob's own type
  × keeps the contentType of a Buffer body
  × sends no content type for a typeless body rather than an empty one
  Tests  3 failed | 10 passed | 1 skipped

=== against the fixed S3Driver:
  Tests  13 passed | 1 skipped
```

They drive `put()` through a stubbed `client.send` and assert on the `PutObjectCommand` input, so nothing touches the network. Typecheck clean; the repo's pre-existing failure set is unchanged.

## Notes

- Based on #36 rather than `main`, because `S3Driver.test.ts` is created there — a `main`-based branch would have to add the same file and collide. It touches none of that PR's code, so it can merge straight after. Sibling of #37, not stacked under it.
- `contentType` was typed `string` while being assigned `undefined`; now `string | undefined`.
- The note in `docs/file-storage.md` described the old behaviour ("the S3 driver derives `contentType` from the blob/file"). Updated to say an explicit value is used as-is, and that a `Buffer` body needs one passed alongside it.
- `AzureBlobDriver` in #37 already has the correct behaviour and a test pinning it, so the two drivers now agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
