### PR TITLE
Guard the RPC types, and stop ApiRoutes accepting any value

### DIFF
--- a/packages/gemi/http/ApiRouter.test-d.ts
+++ b/packages/gemi/http/ApiRouter.test-d.ts
@@ -1,0 +1,135 @@
+/**
+ * Type-level tests for the RPC surface.
+ *
+ * `CreateRPC` is what gives an app's client typed, autocompleted calls against
+ * its own API, and it is derived entirely through conditional types — so it can
+ * silently stop matching a route without any runtime test noticing. These
+ * assertions fail the build if that happens.
+ *
+ * Run with `bun run test:types`.
+ */
+import { describe, expectTypeOf, test } from "vitest";
+
+import {
+  ApiRouter,
+  type ApiRoutes,
+  type CreateRPC,
+  type FileHandler,
+  type RouteHandler,
+  type StreamHandler,
+} from "./ApiRouter";
+import { Controller } from "./Controller";
+import type { HttpRequest } from "./HttpRequest";
+
+class UserController extends Controller {
+  show(req: HttpRequest<{ q: string }, { id: string }>) {
+    return { id: req.params.id, name: "x" };
+  }
+}
+
+class SubRouter extends ApiRouter {
+  routes = {
+    "/nested": this.get(() => ({ deep: 1 })),
+  };
+}
+
+class Root extends ApiRouter {
+  routes = {
+    "/json": this.get(() => ({ ok: true })),
+    "/created": this.post(() => ({ id: 1 })),
+    "/replaced": this.put(() => ({ id: 1 })),
+    "/patched": this.patch(() => ({ p: true })),
+    "/gone": this.delete(() => ({ d: true })),
+    "/ctrl/:id": this.get(UserController, "show"),
+    "/guarded": this.get(() => ({ g: 1 })).middleware(["auth"]),
+    "/download": this.file(() => null),
+    "/video": this.stream(() => null),
+    "/video-guarded": this.stream(() => null).middleware(["auth"]),
+    "/sub": SubRouter,
+  };
+}
+
+type RPC = CreateRPC<Root>;
+type Keys = keyof RPC;
+
+describe("CreateRPC", () => {
+  test("includes every JSON verb", () => {
+    expectTypeOf<"GET:/json">().toExtend<Keys>();
+    expectTypeOf<"POST:/created">().toExtend<Keys>();
+    expectTypeOf<"PUT:/replaced">().toExtend<Keys>();
+    expectTypeOf<"PATCH:/patched">().toExtend<Keys>();
+    expectTypeOf<"DELETE:/gone">().toExtend<Keys>();
+  });
+
+  test("includes controller-backed and middleware-wrapped routes", () => {
+    expectTypeOf<"GET:/ctrl/:id">().toExtend<Keys>();
+    // .middleware() returns `this`, so the generics must survive the chain.
+    expectTypeOf<"GET:/guarded">().toExtend<Keys>();
+  });
+
+  test("prefixes routes from a nested router", () => {
+    expectTypeOf<"GET:/sub/nested">().toExtend<Keys>();
+  });
+
+  test("preserves the handler's return type", () => {
+    expectTypeOf<ReturnType<RPC["GET:/json"]>>().toEqualTypeOf<{ ok: boolean }>();
+    expectTypeOf<ReturnType<RPC["GET:/sub/nested"]>>().toEqualTypeOf<{ deep: number }>();
+  });
+
+  test("preserves a controller's Input and Params", () => {
+    expectTypeOf<Parameters<RPC["GET:/ctrl/:id"]>[0]>().toEqualTypeOf<
+      HttpRequest<{ q: string }, { id: string }>
+    >();
+  });
+
+  test("excludes byte-stream routes, which a JSON client cannot consume", () => {
+    expectTypeOf<"GET:/download">().not.toExtend<Keys>();
+    expectTypeOf<"GET:/video">().not.toExtend<Keys>();
+    expectTypeOf<"GET:/video-guarded">().not.toExtend<Keys>();
+  });
+});
+
+describe("ApiRoutes", () => {
+  test("rejects values that are not route handlers", () => {
+    // FileHandler and StreamHandler are deliberately near-empty so they stay
+    // out of the RPC types. If either becomes structurally `{}`, every
+    // non-nullish value satisfies it and a route can be assigned anything.
+    expectTypeOf<42>().not.toExtend<ApiRoutes[string]>();
+    expectTypeOf<"hello">().not.toExtend<ApiRoutes[string]>();
+    expectTypeOf<{ nonsense: true }>().not.toExtend<ApiRoutes[string]>();
+    expectTypeOf<() => void>().not.toExtend<ApiRoutes[string]>();
+  });
+
+  test("accepts every real handler form", () => {
+    expectTypeOf<FileHandler>().toExtend<ApiRoutes[string]>();
+    expectTypeOf<StreamHandler>().toExtend<ApiRoutes[string]>();
+    expectTypeOf<RouteHandler<"GET", any, any, any>>().toExtend<ApiRoutes[string]>();
+  });
+});
+
+describe("this.stream()", () => {
+  test("accepts the documented FileStorage.read() shape and a Blob", () => {
+    class R extends ApiRouter {
+      routes = {
+        "/a/:src*": this.stream(async (req: HttpRequest<any, { src: string }>) => {
+          const src: string = req.params.src;
+          return new Blob([src]);
+        }),
+        "/b": this.stream(() => null),
+      };
+    }
+    expectTypeOf<R["routes"]>().toExtend<ApiRoutes>();
+  });
+
+  test("rejects a handler returning something that is not streamable", () => {
+    class R extends ApiRouter {
+      routes = {
+        // @ts-expect-error - a plain JSON object is not a StreamOutput.
+        // The directive itself is the assertion: if this stops erroring,
+        // tsc reports an unused @ts-expect-error and the typecheck fails.
+        "/bad": this.stream(async () => ({ json: true })),
+      };
+    }
+    return R;
+  });
+});

