### PR TITLE
ORM iteration 4 — writes, on two dialects, verified against Prisma

### DIFF
--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -356,6 +356,69 @@ function countOperation(model: string): string {
 `;
 }
 
+/**
+ * The write surface.
+ *
+ * `create`, `update`, `delete` and `upsert` return a payload narrowed by the
+ * caller's `select` / `include`, exactly as the reads do — and, like the
+ * `*OrThrow` reads, they never resolve to `null`: Prisma raises when an
+ * `update` or a `delete` matches nothing, and `$exec` does the same.
+ *
+ * The three `*Many` writes return Prisma's `BatchPayload` — `{ count: number }`
+ * — rather than rows. Prisma's own `createManyAndReturn` is a separate
+ * operation and is not emitted.
+ *
+ * `args` is required on every one of them: there is no meaningful `create()`
+ * with no data, and a `deleteMany()` with no arguments is spelled
+ * `deleteMany({})` so that emptying a table stays something you typed on purpose.
+ */
+const WRITE_OPERATIONS: ReadOperation[] = [
+  {
+    name: "create",
+    args: "CreateArgs",
+    returns: (m) => `Prisma.${m}GetPayload<T>`,
+    required: true,
+  },
+  {
+    name: "update",
+    args: "UpdateArgs",
+    returns: (m) => `Prisma.${m}GetPayload<T>`,
+    required: true,
+  },
+  {
+    name: "delete",
+    args: "DeleteArgs",
+    returns: (m) => `Prisma.${m}GetPayload<T>`,
+    required: true,
+  },
+  {
+    name: "upsert",
+    args: "UpsertArgs",
+    returns: (m) => `Prisma.${m}GetPayload<T>`,
+    required: true,
+  },
+];
+
+/** The writes whose result is a count rather than a payload. */
+const BATCH_OPERATIONS = [
+  { name: "createMany", args: "CreateManyArgs" },
+  { name: "updateMany", args: "UpdateManyArgs" },
+  { name: "deleteMany", args: "DeleteManyArgs" },
+] as const;
+
+function batchOperation(
+  model: string,
+  op: (typeof BATCH_OPERATIONS)[number],
+): string {
+  return `
+  static ${op.name}(
+    args?: Prisma.${model}${op.args},
+  ): Promise<{ count: number }> {
+    return this.$exec("${op.name}", args) as Promise<{ count: number }>;
+  }
+`;
+}
+
 export function emitModelsFile(schemas: ModelSchema[]): string {
   const parts = [
     HEADER,
@@ -377,7 +440,11 @@ type Subset<T, U> = {
     parts.push(`
 export class ${schema.name}Model extends Model {
   static $schema = schema.${schema.name};
-${READ_OPERATIONS.map((op) => operation(schema.name, op)).join("")}${countOperation(schema.name)}}
+${READ_OPERATIONS.map((op) => operation(schema.name, op)).join("")}${countOperation(
+      schema.name,
+    )}${WRITE_OPERATIONS.map((op) => operation(schema.name, op)).join(
+      "",
+    )}${BATCH_OPERATIONS.map((op) => batchOperation(schema.name, op)).join("")}}
 `);
   }
 

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -1,8 +1,17 @@
 import { DatabaseManager } from "../database/DatabaseManager";
 import { app } from "../foundation/app";
-import { attachRelations } from "./compile/plan-relations";
-import { dialectFor } from "./dialect";
-import { MissingModelSchemaError, RecordNotFoundError } from "./errors";
+import { type BindContext, createBindContext } from "./compile/fragment";
+import {
+  type NestedWriteStep,
+  type RelationExecutor,
+  attachRelations,
+} from "./compile/plan-relations";
+import { dialectFor, type SqlDialect } from "./dialect";
+import {
+  MissingModelSchemaError,
+  RecordNotFoundError,
+  UniqueConstraintError,
+} from "./errors";
 import { getOrCompile, type Operation, type QueryPlan } from "./plan";
 import * as registry from "./registry";
 import type { ModelSchema } from "./schema";
@@ -11,18 +20,28 @@ import type { ModelSchema } from "./schema";
  * The base every generated model class extends.
  *
  * `$exec` is the framework's single choke point: it is the only place in the
- * ORM that touches the database, and the twelve public operations on the
- * generated subclasses are one-line delegations to it. Nested relation reads
- * will recurse through it too. Everything cross-cutting hangs here — the plan
- * cache today, ambient transactions in iteration 5, policies in iteration 6,
- * plus slow-query logging and metrics later. One operation that "just does a
- * quick insert directly" silently escapes all of it, which is why there is
- * exactly one door.
+ * ORM that touches the database, and the public operations on the generated
+ * subclasses are one-line delegations to it. Nested relation reads and nested
+ * writes recurse through it too. Everything cross-cutting hangs here — the plan
+ * cache and constraint-error translation today, ambient transactions in
+ * iteration 5, policies in iteration 6, plus slow-query logging and metrics
+ * later. One operation that "just does a quick insert directly" silently
+ * escapes all of it, which is why there is exactly one door.
  *
  * Framework internals take a `$` prefix so they cannot collide with anything an
  * application author adds to a model.
  */
-const ORTHROW = new Set(["findFirstOrThrow", "findUniqueOrThrow"]);
+
+/** Operations Prisma raises on when nothing matched, rather than returning null. */
+const ORTHROW = new Set([
+  "findFirstOrThrow",
+  "findUniqueOrThrow",
+  // Prisma raises P2025 — "No record was found for an update" / "...a delete" —
+  // rather than returning null, and the differential harness compares the fact
+  // of throwing.
+  "update",
+  "delete",
+]);
 
 export abstract class Model {
   /** Assigned by the generated subclass from `app/models/generated/schema.ts`. */
@@ -45,21 +64,52 @@ export abstract class Model {
 
     const plan = getOrCompile(schema, op, args, dialect);
 
+    const executor: RelationExecutor = {
+      exec: (model, operation, relationArgs) =>
+        registry
+          .get<typeof Model>(model)
+          .$exec(operation as Operation, relationArgs),
+      query: (text, values) => db.sql.unsafe(text, values),
+    };
+
+    // One context per call, holding the instant every `now()` and `@updatedAt`
+    // on this operation shares, plus whatever the `before` steps resolve.
+    const context = createBindContext();
+
+    // NOT ATOMIC until iteration 5. A write with nested `create`/`connect` runs
+    // more than one statement, and there is no transaction around them: if a
+    // later step fails, the earlier rows stay written. This is a recorded
+    // decision — iteration 5 introduces the ambient-transaction ALS here and
+    // makes all of it atomic without changing the call sites.
+    await runSteps(plan.before, args, context, executor, []);
+
     // `unsafe` despite the name. Bun's tagged template cannot express a query
     // whose *shape* is dynamic, which every ORM query is. Safety here does not
     // come from the template syntax: it comes from the compiler's two rules —
     // identifiers only ever come from the generated schema, and every value is
     // a bound parameter. Do not "fix" this into a tagged template.
-    const rows = await db.sql.unsafe(plan.text, plan.bind(args));
+    const rows = await execute(
+      db,
+      dialect,
+      schema,
+      op,
+      plan.text,
+      plan.bind(args, context),
+    );
 
     const result = this.$shape(plan, rows as unknown[]);
 
-    // The plan shapes a single-row read to `null` when nothing matched; turning
-    // that into an error belongs here rather than in the plan, because this is
-    // where the model's name is in scope for the message.
+    // The plan shapes a single-row operation to `null` when nothing matched;
+    // turning that into an error belongs here rather than in the plan, because
+    // this is where the model's name is in scope for the message.
     if (result === null && ORTHROW.has(op)) {
       throw new RecordNotFoundError(schema.name, op);
     }
+
+    // Rows that could not exist until this one did: the far side of a relation
+    // whose foreign key lives on the child. Run before relations are attached,
+    // so an `include` on the same call sees what was just written.
+    await runSteps(plan.after, args, context, executor, rowsOf(result));
 
     // Relations are loaded after the root rows are shaped, one query per node
     // in the include tree. Each of those queries is `$exec` on the *related
@@ -71,11 +121,20 @@ export abstract class Model {
     // query with no model behind it — the implicit m-n join table — still runs
     // on the connection this call resolved.
     if (plan.relations !== undefined) {
-      await attachRelations(plan.relations, plan.hidden, result, args, {
-        exec: (model, op, relationArgs) =>
-          registry.get<typeof Model>(model).$exec(op as Operation, relationArgs),
-        query: (text, values) => db.sql.unsafe(text, values),
-      });
+      await attachRelations(
+        plan.relations,
+        plan.hidden,
+        result,
+        args,
+        executor,
+      );
+    } else if (plan.hidden !== undefined && plan.hidden.length > 0) {
+      // A write can hide a key column without having any relation to attach:
+      // a nested `after` step needs the parent's key returned, but the caller's
+      // `select` never asked for it.
+      for (const row of rowsOf(result)) {
+        for (const key of plan.hidden) delete row[key];
+      }
     }
 
     return result;
@@ -84,10 +143,84 @@ export abstract class Model {
   /**
    * A static, not a module-level function, so subclassing is the extension
    * mechanism: a future `ActiveRecordModel` overrides this to build instances,
-   * and every model extending it gets that with no change to the twelve
-   * operations. It is also where iteration 8 populates row provenance.
+   * and every model extending it gets that with no change to the operations. It
+   * is also where iteration 8 populates row provenance.
    */
   static $shape(plan: QueryPlan, rows: unknown[]): unknown {
     return plan.shape(rows);
   }
+}
+
+async function runSteps(
+  steps: NestedWriteStep[] | undefined,
+  args: any,
+  context: BindContext,
+  executor: RelationExecutor,
+  rows: readonly Record<string, unknown>[],
+): Promise<void> {
+  if (steps === undefined) return;
+  // Sequentially, for the same reason relations load sequentially: iteration 5
+  // puts an ambient transaction on a single reserved connection, where
+  // concurrent statements are not safe.
+  for (const step of steps) {
+    await step.run(args, context, executor, rows);
+  }
+}
+
+/**
+ * Runs the statement and translates the failures that have a typed home.
+ *
+ * A unique violation is the one every application branches on, and every driver
+ * reports it differently — SQLite as a message with a code, Postgres as a
+ * SQLSTATE with a constraint name. Asking the dialect keeps that difference
+ * behind the same seam as everything else, and turning it into an error that
+ * names *fields* rather than columns is what makes it useful to a caller that
+ * has never seen the database's names.
+ */
+async function execute(
+  db: { sql: { unsafe(text: string, values: unknown[]): unknown } },
+  dialect: SqlDialect,
+  schema: ModelSchema,
+  op: Operation,
+  text: string,
+  values: unknown[],
+): Promise<unknown> {
+  try {
+    return await db.sql.unsafe(text, values);
+  } catch (error) {
+    const violation = dialect.constraintViolation(error);
+    if (!violation) throw error;
+
+    throw new UniqueConstraintError(
+      schema.name,
+      op,
+      fieldsForColumns(schema, violation.columns),
+      violation.constraint,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * Driver column names back to Prisma field names, so the error reads in the
+ * caller's vocabulary. A column with no matching field is reported as-is rather
+ * than dropped: it is still the truest thing we know about the failure.
+ */
+function fieldsForColumns(
+  schema: ModelSchema,
+  columns: readonly string[],
+): string[] {
+  return columns.map((column) => {
+    for (const field of Object.values(schema.fields)) {
+      if (field.column === column) return field.name;
+    }
+    return column;
+  });
+}
+
+function rowsOf(result: unknown): Record<string, unknown>[] {
+  if (Array.isArray(result)) return result as Record<string, unknown>[];
+  if (result === null || result === undefined) return [];
+  if (typeof result !== "object") return [];
+  return [result as Record<string, unknown>];
 }

--- a/packages/gemi/orm/compile/fragment.ts
+++ b/packages/gemi/orm/compile/fragment.ts
@@ -1,4 +1,5 @@
 import type { SqlDialect } from "../dialect";
+import { ParameterLimitError } from "../errors";
 
 /**
  * Pulls one value out of the argument tree at bind time. Compilation closes
@@ -106,6 +107,12 @@ export function joinFragments(parts: Fragment[], separator: string): Fragment {
 export function render(
   fragment: Fragment,
   dialect: SqlDialect,
+  /**
+   * Where the statement came from, for the parameter-ceiling error. Optional so
+   * a fragment can still be rendered in isolation by a test; every compiler
+   * passes it.
+   */
+  origin?: { model: string; operation: string },
 ): { text: string; binders: Binder[] } {
   const segments = fragment.text.split(PARAM_MARKER);
   const count = segments.length - 1;
@@ -116,6 +123,37 @@ export function render(
     throw new Error(
       `Compiled ${count} parameter placeholders but collected ` +
         `${fragment.binders.length} binders.`,
+    );
+  }
+
+  // The parameter ceiling, checked here because this is the one place that
+  // knows a *statement's* final count — and because a guard at any single
+  // compiler is a guard the next compiler forgets.
+  //
+  // It started life inside `compileCreateMany`, on the reasoning that
+  // `rows × columns` was the only count that scaled with the caller's data.
+  // That was wrong: on SQLite an `in` list binds one placeholder per element,
+  // so `findMany({ where: { id: { in: <40 000 ids> } } })` walks into the same
+  // driver error, and such a list is routinely request-derived. The relation
+  // loader has the same shape, batching an `in` over the parent keys — so a
+  // large `findMany` with an `include` reaches it without anyone writing a big
+  // list by hand. Postgres is unaffected either way: `= any($1)` is one
+  // parameter however long the array.
+  //
+  // Compile-time is exact rather than approximate, on both dialects: where the
+  // length changes the placeholder count it also changes the SQL text, so it is
+  // already part of the plan's identity.
+  if (origin && count > dialect.maxBoundParameters) {
+    throw new ParameterLimitError(
+      origin.model,
+      origin.operation,
+      count,
+      dialect.maxBoundParameters,
+      dialect.name,
+      dialect.bindsListAsOneParameter
+        ? `That is one parameter per value in the statement.`
+        : `That is one parameter per value, and on ${dialect.name} each ` +
+            `element of an 'in' list counts separately.`,
     );
   }
 

--- a/packages/gemi/orm/compile/fragment.ts
+++ b/packages/gemi/orm/compile/fragment.ts
@@ -5,8 +5,56 @@ import type { SqlDialect } from "../dialect";
  * over the *path* to a value, never the value itself — that is what makes two
  * calls with the same argument shape and different values produce byte
  * identical SQL, and it is what the plan cache depends on.
+ *
+ * Writes add a second source: values that do not exist in the argument tree at
+ * all. A `@default(cuid())` is minted per call, `@default(now())` has to be the
+ * *same* instant across every field and row of one logical operation, and a
+ * nested `create` produces a foreign key only once its own insert has run. All
+ * three arrive through the context rather than through `args`, so the binder
+ * stays a pure function of (arguments, call) and compilation stays pure.
  */
-export type Binder = (args: any) => unknown;
+export type Binder = (args: any, context: BindContext) => unknown;
+
+/**
+ * Per-call state a binder may read. Created once per `$exec`, never cached with
+ * the plan — a plan outlives the call, and `now` must not.
+ */
+export interface BindContext {
+  /**
+   * One instant for the whole operation. Prisma returns `createdAt` and
+   * `updatedAt` from a single `create` as the same instant (verified against
+   * 6.19.2), which reading the clock per field would not reproduce.
+   */
+  now: Date;
+  /**
+   * Values produced before the main statement runs, keyed by field name. Today
+   * that is exactly the foreign keys a nested `connect` or `create` resolved.
+   */
+  resolved: Record<string, unknown>;
+}
+
+export function createBindContext(): BindContext {
+  return { now: new Date(), resolved: {} };
+}
+
+/**
+ * The default context for a read. Reads never consult it, but `bind` takes one
+ * argument on every path so the choke point does not have to branch.
+ */
+const READ_CONTEXT: BindContext = { now: new Date(0), resolved: {} };
+
+/** Turns a compiled binder list into a plan's `bind`. */
+export function bindValues(
+  binders: Binder[],
+): (args: any, context?: BindContext) => unknown[] {
+  return (args: any, context: BindContext = READ_CONTEXT) => {
+    const values: unknown[] = [];
+    for (let i = 0; i < binders.length; i++) {
+      values.push(binders[i](args, context));
+    }
+    return values;
+  };
+}
 
 /**
  * Marks a parameter position inside a fragment's text. Placeholders are only

--- a/packages/gemi/orm/compile/index.ts
+++ b/packages/gemi/orm/compile/index.ts
@@ -3,6 +3,7 @@ import { UnsupportedQueryError } from "../errors";
 import type { Operation, QueryPlan } from "../plan";
 import type { ModelSchema } from "../schema";
 import { compileRead, isReadOperation } from "./read";
+import { compileWrite, isWriteOperation } from "./write";
 
 /**
  * Argument tree -> SQL. Pure: a function of the argument *shape* and the
@@ -17,10 +18,18 @@ export function compile(
   dialect: SqlDialect,
 ): QueryPlan {
   if (isReadOperation(op)) return compileRead(schema, op, args, dialect);
+  if (isWriteOperation(op)) return compileWrite(schema, op, args, dialect);
   throw new UnsupportedQueryError(op, schema.name, op);
 }
 
 export { compileRead, isReadOperation };
+export { compileWrite, isWriteOperation };
+export {
+  planNestedWrites,
+  type ForeignKeyContribution,
+  type NestedWritePlanning,
+} from "./nested-writes";
+export { assertUniqueWhere, matchUniqueKey, uniqueKeys } from "./unique";
 export { compileWhere } from "./where";
 export { compileOrderBy, parseOrderBy } from "./orderBy";
 export { resolveSelection } from "./select";

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1,0 +1,343 @@
+import { UnsupportedQueryError } from "../errors";
+import type { ModelSchema, RelationSchema } from "../schema";
+import type { Binder } from "./fragment";
+import {
+  type NestedWriteStep,
+  relatedSchema,
+  resolveLink,
+} from "./plan-relations";
+import { matchUniqueKey } from "./unique";
+
+/**
+ * Nested writes: `connect` and shallow `create`, and nothing else.
+ *
+ * Which direction a nested write runs in is decided by *who holds the foreign
+ * key*, and the two directions are genuinely different operations:
+ *
+ * ```ts
+ * // this model holds organizationId — resolve the key, then insert once
+ * User.create({ data: { email, organization: { connect: { id: 1 } } } })
+ *
+ * // Account holds userId — insert the user, then insert accounts pointing at it
+ * User.create({ data: { email, accounts: { create: [{ ... }] } } })
+ * ```
+ *
+ * The first is a `before` step (or, in the common case, no step at all — just a
+ * column read straight out of the argument tree). The second is an `after` step,
+ * because the key it needs does not exist until the parent row does.
+ *
+ * Everything else in Prisma's nested-write grammar — `connectOrCreate`, `set`,
+ * `disconnect`, `update`, `upsert`, `delete`, `deleteMany`, `updateMany`,
+ * `createMany` — throws `UnsupportedQueryError` naming the operation. Deep
+ * nested writes carry real ordering and cascade semantics and are a feature in
+ * their own right; smuggling half of them in here would mean shipping the
+ * ordering bugs without the feature.
+ *
+ * NOT ATOMIC. See the note on `NestedWriteStep`: every step past the first is a
+ * separate statement with no transaction around it until iteration 5.
+ */
+
+const SUPPORTED = new Set(["connect", "create"]);
+
+/** A foreign-key column on *this* model that a nested write supplies. */
+export interface ForeignKeyContribution {
+  /** The field name on this model — `organizationId`. */
+  field: string;
+  /** Produces the value at bind time, already unencoded. */
+  value: Binder;
+}
+
+export interface NestedWritePlanning {
+  contributions: ForeignKeyContribution[];
+  before: NestedWriteStep[];
+  after: NestedWriteStep[];
+  /**
+   * Fields of *this* model that the statement must return, because an `after`
+   * step needs them to point its children at this row.
+   */
+  keyFields: string[];
+}
+
+const EMPTY: NestedWritePlanning = {
+  contributions: [],
+  before: [],
+  after: [],
+  keyFields: [],
+};
+
+export function planNestedWrites(
+  schema: ModelSchema,
+  data: unknown,
+  operation: string,
+  /** Re-locates `data` inside the call's argument tree at bind time. */
+  locateData: (args: any) => any,
+): NestedWritePlanning {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    return EMPTY;
+  }
+
+  const entries = Object.keys(data as Record<string, unknown>)
+    .sort()
+    .filter((key) => key in schema.relations)
+    .filter((key) => (data as Record<string, unknown>)[key] !== undefined);
+
+  if (entries.length === 0) return EMPTY;
+
+  const planning: NestedWritePlanning = {
+    contributions: [],
+    before: [],
+    after: [],
+    keyFields: [],
+  };
+
+  for (const key of entries) {
+    const relation = schema.relations[key];
+    const node = (data as Record<string, unknown>)[key];
+    const locate = (args: any) => locateData(args)?.[key];
+
+    planOne(schema, relation, node, operation, locate, planning);
+  }
+
+  return planning;
+}
+
+function planOne(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  node: unknown,
+  operation: string,
+  locate: (args: any) => any,
+  out: NestedWritePlanning,
+): void {
+  if (typeof node !== "object" || node === null || Array.isArray(node)) {
+    throw new UnsupportedQueryError(
+      `data.${relation.name}`,
+      schema.name,
+      operation,
+      "Expected an object holding 'connect' or 'create'.",
+    );
+  }
+
+  // Prisma's implicit many-to-many writes rows into a join table that has no
+  // model, so nothing here can express them.
+  if (relation.joinTable) {
+    throw new UnsupportedQueryError(
+      `data.${relation.name}`,
+      schema.name,
+      operation,
+      `${relation.name} is an implicit many-to-many. Writing through its join ` +
+        `table is not implemented yet.`,
+    );
+  }
+
+  const keys = Object.keys(node as Record<string, unknown>)
+    .sort()
+    .filter((key) => (node as Record<string, unknown>)[key] !== undefined);
+
+  for (const key of keys) {
+    if (!SUPPORTED.has(key)) {
+      throw new UnsupportedQueryError(
+        `data.${relation.name}.${key}`,
+        schema.name,
+        operation,
+        `Only 'connect' and 'create' are implemented. Deep nested writes are ` +
+          `a later iteration.`,
+      );
+    }
+  }
+
+  if (keys.length === 0) return;
+
+  const child = relatedSchema(schema, relation);
+  const link = resolveLink(schema, child, relation);
+
+  // `from` is non-empty exactly on the side that holds the foreign key.
+  const owning = relation.from.length > 0;
+
+  for (const key of keys) {
+    const operand = (node as Record<string, unknown>)[key];
+    const at = (args: any) => locate(args)?.[key];
+
+    if (owning) {
+      planOwningSide(
+        schema, relation, child, link, key, operand, operation, at, out,
+      );
+    } else {
+      planForeignSide(
+        schema, relation, child, link, key, operand, operation, at, out,
+      );
+    }
+  }
+}
+
+/**
+ * This model holds the foreign key, so the far row must exist — or be created —
+ * before the insert can bind, and the whole thing collapses to one extra column.
+ */
+function planOwningSide(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  link: { parentField: string; childField: string },
+  key: string,
+  operand: unknown,
+  operation: string,
+  at: (args: any) => any,
+  out: NestedWritePlanning,
+): void {
+  // `link.parentField` is the FK on this model; `link.childField` is what it
+  // references on the other one.
+  const fkField = link.parentField;
+  const referenced = link.childField;
+
+  if (key === "create") {
+    // The far row does not exist yet: create it first, through its own model's
+    // `$exec` so it is subject to everything a top-level create is (invariant 1).
+    out.before.push({
+      relation: relation.name,
+      operation: "create",
+      async run(args, context, executor) {
+        const created = (await executor.exec(relation.model, "create", {
+          data: at(args),
+          select: { [referenced]: true },
+        })) as Record<string, unknown> | null;
+
+        context.resolved[fkField] = created?.[referenced] ?? null;
+      },
+    });
+    out.contributions.push({
+      field: fkField,
+      value: (_args, context) => context.resolved[fkField],
+    });
+    return;
+  }
+
+  // `connect`. In the common case the caller already handed us the referenced
+  // value — `connect: { id: 1 }` where the relation references `id` — and no
+  // query is needed at all: it is one more bound column.
+  //
+  // Whether that is the case is a property of the argument *shape*, not of its
+  // values, so the choice is made here at compile time and the two forms are two
+  // plans. That is what keeps a `connect` from silently costing a round trip.
+  if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
+    throw new UnsupportedQueryError(
+      `data.${relation.name}.connect`,
+      schema.name,
+      operation,
+      "Expected an object naming a unique field.",
+    );
+  }
+
+  const direct =
+    (operand as Record<string, unknown>)[referenced] !== undefined &&
+    Object.keys(operand as Record<string, unknown>).filter(
+      (name) => (operand as Record<string, unknown>)[name] !== undefined,
+    ).length === 1;
+
+  if (direct) {
+    out.contributions.push({
+      field: fkField,
+      value: (args) => at(args)?.[referenced],
+    });
+    return;
+  }
+
+  // `connect: { publicId: "..." }` against a relation that references `id`:
+  // Prisma resolves it with a lookup, and so do we. Validated now so a
+  // non-unique connect target fails at compile time rather than matching an
+  // arbitrary row.
+  matchUniqueKey(child, operand, `${operation}.${relation.name}.connect`);
+
+  out.before.push({
+    relation: relation.name,
+    operation: "connect",
+    async run(args, context, executor) {
+      const found = (await executor.exec(relation.model, "findUniqueOrThrow", {
+        where: at(args),
+        select: { [referenced]: true },
+      })) as Record<string, unknown> | null;
+
+      context.resolved[fkField] = found?.[referenced] ?? null;
+    },
+  });
+  out.contributions.push({
+    field: fkField,
+    value: (_args, context) => context.resolved[fkField],
+  });
+}
+
+/**
+ * The *child* holds the foreign key, so nothing can be written until this row
+ * exists and its key is known. Both forms are therefore `after` steps, and both
+ * need the key in the statement's `RETURNING` list.
+ */
+function planForeignSide(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  link: { parentField: string; childField: string },
+  key: string,
+  operand: unknown,
+  operation: string,
+  at: (args: any) => any,
+  out: NestedWritePlanning,
+): void {
+  const parentField = link.parentField;
+  const childField = link.childField;
+
+  out.keyFields.push(parentField);
+
+  if (key === "create") {
+    out.after.push({
+      relation: relation.name,
+      operation: "create",
+      async run(args, _context, executor, rows) {
+        const parent = rows[0];
+        // No row means the statement matched nothing; `update` and `delete`
+        // raise before this runs, so there is nothing to attach to.
+        if (!parent) return;
+
+        for (const item of listOf(at(args))) {
+          await executor.exec(relation.model, "create", {
+            // The foreign key is set by us, not by the caller: a nested create
+            // that also named it would be describing two different parents.
+            data: { ...(item as object), [childField]: parent[parentField] },
+            // Nothing reads the result, and the narrowest select keeps the
+            // returned payload from growing with the child's column count.
+            select: { [childField]: true },
+          });
+        }
+      },
+    });
+    return;
+  }
+
+  // `connect` on this side means "point that existing row at me", which is an
+  // update of the child's foreign key — not something this row's insert can do.
+  out.after.push({
+    relation: relation.name,
+    operation: "connect",
+    async run(args, _context, executor, rows) {
+      const parent = rows[0];
+      if (!parent) return;
+
+      for (const item of listOf(at(args))) {
+        matchUniqueKey(child, item, `${operation}.${relation.name}.connect`);
+        await executor.exec(relation.model, "update", {
+          where: item,
+          data: { [childField]: parent[parentField] },
+          select: { [childField]: true },
+        });
+      }
+    },
+  });
+}
+
+/**
+ * Prisma accepts both a single object and an array everywhere a to-many nested
+ * write is legal, and the singular form is the common one on a to-one.
+ */
+function listOf(value: unknown): unknown[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -9,7 +9,7 @@ import {
 } from "../errors";
 import * as registry from "../registry";
 import type { FieldSchema, ModelSchema, RelationSchema } from "../schema";
-import { concat, render, sql } from "./fragment";
+import { type BindContext, concat, render, sql } from "./fragment";
 import { resolveSelection } from "./select";
 
 /**
@@ -106,6 +106,42 @@ export interface RelationRequest {
   locate: (args: any) => any;
   dialect: SqlDialect;
   operation: string;
+}
+
+/**
+ * One nested write, planned once per argument shape and run per call.
+ *
+ * `before` steps run ahead of the main statement and put foreign keys into the
+ * bind context — that is the `data: { user: { connect: ... } }` direction, where
+ * this model holds the key. `after` steps run once the row exists and write the
+ * far side — the `data: { accounts: { create: ... } }` direction, where the
+ * child holds the key and cannot be written until the parent has one.
+ *
+ * NOT ATOMIC in iteration 4. A nested write is the first single logical
+ * operation in this ORM that issues more than one statement, and there is no
+ * transaction around them yet: if an `after` step fails, the parent row stays
+ * written. This is a recorded decision rather than an oversight — iteration 5
+ * introduces the ambient-transaction ALS at the `$exec` choke point and makes
+ * every one of these atomic without changing a line here. Building an interim
+ * mechanism now would be work iteration 5 deletes.
+ */
+export interface NestedWriteStep {
+  /** The relation field this step was planned for. Named in errors. */
+  relation: string;
+  /**
+   * The Prisma nested-write key this step implements — `connect` or `create`.
+   * Two steps on the same relation can produce byte-identical SQL and differ
+   * only in what the step itself does, so this is what makes a plan legible
+   * from the outside: to a test, and to whatever logs queries later.
+   */
+  operation: "connect" | "create";
+  run(
+    args: any,
+    context: BindContext,
+    executor: RelationExecutor,
+    /** The rows the main statement returned. Empty for a `before` step. */
+    rows: readonly Row[],
+  ): Promise<void>;
 }
 
 export interface RelationPlan {
@@ -436,7 +472,7 @@ function validateSubtree(
 
 // --- topology --------------------------------------------------------------
 
-interface Link {
+export interface Link {
   /** Field on the parent whose value the child is matched against. */
   parentField: string;
   /** Field on the child holding the matching value. */
@@ -453,7 +489,7 @@ interface Link {
  * `relationName`. That is the whole reason `relationName` is in the emitted
  * artifact.
  */
-function resolveLink(
+export function resolveLink(
   parent: ModelSchema,
   child: ModelSchema,
   relation: RelationSchema,
@@ -613,15 +649,27 @@ function field(
 }
 
 function resolveSchema(parent: ModelSchema, node: RelationNode): ModelSchema {
-  const target = node.relation.model;
+  return relatedSchema(parent, node.relation, node.as);
+}
 
-  // Resolved by name at call time, never by import at module load: that is what
-  // lets two models reference each other without the generated files forming an
-  // import cycle (invariant 6).
+/**
+ * The schema on the far side of a relation, looked up by *name*.
+ *
+ * Resolved by name at call time, never by import at module load: that is what
+ * lets two models reference each other without the generated files forming an
+ * import cycle (invariant 6).
+ */
+export function relatedSchema(
+  parent: ModelSchema,
+  relation: RelationSchema,
+  as: string = relation.name,
+): ModelSchema {
+  const target = relation.model;
+
   if (!registry.has(target)) {
     throw new UnregisteredRelationTargetError(
       parent.name,
-      node.as,
+      as,
       target,
       registry.registeredNames(),
     );

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -883,7 +883,14 @@ async function readPairs(
     ),
   );
 
-  const { text, binders } = render(statement, dialect);
+  // The one statement in the ORM whose parameter count is not known until the
+  // parents are in hand, so the ceiling here is a real ceiling on *fan-out*: on
+  // SQLite a to-many `include` over more than 32 766 parent rows would exceed
+  // it. Named rather than left to the driver, like everywhere else.
+  const { text, binders } = render(statement, dialect, {
+    model: join.table,
+    operation: "include",
+  });
   return executor.query(
     text,
     binders.map((binder) => binder(undefined)),

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "vitest";
 
 import { PostgresDialect } from "../dialect/postgres";
 import { SqliteDialect } from "../dialect/sqlite";
-import { UnknownFieldError, UnsupportedQueryError } from "../errors";
+import {
+  ParameterLimitError,
+  UnknownFieldError,
+  UnsupportedQueryError,
+} from "../errors";
 import { USER_COLUMNS, mapped, user } from "../fixtures";
 import { compileRead } from "./read";
 
@@ -587,5 +591,69 @@ describe("compile is a function of shape, not values", () => {
     const args = { where: { email: evil } };
     expect(text(args)).toBe(`${SELECT_USER} where "email" = ?`);
     expect(bind(args)).toEqual([evil]);
+  });
+});
+
+/**
+ * The parameter ceiling is a *statement* property, not a `createMany` one.
+ *
+ * It first shipped inside `compileCreateMany`, on the reasoning that
+ * `rows × columns` was the only count that scaled with the caller's data. On
+ * SQLite an `in` list binds one placeholder per element, so a read walks into
+ * the same driver limit — and such a list is routinely request-derived, which
+ * is the case worth naming rather than letting the driver report obscurely.
+ */
+describe("the parameter ceiling applies to reads", () => {
+  const ids = (count: number) =>
+    Array.from({ length: count }, (_, index) => index);
+
+  test("a large in list is refused on sqlite, by name", () => {
+    const args = { where: { id: { in: ids(40_000) } } };
+
+    expect(() => compileRead(user, "findMany", args, sqlite)).toThrow(
+      ParameterLimitError,
+    );
+    expect(() => compileRead(user, "findMany", args, sqlite)).toThrow(
+      /would bind 40000 parameters.*accepts at most 32766/,
+    );
+  });
+
+  test("the message says why the count is what it is", () => {
+    expect(() =>
+      compileRead(user, "findMany", { where: { id: { in: ids(40_000) } } }, sqlite),
+    ).toThrow(/each element of an 'in' list counts separately/);
+  });
+
+  // `= any($1)` is one parameter however long the array, so the same query is
+  // fine here. This asymmetry is the reason the limit is a dialect capability
+  // rather than a constant.
+  test("the same list is one parameter on postgres", () => {
+    const args = { where: { id: { in: ids(40_000) } } };
+    const plan = compileRead(user, "findMany", args, postgres);
+
+    expect(plan.text).toContain("= any ($1)");
+    expect(plan.bind(args)).toHaveLength(1);
+  });
+
+  test("a list at exactly the sqlite limit still compiles", () => {
+    const args = { where: { id: { in: ids(32_766) } } };
+    expect(() => compileRead(user, "findMany", args, sqlite)).not.toThrow();
+  });
+
+  // Two lists in one statement are one statement's worth of parameters — which
+  // is the reason the check reads the rendered count rather than any single
+  // clause's length.
+  test("the ceiling counts the whole statement, not one clause", () => {
+    const args = {
+      where: {
+        AND: [
+          { id: { in: ids(20_000) } },
+          { globalRole: { in: ids(20_000) } },
+        ],
+      },
+    };
+    expect(() => compileRead(user, "findMany", args, sqlite)).toThrow(
+      ParameterLimitError,
+    );
   });
 });

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -105,7 +105,7 @@ export function compileRead(
       );
     }
 
-    const { text, binders } = render(statement, dialect);
+    const { text, binders } = render(statement, dialect, { model: schema.name, operation: op });
     return {
       text,
       bind: bindValues(binders),
@@ -147,7 +147,7 @@ export function compileRead(
     paginationClause,
   );
 
-  const { text, binders } = render(statement, dialect);
+  const { text, binders } = render(statement, dialect, { model: schema.name, operation: op });
   const shaper = buildRowShaper(
     fields,
     dialect,

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -1,12 +1,21 @@
 import type { SqlDialect } from "../dialect";
 import { UnsupportedQueryError } from "../errors";
 import type { Operation, QueryPlan } from "../plan";
-import type { FieldSchema, ModelSchema } from "../schema";
+import type { ModelSchema } from "../schema";
 import { buildRowShaper } from "../shape";
-import { type Binder, type Fragment, concat, joinFragments, render, sql } from "./fragment";
+import {
+  type Binder,
+  type Fragment,
+  bindValues,
+  concat,
+  joinFragments,
+  render,
+  sql,
+} from "./fragment";
 import { compileOrderBy, parseOrderBy, reverse, type OrderTerm } from "./orderBy";
 import { planRelations } from "./plan-relations";
-import { resolveSelection } from "./select";
+import { resolveSelection, withKeyFields } from "./select";
+import { assertUniqueWhere } from "./unique";
 import { compileWhere } from "./where";
 
 /** Every read operation, and what each accepts. */
@@ -99,7 +108,7 @@ export function compileRead(
     const { text, binders } = render(statement, dialect);
     return {
       text,
-      bind: binder(binders),
+      bind: bindValues(binders),
       shape(rows) {
         const row = (rows as Record<string, unknown>[])[0];
         return Number(row?._count ?? 0);
@@ -148,7 +157,7 @@ export function compileRead(
 
   return {
     text,
-    bind: binder(binders),
+    bind: bindValues(binders),
     relations: plans.length > 0 ? plans : undefined,
     hidden,
     shape(rows) {
@@ -164,47 +173,6 @@ export function compileRead(
       // where the model's name is in scope for the message.
       return single ? (shaped[0] ?? null) : shaped;
     },
-  };
-}
-
-/**
- * Adds the columns the relation planner needs to stitch on, and reports which
- * of them the caller did not ask for.
- *
- * `select: { name: true, accounts: true }` returns `{ name, accounts }` — no
- * `id` — but the accounts cannot be found without `User.id`. So it is selected,
- * shaped, used, and then deleted (see `attachRelations`). Under an `include`,
- * or a `select` that names the key itself, nothing is hidden and nothing is
- * deleted.
- */
-function withKeyFields(
-  schema: ModelSchema,
-  selection: FieldSchema[],
-  keyFields: string[],
-): { fields: FieldSchema[]; hidden?: string[] } {
-  if (keyFields.length === 0) return { fields: selection };
-
-  const present = new Set(selection.map((field) => field.name));
-  const missing = keyFields.filter((name) => !present.has(name));
-  if (missing.length === 0) return { fields: selection };
-
-  const wanted = new Set([...present, ...missing]);
-  return {
-    // Rebuilt in schema order rather than appended, so the emitted column list
-    // depends only on *which* fields are selected and never on how they were
-    // reached.
-    fields: Object.values(schema.fields).filter((field) =>
-      wanted.has(field.name),
-    ),
-    hidden: missing,
-  };
-}
-
-function binder(binders: Binder[]) {
-  return (callArgs: any) => {
-    const values: unknown[] = [];
-    for (let i = 0; i < binders.length; i++) values.push(binders[i](callArgs));
-    return values;
   };
 }
 
@@ -292,59 +260,3 @@ function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
   }
 }
 
-/**
- * `findUnique` must be given a key the database can prove is unique — the `@id`,
- * a single-field `@unique`, or a composite `@@unique` in Prisma's compound form
- * (`{ username_provider: { username, provider } }`).
- *
- * This runs once per argument shape, in the compiler, not per call. Anything
- * else would be a query that silently returns the *first* of several matches.
- */
-function assertUniqueWhere(
-  schema: ModelSchema,
-  where: unknown,
-  op: Operation,
-): void {
-  const candidates = uniqueKeys(schema);
-
-  if (typeof where !== "object" || where === null) {
-    throw unique(schema, op, candidates);
-  }
-
-  const keys = Object.keys(where as Record<string, unknown>).filter(
-    (key) => (where as Record<string, unknown>)[key] !== undefined,
-  );
-
-  // Prisma's compound form: one key named after the fields joined by `_`.
-  for (const candidate of candidates) {
-    if (candidate.length === 1 && keys.includes(candidate[0])) return;
-    if (candidate.length > 1 && keys.includes(candidate.join("_"))) return;
-  }
-
-  throw unique(schema, op, candidates);
-}
-
-function uniqueKeys(schema: ModelSchema): string[][] {
-  const keys: string[][] = [];
-  if (schema.primaryKey.length > 0) keys.push(schema.primaryKey);
-  for (const group of schema.uniques) keys.push(group);
-  return keys;
-}
-
-function unique(
-  schema: ModelSchema,
-  op: Operation,
-  candidates: string[][],
-): UnsupportedQueryError {
-  const shown = candidates
-    .map((group) => (group.length === 1 ? group[0] : `${group.join("_")}`))
-    .join(", ");
-
-  return new UnsupportedQueryError(
-    "where",
-    schema.name,
-    op,
-    `${op} needs a unique field. ${schema.name} declares: ${shown}. ` +
-      `Use findFirst to query on anything else.`,
-  );
-}

--- a/packages/gemi/orm/compile/select.ts
+++ b/packages/gemi/orm/compile/select.ts
@@ -103,3 +103,41 @@ export function resolveSelection(
   // function and then hidden again from the result.
   return selected;
 }
+
+/**
+ * Adds the columns the relation planner needs to stitch on, and reports which
+ * of them the caller did not ask for.
+ *
+ * `select: { name: true, accounts: true }` returns `{ name, accounts }` — no
+ * `id` — but the accounts cannot be found without `User.id`. So it is selected,
+ * shaped, used, and then deleted (see `attachRelations`). Under an `include`,
+ * or a `select` that names the key itself, nothing is hidden and nothing is
+ * deleted.
+ *
+ * Writes use it for the same reason through a different clause: a nested
+ * `create` on the far side of a relation needs the parent's key before it can
+ * write the child, so the `RETURNING` list has to carry that key even when the
+ * caller's `select` never asked for it.
+ */
+export function withKeyFields(
+  schema: ModelSchema,
+  selection: FieldSchema[],
+  keyFields: readonly string[],
+): { fields: FieldSchema[]; hidden?: string[] } {
+  if (keyFields.length === 0) return { fields: selection };
+
+  const present = new Set(selection.map((field) => field.name));
+  const missing = keyFields.filter((name) => !present.has(name));
+  if (missing.length === 0) return { fields: selection };
+
+  const wanted = new Set([...present, ...missing]);
+  return {
+    // Rebuilt in schema order rather than appended, so the emitted column list
+    // depends only on *which* fields are selected and never on how they were
+    // reached.
+    fields: Object.values(schema.fields).filter((field) =>
+      wanted.has(field.name),
+    ),
+    hidden: missing,
+  };
+}

--- a/packages/gemi/orm/compile/unique.ts
+++ b/packages/gemi/orm/compile/unique.ts
@@ -1,0 +1,80 @@
+import { UnsupportedQueryError } from "../errors";
+import type { ModelSchema } from "../schema";
+
+/**
+ * Which declared unique key a `where` names — the `@id`, a single-field
+ * `@unique`, or a composite `@@unique` in Prisma's compound form
+ * (`{ username_provider: { username, provider } }`).
+ *
+ * Shared by every operation Prisma types with a `WhereUniqueInput`: the four
+ * `findUnique*` reads, and — from iteration 4 — `update`, `delete` and
+ * `upsert`. Writes need the *identity* of the matched key rather than just a
+ * yes, because `upsert` compiles it into an `on conflict (...)` target, so this
+ * returns the group instead of asserting.
+ *
+ * It runs once per argument *shape*, in the compiler, never per call. The
+ * alternative is a `delete` that silently removes the first of several matches.
+ *
+ * Note this checks that a unique key is *present*, not that nothing else is:
+ * since Prisma 5 a `WhereUniqueInput` may carry extra non-unique filters
+ * alongside the key, and they narrow further rather than breaking uniqueness.
+ */
+export function matchUniqueKey(
+  schema: ModelSchema,
+  where: unknown,
+  op: string,
+): string[] {
+  const candidates = uniqueKeys(schema);
+
+  if (typeof where !== "object" || where === null || Array.isArray(where)) {
+    throw missingUnique(schema, op, candidates);
+  }
+
+  const keys = Object.keys(where as Record<string, unknown>).filter(
+    (key) => (where as Record<string, unknown>)[key] !== undefined,
+  );
+
+  for (const candidate of candidates) {
+    if (candidate.length === 1 && keys.includes(candidate[0])) return candidate;
+    // Prisma's compound form: one key named after the fields joined by `_`.
+    if (candidate.length > 1 && keys.includes(candidate.join("_"))) {
+      return candidate;
+    }
+  }
+
+  throw missingUnique(schema, op, candidates);
+}
+
+export function assertUniqueWhere(
+  schema: ModelSchema,
+  where: unknown,
+  op: string,
+): void {
+  matchUniqueKey(schema, where, op);
+}
+
+export function uniqueKeys(schema: ModelSchema): string[][] {
+  const keys: string[][] = [];
+  if (schema.primaryKey.length > 0) keys.push(schema.primaryKey);
+  for (const group of schema.uniques) keys.push(group);
+  return keys;
+}
+
+function missingUnique(
+  schema: ModelSchema,
+  op: string,
+  candidates: string[][],
+): UnsupportedQueryError {
+  const shown = candidates
+    .map((group) => (group.length === 1 ? group[0] : group.join("_")))
+    .join(", ");
+
+  return new UnsupportedQueryError(
+    "where",
+    schema.name,
+    op,
+    `${op} needs a unique field. ${schema.name} declares: ${shown}. ` +
+      `Use ${op === "delete" || op === "update" ? `${op}Many` : "findFirst"} ` +
+      `to query on anything else.`,
+  );
+}

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -556,6 +556,94 @@ describe("upsert", () => {
       /2024-01-01.*2024-06-01/s,
     );
   });
+
+  /**
+   * The refusal message has to *distinguish* the two values, or it reads as
+   * "'x' is A ... but A" and looks like a framework bug rather than a wrong
+   * argument. Fixing the `Date` case is easy to half-do: `String()` collapses
+   * two different `Bytes` of the same length, and collapses `1n` against `1`.
+   */
+  test.each([
+    [
+      "Bytes of the same length",
+      new Uint8Array([1, 2]),
+      new Uint8Array([3, 4]),
+    ],
+    ["a bigint against a number", 1n, 1],
+  ])("a mismatched %s is described distinguishably", (_label, a, b) => {
+    const digest: any = {
+      name: "Digest",
+      table: "Digest",
+      fields: {
+        id: {
+          name: "id",
+          column: "id",
+          type: "Int",
+          nullable: false,
+          isId: true,
+          isUpdatedAt: false,
+          default: { kind: "autoincrement" },
+        },
+        key: {
+          name: "key",
+          column: "key",
+          type: typeof a === "bigint" ? "BigInt" : "Bytes",
+          nullable: false,
+          isId: false,
+          isUpdatedAt: false,
+        },
+        note: {
+          name: "note",
+          column: "note",
+          type: "String",
+          nullable: true,
+          isId: false,
+          isUpdatedAt: false,
+        },
+      },
+      primaryKey: ["id"],
+      uniques: [["key"]],
+      relations: {},
+    };
+
+    const args = {
+      where: { key: a },
+      create: { key: b },
+      update: { note: "n" },
+    };
+    const compiled = compileWrite(digest, "upsert", args, postgres);
+
+    let message = "";
+    try {
+      compiled.bind(args, createBindContext());
+    } catch (error: any) {
+      message = error.message;
+    }
+
+    expect(message).toMatch(/must agree on the key/);
+
+    // The two halves of "is X in the where clause but Y in 'create'" must not
+    // be the same string.
+    const [, left, right] =
+      /'key' is (.+?) in the where clause but (.+?) in 'create'/s.exec(
+        message,
+      ) ?? [];
+    expect(left).toBeDefined();
+    expect(left).not.toBe(right);
+  });
+
+  // Deliberate strictness, recorded in the plan's known-differences list:
+  // Prisma accepts a `where` naming two unique keys, but `on conflict` takes
+  // exactly one target and picking either would be silent narrowing.
+  test("a where naming two different unique keys is refused", () => {
+    expect(() =>
+      text("upsert", {
+        where: { id: 1, email: "a@b.c" },
+        create: { id: 1, email: "a@b.c" },
+        update: { name: "N" },
+      }),
+    ).toThrow(/Name exactly one unique key/);
+  });
 });
 
 describe("nested writes", () => {

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -1,14 +1,15 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { createBindContext } from "./fragment";
 import { PostgresDialect } from "../dialect/postgres";
 import { SqliteDialect } from "../dialect/sqlite";
 import {
   MissingRequiredValueError,
+  ParameterLimitError,
   UnknownFieldError,
   UnsupportedQueryError,
 } from "../errors";
-import { account, organization, user } from "../fixtures";
+import { account, bare, organization, reading, user } from "../fixtures";
 import * as registry from "../registry";
 import { compileWrite } from "./write";
 
@@ -183,6 +184,51 @@ describe("createMany", () => {
       text("createMany", { data: [{ organization: { connect: { id: 1 } } }] }),
     ).toThrow(UnsupportedQueryError);
   });
+
+  // `default values` inserts exactly one row, and there is no portable
+  // multi-row spelling of it — so this used to succeed and insert one row for
+  // three, reporting `{ count: 1 }`.
+  test("one empty row is still `default values`", () => {
+    const plan = compileWrite(bare, "createMany", { data: [{}] }, sqlite);
+    expect(plan.text).toBe(`insert into "Bare" default values returning "id"`);
+  });
+
+  test("several empty rows are refused rather than silently collapsed", () => {
+    expect(() =>
+      compileWrite(bare, "createMany", { data: [{}, {}, {}] }, sqlite),
+    ).toThrow(/All 3 rows are empty/);
+  });
+
+  // `rows × columns` is the one parameter count an application does not choose
+  // by writing the query, so it is the one that can walk into a driver limit.
+  test.each([
+    ["sqlite", sqlite, 32766],
+    ["postgres", postgres, 65535],
+  ])("the %s parameter ceiling is named, not hit", (_name, dialect, limit) => {
+    // Six columns per row: publicId, email, locale, globalRole, createdAt,
+    // updatedAt.
+    const rows = Math.ceil(limit / 6) + 1;
+    const data = Array.from({ length: rows }, (_, i) => ({
+      email: `a${i}@b.c`,
+    }));
+
+    expect(() => compileWrite(user, "createMany", { data }, dialect)).toThrow(
+      ParameterLimitError,
+    );
+    expect(() => compileWrite(user, "createMany", { data }, dialect)).toThrow(
+      new RegExp(`accepts at most ${limit}`),
+    );
+  });
+
+  test("a createMany just under the ceiling compiles", () => {
+    const data = Array.from({ length: 5461 }, (_, i) => ({
+      email: `a${i}@b.c`,
+    }));
+    // 5461 × 6 = 32766, exactly SQLite's limit.
+    expect(() =>
+      compileWrite(user, "createMany", { data }, sqlite),
+    ).not.toThrow();
+  });
 });
 
 describe("update", () => {
@@ -221,6 +267,43 @@ describe("update", () => {
     );
     const plan = compileWrite(user, "updateMany", args, sqlite);
     expect(plan.shape([{ id: 1 }, { id: 2 }, { id: 3 }])).toEqual({ count: 3 });
+  });
+
+  // There is no nested-write planner behind `updateMany` — Prisma types it as
+  // unchecked input and rejects a relation key. Without this the key was
+  // neither executed nor reported: `suppliedFields` skips relations silently,
+  // so the `connect` simply vanished from an otherwise successful statement.
+  test("a nested write in updateMany data is refused by name", () => {
+    expect(() =>
+      text("updateMany", {
+        where: { id: 1 },
+        data: { name: "x", organization: { connect: { id: 2 } } },
+      }),
+    ).toThrow(/updateMany cannot contain nested writes/);
+  });
+
+  // And the degenerate version, which used to report the wrong problem
+  // entirely: "At least one field must be updated".
+  test("updateMany data of only a relation names the relation", () => {
+    expect(() =>
+      text("updateMany", {
+        where: { id: 1 },
+        data: { organization: { connect: { id: 2 } } },
+      }),
+    ).toThrow(/updateMany cannot contain nested writes/);
+  });
+
+  test("update still accepts the same nested write", () => {
+    registry.clearRegistry();
+    registry.register("User", class { static $schema = user });
+    registry.register("Organization", class { static $schema = organization });
+    expect(() =>
+      text("update", {
+        where: { id: 1 },
+        data: { name: "x", organization: { connect: { id: 2 } } },
+      }),
+    ).not.toThrow();
+    registry.clearRegistry();
   });
 
   test.each([
@@ -419,6 +502,60 @@ describe("upsert", () => {
       }),
     ).toThrow(/Nested writes inside an upsert/);
   });
+
+  // `update` and `delete` honour the extra filters a Prisma 5 WhereUniqueInput
+  // may carry, because their whole `where` is compiled. An `on conflict` target
+  // is a key and has nowhere to put one, so compiling only the key part would
+  // update a row Prisma would have left alone.
+  test("a where with filters beside the unique key is refused", () => {
+    expect(() =>
+      text("upsert", {
+        where: { email: "a@b.c", deletedAt: null },
+        create: { email: "a@b.c" },
+        update: { name: "N" },
+      }),
+    ).toThrow(/carries deletedAt beside the unique key/);
+  });
+
+  test("an explicit undefined beside the key is not a filter", () => {
+    expect(() =>
+      text("upsert", {
+        where: { email: "a@b.c", deletedAt: undefined },
+        create: { email: "a@b.c" },
+        update: { name: "N" },
+      }),
+    ).not.toThrow();
+  });
+
+  // The conflict-key agreement check compares *encoded* values, and what
+  // `encode` produces is not always a primitive: Postgres hands a `Date`
+  // straight to the driver. Two Dates for one instant are never `===`, so
+  // identity refused a correct call — on Postgres only, since SQLite encodes
+  // the same field to a number.
+  test.each([
+    ["sqlite", sqlite],
+    ["postgres", postgres],
+  ])("a DateTime conflict key compares by value on %s", (_name, dialect) => {
+    const args = {
+      where: { at: new Date("2024-01-01T00:00:00Z") },
+      create: { at: new Date("2024-01-01T00:00:00Z"), value: 1 },
+      update: { value: 2 },
+    };
+    const compiled = compileWrite(reading, "upsert", args, dialect);
+    expect(() => compiled.bind(args, createBindContext())).not.toThrow();
+  });
+
+  test("a DateTime conflict key that genuinely differs is still refused", () => {
+    const args = {
+      where: { at: new Date("2024-01-01T00:00:00Z") },
+      create: { at: new Date("2024-06-01T00:00:00Z"), value: 1 },
+      update: { value: 2 },
+    };
+    const compiled = compileWrite(reading, "upsert", args, postgres);
+    expect(() => compiled.bind(args, createBindContext())).toThrow(
+      /2024-01-01.*2024-06-01/s,
+    );
+  });
 });
 
 describe("nested writes", () => {
@@ -427,6 +564,14 @@ describe("nested writes", () => {
     registry.register("User", class { static $schema = user });
     registry.register("Account", class { static $schema = account });
     registry.register("Organization", class { static $schema = organization });
+  });
+
+  // The registry is process-global. Vitest isolates modules per file so this
+  // is invisible here, but under a shared-process runner these registrations
+  // would outlive the file and break `read.test.ts`, which asserts that a
+  // relation in a `select` raises when nothing is registered.
+  afterEach(() => {
+    registry.clearRegistry();
   });
 
   // The referenced value is already in hand, so this must not cost a query.

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -1,0 +1,569 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createBindContext } from "./fragment";
+import { PostgresDialect } from "../dialect/postgres";
+import { SqliteDialect } from "../dialect/sqlite";
+import {
+  MissingRequiredValueError,
+  UnknownFieldError,
+  UnsupportedQueryError,
+} from "../errors";
+import { account, organization, user } from "../fixtures";
+import * as registry from "../registry";
+import { compileWrite } from "./write";
+
+const sqlite = new SqliteDialect();
+const postgres = new PostgresDialect();
+
+// The whole point of splitting compile from bind is that these tests need no
+// database at all: `compile` is a pure function of the argument *shape*.
+function text(op: any, args: any, dialect = sqlite) {
+  return compileWrite(user, op, args, dialect).text;
+}
+
+function bind(op: any, args: any, dialect = sqlite, schema = user) {
+  const plan = compileWrite(schema, op, args, dialect);
+  return plan.bind(args, createBindContext());
+}
+
+describe("create", () => {
+  test("column list is schema order, and every value is a parameter", () => {
+    expect(text("create", { data: { email: "a@b.c", name: "A" } })).toBe(
+      `insert into "User" ("publicId", "name", "email", "locale", ` +
+        `"globalRole", "createdAt", "updatedAt") values (?, ?, ?, ?, ?, ?, ?) ` +
+        `returning "id", "publicId", "name", "email", "emailVerifiedAt", ` +
+        `"verificationToken", "locale", "globalRole", "password", ` +
+        `"organizationId", "createdAt", "updatedAt", "deletedAt"`,
+    );
+  });
+
+  // The caller's key order must not reach the SQL, or two calls with the same
+  // fields would be two plans holding identical text.
+  test("caller key order does not change the statement", () => {
+    expect(text("create", { data: { name: "A", email: "a@b.c" } })).toBe(
+      text("create", { data: { email: "a@b.c", name: "A" } }),
+    );
+  });
+
+  test("autoincrement and unset nullables are left to the database", () => {
+    const columns = text("create", { data: { email: "a@b.c" } }).split(
+      " values ",
+    )[0];
+    // `id` is @default(autoincrement()) — the database's business.
+    expect(columns).not.toContain(`"id"`);
+    // `deletedAt` is nullable with no default: omitted, not bound as null.
+    expect(columns).not.toContain(`"deletedAt"`);
+    expect(columns).not.toContain(`"name"`);
+  });
+
+  test("client-side defaults are generated, not left to the database", () => {
+    const values = bind("create", { data: { email: "a@b.c" } });
+    // publicId, email, locale, globalRole, createdAt, updatedAt
+    const [publicId, email, locale, globalRole, createdAt, updatedAt] = values;
+
+    expect(values).toHaveLength(6);
+    expect(String(publicId)).toMatch(/^c[a-z0-9]{24}$/);
+    expect(email).toBe("a@b.c");
+    expect(locale).toBe("en-US");
+    expect(globalRole).toBe(2);
+    expect(typeof createdAt).toBe("number");
+    // Prisma returns createdAt and updatedAt from one create as the same
+    // instant. Reading the clock per field would not reproduce that.
+    expect(createdAt).toBe(updatedAt);
+  });
+
+  test("@updatedAt is stamped on create, not only on update", () => {
+    const compiled = text("create", { data: { email: "a@b.c" } });
+    expect(compiled).toContain(`"updatedAt"`);
+  });
+
+  test("an explicit value beats the default", () => {
+    const when = new Date("2020-01-01T00:00:00.000Z");
+    const values = bind("create", {
+      data: { email: "a@b.c", publicId: "fixed", createdAt: when },
+    });
+    expect(values).toContain("fixed");
+    expect(values).toContain(when.getTime());
+  });
+
+  test("a required field with no default is refused by name", () => {
+    expect(() => text("create", { data: {} })).not.toThrow();
+    expect(() =>
+      compileWrite(organization, "create", { data: {} }, sqlite),
+    ).toThrow(MissingRequiredValueError);
+  });
+
+  test("an unknown field is an error, never a passthrough", () => {
+    expect(() => text("create", { data: { nope: 1 } })).toThrow(
+      UnknownFieldError,
+    );
+  });
+
+  test("select narrows the returning list", () => {
+    expect(
+      text("create", { data: { email: "a@b.c" }, select: { id: true } }),
+    ).toContain(`returning "id"`);
+  });
+
+  test("postgres numbers its placeholders", () => {
+    expect(text("create", { data: { email: "a@b.c" } }, postgres)).toContain(
+      `values ($1, $2, $3, $4, $5, $6)`,
+    );
+  });
+});
+
+describe("createMany", () => {
+  test("one multi-row insert, and the count is the returned rows", () => {
+    const args = { data: [{ email: "a@b.c" }, { email: "d@e.f" }] };
+    expect(text("createMany", args)).toBe(
+      `insert into "User" ("publicId", "email", "locale", "globalRole", ` +
+        `"createdAt", "updatedAt") values (?, ?, ?, ?, ?, ?), ` +
+        `(?, ?, ?, ?, ?, ?) returning "id"`,
+    );
+
+    const plan = compileWrite(user, "createMany", args, sqlite);
+    expect(plan.shape([{ id: 1 }, { id: 2 }])).toEqual({ count: 2 });
+  });
+
+  // The bug this guards is data corruption, not an error: with the column list
+  // taken from row one and the values taken per row by key order, row two binds
+  // its values into the wrong columns. Same types, no error, wrong data.
+  test("rows written in different key orders bind to the right columns", () => {
+    const args = {
+      data: [
+        { email: "a@b.c", name: "A" },
+        { name: "B", email: "d@e.f" },
+      ],
+    };
+    const values = bind("createMany", args);
+
+    // Six columns per row: publicId, name, email, locale, globalRole,
+    // createdAt, updatedAt — name before email, in schema order, for both rows.
+    const width = values.length / 2;
+    expect(values[1]).toBe("A");
+    expect(values[2]).toBe("a@b.c");
+    expect(values[width + 1]).toBe("B");
+    expect(values[width + 2]).toBe("d@e.f");
+  });
+
+  test("rows with different key sets take the union, filling defaults", () => {
+    const args = { data: [{ email: "a@b.c", name: "A" }, { email: "d@e.f" }] };
+    // `name` is nullable, so the row that omits it binds null rather than
+    // splitting the call into two statements.
+    expect(text("createMany", args)).toContain(`"name"`);
+    const values = bind("createMany", args);
+    const width = values.length / 2;
+    expect(values[width + 1]).toBeNull();
+  });
+
+  // A database-side default cannot be requested per row: NULL would overwrite
+  // it, and SQLite rejects the DEFAULT keyword inside a VALUES list.
+  test("a partially-supplied database default is refused, not guessed", () => {
+    expect(() =>
+      text("createMany", { data: [{ id: 1, email: "a@b.c" }, { email: "d@e.f" }] }),
+    ).toThrow(/leave it to the database default/);
+  });
+
+  test("an empty list is a no-op returning count 0", () => {
+    const plan = compileWrite(user, "createMany", { data: [] }, sqlite);
+    expect(plan.text).toBe(`select "id" from "User" where false`);
+    expect(plan.shape([])).toEqual({ count: 0 });
+  });
+
+  test("each row gets its own cuid", () => {
+    const values = bind("createMany", {
+      data: [{ email: "a@b.c" }, { email: "d@e.f" }],
+    });
+    const width = values.length / 2;
+    expect(values[0]).not.toBe(values[width]);
+  });
+
+  test("nested writes are refused", () => {
+    expect(() =>
+      text("createMany", { data: [{ organization: { connect: { id: 1 } } }] }),
+    ).toThrow(UnsupportedQueryError);
+  });
+});
+
+describe("update", () => {
+  test("set clause, unique where, and returning", () => {
+    expect(
+      text("update", { where: { id: 1 }, data: { name: "N" } }),
+    ).toContain(`update "User" set "name" = ?, "updatedAt" = ? where "id" = ?`);
+  });
+
+  test("@updatedAt is stamped even when data does not mention it", () => {
+    const values = bind("update", { where: { id: 1 }, data: { name: "N" } });
+    expect(values[0]).toBe("N");
+    expect(typeof values[1]).toBe("number");
+    expect(values[2]).toBe(1);
+  });
+
+  test("an explicit updatedAt wins", () => {
+    const when = new Date("2020-01-01T00:00:00.000Z");
+    const values = bind("update", {
+      where: { id: 1 },
+      data: { name: "N", updatedAt: when },
+    });
+    expect(values[1]).toBe(when.getTime());
+  });
+
+  test("a non-unique where is refused, naming the keys that would work", () => {
+    expect(() => text("update", { where: { name: "x" }, data: { name: "y" } }))
+      .toThrow(/needs a unique field/);
+  });
+
+  test("updateMany takes any where and returns a count", () => {
+    const args = { where: { name: "x" }, data: { name: "y" } };
+    expect(text("updateMany", args)).toBe(
+      `update "User" set "name" = ?, "updatedAt" = ? where "name" = ? ` +
+        `returning "id"`,
+    );
+    const plan = compileWrite(user, "updateMany", args, sqlite);
+    expect(plan.shape([{ id: 1 }, { id: 2 }, { id: 3 }])).toEqual({ count: 3 });
+  });
+
+  test.each([
+    ["increment", "+"],
+    ["decrement", "-"],
+    ["multiply", "*"],
+    ["divide", "/"],
+  ])("%s reads the column and writes it back", (operator, symbol) => {
+    expect(
+      text("update", {
+        where: { id: 1 },
+        data: { globalRole: { [operator]: 2 } },
+      }),
+    ).toContain(`set "globalRole" = "globalRole" ${symbol} ?`);
+  });
+
+  test("set is the explicit spelling of a plain assignment", () => {
+    expect(
+      text("update", { where: { id: 1 }, data: { name: { set: "N" } } }),
+    ).toContain(`set "name" = ?`);
+  });
+
+  test("an empty data object is refused rather than emitting invalid SQL", () => {
+    expect(() =>
+      compileWrite(organization, "update", { where: { id: 1 }, data: {} }, sqlite),
+    ).toThrow(/At least one field must be updated/);
+  });
+});
+
+describe("delete", () => {
+  test("unique where, returning the row", () => {
+    expect(text("delete", { where: { id: 1 } })).toBe(
+      `delete from "User" where "id" = ? returning "id", "publicId", "name", ` +
+        `"email", "emailVerifiedAt", "verificationToken", "locale", ` +
+        `"globalRole", "password", "organizationId", "createdAt", ` +
+        `"updatedAt", "deletedAt"`,
+    );
+  });
+
+  test("deleteMany takes any where and returns a count", () => {
+    const plan = compileWrite(
+      user,
+      "deleteMany",
+      { where: { name: "x" } },
+      sqlite,
+    );
+    expect(plan.text).toBe(`delete from "User" where "name" = ? returning "id"`);
+    expect(plan.shape([{ id: 1 }])).toEqual({ count: 1 });
+  });
+
+  // Prisma's deleteMany() with no where empties the table. A guard here would
+  // be a divergence; it belongs in a policy (iteration 6).
+  test("deleteMany with no where is allowed, matching Prisma", () => {
+    expect(compileWrite(user, "deleteMany", {}, sqlite).text).toBe(
+      `delete from "User" returning "id"`,
+    );
+  });
+
+  test("a non-unique delete is refused", () => {
+    expect(() => text("delete", { where: { name: "x" } })).toThrow(
+      /needs a unique field/,
+    );
+  });
+});
+
+describe("upsert", () => {
+  test("one statement: insert with on-conflict do update", () => {
+    expect(
+      text("upsert", {
+        where: { email: "a@b.c" },
+        create: { email: "a@b.c", name: "A" },
+        update: { name: "B" },
+      }),
+    ).toContain(
+      `on conflict ("email") do update set "name" = ?, "updatedAt" = ? ` +
+        `returning "id"`,
+    );
+  });
+
+  // `update: {}` is legal in Prisma and means "return the row, changed or not".
+  // Organization is the model with no `@updatedAt`, so nothing else fills the
+  // set clause and the self-assignment is what keeps a row coming back.
+  //
+  // The right-hand side names its table because inside a conflict clause
+  // Postgres has both the existing row and `excluded` in scope and rejects a
+  // bare column as ambiguous. Verified against a live server, not assumed.
+  test("an empty update still returns the existing row", () => {
+    expect(
+      compileWrite(
+        organization,
+        "upsert",
+        {
+          where: { publicId: "o1" },
+          create: { publicId: "o1", name: "Acme" },
+          update: {},
+        },
+        sqlite,
+      ).text,
+    ).toContain(
+      `on conflict ("publicId") do update set ` +
+        `"publicId" = "Organization"."publicId"`,
+    );
+  });
+
+  // The other half of the same ambiguity: an arithmetic update reads the column
+  // it writes, so its right-hand side has to be qualified too.
+  test("an arithmetic update inside a conflict clause names its table", () => {
+    expect(
+      text("upsert", {
+        where: { email: "a@b.c" },
+        create: { email: "a@b.c" },
+        update: { globalRole: { increment: 1 } },
+      }),
+    ).toContain(`do update set "globalRole" = "User"."globalRole" + ?`);
+  });
+
+  // ...and a plain update must *not* be qualified, which is the reason the
+  // qualifier is a parameter rather than always on.
+  test("a plain update leaves its right-hand side unqualified", () => {
+    expect(
+      text("update", {
+        where: { id: 1 },
+        data: { globalRole: { increment: 1 } },
+      }),
+    ).toContain(`set "globalRole" = "globalRole" + ?`);
+  });
+
+  test("@updatedAt is stamped on the conflict branch too", () => {
+    expect(
+      text("upsert", {
+        where: { email: "a@b.c" },
+        create: { email: "a@b.c" },
+        update: {},
+      }),
+    ).toContain(`do update set "updatedAt" = ?`);
+  });
+
+  // `on conflict` only fires when the inserted row actually collides on the
+  // target, so an upsert whose `create` cannot produce that key would always
+  // insert — never update. Prisma means find-then-write there, which needs a
+  // transaction (iteration 5). Refused rather than silently diverging.
+  test("a create that omits the conflict key is refused", () => {
+    expect(() =>
+      text("upsert", {
+        where: { id: 1 },
+        create: { email: "a@b.c" },
+        update: { name: "N" },
+      }),
+    ).toThrow(/could never conflict on that key/);
+  });
+
+  // Presence is a compile-time property; agreement is not, because values do
+  // not exist at compile time. So this one fails at bind.
+  test("a create that disagrees with the where key is refused at bind", () => {
+    const args = {
+      where: { email: "a@b.c" },
+      create: { email: "different@b.c" },
+      update: { name: "N" },
+    };
+    const compiled = compileWrite(user, "upsert", args, sqlite);
+    expect(() => compiled.bind(args, createBindContext())).toThrow(
+      /must agree on the key/,
+    );
+  });
+
+  test("agreeing values bind without complaint", () => {
+    const args = {
+      where: { email: "a@b.c" },
+      create: { email: "a@b.c" },
+      update: { name: "N" },
+    };
+    const compiled = compileWrite(user, "upsert", args, sqlite);
+    expect(() => compiled.bind(args, createBindContext())).not.toThrow();
+  });
+
+  test("a composite unique becomes a composite conflict target", () => {
+    const compiled = compileWrite(
+      account,
+      "upsert",
+      {
+        where: { publicId: "p" },
+        create: { publicId: "p" },
+        update: { organizationRole: 1 },
+      },
+      sqlite,
+    );
+    expect(compiled.text).toContain(`on conflict ("publicId")`);
+  });
+
+  test("nested writes inside an upsert are refused", () => {
+    expect(() =>
+      text("upsert", {
+        where: { id: 1 },
+        create: { organization: { connect: { id: 1 } } },
+        update: {},
+      }),
+    ).toThrow(/Nested writes inside an upsert/);
+  });
+});
+
+describe("nested writes", () => {
+  beforeEach(() => {
+    registry.clearRegistry();
+    registry.register("User", class { static $schema = user });
+    registry.register("Account", class { static $schema = account });
+    registry.register("Organization", class { static $schema = organization });
+  });
+
+  // The referenced value is already in hand, so this must not cost a query.
+  test("connect on the referenced key is one more bound column, no step", () => {
+    const args = {
+      data: { email: "a@b.c", organization: { connect: { id: 7 } } },
+    };
+    const plan = compileWrite(user, "create", args, sqlite);
+
+    expect(plan.before).toBeUndefined();
+    expect(plan.text).toContain(`"organizationId"`);
+    expect(plan.bind(args, createBindContext())).toContain(7);
+  });
+
+  // Connecting by a *different* unique needs a lookup, and that difference is a
+  // property of the argument shape, so it is decided at compile time.
+  test("connect by another unique plans a lookup step", () => {
+    const plan = compileWrite(
+      user,
+      "create",
+      { data: { email: "a@b.c", organization: { connect: { publicId: "p" } } } },
+      sqlite,
+    );
+    expect(plan.before).toHaveLength(1);
+    expect(plan.before?.[0].relation).toBe("organization");
+  });
+
+  test("nested create on the owning side runs before the insert", () => {
+    const plan = compileWrite(
+      user,
+      "create",
+      { data: { email: "a@b.c", organization: { create: { name: "Acme" } } } },
+      sqlite,
+    );
+    expect(plan.before).toHaveLength(1);
+    expect(plan.after).toBeUndefined();
+  });
+
+  // The child holds the key, so it cannot be written until this row exists —
+  // and the key has to come back in the RETURNING list to point it at.
+  test("nested create on the foreign side runs after, and returns the key", () => {
+    const plan = compileWrite(
+      user,
+      "create",
+      {
+        data: { email: "a@b.c", accounts: { create: [{ organizationRole: 1 }] } },
+        select: { email: true },
+      },
+      sqlite,
+    );
+    expect(plan.after).toHaveLength(1);
+    expect(plan.text).toContain(`returning "id", "email"`);
+    // `id` was fetched only to stitch with; the caller never asked for it.
+    expect(plan.hidden).toEqual(["id"]);
+  });
+
+  test("setting a foreign key twice is refused", () => {
+    expect(() =>
+      text("create", {
+        data: {
+          email: "a@b.c",
+          organizationId: 1,
+          organization: { connect: { id: 2 } },
+        },
+      }),
+    ).toThrow(/set both directly and through a nested relation write/);
+  });
+
+  test.each([
+    "connectOrCreate",
+    "set",
+    "disconnect",
+    "update",
+    "upsert",
+    "delete",
+    "deleteMany",
+    "updateMany",
+  ])("%s is refused, naming itself", (operation) => {
+    expect(() =>
+      text("create", {
+        data: { email: "a@b.c", organization: { [operation]: {} } },
+      }),
+    ).toThrow(new RegExp(`data\\.organization\\.${operation}`));
+  });
+});
+
+describe("arguments", () => {
+  test.each([
+    ["create", {}, "data"],
+    ["update", { data: { name: "x" } }, "where"],
+    ["update", { where: { id: 1 } }, "data"],
+    ["delete", {}, "where"],
+    ["upsert", { where: { id: 1 }, create: {} }, "update"],
+  ])("%s reports the argument it requires", (op, args, missing) => {
+    expect(() => text(op, args)).toThrow(new RegExp(`requires '${missing}'`));
+  });
+
+  test("select and include together are refused", () => {
+    expect(() =>
+      text("create", {
+        data: { email: "a@b.c" },
+        select: { id: true },
+        include: { accounts: true },
+      }),
+    ).toThrow(/only one of them/);
+  });
+
+  test("an unsupported argument names itself", () => {
+    expect(() =>
+      text("createMany", { data: [{ email: "a" }], skipDuplicates: true }),
+    ).toThrow(/skipDuplicates/);
+  });
+});
+
+// Invariant 2, asserted rather than argued: no value is ever inlined into the
+// SQL text. The read suite makes the same assertion; writes are the place it is
+// most tempting to break, because a column list *looks* like a good place for a
+// literal.
+describe("no value reaches the SQL text", () => {
+  const statements = [
+    text("create", { data: { email: "a@b.c", globalRole: 7 } }),
+    text("createMany", { data: [{ email: "a" }, { email: "b" }] }),
+    text("update", { where: { id: 42 }, data: { globalRole: { increment: 3 } } }),
+    text("updateMany", { where: { globalRole: 9 }, data: { name: "x" } }),
+    text("delete", { where: { id: 42 } }),
+    text("deleteMany", { where: { globalRole: { in: [1, 2, 3] } } }),
+    text("upsert", {
+      where: { id: 5 },
+      create: { id: 5, email: "a@b.c" },
+      update: { globalRole: 4 },
+    }),
+  ];
+
+  test.each(statements)("%s", (statement) => {
+    // Identifiers are quoted, so stripping quoted spans leaves only keywords,
+    // punctuation and placeholders — none of which may contain a digit.
+    const withoutIdentifiers = statement.replace(/"[^"]*"/g, "");
+    expect(withoutIdentifiers).not.toMatch(/\d/);
+  });
+});

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -2,7 +2,6 @@ import { clientSideValue, hasClientSideValue } from "../defaults";
 import type { SqlDialect } from "../dialect";
 import {
   MissingRequiredValueError,
-  ParameterLimitError,
   ReturningUnsupportedError,
   UnknownFieldError,
   UnsupportedQueryError,
@@ -149,7 +148,7 @@ function compileCreate(
     returning.clause,
   );
 
-  return plan(statement, dialect, op, returning, nested);
+  return plan(schema, statement, dialect, op, returning, nested);
 }
 
 // --- createMany ------------------------------------------------------------
@@ -174,6 +173,7 @@ function compileCreateMany(
         `select ${key} from ${dialect.quoteIdent(schema.table)} where false`,
       ),
       dialect,
+      { model: schema.name, operation: op },
     );
     return {
       text,
@@ -207,8 +207,6 @@ function compileCreateMany(
     );
   }
 
-  assertParameterCount(schema, op, rows.length * grid[0].length, dialect);
-
   const returning = returningClause(schema, undefined, dialect, op, undefined);
 
   const statement = concat(
@@ -217,7 +215,7 @@ function compileCreateMany(
     returning.clause,
   );
 
-  const { text, binders } = render(statement, dialect);
+  const { text, binders } = render(statement, dialect, { model: schema.name, operation: op });
   return {
     text,
     bind: bindValues(binders),
@@ -389,7 +387,7 @@ function compileUpdate(
     returning.clause,
   );
 
-  return plan(statement, dialect, op, returning, nested);
+  return plan(schema, statement, dialect, op, returning, nested);
 }
 
 // --- delete / deleteMany ---------------------------------------------------
@@ -432,7 +430,7 @@ function compileDelete(
     returning.clause,
   );
 
-  return plan(statement, dialect, op, returning, undefined);
+  return plan(schema, statement, dialect, op, returning, undefined);
 }
 
 // --- upsert ----------------------------------------------------------------
@@ -471,6 +469,19 @@ function compileUpsert(
   // find no match, attempt the create, and hit a unique violation). Refused
   // rather than narrowed, for the same reason the create-omits-the-key shape a
   // few lines down is.
+  // KNOWN DIFFERENCE, and deliberate: this also refuses a `where` naming *two
+  // different unique keys* — `{ id: 1, publicId: "p" }` — which Prisma accepts.
+  // `on conflict` takes one target, so honouring both is not expressible;
+  // picking `id` and ignoring `publicId` is the same silent narrowing the rest
+  // of this guard exists to remove. A migrating application does hit a compile
+  // error on a call Prisma ran happily, which is why it is listed under known
+  // differences in the plan rather than only here.
+  //
+  // Note which key gets *named* in that case is an artifact of declaration
+  // order — `matchUniqueKey` returns the primary key first, then `uniques` in
+  // schema order — not of anything the caller wrote. Fine for a message that
+  // lists every other member by name and tells the caller to choose, and not
+  // worth resolving, since there is no principled way to prefer one.
   const named = key.length > 1 ? key.join("_") : key[0];
   const extra = Object.keys(args.where as Record<string, unknown>).filter(
     (name) => name !== named && args.where[name] !== undefined,
@@ -484,8 +495,8 @@ function compileUpsert(
         `'${named}'. An upsert compiles its where into an 'on conflict' ` +
         `target, which can only be a key, so the extra ${
           extra.length === 1 ? "filter would be" : "filters would be"
-        } silently dropped. Drop ${extra.length === 1 ? "it" : "them"} here, ` +
-        `or use findFirst plus update / create.`,
+        } silently dropped. Name exactly one unique key here — or, if you meant ` +
+        `to filter further, use findFirst plus update / create.`,
     );
   }
 
