### PR TITLE
Rewrite the rate limiter and add a Redis driver

### DIFF
--- a/docs/facades.md
+++ b/docs/facades.md
@@ -25,6 +25,7 @@ import {
   Meta,
   Cookie,
   Redis,
+  RateLimiter,
 } from "gemi/facades";
 ```
 
@@ -246,6 +247,29 @@ export default class extends RedisServiceProvider {
 ```
 
 See [Configuration](./configuration.md) and the provider registration in [Project Structure](./project-structure.md).
+
+## RateLimiter
+
+`RateLimiter` is the rate limiter behind the `rate-limit` middleware, callable directly — for budgets that do not belong to a route.
+
+- `RateLimiter.consume(key, { limit, window, cost })` — records one hit against `key` and reports whether it fits. `window` is in **seconds**; `limit` and `window` default to the values on your `RateLimiterServiceProvider`, and `cost` defaults to `1`.
+
+```typescript
+import { RateLimiter } from "gemi/facades";
+
+const result = await RateLimiter.consume(`reset-password:${email}`, {
+  limit: 3,
+  window: 3600,
+});
+
+if (!result.allowed) {
+  return { error: `Try again in ${Math.ceil(result.retryAfter / 1000)}s` };
+}
+```
+
+The result carries `allowed`, `limit`, `remaining`, `resetAt` (epoch ms) and `retryAfter` (ms) — enough to build `X-RateLimit-*` headers or a user-facing message. Counting happens in whichever driver the provider is configured with (in-memory by default, Redis when you run more than one instance), so the same call is process-local in development and shared in production.
+
+See [Rate limiting](./middleware.md#rate-limiting) for drivers and configuration.
 
 ## Related
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -66,9 +66,19 @@ Sets a `Cache-Control` header on `GET` responses. Parameters are `scope`, `maxAg
 | `cache:private,0,no-store` | `private, max-age=0, no-store` |
 | `cache:public,12840,must-revalidate` | `public, max-age=12840, must-revalidate` |
 
-### `rate-limit:N` → `RateLimitMiddleware`
+### `rate-limit:N,W` → `RateLimitMiddleware`
 
-Limits requests per client (keyed by `x-forwarded-for` and route path) using the rate-limiter service. `N` is the max count (default `1000`); over the limit throws a **429**. Example: `rate-limit:100`.
+Limits how often one client may hit a route. `N` is the number of requests, `W` the window in **seconds**; both fall back to the rate-limiter service defaults (`1000` per `60`s). Over the limit the middleware throws a **429**.
+
+| DSL | Meaning |
+| --- | --- |
+| `rate-limit` | provider defaults — 1000 requests per 60s |
+| `rate-limit:100` | 100 requests per 60s |
+| `rate-limit:10,30` | 10 requests per 30s |
+
+The default bucket is the client's IP (left-most `x-forwarded-for` entry, then `x-real-ip`) **plus the route path**, so a client's budget for `/api/search` is separate from its budget for `/api/upload`. Every response carries `X-RateLimit-Limit`, `X-RateLimit-Remaining` and `X-RateLimit-Reset`; a rejected one also carries `Retry-After`.
+
+Counting uses a **sliding window**, so a client cannot spend a full budget at the end of one window and another at the start of the next. See [Rate limiting](#rate-limiting) below for drivers, Redis, and limiting by something other than an IP.
 
 ### `cors` → `CorsMiddleware`
 
@@ -171,6 +181,84 @@ class AdminRouter extends ViewRouter {
 ```
 
 > **Gotcha:** Authorization middleware (like `admin` above) throws to reject. Follow the built-in pattern — throw a `RequestBreakerError` subclass with the right `api`/`view` payload so API callers get a JSON error and browser navigations get a redirect. See [Authorization](./authorization.md).
+
+## Rate limiting
+
+`rate-limit` is a thin wrapper around the rate-limiter service, so the same DSL runs against an in-process counter locally and a shared one in production.
+
+### Drivers
+
+| Driver | Use it when |
+| --- | --- |
+| `InMemoryRateLimiter` (default) | one instance, or local development |
+| `RedisRateLimiter` | more than one instance — counters are shared, so the limit is the limit |
+
+The in-memory driver keeps counters in the process that served the request. With N instances behind a load balancer the effective limit is N × the configured limit, and it resets on every deploy. Switch to Redis as soon as you scale past one:
+
+```typescript
+// app/kernel/providers/RateLimiterServiceProvider.ts
+import { RateLimiterServiceProvider, RedisRateLimiter } from "gemi/services";
+
+export default class extends RateLimiterServiceProvider {
+  driver = new RedisRateLimiter();
+
+  // Defaults for a bare "rate-limit" with no DSL parameters.
+  limit = 1000;
+  window = 60; // seconds
+}
+```
+
+`RedisRateLimiter` uses the connection from your `RedisServiceProvider` — no extra configuration — and runs the whole count-and-decide step as one Lua script, so concurrent requests across instances cannot overspend the budget. It accepts:
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `client` | the app's Redis client | run against a different connection |
+| `prefix` | `gemi:rl` | key namespace |
+| `failOpen` | `true` | admit requests while Redis is unreachable |
+| `onError` | `console.error` | where Redis failures are reported |
+
+`failOpen` is the interesting one: by default a Redis outage lets traffic through rather than taking the site down with it. Set it to `false` on endpoints where an unmetered request is worse than a rejected one — anything that sends email or costs money per call.
+
+### Limiting by something other than an IP
+
+`x-forwarded-for` is trivially spoofed unless a proxy overwrites it, and it does not distinguish two users behind one NAT. `configure()` replaces the key with anything you can read off the request:
+
+```typescript
+import { RateLimitMiddleware, clientIp } from "gemi/http";
+
+export default class extends MiddlewareServiceProvider {
+  aliases = {
+    "rate-limit": RateLimitMiddleware,
+    // Signed-in users get a per-user budget; anonymous ones fall back to IP.
+    "user-rate-limit": RateLimitMiddleware.configure({
+      limit: 60,
+      window: 60,
+      key: (req) => `user:${req.ctx().user?.id ?? clientIp(req)}`,
+    }),
+  };
+}
+```
+
+`configure()` also takes `headers: false` to suppress the `X-RateLimit-*` response headers.
+
+### Limiting outside of middleware
+
+Some budgets do not belong to a route — a cooldown on password-reset emails, a quota on a paid third-party API. The `RateLimiter` facade is the same limiter, callable from anywhere:
+
+```typescript
+import { RateLimiter } from "gemi/facades";
+
+const { allowed, retryAfter } = await RateLimiter.consume(`reset:${email}`, {
+  limit: 3,
+  window: 3600, // seconds
+});
+
+if (!allowed) {
+  return { error: `Try again in ${Math.ceil(retryAfter / 1000)}s` };
+}
+```
+
+Pass `cost` to charge a request more than one unit — useful when a single call does far more work than the others sharing its budget.
 
 ## See also
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -120,7 +120,7 @@ The base `Kernel` defines a slot for every built-in service. Each slot has a wor
 | `queueServiceProvider` | `gemi/services` | Background job queue. |
 | `cronServiceProvider` | `gemi/services` | Scheduled `CronJob`s. |
 | `redisServiceProvider` | `gemi/services` | Redis connection. |
-| `rateLimiterServiceProvider` | `gemi/services` | Rate-limiter driver (default in-memory). |
+| `rateLimiterServiceProvider` | `gemi/services` | Rate-limiter driver (`InMemoryRateLimiter` by default, `RedisRateLimiter` for multi-instance) and its default limit/window. |
 | `broadcastingsServiceProvider` | `gemi/services` | WebSocket pub/sub. |
 | `imageServiceProvider` | `gemi/services` | Image optimization (sharp). |
 | `kernelIdServiceProvider` | (internal) | Per-kernel identity for multi-process coordination. |

--- a/packages/gemi/facades/RateLimiter.ts
+++ b/packages/gemi/facades/RateLimiter.ts
@@ -1,0 +1,31 @@
+import {
+  type ConsumeOptions,
+  RateLimiterServiceContainer,
+} from "../services/rate-limiter/RateLimiterServiceContainer";
+import type { RateLimitResult } from "../services/rate-limiter/types";
+
+/**
+ * The rate limiter, outside of middleware — for the things a route-level limit
+ * cannot express: a per-user budget on an expensive job, a cooldown on
+ * password-reset emails, a quota on a third-party API you pay for.
+ *
+ * ```ts
+ * const result = await RateLimiter.consume(`reset-password:${email}`, {
+ *   limit: 3,
+ *   window: 3600,
+ * });
+ *
+ * if (!result.allowed) {
+ *   return { error: `Try again in ${Math.ceil(result.retryAfter / 1000)}s` };
+ * }
+ * ```
+ */
+export class RateLimiter {
+  /** Records one hit against `key` and reports whether it fits the budget. */
+  static consume(
+    key: string,
+    options: ConsumeOptions = {},
+  ): Promise<RateLimitResult> {
+    return RateLimiterServiceContainer.use().consume(key, options);
+  }
+}

--- a/packages/gemi/facades/index.ts
+++ b/packages/gemi/facades/index.ts
@@ -9,3 +9,4 @@ export { Log } from "./Log";
 export { Meta } from "./Meta";
 export { Cookie } from "./Cookie";
 export { Redis } from "./Redis";
+export { RateLimiter } from "./RateLimiter";

--- a/packages/gemi/http/RateLimitMiddleware.test.ts
+++ b/packages/gemi/http/RateLimitMiddleware.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { kernelContext } from "../kernel/context";
+import { InMemoryRateLimiter } from "../services/rate-limiter/drivers/InMemoryRateLimiterDriver";
+import { RateLimiterServiceContainer } from "../services/rate-limiter/RateLimiterServiceContainer";
+import { RateLimiterServiceProvider } from "../services/rate-limiter/RateLimiterServiceProvider";
+import { HttpRequest } from "./HttpRequest";
+import { RateLimitMiddleware } from "./RateLimitMiddleware";
+import { RequestContext } from "./requestContext";
+
+/**
+ * Runs `middleware.run(...)` the way the router does: inside a kernel context
+ * that has the rate limiter registered, and inside a request context so the
+ * middleware can set response headers.
+ */
+function runMiddleware(options: {
+  Middleware?: typeof RateLimitMiddleware;
+  provider?: RateLimiterServiceProvider;
+  headers?: Record<string, string>;
+  routePath?: string;
+  args?: (string | number)[];
+}) {
+  const provider = options.provider ?? new RateLimiterServiceProvider();
+  const services = {
+    [RateLimiterServiceContainer._name]: new RateLimiterServiceContainer(
+      provider,
+    ),
+  };
+
+  const request = new HttpRequest(
+    new Request("http://localhost/api/search", {
+      headers: options.headers ?? { "x-forwarded-for": "1.2.3.4" },
+    }),
+    {},
+    "api",
+    options.routePath ?? "/search",
+  );
+
+  const MiddlewareClass = options.Middleware ?? RateLimitMiddleware;
+
+  return kernelContext.run(services, () =>
+    RequestContext.run(request, async () => {
+      const middleware = new MiddlewareClass(request);
+      try {
+        await middleware.run(...((options.args ?? []) as []));
+        return {
+          rejected: false as const,
+          headers: RequestContext.getStore().headers,
+        };
+      } catch (error) {
+        return {
+          rejected: true as const,
+          error: error as any,
+          headers: RequestContext.getStore().headers,
+        };
+      }
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(60_000);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("run", () => {
+  test("passes requests under the limit and reports the budget", async () => {
+    const provider = new RateLimiterServiceProvider();
+
+    const first = await runMiddleware({ provider, args: ["3", "60"] });
+
+    expect(first.rejected).toBe(false);
+    expect(first.headers.get("X-RateLimit-Limit")).toBe("3");
+    expect(first.headers.get("X-RateLimit-Remaining")).toBe("2");
+    // Epoch seconds of the end of the current 60s window.
+    expect(first.headers.get("X-RateLimit-Reset")).toBe("120");
+    expect(first.headers.get("Retry-After")).toBe(null);
+  });
+
+  test("rejects with a 429 and a Retry-After once the budget is spent", async () => {
+    const provider = new RateLimiterServiceProvider();
+    const args = ["2", "60"];
+
+    await runMiddleware({ provider, args });
+    await runMiddleware({ provider, args });
+    const third = await runMiddleware({ provider, args });
+
+    expect(third.rejected).toBe(true);
+    expect(third.error.payload.api.status).toBe(429);
+    // The whole budget went in at the start of the window, so half of the next
+    // one has to pass before a request fits again.
+    expect(third.error.payload.api.headers["Retry-After"]).toBe("90");
+    expect(third.error.payload.api.headers["X-RateLimit-Remaining"]).toBe("0");
+    // The router builds the 429 from the payload, so the headers have to be
+    // there too — not only on the request context.
+    expect(third.error.payload.view.status).toBe(429);
+  });
+
+  test("keys by client and route, so one route cannot spend another's budget", async () => {
+    const provider = new RateLimiterServiceProvider();
+    const args = ["1", "60"];
+
+    await runMiddleware({ provider, args, routePath: "/search" });
+
+    const sameRoute = await runMiddleware({
+      provider,
+      args,
+      routePath: "/search",
+    });
+    const otherRoute = await runMiddleware({
+      provider,
+      args,
+      routePath: "/upload",
+    });
+    const otherClient = await runMiddleware({
+      provider,
+      args,
+      routePath: "/search",
+      headers: { "x-forwarded-for": "5.6.7.8" },
+    });
+
+    expect(sameRoute.rejected).toBe(true);
+    expect(otherRoute.rejected).toBe(false);
+    expect(otherClient.rejected).toBe(false);
+  });
+
+  test("reads only the left-most x-forwarded-for entry", async () => {
+    const provider = new RateLimiterServiceProvider();
+    const args = ["1", "60"];
+
+    await runMiddleware({
+      provider,
+      args,
+      headers: { "x-forwarded-for": "1.2.3.4, 10.0.0.1" },
+    });
+
+    // Same client, different proxy chain: it must not buy a fresh budget.
+    const second = await runMiddleware({
+      provider,
+      args,
+      headers: { "x-forwarded-for": "1.2.3.4, 10.0.0.9, 10.0.0.7" },
+    });
+
+    expect(second.rejected).toBe(true);
+  });
+
+  test("falls back to x-real-ip", async () => {
+    const provider = new RateLimiterServiceProvider();
+    const args = ["1", "60"];
+    const headers = { "x-real-ip": "9.9.9.9" };
+
+    await runMiddleware({ provider, args, headers });
+    const second = await runMiddleware({ provider, args, headers });
+    const other = await runMiddleware({
+      provider,
+      args,
+      headers: { "x-real-ip": "8.8.8.8" },
+    });
+
+    expect(second.rejected).toBe(true);
+    expect(other.rejected).toBe(false);
+  });
+
+  test("falls back to the provider defaults when the DSL passes nothing", async () => {
+    class Provider extends RateLimiterServiceProvider {
+      driver = new InMemoryRateLimiter();
+      limit = 1;
+      window = 30;
+    }
+    const provider = new Provider();
+
+    const first = await runMiddleware({ provider });
+    const second = await runMiddleware({ provider });
+
+    expect(first.headers.get("X-RateLimit-Limit")).toBe("1");
+    expect(second.rejected).toBe(true);
+  });
+
+  test("ignores unusable DSL parameters instead of limiting to zero", async () => {
+    const provider = new RateLimiterServiceProvider();
+
+    const result = await runMiddleware({ provider, args: ["abc", "0"] });
+
+    expect(result.rejected).toBe(false);
+    expect(result.headers.get("X-RateLimit-Limit")).toBe("1000");
+  });
+
+  test("takes the limit from configure() when the DSL omits one", async () => {
+    const provider = new RateLimiterServiceProvider();
+    const Configured = RateLimitMiddleware.configure({
+      limit: 1,
+      window: 60,
+    }) as typeof RateLimitMiddleware;
+
+    const first = await runMiddleware({ provider, Middleware: Configured });
+    const second = await runMiddleware({ provider, Middleware: Configured });
+
+    expect(first.headers.get("X-RateLimit-Limit")).toBe("1");
+    expect(second.rejected).toBe(true);
+  });
+
+  test("lets configure() replace what counts as one client", async () => {
+    const provider = new RateLimiterServiceProvider();
+    const Configured = RateLimitMiddleware.configure({
+      limit: 1,
+      key: () => "tenant:acme",
+    }) as typeof RateLimitMiddleware;
+
+    await runMiddleware({ provider, Middleware: Configured });
+    // Different IP and route, same tenant — one shared budget.
+    const second = await runMiddleware({
+      provider,
+      Middleware: Configured,
+      routePath: "/upload",
+      headers: { "x-forwarded-for": "5.6.7.8" },
+    });
+
+    expect(second.rejected).toBe(true);
+  });
+
+  test("can be told not to set headers", async () => {
+    const provider = new RateLimiterServiceProvider();
+    const Configured = RateLimitMiddleware.configure({
+      headers: false,
+    }) as typeof RateLimitMiddleware;
+
+    const result = await runMiddleware({ provider, Middleware: Configured });
+
+    expect(result.headers.get("X-RateLimit-Limit")).toBe(null);
+  });
+});
+
+describe("invalid configuration", () => {
+  test("says so instead of limiting in an unexplainable way", async () => {
+    class Provider extends RateLimiterServiceProvider {
+      window = 0;
+    }
+
+    const result = await runMiddleware({ provider: new Provider() });
+
+    expect(result.rejected).toBe(true);
+    expect(result.error.message).toMatch(/window must be greater than zero/);
+  });
+});
+
+describe("without a kernel", () => {
+  test("does not reject requests when the service is missing", async () => {
+    const request = new HttpRequest(
+      new Request("http://localhost/api/search"),
+      {},
+      "api",
+      "/search",
+    );
+
+    const result = await kernelContext.run({}, () =>
+      RequestContext.run(request, () =>
+        new RateLimitMiddleware(request).run("1"),
+      ),
+    );
+
+    expect(result).toEqual({});
+  });
+});

--- a/packages/gemi/http/RateLimitMiddleware.ts
+++ b/packages/gemi/http/RateLimitMiddleware.ts
@@ -1,10 +1,17 @@
 import { RateLimiterServiceContainer } from "../services/rate-limiter/RateLimiterServiceContainer";
+import type { RateLimitResult } from "../services/rate-limiter/types";
 import { RequestBreakerError } from "./Error";
+import type { HttpRequest } from "./HttpRequest";
 import { Middleware } from "./Middleware";
 
-class RateLimitExceededError extends RequestBreakerError {
-  constructor() {
+export class RateLimitExceededError extends RequestBreakerError {
+  constructor(result?: RateLimitResult) {
     super("Rate limit exceeded");
+    const headers = {
+      "Content-Type": "application/json",
+      ...(result ? rateLimitHeaders(result) : {}),
+    };
+
     this.payload = {
       api: {
         status: 429,
@@ -13,29 +20,139 @@ class RateLimitExceededError extends RequestBreakerError {
             message: "Rate limit exceeded",
           },
         },
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers,
       },
       view: {
         error: {
           message: "Rate limit exceeded",
         },
         status: 429,
+        headers,
       },
     };
   }
 }
 
-export class RateLimitMiddleware extends Middleware {
-  async run(limit = 1000) {
-    const userId = this.req.headers.get("x-forwarded-for");
-    const driver = RateLimiterServiceContainer.use().service.driver;
-    const result = driver.consume.call(driver, userId, this.req.routePath);
-    if (result > limit) {
-      throw new RateLimitExceededError();
+export interface RateLimitMiddlewareConfig {
+  /** Requests allowed per window. The DSL parameter wins over this. */
+  limit?: number;
+  /** Window length in **seconds**. The DSL parameter wins over this. */
+  window?: number;
+  /**
+   * What counts as one client. Defaults to the caller's IP plus the route
+   * path, so a client's budget for `/api/search` is separate from its budget
+   * for `/api/upload`.
+   *
+   * Override it to limit by something more trustworthy than a header —
+   * a session, an API key, a tenant:
+   *
+   * ```ts
+   * RateLimitMiddleware.configure({
+   *   limit: 60,
+   *   key: (req) => `user:${req.ctx().user?.id ?? clientIp(req)}`,
+   * })
+   * ```
+   */
+  key?: (req: HttpRequest) => string;
+  /** Set `X-RateLimit-*` response headers. Defaults to `true`. */
+  headers?: boolean;
+}
+
+/**
+ * Limits how often one client may hit a route.
+ *
+ * ```
+ * "rate-limit"          // provider defaults (1000 per 60s)
+ * "rate-limit:100"      // 100 per 60s
+ * "rate-limit:10,30"    // 10 per 30s
+ * ```
+ *
+ * The counting itself is the rate-limiter service's job, so the same DSL runs
+ * against the in-memory driver locally and Redis in production.
+ */
+export class RateLimitMiddleware extends Middleware<RateLimitMiddlewareConfig> {
+  async run(limit?: string | number, window?: string | number) {
+    const container = RateLimiterServiceContainer.use();
+
+    // No kernel, no limiter. Rejecting every request because a service is
+    // missing would be a worse failure than not limiting.
+    if (!container) return {};
+
+    const result = await container.consume(this.key(), {
+      // The DSL passes strings (`"rate-limit:100,30"`), so both parameters are
+      // parsed rather than trusted; anything unusable falls back to config and
+      // then to the provider defaults.
+      limit: toPositiveNumber(limit) ?? this.config.limit,
+      window: toPositiveNumber(window) ?? this.config.window,
+    });
+
+    if (this.config.headers !== false) {
+      const ctx = this.req.ctx?.();
+      if (ctx) {
+        for (const [name, value] of Object.entries(rateLimitHeaders(result))) {
+          ctx.setHeaders(name, value);
+        }
+      }
+    }
+
+    if (!result.allowed) {
+      throw new RateLimitExceededError(result);
     }
 
     return {};
   }
+
+  private key() {
+    if (this.config.key) {
+      return this.config.key(this.req);
+    }
+    return `${clientIp(this.req)}:${this.req.routePath ?? "*"}`;
+  }
+}
+
+/**
+ * Best-effort client address.
+ *
+ * `x-forwarded-for` is a list — `client, proxy1, proxy2` — and the old
+ * implementation used the whole string as the key, so a request arriving
+ * through a different proxy chain got a fresh budget. Only the left-most entry
+ * names the client.
+ *
+ * Both headers are trivially spoofed by anyone talking to the app directly, so
+ * this is only sound behind a proxy that overwrites them. When you have
+ * something better (a session, an API key), pass `key` in the config.
+ */
+export function clientIp(req: HttpRequest) {
+  const forwardedFor = req.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const [client] = forwardedFor.split(",");
+    if (client?.trim()) return client.trim();
+  }
+
+  return req.headers.get("x-real-ip")?.trim() || "unknown";
+}
+
+function rateLimitHeaders(result: RateLimitResult): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-RateLimit-Limit": String(result.limit),
+    "X-RateLimit-Remaining": String(result.remaining),
+    "X-RateLimit-Reset": String(Math.ceil(result.resetAt / 1000)),
+  };
+
+  if (!result.allowed) {
+    // Seconds, and never `0` — a `Retry-After: 0` invites an immediate retry
+    // that is certain to be rejected again.
+    headers["Retry-After"] = String(
+      Math.max(1, Math.ceil(result.retryAfter / 1000)),
+    );
+  }
+
+  return headers;
+}
+
+function toPositiveNumber(value: string | number | undefined) {
+  if (value === undefined || value === null || value === "") return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
 }

--- a/packages/gemi/http/index.ts
+++ b/packages/gemi/http/index.ts
@@ -34,7 +34,12 @@ export { MiddlewareServiceProvider } from "./MiddlewareServiceProvider";
 export { AuthenticationMiddleware } from "./AuthenticationMiddlware";
 export { CacheMiddleware } from "./CacheMiddleware";
 export { CorsMiddleware } from "./CorsMiddleware";
-export { RateLimitMiddleware } from "./RateLimitMiddleware";
+export {
+  RateLimitMiddleware,
+  RateLimitExceededError,
+  clientIp,
+  type RateLimitMiddlewareConfig,
+} from "./RateLimitMiddleware";
 export { CSRFMiddleware } from "./CSRFMiddleware";
 
 export { PoliciesServiceProvider } from "./PoliciesServiceProvider";

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -15,13 +15,27 @@ export type {
 } from "./file-storage/drivers/types";
 export { FileStorageDriver } from "./file-storage/drivers/FileStorageDriver";
 // The toolkit a custom driver needs to resolve a range against its backend.
-export { resolveRange, toRangeHeaderValue, parseContentRange } from "../http/range";
+export {
+  resolveRange,
+  toRangeHeaderValue,
+  parseContentRange,
+} from "../http/range";
 export { FileNotFoundError, RangeNotSatisfiableError } from "../http/errors";
 
 // Ratelimiter
 export { RateLimiterServiceProvider } from "./rate-limiter/RateLimiterServiceProvider";
-export { InMemoryRateLimiter } from "./rate-limiter/drivers/InMemoryRateLimiterDriver";
+export {
+  InMemoryRateLimiter,
+  type InMemoryRateLimiterOptions,
+} from "./rate-limiter/drivers/InMemoryRateLimiterDriver";
+export {
+  RedisRateLimiter,
+  type RedisRateLimiterOptions,
+  type RateLimiterRedisClient,
+} from "./rate-limiter/drivers/RedisRateLimiterDriver";
 export { RateLimiterDriver } from "./rate-limiter/drivers/RateLimiterDriver";
+export type { ConsumeParams, RateLimitResult } from "./rate-limiter/types";
+export type { ConsumeOptions } from "./rate-limiter/RateLimiterServiceContainer";
 
 // Email
 export { EmailServiceProvider } from "./email/EmailServiceProvider";
@@ -48,7 +62,10 @@ export { Job } from "./queue/Job";
 
 // Image optimization
 export { ImageOptimizationServiceProvider } from "./image-optimization/ImageOptimizationServiceProvider";
-export type { FitEnum, ResizeParameters } from "./image-optimization/drivers/types";
+export type {
+  FitEnum,
+  ResizeParameters,
+} from "./image-optimization/drivers/types";
 export { ImageOptimizationDriver } from "./image-optimization/drivers/ImageOptimizationDriver";
 export { Sharp } from "./image-optimization/drivers/SharpDriver";
 

--- a/packages/gemi/services/rate-limiter/RateLimiterServiceContainer.ts
+++ b/packages/gemi/services/rate-limiter/RateLimiterServiceContainer.ts
@@ -1,10 +1,60 @@
 import { ServiceContainer } from "../ServiceContainer";
-import { RateLimiterServiceProvider } from "./RateLimiterServiceProvider";
+import type { RateLimiterServiceProvider } from "./RateLimiterServiceProvider";
+import type { RateLimitResult } from "./types";
+
+export interface ConsumeOptions {
+  /** Requests allowed per window. Defaults to the provider's `limit`. */
+  limit?: number;
+  /** Window length in **seconds**. Defaults to the provider's `window`. */
+  window?: number;
+  /** How much this call costs. Defaults to `1`. */
+  cost?: number;
+}
 
 export class RateLimiterServiceContainer extends ServiceContainer {
   static _name = "RateLimiterServiceContainer";
 
   constructor(public service: RateLimiterServiceProvider) {
     super();
+  }
+
+  /**
+   * Records one hit against `key` and reports whether it fits the budget.
+   *
+   * Windows are given in seconds here — the unit routes, middleware and config
+   * are written in — and converted to the milliseconds drivers work in.
+   */
+  async consume(
+    key: string,
+    options: ConsumeOptions = {},
+  ): Promise<RateLimitResult> {
+    const limit = options.limit ?? this.service.limit;
+    const window = options.window ?? this.service.window;
+    const cost = options.cost ?? 1;
+
+    // A zero window divides by zero inside the sliding-window maths and a
+    // negative cost hands out budget instead of spending it. Both mean the
+    // caller passed something nonsensical, so say so rather than limiting in a
+    // way nobody can explain later.
+    assertPositive("window", window);
+    assertPositive("limit", limit);
+    if (!Number.isFinite(cost) || cost < 0) {
+      throw new Error(`Rate limiter cost must be zero or greater, got ${cost}`);
+    }
+
+    return await this.service.driver.consume({
+      key,
+      limit,
+      window: window * 1000,
+      cost,
+    });
+  }
+}
+
+function assertPositive(name: string, value: number) {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(
+      `Rate limiter ${name} must be greater than zero, got ${value}`,
+    );
   }
 }

--- a/packages/gemi/services/rate-limiter/RateLimiterServiceProvider.ts
+++ b/packages/gemi/services/rate-limiter/RateLimiterServiceProvider.ts
@@ -3,7 +3,17 @@ import { InMemoryRateLimiter } from "./drivers/InMemoryRateLimiterDriver";
 import { RateLimiterDriver } from "./drivers/RateLimiterDriver";
 
 export class RateLimiterServiceProvider extends ServiceProvider {
+  /**
+   * Where counters live. In-process by default; swap in `RedisRateLimiter` once
+   * the app runs on more than one instance.
+   */
   driver: RateLimiterDriver = new InMemoryRateLimiter();
+
+  /** Requests allowed per window when the `rate-limit` DSL omits a limit. */
+  limit = 1000;
+
+  /** Window length in **seconds** when the `rate-limit` DSL omits one. */
+  window = 60;
 
   boot() {}
 }

--- a/packages/gemi/services/rate-limiter/drivers/InMemoryRateLimiterDriver.test.ts
+++ b/packages/gemi/services/rate-limiter/drivers/InMemoryRateLimiterDriver.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { InMemoryRateLimiter } from "./InMemoryRateLimiterDriver";
+
+const WINDOW = 1000;
+
+function consume(limiter: InMemoryRateLimiter, key = "a", cost = 1) {
+  return limiter.consume({ key, limit: 10, window: WINDOW, cost });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Start on a window boundary so elapsed time in each test is obvious.
+  vi.setSystemTime(60_000);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("consume", () => {
+  test("admits requests up to the limit and rejects the next one", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    for (let i = 0; i < 10; i++) {
+      expect(consume(limiter).allowed).toBe(true);
+    }
+
+    const denied = consume(limiter);
+    expect(denied.allowed).toBe(false);
+    expect(denied.remaining).toBe(0);
+    expect(denied.retryAfter).toBeGreaterThan(0);
+  });
+
+  test("counts down the remaining budget", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    expect(consume(limiter).remaining).toBe(9);
+    expect(consume(limiter).remaining).toBe(8);
+  });
+
+  test("charges the given cost", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    expect(consume(limiter, "a", 4).remaining).toBe(6);
+    expect(consume(limiter, "a", 6).remaining).toBe(0);
+    expect(consume(limiter, "a", 1).allowed).toBe(false);
+  });
+
+  test("keeps keys independent", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    for (let i = 0; i < 10; i++) consume(limiter, "a");
+
+    expect(consume(limiter, "a").allowed).toBe(false);
+    expect(consume(limiter, "b").allowed).toBe(true);
+  });
+
+  test("a full window still blocks right after the boundary", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    // Spend the whole budget at the very end of a window — the burst a fixed
+    // window would let through twice.
+    vi.setSystemTime(60_900);
+    for (let i = 0; i < 10; i++) expect(consume(limiter).allowed).toBe(true);
+
+    // 100ms later the window rolls, but 90% of the previous count still counts.
+    vi.setSystemTime(61_000);
+    expect(consume(limiter).allowed).toBe(false);
+  });
+
+  test("lets the budget back in as the previous window decays", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    vi.setSystemTime(60_900);
+    for (let i = 0; i < 10; i++) consume(limiter);
+
+    // Halfway through the next window: usage is 10 * 0.5 = 5, so five fit.
+    vi.setSystemTime(61_500);
+    for (let i = 0; i < 5; i++) expect(consume(limiter).allowed).toBe(true);
+    expect(consume(limiter).allowed).toBe(false);
+  });
+
+  test("starts clean after sitting idle for more than a window", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    for (let i = 0; i < 10; i++) consume(limiter);
+    expect(consume(limiter).allowed).toBe(false);
+
+    vi.setSystemTime(60_000 + WINDOW * 3);
+    expect(consume(limiter).remaining).toBe(9);
+  });
+
+  test("resets a key when its window length changes", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    for (let i = 0; i < 10; i++) consume(limiter);
+    expect(consume(limiter).allowed).toBe(false);
+
+    const result = limiter.consume({ key: "a", limit: 10, window: 5000 });
+    expect(result.allowed).toBe(true);
+  });
+
+  test("reports the end of the current window as the reset point", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    vi.setSystemTime(60_250);
+    expect(consume(limiter).resetAt).toBe(61_000);
+  });
+});
+
+describe("bookkeeping", () => {
+  test("stays within maxKeys under keys that never repeat", () => {
+    const limiter = new InMemoryRateLimiter({ maxKeys: 10 });
+
+    for (let i = 0; i < 500; i++) {
+      limiter.consume({ key: `ip-${i}`, limit: 10, window: WINDOW });
+    }
+
+    expect(limiter.size).toBeLessThanOrEqual(10);
+  });
+
+  test("evicts the least recently used key first", () => {
+    const limiter = new InMemoryRateLimiter({ maxKeys: 2 });
+
+    consume(limiter, "a");
+    consume(limiter, "b");
+    // Touching "a" makes "b" the oldest, so "b" is what the next key displaces.
+    consume(limiter, "a");
+    consume(limiter, "c");
+
+    expect(limiter.size).toBe(2);
+    expect(consume(limiter, "a").remaining).toBe(7);
+    expect(consume(limiter, "b").remaining).toBe(9);
+  });
+
+  test("clear() drops every counter", () => {
+    const limiter = new InMemoryRateLimiter();
+
+    for (let i = 0; i < 10; i++) consume(limiter);
+    expect(consume(limiter).allowed).toBe(false);
+
+    limiter.clear();
+
+    expect(limiter.size).toBe(0);
+    expect(consume(limiter).allowed).toBe(true);
+  });
+});