--- a/packages/gemi/http/ApiRouter.ts
+++ b/packages/gemi/http/ApiRouter.ts
@@ -98,6 +98,18 @@ export class FileHandler {
   constructor(...args: ConstructorParameters<typeof RouteHandler>) {
     return new RouteHandler(...args) as any;
   }
+
+  /**
+   * Declared for two reasons: so `this.file(...).middleware([...])` typechecks,
+   * and so `FileHandler` is not structurally `{}`. As `{}` it accepted every
+   * non-nullish value, which through the `ApiRoutes` union meant a route could
+   * be assigned literally anything — `"/x": 42` typechecked.
+   *
+   * It stays out of the RPC types regardless: `RouteHandlersParser` maps over
+   * `keyof T` and only emits members extending `RouteHandler`, and a method
+   * does not.
+   */
+  declare middleware: (middlewareList: string[]) => FileHandler;
 }
 
 /**

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -43,6 +43,7 @@
     "build:types": "tsc",
     "build:client-types": "tsc -p tsconfig.browser.json",
     "test": "vitest",
+    "test:types": "vitest run --typecheck.only",
     "build:publish": "bun scripts/build-publish.ts",
     "prepublishOnly": "echo 'Do not publish from this directory — its exports point at TS source. Run: bun run build:publish, then publish from .publish/' && exit 1"
   },

--- a/packages/gemi/services/router/createFlatApiRoutes.ts
+++ b/packages/gemi/services/router/createFlatApiRoutes.ts
@@ -38,7 +38,10 @@ function isResouceRoutes(option: ApiRoutes[string]): option is ResourceRoutes<an
   return Object.hasOwn(option, "first") && Object.hasOwn(option, "second");
 }
 
-function isApiRouter(routeHandlers: ApiRoutes[string]): routeHandlers is new () => ApiRouter {
+// Narrows to `typeof ApiRouter`, not `new () => ApiRouter`: the latter lacks
+// the static `__brand` this very guard reads, so it is not a subtype of the
+// parameter and TypeScript rejects the predicate under a strict lib.
+function isApiRouter(routeHandlers: ApiRoutes[string]): routeHandlers is typeof ApiRouter {
   if ("__brand" in routeHandlers) {
     return routeHandlers.__brand === "ApiRouter";
   }


### PR DESCRIPTION
`CreateRPC` is derived entirely through conditional types, so it can silently stop matching a route without any runtime test noticing. This adds a type-level test suite that fails the build if that happens, and fixes what writing it turned up.

## `CreateRPC` is intact

Checked first, before changing anything. `this.stream()` did not change what any existing route resolves to:

| | in RPC |
|---|---|
| `this.get/post/put/patch/delete(...)` | ✅ |
| `this.get(Controller, "method")` — `Input`/`Params` preserved | ✅ |
| `.middleware([...])` chains — `this` return keeps the generics | ✅ |
| nested router, prefixed (`GET:/sub/nested`) | ✅ |
| handler return types preserved | ✅ |
| `this.file(...)` | ❌ excluded |
| `this.stream(...)`, with and without `.middleware()` | ❌ excluded |

The exclusions are correct — a typed JSON client has no way to consume a byte stream.

`packages/gemi/http/ApiRouter.test-d.ts` pins all of it. Run with:

```bash
bun run test:types    # vitest run --typecheck.only
```

## `ApiRoutes` accepted literally any value

Writing the tests turned this up. `FileHandler` declares no members, so its instance type is `{}` — which every non-nullish value satisfies. Through the `ApiRoutes` union that meant:

```typescript
class R extends ApiRouter {
  routes = {
    "/a": 42,                  // typechecked
    "/b": "hello",             // typechecked
    "/c": { nonsense: true },  // typechecked
    "/d": () => {},            // typechecked
  };
}
```

All four compiled clean, on this and every previous version. **This is pre-existing, not from `stream()`** — verified against `a664e21`, the commit before that work: `FileHandler` there is the same empty class, and `42 extends FileHandler` is `true`. `StreamHandler` already declared a `middleware` member, so it was never `{}` and never contributed.

The fix gives `FileHandler` the same declared `middleware` that `StreamHandler` has. That makes it narrower than `{}` and closes the hole, while keeping it out of the RPC types by the same mechanism — `RouteHandlersParser` maps over `keyof T` and only emits members extending `RouteHandler`, and a method does not. Confirmed by the tests above, which still pass unchanged.

Side benefit: `this.file(...).middleware([...])` now typechecks. It never did.

## `isApiRouter`'s predicate was unsound

```typescript
function isApiRouter(routeHandlers: ApiRoutes[string]): routeHandlers is new () => ApiRouter
```

`new () => ApiRouter` lacks the static `__brand` that the guard itself reads, so it is not a subtype of the parameter type. The package tsconfig let it through; a strict lib does not, and it was what blocked the type tests from running at all. Narrowed to `typeof ApiRouter`.

## Verified

- `bun run test:types` — 10 type tests, no type errors
- `tsc -p tsconfig.json` and `tsc -p tsconfig.browser.json` — both clean
- `bun run build` — exit 0
- runtime suite unchanged: same 7 pre-existing failures as `main`

## Upgrading

An app with a bad route value that this previously let through will now fail to typecheck. That is the point, but it is a stricter type than 0.43.0 shipped, so it wants a version bump rather than riding along silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
