### PR TITLE
ORM iteration 3 — motorcycle: relations through the batched planner

### DIFF
--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -1,5 +1,6 @@
 import { DatabaseManager } from "../database/DatabaseManager";
 import { app } from "../foundation/app";
+import { attachRelations } from "./compile/plan-relations";
 import { dialectFor } from "./dialect";
 import { MissingModelSchemaError, RecordNotFoundError } from "./errors";
 import { getOrCompile, type Operation, type QueryPlan } from "./plan";
@@ -57,6 +58,14 @@ export abstract class Model {
     // where the model's name is in scope for the message.
     if (result === null && ORTHROW.has(op)) {
       throw new RecordNotFoundError(schema.name, op);
+    }
+
+    // Relations are loaded after the root rows are shaped, one query per node
+    // in the include tree. Each of those queries is `$exec` on the *related
+    // model's own class*, recursively — not a private helper — so a nested read
+    // is subject to everything a top-level read is.
+    if (plan.relations !== undefined) {
+      await attachRelations(plan.relations, plan.hidden, result, args);
     }
 
     return result;

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -4,6 +4,7 @@ import { attachRelations } from "./compile/plan-relations";
 import { dialectFor } from "./dialect";
 import { MissingModelSchemaError, RecordNotFoundError } from "./errors";
 import { getOrCompile, type Operation, type QueryPlan } from "./plan";
+import * as registry from "./registry";
 import type { ModelSchema } from "./schema";
 
 /**
@@ -64,8 +65,17 @@ export abstract class Model {
     // in the include tree. Each of those queries is `$exec` on the *related
     // model's own class*, recursively — not a private helper — so a nested read
     // is subject to everything a top-level read is.
+    //
+    // The planner is handed the database rather than reaching for it: that is
+    // what keeps `compile/` free of a runtime import, and it is why the one
+    // query with no model behind it — the implicit m-n join table — still runs
+    // on the connection this call resolved.
     if (plan.relations !== undefined) {
-      await attachRelations(plan.relations, plan.hidden, result, args);
+      await attachRelations(plan.relations, plan.hidden, result, args, {
+        exec: (model, op, relationArgs) =>
+          registry.get<typeof Model>(model).$exec(op as Operation, relationArgs),
+        query: (text, values) => db.sql.unsafe(text, values),
+      });
     }
 
     return result;

--- a/packages/gemi/orm/compile/index.ts
+++ b/packages/gemi/orm/compile/index.ts
@@ -24,4 +24,14 @@ export { compileRead, isReadOperation };
 export { compileWhere } from "./where";
 export { compileOrderBy, parseOrderBy } from "./orderBy";
 export { resolveSelection } from "./select";
+export {
+  MAX_RELATION_DEPTH,
+  attachRelations,
+  batchedStrategy,
+  planRelations,
+  type RelationPlan,
+  type RelationPlanning,
+  type RelationRequest,
+  type RelationStrategy,
+} from "./plan-relations";
 export * from "./fragment";

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -1,5 +1,3 @@
-import { DatabaseManager } from "../../database/DatabaseManager";
-import { app } from "../../foundation/app";
 import type { SqlDialect } from "../dialect";
 import {
   MalformedRelationError,
@@ -12,6 +10,7 @@ import {
 import * as registry from "../registry";
 import type { FieldSchema, ModelSchema, RelationSchema } from "../schema";
 import { concat, render, sql } from "./fragment";
+import { resolveSelection } from "./select";
 
 /**
  * The relation planner: an include tree plus a root model in, a *strategy* out.
@@ -28,8 +27,16 @@ import { concat, render, sql } from "./fragment";
  * SQL that takes, and how many statements, is entirely the strategy's business.
  */
 
-/** The keys a relation node accepts. `take` / `skip` are refused; see below. */
+/**
+ * The keys a relation node accepts, which differ by kind. `take` / `skip` are
+ * refused on both; see `assertNodeArgs`.
+ *
+ * Prisma's to-one include argument is `{ where?, select?, include? }` — it
+ * takes a `where` (verified: it filters, and the relation comes back `null`
+ * when nothing matches) but not an `orderBy`, since there is at most one row.
+ */
 const RELATION_ARGS = new Set(["where", "orderBy", "select", "include"]);
+const TO_ONE_ARGS = new Set(["where", "select", "include"]);
 
 /**
  * How deep an include tree may nest. Not a modelling limit — a legal tree can
@@ -41,13 +48,38 @@ export const MAX_RELATION_DEPTH = 10;
 type Row = Record<string, unknown>;
 
 /**
- * The registry hands back model *classes*; the planner only ever needs these
- * two statics off them. Typed structurally rather than by importing `Model`,
- * which would make `compile/` depend on the class it is compiled for.
+ * The registry hands back model *classes*; planning only ever needs the schema
+ * off them. Typed structurally rather than by importing `Model`, which would
+ * make `compile/` depend on the class it is compiled for.
  */
 interface RelatedModel {
   $schema?: ModelSchema;
-  $exec(op: string, args: unknown): Promise<unknown>;
+}
+
+/**
+ * Everything a loaded relation needs from the outside world, handed in by the
+ * caller rather than reached for.
+ *
+ * This is what keeps `compile/` a pure schema-in / SQL-out directory: without
+ * it, planning a relation would put `DatabaseManager` — and so `import { SQL }
+ * from "bun"` — on the load path of every compiler unit test, which is a real
+ * cost and not a theoretical one. It also means the m-n join hop runs on
+ * whatever connection `$exec` resolved, so iteration 5's ambient transaction
+ * will cover both hops of a many-to-many read rather than only the second.
+ */
+export interface RelationExecutor {
+  /**
+   * A read on another model, through *that model's own* `$exec` (invariant 1).
+   * Named rather than passed as a class so resolution stays at call time
+   * (invariant 6).
+   */
+  exec(model: string, op: string, args: unknown): Promise<unknown>;
+  /**
+   * A statement with no model behind it. Exactly one query in the ORM is like
+   * this: Prisma's implicit many-to-many join table, which has no model, no
+   * fields of its own and nothing an application could scope.
+   */
+  query(text: string, values: unknown[]): Promise<unknown>;
 }
 
 /** One relation as it appears in an `include` / `select` argument tree. */
@@ -88,7 +120,7 @@ export interface RelationPlan {
   /** Which strategy produced this plan. Reported by tests and, later, metrics. */
   strategy: string;
   /** Fetches the children for these parents and attaches them in place. */
-  load(parents: Row[], args: any): Promise<void>;
+  load(parents: Row[], args: any, executor: RelationExecutor): Promise<void>;
 }
 
 export interface RelationStrategy {
@@ -160,6 +192,7 @@ export async function attachRelations(
   hidden: readonly string[] | undefined,
   result: unknown,
   args: any,
+  executor: RelationExecutor,
 ): Promise<void> {
   const parents: Row[] = Array.isArray(result)
     ? (result as Row[])
@@ -175,7 +208,7 @@ export async function attachRelations(
   // concurrent statements are not safe. Parallelism belongs with iteration 7,
   // which owns performance and can measure it.
   for (const relation of relations) {
-    await relation.load(parents, args);
+    await relation.load(parents, args, executor);
   }
 
   if (hidden && hidden.length > 0) {
@@ -310,9 +343,25 @@ function assertNodeArgs(
   const args = value as Record<string, unknown>;
   assertExclusive(schema, args.include, args.select, operation, node.as);
 
+  const many = node.relation.kind === "many";
+
   for (const key of Object.keys(args).sort()) {
     if (args[key] === undefined) continue;
-    if (RELATION_ARGS.has(key)) continue;
+    if (many ? RELATION_ARGS.has(key) : TO_ONE_ARGS.has(key)) continue;
+
+    // A to-one relation is at most one row, so ordering it is meaningless and
+    // Prisma rejects it outright — `Unknown argument 'orderBy'`, listing
+    // `where?` as one of the options it *does* take. Accepting it here would be
+    // a silent superset of Prisma on an argument that cannot mean anything.
+    if (key === "orderBy" && !many) {
+      throw new UnsupportedQueryError(
+        `${node.as}.orderBy`,
+        schema.name,
+        operation,
+        `Prisma does not accept 'orderBy' on a to-one relation — there is at ` +
+          `most one row to order.`,
+      );
+    }
 
     // The decision recorded in the PR: `take` / `skip` on a to-many relation
     // throw rather than being implemented under the batched strategy.
@@ -343,7 +392,16 @@ function assertNodeArgs(
   }
 }
 
-/** Walks the rest of the tree for the structural rules and the depth guard. */
+/**
+ * Walks the rest of the tree for the structural rules and the depth guard.
+ *
+ * Field names go through the same walk, not just structure: without it a typo
+ * in a `select` three levels down is an `UnknownFieldError` raised by that
+ * model's own compile — which is to say, after two queries have already run.
+ * The whole reason this walk exists is that a guard seeing one level at a time
+ * catches things a query too late, and that applies to a misspelled column as
+ * much as to an unbounded tree.
+ */
 function validateSubtree(
   schema: ModelSchema,
   node: unknown,
@@ -351,6 +409,12 @@ function validateSubtree(
   depth: number,
 ): void {
   if (typeof node !== "object" || node === null || Array.isArray(node)) return;
+
+  // Validates the scalar keys and rejects unknown ones; the relation keys in a
+  // `select` are this function's own business and it skips them.
+  if ((node as Record<string, unknown>).select !== undefined) {
+    resolveSelection(schema, node, operation);
+  }
 
   const nodes = relationNodes(schema, node, operation);
   if (nodes.length === 0) return;
@@ -590,6 +654,8 @@ export const batchedStrategy: RelationStrategy = {
     // compiled rather than after the root query has already run.
     const parentKeyField = field(request.parent, request.relation, link.parentField);
     const childKeyField = field(request.child, request.relation, link.childField);
+    assertKeyable(request.parent, request.relation, parentKeyField);
+    assertKeyable(request.child, request.relation, childKeyField);
 
     const many = request.relation.kind === "many";
 
@@ -598,22 +664,18 @@ export const batchedStrategy: RelationStrategy = {
       kind: request.relation.kind,
       parentField: link.parentField,
       strategy: BATCHED,
-      load(parents, args) {
+      load(parents, args, executor) {
+        const context = {
+          parentKeyField,
+          childKeyField,
+          many,
+          parents,
+          args,
+          executor,
+        };
         return link.join
-          ? loadThroughJoinTable(request, link, {
-              parentKeyField,
-              childKeyField,
-              many,
-              parents,
-              args,
-            })
-          : loadDirect(request, link, {
-              parentKeyField,
-              childKeyField,
-              many,
-              parents,
-              args,
-            });
+          ? loadThroughJoinTable(request, link, context)
+          : loadDirect(request, link, context);
       },
     };
   },
@@ -625,6 +687,7 @@ interface LoadContext {
   many: boolean;
   parents: Row[];
   args: any;
+  executor: RelationExecutor;
 }
 
 async function loadDirect(
@@ -640,7 +703,8 @@ async function loadDirect(
   const node = request.locate(context.args);
   const query = childQuery(node, link.childField, keys);
 
-  const rows = (await childModel(request).$exec(
+  const rows = (await context.executor.exec(
+    request.relation.model,
     "findMany",
     query.args,
   )) as Row[];
@@ -666,6 +730,12 @@ async function loadDirect(
  * holds two foreign keys. The hop that reads *rows* still goes through `$exec`
  * on the child's own model class, so a policy on `Tag` applies to
  * `include: { tags: true }` exactly as it would to `Tag.findMany`.
+ *
+ * It runs on `executor.query` rather than resolving a connection of its own,
+ * which is what keeps the two hops on the same one. Iteration 5 should keep it
+ * that way: if the ambient transaction is resolved inside `$exec` and this hop
+ * reached for `DatabaseManager` directly, a many-to-many read would straddle
+ * the transaction boundary — second hop enrolled, first not.
  */
 async function loadThroughJoinTable(
   request: RelationRequest,
@@ -682,6 +752,7 @@ async function loadThroughJoinTable(
     dialect,
     join,
     keys.map((key) => dialect.encode(key, context.parentKeyField)),
+    context.executor,
   )) as Row[];
 
   // Parents keyed by the *child* id they link to, so the second hop can stitch
@@ -716,7 +787,8 @@ async function loadThroughJoinTable(
   const node = request.locate(context.args);
   const query = childQuery(node, link.childField, childKeys);
 
-  const rows = (await childModel(request).$exec(
+  const rows = (await context.executor.exec(
+    request.relation.model,
     "findMany",
     query.args,
   )) as Row[];
@@ -747,6 +819,7 @@ async function readPairs(
   dialect: SqlDialect,
   join: NonNullable<Link["join"]>,
   values: unknown[],
+  executor: RelationExecutor,
 ): Promise<unknown> {
   const statement = concat(
     sql(
@@ -763,30 +836,23 @@ async function readPairs(
   );
 
   const { text, binders } = render(statement, dialect);
-  const db = app(DatabaseManager);
-  return db.sql.unsafe(
+  return executor.query(
     text,
     binders.map((binder) => binder(undefined)),
   );
-}
-
-function childModel(request: RelationRequest): RelatedModel {
-  // Resolved here, not at plan time, so the plan cache never holds a class
-  // reference and a re-registered model is picked up (invariant 6). The child
-  // query is `$exec` on the child's own class — the choke point, so policies,
-  // ambient transactions and the plan cache all apply to a nested read exactly
-  // as they do to a top-level one (invariant 1).
-  return registry.get<RelatedModel>(request.relation.model);
 }
 
 /**
  * The child query's arguments: the caller's own relation arguments, plus the
  * key filter, plus the key itself when a `select` left it out.
  *
- * The `in (<parent keys>)` list has the plan-cache problem iteration 2 already
- * has for `in`, at higher volume: on SQLite each distinct parent count is its
- * own plan text. It is the same mechanism and the same answer — the plan
- * cache's LRU bound — rather than a second one.
+ * The `in (<parent keys>)` list is the same mechanism iteration 2 built for
+ * `in`, at higher volume — the list length here is the *parent row count*, so
+ * it varies with the data rather than with the code. On SQLite each distinct
+ * length is its own plan text and the plan cache's LRU bound is what contains
+ * it; on Postgres the whole list binds to one parameter, and `planKey` asks the
+ * dialect so that one entry serves every length rather than one per parent
+ * count. No second mechanism either way.
  */
 function childQuery(
   node: unknown,
@@ -881,10 +947,57 @@ function index(
 
 /**
  * `Map` keys compare by identity for objects, so two `Date`s holding the same
- * instant are two different keys. Both sides of a stitch are decoded by the
- * same dialect from the same declared type, so this only has to cover the
- * decoded shapes that are objects.
+ * instant — or two `Uint8Array`s holding the same bytes — are two different
+ * keys. Both sides of a stitch are decoded by the same dialect from the same
+ * declared type, so only the decoded shapes that are objects need covering, but
+ * they need covering *exhaustively*: a key kind that falls through compares by
+ * reference, every lookup misses, and the relation silently stitches to `[]` or
+ * `null`. That is the same failure this function exists to prevent, and it is
+ * silent in the same way — hence the throw rather than a fallthrough.
  */
 function keyOf(value: unknown): unknown {
-  return value instanceof Date ? value.getTime() : value;
+  if (typeof value !== "object" || value === null) return value;
+  if (value instanceof Date) return value.getTime();
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(
+      (value as ArrayBufferView).buffer,
+      (value as ArrayBufferView).byteOffset,
+      (value as ArrayBufferView).byteLength,
+    );
+    let hex = "";
+    for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
+    return `bytes:${hex}`;
+  }
+  // Unreachable: `assertKeyable` refuses a join key whose declared type decodes
+  // to any other object at plan time, where the model and field are in scope
+  // for the message. Worth asserting rather than falling through to a reference
+  // comparison that returns empty relations.
+  throw new Error(
+    `Cannot key a relation stitch on ${Object.prototype.toString.call(value)}.`,
+  );
+}
+
+/**
+ * Refuses a join key whose values cannot be compared *by value* once decoded.
+ *
+ * Every scalar Prisma can put in a foreign key compares fine — numbers,
+ * strings, bigints, booleans — and `Date` and `Bytes` are normalised by
+ * `keyOf`. `Json` is the one that cannot be: it decodes to a fresh object per
+ * row, so the two sides of a stitch would never match and the relation would
+ * come back empty rather than wrong-looking. Prisma cannot declare such a
+ * relation, so this only fires on a hand-edited artifact — which is exactly
+ * when a clear message is worth having.
+ */
+function assertKeyable(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  key: FieldSchema,
+): void {
+  if (key.type !== "Json") return;
+  throw new MalformedRelationError(
+    schema.name,
+    relation.name,
+    `it joins on '${key.name}', a ${key.type} — which decodes to a new object ` +
+      `per row and so cannot be compared between the two sides.`,
+  );
 }

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -1,0 +1,890 @@
+import { DatabaseManager } from "../../database/DatabaseManager";
+import { app } from "../../foundation/app";
+import type { SqlDialect } from "../dialect";
+import {
+  MalformedRelationError,
+  MissingModelSchemaError,
+  RelationDepthExceededError,
+  UnknownRelationError,
+  UnregisteredRelationTargetError,
+  UnsupportedQueryError,
+} from "../errors";
+import * as registry from "../registry";
+import type { FieldSchema, ModelSchema, RelationSchema } from "../schema";
+import { concat, render, sql } from "./fragment";
+
+/**
+ * The relation planner: an include tree plus a root model in, a *strategy* out.
+ *
+ * Three strategies exist and the right one is dialect- and query-dependent
+ * (invariant 4): batched separate queries, a plain `JOIN`, and `LATERAL` +
+ * `json_agg`. This file implements exactly one — batching — but the seam is the
+ * point: iteration 7's lateral form has to be a sibling `RelationStrategy`, not
+ * a rewrite of everything that reads relations.
+ *
+ * The strategy interface is deliberately narrow: given a parent schema and one
+ * relation node, produce (a) the parent field the stitch keys on, and (b) a
+ * `load` that fetches the children and attaches them to the parent rows. What
+ * SQL that takes, and how many statements, is entirely the strategy's business.
+ */
+
+/** The keys a relation node accepts. `take` / `skip` are refused; see below. */
+const RELATION_ARGS = new Set(["where", "orderBy", "select", "include"]);
+
+/**
+ * How deep an include tree may nest. Not a modelling limit — a legal tree can
+ * be arbitrarily deep and this is far past anything hand-written — but a guard
+ * against an argument tree that was generated or forwarded from a request.
+ */
+export const MAX_RELATION_DEPTH = 10;
+
+type Row = Record<string, unknown>;
+
+/**
+ * The registry hands back model *classes*; the planner only ever needs these
+ * two statics off them. Typed structurally rather than by importing `Model`,
+ * which would make `compile/` depend on the class it is compiled for.
+ */
+interface RelatedModel {
+  $schema?: ModelSchema;
+  $exec(op: string, args: unknown): Promise<unknown>;
+}
+
+/** One relation as it appears in an `include` / `select` argument tree. */
+interface RelationNode {
+  /** The key on the parent's output object. */
+  as: string;
+  relation: RelationSchema;
+  /** `true`, or the node's own `{ where, orderBy, select, include }`. */
+  node: unknown;
+  /**
+   * Re-locates this node inside the caller's argument tree at run time. The
+   * plan is compiled once per argument *shape* and reused across calls, so the
+   * node's `where` *values* have to be read from the call, never captured here.
+   */
+  locate: (args: any) => any;
+}
+
+export interface RelationRequest {
+  parent: ModelSchema;
+  child: ModelSchema;
+  relation: RelationSchema;
+  as: string;
+  node: unknown;
+  locate: (args: any) => any;
+  dialect: SqlDialect;
+  operation: string;
+}
+
+export interface RelationPlan {
+  /** The key this relation is written to on each parent row. */
+  as: string;
+  kind: "one" | "many";
+  /**
+   * The parent *field* whose value keys the stitch. The root query must select
+   * it even when the caller's `select` did not ask for it.
+   */
+  parentField: string;
+  /** Which strategy produced this plan. Reported by tests and, later, metrics. */
+  strategy: string;
+  /** Fetches the children for these parents and attaches them in place. */
+  load(parents: Row[], args: any): Promise<void>;
+}
+
+export interface RelationStrategy {
+  readonly name: string;
+  plan(request: RelationRequest): RelationPlan;
+}
+
+export interface RelationPlanning {
+  plans: RelationPlan[];
+  /** Parent fields the root query must select for stitching to be possible. */
+  keyFields: string[];
+}
+
+export function planRelations(
+  schema: ModelSchema,
+  args: any,
+  dialect: SqlDialect,
+  operation: string,
+  strategy: RelationStrategy = batchedStrategy,
+): RelationPlanning {
+  const nodes = relationNodes(schema, args, operation);
+  if (nodes.length === 0) return { plans: [], keyFields: [] };
+
+  const plans: RelationPlan[] = [];
+  const keyFields = new Set<string>();
+
+  for (const node of nodes) {
+    assertNodeArgs(schema, node, operation);
+    const child = resolveSchema(schema, node);
+
+    // Only the first level becomes a plan here: a child query runs through
+    // `$exec` on the child's own model class, so its own include tree is
+    // compiled by its own call (invariant 1). The *whole* tree is still walked
+    // now, because the depth guard is worthless if it only ever sees one level
+    // at a time — an unbounded tree would be caught one query too late, every
+    // time, forever.
+    validateSubtree(child, node.node, operation, 2);
+
+    const plan = strategy.plan({
+      parent: schema,
+      child,
+      relation: node.relation,
+      as: node.as,
+      node: node.node,
+      locate: node.locate,
+      dialect,
+      operation,
+    });
+
+    plans.push(plan);
+    keyFields.add(plan.parentField);
+  }
+
+  return { plans, keyFields: [...keyFields] };
+}
+
+/**
+ * Runs after the parent rows are shaped: loads every relation node and drops
+ * the key columns that were only selected to make stitching possible.
+ *
+ * One query per **node in the include tree**, not per row. A depth-3 tree with
+ * two branches is 5 queries over 100 parents, not 500 — the thing everyone
+ * assumes is wrong when they first read the query log. `relations.test.ts`
+ * asserts the count, because an accidental N+1 is otherwise invisible until it
+ * is in production.
+ */
+export async function attachRelations(
+  relations: readonly RelationPlan[],
+  hidden: readonly string[] | undefined,
+  result: unknown,
+  args: any,
+): Promise<void> {
+  const parents: Row[] = Array.isArray(result)
+    ? (result as Row[])
+    : result === null || result === undefined
+      ? []
+      : [result as Row];
+
+  if (parents.length === 0) return;
+
+  // Sequentially, not `Promise.all`: sibling relations are independent queries
+  // and running them concurrently is a real win on Postgres, but iteration 5
+  // puts an ambient transaction on a single reserved connection, where
+  // concurrent statements are not safe. Parallelism belongs with iteration 7,
+  // which owns performance and can measure it.
+  for (const relation of relations) {
+    await relation.load(parents, args);
+  }
+
+  if (hidden && hidden.length > 0) {
+    // A `select` that omits the join key still has to *fetch* it. Deleting is
+    // the price of that, and it is confined to exactly this case: with no
+    // `select`, or a `select` that already names the key, `hidden` is empty and
+    // this never runs.
+    for (const parent of parents) {
+      for (const key of hidden) delete parent[key];
+    }
+  }
+}
+
+// --- the include tree ------------------------------------------------------
+
+/**
+ * Pulls the relation nodes out of an `include` or a `select`.
+ *
+ * Prisma allows relations in both, and they mean different things about the
+ * *scalars*: `include` keeps them all, `select` keeps only what it names. What
+ * they mean about relations is identical, so both funnel through here.
+ */
+function relationNodes(
+  schema: ModelSchema,
+  args: any,
+  operation: string,
+): RelationNode[] {
+  if (args === undefined || args === null) return [];
+
+  const include = args.include;
+  const select = args.select;
+
+  assertExclusive(schema, include, select, operation);
+
+  const out: RelationNode[] = [];
+
+  if (include !== undefined && include !== null) {
+    if (typeof include !== "object" || Array.isArray(include)) {
+      throw new UnsupportedQueryError(
+        "include",
+        schema.name,
+        operation,
+        "Expected an object.",
+      );
+    }
+
+    // Sorted for the same reason `where` is: the plan cache canonicalises key
+    // order, so two argument objects differing only in key order are one entry
+    // and must therefore produce one plan.
+    for (const key of Object.keys(include).sort()) {
+      const node = include[key];
+      if (node === undefined || node === false) continue;
+
+      const relation = schema.relations[key];
+      if (!relation) {
+        throw new UnknownRelationError(
+          key,
+          schema.name,
+          Object.keys(schema.relations),
+        );
+      }
+
+      out.push({
+        as: key,
+        relation,
+        node,
+        locate: (args: any) => args?.include?.[key],
+      });
+    }
+    return out;
+  }
+
+  if (select !== undefined && select !== null && typeof select === "object") {
+    for (const key of Object.keys(select).sort()) {
+      const node = (select as Record<string, unknown>)[key];
+      if (node === undefined || node === false) continue;
+
+      // A scalar key, or a typo in one — `resolveSelection` owns both, and
+      // reports a typo against the field list rather than the relation list.
+      const relation = schema.relations[key];
+      if (!relation) continue;
+
+      out.push({
+        as: key,
+        relation,
+        node,
+        locate: (args: any) => args?.select?.[key],
+      });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * `select` and `include` are mutually exclusive at *every* level, not only at
+ * the root: the result shape would be ambiguous either way.
+ */
+function assertExclusive(
+  schema: ModelSchema,
+  include: unknown,
+  select: unknown,
+  operation: string,
+  at?: string,
+): void {
+  if (include === undefined || select === undefined) return;
+  throw new UnsupportedQueryError(
+    at ? `${at}: select + include` : "select + include",
+    schema.name,
+    operation,
+    "Prisma allows only one of them on the same query, at any level.",
+  );
+}
+
+function assertNodeArgs(
+  schema: ModelSchema,
+  node: RelationNode,
+  operation: string,
+): void {
+  const value = node.node;
+  if (value === true) return;
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new UnsupportedQueryError(
+      node.as,
+      schema.name,
+      operation,
+      "Expected true or an object of relation arguments.",
+    );
+  }
+
+  const args = value as Record<string, unknown>;
+  assertExclusive(schema, args.include, args.select, operation, node.as);
+
+  for (const key of Object.keys(args).sort()) {
+    if (args[key] === undefined) continue;
+    if (RELATION_ARGS.has(key)) continue;
+
+    // The decision recorded in the PR: `take` / `skip` on a to-many relation
+    // throw rather than being implemented under the batched strategy.
+    //
+    // `include: { accounts: { take: 5 } }` means five accounts *per user*, not
+    // five overall. Under batching, one query serves every parent, so a
+    // per-parent limit needs `row_number() over (partition by ...)` wrapped in
+    // a subquery — which cannot be expressed through `$exec` on the child's own
+    // model class, and so would need exactly the private query path invariant 1
+    // exists to prevent. It falls out for free from iteration 7's lateral
+    // strategy. The alternative — applying the limit globally — silently
+    // returns wrong data, which is worse than not supporting it.
+    if (key === "take" || key === "skip") {
+      throw new UnsupportedQueryError(
+        `${node.as}.${key}`,
+        schema.name,
+        operation,
+        node.relation.kind === "many"
+          ? `A '${key}' inside a to-many relation is per parent, which the ` +
+            `batched relation planner cannot express. It arrives with the ` +
+            `lateral join strategy; until then, load '${node.as}' as its own ` +
+            `query, or narrow it with 'where'.`
+          : `Prisma does not accept '${key}' on a to-one relation.`,
+      );
+    }
+
+    throw new UnsupportedQueryError(`${node.as}.${key}`, schema.name, operation);
+  }
+}
+
+/** Walks the rest of the tree for the structural rules and the depth guard. */
+function validateSubtree(
+  schema: ModelSchema,
+  node: unknown,
+  operation: string,
+  depth: number,
+): void {
+  if (typeof node !== "object" || node === null || Array.isArray(node)) return;
+
+  const nodes = relationNodes(schema, node, operation);
+  if (nodes.length === 0) return;
+
+  if (depth > MAX_RELATION_DEPTH) {
+    throw new RelationDepthExceededError(schema.name, MAX_RELATION_DEPTH);
+  }
+
+  for (const child of nodes) {
+    assertNodeArgs(schema, child, operation);
+    validateSubtree(
+      resolveSchema(schema, child),
+      child.node,
+      operation,
+      depth + 1,
+    );
+  }
+}
+
+// --- topology --------------------------------------------------------------
+
+interface Link {
+  /** Field on the parent whose value the child is matched against. */
+  parentField: string;
+  /** Field on the child holding the matching value. */
+  childField: string;
+  /** Set for Prisma's implicit many-to-many, which joins through a table. */
+  join?: { table: string; parentColumn: string; childColumn: string };
+}
+
+/**
+ * Which fields on which side actually connect.
+ *
+ * Only the *owning* side of a relation carries `from` / `to`; the other side
+ * carries empty arrays and has to find its counterpart through the shared
+ * `relationName`. That is the whole reason `relationName` is in the emitted
+ * artifact.
+ */
+function resolveLink(
+  parent: ModelSchema,
+  child: ModelSchema,
+  relation: RelationSchema,
+): Link {
+  if (relation.joinTable) return joinTableLink(parent, child, relation);
+
+  if (relation.from.length > 0) {
+    return {
+      parentField: single(parent, relation, relation.from, "from"),
+      childField: single(parent, relation, relation.to, "to"),
+    };
+  }
+
+  const other = otherSide(parent, child, relation);
+  if (other.from.length === 0) {
+    throw new MalformedRelationError(
+      parent.name,
+      relation.name,
+      `neither ${parent.name}.${relation.name} nor ${child.name}.${other.name} ` +
+        `holds the foreign key.`,
+    );
+  }
+
+  return {
+    parentField: single(parent, relation, other.to, "to"),
+    childField: single(parent, relation, other.from, "from"),
+  };
+}
+
+/** The far end of the relation, found by the name both sides share. */
+function otherSide(
+  parent: ModelSchema,
+  child: ModelSchema,
+  relation: RelationSchema,
+): RelationSchema {
+  const candidates = Object.values(child.relations).filter(
+    (candidate) =>
+      candidate.relationName === relation.relationName &&
+      // A self-relation names the same model on both ends, so the *field* is
+      // what distinguishes them.
+      !(child.name === parent.name && candidate.name === relation.name),
+  );
+
+  if (candidates.length !== 1) {
+    throw new MalformedRelationError(
+      parent.name,
+      relation.name,
+      candidates.length === 0
+        ? `${child.name} declares no relation named '${relation.relationName}'.`
+        : `${child.name} declares ${candidates.length} relations named ` +
+          `'${relation.relationName}'.`,
+    );
+  }
+
+  return candidates[0];
+}
+
+/**
+ * Multi-field relations (`@relation(fields: [a, b], references: [c, d])`) would
+ * need a row-value `in`, which the two dialects spell differently and neither
+ * indexes well. Refused rather than quietly matching on the first field.
+ */
+function single(
+  parent: ModelSchema,
+  relation: RelationSchema,
+  fields: string[],
+  side: string,
+): string {
+  if (fields.length !== 1) {
+    throw new UnsupportedQueryError(
+      relation.name,
+      parent.name,
+      "include",
+      `${relation.name} joins on ${fields.length} fields (${side}: ` +
+        `${fields.join(", ") || "none"}). Multi-field relations are not ` +
+        `implemented yet.`,
+    );
+  }
+  return fields[0];
+}
+
+/**
+ * Prisma's implicit many-to-many has no join *model*: it is a bare
+ * `_RelationName` table with an `A` and a `B` column, each holding one side's
+ * id, ordered by the two model names alphabetically.
+ */
+function joinTableLink(
+  parent: ModelSchema,
+  child: ModelSchema,
+  relation: RelationSchema,
+): Link {
+  const { table, a, b } = relation.joinTable!;
+
+  if (a === b) {
+    // A self-referential implicit m-n puts the same model on both ends, so the
+    // emitted record cannot say which column is which — Prisma disambiguates by
+    // field order, which the artifact does not carry. Refusing is honest;
+    // guessing would silently reverse the relation.
+    throw new UnsupportedQueryError(
+      relation.name,
+      parent.name,
+      "include",
+      `${relation.name} is a self-referential implicit many-to-many. The ` +
+        `generated artifact cannot say which of the join table's two columns ` +
+        `is which end, so it is not implemented yet.`,
+    );
+  }
+
+  if (parent.name !== a && parent.name !== b) {
+    throw new MalformedRelationError(
+      parent.name,
+      relation.name,
+      `the join table '${table}' connects ${a} and ${b}, neither of which is ` +
+        `${parent.name}.`,
+    );
+  }
+
+  const parentColumn = parent.name === a ? "A" : "B";
+
+  return {
+    parentField: primaryKey(parent, relation),
+    childField: primaryKey(child, relation),
+    join: {
+      table,
+      parentColumn,
+      childColumn: parentColumn === "A" ? "B" : "A",
+    },
+  };
+}
+
+function primaryKey(schema: ModelSchema, relation: RelationSchema): string {
+  if (schema.primaryKey.length !== 1) {
+    throw new MalformedRelationError(
+      schema.name,
+      relation.name,
+      `an implicit many-to-many joins on ${schema.name}'s primary key, which ` +
+        `has ${schema.primaryKey.length} fields.`,
+    );
+  }
+  return schema.primaryKey[0];
+}
+
+function field(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  name: string,
+): FieldSchema {
+  const found = schema.fields[name];
+  if (!found) {
+    throw new MalformedRelationError(
+      schema.name,
+      relation.name,
+      `it joins on '${name}', which is not a field on ${schema.name}.`,
+    );
+  }
+  return found;
+}
+
+function resolveSchema(parent: ModelSchema, node: RelationNode): ModelSchema {
+  const target = node.relation.model;
+
+  // Resolved by name at call time, never by import at module load: that is what
+  // lets two models reference each other without the generated files forming an
+  // import cycle (invariant 6).
+  if (!registry.has(target)) {
+    throw new UnregisteredRelationTargetError(
+      parent.name,
+      node.as,
+      target,
+      registry.registeredNames(),
+    );
+  }
+
+  const schema = registry.get<RelatedModel>(target)?.$schema;
+  if (!schema) throw new MissingModelSchemaError(target);
+  return schema;
+}
+
+// --- the batched strategy --------------------------------------------------
+
+/**
+ * One query per relation node: collect the parents' key values, fetch every
+ * child in a single `where <key> in (<parent keys>)`, stitch by key.
+ *
+ * SQLite is in-process, so round trips are nearly free and this is close to
+ * optimal there. Postgres over a network is RTT-dominated and the lateral form
+ * will beat it; that is iteration 7, and it plugs in here.
+ */
+const BATCHED = "batched";
+
+export const batchedStrategy: RelationStrategy = {
+  name: BATCHED,
+
+  plan(request: RelationRequest): RelationPlan {
+    const link = resolveLink(request.parent, request.child, request.relation);
+
+    // Resolved at plan time so a stale artifact fails when the query is
+    // compiled rather than after the root query has already run.
+    const parentKeyField = field(request.parent, request.relation, link.parentField);
+    const childKeyField = field(request.child, request.relation, link.childField);
+
+    const many = request.relation.kind === "many";
+
+    return {
+      as: request.as,
+      kind: request.relation.kind,
+      parentField: link.parentField,
+      strategy: BATCHED,
+      load(parents, args) {
+        return link.join
+          ? loadThroughJoinTable(request, link, {
+              parentKeyField,
+              childKeyField,
+              many,
+              parents,
+              args,
+            })
+          : loadDirect(request, link, {
+              parentKeyField,
+              childKeyField,
+              many,
+              parents,
+              args,
+            });
+      },
+    };
+  },
+};
+
+interface LoadContext {
+  parentKeyField: FieldSchema;
+  childKeyField: FieldSchema;
+  many: boolean;
+  parents: Row[];
+  args: any;
+}
+
+async function loadDirect(
+  request: RelationRequest,
+  link: Link,
+  context: LoadContext,
+): Promise<void> {
+  const { keys, byKey } = index(context.parents, link.parentField);
+  // Every parent's key is null: nothing can match, and the defaults the shaper
+  // already wrote (`null` / `[]`) are the answer.
+  if (keys.length === 0) return;
+
+  const node = request.locate(context.args);
+  const query = childQuery(node, link.childField, keys);
+
+  const rows = (await childModel(request).$exec(
+    "findMany",
+    query.args,
+  )) as Row[];
+
+  for (const row of rows) {
+    const bucket = byKey.get(keyOf(row[link.childField]));
+    if (!bucket) continue;
+    for (const parent of bucket) attach(parent, request.as, row, context.many);
+  }
+
+  if (query.hidden) {
+    for (const row of rows) delete row[link.childField];
+  }
+}
+
+/**
+ * Implicit many-to-many, in two hops: read the pairs out of the join table,
+ * then load the children the pairs name.
+ *
+ * The first hop is the one place in the ORM that issues SQL outside
+ * `Model.$exec`, and it is deliberate rather than a shortcut: `_PostToTag` has
+ * no model, no fields of its own and nothing an application could scope — it
+ * holds two foreign keys. The hop that reads *rows* still goes through `$exec`
+ * on the child's own model class, so a policy on `Tag` applies to
+ * `include: { tags: true }` exactly as it would to `Tag.findMany`.
+ */
+async function loadThroughJoinTable(
+  request: RelationRequest,
+  link: Link,
+  context: LoadContext,
+): Promise<void> {
+  const { keys, byKey } = index(context.parents, link.parentField);
+  if (keys.length === 0) return;
+
+  const { dialect } = request;
+  const join = link.join!;
+
+  const pairs = (await readPairs(
+    dialect,
+    join,
+    keys.map((key) => dialect.encode(key, context.parentKeyField)),
+  )) as Row[];
+
+  // Parents keyed by the *child* id they link to, so the second hop can stitch
+  // in one pass over its rows. Built once, not searched per row.
+  const owners = new Map<unknown, Row[]>();
+  const childKeys: unknown[] = [];
+
+  for (const pair of pairs) {
+    const parentKey = keyOf(
+      dialect.decode(pair[join.parentColumn], context.parentKeyField),
+    );
+    const linked = byKey.get(parentKey);
+    if (!linked) continue;
+
+    const childValue = dialect.decode(
+      pair[join.childColumn],
+      context.childKeyField,
+    );
+    const childKey = keyOf(childValue);
+
+    let bucket = owners.get(childKey);
+    if (bucket === undefined) {
+      bucket = [];
+      owners.set(childKey, bucket);
+      childKeys.push(childValue);
+    }
+    for (const parent of linked) bucket.push(parent);
+  }
+
+  if (childKeys.length === 0) return;
+
+  const node = request.locate(context.args);
+  const query = childQuery(node, link.childField, childKeys);
+
+  const rows = (await childModel(request).$exec(
+    "findMany",
+    query.args,
+  )) as Row[];
+
+  // Iterated in the child query's order rather than the pairs' order, so a
+  // relation-level `orderBy` still describes what each parent receives.
+  for (const row of rows) {
+    const bucket = owners.get(keyOf(row[link.childField]));
+    if (!bucket) continue;
+    for (const parent of bucket) attach(parent, request.as, row, context.many);
+  }
+
+  if (query.hidden) {
+    for (const row of rows) delete row[link.childField];
+  }
+}
+
+/**
+ * `select <A>, <B> from <_Relation> where <parent column> in (...)`.
+ *
+ * Built through the same `Fragment` machinery as everything else, so the two
+ * compiler rules still hold: the identifiers come from the generated schema and
+ * every value is a bound parameter. It is assembled per call rather than per
+ * plan only because the number of parents — and so the number of placeholders
+ * on SQLite — is not known until the parents are in hand.
+ */
+async function readPairs(
+  dialect: SqlDialect,
+  join: NonNullable<Link["join"]>,
+  values: unknown[],
+): Promise<unknown> {
+  const statement = concat(
+    sql(
+      `select ${dialect.quoteIdent(join.parentColumn)}, ` +
+        `${dialect.quoteIdent(join.childColumn)} ` +
+        `from ${dialect.quoteIdent(join.table)} where `,
+    ),
+    dialect.inList(
+      dialect.quoteIdent(join.parentColumn),
+      false,
+      values.length,
+      () => values,
+    ),
+  );
+
+  const { text, binders } = render(statement, dialect);
+  const db = app(DatabaseManager);
+  return db.sql.unsafe(
+    text,
+    binders.map((binder) => binder(undefined)),
+  );
+}
+
+function childModel(request: RelationRequest): RelatedModel {
+  // Resolved here, not at plan time, so the plan cache never holds a class
+  // reference and a re-registered model is picked up (invariant 6). The child
+  // query is `$exec` on the child's own class — the choke point, so policies,
+  // ambient transactions and the plan cache all apply to a nested read exactly
+  // as they do to a top-level one (invariant 1).
+  return registry.get<RelatedModel>(request.relation.model);
+}
+
+/**
+ * The child query's arguments: the caller's own relation arguments, plus the
+ * key filter, plus the key itself when a `select` left it out.
+ *
+ * The `in (<parent keys>)` list has the plan-cache problem iteration 2 already
+ * has for `in`, at higher volume: on SQLite each distinct parent count is its
+ * own plan text. It is the same mechanism and the same answer — the plan
+ * cache's LRU bound — rather than a second one.
+ */
+function childQuery(
+  node: unknown,
+  childField: string,
+  keys: unknown[],
+): { args: Record<string, unknown>; hidden: boolean } {
+  const relationArgs = (
+    node === true || node === null || typeof node !== "object" ? {} : node
+  ) as Record<string, unknown>;
+
+  const filter = { [childField]: { in: keys } };
+  const args: Record<string, unknown> = {
+    where:
+      relationArgs.where === undefined
+        ? filter
+        : { AND: [relationArgs.where, filter] },
+  };
+
+  if (relationArgs.orderBy !== undefined) args.orderBy = relationArgs.orderBy;
+  if (relationArgs.include !== undefined) args.include = relationArgs.include;
+
+  const select = relationArgs.select as Record<string, unknown> | undefined;
+  if (select === undefined) return { args, hidden: false };
+
+  if (select[childField] === true) {
+    args.select = select;
+    return { args, hidden: false };
+  }
+
+  // The stitch key has to come back even when the caller did not ask for it.
+  // `attachRelations`' counterpart on the parent side deletes it again.
+  args.select = { ...select, [childField]: true };
+  return { args, hidden: true };
+}
+
+/**
+ * Note that a child row reached by more than one parent is attached to each of
+ * them **by reference** — a hundred users in three organizations get three
+ * organization objects between them, not a hundred. Prisma builds one object
+ * per parent, so this is a deliberate divergence in *identity*: the values are
+ * identical and the differential harness sees no difference, but mutating
+ * `users[0].organization` would be visible through `users[1].organization`.
+ *
+ * The alternative is a clone per extra parent, which on a wide to-one include
+ * is exactly the copying the batched strategy exists to avoid — and a shallow
+ * clone would still alias everything below it, so it would buy less than it
+ * looks. Worth revisiting in iteration 8, where row provenance gives a reason
+ * to care about identity.
+ */
+function attach(parent: Row, as: string, row: Row, many: boolean): void {
+  if (many) {
+    (parent[as] as Row[]).push(row);
+    return;
+  }
+  // The shaper wrote `null`; the first match wins. A to-one cannot legitimately
+  // have two matches, and taking the first is what Prisma does with one.
+  if (parent[as] === null) parent[as] = row;
+}
+
+/**
+ * Parents grouped by their key value, built once per child query. The stitch is
+ * then one pass over the child rows — never a `find()` per row, which is the
+ * quadratic shape this is here to avoid on wide results.
+ */
+function index(
+  parents: Row[],
+  on: string,
+): { keys: unknown[]; byKey: Map<unknown, Row[]> } {
+  const byKey = new Map<unknown, Row[]>();
+  const keys: unknown[] = [];
+
+  for (const parent of parents) {
+    const value = parent[on];
+    // A null foreign key matches nothing — `in` would not match it either —
+    // and the shaper has already written the `null` the caller sees.
+    if (value === null || value === undefined) continue;
+
+    const key = keyOf(value);
+    let bucket = byKey.get(key);
+    if (bucket === undefined) {
+      bucket = [];
+      byKey.set(key, bucket);
+      // The raw value, not the map key: this is what gets bound into the `in`
+      // list, and the dialect's encoder expects the value Prisma would hold.
+      keys.push(value);
+    }
+    bucket.push(parent);
+  }
+
+  return { keys, byKey };
+}
+
+/**
+ * `Map` keys compare by identity for objects, so two `Date`s holding the same
+ * instant are two different keys. Both sides of a stitch are decoded by the
+ * same dialect from the same declared type, so this only has to cover the
+ * decoded shapes that are objects.
+ */
+function keyOf(value: unknown): unknown {
+  return value instanceof Date ? value.getTime() : value;
+}

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -280,9 +280,13 @@ describe("select", () => {
     );
   });
 
-  test("rejects a relation until iteration 3", () => {
+  // Relations inside a `select` are relation nodes, not columns, and they need
+  // the registry — so they live in relations.test.ts next to the planner. What
+  // belongs here is that this file's `text()` helper, which registers nothing,
+  // still reports the reason legibly rather than crashing somewhere downstream.
+  test("a relation in a select needs the registry", () => {
     expect(() => text({ select: { accounts: true } })).toThrow(
-      /'select\.accounts'/,
+      /nothing has registered/,
     );
   });
 
@@ -438,7 +442,10 @@ describe("postgres", () => {
     const args = { where: { id: { in: [1, 2, 3] } } };
     const plan = compileRead(user, "findMany", args, postgres);
     expect(plan.text).toBe(`${SELECT_USER} where "id" = any ($1)`);
-    expect(plan.bind(args)).toEqual([[1, 2, 3]]);
+    // A Postgres array *literal*, not a JS array: Bun's driver refuses an array
+    // bound to `= any($1)`. Still exactly one parameter, and still nothing in
+    // the text.
+    expect(plan.bind(args)).toEqual([`{"1","2","3"}`]);
 
     // ...and the text does not change with the length.
     expect(
@@ -472,12 +479,6 @@ describe("unimplemented arguments still throw", () => {
   ])("%s", (argument, args) => {
     expect(() => text(args)).toThrow(
       `gemi ORM does not support '${argument}' yet (User.findMany).`,
-    );
-  });
-
-  test("include names relations specifically", () => {
-    expect(() => text({ include: { accounts: true } })).toThrow(
-      /Relations are not implemented yet/,
     );
   });
 

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -1,10 +1,11 @@
 import type { SqlDialect } from "../dialect";
 import { UnsupportedQueryError } from "../errors";
 import type { Operation, QueryPlan } from "../plan";
-import type { ModelSchema } from "../schema";
+import type { FieldSchema, ModelSchema } from "../schema";
 import { buildRowShaper } from "../shape";
 import { type Binder, type Fragment, concat, joinFragments, render, sql } from "./fragment";
 import { compileOrderBy, parseOrderBy, reverse, type OrderTerm } from "./orderBy";
+import { planRelations } from "./plan-relations";
 import { resolveSelection } from "./select";
 import { compileWhere } from "./where";
 
@@ -106,7 +107,10 @@ export function compileRead(
     };
   }
 
-  const fields = resolveSelection(schema, args, op);
+  const selection = resolveSelection(schema, args, op);
+  const { plans, keyFields } = planRelations(schema, args, dialect, op);
+  const { fields, hidden } = withKeyFields(schema, selection, keyFields);
+
   const columns = joinFragments(
     fields.map((field) => sql(dialect.quoteIdent(field.column))),
     ", ",
@@ -135,12 +139,18 @@ export function compileRead(
   );
 
   const { text, binders } = render(statement, dialect);
-  const shaper = buildRowShaper(fields, dialect);
+  const shaper = buildRowShaper(
+    fields,
+    dialect,
+    plans.map((plan) => ({ key: plan.as, kind: plan.kind })),
+  );
   const single = SINGLE_ROW.has(op);
 
   return {
     text,
     bind: binder(binders),
+    relations: plans.length > 0 ? plans : undefined,
+    hidden,
     shape(rows) {
       const shaped = shaper(rows);
       // A negative `take` means "the last N". The ordering terms were flipped
@@ -154,6 +164,39 @@ export function compileRead(
       // where the model's name is in scope for the message.
       return single ? (shaped[0] ?? null) : shaped;
     },
+  };
+}
+
+/**
+ * Adds the columns the relation planner needs to stitch on, and reports which
+ * of them the caller did not ask for.
+ *
+ * `select: { name: true, accounts: true }` returns `{ name, accounts }` — no
+ * `id` — but the accounts cannot be found without `User.id`. So it is selected,
+ * shaped, used, and then deleted (see `attachRelations`). Under an `include`,
+ * or a `select` that names the key itself, nothing is hidden and nothing is
+ * deleted.
+ */
+function withKeyFields(
+  schema: ModelSchema,
+  selection: FieldSchema[],
+  keyFields: string[],
+): { fields: FieldSchema[]; hidden?: string[] } {
+  if (keyFields.length === 0) return { fields: selection };
+
+  const present = new Set(selection.map((field) => field.name));
+  const missing = keyFields.filter((name) => !present.has(name));
+  if (missing.length === 0) return { fields: selection };
+
+  const wanted = new Set([...present, ...missing]);
+  return {
+    // Rebuilt in schema order rather than appended, so the emitted column list
+    // depends only on *which* fields are selected and never on how they were
+    // reached.
+    fields: Object.values(schema.fields).filter((field) =>
+      wanted.has(field.name),
+    ),
+    hidden: missing,
   };
 }
 
@@ -245,16 +288,6 @@ function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
     if (args[key] === undefined) continue;
     if (!allowed.has(key)) {
       throw new UnsupportedQueryError(key, schema.name, op);
-    }
-    // `include` is in the accepted set so it reaches this specific message
-    // rather than being reported as if it were a typo.
-    if (key === "include") {
-      throw new UnsupportedQueryError(
-        "include",
-        schema.name,
-        op,
-        "Relations are not implemented yet.",
-      );
     }
   }
 }

--- a/packages/gemi/orm/compile/relations.test.ts
+++ b/packages/gemi/orm/compile/relations.test.ts
@@ -3,12 +3,13 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { SqliteDialect } from "../dialect/sqlite";
 import {
   RelationDepthExceededError,
+  UnknownFieldError,
   UnknownRelationError,
   UnregisteredRelationTargetError,
   UnsupportedQueryError,
 } from "../errors";
 import { account, organization, post, tag, user } from "../fixtures";
-import { clearRegistry, register } from "../registry";
+import { clearRegistry, get, register } from "../registry";
 import type { ModelSchema } from "../schema";
 import { attachRelations } from "./plan-relations";
 import { compileRead } from "./read";
@@ -40,12 +41,24 @@ function matches(row: Row, where: any): boolean {
       continue;
     }
     if (value !== null && typeof value === "object" && "in" in (value as any)) {
-      if (!(value as any).in.includes(row[key])) return false;
+      const wanted = (value as any).in.map(compare);
+      if (!wanted.includes(compare(row[key]))) return false;
       continue;
     }
-    if (row[key] !== value) return false;
+    if (compare(row[key]) !== compare(value)) return false;
   }
   return true;
+}
+
+/**
+ * A real database compares a `Bytes` column by value; `Array.includes` compares
+ * two `Uint8Array`s by reference. Without this the stand-in would find nothing
+ * for a bytes key and the test would pass or fail for the wrong reason.
+ */
+function compare(value: unknown): unknown {
+  return ArrayBuffer.isView(value)
+    ? `bytes:${[...(value as Uint8Array)].join(",")}`
+    : value;
 }
 
 function project(row: Row, select: any): Row {
@@ -84,11 +97,28 @@ function registerAll() {
   return models;
 }
 
+/**
+ * The executor `Model.$exec` would have handed in, built from the same registry
+ * so that spying on a fake model's `$exec` still observes the relation query.
+ * `query` is only reached by the implicit m-n join hop.
+ */
+function executor(pairs: Row[] = []) {
+  return {
+    exec: (model: string, op: string, args: unknown) =>
+      registryGet(model).$exec(op, args),
+    query: vi.fn(async (_text: string, _values: unknown[]) => pairs),
+  };
+}
+
+function registryGet(name: string) {
+  return get<{ $exec: (op: string, args: unknown) => Promise<unknown> }>(name);
+}
+
 /** Compile, shape driver rows, load relations — the whole read path but the SQL. */
 async function read(args: any, rows: Row[] = USER_ROWS) {
   const plan = compileRead(user, "findMany", args, sqlite);
   const shaped = plan.shape(rows);
-  await attachRelations(plan.relations!, plan.hidden, shaped, args);
+  await attachRelations(plan.relations!, plan.hidden, shaped, args, executor());
   return shaped as Row[];
 }
 
@@ -373,6 +403,49 @@ describe("rejected arguments", () => {
     );
   });
 
+  // Verified against Prisma rather than reasoned about: it rejects `orderBy` on
+  // a to-one include — `Unknown argument 'orderBy'`, listing `where?` as one of
+  // the options it does take — and accepts `where`, which filters and leaves
+  // the relation `null` when nothing matches. Both halves matter: gating
+  // `where` too would refuse a query Prisma runs.
+  test("orderBy is refused on a to-one and accepted on a to-many", () => {
+    registerAll();
+    expect(() =>
+      compile({ include: { organization: { orderBy: { id: "asc" } } } }),
+    ).toThrow(/does not accept 'orderBy' on a to-one relation/);
+    expect(() =>
+      compile({ include: { accounts: { orderBy: { id: "asc" } } } }),
+    ).not.toThrow();
+  });
+
+  test("where is accepted on both kinds", () => {
+    registerAll();
+    expect(() =>
+      compile({ include: { organization: { where: { name: "Acme" } } } }),
+    ).not.toThrow();
+    expect(() =>
+      compile({ include: { accounts: { where: { organizationRole: 0 } } } }),
+    ).not.toThrow();
+  });
+
+  // The depth walk exists because a guard that sees one level at a time catches
+  // things a query too late. A misspelled column is one of those things.
+  test("a misspelled field deep in the tree is caught at root compile", () => {
+    registerAll();
+    expect(() =>
+      compile({
+        include: {
+          accounts: { include: { user: { select: { emial: true } } } },
+        },
+      }),
+    ).toThrow(UnknownFieldError);
+    expect(() =>
+      compile({
+        include: { accounts: { select: { organizationRole: true } } },
+      }),
+    ).not.toThrow();
+  });
+
   test("an unknown relation argument is named precisely", () => {
     registerAll();
     expect(() => compile({ include: { accounts: { cursor: {} } } })).toThrow(
@@ -437,6 +510,69 @@ describe("guards", () => {
   });
 });
 
+// Both sides of a stitch are decoded from the same declared type, so the only
+// question is whether that decoded shape compares by value. Anything that does
+// not, and is not normalised, silently produces empty relations rather than
+// wrong ones — the quietest failure in the file.
+describe("join keys that are not plain scalars", () => {
+  /** `Bytes` on both sides: distinct Uint8Arrays holding the same bytes. */
+  function bytesPair() {
+    const owner: ModelSchema = {
+      name: "Blob",
+      table: "Blob",
+      fields: {
+        id: { name: "id", column: "id", type: "Bytes", nullable: false, isId: true, isUpdatedAt: false },
+      },
+      primaryKey: ["id"],
+      uniques: [],
+      relations: {
+        chunks: { name: "chunks", model: "Chunk", kind: "many", relationName: "BlobToChunk", from: [], to: [], nullable: false },
+      },
+    };
+    const child: ModelSchema = {
+      name: "Chunk",
+      table: "Chunk",
+      fields: {
+        id: { name: "id", column: "id", type: "Int", nullable: false, isId: true, isUpdatedAt: false },
+        blobId: { name: "blobId", column: "blobId", type: "Bytes", nullable: false, isId: false, isUpdatedAt: false },
+      },
+      primaryKey: ["id"],
+      uniques: [],
+      relations: {
+        blob: { name: "blob", model: "Blob", kind: "one", relationName: "BlobToChunk", from: ["blobId"], to: ["id"], nullable: false },
+      },
+    };
+    return { owner, child };
+  }
+
+  test("a Bytes key stitches by value, not by reference", async () => {
+    const { owner, child } = bytesPair();
+    register("Blob", fake(owner, []));
+    register("Chunk", fake(child, [
+      // A *different* Uint8Array holding the same bytes as the parent's id,
+      // which is what comes back from a second query.
+      { id: 1, blobId: new Uint8Array([1, 2, 3]) },
+    ]));
+
+    const plan = compileRead(owner, "findMany", { include: { chunks: true } }, sqlite);
+    const rows = plan.shape([{ id: new Uint8Array([1, 2, 3]) }]) as Row[];
+    await attachRelations(plan.relations!, plan.hidden, rows, {}, executor());
+
+    expect(rows[0].chunks).toHaveLength(1);
+  });
+
+  test("a Json key is refused at compile, naming the field", () => {
+    const { owner, child } = bytesPair();
+    const json = { ...owner, fields: { id: { ...owner.fields.id, type: "Json" as const } } };
+    register("Blob", fake(json, []));
+    register("Chunk", fake(child, []));
+
+    expect(() =>
+      compileRead(json, "findMany", { include: { chunks: true } }, sqlite),
+    ).toThrow(/joins on 'id', a Json/);
+  });
+});
+
 describe("implicit many-to-many", () => {
   test("plans a two-hop join through the _Relation table", () => {
     register("Post", fake(post, []));
@@ -450,6 +586,50 @@ describe("implicit many-to-many", () => {
       parentField: "id",
     });
     expect(plan.text).toBe('select "id", "title" from "Post"');
+  });
+
+  // The join table has no model, so its hop is the executor's `query` rather
+  // than an `$exec` — which is exactly what makes it observable here.
+  test("reads the pairs, then the rows, and stitches through both", async () => {
+    register("Post", fake(post, []));
+    const tags = fake(tag, [
+      { id: 1, label: "red" },
+      { id: 2, label: "blue" },
+    ]);
+    register("Tag", tags);
+
+    const plan = compileRead(post, "findMany", { include: { tags: true } }, sqlite);
+    const rows = plan.shape([
+      { id: 1, title: "first" },
+      { id: 2, title: "second" },
+      { id: 3, title: "untagged" },
+    ]) as Row[];
+
+    const run = executor([
+      { A: 1, B: 1 },
+      { A: 1, B: 2 },
+      { A: 2, B: 2 },
+    ]);
+    await attachRelations(plan.relations!, plan.hidden, rows, {}, run);
+
+    // Parent ids go into the `A` side and come back as `B`s...
+    expect(run.query).toHaveBeenCalledTimes(1);
+    expect(run.query.mock.calls[0][0]).toBe(
+      `select "A", "B" from "_PostToTag" where "A" in (?, ?, ?)`,
+    );
+    expect(run.query.mock.calls[0][1]).toEqual([1, 2, 3]);
+
+    // ...and only the tags those pairs name are fetched, once.
+    expect(tags.$exec).toHaveBeenCalledTimes(1);
+    expect(tags.$exec).toHaveBeenCalledWith("findMany", {
+      where: { id: { in: [1, 2] } },
+    });
+
+    expect(rows.map((row) => (row.tags as Row[]).map((t) => t.label))).toEqual([
+      ["red", "blue"],
+      ["blue"],
+      [],
+    ]);
   });
 
   test("refuses a self-referential implicit m-n rather than guessing", () => {

--- a/packages/gemi/orm/compile/relations.test.ts
+++ b/packages/gemi/orm/compile/relations.test.ts
@@ -1,0 +1,477 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { SqliteDialect } from "../dialect/sqlite";
+import {
+  RelationDepthExceededError,
+  UnknownRelationError,
+  UnregisteredRelationTargetError,
+  UnsupportedQueryError,
+} from "../errors";
+import { account, organization, post, tag, user } from "../fixtures";
+import { clearRegistry, register } from "../registry";
+import type { ModelSchema } from "../schema";
+import { attachRelations } from "./plan-relations";
+import { compileRead } from "./read";
+
+const sqlite = new SqliteDialect();
+
+// The batched strategy's own queries are `$exec` calls on the related model's
+// class, and `$exec` is where the database is. So the whole planner — planning,
+// batching, stitching, key hiding — is testable with no database at all, by
+// registering model classes whose `$exec` reads an array. Which is also the
+// assertion iteration 6 depends on: if a relation were loaded through a private
+// helper instead, none of this would be reachable.
+type Row = Record<string, unknown>;
+
+function fake(schema: ModelSchema, table: Row[]) {
+  return class {
+    static $schema = schema;
+    static $exec = vi.fn(async (_op: string, args: any) =>
+      table.filter((row) => matches(row, args?.where)).map((row) => project(row, args?.select)),
+    );
+  };
+}
+
+function matches(row: Row, where: any): boolean {
+  if (!where) return true;
+  for (const [key, value] of Object.entries(where)) {
+    if (key === "AND") {
+      if (!(value as any[]).every((part) => matches(row, part))) return false;
+      continue;
+    }
+    if (value !== null && typeof value === "object" && "in" in (value as any)) {
+      if (!(value as any).in.includes(row[key])) return false;
+      continue;
+    }
+    if (row[key] !== value) return false;
+  }
+  return true;
+}
+
+function project(row: Row, select: any): Row {
+  if (!select) return { ...row };
+  const out: Row = {};
+  for (const [key, wanted] of Object.entries(select)) {
+    if (wanted === true) out[key] = row[key];
+  }
+  return out;
+}
+
+const ACCOUNTS: Row[] = [
+  { id: 10, publicId: "a10", organizationId: 1, organizationRole: 0, userId: 1, createdAt: null, updatedAt: null, deletedAt: null },
+  { id: 11, publicId: "a11", organizationId: 1, organizationRole: 2, userId: 1, createdAt: null, updatedAt: null, deletedAt: null },
+  { id: 12, publicId: "a12", organizationId: null, organizationRole: 2, userId: 2, createdAt: null, updatedAt: null, deletedAt: null },
+];
+
+const ORGANIZATIONS: Row[] = [
+  { id: 1, publicId: "o1", name: "Acme", logoUrl: null, description: null },
+];
+
+// Driver rows, keyed by *column* name — what `plan.shape` is handed.
+const USER_ROWS: Row[] = [
+  { id: 1, publicId: "p1", name: "Ada", email: "ada@x.dev", emailVerifiedAt: null, verificationToken: null, locale: null, globalRole: 0, password: null, organizationId: 1, createdAt: 0, updatedAt: 0, deletedAt: null },
+  { id: 2, publicId: "p2", name: "Grace", email: null, emailVerifiedAt: null, verificationToken: null, locale: null, globalRole: 2, password: null, organizationId: null, createdAt: 0, updatedAt: 0, deletedAt: null },
+  { id: 3, publicId: "p3", name: "Nobody", email: null, emailVerifiedAt: null, verificationToken: null, locale: null, globalRole: 2, password: null, organizationId: 1, createdAt: 0, updatedAt: 0, deletedAt: null },
+];
+
+function registerAll() {
+  const models = {
+    Account: fake(account, ACCOUNTS),
+    Organization: fake(organization, ORGANIZATIONS),
+    User: fake(user, []),
+  };
+  for (const [name, model] of Object.entries(models)) register(name, model);
+  return models;
+}
+
+/** Compile, shape driver rows, load relations — the whole read path but the SQL. */
+async function read(args: any, rows: Row[] = USER_ROWS) {
+  const plan = compileRead(user, "findMany", args, sqlite);
+  const shaped = plan.shape(rows);
+  await attachRelations(plan.relations!, plan.hidden, shaped, args);
+  return shaped as Row[];
+}
+
+function compile(args: any, op: any = "findMany") {
+  return compileRead(user, op, args, sqlite);
+}
+
+afterEach(() => {
+  clearRegistry();
+  vi.restoreAllMocks();
+});
+
+describe("planning", () => {
+  test("an include adds no SQL of its own", () => {
+    registerAll();
+    const plan = compile({ include: { accounts: true } });
+
+    // The root query is exactly the query it would have been without the
+    // include. That is the batched strategy: relations cost queries, not joins.
+    expect(plan.text).toBe(compile({}).text);
+    expect(plan.relations).toHaveLength(1);
+    expect(plan.relations![0]).toMatchObject({
+      as: "accounts",
+      kind: "many",
+      parentField: "id",
+      strategy: "batched",
+    });
+  });
+
+  test("the owning side keys on its foreign key, the other side on the id", () => {
+    registerAll();
+    expect(compile({ include: { organization: true } }).relations![0]).toMatchObject({
+      as: "organization",
+      kind: "one",
+      parentField: "organizationId",
+    });
+    expect(compile({ include: { accounts: true } }).relations![0].parentField).toBe(
+      "id",
+    );
+  });
+
+  test("a select that omits the join key still fetches it, hidden", () => {
+    registerAll();
+    const plan = compile({ select: { name: true, accounts: true } });
+    expect(plan.text).toBe('select "id", "name" from "User"');
+    expect(plan.hidden).toEqual(["id"]);
+  });
+
+  test("a select that names the key hides nothing", () => {
+    registerAll();
+    const plan = compile({ select: { id: true, accounts: true } });
+    expect(plan.text).toBe('select "id" from "User"');
+    expect(plan.hidden).toBeUndefined();
+  });
+
+  test("a select of nothing but relations is legal", () => {
+    registerAll();
+    const plan = compile({ select: { accounts: true } });
+    expect(plan.text).toBe('select "id" from "User"');
+    expect(plan.hidden).toEqual(["id"]);
+  });
+
+  test("a to-one select hides the foreign key it keyed on", () => {
+    registerAll();
+    const plan = compile({ select: { name: true, organization: true } });
+    expect(plan.text).toBe('select "name", "organizationId" from "User"');
+    expect(plan.hidden).toEqual(["organizationId"]);
+  });
+
+  test("two relations sharing a key add one column between them", () => {
+    registerAll();
+    // Both of Organization's relations key on `Organization.id`, so the column
+    // is added once and hidden once.
+    const plan = compileRead(
+      organization,
+      "findMany",
+      { select: { name: true, users: true, accounts: true } },
+      sqlite,
+    );
+    expect(plan.text).toBe('select "id", "name" from "Organization"');
+    expect(plan.hidden).toEqual(["id"]);
+    expect(plan.relations).toHaveLength(2);
+  });
+
+  // Invariant 2: the text is a function of the argument *shape*. A relation's
+  // own `where` is values, so two calls that differ only there are one plan.
+  test("nested filter values do not change the SQL", () => {
+    registerAll();
+    const a = compile({ include: { accounts: { where: { userId: 1 } } } });
+    const b = compile({ include: { accounts: { where: { userId: 9999 } } } });
+    expect(a.text).toBe(b.text);
+  });
+
+  test("count refuses include rather than ignoring it", () => {
+    registerAll();
+    expect(() => compile({ include: { accounts: true } }, "count")).toThrow(
+      "gemi ORM does not support 'include' yet (User.count).",
+    );
+  });
+});
+
+describe("batched loading", () => {
+  test("to-many: children arrive grouped, and an empty one is []", async () => {
+    registerAll();
+    const rows = await read({ include: { accounts: true } });
+
+    expect(rows[0].accounts).toHaveLength(2);
+    expect((rows[0].accounts as Row[]).map((row) => row.id)).toEqual([10, 11]);
+    expect(rows[1].accounts).toHaveLength(1);
+    // Not `null`, not a missing key. Prisma returns `[]`, and the differential
+    // harness compares key presence.
+    expect(rows[2].accounts).toEqual([]);
+    expect("accounts" in rows[2]).toBe(true);
+  });
+
+  test("to-one: a match is the object, no match is null", async () => {
+    registerAll();
+    const rows = await read({ include: { organization: true } });
+
+    expect(rows[0].organization).toMatchObject({ id: 1, name: "Acme" });
+    // A null foreign key: `null`, not `undefined` and not an absent key.
+    expect(rows[1].organization).toBeNull();
+    expect("organization" in rows[1]).toBe(true);
+  });
+
+  test("a null foreign key is never sent to the database", async () => {
+    const models = registerAll();
+    await read({ include: { organization: true } });
+
+    expect(models.Organization.$exec).toHaveBeenCalledWith("findMany", {
+      where: { id: { in: [1] } },
+    });
+  });
+
+  test("one query per relation node, whatever the number of parents", async () => {
+    const models = registerAll();
+    const many = Array.from({ length: 100 }, (_, index) => ({
+      ...USER_ROWS[0],
+      id: index + 1,
+    }));
+
+    await read({ include: { accounts: true, organization: true } }, many);
+
+    // Two nodes, two queries — not 200. This is the assertion that catches an
+    // accidental N+1 later; the count is a property of the *tree*, not of N.
+    expect(models.Account.$exec).toHaveBeenCalledTimes(1);
+    expect(models.Organization.$exec).toHaveBeenCalledTimes(1);
+  });
+
+  test("the relation query is $exec on the related model's own class", async () => {
+    const models = registerAll();
+    await read({ include: { accounts: true } });
+
+    // Iteration 6 hangs policies on `$exec`, so "the nested read went through
+    // the child's own choke point" is the property that makes them apply to
+    // nested reads at all. Asserted by observation, not by reading the code.
+    expect(models.Account.$exec).toHaveBeenCalledTimes(1);
+    expect(models.Account.$exec).toHaveBeenCalledWith("findMany", {
+      where: { userId: { in: [1, 2, 3] } },
+    });
+    expect(models.User.$exec).not.toHaveBeenCalled();
+  });
+
+  test("a relation-level where is ANDed with the key filter", async () => {
+    const models = registerAll();
+    const rows = await read({
+      include: { accounts: { where: { organizationRole: 0 } } },
+    });
+
+    expect(models.Account.$exec).toHaveBeenCalledWith("findMany", {
+      where: {
+        AND: [{ organizationRole: 0 }, { userId: { in: [1, 2, 3] } }],
+      },
+    });
+    expect((rows[0].accounts as Row[]).map((row) => row.id)).toEqual([10]);
+    expect(rows[1].accounts).toEqual([]);
+  });
+
+  test("orderBy and include pass through to the child query", async () => {
+    const models = registerAll();
+    await read({
+      include: {
+        accounts: { orderBy: { id: "desc" }, include: { organization: true } },
+      },
+    });
+
+    expect(models.Account.$exec).toHaveBeenCalledWith("findMany", {
+      where: { userId: { in: [1, 2, 3] } },
+      orderBy: { id: "desc" },
+      include: { organization: true },
+    });
+  });
+
+  test("a nested select fetches the stitch key and then drops it", async () => {
+    const models = registerAll();
+    const rows = await read({
+      include: { accounts: { select: { publicId: true } } },
+    });
+
+    expect(models.Account.$exec).toHaveBeenCalledWith("findMany", {
+      where: { userId: { in: [1, 2, 3] } },
+      select: { publicId: true, userId: true },
+    });
+    // The caller asked for one key and gets exactly one key.
+    expect(rows[0].accounts).toEqual([
+      { publicId: "a10" },
+      { publicId: "a11" },
+    ]);
+  });
+
+  test("a nested select that names the key keeps it", async () => {
+    registerAll();
+    const rows = await read({
+      include: { accounts: { select: { userId: true } } },
+    });
+    expect(rows[0].accounts).toEqual([{ userId: 1 }, { userId: 1 }]);
+  });
+
+  test("the parent's hidden key is gone from the result", async () => {
+    registerAll();
+    const rows = await read({ select: { name: true, accounts: true } });
+
+    expect(Object.keys(rows[0]).sort()).toEqual(["accounts", "name"]);
+    expect(rows[0].accounts).toHaveLength(2);
+  });
+
+  test("no parents means no relation query at all", async () => {
+    const models = registerAll();
+    await read({ include: { accounts: true } }, []);
+    expect(models.Account.$exec).not.toHaveBeenCalled();
+  });
+});
+
+describe("rejected arguments", () => {
+  test("select and include together, at the root", () => {
+    registerAll();
+    expect(() =>
+      compile({ select: { id: true }, include: { accounts: true } }),
+    ).toThrow(/only one of them/);
+  });
+
+  test("select and include together, nested", () => {
+    registerAll();
+    expect(() =>
+      compile({
+        include: {
+          accounts: { select: { id: true }, include: { user: true } },
+        },
+      }),
+    ).toThrow(/accounts: select \+ include/);
+  });
+
+  test("an include naming something that is not a relation", () => {
+    registerAll();
+    expect(() => compile({ include: { email: true } })).toThrow(
+      UnknownRelationError,
+    );
+    expect(() => compile({ include: { nope: true } })).toThrow(
+      /Known relations: organization, accounts/,
+    );
+  });
+
+  // The decision recorded in the PR: refused rather than silently applied
+  // globally, which would return wrong rows.
+  test.each(["take", "skip"])(
+    "%s on a to-many relation is refused, not approximated",
+    (argument) => {
+      registerAll();
+      expect(() =>
+        compile({ include: { accounts: { [argument]: 5 } } }),
+      ).toThrow(UnsupportedQueryError);
+      expect(() =>
+        compile({ include: { accounts: { [argument]: 5 } } }),
+      ).toThrow(/per parent.*lateral join strategy/s);
+    },
+  );
+
+  test("take on a to-one relation says Prisma does not accept it", () => {
+    registerAll();
+    expect(() => compile({ include: { organization: { take: 1 } } })).toThrow(
+      /Prisma does not accept 'take' on a to-one relation/,
+    );
+  });
+
+  test("an unknown relation argument is named precisely", () => {
+    registerAll();
+    expect(() => compile({ include: { accounts: { cursor: {} } } })).toThrow(
+      "gemi ORM does not support 'accounts.cursor' yet (User.findMany).",
+    );
+  });
+
+  test("a relation node that is neither true nor an object", () => {
+    registerAll();
+    expect(() => compile({ include: { accounts: 1 as never } })).toThrow(
+      /Expected true or an object/,
+    );
+  });
+
+  test("include: false leaves the relation out entirely", () => {
+    registerAll();
+    const plan = compile({ include: { accounts: false } });
+    expect(plan.relations).toBeUndefined();
+  });
+});
+
+describe("guards", () => {
+  test("an unregistered target names the model and the fix", () => {
+    register("Organization", fake(organization, ORGANIZATIONS));
+    // `Account` deliberately not registered: what a stale
+    // app/models/generated looks like from the runtime's side.
+    expect(() => compile({ include: { accounts: true } })).toThrow(
+      UnregisteredRelationTargetError,
+    );
+    expect(() => compile({ include: { accounts: true } })).toThrow(
+      /re-run `prisma generate`.*Registered models: Organization/s,
+    );
+  });
+
+  test("a cyclic include is legal as long as it is finite", () => {
+    registerAll();
+    expect(() =>
+      compile({
+        include: { accounts: { include: { user: { include: { accounts: true } } } } },
+      }),
+    ).not.toThrow();
+  });
+
+  test("an unbounded include tree is refused", () => {
+    registerAll();
+
+    // `user -> accounts -> user -> ...`: legal, finite, and unbounded only
+    // because something generated it. Ten levels is the limit; eleven is a tree
+    // nothing wrote by hand.
+    const nest = (levels: number, onUser = true): any =>
+      levels === 0
+        ? true
+        : {
+            include: onUser
+              ? { accounts: nest(levels - 1, false) }
+              : { user: nest(levels - 1, true) },
+          };
+
+    expect(() => compile(nest(10))).not.toThrow();
+    expect(() => compile(nest(11))).toThrow(RelationDepthExceededError);
+    expect(() => compile(nest(11))).toThrow(/nests more than 10 relations deep/);
+  });
+});
+
+describe("implicit many-to-many", () => {
+  test("plans a two-hop join through the _Relation table", () => {
+    register("Post", fake(post, []));
+    register("Tag", fake(tag, []));
+
+    const plan = compileRead(post, "findMany", { include: { tags: true } }, sqlite);
+    expect(plan.relations![0]).toMatchObject({
+      as: "tags",
+      kind: "many",
+      // Both sides join on their own primary key; the join table holds the pair.
+      parentField: "id",
+    });
+    expect(plan.text).toBe('select "id", "title" from "Post"');
+  });
+
+  test("refuses a self-referential implicit m-n rather than guessing", () => {
+    const self: ModelSchema = {
+      ...post,
+      relations: {
+        related: {
+          name: "related",
+          model: "Post",
+          kind: "many",
+          relationName: "PostToPost",
+          from: [],
+          to: [],
+          nullable: false,
+          joinTable: { table: "_PostToPost", a: "Post", b: "Post" },
+        },
+      },
+    };
+    register("Post", fake(self, []));
+
+    expect(() =>
+      compileRead(self, "findMany", { include: { related: true } }, sqlite),
+    ).toThrow(/self-referential implicit many-to-many/);
+  });
+});

--- a/packages/gemi/orm/compile/select.ts
+++ b/packages/gemi/orm/compile/select.ts
@@ -31,6 +31,8 @@ export function resolveSelection(
     );
   }
 
+  // `include` keeps every scalar and adds relations beside them, which is
+  // precisely the default column list.
   if (select === undefined || select === null) {
     return Object.values(schema.fields);
   }
@@ -53,19 +55,21 @@ export function resolveSelection(
     if (wanted === true) selected.push(field);
   }
 
+  let relations = 0;
+
   // Validate everything the caller named, including the keys that were switched
   // off — a typo in a `false` entry is still a typo.
   for (const key of Object.keys(select as Record<string, unknown>)) {
     const value = (select as Record<string, unknown>)[key];
     if (value === undefined) continue;
 
+    // A relation inside a `select` is a relation node, not a column. The
+    // planner owns it, including validating its own arguments; here it only has
+    // to be counted, so that a selection of nothing but relations is not
+    // mistaken for an empty one.
     if (key in schema.relations) {
-      throw new UnsupportedQueryError(
-        `select.${key}`,
-        schema.name,
-        operation,
-        "Selecting a relation is not implemented yet.",
-      );
+      if (value !== false) relations++;
+      continue;
     }
 
     if (!(key in schema.fields)) {
@@ -82,7 +86,7 @@ export function resolveSelection(
     }
   }
 
-  if (selected.length === 0) {
+  if (selected.length === 0 && relations === 0) {
     // Prisma raises rather than returning rows of empty objects, and a
     // `select ... from` with no columns is not valid SQL either way.
     throw new UnsupportedQueryError(
@@ -93,5 +97,9 @@ export function resolveSelection(
     );
   }
 
+  // `select: { accounts: true }` selects no scalar at all, and is legal —
+  // Prisma returns `{ accounts: [...] }`. The column list is still not empty,
+  // because the relation's own key column is added by the caller of this
+  // function and then hidden again from the result.
   return selected;
 }

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -31,6 +31,18 @@ export interface SqlDialect {
    */
   readonly supportsInsensitiveMode: boolean;
 
+  /**
+   * Whether an `in` list binds as a single parameter however long it is.
+   *
+   * True on Postgres (`= any($1)`), false on SQLite (`in (?, ?, ?)`). It is the
+   * plan *cache* that needs to know: where the length does not change the SQL
+   * text, it must not change the cache key either, or every distinct list
+   * length mints another entry holding SQL identical to its neighbours'. That
+   * matters most for relations, where the list length is the parent row count
+   * and so varies with the data rather than with the code.
+   */
+  readonly bindsListAsOneParameter: boolean;
+
   /** Quote a table or column name. Only ever called with names from the schema. */
   quoteIdent(name: string): string;
 

--- a/packages/gemi/orm/dialect/postgres.test.ts
+++ b/packages/gemi/orm/dialect/postgres.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+
+import { user } from "../fixtures";
+import { compileRead } from "../compile/read";
+import { PostgresDialect } from "./postgres";
+
+const postgres = new PostgresDialect();
+
+/**
+ * The array parameter behind `= any($1)`.
+ *
+ * Bun's driver will not bind a JS array to that parameter at all — it fails
+ * with `insufficient data left in message` for numbers and `malformed array
+ * literal` for strings — so the values are serialized to Postgres' own array
+ * literal text. It is still one bound parameter and still nothing in the SQL
+ * text, but the escaping is now ours to get right, which is what these pin.
+ *
+ * Every case below was also run against a real Postgres 16, selecting rows back
+ * out through `= any($1)` on a column of the matching type. Unit tests can only
+ * say the string is the one we meant; the database is what says it is the one
+ * Postgres meant.
+ */
+function literal(values: unknown[]): unknown {
+  const fragment = postgres.inList('"x"', false, values.length, () => values);
+  return fragment.binders[0](undefined);
+}
+
+describe("in-list array literals", () => {
+  test("numbers are quoted, and Postgres casts them back", () => {
+    expect(literal([1, 2, 3])).toBe('{"1","2","3"}');
+  });
+
+  test("strings are quoted and escaped", () => {
+    expect(literal(["plain"])).toBe('{"plain"}');
+    // The four characters the array literal grammar cares about: the quote and
+    // the backslash need escaping; the comma and the braces are inert once the
+    // element is quoted.
+    expect(literal([`wei"rd,{}\\ x`])).toBe('{"wei\\"rd,{}\\\\ x"}');
+  });
+
+  test("null is the one element that cannot be quoted", () => {
+    // `"NULL"` is the four-character string; `NULL` is the null element.
+    expect(literal([null, "NULL"])).toBe('{NULL,"NULL"}');
+  });
+
+  test("dates keep their UTC wall clock", () => {
+    expect(literal([new Date(1600000000123)])).toBe(
+      '{"2020-09-13T12:26:40.123Z"}',
+    );
+  });
+
+  test("bigints keep every digit", () => {
+    // Past 2^53, so a detour through `number` would be visible here.
+    expect(literal([9007199254740993n])).toBe('{"9007199254740993"}');
+  });
+
+  test("bytes are hex, with the backslash doubled for the array parser", () => {
+    expect(literal([new Uint8Array([0, 1, 255, 16])])).toBe(
+      '{"\\\\x0001ff10"}',
+    );
+  });
+
+  test("booleans", () => {
+    expect(literal([true, false])).toBe('{"true","false"}');
+  });
+
+  test("an empty list", () => {
+    // Unreachable through `where` — an empty `in` compiles to a constant-false
+    // predicate before it gets here — but the batched relation loader builds
+    // lists too, so this should be a valid literal rather than a crash.
+    expect(literal([])).toBe("{}");
+  });
+});
+
+describe("the text is still one parameter, whatever the length", () => {
+  test.each([[1], [5], [100]])("%i values", (count) => {
+    const args = {
+      where: { id: { in: Array.from({ length: count }, (_, i) => i) } },
+    };
+    const plan = compileRead(user, "findMany", args, postgres);
+    expect(plan.text).toContain('"id" = any ($1)');
+    expect(plan.bind(args)).toHaveLength(1);
+  });
+});

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -14,6 +14,52 @@ import type { SqlDialect } from "./index";
 // entirely a pass-through. That asymmetry with SQLite is the point: the same
 // query returns the same JavaScript values on both dialects, which is exactly
 // what the differential harness checks.
+/**
+ * `[1, 2]` -> `{"1","2"}`: Postgres' text form for an array value.
+ *
+ * Every element is quoted, including numbers and booleans — Postgres casts a
+ * quoted element to the array's element type, so one rule covers every column
+ * type instead of a per-type branch that has to stay in step with `encode`.
+ * `NULL` is the one thing that cannot be quoted, since `"NULL"` is the string.
+ *
+ * Verified against a real database for `int`, `text` (with quotes, commas,
+ * braces, backslashes and newlines in the value), `timestamp`, `boolean`,
+ * `bigint` past 2^53, `bytea` and `double precision`.
+ */
+function arrayLiteral(values: unknown[]): string {
+  let out = "{";
+  for (let i = 0; i < values.length; i++) {
+    if (i > 0) out += ",";
+    out += arrayElement(values[i]);
+  }
+  return out + "}";
+}
+
+function arrayElement(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+
+  // ISO 8601 keeps the value's own UTC wall clock, which is what Prisma stores
+  // in a `timestamp(3)`; the zone designator is ignored on the way in.
+  if (value instanceof Date) return `"${value.toISOString()}"`;
+
+  if (ArrayBuffer.isView(value)) {
+    let hex = "";
+    for (const byte of new Uint8Array(
+      value.buffer,
+      value.byteOffset,
+      value.byteLength,
+    )) {
+      hex += byte.toString(16).padStart(2, "0");
+    }
+    // `\x…` is Postgres' hex bytea form, and the backslash is doubled because
+    // the array literal parser reads one level of escapes first.
+    return `"\\\\x${hex}"`;
+  }
+
+  const text = typeof value === "string" ? value : String(value);
+  return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
 export class PostgresDialect implements SqlDialect {
   readonly name: Dialect = "postgres";
 
@@ -42,7 +88,16 @@ export class PostgresDialect implements SqlDialect {
 
   // The whole array binds to a single parameter, so every list length shares one
   // SQL text — one plan cache entry and one prepared statement, instead of one
-  // per distinct length the way SQLite needs.
+  // per distinct length the way SQLite needs. That matters more from iteration 3
+  // on, where every batched relation query is an `in` over the parent keys and
+  // the list length is the *number of parent rows*.
+  //
+  // The array is serialized to a Postgres array literal rather than handed over
+  // as a JS array: Bun's driver rejects an array bound to a `= any($1)`
+  // parameter outright — `insufficient data left in message` for numbers,
+  // `malformed array literal` for strings. It is still one bound parameter and
+  // still never touches the SQL text, so nothing about the injection story or
+  // the plan cache changes.
   inList(
     lhs: string,
     negated: boolean,
@@ -50,7 +105,11 @@ export class PostgresDialect implements SqlDialect {
     values: Binder,
   ): Fragment {
     const operator = negated ? "<> all" : "= any";
-    return concat(sql(`${lhs} ${operator} (`), param(values), sql(")"));
+    return concat(
+      sql(`${lhs} ${operator} (`),
+      param((args) => arrayLiteral(values(args) as unknown[])),
+      sql(")"),
+    );
   }
 
   like(lhs: string, insensitive: boolean, pattern: Binder): Fragment {
@@ -79,6 +138,22 @@ export class PostgresDialect implements SqlDialect {
     return value;
   }
 
+  // KNOWN DIVERGENCE, and not one this can fix: Prisma maps `DateTime` to
+  // `timestamp(3)` — no time zone — and stores UTC in it, but Bun's driver
+  // decodes that column differently depending on the *protocol* the statement
+  // used. A query that binds no parameters goes over the simple query protocol
+  // and comes back as zoneless text, which is then parsed as local time; a
+  // query that binds even one parameter goes over the extended protocol, comes
+  // back in binary, and is correct. Same row, same column, two instants, on any
+  // machine whose clock is not already UTC.
+  //
+  //   select "createdAt" from "User" limit 1                -> 10:26:40Z
+  //   select "createdAt" from "User" where "id" = $1        -> 12:26:40Z
+  //   select "createdAt"::text from "User" limit 1          -> 12:26:40
+  //
+  // A `decode` cannot correct it, because the value alone does not say which
+  // protocol produced it; nothing below the plan does. Until it is fixed
+  // upstream, run the process with TZ=UTC, where both paths agree.
   needsDecode(_field: FieldSchema): boolean {
     return false;
   }

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -14,52 +14,6 @@ import type { SqlDialect } from "./index";
 // entirely a pass-through. That asymmetry with SQLite is the point: the same
 // query returns the same JavaScript values on both dialects, which is exactly
 // what the differential harness checks.
-/**
- * `[1, 2]` -> `{"1","2"}`: Postgres' text form for an array value.
- *
- * Every element is quoted, including numbers and booleans — Postgres casts a
- * quoted element to the array's element type, so one rule covers every column
- * type instead of a per-type branch that has to stay in step with `encode`.
- * `NULL` is the one thing that cannot be quoted, since `"NULL"` is the string.
- *
- * Verified against a real database for `int`, `text` (with quotes, commas,
- * braces, backslashes and newlines in the value), `timestamp`, `boolean`,
- * `bigint` past 2^53, `bytea` and `double precision`.
- */
-function arrayLiteral(values: unknown[]): string {
-  let out = "{";
-  for (let i = 0; i < values.length; i++) {
-    if (i > 0) out += ",";
-    out += arrayElement(values[i]);
-  }
-  return out + "}";
-}
-
-function arrayElement(value: unknown): string {
-  if (value === null || value === undefined) return "NULL";
-
-  // ISO 8601 keeps the value's own UTC wall clock, which is what Prisma stores
-  // in a `timestamp(3)`; the zone designator is ignored on the way in.
-  if (value instanceof Date) return `"${value.toISOString()}"`;
-
-  if (ArrayBuffer.isView(value)) {
-    let hex = "";
-    for (const byte of new Uint8Array(
-      value.buffer,
-      value.byteOffset,
-      value.byteLength,
-    )) {
-      hex += byte.toString(16).padStart(2, "0");
-    }
-    // `\x…` is Postgres' hex bytea form, and the backslash is doubled because
-    // the array literal parser reads one level of escapes first.
-    return `"\\\\x${hex}"`;
-  }
-
-  const text = typeof value === "string" ? value : String(value);
-  return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-}
-
 export class PostgresDialect implements SqlDialect {
   readonly name: Dialect = "postgres";
 
@@ -68,6 +22,9 @@ export class PostgresDialect implements SqlDialect {
   // and has no way to opt out. Prisma has the same split; gemi matches Prisma
   // per dialect rather than inventing a uniformity Prisma does not have.
   readonly supportsInsensitiveMode = true;
+
+  // `= any($1)`: one parameter, one SQL text, one plan for every list length.
+  readonly bindsListAsOneParameter = true;
 
   quoteIdent(name: string): string {
     // See the SQLite implementation: NUL is the parameter sentinel in
@@ -161,4 +118,50 @@ export class PostgresDialect implements SqlDialect {
   decode(value: unknown, _field: FieldSchema): unknown {
     return value ?? null;
   }
+}
+
+/**
+ * `[1, 2]` -> `{"1","2"}`: Postgres' text form for an array value.
+ *
+ * Every element is quoted, including numbers and booleans — Postgres casts a
+ * quoted element to the array's element type, so one rule covers every column
+ * type instead of a per-type branch that has to stay in step with `encode`.
+ * `NULL` is the one thing that cannot be quoted, since `"NULL"` is the string.
+ *
+ * Verified against a real database for `int`, `text` (with quotes, commas,
+ * braces, backslashes and newlines in the value), `timestamp`, `boolean`,
+ * `bigint` past 2^53, `bytea` and `double precision`.
+ */
+function arrayLiteral(values: unknown[]): string {
+  let out = "{";
+  for (let i = 0; i < values.length; i++) {
+    if (i > 0) out += ",";
+    out += arrayElement(values[i]);
+  }
+  return out + "}";
+}
+
+function arrayElement(value: unknown): string {
+  if (value === null || value === undefined) return "NULL";
+
+  // ISO 8601 keeps the value's own UTC wall clock, which is what Prisma stores
+  // in a `timestamp(3)`; the zone designator is ignored on the way in.
+  if (value instanceof Date) return `"${value.toISOString()}"`;
+
+  if (ArrayBuffer.isView(value)) {
+    let hex = "";
+    for (const byte of new Uint8Array(
+      value.buffer,
+      value.byteOffset,
+      value.byteLength,
+    )) {
+      hex += byte.toString(16).padStart(2, "0");
+    }
+    // `\x…` is Postgres' hex bytea form, and the backslash is doubled because
+    // the array literal parser reads one level of escapes first.
+    return `"\\\\x${hex}"`;
+  }
+
+  const text = typeof value === "string" ? value : String(value);
+  return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -57,6 +57,9 @@ export class SqliteDialect implements SqlDialect {
   // legitimately return different rows for the same `contains`.
   readonly supportsInsensitiveMode = false;
 
+  // `in (?, ?, ?)`: the length is part of the text, so it is part of the plan.
+  readonly bindsListAsOneParameter = false;
+
   quoteIdent(name: string): string {
     // NUL is the parameter sentinel in compile/fragment.ts, so it is the one
     // character that could shift a placeholder's position rather than merely

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -80,6 +80,98 @@ export class RecordNotFoundError extends Error {
   }
 }
 
+/**
+ * Thrown when an `include` — or a relation-shaped key inside a `select` — names
+ * something the model does not declare as a relation.
+ */
+export class UnknownRelationError extends Error {
+  constructor(
+    public readonly relation: string,
+    public readonly model: string,
+    known: string[],
+  ) {
+    super(
+      `'${relation}' is not a relation on model ${model}. ` +
+        (known.length > 0
+          ? `Known relations: ${known.join(", ")}.`
+          : `${model} declares no relations.`),
+    );
+    this.name = "UnknownRelationError";
+  }
+}
+
+/**
+ * Thrown when an include tree nests deeper than the guard allows.
+ *
+ * A cyclic include is legal and finite — `user -> accounts -> user` terminates
+ * because the caller wrote a finite tree. What this catches is an *unbounded*
+ * one: an argument tree built by a loop, or forwarded from a request body, that
+ * describes a thousand levels. Under the batched planner every level is at least
+ * one query, so the guard is what stops a malformed argument from becoming a
+ * self-inflicted denial of service.
+ */
+export class RelationDepthExceededError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly limit: number,
+  ) {
+    super(
+      `The include tree nests more than ${limit} relations deep (at model ` +
+        `${model}). Deeply nested includes are legal, so this is a guard ` +
+        `against a generated or malformed argument tree rather than a limit on ` +
+        `modelling — every level costs at least one query.`,
+    );
+    this.name = "RelationDepthExceededError";
+  }
+}
+
+/**
+ * Thrown when a relation names a model the registry does not hold. Every
+ * relation in a generated artifact was emitted from a model in the same
+ * `schema.prisma`, so this can only mean the artifact and the registry disagree.
+ */
+export class UnregisteredRelationTargetError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly relation: string,
+    public readonly target: string,
+    known: string[],
+  ) {
+    super(
+      `${model}.${relation} points at model '${target}', which nothing has ` +
+        `registered. The generated artifact and the registry disagree: re-run ` +
+        `\`prisma generate\`, and check that app/models/generated/index.ts is ` +
+        `imported. ` +
+        (known.length > 0
+          ? `Registered models: ${known.join(", ")}.`
+          : `Nothing is registered at all.`),
+    );
+    this.name = "UnregisteredRelationTargetError";
+  }
+}
+
+/**
+ * Thrown when a relation is registered on both sides but the two sides do not
+ * describe a link the planner can follow: no matching `relationName` on the
+ * other model, or a `from` / `to` naming a field that is not there. Like
+ * `UnregisteredRelationTargetError`, it means a stale generated artifact — a
+ * consistent one cannot produce it.
+ */
+export class MalformedRelationError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly relation: string,
+    detail: string,
+  ) {
+    super(
+      `Cannot resolve how ${model}.${relation} joins: ${detail} This means ` +
+        `app/models/generated is stale or hand-edited — re-run ` +
+        `\`prisma generate\`.`,
+    );
+    this.name = "MalformedRelationError";
+  }
+}
+
 /** Thrown when a relation resolves to a model name nothing registered. */
 export class ModelNotRegisteredError extends Error {
   constructor(name: string, known: string[]) {

--- a/packages/gemi/orm/fixtures.ts
+++ b/packages/gemi/orm/fixtures.ts
@@ -146,6 +146,268 @@ export const user: ModelSchema = {
   },
 };
 
+/**
+ * `Account` and `Organization`, copied from the template the same way `user` is.
+ * Together the three cover every shape the relation planner has to resolve:
+ *
+ * - `User.organization` — to-one, and the side that *holds* the foreign key.
+ * - `User.accounts` — to-many, and the side that does not: its `from` / `to` are
+ *   empty, so the planner has to find `Account.user` through `relationName`.
+ * - `Organization.users` — the same, one hop further, for depth.
+ */
+export const account: ModelSchema = {
+  name: "Account",
+  table: "Account",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    publicId: {
+      name: "publicId",
+      column: "publicId",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+      default: { kind: "cuid" },
+    },
+    organizationId: {
+      name: "organizationId",
+      column: "organizationId",
+      type: "Int",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    organizationRole: {
+      name: "organizationRole",
+      column: "organizationRole",
+      type: "Int",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+      default: { kind: "value", value: 2 },
+    },
+    userId: {
+      name: "userId",
+      column: "userId",
+      type: "Int",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    createdAt: {
+      name: "createdAt",
+      column: "createdAt",
+      type: "DateTime",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+      default: { kind: "now" },
+    },
+    updatedAt: {
+      name: "updatedAt",
+      column: "updatedAt",
+      type: "DateTime",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: true,
+    },
+    deletedAt: {
+      name: "deletedAt",
+      column: "deletedAt",
+      type: "DateTime",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [["publicId"]],
+  relations: {
+    organization: {
+      name: "organization",
+      model: "Organization",
+      kind: "one",
+      relationName: "AccountToOrganization",
+      from: ["organizationId"],
+      to: ["id"],
+      nullable: true,
+    },
+    user: {
+      name: "user",
+      model: "User",
+      kind: "one",
+      relationName: "AccountToUser",
+      from: ["userId"],
+      to: ["id"],
+      nullable: true,
+    },
+  },
+};
+
+export const organization: ModelSchema = {
+  name: "Organization",
+  table: "Organization",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    publicId: {
+      name: "publicId",
+      column: "publicId",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+      default: { kind: "cuid" },
+    },
+    name: {
+      name: "name",
+      column: "name",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    logoUrl: {
+      name: "logoUrl",
+      column: "logoUrl",
+      type: "String",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    description: {
+      name: "description",
+      column: "description",
+      type: "String",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [["publicId"]],
+  relations: {
+    users: {
+      name: "users",
+      model: "User",
+      kind: "many",
+      relationName: "OrganizationToUser",
+      from: [],
+      to: [],
+      nullable: false,
+    },
+    accounts: {
+      name: "accounts",
+      model: "Account",
+      kind: "many",
+      relationName: "AccountToOrganization",
+      from: [],
+      to: [],
+      nullable: false,
+    },
+  },
+};
+
+/**
+ * An implicit many-to-many pair, which the template's schema cannot express —
+ * every relation there is 1-1 or 1-n. Prisma gives an implicit m-n no join
+ * *model*: just a `_PostToTag` table with an `A` and a `B` column, the two
+ * models in alphabetical order. Neither side holds a foreign key.
+ *
+ * `templates/saas-starter/app/models/relations.many-to-many.test.ts` builds a
+ * real SQLite database from these and runs the ORM against it.
+ */
+export const post: ModelSchema = {
+  name: "Post",
+  table: "Post",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    title: {
+      name: "title",
+      column: "title",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    tags: {
+      name: "tags",
+      model: "Tag",
+      kind: "many",
+      relationName: "PostToTag",
+      from: [],
+      to: [],
+      nullable: false,
+      joinTable: { table: "_PostToTag", a: "Post", b: "Tag" },
+    },
+  },
+};
+
+export const tag: ModelSchema = {
+  name: "Tag",
+  table: "Tag",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    label: {
+      name: "label",
+      column: "label",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    posts: {
+      name: "posts",
+      model: "Post",
+      kind: "many",
+      relationName: "PostToTag",
+      from: [],
+      to: [],
+      nullable: false,
+      joinTable: { table: "_PostToTag", a: "Post", b: "Tag" },
+    },
+  },
+};
+
 /** `@@map("audit_log")` with `@map`ped columns, plus every decoded scalar type. */
 export const mapped: ModelSchema = {
   name: "AuditLog",

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -14,10 +14,14 @@ export {
 
 export {
   DecodeError,
+  MalformedRelationError,
   MissingModelSchemaError,
   ModelNotRegisteredError,
   RecordNotFoundError,
+  RelationDepthExceededError,
   UnknownFieldError,
+  UnknownRelationError,
+  UnregisteredRelationTargetError,
   UnsupportedQueryError,
 } from "./errors";
 
@@ -32,7 +36,20 @@ export {
 } from "./plan";
 
 export { compile } from "./compile";
-export { buildRowShaper, type RowShaper } from "./shape";
+export { buildRowShaper, type RowShaper, type ShapedRelation } from "./shape";
+
+// The relation planner is a swappable stage (invariant 4): iteration 3 ships
+// the batched strategy, iteration 7 adds lateral + json_agg as a sibling.
+export {
+  MAX_RELATION_DEPTH,
+  attachRelations,
+  batchedStrategy,
+  planRelations,
+  type RelationPlan,
+  type RelationPlanning,
+  type RelationRequest,
+  type RelationStrategy,
+} from "./compile/plan-relations";
 
 export {
   PostgresDialect,

--- a/packages/gemi/orm/plan.discrimination.test.ts
+++ b/packages/gemi/orm/plan.discrimination.test.ts
@@ -72,7 +72,7 @@ describe("plan cache discrimination", () => {
   test("every shape in the table gets its own key", () => {
     const keys = new Map<string, string>();
     for (const [label, args] of DISTINCT_SHAPES) {
-      const key = planKey("sqlite", "User", "findMany", args);
+      const key = planKey(sqlite, "User", "findMany", args);
       const clash = keys.get(key);
       expect(clash, `"${label}" collides with "${clash}"`).toBeUndefined();
       keys.set(key, label);
@@ -123,7 +123,7 @@ describe("plan cache discrimination", () => {
       expect(getOrCompile(user, "findMany", args, sqlite).text, label).toBe(
         base,
       );
-      keys.add(planKey("sqlite", "User", "findMany", args));
+      keys.add(planKey(sqlite, "User", "findMany", args));
     }
 
     expect(keys.size).toBe(VACUOUS.length);
@@ -142,7 +142,7 @@ describe("plan cache discrimination", () => {
       const plan = getOrCompile(user, "findMany", args, sqlite);
       expect(plan.text, label).toMatch(/where false$/);
       expect(plan.bind(args), label).toEqual([]);
-      keys.add(planKey("sqlite", "User", "findMany", args));
+      keys.add(planKey(sqlite, "User", "findMany", args));
     }
     expect(keys.size).toBe(NEVER_MATCHES.length);
   });
@@ -151,11 +151,11 @@ describe("plan cache discrimination", () => {
   // they must share a plan — the magnitude is bound, only the sign is
   // structural.
   test("take magnitude shares a plan but take sign does not", () => {
-    expect(planKey("sqlite", "User", "findMany", { take: 10 })).toBe(
-      planKey("sqlite", "User", "findMany", { take: 20 }),
+    expect(planKey(sqlite, "User", "findMany", { take: 10 })).toBe(
+      planKey(sqlite, "User", "findMany", { take: 20 }),
     );
-    expect(planKey("sqlite", "User", "findMany", { take: 10 })).not.toBe(
-      planKey("sqlite", "User", "findMany", { take: -10 }),
+    expect(planKey(sqlite, "User", "findMany", { take: 10 })).not.toBe(
+      planKey(sqlite, "User", "findMany", { take: -10 }),
     );
   });
 
@@ -163,7 +163,7 @@ describe("plan cache discrimination", () => {
     const args = { where: { id: 1 } };
     const keys = new Set(
       (["findMany", "findFirst", "findUnique", "count"] as const).map((op) =>
-        planKey("sqlite", "User", op, args),
+        planKey(sqlite, "User", op, args),
       ),
     );
     expect(keys.size).toBe(4);
@@ -171,8 +171,8 @@ describe("plan cache discrimination", () => {
 
   test("the dialect is part of the key", () => {
     const args = { where: { id: { in: [1, 2] } } };
-    expect(planKey("sqlite", "User", "findMany", args)).not.toBe(
-      planKey("postgres", "User", "findMany", args),
+    expect(planKey(sqlite, "User", "findMany", args)).not.toBe(
+      planKey(postgres, "User", "findMany", args),
     );
 
     // ...and they really do compile differently, which is why they must not
@@ -183,9 +183,10 @@ describe("plan cache discrimination", () => {
   });
 
   // Postgres is the exception that proves the point: there, every in-length
-  // shares one SQL text on purpose, so the extra cache entries are the cost of
-  // SQLite's expansion rather than something to eliminate everywhere.
-  test("postgres compiles every in-length to one text", () => {
+  // shares one SQL text on purpose — so it shares one cache entry too, and the
+  // extra entries are the cost of SQLite's expansion rather than a fact about
+  // `in` lists. `planKey` asks the dialect which it is.
+  test("postgres compiles every in-length to one text, under one key", () => {
     const texts = new Set(
       [[1], [1, 2], [1, 2, 3]].map(
         (values) =>
@@ -194,6 +195,7 @@ describe("plan cache discrimination", () => {
       ),
     );
     expect(texts.size).toBe(1);
+    expect(planCacheStats()).toMatchObject({ compiles: 1, size: 1 });
   });
 });
 
@@ -299,10 +301,10 @@ describe("the plan cache is bounded", () => {
  */
 describe("structural keying stops at a value boundary", () => {
   test("a nested where does not leak its values into the key", () => {
-    const a = planKey("sqlite", "User", "findMany", {
+    const a = planKey(sqlite, "User", "findMany", {
       include: { accounts: { where: { publicId: "secret-value" } } },
     });
-    const b = planKey("sqlite", "User", "findMany", {
+    const b = planKey(sqlite, "User", "findMany", {
       include: { accounts: { where: { publicId: "another-value" } } },
     });
 
@@ -312,11 +314,11 @@ describe("structural keying stops at a value boundary", () => {
 
   test("but the structural part of a nested selection still discriminates", () => {
     expect(
-      planKey("sqlite", "User", "findMany", {
+      planKey(sqlite, "User", "findMany", {
         include: { accounts: { orderBy: { id: "asc" } } },
       }),
     ).not.toBe(
-      planKey("sqlite", "User", "findMany", {
+      planKey(sqlite, "User", "findMany", {
         include: { accounts: { orderBy: { id: "desc" } } },
       }),
     );

--- a/packages/gemi/orm/plan.test.ts
+++ b/packages/gemi/orm/plan.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 
+import { PostgresDialect } from "./dialect/postgres";
 import { SqliteDialect } from "./dialect/sqlite";
 import { USER_COLUMNS, user } from "./fixtures";
 import {
@@ -11,6 +12,7 @@ import {
 } from "./plan";
 
 const sqlite = new SqliteDialect();
+const postgres = new PostgresDialect();
 
 beforeEach(() => clearPlanCache());
 
@@ -66,12 +68,65 @@ describe("canonicalShape()", () => {
 
 describe("planKey()", () => {
   test("separates dialect, model and operation", () => {
-    expect(planKey("sqlite", "User", "findMany", { where: { id: 1 } })).not.toBe(
-      planKey("postgres", "User", "findMany", { where: { id: 1 } }),
+    expect(planKey(sqlite, "User", "findMany", { where: { id: 1 } })).not.toBe(
+      planKey(postgres, "User", "findMany", { where: { id: 1 } }),
     );
-    expect(planKey("sqlite", "User", "findMany", {})).not.toBe(
-      planKey("sqlite", "Account", "findMany", {}),
+    expect(planKey(sqlite, "User", "findMany", {})).not.toBe(
+      planKey(sqlite, "Account", "findMany", {}),
     );
+  });
+
+  // The length of an `in` list is part of the *text* only where the dialect
+  // expands it into one placeholder per element. Where it binds as a single
+  // parameter, keying on the length mints one entry per distinct length, each
+  // holding SQL identical to its neighbours' — which from iteration 3 is one
+  // entry per distinct parent row count on every relation query.
+  test("an in-list's length is a plan on SQLite and not on Postgres", () => {
+    const two = { where: { id: { in: [1, 2] } } };
+    const three = { where: { id: { in: [1, 2, 3] } } };
+
+    expect(planKey(sqlite, "User", "findMany", two)).not.toBe(
+      planKey(sqlite, "User", "findMany", three),
+    );
+    expect(planKey(postgres, "User", "findMany", two)).toBe(
+      planKey(postgres, "User", "findMany", three),
+    );
+
+    // ...and the collapse is exactly as wide as the SQL is identical: an empty
+    // list compiles to a constant-false predicate on both dialects.
+    expect(planKey(postgres, "User", "findMany", two)).not.toBe(
+      planKey(postgres, "User", "findMany", { where: { id: { in: [] } } }),
+    );
+  });
+
+  test("the collapse does not reach arrays that are structure", () => {
+    // `AND: [a, b]` and `AND: [a]` are different predicates on every dialect.
+    expect(
+      planKey(postgres, "User", "findMany", {
+        where: { AND: [{ id: 1 }, { email: "x" }] },
+      }),
+    ).not.toBe(
+      planKey(postgres, "User", "findMany", { where: { AND: [{ id: 1 }] } }),
+    );
+    expect(
+      planKey(postgres, "User", "findMany", {
+        orderBy: [{ id: "asc" }, { email: "desc" }],
+      }),
+    ).not.toBe(
+      planKey(postgres, "User", "findMany", { orderBy: [{ id: "asc" }] }),
+    );
+  });
+
+  test("one Postgres plan serves every in-list length", () => {
+    for (const length of [1, 2, 3, 50]) {
+      getOrCompile(
+        user,
+        "findMany",
+        { where: { id: { in: Array.from({ length }, (_, i) => i) } } },
+        postgres,
+      );
+    }
+    expect(planCacheStats()).toMatchObject({ compiles: 1, size: 1 });
   });
 });
 

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -1,5 +1,6 @@
 import type { Dialect } from "../database/dialect";
 import { compile } from "./compile";
+import type { RelationPlan } from "./compile/plan-relations";
 import type { SqlDialect } from "./dialect";
 import type { ModelSchema } from "./schema";
 
@@ -34,6 +35,17 @@ export interface QueryPlan {
   text: string;
   bind(args: any): unknown[];
   shape(rows: unknown[]): unknown;
+  /**
+   * The relation nodes this query's `include` / `select` asks for, one plan per
+   * node. Empty — and left undefined — for a query with no relations, so the
+   * choke point can skip the whole stage with one check.
+   */
+  relations?: RelationPlan[];
+  /**
+   * Fields the query had to select to stitch relations, but which the caller's
+   * `select` did not ask for. Dropped once the relations are attached.
+   */
+  hidden?: string[];
 }
 
 /**
@@ -125,9 +137,10 @@ export function canonicalShape(value: unknown, literal = false): string {
  * those verbatim would put user data into a long-lived global map and give
  * every distinct filter value its own cache entry.
  *
- * Inert today, because `include` throws before it can reach the cache. Iteration
- * 3 turns it on, and it is much cheaper to be right about it here than to find
- * it alongside relation compilation.
+ * Live as of iteration 3: `include: { accounts: { where: { deletedAt: null } } }`
+ * is one plan whatever the filter's values are, and the relation loader reads
+ * those values back out of the *call's* argument tree rather than the compiled
+ * plan's.
  */
 const VALUE_KEYS = new Set(["where", "cursor", "data"]);
 

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -1,4 +1,3 @@
-import type { Dialect } from "../database/dialect";
 import { compile } from "./compile";
 import type { RelationPlan } from "./compile/plan-relations";
 import type { SqlDialect } from "./dialect";
@@ -52,11 +51,15 @@ export interface QueryPlan {
  * The cache is bounded because one part of the key space is *not* finite per
  * application: on SQLite an `in` list expands to one placeholder per element,
  * so every distinct list length is its own plan — and list length is routinely
- * request-derived (`?ids=1,2,3` off a query string). Unbounded, that is a slow
- * memory leak reachable from untrusted input.
+ * request-derived (`?ids=1,2,3` off a query string) or, from iteration 3,
+ * derived from the number of parent rows a relation is being loaded for.
+ * Unbounded, that is a slow memory leak reachable from untrusted input.
  *
- * A coarser key cannot fix it: collapsing lengths would hand a plan the wrong
- * number of placeholders. Eviction is the only correct answer.
+ * Postgres binds the whole list to one parameter, so there the length is not
+ * part of the key at all — see `collapsedList`.
+ *
+ * A coarser key cannot fix the SQLite side: collapsing lengths there would hand
+ * a plan the wrong number of placeholders. Eviction is the only correct answer.
  *
  * Least-recently-used, implemented on `Map`'s insertion ordering: re-inserting
  * on a hit moves the entry to the end, so the first key `keys().next()` yields
@@ -99,7 +102,15 @@ const LITERAL_KEYS = new Set([
   "mode",
 ]);
 
-export function canonicalShape(value: unknown, literal = false): string {
+export function canonicalShape(
+  value: unknown,
+  literal = false,
+  /**
+   * Set when the dialect binds an `in` list as a single parameter, so that the
+   * list's *length* stops being part of the key. See `collapsedList`.
+   */
+  collapseLists = false,
+): string {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
 
@@ -111,24 +122,45 @@ export function canonicalShape(value: unknown, literal = false): string {
 
   if (value instanceof Date) return "date";
   if (Array.isArray(value)) {
-    // Element-wise, so the length is part of the shape. That is not a choice:
-    // `in: [a, b]` compiles to `in (?, ?)` and `in: [a, b, c]` to `in (?, ?, ?)`,
-    // so collapsing them to one key would hand a plan the wrong number of
-    // placeholders. Length has to stay visible.
+    // Element-wise by default, so the length is part of the shape. Usually that
+    // is not a choice: `AND: [a, b]` and `AND: [a]` are different predicates,
+    // `orderBy: [a, b]` is a different sort, and on SQLite `in: [a, b]`
+    // compiles to `in (?, ?)` — collapsing any of them would hand a plan the
+    // wrong SQL or the wrong number of placeholders.
     //
-    // This is the one part of the key space an application does not bound:
-    // list length is routinely request-derived. The cache's LRU cap is what
-    // contains it — see `MAX_CACHED_PLANS`. On Postgres the array binds to a
-    // single parameter and every length shares one text, so only SQLite grows
-    // entries this way.
-    return `[${value.map((item) => canonicalShape(item, literal)).join(",")}]`;
+    // The exception is the `in` / `notIn` operand on a dialect that binds it as
+    // one parameter, which `shapeOfMember` takes before this is reached.
+    return `[${value
+      .map((item) => canonicalShape(item, literal, collapseLists))
+      .join(",")}]`;
   }
 
   const entries = Object.entries(value as Record<string, unknown>)
     .filter(([, v]) => v !== undefined)
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    .map(([key, v]) => `${key}:${shapeOfMember(key, v, literal)}`);
+    .map(([key, v]) => `${key}:${shapeOfMember(key, v, literal, collapseLists)}`);
   return `{${entries.join(",")}}`;
+}
+
+/** The operators whose operand is a list of values rather than a structure. */
+const LIST_KEYS = new Set(["in", "notIn"]);
+
+/**
+ * `in: [1, 2]` and `in: [1, 2, 3]` on Postgres are the same SQL text — the
+ * whole array binds to `= any($1)` — so they must be the same cache entry.
+ *
+ * Recording them element-wise there is not *wrong*, but it mints one entry per
+ * distinct list length, each holding SQL identical to its neighbours'. From
+ * iteration 3 on that stops being a curiosity: every batched relation query is
+ * an `in` over the parent keys, so the list length is the number of rows the
+ * parent query returned, and a variably-sized parent set would churn the LRU on
+ * every dialect rather than on the one that needs it.
+ *
+ * An empty list keeps its own key: `in: []` compiles to a constant-false
+ * predicate rather than to `= any($1)`, which is a different text.
+ */
+function collapsedList(value: unknown[]): string {
+  return value.length === 0 ? "[]" : "[*]";
 }
 
 /**
@@ -144,7 +176,12 @@ export function canonicalShape(value: unknown, literal = false): string {
  */
 const VALUE_KEYS = new Set(["where", "cursor", "data"]);
 
-function shapeOfMember(key: string, value: unknown, literal: boolean): string {
+function shapeOfMember(
+  key: string,
+  value: unknown,
+  literal: boolean,
+  collapseLists: boolean,
+): string {
   // `take` is a parameter, but its *sign* is not: a negative take means "the
   // last N", which flips every ordering term and so changes the SQL text. The
   // magnitude stays out of the key, so `take: 10` and `take: 20` still share a
@@ -152,17 +189,34 @@ function shapeOfMember(key: string, value: unknown, literal: boolean): string {
   if (key === "take" && typeof value === "number") {
     return `number:${Math.sign(value)}`;
   }
-  if (VALUE_KEYS.has(key)) return canonicalShape(value, false);
-  return canonicalShape(value, literal || LITERAL_KEYS.has(key));
+  if (collapseLists && LIST_KEYS.has(key) && Array.isArray(value)) {
+    return collapsedList(value);
+  }
+  if (VALUE_KEYS.has(key)) return canonicalShape(value, false, collapseLists);
+  return canonicalShape(
+    value,
+    literal || LITERAL_KEYS.has(key),
+    collapseLists,
+  );
 }
 
+/**
+ * Takes the dialect itself rather than its name: whether an `in` list's length
+ * belongs in the key is a property of how that dialect *binds* the list, and
+ * asking the dialect keeps `if (dialect === "postgres")` out of here the same
+ * way the compiler keeps it out of itself.
+ */
 export function planKey(
-  dialect: Dialect,
+  dialect: SqlDialect,
   model: string,
   op: Operation,
   args: unknown,
 ): string {
-  return `${dialect}:${model}:${op}:${canonicalShape(args)}`;
+  return `${dialect.name}:${model}:${op}:${canonicalShape(
+    args,
+    false,
+    dialect.bindsListAsOneParameter,
+  )}`;
 }
 
 export function getOrCompile(
@@ -171,7 +225,7 @@ export function getOrCompile(
   args: any,
   dialect: SqlDialect,
 ): QueryPlan {
-  const key = planKey(dialect.name, schema.name, op, args);
+  const key = planKey(dialect, schema.name, op, args);
   const cached = cache.get(key);
   if (cached) {
     hits++;

--- a/packages/gemi/orm/shape.ts
+++ b/packages/gemi/orm/shape.ts
@@ -22,9 +22,25 @@ interface ShapedColumn {
   decode: boolean;
 }
 
+/**
+ * One relation the plan will load. The shaper does not fetch anything; it
+ * writes the *empty* value so the key exists on every row before the relation
+ * loader fills in the rows that have children.
+ *
+ * These three lines are where most divergence bugs live, so they are stated
+ * once, here: a to-one with no match is `null` — not `undefined`, not a missing
+ * key — and an empty to-many is `[]` — not `null`, not absent. Prisma returns
+ * exactly that, and the differential harness compares key presence.
+ */
+export interface ShapedRelation {
+  key: string;
+  kind: "one" | "many";
+}
+
 export function buildRowShaper(
   fields: FieldSchema[],
   dialect: SqlDialect,
+  relations: readonly ShapedRelation[] = [],
 ): RowShaper {
   const columns: ShapedColumn[] = fields.map((field) => ({
     key: field.name,
@@ -33,6 +49,15 @@ export function buildRowShaper(
     decode: dialect.needsDecode(field),
   }));
   const width = columns.length;
+
+  // Flattened to `(key, many)` pairs at build time for the same reason the
+  // columns are: the per-row loop does no property lookups it can avoid, and
+  // the common case — no relations — costs one comparison against zero.
+  const related = relations.map((relation) => ({
+    key: relation.key,
+    many: relation.kind === "many",
+  }));
+  const relatedCount = related.length;
 
   return (rows: unknown[]) => {
     // Grown by `push` rather than preallocated: `new Array(n)` produces a holey
@@ -47,6 +72,12 @@ export function buildRowShaper(
         shaped[column.key] = column.decode
           ? dialect.decode(value, column.field)
           : (value ?? null);
+      }
+      for (let j = 0; j < relatedCount; j++) {
+        // A fresh array per row: they are handed to the caller and pushed into
+        // by the relation loader, so sharing one would alias every parent's
+        // children together.
+        shaped[related[j].key] = related[j].many ? [] : null;
       }
       out.push(shaped);
     }

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -48,7 +48,7 @@
     "build:plugin": "vite build -c vite.plugin.config.mts",
     "build:types": "tsc",
     "build:client-types": "tsc -p tsconfig.browser.json",
-    "test": "vitest",
+    "test": "bun --bun vitest",
     "build:publish": "bun scripts/build-publish.ts",
     "prepublishOnly": "echo 'Do not publish from this directory — its exports point at TS source. Run: bun run build:publish, then publish from .publish/' && exit 1"
   },

--- a/templates/saas-starter/app/models/User.test.ts
+++ b/templates/saas-starter/app/models/User.test.ts
@@ -166,10 +166,17 @@ describe("User.findMany()", () => {
     );
   });
 
-  test("throws on include rather than silently dropping the relation", async () => {
-    await expect(
-      User.findMany({ include: { accounts: true } }),
-    ).rejects.toThrow(/Relations are not implemented yet/);
+  // The relation is loaded through the *generated* artifact's topology: this
+  // model class was never told where `accounts` lives, only that it is a
+  // relation named `AccountToUser` on a model named `Account`.
+  test("include loads the relation, and an empty one is an array", async () => {
+    const [user] = await User.findMany({
+      where: { email: SEEDED.email },
+      include: { accounts: true },
+    });
+
+    expect(user.accounts).toEqual([]);
+    expect("accounts" in user).toBe(true);
   });
 });
 

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -297,6 +297,19 @@ const CASES: [string, string, unknown][] = [
 
   // --- relations: to-one -------------------------------------------------
   ["include to-one", "findMany", { include: { organization: true } }],
+  // Prisma's to-one include takes a `where` — it filters, and the relation
+  // comes back null when nothing matches — but not an `orderBy`, since there is
+  // at most one row to order. Both halves are pinned here rather than argued
+  // from the types: the second case is agreement that *both* clients refuse it.
+  ["include to-one with where", "findMany", {
+    include: { organization: { where: { name: "Acme" } } },
+  }],
+  ["include to-one with where matching nothing", "findMany", {
+    include: { organization: { where: { name: "nobody" } } },
+  }],
+  ["include to-one with orderBy is refused by both", "findMany", {
+    include: { organization: { orderBy: { id: "asc" } } },
+  }],
   ["include to-one with select", "findMany", {
     include: { organization: { select: { name: true } } },
   }],

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -1,12 +1,17 @@
 import type { PrismaClient } from "@prisma/client";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 
 import {
   POSTGRES_URL,
   createDifferential,
   type Differential,
 } from "./differential";
-import { SocialAccountModel, UserModel } from "./generated";
+import {
+  AccountModel,
+  OrganizationModel,
+  SocialAccountModel,
+  UserModel,
+} from "./generated";
 
 // Rows chosen so that every case below actually discriminates: nullable columns
 // that are null on some rows and not others, names that tie under `orderBy`,
@@ -14,6 +19,18 @@ import { SocialAccountModel, UserModel } from "./generated";
 const EPOCH = 1600000000000;
 
 async function seed(prisma: PrismaClient) {
+  // Two organizations so a to-one include has something to discriminate, and
+  // so `organization.users` is a to-many with more than one member.
+  await prisma.organization.createMany({
+    data: [
+      { publicId: "o1", name: "Acme", description: "the first one" },
+      { publicId: "o2", name: "Globex" },
+    ],
+  });
+  const [acme, globex] = await prisma.organization.findMany({
+    orderBy: { id: "asc" },
+  });
+
   await prisma.user.createMany({
     data: [
       {
@@ -21,6 +38,7 @@ async function seed(prisma: PrismaClient) {
         name: "Ada",
         email: "ada@example.dev",
         globalRole: 0,
+        organizationId: acme.id,
         createdAt: new Date(EPOCH),
         updatedAt: new Date(EPOCH),
       },
@@ -29,6 +47,7 @@ async function seed(prisma: PrismaClient) {
         name: "Grace",
         email: "grace@example.dev",
         globalRole: 1,
+        organizationId: acme.id,
         createdAt: new Date(EPOCH + 1000),
         updatedAt: new Date(EPOCH + 1000),
         deletedAt: new Date(EPOCH + 5000),
@@ -38,9 +57,12 @@ async function seed(prisma: PrismaClient) {
         name: "Ada",
         email: "ada2@other.test",
         globalRole: 2,
+        organizationId: globex.id,
         createdAt: new Date(EPOCH + 2000),
         updatedAt: new Date(EPOCH + 2000),
       },
+      // No organization: the row that makes a to-one include return `null`
+      // rather than an object, which is the divergence to catch.
       {
         publicId: "p4",
         name: null,
@@ -60,9 +82,63 @@ async function seed(prisma: PrismaClient) {
     ],
   });
 
+  const users = await prisma.user.findMany({ orderBy: { id: "asc" } });
+  const [first, second, third] = users;
+
+  // Ada has two accounts, Grace one, and everyone else none — so one include
+  // covers the many, the one and the empty case at once. The orphan account
+  // belongs to no user and no organization, which is what makes a *reverse*
+  // to-one include return null.
+  await prisma.account.createMany({
+    data: [
+      {
+        publicId: "ac1",
+        userId: first.id,
+        organizationId: acme.id,
+        organizationRole: 0,
+        createdAt: new Date(EPOCH),
+        updatedAt: new Date(EPOCH),
+      },
+      {
+        publicId: "ac2",
+        userId: first.id,
+        organizationId: acme.id,
+        organizationRole: 2,
+        createdAt: new Date(EPOCH + 1000),
+        updatedAt: new Date(EPOCH + 1000),
+        deletedAt: new Date(EPOCH + 6000),
+      },
+      {
+        publicId: "ac3",
+        userId: second.id,
+        organizationId: globex.id,
+        organizationRole: 1,
+        createdAt: new Date(EPOCH + 2000),
+        updatedAt: new Date(EPOCH + 2000),
+      },
+      {
+        publicId: "ac4",
+        organizationRole: 2,
+        createdAt: new Date(EPOCH + 3000),
+        updatedAt: new Date(EPOCH + 3000),
+      },
+    ],
+  });
+
+  // A session for the third user only: a second to-many on the same parent
+  // key, so a two-branch include tree is not two views of one relation.
+  await prisma.session.create({
+    data: {
+      token: "session-1",
+      userId: third.id,
+      createdAt: new Date(EPOCH),
+      expiresAt: new Date(EPOCH + 100000),
+      absoluteExpiresAt: new Date(EPOCH + 200000),
+    },
+  });
+
   // The only model in the template with a composite `@@unique`, so the only one
   // that can exercise Prisma's joined compound key form.
-  const [first] = await prisma.user.findMany({ orderBy: { id: "asc" } });
   await prisma.socialAccount.create({
     data: {
       userId: first.id,
@@ -194,6 +270,109 @@ const CASES: [string, string, unknown][] = [
   ["findUniqueOrThrow", "findUniqueOrThrow", { where: { email: "ada@example.dev" } }],
   ["findUniqueOrThrow missing", "findUniqueOrThrow", { where: { email: "nope@x.dev" } }],
 
+  // --- relations: to-many -----------------------------------------------
+  // Every to-many case that can return more than one child orders explicitly.
+  // Neither client orders a relation query it was not asked to order, so an
+  // unordered comparison would be asserting the storage engine's habits.
+  ["include to-many", "findMany", { include: { accounts: { orderBy: { id: "asc" } } } }],
+  ["include to-many bare", "findMany", { include: { session: true } }],
+  ["include two branches", "findMany", {
+    include: { accounts: { orderBy: { id: "asc" } }, session: true },
+  }],
+  ["include to-many with where", "findMany", {
+    include: { accounts: { where: { deletedAt: null }, orderBy: { id: "asc" } } },
+  }],
+  ["include to-many matching nothing", "findMany", {
+    include: { accounts: { where: { organizationRole: 99 } } },
+  }],
+  ["include to-many ordered desc", "findMany", {
+    include: { accounts: { orderBy: { organizationRole: "desc" } } },
+  }],
+  ["include to-many with select", "findMany", {
+    include: { accounts: { select: { publicId: true }, orderBy: { id: "asc" } } },
+  }],
+  ["include to-many selecting its own key", "findMany", {
+    include: { accounts: { select: { userId: true }, orderBy: { id: "asc" } } },
+  }],
+
+  // --- relations: to-one -------------------------------------------------
+  ["include to-one", "findMany", { include: { organization: true } }],
+  ["include to-one with select", "findMany", {
+    include: { organization: { select: { name: true } } },
+  }],
+  ["include to-one and to-many", "findMany", {
+    include: { organization: true, accounts: { orderBy: { id: "asc" } } },
+  }],
+
+  // --- relations inside select ------------------------------------------
+  ["select a relation beside a scalar", "findMany", {
+    select: { name: true, accounts: { orderBy: { id: "asc" } } },
+  }],
+  ["select nothing but a relation", "findMany", {
+    select: { accounts: { orderBy: { id: "asc" } } },
+  }],
+  ["select a relation and its own key", "findMany", {
+    select: { id: true, accounts: { select: { id: true, userId: true }, orderBy: { id: "asc" } } },
+  }],
+  ["select a to-one relation", "findMany", { select: { name: true, organization: true } }],
+  ["select inside select", "findMany", {
+    select: { publicId: true, organization: { select: { name: true } } },
+  }],
+
+  // --- relations: depth --------------------------------------------------
+  ["depth 2", "findMany", {
+    include: { accounts: { include: { organization: true }, orderBy: { id: "asc" } } },
+  }],
+  ["depth 3", "findMany", {
+    include: {
+      organization: {
+        include: { accounts: { include: { user: true }, orderBy: { id: "asc" } } },
+      },
+    },
+  }],
+  // Legal and finite: a cycle in the *schema* is not a cycle in the argument
+  // tree, and the caller wrote a tree three levels deep.
+  ["cyclic but finite", "findMany", {
+    include: {
+      accounts: {
+        orderBy: { id: "asc" },
+        include: { user: { include: { accounts: { orderBy: { id: "asc" } } } } },
+      },
+    },
+  }],
+  ["depth 3 with select at the leaf", "findMany", {
+    include: {
+      accounts: {
+        orderBy: { id: "asc" },
+        include: { organization: { select: { name: true, publicId: true } } },
+      },
+    },
+  }],
+
+  // --- relations alongside the rest of the surface -----------------------
+  ["include with a root where", "findMany", {
+    where: { globalRole: 2 },
+    include: { accounts: { orderBy: { id: "asc" } } },
+  }],
+  ["include with root pagination", "findMany", {
+    take: 2, skip: 1, orderBy: { id: "asc" }, include: { organization: true },
+  }],
+  ["include on a query matching nothing", "findMany", {
+    where: { email: "nobody@example.dev" }, include: { accounts: true },
+  }],
+  ["include on findFirst", "findFirst", {
+    where: { publicId: "p1" }, include: { accounts: { orderBy: { id: "asc" } } },
+  }],
+  ["include on findFirst matching nothing", "findFirst", {
+    where: { publicId: "nope" }, include: { accounts: true },
+  }],
+  ["include on findUnique", "findUnique", {
+    where: { publicId: "p1" }, include: { organization: true, accounts: { orderBy: { id: "asc" } } },
+  }],
+  ["include on findUniqueOrThrow", "findUniqueOrThrow", {
+    where: { publicId: "p4" }, include: { organization: true },
+  }],
+
   // --- count ------------------------------------------------------------
   ["count", "count", undefined],
   ["count with where", "count", { where: { deletedAt: null } }],
@@ -240,6 +419,8 @@ function suite(label: string, url?: string) {
         models: {
           User: UserModel as never,
           SocialAccount: SocialAccountModel as never,
+          Account: AccountModel as never,
+          Organization: OrganizationModel as never,
         },
         seed,
         url,
@@ -273,6 +454,118 @@ function suite(label: string, url?: string) {
       await differential.expectSame("SocialAccount", "findUnique", {
         where: { username_provider: { username: "nobody", provider: "none" } },
       });
+    });
+
+    // The cases above all read from `User`, which is the owning side of one
+    // relation and the referenced side of the others. These read from the far
+    // end, where the same relation is the other kind.
+    test.each([
+      ["Organization", "findMany", { include: { users: { orderBy: { id: "asc" } } } }],
+      ["Organization", "findMany", {
+        include: { users: { select: { name: true } }, accounts: { orderBy: { id: "asc" } } },
+      }],
+      // ac4 belongs to nobody, so this is the reverse to-one returning null.
+      ["Account", "findMany", { orderBy: { id: "asc" }, include: { user: true } }],
+      ["Account", "findMany", {
+        orderBy: { id: "asc" },
+        include: { user: { select: { publicId: true } }, organization: true },
+      }],
+      ["Account", "findMany", {
+        orderBy: { id: "asc" },
+        select: { publicId: true, user: { select: { name: true } } },
+      }],
+    ] as [string, string, unknown][])(
+      "%s.%o from the far side of the relation",
+      async (model, operation, args) => {
+        await differential.expectSame(model, operation, args);
+      },
+    );
+
+    // One query per *node* in the include tree, not per row. Depth 2 with two
+    // branches over five users is 4 queries, not 20 — and the count is what
+    // catches an accidental N+1 later, since the results look identical either
+    // way.
+    test("query count follows the include tree, not the row count", async () => {
+      differential.resetQueries();
+      await UserModel.findMany({});
+      expect(differential.queries()).toBe(1);
+
+      differential.resetQueries();
+      const rows = await UserModel.findMany({
+        include: {
+          organization: true,
+          accounts: { include: { organization: true } },
+        },
+      });
+      // root + organization + accounts + accounts.organization
+      expect(differential.queries()).toBe(4);
+      expect(rows).toHaveLength(5);
+
+      // And the same tree over one row costs the same four queries, which is
+      // the other half of "proportional to the tree".
+      differential.resetQueries();
+      await UserModel.findFirst({
+        include: {
+          organization: true,
+          accounts: { include: { organization: true } },
+        },
+      });
+      expect(differential.queries()).toBe(4);
+    });
+
+    // A node whose parents have no keys at all is not worth a round trip: the
+    // shaper has already written every answer it could have.
+    test("a relation with no parent keys costs no query", async () => {
+      differential.resetQueries();
+      await UserModel.findMany({
+        where: { publicId: "p4" },
+        include: { organization: true },
+      });
+      expect(differential.queries()).toBe(1);
+    });
+
+    // Iteration 6 attaches policies to `$exec`, so "the nested read went
+    // through the related model's own choke point" is the property that makes
+    // policies apply to nested reads at all. Asserted by observation.
+    test("each relation query is $exec on the related model's class", async () => {
+      const account = vi.spyOn(AccountModel, "$exec");
+      const organization = vi.spyOn(OrganizationModel, "$exec");
+
+      try {
+        await UserModel.findMany({
+          include: { accounts: true, organization: true },
+        });
+
+        expect(account).toHaveBeenCalledTimes(1);
+        expect(account.mock.calls[0][0]).toBe("findMany");
+        expect(organization).toHaveBeenCalledTimes(1);
+      } finally {
+        account.mockRestore();
+        organization.mockRestore();
+      }
+    });
+
+    test("take and skip inside a to-many relation throw rather than lie", async () => {
+      // Prisma implements these; gemi refuses them under the batched planner
+      // rather than applying the limit globally, which would return a
+      // plausible and wrong answer. See the iteration 7 note in
+      // plan-relations.ts.
+      await expect(
+        UserModel.findMany({ include: { accounts: { take: 1 } } }),
+      ).rejects.toThrow(/per parent/);
+      await expect(
+        UserModel.findMany({ include: { accounts: { skip: 1 } } }),
+      ).rejects.toThrow(/lateral join strategy/);
+    });
+
+    test("select and include together throw at any level", async () => {
+      await expect(
+        UserModel.findMany({
+          include: {
+            accounts: { select: { id: true }, include: { user: true } } as never,
+          },
+        }),
+      ).rejects.toThrow(/only one of them/);
     });
 
     // A guard on the harness itself: if `expectSame` compared nothing, every

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -32,6 +32,14 @@ export interface Differential {
     operation: string,
     args?: unknown,
   ): Promise<unknown>;
+  /**
+   * Statements the gemi ORM has executed since the last reset. The point of
+   * counting is the relation planner: one query per *node* in an include tree
+   * and not one per row is a property no result comparison can see, and an
+   * accidental N+1 is otherwise invisible until it is in production.
+   */
+  queries(): number;
+  resetQueries(): void;
   dispose(): Promise<void>;
 }
 
@@ -93,9 +101,18 @@ export async function createDifferential(options: {
   // Postgres runs against whatever `TEST_POSTGRES_URL` names, so the harness
   // clears only the table it seeds and nothing else. The env var's contract is
   // that it points at a scratch database with the schema already applied.
+  await assertPrismaSpeaks(prisma, options.url ? "postgresql" : "sqlite");
+
   if (options.url) {
+    // Children before parents: the schema's foreign keys are enforced on both
+    // dialects, and a scratch database is only scratch for this suite.
     await prisma.socialAccount.deleteMany({});
+    await prisma.session.deleteMany({});
+    await prisma.passwordResetToken.deleteMany({});
+    await prisma.account.deleteMany({});
     await prisma.user.deleteMany({});
+    await prisma.organizationInvitation.deleteMany({});
+    await prisma.organization.deleteMany({});
   }
 
   await options.seed(prisma);
@@ -105,11 +122,31 @@ export async function createDifferential(options: {
   const database = new DatabaseManager({
     url: url.startsWith("file:") ? `sqlite://${url.slice(5)}` : url,
   });
-  app.instance(DatabaseManager, database);
+
+  // What the container hands `$exec` is a counting stand-in rather than the
+  // manager itself. `$exec` resolves the manager per call and reads exactly
+  // `sql.unsafe` and `dialect` off it, so this needs no cooperation from the
+  // ORM — and a test seam the runtime does not know about cannot drift.
+  let executed = 0;
+  app.instance(DatabaseManager, {
+    dialect: database.dialect,
+    url: database.url,
+    sql: {
+      unsafe(text: string, values: unknown[]) {
+        executed++;
+        return database.sql.unsafe(text, values);
+      },
+    },
+  } as never);
   Application.setInstance(app);
 
   return {
     prisma,
+
+    queries: () => executed,
+    resetQueries: () => {
+      executed = 0;
+    },
 
     async expectSame(model, operation, args) {
       clearPlanCache();
@@ -178,6 +215,48 @@ async function applyMigrations(path: string): Promise<void> {
     }
   } finally {
     await sql.close();
+  }
+}
+
+/**
+ * The gemi side of the harness is dialect-agnostic — `DatabaseManager` reads the
+ * dialect off the URL — but the *Prisma* side is not: a generated client carries
+ * its schema's `datasource` provider, and refuses any other protocol outright.
+ * So covering Postgres is a two-step workflow, and the error Prisma raises on
+ * its own does not say so:
+ *
+ *   1. flip `datasource db { provider }` in prisma/schema.prisma to postgresql
+ *   2. `prisma generate` (the gemi artifacts are dialect-agnostic and do not
+ *      change — that is worth confirming with `git status` while you are here)
+ *   3. TZ=UTC TEST_POSTGRES_URL=postgres://... vitest
+ *   4. flip back and regenerate
+ *
+ * The SQLite suite cannot run in the same process while the client is built for
+ * Postgres, which is why the two dialects are two runs rather than one.
+ *
+ * TZ=UTC is not incidental: Bun's Postgres driver decodes a zoneless
+ * `timestamp` as local time when a statement binds no parameters and as UTC
+ * when it binds one, so on a machine that is not UTC the two protocols disagree
+ * with each other and with Prisma. See the note in orm/dialect/postgres.ts.
+ */
+async function assertPrismaSpeaks(
+  prisma: PrismaClient,
+  provider: "sqlite" | "postgresql",
+): Promise<void> {
+  try {
+    await prisma.$queryRaw`select 1`;
+  } catch (error: any) {
+    if (!/must start with the protocol/.test(String(error?.message))) throw error;
+    throw new Error(
+      `This suite needs @prisma/client generated for the '${provider}' ` +
+        `provider, and it is not. Set datasource db { provider = ` +
+        `"${provider}" } in prisma/schema.prisma and re-run ` +
+        `\`prisma generate\`. Only one dialect's suite can run at a time, ` +
+        `which is why the other one is failing rather than skipping.` +
+        (provider === "postgresql"
+          ? ` Run it as: TZ=UTC TEST_POSTGRES_URL=postgres://... vitest`
+          : ` Unset TEST_POSTGRES_URL to run only this one.`),
+    );
   }
 }
 

--- a/templates/saas-starter/app/models/relations.many-to-many.test.ts
+++ b/templates/saas-starter/app/models/relations.many-to-many.test.ts
@@ -1,0 +1,314 @@
+import { SQL } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DatabaseManager } from "gemi/database";
+import { Application } from "gemi/foundation";
+import { Model, clearPlanCache, register, type ModelSchema } from "gemi/orm";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+
+import { POSTGRES_URL } from "./differential";
+
+/**
+ * Prisma's *implicit* many-to-many, which the template's own schema cannot
+ * exercise — every relation in it is 1-1 or 1-n.
+ *
+ * An implicit m-n has no join *model*: Prisma creates a bare `_<RelationName>`
+ * table with an `A` and a `B` column holding the two ids, the models in
+ * alphabetical order. So the planner needs a two-hop load, and nothing in
+ * `differential.test.ts` can reach it.
+ *
+ * This fixture is therefore a database rather than a Prisma client: the DDL
+ * below is what `prisma migrate` emits for the two models in the comment, and
+ * the assertions are against Prisma's documented result shape rather than
+ * against a second generated client. That is the trade recorded in the PR —
+ * covering the join-table logic for real, without a second `prisma generate` in
+ * the test path. The shape rules it relies on (`[]` for an empty to-many, a
+ * nested `select` keeping exactly its keys) are the same code the differential
+ * suite pins against Prisma on the 1-n relations.
+ *
+ * ```prisma
+ * model Post { id Int @id @default(autoincrement())  title String  tags Tag[] }
+ * model Tag  { id Int @id @default(autoincrement())  label String  posts Post[] }
+ * ```
+ */
+
+// Verbatim from `prisma migrate diff --from-empty --to-schema-datamodel`, so
+// the table this test joins through is the table Prisma would have created,
+// down to the index names.
+const DDL = [
+  `CREATE TABLE "Post" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL
+)`,
+  `CREATE TABLE "Tag" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "label" TEXT NOT NULL
+)`,
+  `CREATE TABLE "_PostToTag" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+    CONSTRAINT "_PostToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Post" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_PostToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+)`,
+  `CREATE UNIQUE INDEX "_PostToTag_AB_unique" ON "_PostToTag"("A", "B")`,
+  `CREATE INDEX "_PostToTag_B_index" ON "_PostToTag"("B")`,
+];
+
+// What the gemi generator emits for the two models above — confirmed by running
+// `prisma generate` over that schema with the generator block, not assumed:
+// neither side holds a foreign key, and both carry the same `joinTable`.
+const JOIN_TABLE = { table: "_PostToTag", a: "Post", b: "Tag" };
+
+const postSchema: ModelSchema = {
+  name: "Post",
+  table: "Post",
+  fields: {
+    id: { name: "id", column: "id", type: "Int", nullable: false, isId: true, isUpdatedAt: false, default: { kind: "autoincrement" } },
+    title: { name: "title", column: "title", type: "String", nullable: false, isId: false, isUpdatedAt: false },
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    tags: {
+      name: "tags",
+      model: "Tag",
+      kind: "many",
+      relationName: "PostToTag",
+      from: [],
+      to: [],
+      nullable: false,
+      joinTable: JOIN_TABLE,
+    },
+  },
+};
+
+const tagSchema: ModelSchema = {
+  name: "Tag",
+  table: "Tag",
+  fields: {
+    id: { name: "id", column: "id", type: "Int", nullable: false, isId: true, isUpdatedAt: false, default: { kind: "autoincrement" } },
+    label: { name: "label", column: "label", type: "String", nullable: false, isId: false, isUpdatedAt: false },
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    posts: {
+      name: "posts",
+      model: "Post",
+      kind: "many",
+      relationName: "PostToTag",
+      from: [],
+      to: [],
+      nullable: false,
+      joinTable: JOIN_TABLE,
+    },
+  },
+};
+
+class Post extends Model {
+  static $schema = postSchema;
+  static findMany(args?: unknown) {
+    return this.$exec("findMany", args) as Promise<Record<string, any>[]>;
+  }
+}
+
+class Tag extends Model {
+  static $schema = tagSchema;
+  static findMany(args?: unknown) {
+    return this.$exec("findMany", args) as Promise<Record<string, any>[]>;
+  }
+}
+
+// The Postgres form of the same three tables, also verbatim from
+// `prisma migrate diff`. The join hop is the one query the ORM assembles
+// outside the compiler, so it is worth running on both dialects: the parent-key
+// filter goes through the dialect's own `inList`, which is `in (?, ?)` on SQLite
+// and `= any($1)` over an array literal here.
+const PG_DDL = [
+  `DROP TABLE IF EXISTS "_PostToTag"`,
+  `DROP TABLE IF EXISTS "Post"`,
+  `DROP TABLE IF EXISTS "Tag"`,
+  `CREATE TABLE "Post" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    CONSTRAINT "Post_pkey" PRIMARY KEY ("id")
+)`,
+  `CREATE TABLE "Tag" (
+    "id" SERIAL NOT NULL,
+    "label" TEXT NOT NULL,
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+)`,
+  `CREATE TABLE "_PostToTag" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+    CONSTRAINT "_PostToTag_AB_pkey" PRIMARY KEY ("A","B")
+)`,
+  `CREATE INDEX "_PostToTag_B_index" ON "_PostToTag"("B")`,
+  `ALTER TABLE "_PostToTag" ADD CONSTRAINT "_PostToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+  `ALTER TABLE "_PostToTag" ADD CONSTRAINT "_PostToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+];
+
+// Post 1 carries two tags, post 2 one, post 3 none — the many / one / empty
+// spread the 1-n cases use, and one tag nobody references.
+const ROWS = [
+  `INSERT INTO "Post" ("id", "title") VALUES (1, 'first'), (2, 'second'), (3, 'untagged')`,
+  `INSERT INTO "Tag" ("id", "label") VALUES (1, 'red'), (2, 'blue'), (3, 'unused')`,
+  `INSERT INTO "_PostToTag" ("A", "B") VALUES (1, 1), (1, 2), (2, 2)`,
+];
+
+let workspace: string | undefined;
+let database: DatabaseManager;
+let previous: Application | undefined;
+let queries = 0;
+
+async function setup(url: string, ddl: string[]) {
+  const sql = new SQL(url);
+  try {
+    for (const statement of [...ddl, ...ROWS]) await sql.unsafe(statement);
+  } finally {
+    await sql.close();
+  }
+
+  previous = Application.getInstance();
+  const app = new Application();
+  database = new DatabaseManager({ url });
+  // `$exec` resolves the manager per call and reads exactly `sql.unsafe` and
+  // `dialect` off it, so a counting stand-in needs no cooperation from the ORM.
+  app.instance(DatabaseManager, {
+    dialect: database.dialect,
+    url: database.url,
+    sql: {
+      unsafe(text: string, values: unknown[]) {
+        queries++;
+        return database.sql.unsafe(text, values);
+      },
+    },
+  } as never);
+  Application.setInstance(app);
+
+  register("Post", Post);
+  register("Tag", Tag);
+  clearPlanCache();
+}
+
+async function teardown() {
+  await database?.close();
+  Application.setInstance(previous);
+  if (workspace) rmSync(workspace, { recursive: true, force: true });
+}
+
+function suite(label: string, start: () => Promise<void>) {
+  describe(label, () => {
+    beforeAll(start, 60_000);
+    afterAll(teardown);
+    cases();
+  });
+}
+
+suite("implicit many-to-many — sqlite", async () => {
+  workspace = mkdtempSync(join(tmpdir(), "gemi-orm-mn-"));
+  await setup(`sqlite://${join(workspace, "mn.db")}`, DDL);
+});
+
+// Same contract as the differential suite's: a scratch database, and the tables
+// this fixture owns are dropped and recreated in it.
+const postgresUrl = POSTGRES_URL;
+if (postgresUrl) {
+  suite("implicit many-to-many — postgres", async () => {
+    workspace = undefined;
+    await setup(postgresUrl, PG_DDL);
+  });
+}
+
+function cases() {
+  test("loads through the join table, in both directions", async () => {
+    const posts = await Post.findMany({
+      orderBy: { id: "asc" },
+      include: { tags: { orderBy: { id: "asc" } } },
+    });
+
+    expect(posts.map((post) => [post.title, post.tags.map((t: any) => t.label)]))
+      .toEqual([
+        ["first", ["red", "blue"]],
+        ["second", ["blue"]],
+        // Not null, not absent: an empty to-many is `[]`.
+        ["untagged", []],
+      ]);
+
+    // The other side reads the same table through the *other* column, which is
+    // the half a one-directional implementation gets wrong.
+    const tags = await Tag.findMany({
+      orderBy: { id: "asc" },
+      include: { posts: { orderBy: { id: "asc" } } },
+    });
+    expect(tags.map((tag) => [tag.label, tag.posts.map((p: any) => p.title)]))
+      .toEqual([
+        ["red", ["first"]],
+        ["blue", ["first", "second"]],
+        ["unused", []],
+      ]);
+  });
+
+  test("the relation's own arguments apply to the second hop", async () => {
+    const posts = await Post.findMany({
+      orderBy: { id: "asc" },
+      include: { tags: { where: { label: "blue" } } },
+    });
+    expect(posts.map((post) => post.tags.map((t: any) => t.label))).toEqual([
+      ["blue"],
+      ["blue"],
+      [],
+    ]);
+
+    // Descending, to prove the ordering is the child query's and not the join
+    // table's row order.
+    const ordered = await Post.findMany({
+      where: { id: 1 },
+      include: { tags: { orderBy: { label: "asc" } } },
+    });
+    expect(ordered[0].tags.map((t: any) => t.label)).toEqual(["blue", "red"]);
+  });
+
+  test("a nested select returns exactly its keys", async () => {
+    const posts = await Post.findMany({
+      where: { id: 1 },
+      select: { title: true, tags: { select: { label: true } } },
+    });
+
+    // `Post.id` and `Tag.id` were both fetched to make the stitch possible and
+    // both are gone again.
+    expect(posts).toEqual([
+      { title: "first", tags: [{ label: "red" }, { label: "blue" }] },
+    ]);
+  });
+
+  test("two hops per node, not one per row", async () => {
+    queries = 0;
+    await Post.findMany({ include: { tags: true } });
+    // root + the join table + the tags themselves.
+    expect(queries).toBe(3);
+  });
+
+  test("the row hop is $exec on the related model's class", async () => {
+    const spy = vi.spyOn(Tag, "$exec");
+    try {
+      await Post.findMany({ where: { id: 1 }, include: { tags: true } });
+      // The join table has no model — it holds two foreign keys and nothing an
+      // application could scope — but the hop that reads *rows* goes through
+      // the choke point, so iteration 6's policies reach it.
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0]).toBe("findMany");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("no links means no second hop", async () => {
+    queries = 0;
+    await Post.findMany({ where: { id: 3 }, include: { tags: true } });
+    // root + join table, and then nothing to fetch.
+    expect(queries).toBe(2);
+  });
+}


### PR DESCRIPTION
Third in the ORM stack, on top of #46. Implements
[plans/orm/03-motorcycle-relations.md](../blob/feat/orm-03-motorcycle/plans/orm/03-motorcycle-relations.md):
`include` and nested `select` / `include` to arbitrary depth, through the
batched planner.

## The planner is a stage, not a branch

`packages/gemi/orm/compile/plan-relations.ts` holds a `RelationStrategy`: given
a parent schema and one relation node, produce the parent field the stitch keys
on plus a `load` that fetches the children and attaches them. `batchedStrategy`
is the only implementation. Iteration 7's `LATERAL` + `json_agg` has to be a
sibling implementation of the same interface — that is the whole point of the
seam (invariant 4).

## One query per node, through the child's own `$exec`

For `include: { accounts: true }` over 100 users: run the root query, collect
the parent keys, run **one** child query with `where userId in (<keys>)`, stitch
by key. A depth-2 tree with two branches is 4 queries over 5 rows and 4 queries
over 1 row — asserted, because an accidental N+1 is invisible in the results and
only shows up in production.

Each child query is `$exec` on the **related model's own class**, resolved by
name from the registry at call time — not a private helper (invariant 1). That
is what makes iteration 6's policies apply to nested reads, and there is a test
that spies on `$exec` to keep it that way. Nested trees need no special handling
for the same reason: a child's subtree is just its own call's arguments.

The `in (<parent keys>)` list has iteration 2's variable-length plan-cache
problem at higher volume, and reuses iteration 2's answer (the LRU bound) rather
than inventing a second mechanism.

## Result shape

The three lines most divergence bugs live on:

- to-one present → the object
- to-one absent → `null`, not `undefined`, not a missing key
- to-many empty → `[]`, not `null`, not absent

The precompiled shaper writes the empty value per row, so the key exists before
anything is loaded. Stitching builds one `Map` from parent key to parent rows
per child query — never a `find()` per row.

A `select` that omits the join key still has to fetch it: those columns are
selected, used, and deleted (`plan.hidden`). With `include`, or a `select` that
names the key, nothing is hidden and nothing is deleted.

**One deliberate divergence:** a child row reached by several parents is
attached by reference, so 100 users in 3 organizations share 3 objects rather
than getting 100 copies. Values are identical and the differential harness sees
nothing; identity differs from Prisma. Cloning is the copying the batched
strategy exists to avoid, and a shallow clone would still alias everything
below it. Noted in the code, worth revisiting in iteration 8.

## The two decisions the doc asked for

**`take` / `skip` on a to-many relation throws `UnsupportedQueryError`.** It
means N *per parent*, which under batching needs
`row_number() over (partition by ...)` in a wrapping subquery — not expressible
through `$exec` on the child's model class, so it would need exactly the private
query path invariant 1 exists to prevent. Applying the limit globally returns
wrong data, which is worse than not supporting it. It falls out of iteration 7's
lateral strategy. The error says so. Tested as a compiler error and end to end.

**Implicit many-to-many is implemented**, not thrown — two hops: read the
`_PostToTag` pairs, then load the rows through `Tag.$exec`. The join table is
the one query the ORM issues outside `$exec`, deliberately: it has no model, no
fields of its own, and nothing an application could scope. The hop that reads
*rows* still goes through the choke point, so a policy on `Tag` will apply to
`include: { tags: true }`. A self-referential implicit m-n throws, because the
generated artifact cannot say which of `A` / `B` is which end.

The fixture is a real database rather than a second Prisma client
(`relations.many-to-many.test.ts`): the DDL is verbatim
`prisma migrate diff --from-empty --to-schema-datamodel` output, and the
generator's `joinTable` emission was confirmed by running `prisma generate` over
that schema against real DMMF rather than assumed. It runs on both dialects.

That is weaker than the doc's first choice — a differential run against a
generated fixture client — and stronger than its stated fallback. The cost I
declined was a second `prisma generate` inside the test path. Say the word and
it can be upgraded; it is one file.

## Guards

- Depth limit of 10, with the *whole* tree walked at root compile — a guard that
  only ever sees one level catches an unbounded tree one query too late, every
  time.
- A relation naming an unregistered model reports the model, the fix
  (`prisma generate`), and what *is* registered — it can only mean a stale
  generated artifact.
- `select` + `include` together throws at every level, not just the root.
- Multi-field relations and self-referential implicit m-n throw rather than
  guessing.

## Two Postgres defects found — one fixed here, one for review

The Postgres differential had never actually run: a generated Prisma client is
provider-bound, so `TEST_POSTGRES_URL` alone fails before any query is issued.
Covering it means flipping `datasource db { provider }`, regenerating, and
running the suite — during which the SQLite suite cannot run. The harness now
says that in an error message instead of surfacing Prisma's own. (The gemi
artifacts are byte-identical under either provider, which is its own
confirmation that generated output is dialect-agnostic.)

**Fixed here, because every batched relation query depends on it:** Bun's driver
rejects a JS array bound to `= any($1)` outright — `insufficient data left in
message` for numbers, `malformed array literal` for strings. So iteration 2's
Postgres `in` never worked at runtime. The values are now serialized to a
Postgres array literal: still one bound parameter, still nothing in the SQL text,
so neither the injection story nor the plan cache changes. Verified against
Postgres 16 for `int`, `text` (quotes, commas, braces, backslashes, newlines),
`timestamp`, `boolean`, `bigint` past 2^53, `bytea` and `double precision`, with
unit tests pinning the escaping.

**Not fixed, and I do not think it belongs in this PR:** Bun decodes a zoneless
`timestamp` — which is what Prisma maps `DateTime` to — as **local** time when a
statement binds no parameters, and as UTC when it binds one. Same row, same
column, two instants, on any machine that is not already UTC:

```
select "createdAt" from "User" limit 1           -> 10:26:40Z
select "createdAt" from "User" where "id" = $1   -> 12:26:40Z
select "createdAt"::text from "User" limit 1     -> 12:26:40     (what is stored)
```

A dialect `decode` cannot correct it: the value does not say which protocol
produced it, and nothing below the plan does. It is iteration-2 surface, it
affects every `DateTime` rather than anything about relations, and the real fix
is either upstream in Bun or a change to the SQL emitted for timestamp columns —
which deserves its own review. Documented in `orm/dialect/postgres.ts` with the
reproduction. Interim mitigation: run with `TZ=UTC`, where both paths agree.

## Verification

- **SQLite:** 145 template tests, 252 package tests, green.
- **Postgres** (`TZ=UTC`, provider flipped, scratch database): all 123
  differential cases — including ~35 new relation cases — plus the m-n fixture,
  green.
- The differential matrix now covers: to-one, to-many, empty to-many, null
  to-one, `select` inside `include`, `include` inside `select`, a relation
  selected with no scalars at all, relation-level `where` / `orderBy`, depth 3,
  a cyclic-but-finite tree, relations on `findFirst` / `findUnique*`, and both
  far sides of every relation.
- `bun run lint` 0 errors; `tsc` clean in both packages.
- The 7 pre-existing router / i18n failures in `packages/gemi` are unchanged.

## Out of scope, as scheduled

Lateral / `json_agg` (iteration 7), `_count` on relations, relation filters in
`where` (`some` / `every` / `none` — they belong in the where compiler as
`EXISTS` subqueries and are worth scheduling explicitly), all writes,
transactions, policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