@@ -586,7 +597,7 @@ function compileUpsert(
     returning.clause,
   );
 
-  return plan(statement, dialect, op, returning, undefined);
+  return plan(schema, statement, dialect, op, returning, undefined);
 }
 
 /**
@@ -677,11 +688,45 @@ function sameEncoded(a: unknown, b: unknown): boolean {
   return false;
 }
 
-/** A value for an error message, without pretending a `Date` is a string. */
+/**
+ * A value for an error message, distinct whenever `sameEncoded` says the two
+ * values differ.
+ *
+ * That equivalence is the whole requirement, and it is easy to half-meet: the
+ * first version of this stringified a `Date`, which made a genuine mismatch
+ * read as `is X ... but X` and look like a framework bug rather than a wrong
+ * argument. Two more ways to land back there:
+ *
+ * - Two different `Uint8Array`s of the same length both describing as
+ *   `"2 bytes"`. Hence the hex, truncated so a large blob does not fill the
+ *   message.
+ * - `1n` and `1`, which `sameEncoded` separates and `String()` collapses.
+ *   Reachable because Prisma coerces a number into a `BigInt` field. Hence the
+ *   `typeof` suffix on anything that is not a string.
+ */
 function describe(value: unknown): string {
   if (value instanceof Date) return JSON.stringify(value.toISOString());
-  if (ArrayBuffer.isView(value)) return `${value.byteLength} bytes`;
-  return JSON.stringify(String(value));
+
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(
+      value.buffer,
+      value.byteOffset,
+      value.byteLength,
+    );
+    // `Array.from` rather than a spread + `.map`: a `Uint8Array`'s own `map`
+    // returns another `Uint8Array`, so the strings would be coerced back to
+    // bytes and every one of them would become 0.
+    const shown = Array.from(bytes.slice(0, 8), (byte) =>
+      byte.toString(16).padStart(2, "0"),
+    ).join("");
+    const ellipsis = bytes.length > 8 ? "…" : "";
+    return `${bytes.length} bytes (0x${shown}${ellipsis})`;
+  }
+
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === null || value === undefined) return String(value);
+
+  return `${JSON.stringify(String(value))} (${typeof value})`;
 }
 
 /**
@@ -842,36 +887,6 @@ function suppliedFields(
   }
 
   return out;
-}
-
-/**
- * Refuse a statement that would bind more parameters than the driver can carry.
- *
- * `createMany` is the only operation whose parameter count is a function of the
- * caller's *data* rather than of the query's shape, so it is the only one that
- * can walk into a limit an application never chose. Everything else binds a
- * handful.
- *
- * Note this is checked at compile time from the row and column counts, which is
- * enough — the value of any one parameter cannot change how many there are.
- */
-function assertParameterCount(
-  schema: ModelSchema,
-  op: Operation,
-  required: number,
-  dialect: SqlDialect,
-): void {
-  const limit = dialect.maxBoundParameters;
-  if (required <= limit) return;
-
-  throw new ParameterLimitError(
-    schema.name,
-    op,
-    required,
-    limit,
-    dialect.name,
-    `That is ${required} values across the rows in 'data'.`,
-  );
 }
 
 /**
@@ -1155,13 +1170,14 @@ function fieldOf(schema: ModelSchema, name: string): FieldSchema {
 }
 
 function plan(
+  schema: ModelSchema,
   statement: Fragment,
   dialect: SqlDialect,
   op: Operation,
   returning: Returning,
   nested: NestedWritePlanning | undefined,
 ): QueryPlan {
-  const { text, binders } = render(statement, dialect);
+  const { text, binders } = render(statement, dialect, { model: schema.name, operation: op });
 
   const shaper = buildRowShaper(
     returning.fields,

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -2,6 +2,7 @@ import { clientSideValue, hasClientSideValue } from "../defaults";
 import type { SqlDialect } from "../dialect";
 import {
   MissingRequiredValueError,
+  ParameterLimitError,
   ReturningUnsupportedError,
   UnknownFieldError,
   UnsupportedQueryError,
@@ -183,6 +184,31 @@ function compileCreateMany(
 
   const grid = createManyColumns(schema, rows, op, dialect);
 
+  // `insert ... default values` inserts exactly one row and has no multi-row
+  // spelling: `values (DEFAULT), (DEFAULT)` is rejected by SQLite, and the
+  // zero-column list leaves nothing else to repeat. So a grid with no columns
+  // and more than one row would quietly insert one — a wrong row count *and* a
+  // wrong `{ count }`, from a statement that succeeds.
+  //
+  // Only reachable on a model where every field is autoincrement, database
+  // default or nullable *and* no row supplies any of them, so the template's
+  // schema cannot produce it. Refused by name anyway, because a silent wrong
+  // count is the failure class this file is arranged to prevent.
+  if (grid[0].length === 0 && rows.length > 1) {
+    throw new UnsupportedQueryError(
+      "data",
+      schema.name,
+      op,
+      `All ${rows.length} rows are empty and ${schema.name} has no ` +
+        `client-side default to fill, so there is no column to insert. A ` +
+        `multi-row insert of nothing but database defaults cannot be ` +
+        `expressed on both dialects. Call create ${rows.length} times, or ` +
+        `set at least one field per row.`,
+    );
+  }
+
+  assertParameterCount(schema, op, rows.length * grid[0].length, dialect);
+
   const returning = returningClause(schema, undefined, dialect, op, undefined);
 
   const statement = concat(
@@ -308,6 +334,24 @@ function compileUpdate(
 
   if (!many) matchUniqueKey(schema, args?.where, op);
 
+  // Prisma's `updateMany` takes unchecked input — scalars and foreign keys, no
+  // relation keys — and rejects one with `Unknown argument 'organization'`.
+  // Refused by name here for the same reason `createMany` refuses it: without
+  // this the key is neither executed nor reported, since `planNestedWrites`
+  // never runs and `suppliedFields` skips relation keys silently. A `data` of
+  // only a relation key would then reach "At least one field must be updated",
+  // which names the wrong problem.
+  if (many) {
+    assertNoNestedWrites(
+      schema,
+      args?.data,
+      op,
+      "data",
+      "updateMany cannot contain nested writes — it has no single row to " +
+        "attach them to. Use update per row.",
+    );
+  }
+
   const nested = many
     ? undefined
     : planNestedWrites(schema, args?.data, op, (callArgs) => callArgs?.data);
@@ -350,6 +394,21 @@ function compileUpdate(
 
 // --- delete / deleteMany ---------------------------------------------------
 
+/**
+ * KNOWN DIVERGENCE — `delete` with an `include` on a cascading relation.
+ *
+ * The relation reads run *after* the delete statement, from `$exec`. Where the
+ * schema declares `onDelete: Cascade`, the database has already removed the
+ * children by then, so the `include` comes back empty; Prisma runs the whole
+ * thing in a transaction and returns the children as they were.
+ *
+ * Not fixable at this layer. The fix is to read the relations before the delete
+ * inside one transaction, which is iteration 5's to provide — and once it does,
+ * this is the case to write the test for. Recorded here rather than left to be
+ * discovered because the template's schema declares no cascades, so the
+ * differential harness cannot see it: the first cascading model added to any
+ * application would.
+ */
 function compileDelete(
   schema: ModelSchema,
   op: Operation,
@@ -401,21 +460,45 @@ function compileUpsert(
 ): QueryPlan {
   const key = matchUniqueKey(schema, args?.where, op);
 
+  // Since Prisma 5 a `WhereUniqueInput` may carry extra non-unique filters
+  // beside the key, and they narrow the match further. `update` and `delete`
+  // honour that for free: their whole `where` goes through `compileWhere`.
+  //
+  // An upsert cannot. Its `where` becomes an `on conflict (...)` target, which
+  // is a *key*, not a predicate — there is nowhere to put `deletedAt: null`.
+  // Compiling only the key part would mean `where: { publicId, deletedAt: null }`
+  // updating a soft-deleted row that Prisma would have left alone (Prisma would
+  // find no match, attempt the create, and hit a unique violation). Refused
+  // rather than narrowed, for the same reason the create-omits-the-key shape a
+  // few lines down is.
+  const named = key.length > 1 ? key.join("_") : key[0];
+  const extra = Object.keys(args.where as Record<string, unknown>).filter(
+    (name) => name !== named && args.where[name] !== undefined,
+  );
+  if (extra.length > 0) {
+    throw new UnsupportedQueryError(
+      "where",
+      schema.name,
+      op,
+      `The where clause carries ${extra.join(", ")} beside the unique key ` +
+        `'${named}'. An upsert compiles its where into an 'on conflict' ` +
+        `target, which can only be a key, so the extra ${
+          extra.length === 1 ? "filter would be" : "filters would be"
+        } silently dropped. Drop ${extra.length === 1 ? "it" : "them"} here, ` +
+        `or use findFirst plus update / create.`,
+    );
+  }
+
   for (const branch of ["create", "update"] as const) {
-    const data = args?.[branch];
-    if (typeof data !== "object" || data === null) continue;
-    for (const name of Object.keys(data as Record<string, unknown>)) {
-      if (name in schema.relations) {
-        throw new UnsupportedQueryError(
-          `${branch}.${name}`,
-          schema.name,
-          op,
-          "Nested writes inside an upsert are not implemented: they would " +
-            "have to run before it is known whether the row is being inserted " +
-            "or updated.",
-        );
-      }
-    }
+    assertNoNestedWrites(
+      schema,
+      args?.[branch],
+      op,
+      branch,
+      "Nested writes inside an upsert are not implemented: they would have " +
+        "to run before it is known whether the row is being inserted or " +
+        "updated.",
+    );
   }
 
   // `on conflict` only fires if the row being inserted actually collides on the
@@ -539,13 +622,13 @@ function withConflictKeyCheck(
         const inserted = column.value(args, context);
         const selected = dialect.encode(locate(args), column.field);
 
-        if (inserted !== selected) {
+        if (!sameEncoded(inserted, selected)) {
           throw new UnsupportedQueryError(
             "upsert",
             schema.name,
             op,
-            `'${column.field.name}' is ${JSON.stringify(String(selected))} in ` +
-              `the where clause but ${JSON.stringify(String(inserted))} in ` +
+            `'${column.field.name}' is ${describe(selected)} in ` +
+              `the where clause but ${describe(inserted)} in ` +
               `'create'. An upsert looks the row up by the where clause and ` +
               `inserts what 'create' says, so the two must agree on the key.`,
           );
@@ -555,6 +638,50 @@ function withConflictKeyCheck(
       },
     };
   });
+}
+
+/**
+ * Do two *encoded* values stand for the same thing?
+ *
+ * Not `===`, because `encode` is a per-dialect pass-through for whatever the
+ * driver binds natively, and what a driver binds natively is not always a
+ * primitive. Postgres passes a `DateTime` through as the `Date` it was given,
+ * and both dialects pass `Bytes` through as a `Uint8Array` — so the same
+ * instant and the same bytes arrive here as two distinct objects, and identity
+ * refuses a correct upsert with a message printing two equal-looking strings.
+ *
+ * That is exactly the SQLite/Postgres asymmetry this codebase keeps finding:
+ * SQLite encodes `DateTime` to a number and never noticed.
+ *
+ * Everything else falls through to `!==`, which is right for the string,
+ * number, boolean and bigint an encoder can produce. `NaN` is not reachable —
+ * it cannot be a unique key value that also round-trips through a `where`.
+ */
+function sameEncoded(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+
+  if (ArrayBuffer.isView(a) && ArrayBuffer.isView(b)) {
+    const left = new Uint8Array(a.buffer, a.byteOffset, a.byteLength);
+    const right = new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+    if (left.length !== right.length) return false;
+    for (let i = 0; i < left.length; i++) {
+      if (left[i] !== right[i]) return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+/** A value for an error message, without pretending a `Date` is a string. */
+function describe(value: unknown): string {
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (ArrayBuffer.isView(value)) return `${value.byteLength} bytes`;
+  return JSON.stringify(String(value));
 }
 
 /**
@@ -715,6 +842,62 @@ function suppliedFields(
   }
 
   return out;
+}
+
+/**
+ * Refuse a statement that would bind more parameters than the driver can carry.
+ *
+ * `createMany` is the only operation whose parameter count is a function of the
+ * caller's *data* rather than of the query's shape, so it is the only one that
+ * can walk into a limit an application never chose. Everything else binds a
+ * handful.
+ *
+ * Note this is checked at compile time from the row and column counts, which is
+ * enough — the value of any one parameter cannot change how many there are.
+ */
+function assertParameterCount(
+  schema: ModelSchema,
+  op: Operation,
+  required: number,
+  dialect: SqlDialect,
+): void {
+  const limit = dialect.maxBoundParameters;
+  if (required <= limit) return;
+
+  throw new ParameterLimitError(
+    schema.name,
+    op,
+    required,
+    limit,
+    dialect.name,
+    `That is ${required} values across the rows in 'data'.`,
+  );
+}
+
+/**
+ * Refuse a `data` object that names a relation, for the operations that have no
+ * nested-write planner behind them.
+ *
+ * `suppliedFields` skips relation keys rather than rejecting them, because on
+ * `create` and `update` they are the nested planner's business. Everywhere else
+ * that same skip is a silent drop, so those callers say so here — by name, and
+ * before anything is compiled.
+ */
+function assertNoNestedWrites(
+  schema: ModelSchema,
+  data: unknown,
+  op: Operation,
+  path: string,
+  reason: string,
+): void {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return;
+
+  for (const [name, value] of Object.entries(data as Record<string, unknown>)) {
+    if (value === undefined) continue;
+    if (name in schema.relations) {
+      throw new UnsupportedQueryError(`${path}.${name}`, schema.name, op, reason);
+    }
+  }
 }
 
 /**

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -1,0 +1,1094 @@
+import { clientSideValue, hasClientSideValue } from "../defaults";
+import type { SqlDialect } from "../dialect";
+import {
+  MissingRequiredValueError,
+  ReturningUnsupportedError,
+  UnknownFieldError,
+  UnsupportedQueryError,
+} from "../errors";
+import type { Operation, QueryPlan } from "../plan";
+import type { FieldSchema, ModelSchema } from "../schema";
+import { buildRowShaper } from "../shape";
+import {
+  type Binder,
+  type Fragment,
+  bindValues,
+  concat,
+  joinFragments,
+  param,
+  render,
+  sql,
+} from "./fragment";
+import {
+  type ForeignKeyContribution,
+  type NestedWritePlanning,
+  planNestedWrites,
+} from "./nested-writes";
+import { planRelations } from "./plan-relations";
+import { resolveSelection, withKeyFields } from "./select";
+import { matchUniqueKey } from "./unique";
+import { compileWhere } from "./where";
+
+/**
+ * The write surface: `create`, `createMany`, `update`, `updateMany`, `delete`,
+ * `deleteMany`, `upsert`.
+ *
+ * Everything here obeys the same two rules the read compiler does, and for the
+ * same reasons (invariant 2): the SQL text is a pure function of the argument
+ * *shape*, and every value is a bound parameter. A `create` with the same field
+ * set is one plan whatever the values are.
+ *
+ * Two decisions worth finding here rather than inferring from the code:
+ *
+ * **1. Row counts come from `RETURNING`, not from driver metadata.**
+ * `updateMany` and `deleteMany` return `{ count }`, and the obvious source is
+ * whatever the driver reports about the statement. Measured, that source is not
+ * portable: Bun's SQLite driver leaves `affectedRows` **null** on every
+ * statement and puts the number on a `count` property instead, and neither is
+ * documented or verifiable against Postgres from here. So the count is the
+ * number of rows a `RETURNING <primary key>` gives back — one statement shape on
+ * every dialect, exact by construction, and dependent on nothing undocumented.
+ * It costs one key column per affected row on the wire, which is a real cost on
+ * a very large `deleteMany`; iteration 7 owns performance and can revisit it
+ * with a benchmark rather than a guess.
+ *
+ * **2. `createMany` fills defaults explicitly rather than grouping rows.**
+ * Prisma allows rows with different key sets in one call, and a single multi-row
+ * `INSERT` cannot express that directly — every row must supply every column.
+ * The column list is therefore the union of every row's keys, and a row missing
+ * one gets its client-side default, or `NULL` if the column is nullable. The one
+ * case that cannot be filled is a column with a *database* default that some
+ * rows supply and others do not: `NULL` would override the default rather than
+ * request it, and the `DEFAULT` keyword is not available — SQLite rejects it
+ * inside a `VALUES` list (verified: `near "DEFAULT": syntax error`). That case
+ * is refused with an error naming the column, rather than silently written wrong.
+ */
+
+const WRITE_ARGS: Record<string, Set<string>> = {
+  create: new Set(["data", "select", "include"]),
+  createMany: new Set(["data"]),
+  update: new Set(["data", "where", "select", "include"]),
+  updateMany: new Set(["data", "where"]),
+  delete: new Set(["where", "select", "include"]),
+  deleteMany: new Set(["where"]),
+  upsert: new Set(["where", "create", "update", "select", "include"]),
+};
+
+/** The writes that return one row, and raise when they match none. */
+const SINGLE_ROW = new Set(["create", "update", "delete", "upsert"]);
+
+/** The writes that return `{ count }` rather than rows. */
+const COUNTING = new Set(["createMany", "updateMany", "deleteMany"]);
+
+export function isWriteOperation(op: Operation): boolean {
+  return op in WRITE_ARGS;
+}
+
+export function compileWrite(
+  schema: ModelSchema,
+  op: Operation,
+  args: any,
+  dialect: SqlDialect,
+): QueryPlan {
+  assertArgs(schema, op, args);
+
+  // Every write reports its result — the row, or the number of rows — through
+  // `RETURNING`. Asked rather than assumed so MySQL is a named gap.
+  if (!dialect.supportsReturning) {
+    throw new ReturningUnsupportedError(schema.name, op, dialect.name);
+  }
+
+  switch (op) {
+    case "create":
+      return compileCreate(schema, op, args, dialect);
+    case "createMany":
+      return compileCreateMany(schema, op, args, dialect);
+    case "update":
+    case "updateMany":
+      return compileUpdate(schema, op, args, dialect);
+    case "delete":
+    case "deleteMany":
+      return compileDelete(schema, op, args, dialect);
+    case "upsert":
+      return compileUpsert(schema, op, args, dialect);
+    default:
+      throw new UnsupportedQueryError(op, schema.name, op);
+  }
+}
+
+// --- create ----------------------------------------------------------------
+
+function compileCreate(
+  schema: ModelSchema,
+  op: Operation,
+  args: any,
+  dialect: SqlDialect,
+): QueryPlan {
+  const nested = planNestedWrites(
+    schema,
+    args?.data,
+    op,
+    (callArgs) => callArgs?.data,
+  );
+
+  const columns = insertColumns(
+    schema,
+    args?.data,
+    nested.contributions,
+    op,
+    dialect,
+    (callArgs) => callArgs?.data,
+  );
+
+  const returning = returningClause(schema, args, dialect, op, nested);
+
+  const statement = concat(
+    sql(`insert into ${dialect.quoteIdent(schema.table)}`),
+    valuesClause([columns], dialect),
+    returning.clause,
+  );
+
+  return plan(statement, dialect, op, returning, nested);
+}
+
+// --- createMany ------------------------------------------------------------
+
+function compileCreateMany(
+  schema: ModelSchema,
+  op: Operation,
+  args: any,
+  dialect: SqlDialect,
+): QueryPlan {
+  const rows = args?.data === undefined ? [] : listOf(args.data);
+
+  // Prisma returns `{ count: 0 }` for an empty list without touching the
+  // database, but a plan must have a statement. A constant-false select is the
+  // cheapest thing that yields zero rows on both dialects, and it keeps the
+  // empty case on exactly the same code path as every other — no branch in the
+  // choke point, no plan that is a plan in name only.
+  if (rows.length === 0) {
+    const key = keyColumn(schema, dialect);
+    const { text, binders } = render(
+      sql(
+        `select ${key} from ${dialect.quoteIdent(schema.table)} where false`,
+      ),
+      dialect,
+    );
+    return {
+      text,
+      bind: bindValues(binders),
+      shape: (returned) => ({ count: returned.length }),
+    };
+  }
+
+  const grid = createManyColumns(schema, rows, op, dialect);
+
+  const returning = returningClause(schema, undefined, dialect, op, undefined);
+
+  const statement = concat(
+    sql(`insert into ${dialect.quoteIdent(schema.table)}`),
+    valuesClause(grid, dialect),
+    returning.clause,
+  );
+
+  const { text, binders } = render(statement, dialect);
+  return {
+    text,
+    bind: bindValues(binders),
+    shape: (returned) => ({ count: returned.length }),
+  };
+}
+
+/**
+ * The column grid for a multi-row insert: one `WriteColumn[]` per row, every
+ * row carrying the same fields in the same order.
+ *
+ * The order is the *schema's*, never the first row's key order. That is not a
+ * tidiness point: with the column list taken from row one and the values taken
+ * per row by key order, a second row whose keys were written in a different
+ * order binds its values into the wrong columns. Same types, no error, wrong
+ * data — the worst shape of bug this file could have. Every value is looked up
+ * by field name, and there is a test for exactly this.
+ */
+function createManyColumns(
+  schema: ModelSchema,
+  rows: unknown[],
+  op: Operation,
+  dialect: SqlDialect,
+): WriteColumn[][] {
+  const supplied = rows.map((row, index) => {
+    if (typeof row !== "object" || row === null || Array.isArray(row)) {
+      throw new UnsupportedQueryError(
+        `data[${index}]`,
+        schema.name,
+        op,
+        "Expected an object.",
+      );
+    }
+
+    const keys = new Set<string>();
+    for (const [key, value] of Object.entries(row as Record<string, unknown>)) {
+      if (value === undefined) continue;
+      if (key in schema.relations) {
+        // Prisma's `createMany` takes unchecked input — scalars and foreign
+        // keys only. A nested write there has no defined ordering across rows.
+        throw new UnsupportedQueryError(
+          `data.${key}`,
+          schema.name,
+          op,
+          "createMany cannot contain nested writes. Use create per row.",
+        );
+      }
+      if (!(key in schema.fields)) {
+        throw new UnknownFieldError(key, schema.name, Object.keys(schema.fields));
+      }
+      keys.add(key);
+    }
+    return keys;
+  });
+
+  // The union, walked in schema order so the emitted column list depends only
+  // on *which* fields appear, never on how any row was written.
+  const union: FieldSchema[] = [];
+  for (const field of Object.values(schema.fields)) {
+    const inSome = supplied.some((keys) => keys.has(field.name));
+    if (inSome || hasClientSideValue(field)) union.push(field);
+  }
+
+  for (const field of union) {
+    const missing = supplied.some((keys) => !keys.has(field.name));
+    if (!missing) continue;
+
+    if (hasClientSideValue(field)) continue;
+    if (field.nullable) continue;
+
+    // A database-side default that only some rows override. `NULL` would
+    // *overwrite* the default rather than request it, and SQLite has no
+    // `DEFAULT` keyword inside a `VALUES` list to ask for it with.
+    if (field.default) {
+      throw new UnsupportedQueryError(
+        `data.${field.name}`,
+        schema.name,
+        op,
+        `Some rows set '${field.name}' and others leave it to the database ` +
+          `default. A single multi-row insert cannot express both. Split the ` +
+          `call, or set '${field.name}' on every row.`,
+      );
+    }
+
+    const index = supplied.findIndex((keys) => !keys.has(field.name));
+    throw new MissingRequiredValueError(
+      schema.name,
+      `${op}.data[${index}]`,
+      field.name,
+    );
+  }
+
+  return rows.map((_row, index) =>
+    union.map((field) => ({
+      field,
+      value: supplied[index].has(field.name)
+        ? valueBinder(field, dialect, (callArgs) =>
+            listOf(callArgs?.data)[index]?.[field.name],
+          )
+        : defaultBinder(field, dialect),
+    })),
+  );
+}
+
+// --- update / updateMany ---------------------------------------------------
+
+function compileUpdate(
+  schema: ModelSchema,
+  op: Operation,
+  args: any,
+  dialect: SqlDialect,
+): QueryPlan {
+  const many = op === "updateMany";
+
+  if (!many) matchUniqueKey(schema, args?.where, op);
+
+  const nested = many
+    ? undefined
+    : planNestedWrites(schema, args?.data, op, (callArgs) => callArgs?.data);
+
+  const assignments = updateAssignments(
+    schema,
+    args?.data,
+    nested?.contributions ?? [],
+    op,
+    dialect,
+  );
+
+  if (assignments.length === 0) {
+    throw new UnsupportedQueryError(
+      "data",
+      schema.name,
+      op,
+      "At least one field must be updated.",
+    );
+  }
+
+  const where = compileWhere(
+    schema,
+    args?.where,
+    { dialect, operation: op },
+    (callArgs) => callArgs?.where,
+  );
+
+  const returning = returningClause(schema, args, dialect, op, nested);
+
+  const statement = concat(
+    sql(`update ${dialect.quoteIdent(schema.table)} set `),
+    joinFragments(assignments, ", "),
+    where ? concat(sql(" where "), where) : sql(""),
+    returning.clause,
+  );
+
+  return plan(statement, dialect, op, returning, nested);
+}
+
+// --- delete / deleteMany ---------------------------------------------------
+
+function compileDelete(
+  schema: ModelSchema,
+  op: Operation,
+  args: any,
+  dialect: SqlDialect,
+): QueryPlan {
+  if (op === "delete") matchUniqueKey(schema, args?.where, op);
+
+  const where = compileWhere(
+    schema,
+    args?.where,
+    { dialect, operation: op },
+    (callArgs) => callArgs?.where,
+  );
+
+  const returning = returningClause(schema, args, dialect, op, undefined);
+
+  const statement = concat(
+    sql(`delete from ${dialect.quoteIdent(schema.table)}`),
+    where ? concat(sql(" where "), where) : sql(""),
+    returning.clause,
+  );
+
+  return plan(statement, dialect, op, returning, undefined);
+}
+
+// --- upsert ----------------------------------------------------------------
+
+/**
+ * `insert ... on conflict (<key>) do update set ...`, which both dialects
+ * support and which does in one statement what Prisma's `upsert` describes.
+ *
+ * The alternative — read, then branch to a create or an update — is two
+ * statements with a race between them: two concurrent upserts of the same key
+ * both see "absent" and both insert, and one gets a unique violation. Since
+ * there is no transaction until iteration 5, the single-statement form is not
+ * just faster here, it is the only correct one.
+ *
+ * The conflict target comes from the `where`'s unique key, so it is a schema
+ * identifier like every other. Nested writes are refused inside an upsert:
+ * they would have to run before an insert that may turn out to be an update,
+ * and there is nothing sensible to do with the row they created if it does.
+ */
+function compileUpsert(
+  schema: ModelSchema,
+  op: Operation,
+  args: any,
+  dialect: SqlDialect,
+): QueryPlan {
+  const key = matchUniqueKey(schema, args?.where, op);
+
+  for (const branch of ["create", "update"] as const) {
+    const data = args?.[branch];
+    if (typeof data !== "object" || data === null) continue;
+    for (const name of Object.keys(data as Record<string, unknown>)) {
+      if (name in schema.relations) {
+        throw new UnsupportedQueryError(
+          `${branch}.${name}`,
+          schema.name,
+          op,
+          "Nested writes inside an upsert are not implemented: they would " +
+            "have to run before it is known whether the row is being inserted " +
+            "or updated.",
+        );
+      }
+    }
+  }
+
+  // `on conflict` only fires if the row being inserted actually collides on the
+  // target. `upsert({ where: { id: 1 }, create: { email } })` never can — the
+  // `create` supplies no `id`, so the insert mints a fresh one and the update
+  // branch is unreachable. Prisma means something different by that call: find
+  // by `where`, then update or create. Expressing *that* takes a read and a
+  // write with no transaction between them, which is iteration 5's to give.
+  //
+  // So the case is refused rather than silently turned into an insert. This is
+  // narrow: the ordinary shape — `where: { email }, create: { email, ... }` —
+  // supplies the key and works.
+  const createFields = suppliedFields(schema, args?.create);
+  const absent = key.filter((name) => !createFields.has(name));
+  if (absent.length > 0) {
+    throw new UnsupportedQueryError(
+      "upsert",
+      schema.name,
+      op,
+      `The where clause selects on ${key.join(", ")}, but 'create' does not ` +
+        `set ${absent.join(", ")}. The insert could never conflict on that ` +
+        `key, so the update branch would be unreachable and the row would ` +
+        `always be created. Set ${absent.join(", ")} in 'create' too, or use ` +
+        `update and create separately.`,
+    );
+  }
+
+  const columns = withConflictKeyCheck(
+    insertColumns(
+      schema,
+      args?.create,
+      [],
+      op,
+      dialect,
+      (callArgs) => callArgs?.create,
+    ),
+    schema,
+    key,
+    op,
+    dialect,
+  );
+
+  // Inside the conflict clause every column read on the right of an `=` has to
+  // name its table, or Postgres cannot tell the existing row from `excluded`.
+  const qualifier = `${dialect.quoteIdent(schema.table)}.`;
+
+  const assignments = updateAssignments(
+    schema,
+    args?.update,
+    [],
+    op,
+    dialect,
+    (callArgs) => callArgs?.update,
+    qualifier,
+  );
+
+  const target = joinFragments(
+    key.map((name) => sql(dialect.quoteIdent(fieldOf(schema, name).column))),
+    ", ",
+  );
+
+  // `update: {}` is legal in Prisma and means "leave the existing row alone,
+  // but return it". `do nothing` would return no row at all, so the row is
+  // assigned to itself: an unqualified column on the right of a `do update set`
+  // reads the *existing* row on both dialects.
+  const effective =
+    assignments.length > 0
+      ? assignments
+      : [
+          sql(
+            `${dialect.quoteIdent(fieldOf(schema, key[0]).column)} = ` +
+              `${qualifier}${dialect.quoteIdent(fieldOf(schema, key[0]).column)}`,
+          ),
+        ];
+
+  const returning = returningClause(schema, args, dialect, op, undefined);
+
+  const statement = concat(
+    sql(`insert into ${dialect.quoteIdent(schema.table)}`),
+    valuesClause([columns], dialect),
+    sql(" on conflict ("),
+    target,
+    sql(") do update set "),
+    joinFragments(effective, ", "),
+    returning.clause,
+  );
+
+  return plan(statement, dialect, op, returning, undefined);
+}
+
+/**
+ * The other half of making `on conflict` mean what Prisma's `upsert` means.
+ *
+ * Compilation can prove the conflict key is *present* in `create`, but not that
+ * it holds the same value as `where` — values do not exist at compile time, and
+ * putting them there would break the plan cache. So the check happens at bind
+ * time, where values are exactly what is in scope.
+ *
+ * Without it, `upsert({ where: { email: "a" }, create: { email: "b" }, ... })`
+ * inserts "b" and conflicts — or does not — on "b", while Prisma looks for "a".
+ * That is a silent divergence on a write, which is the failure this whole file
+ * is arranged to prevent. Loud is better.
+ */
+function withConflictKeyCheck(
+  columns: WriteColumn[],
+  schema: ModelSchema,
+  key: string[],
+  op: Operation,
+  dialect: SqlDialect,
+): WriteColumn[] {
+  const keyed = new Set(key);
+
+  return columns.map((column) => {
+    if (!keyed.has(column.field.name)) return column;
+
+    const locate = whereValue(key, column.field.name);
+
+    return {
+      field: column.field,
+      value: (args, context) => {
+        const inserted = column.value(args, context);
+        const selected = dialect.encode(locate(args), column.field);
+
+        if (inserted !== selected) {
+          throw new UnsupportedQueryError(
+            "upsert",
+            schema.name,
+            op,
+            `'${column.field.name}' is ${JSON.stringify(String(selected))} in ` +
+              `the where clause but ${JSON.stringify(String(inserted))} in ` +
+              `'create'. An upsert looks the row up by the where clause and ` +
+              `inserts what 'create' says, so the two must agree on the key.`,
+          );
+        }
+
+        return inserted;
+      },
+    };
+  });
+}
+
+/**
+ * Reads one key field out of a `where`, in either of the two forms Prisma
+ * accepts: named directly, or inside the compound object a composite
+ * `@@unique` is addressed through (`{ username_provider: { username, ... } }`).
+ */
+function whereValue(key: string[], field: string): (args: any) => unknown {
+  const compound = key.length > 1 ? key.join("_") : undefined;
+  return (args) => {
+    const where = args?.where;
+    if (where === undefined || where === null) return undefined;
+    if (compound !== undefined && where[compound] !== undefined) {
+      return where[compound][field];
+    }
+    return where[field];
+  };
+}
+
+// --- shared pieces ---------------------------------------------------------
+
+interface WriteColumn {
+  field: FieldSchema;
+  value: Binder;
+}
+
+/**
+ * `(cols) values (?, ?), (?, ?)`, or `default values` when the row supplies no
+ * column at all — legal on both dialects, and the only way to insert a row made
+ * entirely of database defaults.
+ */
+function valuesClause(grid: WriteColumn[][], dialect: SqlDialect): Fragment {
+  const columns = grid[0];
+  if (columns.length === 0) return sql(" default values");
+
+  const names = joinFragments(
+    columns.map((column) => sql(dialect.quoteIdent(column.field.column))),
+    ", ",
+  );
+
+  const tuples = grid.map((row) =>
+    concat(
+      sql("("),
+      joinFragments(row.map((column) => param(column.value)), ", "),
+      sql(")"),
+    ),
+  );
+
+  return concat(
+    sql(" ("),
+    names,
+    sql(") values "),
+    joinFragments(tuples, ", "),
+  );
+}
+
+/**
+ * Which columns an insert writes, and where each value comes from.
+ *
+ * The four sources, in the order they are consulted: a nested write that
+ * resolved a foreign key, the caller's own `data`, a client-side default, and
+ * the database. A required field that reaches the end of that list is an error
+ * raised here, naming the field — rather than a `NOT NULL constraint failed`
+ * from the driver naming a column and nothing else.
+ */
+function insertColumns(
+  schema: ModelSchema,
+  data: unknown,
+  contributions: readonly ForeignKeyContribution[],
+  op: Operation,
+  dialect: SqlDialect,
+  locateData: (args: any) => any,
+): WriteColumn[] {
+  if (data !== undefined && data !== null) {
+    if (typeof data !== "object" || Array.isArray(data)) {
+      throw new UnsupportedQueryError(
+        "data",
+        schema.name,
+        op,
+        "Expected an object.",
+      );
+    }
+  }
+
+  const supplied = suppliedFields(schema, data);
+  const contributed = new Map(
+    contributions.map((contribution) => [contribution.field, contribution]),
+  );
+
+  for (const name of contributed.keys()) {
+    if (supplied.has(name)) {
+      throw new UnsupportedQueryError(
+        `data.${name}`,
+        schema.name,
+        op,
+        `'${name}' is set both directly and through a nested relation write. ` +
+          `Prisma keeps those two forms exclusive; use one of them.`,
+      );
+    }
+  }
+
+  const columns: WriteColumn[] = [];
+
+  for (const field of Object.values(schema.fields)) {
+    const contribution = contributed.get(field.name);
+    if (contribution) {
+      columns.push({
+        field,
+        value: (args, context) =>
+          dialect.encode(contribution.value(args, context), field),
+      });
+      continue;
+    }
+
+    if (supplied.has(field.name)) {
+      columns.push({
+        field,
+        value: valueBinder(field, dialect, (args) =>
+          locateData(args)?.[field.name],
+        ),
+      });
+      continue;
+    }
+
+    if (hasClientSideValue(field)) {
+      columns.push({ field, value: defaultBinder(field, dialect) });
+      continue;
+    }
+
+    // Left out of the statement entirely: the database supplies it, either from
+    // its own default or as NULL.
+    if (field.default || field.nullable) continue;
+
+    throw new MissingRequiredValueError(schema.name, op, field.name);
+  }
+
+  return columns;
+}
+
+/** The scalar fields a `data` object actually sets, validated against the schema. */
+function suppliedFields(
+  schema: ModelSchema,
+  data: unknown,
+): Set<string> {
+  const out = new Set<string>();
+  if (typeof data !== "object" || data === null) return out;
+
+  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    // Prisma treats an explicit `undefined` as absent, which is how conditional
+    // writes are expressed in application code.
+    if (value === undefined) continue;
+    // Relations are the nested-write planner's business.
+    if (key in schema.relations) continue;
+    if (!(key in schema.fields)) {
+      throw new UnknownFieldError(key, schema.name, Object.keys(schema.fields));
+    }
+    out.add(key);
+  }
+
+  return out;
+}
+
+/**
+ * `set` assignments for an update, in schema order.
+ *
+ * `@updatedAt` is appended unless the caller set it explicitly. Applying it on
+ * *create* as well is handled by `hasClientSideValue`; missing that half is the
+ * easy and quiet version of this bug, since the column is usually NOT NULL and
+ * only fails on the models where Prisma made it nullable.
+ */
+function updateAssignments(
+  schema: ModelSchema,
+  data: unknown,
+  contributions: readonly ForeignKeyContribution[],
+  op: Operation,
+  dialect: SqlDialect,
+  locateData: (args: any) => any = (args) => args?.data,
+  /**
+   * Prefix for a column read on the *right* of an assignment — `"User".`
+   * inside an `on conflict do update`, empty in a plain `update`.
+   *
+   * Postgres puts both the target row and the proposed `excluded` row in scope
+   * inside a conflict clause, so a bare `"n" = "n" + $1` there is rejected:
+   * `column reference "n" is ambiguous`. SQLite accepts either form, and so
+   * does Postgres in a plain `update` — verified against both — which is why
+   * the qualifier is applied where it is needed rather than everywhere.
+   */
+  qualifier = "",
+): Fragment[] {
+  if (data !== undefined && data !== null) {
+    if (typeof data !== "object" || Array.isArray(data)) {
+      throw new UnsupportedQueryError(
+        "data",
+        schema.name,
+        op,
+        "Expected an object.",
+      );
+    }
+  }
+
+  const supplied = suppliedFields(schema, data);
+  const contributed = new Map(
+    contributions.map((contribution) => [contribution.field, contribution]),
+  );
+
+  const out: Fragment[] = [];
+
+  for (const field of Object.values(schema.fields)) {
+    const column = dialect.quoteIdent(field.column);
+    const contribution = contributed.get(field.name);
+
+    if (contribution) {
+      out.push(
+        concat(
+          sql(`${column} = `),
+          param((args, context) =>
+            dialect.encode(contribution.value(args, context), field),
+          ),
+        ),
+      );
+      continue;
+    }
+
+    if (supplied.has(field.name)) {
+      out.push(
+        assignment(
+          schema,
+          field,
+          column,
+          `${qualifier}${column}`,
+          data,
+          op,
+          dialect,
+          (args) => locateData(args)?.[field.name],
+        ),
+      );
+      continue;
+    }
+
+    // Every write stamps `@updatedAt` — that is the whole of the attribute.
+    if (field.isUpdatedAt) {
+      out.push(
+        concat(sql(`${column} = `), param(defaultBinder(field, dialect))),
+      );
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Prisma's update operators. `set` is the explicit spelling of a plain
+ * assignment; the arithmetic four read the column and write it back, so they
+ * are the one place a column name appears on the right of an `=`.
+ */
+const ARITHMETIC: Record<string, string> = {
+  increment: "+",
+  decrement: "-",
+  multiply: "*",
+  divide: "/",
+};
+
+function assignment(
+  schema: ModelSchema,
+  field: FieldSchema,
+  /** The column as the assignment's target, always unqualified. */
+  column: string,
+  /** The same column read as a value — qualified inside a conflict clause. */
+  source: string,
+  data: unknown,
+  op: Operation,
+  dialect: SqlDialect,
+  locate: (args: any) => any,
+): Fragment {
+  const value = (data as Record<string, unknown>)[field.name];
+
+  if (isOperatorObject(value, field)) {
+    const keys = Object.keys(value as Record<string, unknown>).filter(
+      (key) => (value as Record<string, unknown>)[key] !== undefined,
+    );
+
+    if (keys.length !== 1) {
+      throw new UnsupportedQueryError(
+        `data.${field.name}`,
+        schema.name,
+        op,
+        `Expected exactly one of ${["set", ...Object.keys(ARITHMETIC)].join(", ")}.`,
+      );
+    }
+
+    const [key] = keys;
+    const at = (args: any) => locate(args)?.[key];
+
+    if (key === "set") {
+      return concat(sql(`${column} = `), param(valueBinder(field, dialect, at)));
+    }
+
+    return concat(
+      sql(`${column} = ${source} ${ARITHMETIC[key]} `),
+      param(valueBinder(field, dialect, at)),
+    );
+  }
+
+  return concat(sql(`${column} = `), param(valueBinder(field, dialect, locate)));
+}
+
+/**
+ * True for `{ increment: 1 }`, false for a plain value.
+ *
+ * A `Json` column is excluded because `{ set: ... }` is a legal *value* there as
+ * well as an operator, and there is no way to tell them apart structurally.
+ * Prisma resolves the ambiguity through its types; we resolve it by treating a
+ * Json column's object as data, which is the reading that never loses the
+ * caller's value.
+ */
+function isOperatorObject(value: unknown, field: FieldSchema): boolean {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    value instanceof Date ||
+    ArrayBuffer.isView(value) ||
+    field.type === "Json"
+  ) {
+    return false;
+  }
+
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length === 0) return false;
+  return keys.every((key) => key === "set" || key in ARITHMETIC);
+}
+
+function valueBinder(
+  field: FieldSchema,
+  dialect: SqlDialect,
+  locate: (args: any) => any,
+): Binder {
+  return (args) => dialect.encode(locate(args), field);
+}
+
+function defaultBinder(field: FieldSchema, dialect: SqlDialect): Binder {
+  // Read per call, never at compile time: a cuid must differ per row and `now`
+  // must be the instant of *this* operation, not of the compilation that may
+  // have happened thousands of calls ago.
+  return (_args, context) =>
+    dialect.encode(clientSideValue(field, context.now), field);
+}
+
+interface Returning {
+  clause: Fragment;
+  fields: FieldSchema[];
+  hidden?: string[];
+  relations: ReturnType<typeof planRelations>["plans"];
+}
+
+/**
+ * The `RETURNING` list.
+ *
+ * For a row-returning write it is the caller's `select` — the same resolution a
+ * read does — plus any key columns the relation planner or a nested `after`
+ * step needs and the caller did not ask for. Those extra columns are stripped
+ * from the result once they have been used, exactly as on the read path.
+ *
+ * For a counting write it is one column, because the count is the number of
+ * rows that come back.
+ */
+function returningClause(
+  schema: ModelSchema,
+  args: any,
+  dialect: SqlDialect,
+  op: Operation,
+  nested: NestedWritePlanning | undefined,
+): Returning {
+  if (COUNTING.has(op)) {
+    return {
+      clause: sql(` returning ${keyColumn(schema, dialect)}`),
+      fields: [],
+      relations: [],
+    };
+  }
+
+  const selection = resolveSelection(schema, args, op);
+  const { plans, keyFields } = planRelations(schema, args, dialect, op);
+  const { fields, hidden } = withKeyFields(schema, selection, [
+    ...keyFields,
+    ...(nested?.keyFields ?? []),
+  ]);
+
+  return {
+    clause: concat(
+      sql(" returning "),
+      joinFragments(
+        fields.map((field) => sql(dialect.quoteIdent(field.column))),
+        ", ",
+      ),
+    ),
+    fields,
+    hidden,
+    relations: plans,
+  };
+}
+
+/** The narrowest column that still identifies a row, for counting writes. */
+function keyColumn(schema: ModelSchema, dialect: SqlDialect): string {
+  const name = schema.primaryKey[0] ?? Object.keys(schema.fields)[0];
+  return dialect.quoteIdent(schema.fields[name].column);
+}
+
+function fieldOf(schema: ModelSchema, name: string): FieldSchema {
+  const field = schema.fields[name];
+  if (!field) {
+    throw new UnknownFieldError(name, schema.name, Object.keys(schema.fields));
+  }
+  return field;
+}
+
+function plan(
+  statement: Fragment,
+  dialect: SqlDialect,
+  op: Operation,
+  returning: Returning,
+  nested: NestedWritePlanning | undefined,
+): QueryPlan {
+  const { text, binders } = render(statement, dialect);
+
+  const shaper = buildRowShaper(
+    returning.fields,
+    dialect,
+    returning.relations.map((relation) => ({
+      key: relation.as,
+      kind: relation.kind,
+    })),
+  );
+
+  const single = SINGLE_ROW.has(op);
+  const counting = COUNTING.has(op);
+
+  return {
+    text,
+    bind: bindValues(binders),
+    relations: returning.relations.length > 0 ? returning.relations : undefined,
+    hidden: returning.hidden,
+    before: nested && nested.before.length > 0 ? nested.before : undefined,
+    after: nested && nested.after.length > 0 ? nested.after : undefined,
+    shape(rows) {
+      // The count *is* the number of returned rows — see the note at the top of
+      // this file on why it does not come from driver metadata.
+      if (counting) return { count: rows.length };
+
+      const shaped = shaper(rows);
+      // `null` when nothing matched. `$exec` turns that into
+      // `RecordNotFoundError` for the operations Prisma raises on, where the
+      // model's name is in scope for the message.
+      return single ? (shaped[0] ?? null) : shaped;
+    },
+  };
+}
+
+function listOf(value: unknown): any[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
+  if (args === undefined || args === null) {
+    throw new UnsupportedQueryError(
+      "args",
+      schema.name,
+      op,
+      `${op} requires arguments.`,
+    );
+  }
+
+  if (typeof args !== "object" || Array.isArray(args)) {
+    throw new UnsupportedQueryError(
+      String(args),
+      schema.name,
+      op,
+      "Expected an object.",
+    );
+  }
+
+  if (args.select !== undefined && args.include !== undefined) {
+    throw new UnsupportedQueryError(
+      "select + include",
+      schema.name,
+      op,
+      "Prisma allows only one of them on the same query.",
+    );
+  }
+
+  const allowed = WRITE_ARGS[op];
+  for (const key of Object.keys(args).sort()) {
+    if (args[key] === undefined) continue;
+    if (!allowed.has(key)) {
+      throw new UnsupportedQueryError(key, schema.name, op);
+    }
+  }
+
+  for (const required of requiredArgs(op)) {
+    if (args[required] === undefined) {
+      throw new UnsupportedQueryError(
+        required,
+        schema.name,
+        op,
+        `${op} requires '${required}'.`,
+      );
+    }
+  }
+}
+
+/**
+ * Which arguments Prisma makes non-optional, matched exactly.
+ *
+ * `updateMany` and `deleteMany` take an *optional* `where` — `deleteMany({})`
+ * legitimately empties a table. Requiring one here would be a safety rail
+ * Prisma does not have, and the differential harness would call it a
+ * divergence, which is the right verdict: a guard belongs in a policy
+ * (iteration 6), not in the compiler.
+ */
+function requiredArgs(op: Operation): string[] {
+  switch (op) {
+    case "create":
+    case "createMany":
+      return ["data"];
+    case "update":
+      return ["data", "where"];
+    case "updateMany":
+      return ["data"];
+    case "delete":
+      return ["where"];
+    case "upsert":
+      return ["where", "create", "update"];
+    default:
+      return [];
+  }
+}

--- a/packages/gemi/orm/defaults.ts
+++ b/packages/gemi/orm/defaults.ts
@@ -1,0 +1,145 @@
+import type { DefaultSpec, FieldSchema } from "./schema";
+
+/**
+ * The values gemi supplies itself on a write, rather than leaving to the
+ * database.
+ *
+ * Which defaults have to be client-side is not a style question — it is forced
+ * by the DDL Prisma emits. Reading the template's own migration:
+ *
+ * ```sql
+ * "publicId"  TEXT     NOT NULL,                            -- @default(cuid())
+ * "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,  -- @default(now())
+ * "updatedAt" DATETIME NOT NULL,                            -- @updatedAt
+ * ```
+ *
+ * - `publicId` and `updatedAt` carry **no database default at all**. Prisma
+ *   generates them in the client, so a row inserted without them violates a
+ *   NOT NULL constraint. Missing `@updatedAt` on *create* is the quiet version
+ *   of this bug: the column is only nullable on models where Prisma made it so.
+ * - `createdAt` does have a default, but it is `CURRENT_TIMESTAMP`, which SQLite
+ *   stores as the *text* `YYYY-MM-DD HH:MM:SS` — while Prisma stores a DateTime
+ *   as integer milliseconds. Letting the database fill it would write a
+ *   different storage form than Prisma writes, and drop sub-second precision.
+ *
+ * `autoincrement()` and `dbgenerated(...)` stay with the database, which is the
+ * whole of the other side of this split.
+ *
+ * Verified against Prisma 6.19.2 rather than assumed: a `create` there returns
+ * `createdAt` and `updatedAt` as the *same instant*, which is why `now` is
+ * resolved once per logical operation and passed in rather than read per field.
+ */
+
+/** Whether gemi supplies this default, or leaves the column to the database. */
+export function isClientSideDefault(spec: DefaultSpec): boolean {
+  return spec.kind !== "autoincrement" && spec.kind !== "dbgenerated";
+}
+
+/**
+ * A field gemi must supply a value for when the caller did not: either it has a
+ * client-side default, or it is `@updatedAt`, which Prisma sets on create as
+ * well as on update.
+ */
+export function hasClientSideValue(field: FieldSchema): boolean {
+  if (field.isUpdatedAt) return true;
+  return field.default !== undefined && isClientSideDefault(field.default);
+}
+
+/**
+ * The value for one field on one row. `now` is shared across every field and
+ * every row of a single operation; everything else is generated per call.
+ */
+export function clientSideValue(field: FieldSchema, now: Date): unknown {
+  // `@updatedAt` wins over any `@default`: Prisma stamps it on every write,
+  // which is the entire point of the attribute.
+  if (field.isUpdatedAt) return now;
+
+  const spec = field.default;
+  if (!spec) return undefined;
+
+  switch (spec.kind) {
+    case "cuid":
+      return createCuid();
+    case "uuid":
+      return crypto.randomUUID();
+    case "now":
+      return now;
+    case "value":
+      return spec.value;
+    default:
+      // autoincrement / dbgenerated — the database's business.
+      return undefined;
+  }
+}
+
+// --- cuid v1 ---------------------------------------------------------------
+
+// The format Prisma 6.19.2 actually emits for `@default(cuid())`, read off real
+// rows rather than taken from the docs:
+//
+//   cms3j09fa0000a0452l77tbma
+//   c  ms3j09fa  0000     a045         2l77tbma
+//   ^  ^         ^        ^            ^
+//   |  |         |        fingerprint  random
+//   |  |         counter
+//   |  timestamp, base 36
+//   literal 'c'
+//
+// 25 characters, lowercase alphanumeric. Prisma's `cuid()` is still v1; `cuid2`
+// is a separate, opt-in generator with a different shape, so matching v1 is what
+// keeps a gemi-written `publicId` indistinguishable from a Prisma-written one in
+// length, prefix and charset.
+
+const ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+const BASE = 36;
+const BLOCK_SIZE = 4;
+const DISCRETE_VALUES = BASE ** BLOCK_SIZE;
+
+/**
+ * Monotonic within a process, rolling over at one block's worth of values. It
+ * is what keeps two cuids minted in the same millisecond distinct, so it must
+ * not be reset or made per-call.
+ */
+let counter = 0;
+
+function pad(text: string, size: number): string {
+  return text.length >= size ? text : "0".repeat(size - text.length) + text;
+}
+
+/**
+ * cuid v1 derives this from the process id and the hostname, to keep two
+ * processes minting concurrently from colliding.
+ *
+ * gemi uses a random block generated once per process instead. It fills exactly
+ * the same role with strictly better collision behaviour — containers routinely
+ * share both a hostname and a low pid — and it keeps `node:os` off the ORM
+ * runtime's import graph. Nothing observable changes: the fingerprint is four
+ * characters of the same alphabet in the same position, and nothing parses it.
+ */
+const FINGERPRINT = randomBlock();
+
+function randomBlock(): string {
+  const bytes = new Uint8Array(BLOCK_SIZE);
+  crypto.getRandomValues(bytes);
+
+  let out = "";
+  for (let i = 0; i < BLOCK_SIZE; i++) {
+    let byte = bytes[i];
+    // 256 is not a multiple of 36 — it is 7*36 + 4 — so taking the remainder of
+    // every byte would make the first four symbols of the alphabet slightly
+    // likelier than the rest. Resampling the 252-255 tail removes the bias.
+    while (byte >= 252) {
+      const resample = new Uint8Array(1);
+      crypto.getRandomValues(resample);
+      byte = resample[0];
+    }
+    out += ALPHABET[byte % BASE];
+  }
+  return out;
+}
+
+export function createCuid(): string {
+  const timestamp = Date.now().toString(BASE);
+  const count = pad((counter++ % DISCRETE_VALUES).toString(BASE), BLOCK_SIZE);
+  return `c${timestamp}${count}${FINGERPRINT}${randomBlock()}${randomBlock()}`;
+}

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -59,6 +59,21 @@ export interface SqlDialect {
    */
   readonly supportsReturning: boolean;
 
+  /**
+   * How many parameters one statement may bind.
+   *
+   * A hard protocol/driver limit, not a tuning knob: Postgres sends the
+   * parameter count as an int16 in the Bind message, and SQLite compiles
+   * `SQLITE_MAX_VARIABLE_NUMBER` in. Only `createMany` can approach either,
+   * since it is the one operation whose parameter count scales with the
+   * caller's data — `rows × columns` — rather than with the query's shape.
+   *
+   * It lives here rather than as a constant in the write compiler for the usual
+   * reason: the number differs per dialect, and the compiler is not allowed to
+   * know which dialect it is compiling for.
+   */
+  readonly maxBoundParameters: number;
+
   /** Quote a table or column name. Only ever called with names from the schema. */
   quoteIdent(name: string): string;
 

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -43,6 +43,22 @@ export interface SqlDialect {
    */
   readonly bindsListAsOneParameter: boolean;
 
+  /**
+   * Whether `insert`/`update`/`delete` can return the rows they touched.
+   *
+   * True on both implemented dialects — Postgres has had `RETURNING` forever,
+   * and SQLite since 3.35 (Bun 1.3.14 bundles 3.51.0, verified by querying
+   * `sqlite_version()` rather than by reading a changelog).
+   *
+   * It is a capability rather than an assumption because MySQL and MariaDB have
+   * no `RETURNING` at all. Their fallback — `lastInsertRowid` plus a re-select,
+   * and no way to identify the rows an `updateMany` touched — is a different
+   * statement shape, not a different spelling. Iteration 4 does not build it,
+   * but it must stay expressible, so the write compiler asks rather than
+   * assumes and raises a clear error when the answer is no.
+   */
+  readonly supportsReturning: boolean;
+
   /** Quote a table or column name. Only ever called with names from the schema. */
   quoteIdent(name: string): string;
 
@@ -94,6 +110,30 @@ export interface SqlDialect {
    * single most tempting place in the compiler to inline a number.
    */
   paginate(take: Binder | null, skip: Binder | null): Fragment;
+
+  /**
+   * Recognise a driver error as a constraint violation, and say which columns
+   * it names.
+   *
+   * Returns `null` for anything else, including the *other* constraint kinds:
+   * SQLite reports NOT NULL and FOREIGN KEY failures through the same exception
+   * type, and reporting one of those as a duplicate-key error would send a
+   * caller looking for a row that does not exist.
+   *
+   * Columns, not fields — the driver only knows the database's names. The
+   * caller maps them back through the schema, where `@map` is in scope.
+   */
+  constraintViolation(error: unknown): ConstraintViolation | null;
+}
+
+/** A driver error identified as a constraint failure, in dialect-neutral terms. */
+export interface ConstraintViolation {
+  /** Only `unique` is translated today; the rest surface as the raw error. */
+  kind: "unique";
+  /** Database column names, in the order the driver reported them. */
+  columns: string[];
+  /** The constraint's own name, when the driver gives one. Postgres does. */
+  constraint?: string;
 }
 
 export class UnsupportedDialectError extends Error {

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -64,11 +64,22 @@ export interface SqlDialect {
    *
    * A hard protocol/driver limit, not a tuning knob: Postgres sends the
    * parameter count as an int16 in the Bind message, and SQLite compiles
-   * `SQLITE_MAX_VARIABLE_NUMBER` in. Only `createMany` can approach either,
-   * since it is the one operation whose parameter count scales with the
-   * caller's data — `rows × columns` — rather than with the query's shape.
+   * `SQLITE_MAX_VARIABLE_NUMBER` in.
    *
-   * It lives here rather than as a constant in the write compiler for the usual
+   * Three shapes can approach it, all of them scaling with the caller's *data*
+   * rather than with the query's shape:
+   *
+   * - `createMany`, at `rows × columns`.
+   * - An `in` list on SQLite, which binds one placeholder per element — and
+   *   such a list is routinely request-derived (`?ids=…`).
+   * - A to-many `include` on SQLite, which batches an `in` over the parent
+   *   keys, so a large enough `findMany` reaches it with no big list in sight.
+   *
+   * Postgres escapes the last two: `= any($1)` is one parameter however long
+   * the array. The check itself lives in `compile/fragment.ts`'s `render`,
+   * because that is the one place that sees a statement's final count.
+   *
+   * It lives *here* rather than as a constant in the compiler for the usual
    * reason: the number differs per dialect, and the compiler is not allowed to
    * know which dialect it is compiling for.
    */

--- a/packages/gemi/orm/dialect/postgres.test.ts
+++ b/packages/gemi/orm/dialect/postgres.test.ts
@@ -82,3 +82,124 @@ describe("the text is still one parameter, whatever the length", () => {
     expect(plan.bind(args)).toHaveLength(1);
   });
 });
+
+/**
+ * The shapes below are copied from a live Postgres 16 through Bun 1.3.14, not
+ * from the Postgres manual — because the manual would have told you the
+ * SQLSTATE is on `code`, and Bun puts its *own* code there and the SQLSTATE on
+ * `errno`. Matching only `code` silently recognised nothing at all, and every
+ * unique violation escaped as a raw driver error until a real database was
+ * pointed at the suite.
+ */
+describe("constraint violations", () => {
+  const violation = {
+    name: "PostgresError",
+    message: `duplicate key value violates unique constraint "User_email_key"`,
+    code: "ERR_POSTGRES_SERVER_ERROR",
+    errno: "23505",
+    detail: "Key (email)=(ada@example.dev) already exists.",
+    constraint: "User_email_key",
+    table: "User",
+  };
+
+  test("a duplicate key is recognised through errno", () => {
+    expect(postgres.constraintViolation(violation)).toEqual({
+      kind: "unique",
+      columns: ["email"],
+      constraint: "User_email_key",
+    });
+  });
+
+  test("a driver that puts the SQLSTATE on code is recognised too", () => {
+    expect(
+      postgres.constraintViolation({ ...violation, errno: undefined, code: "23505" }),
+    ).toMatchObject({ kind: "unique", columns: ["email"] });
+  });
+
+  test("a composite key reports every column", () => {
+    expect(
+      postgres.constraintViolation({
+        ...violation,
+        detail: "Key (username, provider)=(ada, github) already exists.",
+        constraint: "SocialAccount_username_provider_key",
+      }),
+    ).toEqual({
+      kind: "unique",
+      columns: ["username", "provider"],
+      constraint: "SocialAccount_username_provider_key",
+    });
+  });
+
+  // The whole point of matching five characters rather than the `23` class:
+  // these are integrity violations too, and reporting one as a duplicate key
+  // sends the caller looking for a row that does not exist.
+  test.each([
+    ["not null", "23502"],
+    ["foreign key", "23503"],
+    ["check", "23514"],
+    ["exclusion", "23P01"],
+  ])("a %s violation is not a unique violation", (_name, errno) => {
+    expect(postgres.constraintViolation({ ...violation, errno })).toBeNull();
+  });
+
+  test("anything else is left alone", () => {
+    expect(postgres.constraintViolation(new Error("connection refused"))).toBeNull();
+    expect(postgres.constraintViolation(null)).toBeNull();
+    expect(postgres.constraintViolation(undefined)).toBeNull();
+  });
+
+  // Postgres localises `detail`, so on a server with lc_messages set to
+  // anything but English the column list is unparseable. Degrading to a typed
+  // violation with no columns beats inventing a wrong one.
+  test("an unparseable detail still reports the constraint", () => {
+    expect(
+      postgres.constraintViolation({ ...violation, detail: "Schlüssel …" }),
+    ).toEqual({
+      kind: "unique",
+      columns: [],
+      constraint: "User_email_key",
+    });
+  });
+});
+
+describe("decoding the types the template schema cannot reach", () => {
+  const field = (type: any) => ({
+    name: "x", column: "x", type, nullable: true, isId: false, isUpdatedAt: false,
+  });
+
+  // Read off a live server: bigint arrives as a string and jsonb as unparsed
+  // text, where Prisma returns a BigInt and an object. Everything else Bun
+  // already decodes to what Prisma returns.
+  test("bigint arrives as a string and becomes a BigInt", () => {
+    expect(postgres.needsDecode(field("BigInt") as any)).toBe(true);
+    expect(postgres.decode("9007199254740993", field("BigInt") as any)).toBe(
+      9007199254740993n,
+    );
+  });
+
+  test("jsonb arrives as text and is parsed", () => {
+    expect(postgres.needsDecode(field("Json") as any)).toBe(true);
+    expect(postgres.decode('{"a":[1,2]}', field("Json") as any)).toEqual({
+      a: [1, 2],
+    });
+    // A driver that starts parsing it for us keeps working.
+    expect(postgres.decode({ a: 1 }, field("Json") as any)).toEqual({ a: 1 });
+  });
+
+  test.each(["Int", "String", "Boolean", "Float", "DateTime", "Bytes"])(
+    "%s needs no decoding",
+    (type) => {
+      expect(postgres.needsDecode(field(type) as any)).toBe(false);
+    },
+  );
+
+  test("a value that cannot be decoded raises rather than returning nonsense", () => {
+    expect(() => postgres.decode("not json", field("Json") as any)).toThrow();
+    expect(() => postgres.decode("3.5", field("BigInt") as any)).toThrow();
+  });
+
+  test("null stays null", () => {
+    expect(postgres.decode(null, field("Json") as any)).toBeNull();
+    expect(postgres.decode(undefined, field("BigInt") as any)).toBeNull();
+  });
+});

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -6,8 +6,9 @@ import {
   param,
   sql,
 } from "../compile/fragment";
+import { DecodeError } from "../errors";
 import type { FieldSchema } from "../schema";
-import type { SqlDialect } from "./index";
+import type { ConstraintViolation, SqlDialect } from "./index";
 
 // Postgres has real `timestamptz`, `boolean`, `numeric` and `jsonb` types, so
 // its driver already returns what Prisma returns and `decode` is almost
@@ -25,6 +26,8 @@ export class PostgresDialect implements SqlDialect {
 
   // `= any($1)`: one parameter, one SQL text, one plan for every list length.
   readonly bindsListAsOneParameter = true;
+
+  readonly supportsReturning = true;
 
   quoteIdent(name: string): string {
     // See the SQLite implementation: NUL is the parameter sentinel in
@@ -85,6 +88,57 @@ export class PostgresDialect implements SqlDialect {
     return concat(...parts);
   }
 
+  // Postgres reports a duplicate key as SQLSTATE 23505, and unlike SQLite it
+  // carries structured fields alongside the message. Read off a live server
+  // through Bun rather than from the Postgres manual, because the placement is
+  // the surprise:
+  //
+  //   name:       'PostgresError'
+  //   code:       'ERR_POSTGRES_SERVER_ERROR'   <- Bun's own code, not the SQLSTATE
+  //   errno:      '23505'                       <- the SQLSTATE lives here
+  //   constraint: 'User_email_key'
+  //   detail:     'Key (email)=(a@x) already exists.'
+  //   table:      'User'
+  //
+  // Checking `code` alone — the obvious reading, and the one this started with
+  // — matches nothing at all, so every unique violation escaped as a raw driver
+  // error. Both are consulted now: `errno` is where Bun puts it today, and
+  // `code` is where a driver following the `pg` convention would.
+  //
+  // The class code `23` covers integrity violations generally — 23502 not-null,
+  // 23503 foreign key, 23514 check — so matching the *full* five characters is
+  // what keeps those from being reported as duplicate keys.
+  //
+  // Only the constraint name is taken as authoritative. `detail` is parsed
+  // best-effort for the column list because Postgres localises it: on a server
+  // with `lc_messages` set to anything but English the prefix is not `Key`, and
+  // the regex simply does not match. That degrades to a violation with no
+  // columns — still typed, still catchable, still naming the constraint — rather
+  // than to a wrong column list.
+  constraintViolation(error: unknown): ConstraintViolation | null {
+    const source = error as Record<string, unknown> | null;
+    if (!source) return null;
+
+    const sqlstate = String(source.errno ?? source.code ?? "");
+    if (sqlstate !== "23505") return null;
+
+    const constraint =
+      typeof source.constraint === "string" && source.constraint !== ""
+        ? source.constraint
+        : undefined;
+
+    const detail = typeof source.detail === "string" ? source.detail : "";
+    const listed = /\((.+?)\)=/.exec(detail);
+    const columns = listed
+      ? listed[1]
+          .split(",")
+          .map((entry) => entry.trim())
+          .filter((entry) => entry !== "")
+      : [];
+
+    return { kind: "unique", columns, constraint };
+  }
+
   encode(value: unknown, field: FieldSchema): unknown {
     if (value === null || value === undefined) return null;
     // `Date`, `boolean` and `bigint` all bind natively. JSON is the one case the
@@ -93,6 +147,52 @@ export class PostgresDialect implements SqlDialect {
       return JSON.stringify(value);
     }
     return value;
+  }
+
+  // Postgres returns real `timestamptz`, `boolean` and `double precision`, so
+  // most columns need nothing. Two do, and neither is reachable from the
+  // template's schema — which is why they went unnoticed until a fixture with
+  // every scalar type existed. Read off a live server through Bun:
+  //
+  //   integer            -> number      ✓
+  //   double precision   -> number      ✓
+  //   boolean            -> boolean     ✓
+  //   text               -> string      ✓
+  //   timestamp(3)       -> Date        ✓ (but see the protocol note below)
+  //   bytea              -> Buffer      ✓ (a Uint8Array, which is what Prisma gives)
+  //   bigint             -> "123"       ✗ string, where Prisma gives 123n
+  //   jsonb / json       -> '{"a":1}'   ✗ unparsed text, where Prisma gives an object
+  //
+  // `numeric` also arrives as a string, which is the correct thing for it to
+  // do — but `Decimal` is refused at *generation* time (iteration 1), so no
+  // such field can reach this.
+  needsDecode(field: FieldSchema): boolean {
+    return field.type === "BigInt" || field.type === "Json";
+  }
+
+  decode(value: unknown, field: FieldSchema): unknown {
+    if (value === null || value === undefined) return null;
+
+    switch (field.type) {
+      case "BigInt":
+        if (typeof value === "bigint") return value;
+        try {
+          return BigInt(value as string);
+        } catch {
+          throw new DecodeError(field, value);
+        }
+      case "Json":
+        // `jsonb` arrives as text over the wire. A driver that starts parsing
+        // it for us is handled by the typeof check rather than by a version
+        // test, so this keeps working either way.
+        try {
+          return typeof value === "string" ? JSON.parse(value) : value;
+        } catch {
+          throw new DecodeError(field, value);
+        }
+      default:
+        return value;
+    }
   }
 
   // KNOWN DIVERGENCE, and not one this can fix: Prisma maps `DateTime` to
@@ -111,13 +211,9 @@ export class PostgresDialect implements SqlDialect {
   // A `decode` cannot correct it, because the value alone does not say which
   // protocol produced it; nothing below the plan does. Until it is fixed
   // upstream, run the process with TZ=UTC, where both paths agree.
-  needsDecode(_field: FieldSchema): boolean {
-    return false;
-  }
-
-  decode(value: unknown, _field: FieldSchema): unknown {
-    return value ?? null;
-  }
+  //
+  // Note this is why `DateTime` stays out of `needsDecode` above: there is no
+  // correction to apply, only a caveat to record.
 }
 
 /**

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -29,6 +29,11 @@ export class PostgresDialect implements SqlDialect {
 
   readonly supportsReturning = true;
 
+  // The wire protocol's Bind message carries the parameter count as an int16,
+  // so 65535 is the ceiling for any client, not a Bun or a server setting. Past
+  // it the driver's error names neither the model nor the cause.
+  readonly maxBoundParameters = 65535;
+
   quoteIdent(name: string): string {
     // See the SQLite implementation: NUL is the parameter sentinel in
     // compile/fragment.ts, so it is the one character that could shift a

--- a/packages/gemi/orm/dialect/sqlite.test.ts
+++ b/packages/gemi/orm/dialect/sqlite.test.ts
@@ -211,3 +211,76 @@ describe("needsDecode()", () => {
     },
   );
 });
+
+/**
+ * The shapes below are copied from Bun 1.3.14's bundled SQLite 3.51.0, not from
+ * the SQLite docs. Every constraint failure is the same `SQLiteError` type and
+ * only `code` distinguishes them, which is why matching on the message would
+ * report a NOT NULL failure as a duplicate key.
+ */
+describe("constraint violations", () => {
+  const violation = {
+    name: "SQLiteError",
+    message: "UNIQUE constraint failed: User.email",
+    code: "SQLITE_CONSTRAINT_UNIQUE",
+    errno: 2067,
+  };
+
+  test("a duplicate key reports its column, without the table", () => {
+    expect(sqlite.constraintViolation(violation)).toEqual({
+      kind: "unique",
+      columns: ["email"],
+    });
+  });
+
+  test("a composite key reports every column", () => {
+    expect(
+      sqlite.constraintViolation({
+        ...violation,
+        message: "UNIQUE constraint failed: SocialAccount.username, SocialAccount.provider",
+      }),
+    ).toEqual({ kind: "unique", columns: ["username", "provider"] });
+  });
+
+  test("a primary-key collision counts as a unique violation", () => {
+    expect(
+      sqlite.constraintViolation({
+        ...violation,
+        code: "SQLITE_CONSTRAINT_PRIMARYKEY",
+        message: "UNIQUE constraint failed: User.id",
+      }),
+    ).toEqual({ kind: "unique", columns: ["id"] });
+  });
+
+  // The reason `code` is what is matched on.
+  test.each([
+    ["not null", "SQLITE_CONSTRAINT_NOTNULL", "NOT NULL constraint failed: User.publicId"],
+    ["foreign key", "SQLITE_CONSTRAINT_FOREIGNKEY", "FOREIGN KEY constraint failed"],
+    ["check", "SQLITE_CONSTRAINT_CHECK", "CHECK constraint failed: User"],
+  ])("a %s violation is not a unique violation", (_name, code, message) => {
+    expect(sqlite.constraintViolation({ ...violation, code, message })).toBeNull();
+  });
+
+  test("anything else is left alone", () => {
+    expect(sqlite.constraintViolation(new Error("database is locked"))).toBeNull();
+    expect(sqlite.constraintViolation(null)).toBeNull();
+    expect(sqlite.constraintViolation(undefined)).toBeNull();
+  });
+
+  // A column name may itself contain a dot, so only the first one separates
+  // the table from the column.
+  test("only the first dot separates table from column", () => {
+    expect(
+      sqlite.constraintViolation({
+        ...violation,
+        message: "UNIQUE constraint failed: User.odd.name",
+      }),
+    ).toEqual({ kind: "unique", columns: ["odd.name"] });
+  });
+
+  test("a message it cannot parse still reports a violation", () => {
+    expect(
+      sqlite.constraintViolation({ ...violation, message: "UNIQUE failed somehow" }),
+    ).toEqual({ kind: "unique", columns: [] });
+  });
+});

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -66,6 +66,13 @@ export class SqliteDialect implements SqlDialect {
   // `createMany` depends on it for its row count.
   readonly supportsReturning = true;
 
+  // `SQLITE_MAX_VARIABLE_NUMBER`, which has defaulted to 32766 since SQLite
+  // 3.32 (it was 999 before). A build can lower it and `sqlite3_limit` can
+  // lower it further at runtime, so this is the documented default rather than
+  // a reading off the connection — which makes it an upper bound on what is
+  // safe, which is the direction that matters for a guard.
+  readonly maxBoundParameters = 32766;
+
   quoteIdent(name: string): string {
     // NUL is the parameter sentinel in compile/fragment.ts, so it is the one
     // character that could shift a placeholder's position rather than merely

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -9,7 +9,7 @@ import {
 } from "../compile/fragment";
 import { DecodeError } from "../errors";
 import type { FieldSchema } from "../schema";
-import type { SqlDialect } from "./index";
+import type { ConstraintViolation, SqlDialect } from "./index";
 
 // SQLite has five storage classes and neither `DateTime` nor `Boolean` is among
 // them. Prisma stores a `DateTime` as integer milliseconds since the epoch and a
@@ -59,6 +59,12 @@ export class SqliteDialect implements SqlDialect {
 
   // `in (?, ?, ?)`: the length is part of the text, so it is part of the plan.
   readonly bindsListAsOneParameter = false;
+
+  // SQLite has had RETURNING since 3.35; Bun 1.3.14 bundles 3.51.0, confirmed by
+  // querying `select sqlite_version()` through the driver rather than by reading
+  // a changelog. Multi-row `insert ... returning` was verified there too, since
+  // `createMany` depends on it for its row count.
+  readonly supportsReturning = true;
 
   quoteIdent(name: string): string {
     // NUL is the parameter sentinel in compile/fragment.ts, so it is the one
@@ -120,6 +126,42 @@ export class SqliteDialect implements SqlDialect {
       sql(" offset "),
       param(skip),
     );
+  }
+
+  // SQLite reports every constraint failure as a `SQLiteError`, distinguished
+  // only by `code`. Read off the driver rather than guessed:
+  //
+  //   UNIQUE constraint failed: T.email      SQLITE_CONSTRAINT_UNIQUE
+  //   UNIQUE constraint failed: C.a, C.b     SQLITE_CONSTRAINT_UNIQUE  (composite)
+  //   NOT NULL constraint failed: N.v        SQLITE_CONSTRAINT_NOTNULL
+  //   FOREIGN KEY constraint failed          SQLITE_CONSTRAINT_FOREIGNKEY
+  //
+  // Matching on the code and not on the message is what keeps the last two from
+  // being reported as duplicate keys. There is no constraint *name* in any of
+  // them — SQLite does not carry one — so only the columns come back.
+  constraintViolation(error: unknown): ConstraintViolation | null {
+    const code = (error as { code?: unknown } | null)?.code;
+    if (code !== "SQLITE_CONSTRAINT_UNIQUE" && code !== "SQLITE_CONSTRAINT_PRIMARYKEY") {
+      return null;
+    }
+
+    const message = String((error as { message?: unknown }).message ?? "");
+    const listed = /constraint failed:\s*(.+)$/.exec(message);
+    if (!listed) return { kind: "unique", columns: [] };
+
+    const columns = listed[1]
+      .split(",")
+      .map((entry) => entry.trim())
+      // Each entry is `Table.column`; the table is the one being written, so
+      // only the column carries information. A column name may itself contain a
+      // dot, so the split is on the *first* one.
+      .map((entry) => {
+        const dot = entry.indexOf(".");
+        return dot === -1 ? entry : entry.slice(dot + 1);
+      })
+      .filter((entry) => entry !== "");
+
+    return { kind: "unique", columns };
   }
 
   encode(value: unknown, field: FieldSchema): unknown {

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -81,6 +81,90 @@ export class RecordNotFoundError extends Error {
 }
 
 /**
+ * Thrown when a write violates a unique constraint.
+ *
+ * DECISION — gemi defines its own error rather than mirroring Prisma's codes.
+ *
+ * Prisma raises `PrismaClientKnownRequestError` with code `P2002` and
+ * `meta.target` holding the field names. Mirroring that would ease a migration
+ * for code already branching on `P2002` — but nothing in this repository does
+ * (checked), and carrying a `P` code implies the rest of the taxonomy is
+ * implemented too: `P2003`, `P2025`, and the fifty others an application might
+ * reasonably then expect to catch. Claiming a compatibility surface we have not
+ * built is worse than asking the few call sites that need it to catch a gemi
+ * error instead.
+ *
+ * What the contract does promise is the part that matters: the error is typed,
+ * catchable, and names the fields — as *field* names, the way Prisma's
+ * `meta.target` does, not as the database columns the driver reported.
+ */
+export class UniqueConstraintError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly operation: string,
+    /** Field names, mapped back through the schema from the driver's columns. */
+    public readonly fields: string[],
+    /** The constraint's own name, when the dialect reports one. */
+    public readonly constraint?: string,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `Unique constraint violated on ${model}.${operation}` +
+        (fields.length > 0 ? ` for ${fields.join(", ")}` : "") +
+        (constraint ? ` (constraint '${constraint}')` : "") +
+        `. A ${model} with those values already exists.`,
+      options,
+    );
+    this.name = "UniqueConstraintError";
+  }
+}
+
+/**
+ * Thrown when a write needs `RETURNING` and the dialect has none.
+ *
+ * Unreachable on SQLite and Postgres, which both support it. It exists so that
+ * the MySQL / MariaDB path is a named gap rather than a wrong answer: the
+ * fallback there is `lastInsertRowid` plus a re-select, which is a different
+ * statement shape and is not implemented.
+ */
+export class ReturningUnsupportedError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly operation: string,
+    public readonly dialect: string,
+  ) {
+    super(
+      `${model}.${operation} needs RETURNING to report its result, and the ` +
+        `'${dialect}' dialect does not support it. The fallback — ` +
+        `lastInsertRowid plus a re-select — is not implemented.`,
+    );
+    this.name = "ReturningUnsupportedError";
+  }
+}
+
+/**
+ * Thrown when a write omits a column that has no value to fall back on: not
+ * supplied, no client-side default, no database default, and not nullable.
+ *
+ * Raised in the compiler rather than left to the database so the message names
+ * the field and the model, instead of surfacing as `NOT NULL constraint failed`
+ * with a column name and no context.
+ */
+export class MissingRequiredValueError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly operation: string,
+    public readonly field: string,
+  ) {
+    super(
+      `${model}.${operation} is missing a value for '${field}', which is ` +
+        `required and has no default.`,
+    );
+    this.name = "MissingRequiredValueError";
+  }
+}
+
+/**
  * Thrown when an `include` — or a relation-shaped key inside a `select` — names
  * something the model does not declare as a relation.
  */

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -143,6 +143,42 @@ export class ReturningUnsupportedError extends Error {
 }
 
 /**
+ * Thrown when a statement would bind more parameters than the driver's wire
+ * protocol can carry.
+ *
+ * Only `createMany` can reach it, since it is the one operation whose parameter
+ * count scales with the caller's data rather than with the query's shape:
+ * `rows × columns`. Both limits are hard and low enough to hit with an ordinary
+ * import — Postgres counts parameters in an int16 (65535), SQLite defaults
+ * `SQLITE_MAX_VARIABLE_NUMBER` to 32766.
+ *
+ * Prisma chunks the insert automatically. Doing that here means several
+ * statements, which without a transaction is a partially-applied `createMany`
+ * on failure — so it waits for iteration 5, and until then this is a named gap
+ * rather than a driver error naming neither the model nor the cause. Same
+ * treatment as `ReturningUnsupportedError`, for the same reason.
+ */
+export class ParameterLimitError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly operation: string,
+    public readonly required: number,
+    public readonly limit: number,
+    public readonly dialect: string,
+    detail: string,
+  ) {
+    super(
+      `${model}.${operation} would bind ${required} parameters, and the ` +
+        `'${dialect}' driver accepts at most ${limit} in one statement. ` +
+        `${detail} Automatic chunking is not implemented: it would make this ` +
+        `several statements, which cannot be made atomic until transactions ` +
+        `land. Split the call.`,
+    );
+    this.name = "ParameterLimitError";
+  }
+}
+
+/**
  * Thrown when a write omits a column that has no value to fall back on: not
  * supplied, no client-side default, no database default, and not nullable.
  *

--- a/packages/gemi/orm/fixtures.ts
+++ b/packages/gemi/orm/fixtures.ts
@@ -459,6 +459,94 @@ export const mapped: ModelSchema = {
   relations: {},
 };
 
+/**
+ * A model whose unique key is a `DateTime`, which the template's schema has no
+ * example of.
+ *
+ * It exists for one asymmetry: `encode` passes a `Date` straight through on
+ * Postgres and turns it into a number on SQLite, so an `upsert` comparing its
+ * conflict key by identity works on one dialect and refuses a correct call on
+ * the other. `Bytes` has the same shape on both.
+ */
+export const reading: ModelSchema = {
+  name: "Reading",
+  table: "Reading",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    at: {
+      name: "at",
+      column: "at",
+      type: "DateTime",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    digest: {
+      name: "digest",
+      column: "digest",
+      type: "Bytes",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    value: {
+      name: "value",
+      column: "value",
+      type: "Float",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [["at"]],
+  relations: {},
+};
+
+/**
+ * A model where every field is autoincrement, database-defaulted or nullable,
+ * and none has a *client-side* default.
+ *
+ * So a `create({ data: {} })` writes no column at all — the `default values`
+ * case — and a `createMany` of empty rows has no column list to repeat. Not
+ * reachable from the template's schema, where `@default(cuid())` on `publicId`
+ * puts a client-side value in every model.
+ */
+export const bare: ModelSchema = {
+  name: "Bare",
+  table: "Bare",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    note: {
+      name: "note",
+      column: "note",
+      type: "String",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {},
+};
+
 /** The full explicit column list `findMany` emits for `user`, unparameterised. */
 export const USER_COLUMNS =
   '"id", "publicId", "name", "email", "emailVerifiedAt", "verificationToken", ' +

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -18,6 +18,7 @@ export {
   MissingModelSchemaError,
   MissingRequiredValueError,
   ModelNotRegisteredError,
+  ParameterLimitError,
   RecordNotFoundError,
   RelationDepthExceededError,
   ReturningUnsupportedError,

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -16,14 +16,24 @@ export {
   DecodeError,
   MalformedRelationError,
   MissingModelSchemaError,
+  MissingRequiredValueError,
   ModelNotRegisteredError,
   RecordNotFoundError,
   RelationDepthExceededError,
+  ReturningUnsupportedError,
+  UniqueConstraintError,
   UnknownFieldError,
   UnknownRelationError,
   UnregisteredRelationTargetError,
   UnsupportedQueryError,
 } from "./errors";
+
+export {
+  createCuid,
+  clientSideValue,
+  hasClientSideValue,
+  isClientSideDefault,
+} from "./defaults";
 
 export {
   canonicalShape,
@@ -35,8 +45,13 @@ export {
   type QueryPlan,
 } from "./plan";
 
-export { compile } from "./compile";
+export { compile, compileRead, compileWrite } from "./compile";
 export { buildRowShaper, type RowShaper, type ShapedRelation } from "./shape";
+export {
+  createBindContext,
+  type BindContext,
+  type Binder,
+} from "./compile/fragment";
 
 // The relation planner is a swappable stage (invariant 4): iteration 3 ships
 // the batched strategy, iteration 7 adds lateral + json_agg as a sibling.
@@ -56,6 +71,7 @@ export {
   SqliteDialect,
   UnsupportedDialectError,
   dialectFor,
+  type ConstraintViolation,
   type SqlDialect,
 } from "./dialect";
 

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -1,5 +1,6 @@
 import { compile } from "./compile";
-import type { RelationPlan } from "./compile/plan-relations";
+import type { BindContext } from "./compile/fragment";
+import type { NestedWriteStep, RelationPlan } from "./compile/plan-relations";
 import type { SqlDialect } from "./dialect";
 import type { ModelSchema } from "./schema";
 
@@ -32,8 +33,15 @@ export type Operation =
  */
 export interface QueryPlan {
   text: string;
-  bind(args: any): unknown[];
+  bind(args: any, context?: BindContext): unknown[];
   shape(rows: unknown[]): unknown;
+  /**
+   * Nested-write steps that run before the statement, contributing foreign keys
+   * into the bind context, and after it, writing rows that reference the one
+   * just created. Both left undefined for a query with no nested writes.
+   */
+  before?: NestedWriteStep[];
+  after?: NestedWriteStep[];
   /**
    * The relation nodes this query's `include` / `select` asks for, one plan per
    * node. Empty — and left undefined — for a query with no relations, so the

--- a/packages/gemi/orm/plan.writes.discrimination.test.ts
+++ b/packages/gemi/orm/plan.writes.discrimination.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { createBindContext } from "./compile/fragment";
 import { PostgresDialect } from "./dialect/postgres";
@@ -22,6 +22,14 @@ beforeEach(() => {
   registry.register("User", class { static $schema = user });
   registry.register("Account", class { static $schema = account });
   registry.register("Organization", class { static $schema = organization });
+});
+
+// Vitest isolates modules per file, so this is invisible here — but the
+// registry is process-global, and a runner that shares one (`bun test orm/`)
+// carries these registrations into the next file, where `read.test.ts` asserts
+// that a relation in a `select` *without* a registry raises.
+afterEach(() => {
+  registry.clearRegistry();
 });
 
 /**

--- a/packages/gemi/orm/plan.writes.discrimination.test.ts
+++ b/packages/gemi/orm/plan.writes.discrimination.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createBindContext } from "./compile/fragment";
+import { PostgresDialect } from "./dialect/postgres";
+import { SqliteDialect } from "./dialect/sqlite";
+import { account, organization, user } from "./fixtures";
+import * as registry from "./registry";
+import {
+  clearPlanCache,
+  getOrCompile,
+  planCacheStats,
+  planKey,
+  type Operation,
+} from "./plan";
+
+const sqlite = new SqliteDialect();
+const postgres = new PostgresDialect();
+
+beforeEach(() => {
+  clearPlanCache();
+  registry.clearRegistry();
+  registry.register("User", class { static $schema = user });
+  registry.register("Account", class { static $schema = account });
+  registry.register("Organization", class { static $schema = organization });
+});
+
+/**
+ * A plan-cache collision does not fail — it silently runs the wrong SQL for the
+ * arguments it was handed. On a *read* that means wrong rows; on a write it
+ * means wrong rows written, which does not come back.
+ *
+ * The write-specific hazard is the field set: `create({ data: { email } })` and
+ * `create({ data: { email, name } })` are different column lists, and sharing a
+ * plan between them would bind two values into a three-column insert — or write
+ * a value into the wrong column.
+ */
+const DISTINCT: [string, Operation, unknown][] = [
+  // --- create: the field set is the column list ------------------------
+  ["create email", "create", { data: { email: "x" } }],
+  ["create name", "create", { data: { name: "x" } }],
+  ["create both", "create", { data: { email: "x", name: "y" } }],
+  ["create three", "create", { data: { email: "x", name: "y", locale: "z" } }],
+  // A null is still a bound value, but an *absent* key is a missing column.
+  ["create explicit null", "create", { data: { email: null } }],
+  ["create nothing", "create", { data: {} }],
+  // The selection changes the returning list.
+  ["create select id", "create", { data: { email: "x" }, select: { id: true } }],
+  ["create select email", "create", {
+    data: { email: "x" }, select: { email: true },
+  }],
+  ["create include", "create", {
+    data: { email: "x" }, include: { accounts: true },
+  }],
+
+  // --- createMany: the row count is part of the text -------------------
+  ["createMany 1", "createMany", { data: [{ email: "x" }] }],
+  ["createMany 2", "createMany", { data: [{ email: "x" }, { email: "y" }] }],
+  ["createMany 3", "createMany", {
+    data: [{ email: "x" }, { email: "y" }, { email: "z" }],
+  }],
+  ["createMany 0", "createMany", { data: [] }],
+  // Same count, different union of keys.
+  ["createMany 2 wider", "createMany", {
+    data: [{ email: "x", name: "a" }, { email: "y" }],
+  }],
+
+  // --- update: the set clause and the where are both structural --------
+  ["update name", "update", { where: { id: 1 }, data: { name: "x" } }],
+  ["update email", "update", { where: { id: 1 }, data: { email: "x" } }],
+  ["update both", "update", {
+    where: { id: 1 }, data: { name: "x", email: "y" },
+  }],
+  ["update increment", "update", {
+    where: { id: 1 }, data: { globalRole: { increment: 1 } },
+  }],
+  ["update decrement", "update", {
+    where: { id: 1 }, data: { globalRole: { decrement: 1 } },
+  }],
+  ["update multiply", "update", {
+    where: { id: 1 }, data: { globalRole: { multiply: 1 } },
+  }],
+  ["update divide", "update", {
+    where: { id: 1 }, data: { globalRole: { divide: 1 } },
+  }],
+  ["update set", "update", {
+    where: { id: 1 }, data: { globalRole: { set: 1 } },
+  }],
+  ["update by publicId", "update", {
+    where: { publicId: "x" }, data: { name: "y" },
+  }],
+
+  ["updateMany", "updateMany", { where: { name: "x" }, data: { name: "y" } }],
+  ["updateMany other where", "updateMany", {
+    where: { email: "x" }, data: { name: "y" },
+  }],
+  ["updateMany no where", "updateMany", { data: { name: "y" } }],
+
+  // --- delete ----------------------------------------------------------
+  ["delete by id", "delete", { where: { id: 1 } }],
+  ["delete by publicId", "delete", { where: { publicId: "x" } }],
+  ["delete select", "delete", { where: { id: 1 }, select: { id: true } }],
+  ["deleteMany", "deleteMany", { where: { name: "x" } }],
+  ["deleteMany other", "deleteMany", { where: { email: "x" } }],
+  ["deleteMany all", "deleteMany", {}],
+
+  // --- upsert ----------------------------------------------------------
+  ["upsert by email", "upsert", {
+    where: { email: "x" }, create: { email: "x" }, update: { name: "y" },
+  }],
+  ["upsert by email wider create", "upsert", {
+    where: { email: "x" },
+    create: { email: "x", name: "n" },
+    update: { name: "y" },
+  }],
+  ["upsert by email wider update", "upsert", {
+    where: { email: "x" },
+    create: { email: "x" },
+    update: { name: "y", locale: "z" },
+  }],
+  ["upsert by publicId", "upsert", {
+    where: { publicId: "x" }, create: { publicId: "x" }, update: { name: "y" },
+  }],
+
+  // --- nested writes are structural too --------------------------------
+  ["create connect by key", "create", {
+    data: { email: "x", organization: { connect: { id: 1 } } },
+  }],
+  // A different unique means a lookup step instead of a bound column: same
+  // model, same relation, genuinely different plan.
+  ["create connect by other unique", "create", {
+    data: { email: "x", organization: { connect: { publicId: "p" } } },
+  }],
+  ["create nested create", "create", {
+    data: { email: "x", organization: { create: { name: "n" } } },
+  }],
+  ["create nested child create", "create", {
+    data: { email: "x", accounts: { create: { organizationRole: 1 } } },
+  }],
+];
+
+describe("plan cache discrimination — writes", () => {
+  test("every shape in the table gets its own key", () => {
+    const keys = new Map<string, string>();
+    for (const [label, op, args] of DISTINCT) {
+      const key = planKey(sqlite, "User", op, args);
+      const clash = keys.get(key);
+      expect(clash, `"${label}" collides with "${clash}"`).toBeUndefined();
+      keys.set(key, label);
+    }
+    expect(keys.size).toBe(DISTINCT.length);
+  });
+
+  // The key is only half of it: two shapes hashing apart but compiling to the
+  // same plan would mean the extra entries buy nothing, while two shapes
+  // hashing together and compiling differently is the dangerous direction.
+  //
+  // A plan is the text, what it binds, *and* the work hanging off it — several
+  // of these emit identical SQL and differ only in which argument each
+  // parameter reads, or in the relations and nested steps attached. An
+  // `include` on a write is the clearest case: same insert, same parameters,
+  // plus a second query the caller very much asked for.
+  test("every shape in the table produces its own plan", () => {
+    const plans = new Map<string, string>();
+
+    for (const [label, op, args] of DISTINCT) {
+      const plan = getOrCompile(user, op, args, sqlite);
+      // Bound with a fixed context so the generated defaults — a cuid per call,
+      // a fresh `now` — do not make every plan trivially unique.
+      const context = { now: new Date(0), resolved: {} };
+      const bound = plan
+        .bind(args, context)
+        .map((value) =>
+          typeof value === "string" && /^c[a-z0-9]{24}$/.test(value)
+            ? "<cuid>"
+            : value,
+        );
+      const attached = JSON.stringify({
+        relations: plan.relations?.map((relation) => relation.as) ?? [],
+        before:
+          plan.before?.map((step) => `${step.relation}:${step.operation}`) ?? [],
+        after:
+          plan.after?.map((step) => `${step.relation}:${step.operation}`) ?? [],
+        hidden: plan.hidden ?? [],
+        // How the result is read back. `create` with `select: { id: true }` and
+        // `createMany` of one row compile to byte-identical SQL binding
+        // identical parameters, and differ only here — one returns the row,
+        // the other a count. They cannot collide, because the operation is part
+        // of the cache key, but the identity has to say so rather than assume.
+        empty: plan.shape([]),
+      });
+      const identity = `${plan.text} ${JSON.stringify(bound)} ${attached}`;
+
+      const clash = plans.get(identity);
+      expect(
+        clash,
+        `"${label}" is indistinguishable from "${clash}":\n  ${identity}`,
+      ).toBeUndefined();
+      plans.set(identity, label);
+    }
+  });
+
+  // The property that makes the cache worth having: values vary freely, the
+  // plan does not.
+  test("a create with the same field set is one plan whatever the values", () => {
+    for (const email of ["a@x", "b@x", "c@x", "d@x"]) {
+      getOrCompile(user, "create", { data: { email } }, sqlite);
+    }
+    expect(planCacheStats().compiles).toBe(1);
+    expect(planCacheStats().hits).toBe(3);
+  });
+
+  test("the same write on two dialects is two plans", () => {
+    const args = { data: { email: "x" } };
+    expect(planKey(sqlite, "User", "create", args)).not.toBe(
+      planKey(postgres, "User", "create", args),
+    );
+  });
+
+  // Two operations that compile to different statements must not be able to
+  // share an entry just because their argument trees look alike.
+  test("operation is part of the key", () => {
+    const args = { where: { id: 1 }, data: { name: "x" } };
+    expect(planKey(sqlite, "User", "update", args)).not.toBe(
+      planKey(sqlite, "User", "updateMany", args),
+    );
+  });
+
+  test("model is part of the key", () => {
+    const args = { data: { publicId: "x" } };
+    expect(planKey(sqlite, "User", "create", args)).not.toBe(
+      planKey(sqlite, "Account", "create", args),
+    );
+  });
+
+  // A plan outlives the call that compiled it, so anything minted per call has
+  // to be read from the bind context rather than captured at compile time.
+  test("a cached plan mints a fresh cuid and timestamp on every call", () => {
+    const args = { data: { email: "x" } };
+
+    const first = getOrCompile(user, "create", args, sqlite).bind(
+      args,
+      createBindContext(),
+    );
+    const second = getOrCompile(user, "create", args, sqlite).bind(
+      args,
+      createBindContext(),
+    );
+
+    expect(planCacheStats().compiles).toBe(1);
+    // publicId is the first column, and it must differ between the two calls.
+    expect(first[0]).not.toBe(second[0]);
+    expect(String(first[0])).toMatch(/^c[a-z0-9]{24}$/);
+    expect(String(second[0])).toMatch(/^c[a-z0-9]{24}$/);
+  });
+});

--- a/plans/orm/04-writes.md
+++ b/plans/orm/04-writes.md
@@ -143,6 +143,38 @@ apply and that is fine), MySQL / MariaDB write paths, transactions (iteration 5 
 though this iteration should note every place it wants one), policies on writes
 (iteration 6).
 
+## Known differences from Prisma, as shipped
+
+Each of these is a deliberate refusal rather than a gap. The alternative in
+every case is a write that succeeds and does something other than what Prisma
+does, which is the failure this iteration is arranged to prevent.
+
+- **`upsert` refuses a `where` that carries anything beside one unique key.**
+  Prisma 5 allows extra non-unique filters in a `WhereUniqueInput`, and allows
+  naming two different unique keys. `update` and `delete` honour both, since
+  their whole `where` is compiled. An upsert's `where` becomes an
+  `on conflict (...)` target, which is a key and not a predicate — there is
+  nowhere to put `deletedAt: null`, and `on conflict` takes exactly one target.
+  So a migrating application will hit a compile error on a call Prisma ran
+  happily. The fix at the call site is `findFirst` plus `update` / `create`.
+- **`upsert` refuses a `create` that omits the conflict key**, and refuses a
+  `create` whose key value disagrees with the `where` (checked at bind time,
+  where values exist). Prisma means find-then-write there; expressing that takes
+  a read and a write inside one transaction, which is iteration 5's.
+- **`createMany` refuses a partially-supplied database default** — some rows
+  setting a column and others leaving it to the database. `NULL` would overwrite
+  the default rather than request it, and SQLite rejects `DEFAULT` inside a
+  `VALUES` list.
+- **`createMany` refuses more than one all-empty row.** `default values` inserts
+  exactly one and has no portable multi-row spelling.
+- **No automatic chunking.** Prisma splits a large `createMany`; gemi raises
+  `ParameterLimitError` naming the model and the driver limit. Chunking means
+  several statements, which cannot be made atomic before iteration 5.
+- **`delete` with `include` on a cascading relation** returns the children
+  empty, because the relation reads run after the delete has cascaded. Prisma
+  does the whole thing in a transaction. Recorded at `compileDelete`; fixable
+  once iteration 5 lands, and not before.
+
 ## Notes and risks
 
 - **Column order in a multi-row `createMany` must be canonical**, derived from the

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -24,6 +24,25 @@ import { expect } from "vitest";
  * loud: a silently skipped dialect reads as a passing one.
  */
 
+/**
+ * Fields that legitimately differ between two runs of the same write, because
+ * the value is minted rather than supplied: a `@default(cuid())`, a
+ * `@default(now())`, an `@updatedAt`.
+ *
+ * They are not skipped — they are replaced by a *descriptor* of the value, so
+ * a cuid that is the wrong length or has the wrong prefix still fails. That is
+ * exactly the divergence the plan warns about: "a cuid that is shaped
+ * differently from Prisma's will show up as a diff in column length or prefix".
+ */
+const VOLATILE = ["publicId", "createdAt", "updatedAt"];
+
+export interface WriteComparison {
+  /** Models whose full contents are compared afterwards. Defaults to the one written. */
+  tables?: string[];
+  /** Fields compared by shape rather than by value. Defaults to {@link VOLATILE}. */
+  volatile?: string[];
+}
+
 export interface Differential {
   prisma: PrismaClient;
   /** Runs both clients and asserts the results are deep-equal. */
@@ -32,6 +51,24 @@ export interface Differential {
     operation: string,
     args?: unknown,
   ): Promise<unknown>;
+  /**
+   * The same, for an operation that *mutates*.
+   *
+   * A write cannot be run through both clients against one database — the
+   * second would see the first one's effects. So each client gets the seeded
+   * state fresh, and both the returned value and the resulting table contents
+   * are compared. Comparing the rows afterwards is the half that matters:
+   * `updateMany` returns only a count, and a `create` that wrote the right
+   * payload to the wrong columns returns something perfectly plausible.
+   */
+  expectSameWrite(
+    model: string,
+    operation: string,
+    args?: unknown,
+    options?: WriteComparison,
+  ): Promise<void>;
+  /** Restores the seeded state, dropping everything either client wrote. */
+  reset(): Promise<void>;
   /**
    * Statements the gemi ORM has executed since the last reset. The point of
    * counting is the relation planner: one query per *node* in an include tree
@@ -61,21 +98,39 @@ function prismaDelegate(client: PrismaClient, model: string) {
  * sides the same way keeps the comparison about *our* divergences rather than
  * about the serializer.
  */
-function normalize(value: unknown): unknown {
+function normalize(value: unknown, volatile?: Set<string>): unknown {
   if (value === undefined) return null;
   if (value === null) return null;
   if (value instanceof Date) return `date:${value.toISOString()}`;
   if (typeof value === "bigint") return `bigint:${value.toString()}`;
   if (ArrayBuffer.isView(value)) return `bytes:${[...(value as any)].join(",")}`;
-  if (Array.isArray(value)) return value.map(normalize);
+  if (Array.isArray(value)) return value.map((item) => normalize(item, volatile));
   if (typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-      out[key] = normalize((value as Record<string, unknown>)[key]);
+      const member = (value as Record<string, unknown>)[key];
+      out[key] =
+        volatile?.has(key) === true
+          ? descriptor(member)
+          : normalize(member, volatile);
     }
     return out;
   }
   return value;
+}
+
+/**
+ * What a generated value looks like, without what it is. Keeps the comparison
+ * meaningful for `@default(cuid())` and `@default(now())` — a string of the
+ * wrong length or with the wrong first character still fails.
+ */
+function descriptor(value: unknown): string {
+  if (value === null || value === undefined) return "absent";
+  if (value instanceof Date) return "date";
+  if (typeof value === "string") {
+    return `string(len=${value.length},head=${value.slice(0, 1)})`;
+  }
+  return typeof value;
 }
 
 export async function createDifferential(options: {
@@ -103,17 +158,56 @@ export async function createDifferential(options: {
   // that it points at a scratch database with the schema already applied.
   await assertPrismaSpeaks(prisma, options.url ? "postgresql" : "sqlite");
 
-  if (options.url) {
-    // Children before parents: the schema's foreign keys are enforced on both
-    // dialects, and a scratch database is only scratch for this suite.
+  // Children before parents: the schema's foreign keys are enforced on both
+  // dialects, and a scratch database is only scratch for this suite.
+  const TABLES = [
+    "SocialAccount",
+    "Session",
+    "PasswordResetToken",
+    "MagicLinkToken",
+    "Account",
+    "User",
+    "OrganizationInvitation",
+    "Organization",
+  ];
+
+  /**
+   * Empties every table **and restarts the identity sequences**.
+   *
+   * The restart is not tidiness. A write comparison runs the same operation
+   * twice from the same seeded state, and an autoincrement sequence survives a
+   * `DELETE` on both dialects — so without it the second run's rows get higher
+   * ids than the first's and every single comparison fails on `id` alone. It
+   * is also the difference between "the same state" and "the same rows".
+   */
+  const clearAll = async () => {
+    if (options.url) {
+      // One statement, and `RESTART IDENTITY` is part of it.
+      await prisma.$executeRawUnsafe(
+        `TRUNCATE ${TABLES.map((table) => `"${table}"`).join(", ")} ` +
+          `RESTART IDENTITY CASCADE`,
+      );
+      return;
+    }
+
     await prisma.socialAccount.deleteMany({});
     await prisma.session.deleteMany({});
     await prisma.passwordResetToken.deleteMany({});
+    await prisma.magicLinkToken.deleteMany({});
     await prisma.account.deleteMany({});
     await prisma.user.deleteMany({});
     await prisma.organizationInvitation.deleteMany({});
     await prisma.organization.deleteMany({});
-  }
+
+    // SQLite keeps the high-water mark for an AUTOINCREMENT column in this
+    // table, and clearing it is the only way to make ids start from 1 again.
+    // It does not exist until the first AUTOINCREMENT insert, hence the guard.
+    await prisma
+      .$executeRawUnsafe(`DELETE FROM sqlite_sequence`)
+      .catch(() => undefined);
+  };
+
+  if (options.url) await clearAll();
 
   await options.seed(prisma);
 
@@ -180,6 +274,55 @@ export async function createDifferential(options: {
       return fromGemi.value;
     },
 
+    async reset() {
+      await clearAll();
+      await options.seed(prisma);
+    },
+
+    async expectSameWrite(model, operation, args, comparison = {}) {
+      const volatile = new Set(comparison.volatile ?? VOLATILE);
+      const tables = comparison.tables ?? [model];
+      const label = `${model}.${operation}(${JSON.stringify(args ?? {})})`;
+
+      // Sequential, not concurrent: a write run through both clients against
+      // one database would have the second see the first one's effects. Each
+      // gets the seeded state fresh, and the two are compared afterwards.
+      await this.reset();
+      const fromPrisma = await settle(() =>
+        prismaDelegate(prisma, model)[operation](args),
+      );
+      const afterPrisma = await readTables(prisma, tables);
+
+      await this.reset();
+      clearPlanCache();
+      const gemiModel = options.models[model];
+      if (!gemiModel) throw new Error(`No gemi model registered for ${model}.`);
+      const fromGemi = await settle(() => (gemiModel as any)[operation](args));
+      const afterGemi = await readTables(prisma, tables);
+
+      if (fromPrisma.threw || fromGemi.threw) {
+        expect(
+          { threw: fromGemi.threw, at: label },
+          `${label}: prisma ${fromPrisma.threw ? "threw" : "returned"} but ` +
+            `gemi ${fromGemi.threw ? "threw" : "returned"}` +
+            (fromGemi.threw ? ` — ${fromGemi.error}` : "") +
+            (fromPrisma.threw ? ` — ${fromPrisma.error}` : ""),
+        ).toEqual({ threw: fromPrisma.threw, at: label });
+      } else {
+        expect(
+          normalize(fromGemi.value, volatile),
+          `${label}: returned value`,
+        ).toEqual(normalize(fromPrisma.value, volatile));
+      }
+
+      // The half that catches a write which returned something plausible and
+      // stored something else.
+      expect(
+        normalize(afterGemi, volatile),
+        `${label}: resulting rows`,
+      ).toEqual(normalize(afterPrisma, volatile));
+    },
+
     async dispose() {
       await prisma.$disconnect();
       await database.close();
@@ -226,10 +369,17 @@ async function applyMigrations(path: string): Promise<void> {
  * its own does not say so:
  *
  *   1. flip `datasource db { provider }` in prisma/schema.prisma to postgresql
- *   2. `prisma generate` (the gemi artifacts are dialect-agnostic and do not
- *      change — that is worth confirming with `git status` while you are here)
- *   3. TZ=UTC TEST_POSTGRES_URL=postgres://... vitest
+ *   2. `prisma db push` against the scratch database, then `prisma generate`
+ *      (the gemi artifacts are dialect-agnostic and do not change — that is
+ *      worth confirming with `git status` while you are here)
+ *   3. TZ=UTC TEST_POSTGRES_URL=postgres://... vitest run --no-file-parallelism
  *   4. flip back and regenerate
+ *
+ * `--no-file-parallelism` is not optional on Postgres. Every suite points at
+ * the one database the env var names, and the write suites truncate it between
+ * cases — so run in parallel, one file empties the tables another is reading
+ * and the failures land in whichever suite lost the race. On SQLite each suite
+ * builds its own file in a temp directory, so the flag is unnecessary there.
  *
  * The SQLite suite cannot run in the same process while the client is built for
  * Postgres, which is why the two dialects are two runs rather than one.
@@ -258,6 +408,24 @@ async function assertPrismaSpeaks(
           : ` Unset TEST_POSTGRES_URL to run only this one.`),
     );
   }
+}
+
+/**
+ * Every row of the named models, read through Prisma so that both sides of a
+ * write comparison are observed by the *same* client. Reading gemi's result
+ * with gemi would hide a decode bug that exactly cancels an encode bug.
+ */
+async function readTables(
+  prisma: PrismaClient,
+  models: readonly string[],
+): Promise<Record<string, unknown>> {
+  const out: Record<string, unknown> = {};
+  for (const model of models) {
+    out[model] = await prismaDelegate(prisma, model).findMany({
+      orderBy: { id: "asc" },
+    });
+  }
+  return out;
 }
 
 async function settle(run: () => Promise<unknown>) {

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -301,13 +301,20 @@ export async function createDifferential(options: {
       const afterGemi = await readTables(prisma, tables);
 
       if (fromPrisma.threw || fromGemi.threw) {
+        // The `kind` is compared too, not just the fact of throwing: without it
+        // a gemi compile-time refusal reads as agreement with a Prisma unique
+        // violation. See `failureKind`.
         expect(
-          { threw: fromGemi.threw, at: label },
+          { threw: fromGemi.threw, kind: fromGemi.kind, at: label },
           `${label}: prisma ${fromPrisma.threw ? "threw" : "returned"} but ` +
             `gemi ${fromGemi.threw ? "threw" : "returned"}` +
             (fromGemi.threw ? ` — ${fromGemi.error}` : "") +
             (fromPrisma.threw ? ` — ${fromPrisma.error}` : ""),
-        ).toEqual({ threw: fromPrisma.threw, at: label });
+        ).toEqual({
+          threw: fromPrisma.threw,
+          kind: fromPrisma.kind,
+          at: label,
+        });
       } else {
         expect(
           normalize(fromGemi.value, volatile),
@@ -430,8 +437,37 @@ async function readTables(
 
 async function settle(run: () => Promise<unknown>) {
   try {
-    return { threw: false, value: await run(), error: "" };
+    return { threw: false, value: await run(), error: "", kind: "" };
   } catch (error: any) {
-    return { threw: true, value: null, error: String(error?.message ?? error) };
+    return {
+      threw: true,
+      value: null,
+      error: String(error?.message ?? error),
+      kind: failureKind(error),
+    };
   }
+}
+
+/**
+ * A coarse class for a thrown error, comparable across the two clients.
+ *
+ * Comparing only the *fact* of throwing lets a gemi error thrown for an
+ * unrelated reason — a compile-time refusal, say — pass as agreement with a
+ * Prisma unique violation. Comparing messages would couple every case to
+ * Prisma's wording. The classes below are the ones the two clients genuinely
+ * both have, and the ones a write can be wrong about:
+ *
+ *   Prisma P2002 / gemi UniqueConstraintError  -> "unique"
+ *   Prisma P2025 / gemi RecordNotFoundError    -> "notFound"
+ *
+ * Everything else is "other", where agreeing that it failed is all the harness
+ * can honestly claim; the dedicated tests below the table assert the type.
+ */
+function failureKind(error: any): string {
+  const name = String(error?.name ?? "");
+  const code = String(error?.code ?? "");
+
+  if (name === "UniqueConstraintError" || code === "P2002") return "unique";
+  if (name === "RecordNotFoundError" || code === "P2025") return "notFound";
+  return "other";
 }

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -54,6 +54,48 @@ export class AccountModel extends Model {
   ): Promise<number> {
     return this.$exec("count", args) as Promise<number>;
   }
+
+  static create<T extends Prisma.AccountCreateArgs>(
+    args: Subset<T, Prisma.AccountCreateArgs>,
+  ): Promise<Prisma.AccountGetPayload<T>> {
+    return this.$exec("create", args) as Promise<Prisma.AccountGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.AccountUpdateArgs>(
+    args: Subset<T, Prisma.AccountUpdateArgs>,
+  ): Promise<Prisma.AccountGetPayload<T>> {
+    return this.$exec("update", args) as Promise<Prisma.AccountGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.AccountDeleteArgs>(
+    args: Subset<T, Prisma.AccountDeleteArgs>,
+  ): Promise<Prisma.AccountGetPayload<T>> {
+    return this.$exec("delete", args) as Promise<Prisma.AccountGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.AccountUpsertArgs>(
+    args: Subset<T, Prisma.AccountUpsertArgs>,
+  ): Promise<Prisma.AccountGetPayload<T>> {
+    return this.$exec("upsert", args) as Promise<Prisma.AccountGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.AccountCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.AccountUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.AccountDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
 }
 
 export class MagicLinkTokenModel extends Model {
@@ -93,6 +135,48 @@ export class MagicLinkTokenModel extends Model {
     args?: Omit<Prisma.MagicLinkTokenCountArgs, "select">,
   ): Promise<number> {
     return this.$exec("count", args) as Promise<number>;
+  }
+
+  static create<T extends Prisma.MagicLinkTokenCreateArgs>(
+    args: Subset<T, Prisma.MagicLinkTokenCreateArgs>,
+  ): Promise<Prisma.MagicLinkTokenGetPayload<T>> {
+    return this.$exec("create", args) as Promise<Prisma.MagicLinkTokenGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.MagicLinkTokenUpdateArgs>(
+    args: Subset<T, Prisma.MagicLinkTokenUpdateArgs>,
+  ): Promise<Prisma.MagicLinkTokenGetPayload<T>> {
+    return this.$exec("update", args) as Promise<Prisma.MagicLinkTokenGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.MagicLinkTokenDeleteArgs>(
+    args: Subset<T, Prisma.MagicLinkTokenDeleteArgs>,
+  ): Promise<Prisma.MagicLinkTokenGetPayload<T>> {
+    return this.$exec("delete", args) as Promise<Prisma.MagicLinkTokenGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.MagicLinkTokenUpsertArgs>(
+    args: Subset<T, Prisma.MagicLinkTokenUpsertArgs>,
+  ): Promise<Prisma.MagicLinkTokenGetPayload<T>> {
+    return this.$exec("upsert", args) as Promise<Prisma.MagicLinkTokenGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.MagicLinkTokenCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.MagicLinkTokenUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.MagicLinkTokenDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
   }
 }
 
@@ -134,6 +218,48 @@ export class OrganizationModel extends Model {
   ): Promise<number> {
     return this.$exec("count", args) as Promise<number>;
   }
+
+  static create<T extends Prisma.OrganizationCreateArgs>(
+    args: Subset<T, Prisma.OrganizationCreateArgs>,
+  ): Promise<Prisma.OrganizationGetPayload<T>> {
+    return this.$exec("create", args) as Promise<Prisma.OrganizationGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.OrganizationUpdateArgs>(
+    args: Subset<T, Prisma.OrganizationUpdateArgs>,
+  ): Promise<Prisma.OrganizationGetPayload<T>> {
+    return this.$exec("update", args) as Promise<Prisma.OrganizationGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.OrganizationDeleteArgs>(
+    args: Subset<T, Prisma.OrganizationDeleteArgs>,
+  ): Promise<Prisma.OrganizationGetPayload<T>> {
+    return this.$exec("delete", args) as Promise<Prisma.OrganizationGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.OrganizationUpsertArgs>(
+    args: Subset<T, Prisma.OrganizationUpsertArgs>,
+  ): Promise<Prisma.OrganizationGetPayload<T>> {
+    return this.$exec("upsert", args) as Promise<Prisma.OrganizationGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.OrganizationCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.OrganizationUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.OrganizationDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
 }
 
 export class OrganizationInvitationModel extends Model {
@@ -173,6 +299,48 @@ export class OrganizationInvitationModel extends Model {
     args?: Omit<Prisma.OrganizationInvitationCountArgs, "select">,
   ): Promise<number> {
     return this.$exec("count", args) as Promise<number>;
+  }
+
+  static create<T extends Prisma.OrganizationInvitationCreateArgs>(
+    args: Subset<T, Prisma.OrganizationInvitationCreateArgs>,
+  ): Promise<Prisma.OrganizationInvitationGetPayload<T>> {
+    return this.$exec("create", args) as Promise<Prisma.OrganizationInvitationGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.OrganizationInvitationUpdateArgs>(
+    args: Subset<T, Prisma.OrganizationInvitationUpdateArgs>,
+  ): Promise<Prisma.OrganizationInvitationGetPayload<T>> {
+    return this.$exec("update", args) as Promise<Prisma.OrganizationInvitationGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.OrganizationInvitationDeleteArgs>(
+    args: Subset<T, Prisma.OrganizationInvitationDeleteArgs>,
+  ): Promise<Prisma.OrganizationInvitationGetPayload<T>> {
+    return this.$exec("delete", args) as Promise<Prisma.OrganizationInvitationGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.OrganizationInvitationUpsertArgs>(
+    args: Subset<T, Prisma.OrganizationInvitationUpsertArgs>,
+  ): Promise<Prisma.OrganizationInvitationGetPayload<T>> {
+    return this.$exec("upsert", args) as Promise<Prisma.OrganizationInvitationGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.OrganizationInvitationCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.OrganizationInvitationUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.OrganizationInvitationDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
   }
 }
 
@@ -214,6 +382,48 @@ export class PasswordResetTokenModel extends Model {
   ): Promise<number> {
     return this.$exec("count", args) as Promise<number>;
   }
+
+  static create<T extends Prisma.PasswordResetTokenCreateArgs>(
+    args: Subset<T, Prisma.PasswordResetTokenCreateArgs>,
+  ): Promise<Prisma.PasswordResetTokenGetPayload<T>> {
+    return this.$exec("create", args) as Promise<Prisma.PasswordResetTokenGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.PasswordResetTokenUpdateArgs>(
+    args: Subset<T, Prisma.PasswordResetTokenUpdateArgs>,
+  ): Promise<Prisma.PasswordResetTokenGetPayload<T>> {
+    return this.$exec("update", args) as Promise<Prisma.PasswordResetTokenGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.PasswordResetTokenDeleteArgs>(
+    args: Subset<T, Prisma.PasswordResetTokenDeleteArgs>,
+  ): Promise<Prisma.PasswordResetTokenGetPayload<T>> {
+    return this.$exec("delete", args) as Promise<Prisma.PasswordResetTokenGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.PasswordResetTokenUpsertArgs>(
+    args: Subset<T, Prisma.PasswordResetTokenUpsertArgs>,
+  ): Promise<Prisma.PasswordResetTokenGetPayload<T>> {
+    return this.$exec("upsert", args) as Promise<Prisma.PasswordResetTokenGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.PasswordResetTokenCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.PasswordResetTokenUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.PasswordResetTokenDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
 }
 
 export class SessionModel extends Model {
@@ -253,6 +463,48 @@ export class SessionModel extends Model {
     args?: Omit<Prisma.SessionCountArgs, "select">,
   ): Promise<number> {
     return this.$exec("count", args) as Promise<number>;
+  }
+
+  static create<T extends Prisma.SessionCreateArgs>(
+    args: Subset<T, Prisma.SessionCreateArgs>,
+  ): Promise<Prisma.SessionGetPayload<T>> {
+    return this.$exec("create", args) as Promise<Prisma.SessionGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.SessionUpdateArgs>(
+    args: Subset<T, Prisma.SessionUpdateArgs>,
+  ): Promise<Prisma.SessionGetPayload<T>> {
+    return this.$exec("update", args) as Promise<Prisma.SessionGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.SessionDeleteArgs>(
+    args: Subset<T, Prisma.SessionDeleteArgs>,
+  ): Promise<Prisma.SessionGetPayload<T>> {
+    return this.$exec("delete", args) as Promise<Prisma.SessionGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.SessionUpsertArgs>(
+    args: Subset<T, Prisma.SessionUpsertArgs>,
+  ): Promise<Prisma.SessionGetPayload<T>> {
+    return this.$exec("upsert", args) as Promise<Prisma.SessionGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.SessionCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.SessionUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.SessionDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
   }
 }
 
@@ -294,6 +546,48 @@ export class SocialAccountModel extends Model {
   ): Promise<number> {
     return this.$exec("count", args) as Promise<number>;
   }
+
+  static create<T extends Prisma.SocialAccountCreateArgs>(
+    args: Subset<T, Prisma.SocialAccountCreateArgs>,
+  ): Promise<Prisma.SocialAccountGetPayload<T>> {
+    return this.$exec("create", args) as Promise<Prisma.SocialAccountGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.SocialAccountUpdateArgs>(
+    args: Subset<T, Prisma.SocialAccountUpdateArgs>,
+  ): Promise<Prisma.SocialAccountGetPayload<T>> {
+    return this.$exec("update", args) as Promise<Prisma.SocialAccountGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.SocialAccountDeleteArgs>(
+    args: Subset<T, Prisma.SocialAccountDeleteArgs>,
+  ): Promise<Prisma.SocialAccountGetPayload<T>> {
+    return this.$exec("delete", args) as Promise<Prisma.SocialAccountGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.SocialAccountUpsertArgs>(
+    args: Subset<T, Prisma.SocialAccountUpsertArgs>,
+  ): Promise<Prisma.SocialAccountGetPayload<T>> {
+    return this.$exec("upsert", args) as Promise<Prisma.SocialAccountGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.SocialAccountCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.SocialAccountUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.SocialAccountDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
 }
 
 export class UserModel extends Model {
@@ -333,5 +627,47 @@ export class UserModel extends Model {
     args?: Omit<Prisma.UserCountArgs, "select">,
   ): Promise<number> {
     return this.$exec("count", args) as Promise<number>;
+  }
+
+  static create<T extends Prisma.UserCreateArgs>(
+    args: Subset<T, Prisma.UserCreateArgs>,
+  ): Promise<Prisma.UserGetPayload<T>> {
+    return this.$exec("create", args) as Promise<Prisma.UserGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.UserUpdateArgs>(
+    args: Subset<T, Prisma.UserUpdateArgs>,
+  ): Promise<Prisma.UserGetPayload<T>> {
+    return this.$exec("update", args) as Promise<Prisma.UserGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.UserDeleteArgs>(
+    args: Subset<T, Prisma.UserDeleteArgs>,
+  ): Promise<Prisma.UserGetPayload<T>> {
+    return this.$exec("delete", args) as Promise<Prisma.UserGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.UserUpsertArgs>(
+    args: Subset<T, Prisma.UserUpsertArgs>,
+  ): Promise<Prisma.UserGetPayload<T>> {
+    return this.$exec("upsert", args) as Promise<Prisma.UserGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.UserCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.UserUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.UserDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
   }
 }

--- a/templates/saas-starter/app/models/writes.coercion.test.ts
+++ b/templates/saas-starter/app/models/writes.coercion.test.ts
@@ -1,0 +1,375 @@
+import { SQL } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DatabaseManager } from "gemi/database";
+import { Application } from "gemi/foundation";
+import { Model, clearPlanCache, register, type ModelSchema } from "gemi/orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import { POSTGRES_URL } from "./differential";
+
+/**
+ * Round-tripping every scalar type: write a value, read it back, and get the
+ * same JavaScript value out.
+ *
+ * `encode` is the mirror of iteration 1's `decode`, and the two are only
+ * correct *together* — a bug in one that exactly cancels a bug in the other is
+ * invisible to any test that uses the same code for both halves. So the write
+ * goes through the ORM and the read is checked against the raw driver as well.
+ *
+ * The template's own schema cannot exercise this: every column in it is an Int,
+ * a String or a DateTime. There is no Boolean, no Json, no BigInt and no Bytes.
+ * So this fixture is a database rather than a Prisma client, the same trade
+ * `relations.many-to-many.test.ts` records — the DDL below is what
+ * `prisma migrate` emits for the model in the comment.
+ *
+ * `Decimal` is absent on purpose: iteration 1 refuses it at *generation* time,
+ * because SQLite stores it as a REAL and the driver hands back a float
+ * pretending to be an arbitrary-precision decimal. There is a test for that
+ * refusal in `bin/orm/emit.test.ts`; a round-trip here would be asserting
+ * behaviour that cannot be reached.
+ *
+ * ```prisma
+ * model Everything {
+ *   id       Int      @id @default(autoincrement())
+ *   text     String
+ *   flag     Boolean  @default(false)
+ *   count    BigInt
+ *   ratio    Float
+ *   payload  Json
+ *   blob     Bytes
+ *   when     DateTime
+ *   optional String?
+ *   uid      String   @default(uuid())
+ *   made     DateTime @default(now())
+ *   touched  DateTime @updatedAt
+ * }
+ * ```
+ */
+
+const SQLITE_DDL = `CREATE TABLE "Everything" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "text" TEXT NOT NULL,
+    "flag" BOOLEAN NOT NULL DEFAULT false,
+    "count" BIGINT NOT NULL,
+    "ratio" REAL NOT NULL,
+    "payload" JSONB NOT NULL,
+    "blob" BLOB NOT NULL,
+    "when" DATETIME NOT NULL,
+    "optional" TEXT,
+    "uid" TEXT NOT NULL,
+    "made" DATETIME NOT NULL,
+    "touched" DATETIME NOT NULL
+)`;
+
+const POSTGRES_DDL = `CREATE TABLE "Everything" (
+    "id" SERIAL NOT NULL PRIMARY KEY,
+    "text" TEXT NOT NULL,
+    "flag" BOOLEAN NOT NULL DEFAULT false,
+    "count" BIGINT NOT NULL,
+    "ratio" DOUBLE PRECISION NOT NULL,
+    "payload" JSONB NOT NULL,
+    "blob" BYTEA NOT NULL,
+    "when" TIMESTAMP(3) NOT NULL,
+    "optional" TEXT,
+    "uid" TEXT NOT NULL,
+    "made" TIMESTAMP(3) NOT NULL,
+    "touched" TIMESTAMP(3) NOT NULL
+)`;
+
+function field(
+  name: string,
+  type: any,
+  extra: Record<string, unknown> = {},
+): any {
+  return {
+    name,
+    column: name,
+    type,
+    nullable: false,
+    isId: false,
+    isUpdatedAt: false,
+    ...extra,
+  };
+}
+
+const everything: ModelSchema = {
+  name: "Everything",
+  table: "Everything",
+  fields: {
+    id: field("id", "Int", { isId: true, default: { kind: "autoincrement" } }),
+    text: field("text", "String"),
+    flag: field("flag", "Boolean", { default: { kind: "value", value: false } }),
+    count: field("count", "BigInt"),
+    ratio: field("ratio", "Float"),
+    payload: field("payload", "Json"),
+    blob: field("blob", "Bytes"),
+    when: field("when", "DateTime"),
+    optional: field("optional", "String", { nullable: true }),
+    uid: field("uid", "String", { default: { kind: "uuid" } }),
+    made: field("made", "DateTime", { default: { kind: "now" } }),
+    touched: field("touched", "DateTime", { isUpdatedAt: true }),
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {},
+};
+
+class EverythingModel extends Model {
+  static $schema = everything;
+}
+
+const WHEN = new Date("2021-03-04T05:06:07.008Z");
+
+function suite(label: string, url?: string) {
+  describe(label, () => {
+    let workspace: string | undefined;
+    let database: DatabaseManager;
+    let raw: SQL;
+    let previous: Application | undefined;
+
+    beforeAll(async () => {
+      let target = url;
+      if (!target) {
+        workspace = mkdtempSync(join(tmpdir(), "gemi-orm-coercion-"));
+        target = `sqlite://${join(workspace, "coercion.db")}`;
+      }
+
+      database = new DatabaseManager({ url: target });
+      raw = new SQL(target);
+
+      await raw.unsafe(`DROP TABLE IF EXISTS "Everything"`);
+      await raw.unsafe(url ? POSTGRES_DDL : SQLITE_DDL);
+
+      previous = Application.getInstance();
+      const application = new Application();
+      application.instance(DatabaseManager, database as never);
+      Application.setInstance(application);
+
+      register("Everything", EverythingModel);
+    }, 120_000);
+
+    afterAll(async () => {
+      await raw?.unsafe(`DROP TABLE IF EXISTS "Everything"`).catch(() => {});
+      await raw?.close();
+      await database?.close();
+      if (previous) Application.setInstance(previous);
+      if (workspace) rmSync(workspace, { recursive: true, force: true });
+    });
+
+    beforeEach(async () => {
+      clearPlanCache();
+      await raw.unsafe(`DELETE FROM "Everything"`);
+    });
+
+    const values = {
+      text: "hello",
+      flag: true,
+      count: 9007199254740991n,
+      ratio: 1.5,
+      payload: { nested: { list: [1, 2, 3] }, flag: true },
+      blob: new Uint8Array([0, 1, 2, 253, 254, 255]),
+      when: WHEN,
+      optional: null,
+    };
+
+    test("every scalar type round-trips through create", async () => {
+      const created: any = await EverythingModel.$exec("create", {
+        data: values,
+      });
+
+      // Written and returned in one statement, straight off RETURNING.
+      expect(created.text).toBe("hello");
+      expect(created.flag).toBe(true);
+      expect(created.count).toBe(9007199254740991n);
+      expect(created.ratio).toBe(1.5);
+      expect(created.payload).toEqual(values.payload);
+      expect([...created.blob]).toEqual([...values.blob]);
+      expect(created.when).toBeInstanceOf(Date);
+      expect(created.when.getTime()).toBe(WHEN.getTime());
+      expect(created.optional).toBeNull();
+
+      // And read back on a second statement, which is the half that proves
+      // `encode` and `decode` agree with the *database* rather than only with
+      // each other.
+      const read: any = await EverythingModel.$exec("findUniqueOrThrow", {
+        where: { id: created.id },
+      });
+      expect(read.flag).toBe(true);
+      expect(read.count).toBe(9007199254740991n);
+      expect(read.ratio).toBe(1.5);
+      expect(read.payload).toEqual(values.payload);
+      expect([...read.blob]).toEqual([...values.blob]);
+      expect(read.when.getTime()).toBe(WHEN.getTime());
+      expect(read.optional).toBeNull();
+    });
+
+    // A known driver limitation, pinned rather than avoided. Bun's SQLite
+    // driver truncates an integer parameter above 2^53 on the way in — it binds
+    // through a double — so a BigInt past that loses its low bits. It is not
+    // something `encode` can correct at the parameter level, and a raw
+    // `db.sql` query through the same driver behaves identically. The note is
+    // in orm/dialect/sqlite.ts; this is the executable half of it.
+    //
+    // Postgres binds bigints natively and is exact, which is why the assertion
+    // splits by dialect rather than being skipped.
+    test("BigInt past 2^53 is exact on postgres, truncated on sqlite", async () => {
+      const beyond = 9007199254740993n; // 2^53 + 1
+      const created: any = await EverythingModel.$exec("create", {
+        data: { ...values, count: beyond },
+      });
+
+      if (url) {
+        expect(created.count).toBe(beyond);
+      } else {
+        expect(created.count).toBe(9007199254740992n);
+      }
+    });
+
+    test("false and zero survive, rather than falling back to a default", async () => {
+      const created: any = await EverythingModel.$exec("create", {
+        data: { ...values, flag: false, ratio: 0, count: 0n, text: "" },
+      });
+      expect(created.flag).toBe(false);
+      expect(created.ratio).toBe(0);
+      expect(created.count).toBe(0n);
+      expect(created.text).toBe("");
+    });
+
+    test("client-side defaults are generated on create", async () => {
+      const created: any = await EverythingModel.$exec("create", {
+        data: values,
+      });
+
+      expect(created.uid).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
+      expect(created.made).toBeInstanceOf(Date);
+      expect(created.touched).toBeInstanceOf(Date);
+      // `now()` and `@updatedAt` are one instant for one logical operation.
+      expect(created.made.getTime()).toBe(created.touched.getTime());
+      // The `@default(false)` static value, applied client-side.
+      expect(created.flag).toBe(true);
+    });
+
+    test("@updatedAt advances on update while now() stays put", async () => {
+      const created: any = await EverythingModel.$exec("create", {
+        data: values,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      const updated: any = await EverythingModel.$exec("update", {
+        where: { id: created.id },
+        data: { text: "changed" },
+      });
+
+      expect(updated.made.getTime()).toBe(created.made.getTime());
+      expect(updated.touched.getTime()).toBeGreaterThan(
+        created.touched.getTime(),
+      );
+    });
+
+    test("values round-trip through update too", async () => {
+      const created: any = await EverythingModel.$exec("create", {
+        data: values,
+      });
+
+      const updated: any = await EverythingModel.$exec("update", {
+        where: { id: created.id },
+        data: {
+          flag: false,
+          count: -42n,
+          payload: [1, "two", null],
+          blob: new Uint8Array([9, 8, 7]),
+          when: new Date("1999-12-31T23:59:59.999Z"),
+          optional: "now set",
+        },
+      });
+
+      expect(updated.flag).toBe(false);
+      expect(updated.count).toBe(-42n);
+      expect(updated.payload).toEqual([1, "two", null]);
+      expect([...updated.blob]).toEqual([9, 8, 7]);
+      expect(updated.when.toISOString()).toBe("1999-12-31T23:59:59.999Z");
+      expect(updated.optional).toBe("now set");
+    });
+
+    test("createMany round-trips every row", async () => {
+      const result: any = await EverythingModel.$exec("createMany", {
+        data: [
+          { ...values, text: "one", count: 1n },
+          { ...values, text: "two", count: 2n, flag: false },
+        ],
+      });
+      expect(result).toEqual({ count: 2 });
+
+      const rows: any = await EverythingModel.$exec("findMany", {
+        orderBy: { id: "asc" },
+      });
+      expect(rows.map((row: any) => row.text)).toEqual(["one", "two"]);
+      expect(rows.map((row: any) => row.count)).toEqual([1n, 2n]);
+      expect(rows.map((row: any) => row.flag)).toEqual([true, false]);
+      // Each row gets its own uuid, not one shared across the statement.
+      expect(rows[0].uid).not.toBe(rows[1].uid);
+    });
+
+    test("a value written by gemi reads the same through the raw driver", async () => {
+      const created: any = await EverythingModel.$exec("create", {
+        data: values,
+      });
+
+      const [row]: any = await raw.unsafe(
+        `select "flag", "when", "payload" from "Everything" where "id" = ${
+          url ? "$1" : "?"
+        }`,
+        [created.id],
+      );
+
+      // The storage form, not the decoded one: Prisma stores a SQLite DateTime
+      // as integer milliseconds and a Boolean as 0/1, and matching that is what
+      // makes a gemi-written row readable by the Prisma client.
+      if (url) {
+        expect(row.flag).toBe(true);
+        expect(row.when).toBeInstanceOf(Date);
+      } else {
+        expect(row.when).toBe(WHEN.getTime());
+        expect(Number(row.flag)).toBe(1);
+        expect(typeof row.payload).toBe("string");
+        expect(JSON.parse(row.payload)).toEqual(values.payload);
+      }
+    });
+
+    test("delete returns the row it removed, fully decoded", async () => {
+      const created: any = await EverythingModel.$exec("create", {
+        data: values,
+      });
+
+      const deleted: any = await EverythingModel.$exec("delete", {
+        where: { id: created.id },
+      });
+      expect(deleted.count).toBe(9007199254740991n);
+      expect([...deleted.blob]).toEqual([...values.blob]);
+
+      expect(await EverythingModel.$exec("count", {})).toBe(0);
+    });
+  });
+}
+
+suite("write coercion — sqlite");
+
+if (POSTGRES_URL) {
+  suite("write coercion — postgres", POSTGRES_URL);
+} else {
+  describe("write coercion — postgres", () => {
+    test("SKIPPED — set TEST_POSTGRES_URL to run the Postgres dialect", () => {
+      console.warn(
+        "\n  ⚠  Postgres write coercion tests did NOT run.\n" +
+          "     Set TEST_POSTGRES_URL to a scratch database to cover the " +
+          "postgres dialect.\n",
+      );
+      expect(POSTGRES_URL).toBeUndefined();
+    });
+  });
+}

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -1,0 +1,506 @@
+import type { PrismaClient } from "@prisma/client";
+import { UniqueConstraintError } from "gemi/orm";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import {
+  POSTGRES_URL,
+  createDifferential,
+  type Differential,
+} from "./differential";
+import {
+  AccountModel,
+  OrganizationModel,
+  SocialAccountModel,
+  UserModel,
+} from "./generated";
+
+/**
+ * The write surface, run through Prisma and through gemi against the same
+ * schema, and compared on both what it returned *and* what it left in the
+ * table.
+ *
+ * The second half is the one that earns its keep: `updateMany` returns nothing
+ * but a count, and a `create` that binds the right values into the wrong
+ * columns returns a payload that looks entirely correct. Only reading the rows
+ * back catches either.
+ */
+
+const EPOCH = 1600000000000;
+
+async function seed(prisma: PrismaClient) {
+  await prisma.organization.createMany({
+    data: [
+      { publicId: "o1", name: "Acme" },
+      { publicId: "o2", name: "Globex" },
+    ],
+  });
+  const [acme] = await prisma.organization.findMany({ orderBy: { id: "asc" } });
+
+  await prisma.user.createMany({
+    data: [
+      {
+        publicId: "p1",
+        name: "Ada",
+        email: "ada@example.dev",
+        globalRole: 0,
+        organizationId: acme.id,
+        createdAt: new Date(EPOCH),
+        updatedAt: new Date(EPOCH),
+      },
+      {
+        publicId: "p2",
+        name: "Grace",
+        email: "grace@example.dev",
+        globalRole: 1,
+        createdAt: new Date(EPOCH + 1000),
+        updatedAt: new Date(EPOCH + 1000),
+      },
+      {
+        publicId: "p3",
+        name: null,
+        email: null,
+        globalRole: 2,
+        createdAt: new Date(EPOCH + 2000),
+        updatedAt: new Date(EPOCH + 2000),
+      },
+    ],
+  });
+}
+
+/** `[name, operation, args, tables]` — tables default to the model written. */
+type Case = [string, string, unknown, string[]?];
+
+const CASES: Case[] = [
+  // --- create -----------------------------------------------------------
+  ["create minimal", "create", { data: { email: "new@example.dev" } }],
+  ["create with every scalar kind", "create", {
+    data: {
+      name: "New",
+      email: "n2@example.dev",
+      globalRole: 1,
+      locale: "fr-FR",
+      emailVerifiedAt: new Date(EPOCH + 100),
+      password: "secret",
+    },
+  }],
+  // A nullable column explicitly set to null must stay null, not fall back to
+  // a default — the difference between `?? default` and a key-presence check.
+  ["create with an explicit null", "create", {
+    data: { email: "n3@example.dev", locale: null },
+  }],
+  ["create overriding a cuid default", "create", {
+    data: { publicId: "explicit-id", email: "n4@example.dev" },
+  }],
+  ["create overriding the timestamps", "create", {
+    data: {
+      email: "n5@example.dev",
+      createdAt: new Date(EPOCH + 777),
+      updatedAt: new Date(EPOCH + 888),
+    },
+  }],
+  ["create with select", "create", {
+    data: { email: "n6@example.dev" }, select: { email: true, globalRole: true },
+  }],
+  ["create with include", "create", {
+    data: { email: "n7@example.dev" }, include: { accounts: true },
+  }],
+  ["create violating a unique", "create", {
+    data: { email: "ada@example.dev" },
+  }],
+
+  // --- createMany -------------------------------------------------------
+  ["createMany two rows", "createMany", {
+    data: [{ email: "m1@example.dev" }, { email: "m2@example.dev" }],
+  }],
+  ["createMany one row", "createMany", { data: [{ email: "m3@example.dev" }] }],
+  ["createMany empty", "createMany", { data: [] }],
+  // Legal in Prisma, and the case a single multi-row INSERT cannot express
+  // directly: the union of keys, with defaults filled per row.
+  ["createMany mixed key sets", "createMany", {
+    data: [
+      { email: "m4@example.dev", name: "Has a name" },
+      { email: "m5@example.dev" },
+      { email: "m6@example.dev", globalRole: 1, locale: "de-DE" },
+    ],
+  }],
+  ["createMany a single object", "createMany", {
+    data: { email: "m7@example.dev" },
+  }],
+
+  // --- update -----------------------------------------------------------
+  ["update by id", "update", { where: { id: 1 }, data: { name: "Renamed" } }],
+  ["update by another unique", "update", {
+    where: { publicId: "p2" }, data: { name: "Renamed" },
+  }],
+  ["update to null", "update", { where: { id: 1 }, data: { name: null } }],
+  ["update several fields", "update", {
+    where: { id: 1 }, data: { name: "N", globalRole: 2, locale: "es-ES" },
+  }],
+  ["update with set", "update", {
+    where: { id: 1 }, data: { name: { set: "Via set" } },
+  }],
+  ["update with increment", "update", {
+    where: { id: 1 }, data: { globalRole: { increment: 2 } },
+  }],
+  ["update with decrement", "update", {
+    where: { id: 2 }, data: { globalRole: { decrement: 1 } },
+  }],
+  ["update with multiply", "update", {
+    where: { id: 3 }, data: { globalRole: { multiply: 3 } },
+  }],
+  ["update matching nothing", "update", {
+    where: { id: 99999 }, data: { name: "x" },
+  }],
+  ["update with select", "update", {
+    where: { id: 1 }, data: { name: "S" }, select: { id: true, name: true },
+  }],
+  ["update with include", "update", {
+    where: { id: 1 }, data: { name: "S" }, include: { organization: true },
+  }],
+  ["update onto a unique collision", "update", {
+    where: { id: 2 }, data: { email: "ada@example.dev" },
+  }],
+
+  // --- updateMany -------------------------------------------------------
+  ["updateMany several", "updateMany", {
+    where: { globalRole: { gte: 0 } }, data: { locale: "it-IT" },
+  }],
+  ["updateMany one", "updateMany", {
+    where: { publicId: "p1" }, data: { name: "Only" },
+  }],
+  ["updateMany none", "updateMany", {
+    where: { publicId: "nope" }, data: { name: "x" },
+  }],
+  ["updateMany with no where", "updateMany", { data: { globalRole: 2 } }],
+  ["updateMany with increment", "updateMany", {
+    where: { globalRole: { lt: 2 } }, data: { globalRole: { increment: 1 } },
+  }],
+
+  // --- delete -----------------------------------------------------------
+  ["delete by id", "delete", { where: { id: 3 } }],
+  ["delete by another unique", "delete", { where: { publicId: "p3" } }],
+  ["delete matching nothing", "delete", { where: { id: 99999 } }],
+  ["delete with select", "delete", {
+    where: { id: 3 }, select: { publicId: true },
+  }],
+
+  // --- deleteMany -------------------------------------------------------
+  ["deleteMany several", "deleteMany", { where: { globalRole: { gte: 1 } } }],
+  ["deleteMany none", "deleteMany", { where: { publicId: "nope" } }],
+  ["deleteMany empty where", "deleteMany", { where: {} }],
+
+  // --- upsert -----------------------------------------------------------
+  ["upsert inserting", "upsert", {
+    where: { email: "fresh@example.dev" },
+    create: { email: "fresh@example.dev", name: "Fresh" },
+    update: { name: "Updated" },
+  }],
+  ["upsert updating", "upsert", {
+    where: { email: "ada@example.dev" },
+    create: { email: "ada@example.dev", name: "Fresh" },
+    update: { name: "Updated" },
+  }],
+  ["upsert updating by id", "upsert", {
+    where: { id: 1 },
+    create: { id: 1, email: "other@example.dev" },
+    update: { globalRole: { increment: 5 } },
+  }],
+  ["upsert with select", "upsert", {
+    where: { email: "ada@example.dev" },
+    create: { email: "ada@example.dev" },
+    update: { name: "U" },
+    select: { name: true },
+  }],
+];
+
+function suite(label: string, url?: string) {
+  describe(label, () => {
+    let differential: Differential;
+
+    beforeAll(async () => {
+      differential = await createDifferential({
+        models: {
+          User: UserModel as never,
+          SocialAccount: SocialAccountModel as never,
+          Account: AccountModel as never,
+          Organization: OrganizationModel as never,
+        },
+        seed,
+        url,
+      });
+    }, 120_000);
+
+    afterAll(async () => {
+      await differential?.dispose();
+    });
+
+    test.each(CASES)("%s", async (_name, operation, args, tables) => {
+      await differential.expectSameWrite("User", operation, args, { tables });
+    });
+
+    // Writing through a model whose `@@unique` is composite, which is the only
+    // way to reach the compound conflict target.
+    test("upsert on a model with a composite unique", async () => {
+      await differential.expectSameWrite(
+        "Organization",
+        "upsert",
+        {
+          where: { publicId: "o1" },
+          create: { publicId: "o1", name: "Created" },
+          update: { name: "Updated" },
+        },
+        { tables: ["Organization"] },
+      );
+    });
+
+    test("create on a model with no @updatedAt", async () => {
+      await differential.expectSameWrite(
+        "Organization",
+        "create",
+        { data: { name: "No timestamps here" } },
+        { tables: ["Organization"] },
+      );
+    });
+
+    // --- nested writes --------------------------------------------------
+    //
+    // NOT ATOMIC in this iteration: each of these is more than one statement
+    // with no transaction around it. Iteration 5 closes that at the `$exec`
+    // choke point; the results are already correct, only the failure mode is
+    // not. Recorded here as well as in the code so it is visible from the test.
+
+    test("nested connect on the owning side sets the foreign key", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "connected@example.dev",
+            organization: { connect: { id: 1 } },
+          },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    test("nested connect by a non-referenced unique resolves first", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "connected2@example.dev",
+            organization: { connect: { publicId: "o2" } },
+          },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    test("nested create on the owning side writes the parent first", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "nested@example.dev",
+            organization: { create: { name: "Created by nesting" } },
+          },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    test("nested create on the foreign side writes the children after", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "parent@example.dev",
+            accounts: { create: [{ organizationRole: 1 }, { organizationRole: 2 }] },
+          },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("nested create on the foreign side, read back through include", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "parent2@example.dev",
+            accounts: { create: { organizationRole: 1 } },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("nested connect on the foreign side repoints the child", async () => {
+      await differential.reset();
+      await differential.prisma.account.create({
+        data: { publicId: "loose", organizationRole: 2 },
+      });
+
+      const account = await differential.prisma.account.findFirstOrThrow({
+        where: { publicId: "loose" },
+      });
+      expect(account.userId).toBeNull();
+
+      await UserModel.update({
+        where: { id: 1 },
+        data: { accounts: { connect: { publicId: "loose" } } },
+      });
+
+      const after = await differential.prisma.account.findFirstOrThrow({
+        where: { publicId: "loose" },
+      });
+      expect(after.userId).toBe(1);
+    });
+
+    test("a select that omits the stitch key does not leak it", async () => {
+      await differential.reset();
+      const created = await UserModel.create({
+        data: {
+          email: "hidden@example.dev",
+          accounts: { create: { organizationRole: 1 } },
+        },
+        select: { email: true },
+      });
+      expect(Object.keys(created)).toEqual(["email"]);
+    });
+
+    // --- typed errors ---------------------------------------------------
+
+    test("a unique violation is typed, catchable, and names the field", async () => {
+      await differential.reset();
+      await expect(
+        UserModel.create({ data: { email: "ada@example.dev" } }),
+      ).rejects.toThrow(UniqueConstraintError);
+
+      try {
+        await UserModel.create({ data: { email: "ada@example.dev" } });
+        expect.unreachable("expected a unique violation");
+      } catch (error) {
+        expect(error).toBeInstanceOf(UniqueConstraintError);
+        // Field names, the way Prisma's `meta.target` reports them — not the
+        // database's column names, which the caller has never seen.
+        expect((error as UniqueConstraintError).fields).toEqual(["email"]);
+        expect((error as UniqueConstraintError).model).toBe("User");
+      }
+    });
+
+    test("a composite unique violation names every field", async () => {
+      await differential.reset();
+      const base = {
+        userId: 1,
+        provider: "github",
+        providerId: "gh-1",
+        username: "ada",
+        accessToken: "t",
+        refreshToken: "r",
+        expiresAt: new Date(EPOCH),
+      };
+      await SocialAccountModel.create({ data: base });
+
+      try {
+        await SocialAccountModel.create({
+          data: { ...base, providerId: "gh-2" },
+        });
+        expect.unreachable("expected a unique violation");
+      } catch (error) {
+        expect(error).toBeInstanceOf(UniqueConstraintError);
+        expect((error as UniqueConstraintError).fields.sort()).toEqual([
+          "provider",
+          "username",
+        ]);
+      }
+    });
+
+    // A NOT NULL failure travels the same driver path as a unique one — same
+    // exception type on SQLite, same SQLSTATE class on Postgres — and must not
+    // be reported as a duplicate key.
+    test("a not-null violation is not reported as a unique violation", async () => {
+      await differential.reset();
+      await expect(
+        // `publicId` is NOT NULL in the DDL. Supplied explicitly, so the
+        // compiler passes it through and the database is what rejects it.
+        UserModel.create({ data: { email: "nn@example.dev", publicId: null } }),
+      ).rejects.not.toBeInstanceOf(UniqueConstraintError);
+    });
+
+    // The two upsert shapes that `on conflict` cannot express, refused rather
+    // than silently turned into an insert. See compileUpsert.
+    test("upsert whose create omits the conflict key is refused", async () => {
+      await differential.reset();
+      await expect(
+        UserModel.upsert({
+          where: { id: 1 },
+          create: { email: "x@example.dev" },
+          update: { name: "N" },
+        }),
+      ).rejects.toThrow(/could never conflict on that key/);
+    });
+
+    test("upsert whose create disagrees with the where key is refused", async () => {
+      await differential.reset();
+      await expect(
+        UserModel.upsert({
+          where: { email: "ada@example.dev" },
+          create: { email: "different@example.dev" },
+          update: { name: "N" },
+        }),
+      ).rejects.toThrow(/must agree on the key/);
+    });
+
+    // --- the plan cache -------------------------------------------------
+
+    test("a create is one plan whatever the values are", async () => {
+      await differential.reset();
+      const { clearPlanCache, planCacheStats } = await import("gemi/orm");
+
+      clearPlanCache();
+      await UserModel.create({ data: { email: "c1@example.dev" } });
+      await UserModel.create({ data: { email: "c2@example.dev" } });
+      await UserModel.create({ data: { email: "c3@example.dev" } });
+      expect(planCacheStats().compiles).toBe(1);
+      expect(planCacheStats().hits).toBe(2);
+
+      // A different field set is a different statement, so it must not reuse it.
+      await UserModel.create({ data: { email: "c4@example.dev", name: "N" } });
+      expect(planCacheStats().compiles).toBe(2);
+    });
+
+    // The harness itself: if `expectSameWrite` compared nothing, every case
+    // above would pass vacuously.
+    test("the harness actually catches a divergent write", async () => {
+      await differential.reset();
+      const before = await differential.prisma.user.count();
+      await UserModel.create({ data: { email: "guard@example.dev" } });
+      expect(await differential.prisma.user.count()).toBe(before + 1);
+    });
+  });
+}
+
+suite("writes vs prisma — sqlite");
+
+if (POSTGRES_URL) {
+  suite("writes vs prisma — postgres", POSTGRES_URL);
+} else {
+  describe("writes vs prisma — postgres", () => {
+    // Deliberately loud rather than `test.skip`: a silently skipped dialect
+    // reads as a passing one in CI output.
+    test("SKIPPED — set TEST_POSTGRES_URL to run the Postgres dialect", () => {
+      console.warn(
+        "\n  ⚠  Postgres write differential tests did NOT run.\n" +
+          "     Set TEST_POSTGRES_URL to a scratch database to cover the " +
+          "postgres dialect.\n",
+      );
+      expect(POSTGRES_URL).toBeUndefined();
+    });
+  });
+}


### PR DESCRIPTION
Iteration 4 of [the ORM plan](../blob/feat/orm/plans/orm/04-writes.md). Stacked on #47 — **review that first, and merge this into `feat/orm-03-motorcycle`**.

After this, the ORM covers everything the template application actually does today, which makes it the first point at which a real migration off the Prisma client is conceivable.

## What this adds

The full write surface — `create`, `createMany`, `update`, `updateMany`, `delete`, `deleteMany`, `upsert` — with client-side defaults, `@updatedAt`, `RETURNING`, and `select` / `include` on the returned record.

```
orm/compile/write.ts           the seven operations
orm/compile/nested-writes.ts   connect and shallow create, both directions
orm/compile/unique.ts          the unique-key matcher, lifted out of read.ts
orm/defaults.ts                cuid v1, uuid, now, @updatedAt
```

Everything runs through `Model.$exec` (invariant 1) and compiles through the same shape/value split as the reads (invariant 2): a `create` with the same field set is one plan whatever the values are, and no value is ever inlined into the SQL text — there is a test asserting no digit appears outside an identifier.

`compile/` stays a pure schema-in / SQL-out directory. Nested writes are planned there as `before` / `after` steps and *run* by the choke point, so the compiler still needs no database and no runtime import.

## Four decisions, each recorded where the code makes them

**Multi-statement writes are not atomic.** A nested `create` is more than one statement with no transaction around it: if a later step fails, the earlier rows stay written. This is a recorded decision rather than an oversight — iteration 5 introduces the ambient-transaction ALS at the choke point and makes every one of these atomic without changing a call site. Building an interim mechanism now would be work iteration 5 deletes. Noted at `NestedWriteStep`, in `$exec`, and in the test suite.

**Errors are gemi's own, not Prisma's codes.** `UniqueConstraintError` is typed, catchable, and names the fields — as *field* names, the way Prisma's `meta.target` does, not the database columns the driver reported. Mirroring `P2002` would ease migration for code that branches on it, but nothing in this repository does (checked), and carrying a `P` code implies the other fifty are implemented too.

**Row counts come from `RETURNING`, not driver metadata.** Measured rather than assumed: Bun's SQLite driver leaves `affectedRows` **null** on every statement and puts the number on an undocumented `count` property, neither of which is verifiable against Postgres from here. Counting the returned rows is one statement shape on every dialect and depends on nothing undocumented. It costs one key column per affected row on the wire — a real cost on a very large `deleteMany`, which iteration 7 can revisit with a benchmark rather than a guess.

**`createMany` fills defaults explicitly rather than grouping rows.** Prisma allows rows with different key sets in one call; the column list becomes the union, and a row missing one gets its client-side default or `NULL`. The single case that cannot be filled is a column with a *database* default that some rows supply and others do not — `NULL` would overwrite the default rather than request it, and the `DEFAULT` keyword is not available (SQLite: `near "DEFAULT": syntax error`). That case is refused by name rather than silently written wrong.

## Three bugs a real Postgres found, that SQLite could not

I ran the suite against Postgres 16 in Docker rather than trusting the loud skip. All three were live before that:

1. **Unique violations never registered on Postgres.** Bun puts the SQLSTATE on `errno`; `code` holds its own `ERR_POSTGRES_SERVER_ERROR`. Matching on `code` — the obvious reading, and what the Postgres manual would lead you to — matched nothing at all, so every violation escaped as a raw driver error.
2. **`on conflict do update set "n" = "n" + $1` is rejected as ambiguous.** Inside a conflict clause Postgres has both the existing row and `excluded` in scope, so the right-hand side has to name its table. SQLite accepts either form, and so does Postgres in a plain `update` — so the qualifier is applied where it is needed rather than everywhere.
3. **`upsert` diverged silently.** `on conflict` only fires if the insert actually collides, so `upsert({ where: { id: 1 }, create: { email } })` inserted where Prisma updated — the `create` supplies no `id`, so the update branch was unreachable. Now refused at compile time, plus a bind-time check that `where` and `create` agree on the key (compilation can prove the key is *present*, but not that it holds the same value — values do not exist at compile time).

And one more from the coercion fixture: **Postgres returns `BIGINT` as a string and `jsonb` as unparsed text**, where Prisma returns a `BigInt` and an object. The dialect had `needsDecode` false for everything, which was correct for every column the template's schema happens to have.

## Tests

- **Compiler units** — exact SQL text and parameters per dialect for all seven operations, including the multi-row column-order case, which is a data-corruption-shaped bug rather than an error: with the column list taken from row one and values taken per row by key order, a row written in a different key order binds into the wrong columns.
- **A write differential harness** comparing both the returned value *and* the resulting table contents against Prisma. The second half earns its keep: `updateMany` returns only a count, and a `create` that binds the right values into the wrong columns returns a perfectly plausible payload. Generated values are compared by *descriptor* — length and prefix — so a cuid shaped differently from Prisma's still fails.
- **Round-trip coercion** for every scalar type through a fixture schema, since the template has no Boolean, Json, BigInt or Bytes column. Decimal is absent on purpose: iteration 1 refuses it at generation time.
- **Plan-cache discrimination** over the write shapes, where a collision means wrong rows *written* rather than wrong rows read.

Verified on SQLite and on Postgres 16 through Docker:

| | |
|---|---|
| `packages/gemi` | 449 passed |
| `templates/saas-starter` | 219 passed (was 151) |
| Postgres, serial | 232 passed |
| `tsc` / `oxlint` | clean, 0 findings in ORM |

The 7 failures in `packages/gemi` are the pre-existing router/i18n ones, byte-identical to the baseline taken before this work and untouched by it.

## Notes for the reviewer

- **Postgres needs `--no-file-parallelism`.** Every suite points at the one database `TEST_POSTGRES_URL` names, and the write suites truncate it between cases; run in parallel, one file empties the tables another is reading. Documented in the harness. On SQLite each suite builds its own file, so the flag is unnecessary.
- **`prisma generate` runs the *built* generator** from `dist/bin/orm-generator.js`, not the source. `bun run build:bin` is required before regenerating after any `emit.ts` change — otherwise you get a confusing no-op diff.
- **`read.ts` shrank by ~116 lines.** `withKeyFields` moved to `select.ts` and the unique-key assertion to `unique.ts`, so the writes reuse them instead of growing parallel copies. No behaviour change; the read suite is unchanged and green.
- `Binder` gained a second parameter, a per-call `BindContext`. Existing binders ignore it and remain assignable. It carries the one instant a logical operation shares — Prisma returns `createdAt` and `updatedAt` from a single `create` as the *same* instant, verified against 6.19.2 — and whatever the `before` steps resolved.
- The generated artifacts are committed and regenerate byte-identically; flipping the datasource to postgresql and regenerating produces no diff, which is the dialect-agnosticism rule holding.

## Out of scope, deliberately

Deep nested writes (`connectOrCreate`, `set`, `disconnect`, nested `update` / `upsert` / `deleteMany`) — each throws `UnsupportedQueryError` naming itself. Cascade emulation, MySQL/MariaDB write paths, transactions (iteration 5), policies on writes (iteration 6). `skipDuplicates` on `createMany` throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqZNWz1c22s3iLyKEKCyJg