--- a/packages/gemi/services/rate-limiter/drivers/InMemoryRateLimiterDriver.ts
+++ b/packages/gemi/services/rate-limiter/drivers/InMemoryRateLimiterDriver.ts
@@ -1,21 +1,134 @@
+import { buildResult, estimateUsage, windowStartFor } from "../slidingWindow";
+import type { ConsumeParams, RateLimitResult } from "../types";
 import { RateLimiterDriver } from "./RateLimiterDriver";
 
-export class InMemoryRateLimiter extends RateLimiterDriver {
-  requests: Map<string, { date: number; count: number }> = new Map();
+interface Bucket {
+  /** Window length this bucket was counted with, so config changes reset it. */
+  window: number;
+  windowStart: number;
+  current: number;
+  previous: number;
+}
 
-  consume(id: string, path: string) {
-    if (!this.requests.has(id)) {
-      this.requests.set(id, { date: Date.now(), count: 1 });
-    } else {
-      const record = this.requests.get(id);
-      const now = Date.now();
-      if (now - record.date >= 1000 * 60) {
-        this.requests.set(id, { date: now, count: 1 });
-      } else {
-        this.requests.set(id, { date: record.date, count: record.count + 1 });
+export interface InMemoryRateLimiterOptions {
+  /**
+   * Hard cap on tracked keys. Reached only by traffic that never repeats a key
+   * (spoofed `x-forwarded-for`, for instance); the map is swept of dead buckets
+   * first and only then evicts live ones, oldest touched first.
+   *
+   * Defaults to 100k keys — a few MB, and far more than a single instance
+   * legitimately sees inside one window.
+   */
+  maxKeys?: number;
+}
+
+/**
+ * Per-process rate limiter. The default driver, and the right one for a single
+ * instance or for development.
+ *
+ * State lives in this process only: with N instances behind a load balancer the
+ * effective limit is N × the configured limit, and it resets on deploy. Point
+ * the service provider at `RedisRateLimiter` once you run more than one.
+ */
+export class InMemoryRateLimiter extends RateLimiterDriver {
+  private buckets = new Map<string, Bucket>();
+  private maxKeys: number;
+
+  constructor(options: InMemoryRateLimiterOptions = {}) {
+    super();
+    this.maxKeys = Math.max(1, options.maxKeys ?? 100_000);
+  }
+
+  consume(params: ConsumeParams): RateLimitResult {
+    const { key, limit, window } = params;
+    const cost = params.cost ?? 1;
+    const now = Date.now();
+    const windowStart = windowStartFor(now, window);
+    const elapsed = now - windowStart;
+
+    const bucket = this.roll(key, window, windowStart);
+    const usage = estimateUsage(
+      bucket.current,
+      bucket.previous,
+      elapsed,
+      window,
+    );
+    const allowed = usage + cost <= limit;
+
+    if (allowed) {
+      bucket.current += cost;
+    }
+
+    // Re-inserting moves the key to the end of the iteration order, which is
+    // what makes eviction least-recently-used rather than arbitrary.
+    this.buckets.delete(key);
+    this.buckets.set(key, bucket);
+    if (this.buckets.size > this.maxKeys) {
+      this.evict(now);
+    }
+
+    return buildResult({
+      allowed,
+      current: bucket.current,
+      previous: bucket.previous,
+      now,
+      elapsed,
+      window,
+      limit,
+      cost,
+    });
+  }
+
+  /** Drops all counters. Mainly useful in tests. */
+  clear() {
+    this.buckets.clear();
+  }
+
+  /** Number of tracked keys. Exposed for tests and diagnostics. */
+  get size() {
+    return this.buckets.size;
+  }
+
+  /** Advances a bucket to `windowStart`, creating it when absent or stale. */
+  private roll(key: string, window: number, windowStart: number): Bucket {
+    const bucket = this.buckets.get(key);
+
+    if (!bucket || bucket.window !== window) {
+      return { window, windowStart, current: 0, previous: 0 };
+    }
+
+    if (bucket.windowStart === windowStart) {
+      return bucket;
+    }
+
+    if (bucket.windowStart + window === windowStart) {
+      bucket.previous = bucket.current;
+      bucket.current = 0;
+      bucket.windowStart = windowStart;
+      return bucket;
+    }
+
+    // Idle for more than a full window: everything it held has decayed away.
+    bucket.previous = 0;
+    bucket.current = 0;
+    bucket.windowStart = windowStart;
+    return bucket;
+  }
+
+  private evict(now: number) {
+    for (const [key, bucket] of this.buckets) {
+      // Fully decayed — it would be reset on the next read anyway.
+      if (now - bucket.windowStart >= bucket.window * 2) {
+        this.buckets.delete(key);
       }
     }
 
-    return this.requests.get(id).count;
+    // Still over the cap, so the traffic is live rather than stale. Drop the
+    // least recently touched keys; the worst case is that a client whose bucket
+    // was dropped gets a fresh budget, which beats growing without bound.
+    for (const key of this.buckets.keys()) {
+      if (this.buckets.size <= this.maxKeys) break;
+      this.buckets.delete(key);
+    }
   }
 }

--- a/packages/gemi/services/rate-limiter/drivers/RateLimiterDriver.ts
+++ b/packages/gemi/services/rate-limiter/drivers/RateLimiterDriver.ts
@@ -1,3 +1,16 @@
+import type { ConsumeParams, RateLimitResult } from "../types";
+
 export abstract class RateLimiterDriver {
-  abstract consume(userId: string, requestPath: string): number;
+  /**
+   * Records one request against `params.key` and reports whether it fits.
+   *
+   * Implementations must decide *and* record atomically — two concurrent calls
+   * for the same key may never both be told they were the last one that fit.
+   *
+   * May be sync or async: the in-memory driver answers immediately, a network
+   * backed driver returns a promise. Callers always `await` the result.
+   */
+  abstract consume(
+    params: ConsumeParams,
+  ): Promise<RateLimitResult> | RateLimitResult;
 }

--- a/packages/gemi/services/rate-limiter/drivers/RedisRateLimiterDriver.test.ts
+++ b/packages/gemi/services/rate-limiter/drivers/RedisRateLimiterDriver.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { RedisRateLimiter } from "./RedisRateLimiterDriver";
+
+type Reply = any | Error | ((args: string[]) => any);
+
+/**
+ * A stand-in for Bun's `RedisClient`, so these tests never need a server. It
+ * records every command and answers from a programmable queue.
+ */
+function fakeRedis(
+  options: {
+    load?: Reply;
+    /** Reply to every EVALSHA. */
+    evalsha?: Reply;
+    /** Reply to consecutive EVALSHAs, for testing retries. Wins over `evalsha`. */
+    evalshaQueue?: Reply[];
+  } = {},
+) {
+  const calls: { command: string; args: string[] }[] = [];
+  const evalshaReplies = options.evalshaQueue
+    ? [...options.evalshaQueue]
+    : undefined;
+
+  function resolve(reply: Reply, args: string[]) {
+    const value = typeof reply === "function" ? reply(args) : reply;
+    if (value instanceof Error) throw value;
+    return value;
+  }
+
+  return {
+    calls,
+    evalshaCalls: () => calls.filter((call) => call.command === "EVALSHA"),
+    loadCalls: () => calls.filter((call) => call.command === "SCRIPT"),
+    async send(command: string, args: string[]) {
+      calls.push({ command, args });
+
+      if (command === "SCRIPT") {
+        return resolve(options.load ?? "sha-1", args);
+      }
+
+      if (command === "EVALSHA") {
+        const reply = evalshaReplies
+          ? (evalshaReplies.shift() ?? [1, 1, 0])
+          : (options.evalsha ?? [1, 1, 0]);
+        return resolve(reply, args);
+      }
+
+      return null;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(60_400);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("consume", () => {
+  test("runs the script against the current and previous window keys", async () => {
+    const client = fakeRedis();
+    const limiter = new RedisRateLimiter({ client });
+
+    await limiter.consume({ key: "1.2.3.4:/api/x", limit: 10, window: 1000 });
+
+    const [call] = client.evalshaCalls();
+    expect(call.args).toEqual([
+      "sha-1",
+      "2",
+      "gemi:rl:1.2.3.4:/api/x:60",
+      "gemi:rl:1.2.3.4:/api/x:59",
+      "10",
+      "1000",
+      "400", // elapsed into the current window
+      "1",
+    ]);
+  });
+
+  test("honours a custom prefix and cost", async () => {
+    const client = fakeRedis();
+    const limiter = new RedisRateLimiter({ client, prefix: "app" });
+
+    await limiter.consume({ key: "k", limit: 10, window: 1000, cost: 3 });
+
+    const [call] = client.evalshaCalls();
+    expect(call.args[2]).toBe("app:k:60");
+    expect(call.args.at(-1)).toBe("3");
+  });
+
+  test("loads the script once and reuses the digest", async () => {
+    const client = fakeRedis();
+    const limiter = new RedisRateLimiter({ client });
+
+    await limiter.consume({ key: "k", limit: 10, window: 1000 });
+    await limiter.consume({ key: "k", limit: 10, window: 1000 });
+
+    expect(client.loadCalls()).toHaveLength(1);
+    expect(client.evalshaCalls()).toHaveLength(2);
+  });
+
+  test("turns an allowed reply into remaining budget", async () => {
+    // 3 in this window, 10 in the previous one, 400ms in => usage 3 + 6 = 9.
+    const client = fakeRedis({ evalsha: [1, 3, 10] });
+    const limiter = new RedisRateLimiter({ client });
+
+    const result = await limiter.consume({
+      key: "k",
+      limit: 20,
+      window: 1000,
+    });
+
+    expect(result).toEqual({
+      allowed: true,
+      limit: 20,
+      remaining: 11,
+      resetAt: 61_000,
+      retryAfter: 0,
+    });
+  });
+
+  test("turns a rejected reply into a retry delay", async () => {
+    const client = fakeRedis({ evalsha: [0, 10, 0] });
+    const limiter = new RedisRateLimiter({ client });
+
+    const result = await limiter.consume({
+      key: "k",
+      limit: 10,
+      window: 1000,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfter).toBe(700);
+  });
+
+  test("reloads the script and retries once after a flush", async () => {
+    const client = fakeRedis({
+      evalshaQueue: [new Error("NOSCRIPT No matching script"), [1, 1, 0]],
+    });
+    const limiter = new RedisRateLimiter({ client });
+
+    const result = await limiter.consume({
+      key: "k",
+      limit: 10,
+      window: 1000,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(client.loadCalls()).toHaveLength(2);
+    expect(client.evalshaCalls()).toHaveLength(2);
+  });
+
+  test("gives up after a second NOSCRIPT rather than looping", async () => {
+    const onError = vi.fn();
+    const client = fakeRedis({
+      evalsha: new Error("NOSCRIPT No matching script"),
+    });
+    const limiter = new RedisRateLimiter({ client, onError });
+
+    await limiter.consume({ key: "k", limit: 10, window: 1000 });
+
+    expect(client.evalshaCalls()).toHaveLength(2);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("when redis is unreachable", () => {
+  test("admits the request and reports the failure by default", async () => {
+    const onError = vi.fn();
+    const client = fakeRedis({ evalsha: new Error("connection refused") });
+    const limiter = new RedisRateLimiter({ client, onError });
+
+    const result = await limiter.consume({
+      key: "k",
+      limit: 10,
+      window: 1000,
+      cost: 2,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(8);
+    expect(result.resetAt).toBe(61_000);
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  test("rejects instead when failOpen is off", async () => {
+    const client = fakeRedis({ evalsha: new Error("connection refused") });
+    const limiter = new RedisRateLimiter({
+      client,
+      failOpen: false,
+      onError: () => {},
+    });
+
+    const result = await limiter.consume({
+      key: "k",
+      limit: 10,
+      window: 1000,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfter).toBe(1000);
+  });
+
+  test("does not cache a failed script load", async () => {
+    let attempt = 0;
+    const client = fakeRedis({
+      load: () => {
+        attempt += 1;
+        if (attempt === 1) throw new Error("connection refused");
+        return "sha-1";
+      },
+    });
+    const limiter = new RedisRateLimiter({ client, onError: () => {} });
+
+    const first = await limiter.consume({ key: "k", limit: 10, window: 1000 });
+    const second = await limiter.consume({ key: "k", limit: 10, window: 1000 });
+
+    // The first call failed open; the second must be able to load and count.
+    expect(first.allowed).toBe(true);
+    expect(client.evalshaCalls()).toHaveLength(1);
+    expect(second.allowed).toBe(true);
+  });
+});

--- a/packages/gemi/services/rate-limiter/drivers/RedisRateLimiterDriver.ts
+++ b/packages/gemi/services/rate-limiter/drivers/RedisRateLimiterDriver.ts
@@ -1,0 +1,217 @@
+import { kernelContext } from "../../../kernel/context";
+import type { RedisServiceContainer } from "../../redis/RedisServiceContainer";
+import { buildResult, windowStartFor } from "../slidingWindow";
+import type { ConsumeParams, RateLimitResult } from "../types";
+import { RateLimiterDriver } from "./RateLimiterDriver";
+
+/**
+ * The slice of Bun's `RedisClient` this driver needs. Narrow on purpose: any
+ * client exposing `send(command, args)` works, which keeps the driver testable
+ * without a live server.
+ */
+export interface RateLimiterRedisClient {
+  send(command: string, args: string[]): Promise<any>;
+}
+
+export interface RedisRateLimiterOptions {
+  /**
+   * Client to run against. Defaults to the app's shared client from
+   * `RedisServiceProvider`, resolved lazily so constructing the driver never
+   * requires a kernel or a connection.
+   */
+  client?: RateLimiterRedisClient;
+  /** Key namespace. Defaults to `gemi:rl`. */
+  prefix?: string;
+  /**
+   * What to do when Redis is unreachable. `true` (the default) admits the
+   * request — a limiter outage should not take the site down with it. Set
+   * `false` for endpoints where an unmetered request is worse than a rejected
+   * one (payments, sign-up, anything that costs money per call).
+   */
+  failOpen?: boolean;
+  /** Called with every Redis failure. Defaults to `console.error`. */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * The counters and the decision have to move together — a GET, a check, then an
+ * INCR from the app would let concurrent requests read the same count and all
+ * conclude they fit. This script does the whole sliding-window step inside
+ * Redis, which is single-threaded, so the read-decide-write is atomic.
+ *
+ * Only integers cross the boundary: Lua converts numbers to integers on the way
+ * out, so the weighted (fractional) usage stays inside the script and the JS
+ * side rebuilds the result from the raw counts.
+ */
+const CONSUME_SCRIPT = `
+local currentKey = KEYS[1]
+local previousKey = KEYS[2]
+local limit = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local elapsed = tonumber(ARGV[3])
+local cost = tonumber(ARGV[4])
+
+local current = tonumber(redis.call("GET", currentKey)) or 0
+local previous = tonumber(redis.call("GET", previousKey)) or 0
+
+local weight = (window - elapsed) / window
+if weight < 0 then weight = 0 end
+if weight > 1 then weight = 1 end
+
+local usage = previous * weight + current
+
+if usage + cost > limit then
+  return {0, current, previous}
+end
+
+current = redis.call("INCRBY", currentKey, cost)
+-- Two windows of lifetime: the key still has to be readable as "previous"
+-- while the next window is running.
+redis.call("PEXPIRE", currentKey, window * 2)
+
+return {1, current, previous}
+`;
+
+/**
+ * Rate limiter backed by Redis, so every instance of the app counts against the
+ * same budget. Use it as soon as you run more than one process.
+ *
+ * ```ts
+ * // app/kernel/providers/RateLimiterServiceProvider.ts
+ * export default class extends RateLimiterServiceProvider {
+ *   driver = new RedisRateLimiter();
+ * }
+ * ```
+ *
+ * Window boundaries come from the app server's clock, not Redis's, so keep
+ * instances on NTP. A few seconds of skew only shifts where a window starts; it
+ * cannot double a budget the way an unsynchronised fixed window would.
+ */
+export class RedisRateLimiter extends RateLimiterDriver {
+  private injectedClient?: RateLimiterRedisClient;
+  private prefix: string;
+  private failOpen: boolean;
+  private onError: (error: unknown) => void;
+
+  /** Cached `SCRIPT LOAD` result, so the script body is sent at most once. */
+  private scriptSha: Promise<string> | null = null;
+
+  constructor(options: RedisRateLimiterOptions = {}) {
+    super();
+    this.injectedClient = options.client;
+    this.prefix = options.prefix ?? "gemi:rl";
+    this.failOpen = options.failOpen ?? true;
+    this.onError = options.onError ?? ((error) => console.error(error));
+  }
+
+  async consume(params: ConsumeParams): Promise<RateLimitResult> {
+    const { key, limit, window } = params;
+    const cost = params.cost ?? 1;
+    const now = Date.now();
+    const windowStart = windowStartFor(now, window);
+    const elapsed = now - windowStart;
+    const bucket = windowStart / window;
+
+    try {
+      const reply = await this.run(
+        [
+          `${this.prefix}:${key}:${bucket}`,
+          `${this.prefix}:${key}:${bucket - 1}`,
+        ],
+        [String(limit), String(window), String(elapsed), String(cost)],
+      );
+
+      const [allowed, current, previous] = (
+        Array.isArray(reply) ? reply : []
+      ).map(Number);
+
+      return buildResult({
+        allowed: allowed === 1,
+        current: Number.isFinite(current) ? current : 0,
+        previous: Number.isFinite(previous) ? previous : 0,
+        now,
+        elapsed,
+        window,
+        limit,
+        cost,
+      });
+    } catch (error) {
+      this.onError(error);
+
+      if (!this.failOpen) {
+        return {
+          allowed: false,
+          limit,
+          remaining: 0,
+          // Nothing was counted, so there is no decay to wait for — retrying is
+          // worth it as soon as Redis is back.
+          resetAt: now + window,
+          retryAfter: window,
+        };
+      }
+
+      return {
+        allowed: true,
+        limit,
+        remaining: Math.max(0, Math.floor(limit - cost)),
+        resetAt: windowStart + window,
+        retryAfter: 0,
+      };
+    }
+  }
+
+  private get client(): RateLimiterRedisClient {
+    if (this.injectedClient) return this.injectedClient;
+
+    // Looked up by name instead of through the container class: that module
+    // imports Bun's `RedisClient` as a value, and importing it here would make
+    // this driver — and anything that re-exports it — unloadable outside the
+    // Bun runtime.
+    const store = kernelContext.getStore() as
+      | Record<string, RedisServiceContainer | undefined>
+      | undefined;
+    const client = store?.RedisServiceContainer?.client;
+
+    if (!client) {
+      throw new Error(
+        "RedisRateLimiter could not reach the Redis client. Register RedisServiceProvider on your kernel, or pass a client: new RedisRateLimiter({ client }).",
+      );
+    }
+    return client;
+  }
+
+  /** Runs the script by digest, loading it on first use and after a flush. */
+  private async run(keys: string[], args: string[]): Promise<any> {
+    const client = this.client;
+    const argv = [String(keys.length), ...keys, ...args];
+
+    try {
+      return await client.send("EVALSHA", [await this.load(client), ...argv]);
+    } catch (error) {
+      // The server restarted or someone ran SCRIPT FLUSH between our load and
+      // this call. Re-load once and retry; a second failure is a real error.
+      if (!isNoScriptError(error)) throw error;
+      this.scriptSha = null;
+      return await client.send("EVALSHA", [await this.load(client), ...argv]);
+    }
+  }
+
+  private load(client: RateLimiterRedisClient) {
+    if (!this.scriptSha) {
+      this.scriptSha = Promise.resolve(
+        client.send("SCRIPT", ["LOAD", CONSUME_SCRIPT]),
+      )
+        .then(String)
+        .catch((error) => {
+          // Never cache a rejection — the next request must be free to retry.
+          this.scriptSha = null;
+          throw error;
+        });
+    }
+    return this.scriptSha;
+  }
+}
+
+function isNoScriptError(error: unknown) {
+  return String((error as Error)?.message ?? error).includes("NOSCRIPT");
+}

--- a/packages/gemi/services/rate-limiter/slidingWindow.test.ts
+++ b/packages/gemi/services/rate-limiter/slidingWindow.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildResult,
+  estimateUsage,
+  previousWeight,
+  timeUntilAllowed,
+  windowStartFor,
+} from "./slidingWindow";
+
+describe("windowStartFor", () => {
+  test("aligns windows to the epoch", () => {
+    expect(windowStartFor(60_000, 60_000)).toBe(60_000);
+    expect(windowStartFor(60_001, 60_000)).toBe(60_000);
+    expect(windowStartFor(119_999, 60_000)).toBe(60_000);
+    expect(windowStartFor(120_000, 60_000)).toBe(120_000);
+  });
+});
+
+describe("previousWeight", () => {
+  test("decays from a full window to nothing", () => {
+    expect(previousWeight(0, 1000)).toBe(1);
+    expect(previousWeight(250, 1000)).toBe(0.75);
+    expect(previousWeight(1000, 1000)).toBe(0);
+  });
+
+  test("clamps outside the window", () => {
+    expect(previousWeight(2000, 1000)).toBe(0);
+    expect(previousWeight(-500, 1000)).toBe(1);
+  });
+});
+
+describe("estimateUsage", () => {
+  test("weights the previous window by its overlap", () => {
+    // Three quarters into the window, a quarter of the previous count remains.
+    expect(estimateUsage(10, 100, 750, 1000)).toBe(35);
+  });
+
+  test("ignores the previous window once it has fully decayed", () => {
+    expect(estimateUsage(10, 100, 1000, 1000)).toBe(10);
+  });
+});
+
+describe("timeUntilAllowed", () => {
+  test("waits only until enough of the previous window decays", () => {
+    // usage = 100 * (1000 - e)/1000 + 0, and a limit of 50 needs usage <= 49.
+    const wait = timeUntilAllowed({
+      current: 0,
+      previous: 100,
+      elapsed: 0,
+      window: 1000,
+      limit: 50,
+      cost: 1,
+    });
+
+    expect(wait).toBe(510);
+  });
+
+  test("waits past the boundary when the current window is already full", () => {
+    // Nothing frees up while `current` is the live counter; after the roll it
+    // becomes `previous` and has to decay to 9 before a 10th request fits.
+    const wait = timeUntilAllowed({
+      current: 10,
+      previous: 0,
+      elapsed: 400,
+      window: 1000,
+      limit: 10,
+      cost: 1,
+    });
+
+    expect(wait).toBe(600 + 100);
+  });
+
+  test("never reports longer than a window for an impossible cost", () => {
+    const wait = timeUntilAllowed({
+      current: 0,
+      previous: 0,
+      elapsed: 0,
+      window: 1000,
+      limit: 5,
+      cost: 10,
+    });
+
+    expect(wait).toBe(1000);
+  });
+});
+
+describe("buildResult", () => {
+  test("reports the window end and whole remaining requests when allowed", () => {
+    const result = buildResult({
+      allowed: true,
+      current: 3,
+      previous: 10,
+      now: 60_500,
+      elapsed: 500,
+      window: 1000,
+      limit: 10,
+      cost: 1,
+    });
+
+    // usage = 10 * 0.5 + 3 = 8
+    expect(result).toEqual({
+      allowed: true,
+      limit: 10,
+      remaining: 2,
+      resetAt: 61_000,
+      retryAfter: 0,
+    });
+  });
+
+  test("never reports negative headroom", () => {
+    const result = buildResult({
+      allowed: true,
+      current: 12,
+      previous: 0,
+      now: 1000,
+      elapsed: 0,
+      window: 1000,
+      limit: 10,
+      cost: 1,
+    });
+
+    expect(result.remaining).toBe(0);
+  });
+
+  test("lines resetAt up with the retry delay when denied", () => {
+    const result = buildResult({
+      allowed: false,
+      current: 10,
+      previous: 0,
+      now: 60_400,
+      elapsed: 400,
+      window: 1000,
+      limit: 10,
+      cost: 1,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfter).toBe(700);
+    expect(result.resetAt).toBe(60_400 + 700);
+  });
+});

--- a/packages/gemi/services/rate-limiter/slidingWindow.ts
+++ b/packages/gemi/services/rate-limiter/slidingWindow.ts
@@ -1,0 +1,130 @@
+import type { RateLimitResult } from "./types";
+
+/**
+ * The sliding-window-counter algorithm, shared by every driver.
+ *
+ * A fixed window is cheap but lets a client spend its whole budget at the end
+ * of one window and again at the start of the next — twice the limit across a
+ * window's worth of time. A true sliding log fixes that but has to keep a
+ * timestamp per request.
+ *
+ * The counter variant keeps two integers per key (this window and the one
+ * before it) and estimates usage by weighting the previous window by how much
+ * of it still overlaps the trailing window:
+ *
+ *     usage = previous * (window - elapsed) / window + current
+ *
+ * That is a ~0.003% error on real traffic and costs two integers per key, so
+ * it is what the in-memory and Redis drivers both implement.
+ */
+
+/** Epoch ms of the start of the window `now` falls into. */
+export function windowStartFor(now: number, window: number) {
+  return Math.floor(now / window) * window;
+}
+
+/** Weight of the previous window's count, from `1` down to `0`. */
+export function previousWeight(elapsed: number, window: number) {
+  if (window <= 0) return 0;
+  return Math.min(1, Math.max(0, (window - elapsed) / window));
+}
+
+/** Estimated usage of the trailing `window` ending at `now`. */
+export function estimateUsage(
+  current: number,
+  previous: number,
+  elapsed: number,
+  window: number,
+) {
+  return previous * previousWeight(elapsed, window) + current;
+}
+
+/**
+ * How long until a request costing `cost` would be admitted, in milliseconds.
+ *
+ * Solves the usage equation for `elapsed` instead of guessing: the caller gets
+ * a `Retry-After` that lands the moment capacity actually frees up rather than
+ * at the end of the window, which for a sliding window is usually far too late.
+ */
+export function timeUntilAllowed(params: {
+  current: number;
+  previous: number;
+  elapsed: number;
+  window: number;
+  limit: number;
+  cost: number;
+}) {
+  const { current, previous, elapsed, window, limit, cost } = params;
+  // Usage the bucket may sit at for this request to still fit.
+  const budget = limit - cost;
+
+  // The request can never fit, no matter how long the caller waits. Report a
+  // full window rather than `Infinity` so a `Retry-After` header stays usable.
+  if (budget < 0) return window;
+
+  const remainingWindow = Math.max(0, window - elapsed);
+
+  // Phase 1 — capacity frees up inside the current window as `previous` decays.
+  if (previous > 0) {
+    // previous * (window - e) / window + current = budget  =>  solve for e
+    const target = window * (1 - (budget - current) / previous);
+    if (target <= window) {
+      return Math.max(0, Math.ceil(target - elapsed));
+    }
+  }
+
+  // Phase 2 — `current` alone is already over budget, so nothing frees up until
+  // the window rolls and `current` becomes the decaying `previous`.
+  if (current <= budget) return remainingWindow;
+  if (current <= 0) return remainingWindow;
+
+  const target = window * (1 - budget / current);
+  return remainingWindow + Math.max(0, Math.ceil(target));
+}
+
+/**
+ * Turns a driver's post-operation counters into the result the caller sees.
+ * `current` and `previous` are the counts *after* an allowed request has been
+ * recorded, so every driver reports the same numbers for the same state.
+ */
+export function buildResult(params: {
+  allowed: boolean;
+  current: number;
+  previous: number;
+  now: number;
+  elapsed: number;
+  window: number;
+  limit: number;
+  cost: number;
+}): RateLimitResult {
+  const { allowed, current, previous, now, elapsed, window, limit, cost } =
+    params;
+
+  if (allowed) {
+    const usage = estimateUsage(current, previous, elapsed, window);
+    return {
+      allowed: true,
+      limit,
+      remaining: Math.max(0, Math.floor(limit - usage)),
+      resetAt: now - elapsed + window,
+      retryAfter: 0,
+    };
+  }
+
+  const retryAfter = timeUntilAllowed({
+    current,
+    previous,
+    elapsed,
+    window,
+    limit,
+    cost,
+  });
+
+  return {
+    allowed: false,
+    limit,
+    remaining: 0,
+    resetAt: now + retryAfter,
+    retryAfter,
+  };
+}

--- a/packages/gemi/services/rate-limiter/types.ts
+++ b/packages/gemi/services/rate-limiter/types.ts
@@ -1,0 +1,36 @@
+/**
+ * A single request for capacity from the rate limiter.
+ *
+ * `key` identifies the bucket — everything the caller wants counted together.
+ * The limiter never invents part of the key on its own, so callers stay in
+ * control of what is limited (an IP, an IP plus a route, a user id, ...).
+ */
+export interface ConsumeParams {
+  key: string;
+  /** Maximum cost allowed inside one window. */
+  limit: number;
+  /** Window length in **milliseconds**. */
+  window: number;
+  /** How much this request costs. Defaults to `1`. */
+  cost?: number;
+}
+
+export interface RateLimitResult {
+  /** `false` means the caller is over budget and should be rejected. */
+  allowed: boolean;
+  /** The limit this decision was made against. */
+  limit: number;
+  /**
+   * Capacity left in the window, floored to a whole request. `0` when the
+   * request was denied.
+   */
+  remaining: number;
+  /**
+   * Epoch milliseconds. When allowed, the end of the current window — the
+   * point where the oldest counted requests have fully decayed away. When
+   * denied, the earliest moment a retry of the same cost can succeed.
+   */
+  resetAt: number;
+  /** Milliseconds to wait before retrying. `0` when the request was allowed. */
+  retryAfter: number;
+}


### PR DESCRIPTION
## Why

The old limiter was a fixed window over a `Map` that never gave anything back:

- **The route path was ignored.** `consume(userId, path)` took the path and never used it, so every route shared one budget — despite the docs promising otherwise. The key was the raw `x-forwarded-for` header, which is a *list* (`client, proxy1, proxy2`), so the same client arriving through a different proxy chain got a fresh budget.
- **Nothing was ever evicted.** One entry per distinct key, held forever.
- **Fixed windows burst.** A client could spend a full budget at the end of one window and another at the start of the next — 2× the limit across a window's worth of time.
- **The interface was sync and returned a bare count**, so no driver that talks over a network could implement it, and callers could never be told *when* to retry.

## What changed

**Sliding window.** Two counters per key; the previous window is weighted by how much of it still overlaps the trailing window. The maths lives in `slidingWindow.ts` so both drivers make identical decisions, and `Retry-After` is *solved for* rather than rounded up to the end of the window.

**Driver contract.** `consume({ key, limit, window, cost })` → `{ allowed, limit, remaining, resetAt, retryAfter }`, sync or async. Callers own the whole key, so the limiter never invents part of it.

**`InMemoryRateLimiter`** — same role, but bounded: an LRU cap (100k keys default) that sweeps dead buckets before evicting live ones.

**`RedisRateLimiter`** (new) — runs the entire count-and-decide step as one Lua script, so instances cannot overspend a shared budget. Loaded by digest, reloaded once on `NOSCRIPT`. Uses the connection from `RedisServiceProvider` with no extra config, and **fails open by default** — a limiter outage should not take the site down with it (`failOpen: false` for endpoints where an unmetered request costs money).

**Middleware.** Takes a window (`rate-limit:10,30`), keys by client IP **plus** route path, sets `X-RateLimit-Limit/Remaining/Reset`, and puts `Retry-After` on the 429 — the router builds that response from the error payload, so the headers have to travel with it. `configure({ key })` covers per-user or per-tenant budgets.

**`RateLimiter` facade** (new) — for budgets that do not belong to a route: a cooldown on password-reset emails, a quota on a paid API.

## Testing

45 unit tests across the algorithm, both drivers, and the middleware — including the burst-across-a-boundary case the old implementation allowed.

The Lua script is the part unit tests cannot reach, so it was verified against **Redis 7 in Docker**:

- 50 concurrent requests against a limit of 10 admit **exactly** 10
- key TTLs land within two windows
- a burst across a window boundary is blocked, then recovers as the previous window decays
- a `SCRIPT FLUSH` mid-flight recovers

## Breaking change

`RateLimiterDriver.consume(userId, path): number` is now `consume(params): RateLimitResult`. Custom drivers need updating. Apps using the `rate-limit` DSL need no changes — `rate-limit:100` still means 100 requests, now over a configurable window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)