### PR TITLE
serve azure `bytes=0-` as a 206 instead of a full 200

### DIFF
--- a/packages/gemi/services/file-storage/drivers/AzureBlobDriver.test.ts
+++ b/packages/gemi/services/file-storage/drivers/AzureBlobDriver.test.ts
@@ -150,6 +150,44 @@ describe("AzureBlobDriver.read()", () => {
     expect(calls.getProperties).toBe(0);
   });
 
+  test("resolves `bytes=0-` against the size instead of downloading unranged", async () => {
+    // `download(0, undefined)` emits no Range header at all, so Azure answers
+    // 200 and the read comes back non-partial — and `bytes=0-` is the first
+    // range a <video> sends, so that silently kills seeking. Resolve the
+    // length, exactly as the suffix branch does.
+    const { driver, calls } = driverWith({
+      properties: { contentLength: 12345, contentType: "video/mp4" },
+      download: () => ({
+        blobBody: Promise.resolve(new Blob(["x".repeat(12345)])),
+        contentRange: "bytes 0-12344/12345",
+        contentType: "video/mp4",
+      }),
+    });
+
+    const result = await driver.read({
+      name: "clip.mp4",
+      range: parseRangeHeader("bytes=0-"),
+    });
+
+    expect(calls.getProperties).toBe(1);
+    expect(calls.downloads).toEqual([{ offset: 0, count: 12345 }]);
+    expect(result).toMatchObject({
+      start: 0,
+      end: 12344,
+      total: 12345,
+      partial: true,
+    });
+  });
+
+  test("rejects `bytes=0-` over an empty blob without downloading", async () => {
+    const { driver, calls } = driverWith({ properties: { contentLength: 0 } });
+
+    await expect(
+      driver.read({ name: "empty.bin", range: parseRangeHeader("bytes=0-") }),
+    ).rejects.toBeInstanceOf(RangeNotSatisfiableError);
+    expect(calls.downloads).toEqual([]);
+  });
+
   test("resolves a suffix range against the size, since Azure has no suffix support", async () => {
     const { driver, calls } = driverWith({
       properties: { contentLength: 12345, contentType: "video/mp4" },

--- a/packages/gemi/services/file-storage/drivers/AzureBlobDriver.ts
+++ b/packages/gemi/services/file-storage/drivers/AzureBlobDriver.ts
@@ -213,14 +213,27 @@ export class AzureBlobDriver extends FileStorageDriver {
 
     const blob = await this.blob(name, bucket);
 
-    // Azure has no suffix range: `download()` takes an absolute offset, so
-    // `bytes=-N` has to be resolved against the size first. This is the one
-    // shape that costs a second round trip; `bytes=S-` and `bytes=S-E` go
-    // straight to the download and read the total back off its Content-Range.
+    // Azure's `download()` takes an absolute offset rather than a Range header,
+    // and only emits one when the offset is non-zero or a count is given. Two
+    // shapes therefore have to be resolved against the size first, at the cost
+    // of a second round trip:
+    //
+    //   - `bytes=-N`, which Azure cannot express at all; and
+    //   - `bytes=0-`, because `download(0, undefined)` is byte-identical to an
+    //     unranged read, so Azure answers 200 with no Content-Range and the
+    //     result comes back non-partial. That is the *first* range a <video>
+    //     sends, so getting it wrong silently breaks seeking.
+    //
+    // `bytes=S-` and `bytes=S-E` go straight to the download and read the total
+    // back off its Content-Range.
     let offset: number | undefined;
     let count: number | undefined;
 
-    if (range?.kind === "suffix") {
+    const needsResolvedLength =
+      range?.kind === "suffix" ||
+      (range?.kind === "offset" && range.end === null && range.start === 0);
+
+    if (range && needsResolvedLength) {
       const total = await this.size({ name, bucket });
       const resolved = resolveRange(range, total);
       if (!resolved) {
@@ -228,7 +241,7 @@ export class AzureBlobDriver extends FileStorageDriver {
       }
       offset = resolved.start;
       count = resolved.length;
-    } else if (range) {
+    } else if (range?.kind === "offset") {
       offset = range.start;
       count = range.end === null ? undefined : range.end - range.start + 1;
     }

--- a/packages/gemi/services/file-storage/drivers/S3Driver.test.ts
+++ b/packages/gemi/services/file-storage/drivers/S3Driver.test.ts
@@ -175,6 +175,33 @@ describe("S3Driver.read()", () => {
     expect(result.total).toBe(12345);
   });
 
+  test("forwards `bytes=0-` as a real Range header, so it stays partial", async () => {
+    // AzureBlobDriver has to special-case this shape because its SDK takes an
+    // offset rather than a header and `download(0, undefined)` emits none. S3
+    // sends the header verbatim and needs no such workaround — pin that.
+    let input: any;
+    const driver = driverWith(async (command) => {
+      input = command.input;
+      return objectOutput({
+        ContentRange: "bytes 0-12344/12345",
+        $metadata: { httpStatusCode: 206 },
+      });
+    });
+
+    const result = await driver.read({
+      name: "video.mp4",
+      range: parseRangeHeader("bytes=0-"),
+    });
+
+    expect(input.Range).toBe("bytes=0-");
+    expect(result).toMatchObject({
+      start: 0,
+      end: 12344,
+      total: 12345,
+      partial: true,
+    });
+  });
+
   test("reports partial: false when S3 answered 200 despite a range", async () => {
     const driver = driverWith(async () => objectOutput());
 


### PR DESCRIPTION
Fixes #40.

## Cause

`AzureBlobDriver.read()` mapped every non-suffix range straight onto `download(offset, count)`:

```ts
} else if (range) {
  offset = range.start;
  count = range.end === null ? undefined : range.end - range.start + 1;
}
```

For `bytes=0-` that yields `download(0, undefined)`, and `@azure/storage-blob` only emits a `Range` header when the offset is non-zero or a count is given — so that call is byte-identical to an unranged read. Azure replies `200` with no `Content-Range`, `parseContentRange` returns `null`, and `partial` is `false`. `createStreamResponse` then hits its documented fallback and serves the complete representation, which is correct given a non-partial `ReadResult`; the driver just shouldn't have produced one.

`bytes=0-` is the *first* range a `<video>` sends, so the player opened a 140 MB unbounded download it could never satisfy a seek from and the scrubber didn't move. `bytes=1-` worked precisely because a non-zero offset does produce a range header.

## Fix

`bytes=0-` joins `bytes=-N` on the resolve-the-size-first path. The branch condition is now a named `needsResolvedLength`, and the fallthrough narrowed from `else if (range)` to `else if (range?.kind === "offset")` so `range.start` / `range.end` are reached only on the shape that actually has them, rather than by inference from the earlier `kind` check.

```ts
const needsResolvedLength =
  range?.kind === "suffix" ||
  (range?.kind === "offset" && range.end === null && range.start === 0);
```

Costs one extra `getProperties`, and only for `bytes=0-`. `bytes=S-` and `bytes=S-E` still go straight to the download and read the total back off its `Content-Range`.

## Tests

- `bytes=0-` → one `getProperties`, `download(0, 12345)`, and `partial: true` with the full `Content-Range`. The failure is silent by design, so this asserts `partial` directly.
- `bytes=0-` over an empty blob → `RangeNotSatisfiableError` with no download at all (`resolveRange` returns `null` at `total <= 0`).
- An `S3Driver` test pinning that `bytes=0-` is forwarded as a literal `Range` header there. S3 does **not** share the blind spot — it builds the header via `toRangeHeaderValue` and gets a 206 back — so this keeps the workaround Azure-only.

Both Azure tests fail against the unpatched driver and pass with it.

## Checks

`tsc --noEmit` clean; the three file-storage test files pass (40 tests, 2 skipped). The full suite has 7 pre-existing failures in the route-manifest tests — identical on a clean `main`, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)