### PR TITLE
ORM iteration 5 — ambient transactions, on two dialects

### DIFF
--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -79,11 +79,36 @@ function scalarType(model: string, field: DMMF.Field): ScalarType {
   return mapped;
 }
 
+/**
+ * Is this DMMF default a *function* call — `autoincrement()`, `cuid()`, `now()`
+ * — rather than a literal or a list?
+ *
+ * A hand-written predicate rather than the inline
+ * `typeof value === "object" && !Array.isArray(value)` this replaces, for two
+ * reasons. TypeScript does not narrow a `readonly T[]` out of a union through
+ * `Array.isArray`, whose signature asserts `arg is any[]` — so the inline form
+ * left `value.name` unresolved, which is the error that surfaced the moment
+ * `bin/orm` entered the tsconfig. And `typeof null === "object"`, so the inline
+ * form would have dereferenced a null default rather than falling through to
+ * the literal branch.
+ */
+function isFunctionDefault(
+  value: unknown,
+): value is { name: string; args: readonly (string | number)[] } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    "name" in value &&
+    typeof (value as { name: unknown }).name === "string"
+  );
+}
+
 function defaultSpec(field: DMMF.Field): DefaultSpec | undefined {
   if (!field.hasDefaultValue || field.default === undefined) return undefined;
 
   const value = field.default;
-  if (typeof value === "object" && !Array.isArray(value)) {
+  if (isFunctionDefault(value)) {
     switch (value.name) {
       case "autoincrement":
       case "cuid":

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -91,17 +91,21 @@ function scalarType(model: string, field: DMMF.Field): ScalarType {
  * `bin/orm` entered the tsconfig. And `typeof null === "object"`, so the inline
  * form would have dereferenced a null default rather than falling through to
  * the literal branch.
+ *
+ * Note it does **not** additionally require a string `name`, though the first
+ * version of it did. That looked like a tightening and was a behaviour change:
+ * an object default carrying no `name` used to reach `switch (undefined)` and
+ * come out as `{ kind: "dbgenerated" }`, and requiring the name sent it to
+ * `{ kind: "value" }` instead. DMMF's `FieldDefault` always carries one, so
+ * neither path is reachable — but the two are not equally safe if it ever is:
+ * `dbgenerated` omits the column and lets the database supply it, while `value`
+ * would try to bind the object itself as the column's value. The safer of two
+ * unreachable branches is still the one to keep.
  */
 function isFunctionDefault(
   value: unknown,
-): value is { name: string; args: readonly (string | number)[] } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    "name" in value &&
-    typeof (value as { name: unknown }).name === "string"
-  );
+): value is { name?: string; args?: readonly (string | number)[] } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function defaultSpec(field: DMMF.Field): DefaultSpec | undefined {

--- a/packages/gemi/facades/DB.ts
+++ b/packages/gemi/facades/DB.ts
@@ -1,6 +1,7 @@
 import type { SQL } from "bun";
 import { DatabaseManager } from "../database/DatabaseManager";
 import type { Dialect } from "../database/dialect";
+import { withTransaction } from "../orm/context";
 import { Facade } from "./Facade";
 
 // Access to the app's database connection. Bun's `SQL` client is a tagged
@@ -29,9 +30,19 @@ export class DB extends Facade {
   }
 
   // Runs the callback inside a transaction, committing when it resolves and
-  // rolling back if it throws.
+  // rolling back if it throws. The callback still receives the raw handle, as
+  // it always has.
+  //
+  // It goes through the ORM's `withTransaction` rather than straight to
+  // `sql.begin` so that the two transaction systems are one: a `User.create`
+  // inside a `DB.transaction` joins it instead of committing separately on a
+  // pooled connection, and a `DB.transaction` nested inside a
+  // `Model.transaction` becomes a savepoint instead of throwing (Bun refuses
+  // `begin` inside a transaction). Two systems that silently ignored each other
+  // would be worse than either alone — a rollback would leave half the work
+  // committed.
   static transaction<T>(fn: (tx: SQL) => Promise<T>): Promise<T> {
-    return this.sql.begin(fn as any) as Promise<T>;
+    return withTransaction(this.sql, fn as (tx: SQL) => Promise<T>);
   }
 
   static close(): Promise<void> {

--- a/packages/gemi/kernel/context.ts
+++ b/packages/gemi/kernel/context.ts
@@ -1,3 +1,35 @@
 import { AsyncLocalStorage } from "async_hooks";
 
+/**
+ * The kernel's AsyncLocalStorage. It holds the Application, and nothing else —
+ * `Kernel.run()` enters it once per request, websocket message or cron tick,
+ * and `foundation/app.ts` reads it to resolve services.
+ *
+ * There was exactly one AsyncLocalStorage in the framework until iteration 5 of
+ * the ORM. There are now two, and this note is here so that claim does not
+ * quietly become false where someone would otherwise still be relying on it.
+ *
+ * The second is `packages/gemi/orm/context.ts`, holding an open transaction
+ * handle and its nesting depth. It is deliberately separate rather than merged
+ * into this one:
+ *
+ * - A transaction scope nests *inside* an Application scope without replacing
+ *   it. Re-entering this store with a `{ app, tx }` wrapper would mean every
+ *   reader of it — `app()` above all — has to handle two shapes forever, and a
+ *   miss there is not a transaction bug, it is a service resolving off the
+ *   wrong Application.
+ * - The alternative of hanging the handle off the Application is worse than a
+ *   style question: one Application serves every concurrent request, so two
+ *   overlapping transactions would overwrite each other's handle and statements
+ *   would land in the wrong one. That is silent data corruption.
+ *
+ * The cost is honest: two stores on the hot path of every query instead of one.
+ * The ORM's is shallow — one small object, entered only inside
+ * `Model.transaction` or `DB.transaction`, never per request — so a query
+ * outside a transaction pays one `getStore()` returning undefined.
+ *
+ * If a third is ever proposed, this is the note to read first: the bar is that
+ * the state is genuinely per-async-scope *and* cannot live in an existing
+ * store without making that store's readers ambiguous.
+ */
 export const kernelContext = new AsyncLocalStorage();

--- a/packages/gemi/kernel/context.ts
+++ b/packages/gemi/kernel/context.ts
@@ -5,13 +5,22 @@ import { AsyncLocalStorage } from "async_hooks";
  * `Kernel.run()` enters it once per request, websocket message or cron tick,
  * and `foundation/app.ts` reads it to resolve services.
  *
- * There was exactly one AsyncLocalStorage in the framework until iteration 5 of
- * the ORM. There are now two, and this note is here so that claim does not
- * quietly become false where someone would otherwise still be relying on it.
+ * "The framework's only AsyncLocalStorage" is a claim that used to sit here. It
+ * was already not true — the *kernel's* is the only one, but `http/`, `pubsub/`
+ * and now the ORM each keep their own:
  *
- * The second is `packages/gemi/orm/context.ts`, holding an open transaction
- * handle and its nesting depth. It is deliberately separate rather than merged
- * into this one:
+ *   kernel     kernel/context.ts                     the Application
+ *   request    http/requestContext.ts                req, user, cookies, locale
+ *   broadcast  services/pubsub/BroadcastManager.ts   headers, cookies
+ *   orm        orm/context.ts                        an open transaction
+ *
+ * The pattern is one store per scope with one owner, entered by that owner and
+ * read through its own accessor — `app()`, `RequestContext.getStore()`,
+ * `currentTransaction()`. What matters is that this one holds the Application
+ * and nothing else, because `foundation/app.ts` reads it unconditionally.
+ *
+ * The ORM's, added in iteration 5, holds an open transaction handle and its
+ * nesting depth. It is deliberately separate rather than merged into this one:
  *
  * - A transaction scope nests *inside* an Application scope without replacing
  *   it. Re-entering this store with a `{ app, tx }` wrapper would mean every
@@ -23,13 +32,13 @@ import { AsyncLocalStorage } from "async_hooks";
  *   overlapping transactions would overwrite each other's handle and statements
  *   would land in the wrong one. That is silent data corruption.
  *
- * The cost is honest: two stores on the hot path of every query instead of one.
- * The ORM's is shallow — one small object, entered only inside
- * `Model.transaction` or `DB.transaction`, never per request — so a query
- * outside a transaction pays one `getStore()` returning undefined.
+ * The cost is honest: one more store on the hot path of every query. The ORM's
+ * is shallow — one small object, entered only inside `Model.transaction` or
+ * `DB.transaction`, never per request — so a query outside a transaction pays
+ * one `getStore()` returning undefined.
  *
- * If a third is ever proposed, this is the note to read first: the bar is that
- * the state is genuinely per-async-scope *and* cannot live in an existing
- * store without making that store's readers ambiguous.
+ * If another is ever proposed, this is the note to read first: the bar is that
+ * the state is genuinely per-async-scope *and* cannot live in an existing store
+ * without making that store's readers ambiguous.
  */
 export const kernelContext = new AsyncLocalStorage();

--- a/packages/gemi/kernel/context.ts
+++ b/packages/gemi/kernel/context.ts
@@ -7,7 +7,9 @@ import { AsyncLocalStorage } from "async_hooks";
  *
  * "The framework's only AsyncLocalStorage" is a claim that used to sit here. It
  * was already not true — the *kernel's* is the only one, but `http/`, `pubsub/`
- * and now the ORM each keep their own:
+ * and now the ORM each keep their own. Four in the shipped framework (a fifth
+ * sits in `rfc/workflow.ts`, an unreferenced design sketch that is outside
+ * `package.json`'s exports and that nothing imports):
  *
  *   kernel     kernel/context.ts                     the Application
  *   request    http/requestContext.ts                req, user, cookies, locale

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -1,6 +1,8 @@
+import type { SQL } from "bun";
 import { DatabaseManager } from "../database/DatabaseManager";
 import { app } from "../foundation/app";
 import { type BindContext, createBindContext } from "./compile/fragment";
+import { currentTransaction, withTransaction } from "./context";
 import {
   type NestedWriteStep,
   type RelationExecutor,
@@ -53,14 +55,45 @@ export abstract class Model {
     return schema;
   }
 
+  /**
+   * Runs `fn` inside a transaction. Every ORM query in it — at any call depth,
+   * through any number of services, including the nested reads an `include`
+   * fans out into — joins it automatically.
+   *
+   * The callback takes **no argument**, and that is the whole feature. Handing
+   * back a `tx` would put it in the signature of every function between here
+   * and the query, which is precisely the threading Prisma's `$transaction`
+   * forces and this exists to remove. If a raw query genuinely needs the
+   * handle, `currentTransaction()` hands it over without putting it in anyone's
+   * parameter list.
+   *
+   * Nesting is a savepoint: an inner failure rolls back to it and leaves the
+   * outer transaction usable, so a caller that catches keeps going.
+   *
+   *     await User.transaction(async () => {
+   *       const user = await User.create({ data: { email } })
+   *       await audit(user)          // its queries are in the transaction too
+   *     })
+   */
+  static transaction<T>(fn: () => Promise<T>): Promise<T> {
+    return withTransaction(app(DatabaseManager).sql, () => fn());
+  }
+
   static async $exec(op: Operation, args: any = {}): Promise<unknown> {
     const schema = this.$modelSchema();
 
     // Resolved per call, never captured at module scope: that is what keeps the
-    // connection swappable in tests, and it is the hook iteration 5 uses to
-    // pick up an ambient transaction instead of the pooled connection.
+    // connection swappable in tests.
     const db = app(DatabaseManager);
     const dialect = dialectFor(db.dialect);
+
+    // The ambient-transaction hook, and the entire integration. It is one line
+    // — and it covers every operation, every nested write and every relation
+    // read — only because invariant 1 held: `$exec` is the single door. An
+    // operation that acquired a private path to the database would show up
+    // here as a statement silently running outside the transaction, committed
+    // while its neighbours roll back.
+    const conn = currentTransaction() ?? db.sql;
 
     const plan = getOrCompile(schema, op, args, dialect);
 
@@ -69,18 +102,23 @@ export abstract class Model {
         registry
           .get<typeof Model>(model)
           .$exec(operation as Operation, relationArgs),
-      query: (text, values) => db.sql.unsafe(text, values),
+      // The one query with no model behind it — the implicit m-n join table —
+      // resolves its connection here rather than reaching for the pool, so it
+      // joins the transaction like everything else.
+      query: (text, values) => conn.unsafe(text, values),
     };
 
     // One context per call, holding the instant every `now()` and `@updatedAt`
     // on this operation shares, plus whatever the `before` steps resolve.
     const context = createBindContext();
 
-    // NOT ATOMIC until iteration 5. A write with nested `create`/`connect` runs
-    // more than one statement, and there is no transaction around them: if a
-    // later step fails, the earlier rows stay written. This is a recorded
-    // decision — iteration 5 introduces the ambient-transaction ALS here and
-    // makes all of it atomic without changing the call sites.
+    // A write with a nested `create` / `connect` runs more than one statement.
+    // Atomic exactly when the caller wrapped the call in `Model.transaction` —
+    // *not* implicitly. A write does not open its own transaction, because
+    // `$exec` cannot know whether it is one step of a larger unit; opening one
+    // per call would put a `BEGIN` around every query in the framework and turn
+    // a caller's transaction into a nest of savepoints it never asked for.
+    // Outside one, a failing later step still leaves the earlier rows written.
     await runSteps(plan.before, args, context, executor, []);
 
     // `unsafe` despite the name. Bun's tagged template cannot express a query
@@ -89,7 +127,7 @@ export abstract class Model {
     // identifiers only ever come from the generated schema, and every value is
     // a bound parameter. Do not "fix" this into a tagged template.
     const rows = await execute(
-      db,
+      conn,
       dialect,
       schema,
       op,
@@ -159,8 +197,8 @@ async function runSteps(
   rows: readonly Record<string, unknown>[],
 ): Promise<void> {
   if (steps === undefined) return;
-  // Sequentially, for the same reason relations load sequentially: iteration 5
-  // puts an ambient transaction on a single reserved connection, where
+  // Sequentially, for the same reason relations load sequentially: inside an
+  // ambient transaction every statement runs on one reserved connection, where
   // concurrent statements are not safe.
   for (const step of steps) {
     await step.run(args, context, executor, rows);
@@ -178,7 +216,7 @@ async function runSteps(
  * has never seen the database's names.
  */
 async function execute(
-  db: { sql: { unsafe(text: string, values: unknown[]): unknown } },
+  conn: Pick<SQL, "unsafe">,
   dialect: SqlDialect,
   schema: ModelSchema,
   op: Operation,
@@ -186,7 +224,7 @@ async function execute(
   values: unknown[],
 ): Promise<unknown> {
   try {
-    return await db.sql.unsafe(text, values);
+    return await conn.unsafe(text, values);
   } catch (error) {
     const violation = dialect.constraintViolation(error);
     if (!violation) throw error;

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -74,6 +74,41 @@ export abstract class Model {
    *       const user = await User.create({ data: { email } })
    *       await audit(user)          // its queries are in the transaction too
    *     })
+   *
+   * **KNOWN DIALECT ASYMMETRY — catching an error inside a transaction.**
+   * The sentence above holds for a *nested* `Model.transaction`. It does not
+   * hold for a bare statement: on Postgres any failed statement aborts the
+   * whole transaction block, so catching it and carrying on loses everything.
+   * SQLite does not care. Verified against Postgres 16 and SQLite:
+   *
+   *     await Model.transaction(async () => {
+   *       try { await User.create({ data: { email } }) }
+   *       catch (e) { if (!(e instanceof UniqueConstraintError)) throw e }
+   *       await Audit.create({ ... })   // fine on SQLite; on Postgres this
+   *     })                              // throws 'current transaction is
+   *                                     // aborted', and the whole transaction
+   *                                     // is lost
+   *
+   * That is a bug that passes in development on SQLite and takes out the
+   * transaction in production on Postgres, with an error naming neither the
+   * statement that failed nor the one that caused it.
+   *
+   * The fix is already here: wrap the fallible statement in a nested
+   * `Model.transaction`, which makes it a savepoint, and rolling back to that
+   * savepoint clears the aborted state. Works on both dialects.
+   *
+   *     await Model.transaction(async () => {
+   *       try {
+   *         await Model.transaction(() => User.create({ data: { email } }))
+   *       } catch (e) { if (!(e instanceof UniqueConstraintError)) throw e }
+   *       await Audit.create({ ... })   // fine on both
+   *     })
+   *
+   * **One statement at a time.** Every query in scope runs on one reserved
+   * connection, so `Promise.all` over several ORM calls inside the callback is
+   * not safe here — the ordinary, encouraged thing everywhere else in a Bun
+   * codebase. Await them in sequence. (`$exec` already runs its own nested
+   * writes and relation reads sequentially for this reason.)
    */
   static transaction<T>(fn: () => Promise<T>): Promise<T> {
     return withTransaction(app(DatabaseManager).sql, () => fn());

--- a/packages/gemi/orm/context.test.ts
+++ b/packages/gemi/orm/context.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  currentTransaction,
+  ormContext,
+  transactionDepth,
+  withTransaction,
+} from "./context";
+
+/**
+ * The ambient-transaction scope, tested without a database.
+ *
+ * The property that matters here is not what SQL runs — `transactions.test.ts`
+ * in the template covers that against both dialects. It is that the scope is
+ * *per async subtree*: two concurrent transactions must never see each other's
+ * handle, at any interleaving. That is a property of the storage mechanism, so
+ * it is worth pinning where a fake handle can produce interleavings a real
+ * database would not reliably reproduce.
+ *
+ * The fake below is the smallest thing `withTransaction` actually calls:
+ * `begin(fn)` and `savepoint(fn)`. It also records the statements issued
+ * through it, which is how "this query ran on that handle" is *observed* rather
+ * than inferred.
+ */
+function fakePool(name: string) {
+  const log: string[] = [];
+
+  const handle: any = {
+    name,
+    log,
+    unsafe(text: string) {
+      log.push(text);
+      return Promise.resolve([]);
+    },
+    savepoint(fn: (sp: any) => Promise<unknown>) {
+      // Matches Bun, which hands the savepoint callback the same object.
+      return Promise.resolve().then(() => fn(handle));
+    },
+  };
+
+  return {
+    handle,
+    log,
+    begin(fn: (tx: any) => Promise<unknown>) {
+      return Promise.resolve().then(() => fn(handle));
+    },
+  } as any;
+}
+
+describe("the ambient transaction scope", () => {
+  test("there is no scope outside a transaction", () => {
+    expect(currentTransaction()).toBeUndefined();
+    expect(transactionDepth()).toBeNull();
+  });
+
+  test("the handle is the one the pool gave out", async () => {
+    const pool = fakePool("a");
+
+    await withTransaction(pool, async (tx) => {
+      expect(tx).toBe(pool.handle);
+      expect(currentTransaction()).toBe(pool.handle);
+      expect(transactionDepth()).toBe(0);
+    });
+  });
+
+  test("the scope closes with the callback", async () => {
+    const pool = fakePool("a");
+    await withTransaction(pool, async () => {});
+
+    expect(currentTransaction()).toBeUndefined();
+    expect(transactionDepth()).toBeNull();
+  });
+
+  // Bun's handle stays callable after `begin` resolves — it just runs on the
+  // pool, outside any transaction, and succeeds. So a leaked scope would not
+  // announce itself; it would silently write outside the transaction.
+  test("the scope closes even when the callback throws", async () => {
+    const pool = fakePool("a");
+
+    await expect(
+      withTransaction(pool, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(currentTransaction()).toBeUndefined();
+  });
+
+  test("nesting increments depth and restores it on the way out", async () => {
+    const pool = fakePool("a");
+
+    await withTransaction(pool, async () => {
+      expect(transactionDepth()).toBe(0);
+      await withTransaction(pool, async () => {
+        expect(transactionDepth()).toBe(1);
+        await withTransaction(pool, async () => {
+          expect(transactionDepth()).toBe(2);
+        });
+        expect(transactionDepth()).toBe(1);
+      });
+      expect(transactionDepth()).toBe(0);
+    });
+  });
+
+  // A nested call must go through `savepoint`, not `begin` — Bun rejects a
+  // `begin` inside a transaction outright, so getting this wrong is a runtime
+  // failure the moment anyone nests.
+  test("a nested transaction opens a savepoint, never a second begin", async () => {
+    const pool = fakePool("a");
+    let begins = 0;
+    let savepoints = 0;
+
+    const counting: any = {
+      ...pool,
+      begin(fn: (tx: any) => Promise<unknown>) {
+        begins++;
+        return pool.begin(fn);
+      },
+    };
+    pool.handle.savepoint = (fn: (sp: any) => Promise<unknown>) => {
+      savepoints++;
+      return Promise.resolve().then(() => fn(pool.handle));
+    };
+
+    await withTransaction(counting, async () => {
+      await withTransaction(counting, async () => {
+        await withTransaction(counting, async () => {});
+      });
+    });
+
+    expect(begins).toBe(1);
+    expect(savepoints).toBe(2);
+  });
+
+  /**
+   * The test the whole storage choice exists for.
+   *
+   * Two transactions run concurrently with awaits interleaved between every
+   * step, so each one is suspended while the other is running. If the handle
+   * lived anywhere shared — a field on the Application, a module-level variable
+   * — the second `begin` would overwrite the first and the first transaction's
+   * statements would land in the second one. Not an error: committed data in
+   * the wrong transaction.
+   */
+  test("two concurrent transactions never see each other's handle", async () => {
+    const first = fakePool("first");
+    const second = fakePool("second");
+    const seen: string[] = [];
+
+    async function run(pool: any, label: string, delays: number[]) {
+      await withTransaction(pool, async () => {
+        for (const delay of delays) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          const handle = currentTransaction() as any;
+          seen.push(`${label}:${handle.name}`);
+          await handle.unsafe(`${label} step`);
+        }
+      });
+    }
+
+    await Promise.all([
+      run(first, "A", [0, 4, 0, 6]),
+      run(second, "B", [2, 0, 5, 0]),
+    ]);
+
+    // Every observation matched its own transaction...
+    expect(seen.filter((entry) => entry === "A:first")).toHaveLength(4);
+    expect(seen.filter((entry) => entry === "B:second")).toHaveLength(4);
+
+    // ...and the statements landed on the right handles, not just the reads.
+    expect(first.handle.log).toEqual(["A step", "A step", "A step", "A step"]);
+    expect(second.handle.log).toEqual(["B step", "B step", "B step", "B step"]);
+
+    // The interleaving was real — otherwise this would be testing two
+    // sequential runs and proving nothing.
+    expect(seen.join(",")).not.toBe(
+      "A:first,A:first,A:first,A:first,B:second,B:second,B:second,B:second",
+    );
+  });
+
+  test("a transaction inside a concurrent sibling's scope still nests on its own", async () => {
+    const outer = fakePool("outer");
+    const other = fakePool("other");
+    let innerDepth: number | null = null;
+    let siblingDepth: number | null = null;
+
+    await Promise.all([
+      withTransaction(outer, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        await withTransaction(outer, async () => {
+          innerDepth = transactionDepth();
+        });
+      }),
+      withTransaction(other, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        siblingDepth = transactionDepth();
+      }),
+    ]);
+
+    expect(innerDepth).toBe(1);
+    // The sibling is at depth 0 despite overlapping with a nested scope.
+    expect(siblingDepth).toBe(0);
+  });
+
+  test("the store is exactly what withTransaction put there", async () => {
+    const pool = fakePool("a");
+
+    await withTransaction(pool, async () => {
+      expect(ormContext.getStore()).toEqual({ tx: pool.handle, depth: 0 });
+    });
+  });
+});

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -5,13 +5,15 @@ import { AsyncLocalStorage } from "node:async_hooks";
  * The ambient transaction: the ORM's own `AsyncLocalStorage`, holding nothing
  * but the open handle and how deep the nesting is.
  *
- * This is the second `AsyncLocalStorage` in the framework, and the first one
- * that is not the kernel's. `packages/gemi/kernel/context.ts` carries the
- * Application and says so; the reasoning for adding a second rather than
- * widening that one is written up beside it, and the short version is that a
- * transaction scope has to *nest inside* an Application scope without replacing
- * it, and `foundation/app.ts` must keep reading exactly one shape out of the
- * kernel store or resolving a service becomes a transaction concern.
+ * One store per scope with one owner, which is the pattern the framework
+ * already follows — `kernel/context.ts` holds the Application,
+ * `http/requestContext.ts` the request and its user,
+ * `services/pubsub/BroadcastManager.ts` a socket's headers. The reasoning for
+ * not folding this into the kernel's is written up beside it, and the short
+ * version is that a transaction scope has to *nest inside* an Application scope
+ * without replacing it, and `foundation/app.ts` must keep reading exactly one
+ * shape out of the kernel store or resolving a service becomes a transaction
+ * concern.
  *
  * What makes an ALS the right home rather than a field somewhere: two concurrent
  * requests each in their own transaction must never see each other's handle.

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -92,6 +92,18 @@ export function withTransaction<T>(
 ): Promise<T> {
   const current = ormContext.getStore();
 
+  // SINGLE-CONNECTION ASSUMPTION, pinned here so it is found rather than
+  // discovered. The savepoint branch ignores `pool` entirely, which is correct
+  // today: there is one `DatabaseManager` and one `SQL`, so the ambient handle
+  // and whatever pool the caller passed are necessarily the same database.
+  //
+  // It stops being correct the moment a second connection is configurable. A
+  // `DB.transaction` against connection B, called inside a `Model.transaction`
+  // on A, would open a savepoint on **A** and hand the callback A's handle —
+  // statements landing in the wrong database, with no error. That is the same
+  // failure shape as the "handle on the Application" alternative this file
+  // argues against. Multi-connection support must compare the two and either
+  // join or refuse, not fall through to here.
   if (current) {
     return current.tx.savepoint((sp) => {
       const nested = sp as TransactionSQL;

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -1,0 +1,105 @@
+import type { SQL, TransactionSQL } from "bun";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * The ambient transaction: the ORM's own `AsyncLocalStorage`, holding nothing
+ * but the open handle and how deep the nesting is.
+ *
+ * This is the second `AsyncLocalStorage` in the framework, and the first one
+ * that is not the kernel's. `packages/gemi/kernel/context.ts` carries the
+ * Application and says so; the reasoning for adding a second rather than
+ * widening that one is written up beside it, and the short version is that a
+ * transaction scope has to *nest inside* an Application scope without replacing
+ * it, and `foundation/app.ts` must keep reading exactly one shape out of the
+ * kernel store or resolving a service becomes a transaction concern.
+ *
+ * What makes an ALS the right home rather than a field somewhere: two concurrent
+ * requests each in their own transaction must never see each other's handle.
+ * Anything reachable from the Application — which is one object shared by every
+ * in-flight request — fails that by construction, and fails it as silently
+ * written data, not as an error. "two concurrent transactions never see each
+ * other's handle" in `context.test.ts` is the test that would catch it.
+ */
+export interface TransactionScope {
+  /**
+   * Bun's transaction handle. Every ORM statement in scope runs on it, which
+   * means they all run on one reserved connection — so nothing here may issue
+   * two statements concurrently. `Model.$exec` already runs its nested writes
+   * and its relation reads sequentially, for exactly this reason.
+   */
+  tx: TransactionSQL;
+  /** 0 for the outermost transaction, 1+ for each savepoint inside it. */
+  depth: number;
+}
+
+export const ormContext = new AsyncLocalStorage<TransactionScope>();
+
+/**
+ * The open transaction, or `undefined` outside one. This is what `Model.$exec`
+ * consults to decide which connection a statement runs on.
+ *
+ * Exported as the escape hatch for code that genuinely needs the handle — a raw
+ * query that must join the surrounding transaction, say. **Do not store what it
+ * returns.** Bun's handle stays callable after its `begin` resolves: queries on
+ * it then run on the pooled connection, outside any transaction, and succeed.
+ * Verified against both dialects, and it is the reason `Model.transaction`'s
+ * callback takes no argument.
+ */
+export function currentTransaction(): TransactionSQL | undefined {
+  return ormContext.getStore()?.tx;
+}
+
+/** How deeply nested the current transaction is; `null` outside one. */
+export function transactionDepth(): number | null {
+  return ormContext.getStore()?.depth ?? null;
+}
+
+/**
+ * Run `fn` inside a transaction, entering the ambient scope for its whole async
+ * subtree.
+ *
+ * The single implementation behind both `Model.transaction` and
+ * `DB.transaction`, so the two cannot become transaction systems that ignore
+ * each other: a `Model.create` inside a `DB.transaction` joins it, and a raw
+ * `DB.sql` inside a `Model.transaction` can join it through
+ * `currentTransaction()`.
+ *
+ * Nesting becomes a savepoint. Not a preference — Bun refuses the alternative
+ * outright (`cannot call begin inside a transaction use savepoint() instead`),
+ * and a savepoint is the semantics worth having anyway: an inner failure rolls
+ * back to it and leaves the outer transaction usable, which a caller that
+ * catches can rely on. Verified on SQLite and Postgres.
+ *
+ * Note Bun hands the savepoint callback the *same* handle object as the outer
+ * transaction (`sp === tx`), so the depth counter is the only thing that
+ * actually changes on the way in. The callback's argument is still what gets
+ * stored, so this keeps working if that ever stops being true. The cast is
+ * because Bun types a savepoint handle as plain `SQL` — without `savepoint` on
+ * it — while the runtime object does carry the method, which is what makes
+ * three levels of nesting work.
+ *
+ * The return type is asserted rather than inferred for one reason worth
+ * knowing: Bun's `begin` unwraps a callback that resolves to an *array of
+ * promises*, awaiting each. So `Model.transaction(async () => [a, b])` where
+ * `a` and `b` are promises resolves to their values, not to the promises. That
+ * is Bun's behaviour and is left alone; it is only surprising if unmentioned.
+ */
+export function withTransaction<T>(
+  pool: SQL,
+  fn: (tx: TransactionSQL) => Promise<T>,
+): Promise<T> {
+  const current = ormContext.getStore();
+
+  if (current) {
+    return current.tx.savepoint((sp) => {
+      const nested = sp as TransactionSQL;
+      return ormContext.run({ tx: nested, depth: current.depth + 1 }, () =>
+        fn(nested),
+      );
+    }) as Promise<T>;
+  }
+
+  return pool.begin((tx) =>
+    ormContext.run({ tx, depth: 0 }, () => fn(tx)),
+  ) as Promise<T>;
+}

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -46,6 +46,17 @@ export {
   type QueryPlan,
 } from "./plan";
 
+// The ambient transaction. `Model.transaction` is the surface an application
+// uses; these are for code that has to *observe* the scope rather than open one
+// — a raw query joining it, or a test asserting a statement ran inside it.
+export {
+  currentTransaction,
+  ormContext,
+  transactionDepth,
+  withTransaction,
+  type TransactionScope,
+} from "./context";
+
 export { compile, compileRead, compileWrite } from "./compile";
 export { buildRowShaper, type RowShaper, type ShapedRelation } from "./shape";
 export {

--- a/packages/gemi/tsconfig.json
+++ b/packages/gemi/tsconfig.json
@@ -5,6 +5,28 @@
     "emitDeclarationOnly": true,
     "downlevelIteration": true
   },
+  // Every directory of server source belongs here. That was not true until
+  // iteration 5 of the ORM: `orm`, `auth`, `config`, `internal`, `runtime` and
+  // `bin/orm` were all outside it, so `tsc --noEmit` passed without looking at
+  // them — and `orm` and `config` are public exports. Six directories, two of
+  // them shipped, none of them checked.
+  //
+  // `client` is covered by tsconfig.browser.json instead.
+  //
+  // KNOWINGLY EXCLUDED, and not for the reason it looks like: `bun/` holds two
+  // public exports of its own — `./bun/preload` and `./bun/plugin` — so the
+  // "sketches and build glue" argument that covers `rfc`, `scripts`, `vite` and
+  // `ide` does not cover it. It is out because including it needs more than a
+  // line here:
+  //
+  //   bun/customRequestParser.ts  TS2307  no types for 'recast/parsers/typescript'
+  //   bun/preload.ts              TS1309  top-level await under the inherited
+  //                                       CommonJS `module` setting, which is
+  //                                       wrong for files Bun loads as ESM
+  //
+  // The second is a config mismatch rather than a code bug, so `bun/` wants a
+  // nested tsconfig with its own `module`, not an edit to the file. Recorded
+  // here so the next audit of this list does not reach "build glue" and stop.
   "include": [
     "app/index.ts",
     "http",

--- a/packages/gemi/tsconfig.json
+++ b/packages/gemi/tsconfig.json
@@ -22,7 +22,12 @@
     "support",
     "database",
     "orm",
-    "bin/migrate"
+    "bin/migrate",
+    "bin/orm",
+    "auth",
+    "config",
+    "internal",
+    "runtime"
   ],
   "exclude": [
     "node_modules",

--- a/plans/orm/README.md
+++ b/plans/orm/README.md
@@ -312,7 +312,7 @@ packages/gemi/orm/
   errors.ts           UnsupportedQueryError, RecordNotFoundError, ...
   compile/            arg tree → SQL fragments
   dialect/            Dialect strategy: sqlite.ts, postgres.ts
-  context.ts          ambient transaction ALS            (iteration 5)
+  context.ts          ambient transaction ALS
   policy.ts           policy hook                        (iteration 6)
 
 packages/gemi/bin/orm-generator.ts  Prisma generator plugin: DMMF → artifacts.
@@ -379,12 +379,16 @@ than before it.
 
 ## Open decisions
 
-- **Ambient transaction storage.** `packages/gemi/kernel/context.ts` deliberately
-  holds the framework's *only* `AsyncLocalStorage`, and it carries the
-  Application. A transaction scope must nest inside a request without replacing
-  it, so iteration 5 proposes a second, ORM-owned ALS. That is a conscious
-  deviation from a documented design choice and needs sign-off — see
-  [05](./05-ambient-transactions.md).
+- ~~**Ambient transaction storage.**~~ **Settled in iteration 5: a second,
+  ORM-owned `AsyncLocalStorage`** in `packages/gemi/orm/context.ts`, holding
+  `{ tx, depth }` and nothing else. `packages/gemi/kernel/context.ts` keeps
+  carrying only the Application, and the reasoning for a second store rather
+  than a wider one is written up there so the "exactly one ALS" claim does not
+  silently become false. The two alternatives were rejected on the record:
+  re-entering the kernel store with a `{ app, tx }` wrapper makes every reader
+  of it — `app()` above all — handle two shapes forever, and hanging the handle
+  off the Application shares it across concurrent requests, which is data
+  corruption rather than a style question.
 - **MySQL / MariaDB.** Deferred. `DatabaseManager` already infers all four
   dialects, and the strategy seam keeps the door open, but only SQLite and
   Postgres are built and tested. Confirm this is acceptable.

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -345,7 +345,7 @@ export async function createDifferential(options: {
  * timestamp. Statements are split on `;` at end of line, which is enough for
  * the DDL Prisma emits and involves no SQL parsing.
  */
-async function applyMigrations(path: string): Promise<void> {
+export async function applyMigrations(path: string): Promise<void> {
   const root = join(import.meta.dirname, "../../prisma/migrations");
   const sql = new SQL(`sqlite://${path}`);
 

--- a/templates/saas-starter/app/models/transactions.test.ts
+++ b/templates/saas-starter/app/models/transactions.test.ts
@@ -452,6 +452,86 @@ function suite(label: string, url?: string) {
       ]);
     });
 
+    // --- the dialect asymmetry that documentation alone would not hold ----
+
+    /**
+     * KNOWN DIALECT ASYMMETRY, pinned rather than only described.
+     *
+     * On Postgres a *failed statement* aborts the whole transaction block, so
+     * catching the error and carrying on loses everything. SQLite does not
+     * care. That makes the natural thing to write —
+     *
+     *     try { await User.create(...) } catch { }
+     *     await Account.create(...)
+     *
+     * — pass in development on SQLite and take out the transaction in
+     * production on Postgres, with an error naming neither statement.
+     *
+     * Both halves are asserted per dialect rather than skipping the SQLite one:
+     * the point is that the two genuinely differ, and a test that ran only
+     * where the answer is convenient would not say that.
+     */
+    test("catching a bare failed statement: the two dialects differ", async () => {
+      const first = await Model.transaction(async () => {
+        const user = await User.create({ data: { email: "dup@x.test" } });
+
+        let aborted = false;
+        try {
+          // Same unique email, so this fails at the database.
+          await User.create({ data: { email: "dup@x.test" } });
+        } catch {
+          // Swallowed, which is the whole point.
+        }
+
+        try {
+          await AccountModel.create({ data: { userId: user.id } });
+        } catch {
+          aborted = true;
+        }
+
+        return aborted;
+      }).catch(() => "transaction-lost" as const);
+
+      if (url) {
+        // Postgres: the statement after the caught failure cannot run —
+        // "current transaction is aborted, commands ignored until end of
+        // transaction block". Asserted as `true` rather than "not false", so
+        // this cannot pass by the transaction failing some other way.
+        expect(first).toBe(true);
+        expect(await userCount()).toBe(0);
+      } else {
+        // SQLite: carried on, and both rows are there.
+        expect(first).toBe(false);
+        expect(await userCount()).toBe(1);
+      }
+    });
+
+    /**
+     * ...and the remedy this iteration already ships: wrapping the fallible
+     * statement in a nested `Model.transaction` makes it a savepoint, and
+     * rolling back to the savepoint clears the aborted state. Identical on both
+     * dialects, which is what makes it the thing to recommend.
+     */
+    test("wrapping the fallible statement in a nested transaction recovers", async () => {
+      await Model.transaction(async () => {
+        const user = await User.create({ data: { email: "dup2@x.test" } });
+
+        try {
+          await Model.transaction(() =>
+            User.create({ data: { email: "dup2@x.test" } }),
+          );
+        } catch {
+          // Rolled back to the savepoint; the outer transaction is intact.
+        }
+
+        await AccountModel.create({ data: { userId: user.id } });
+      });
+
+      expect(await userCount()).toBe(1);
+      const rows: any = await raw.unsafe(`SELECT "id" FROM "Account"`);
+      expect([...rows]).toHaveLength(1);
+    });
+
     // --- criterion 7: plan cache ------------------------------------------
 
     // The cache is keyed on dialect, model, operation and argument shape — not

--- a/templates/saas-starter/app/models/transactions.test.ts
+++ b/templates/saas-starter/app/models/transactions.test.ts
@@ -1,0 +1,491 @@
+import { SQL } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DB } from "gemi/facades";
+import { DatabaseManager } from "gemi/database";
+import { Application } from "gemi/foundation";
+import {
+  Model,
+  clearPlanCache,
+  currentTransaction,
+  planCacheStats,
+  transactionDepth,
+} from "gemi/orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import { POSTGRES_URL, applyMigrations } from "./differential";
+import { AccountModel } from "./generated";
+import { User } from "./User";
+
+/**
+ * Ambient transactions: `Model.transaction(cb)` with no `tx` threaded through
+ * anything.
+ *
+ * The property under test is not "a transaction works" — Bun's `sql.begin`
+ * already does that. It is that **every** query inside the callback joins it:
+ * at any call depth, through a service that never heard of the transaction,
+ * inside the nested reads an `include` fans out into, and inside the extra
+ * statements a nested write runs. That only holds because `Model.$exec` is the
+ * single door to the database (invariant 1), so this suite is also the test
+ * that would fail first if some operation ever acquired a private path.
+ *
+ * Both dialects, because the two do not agree for free: SQLite's transactions
+ * are file locks and Postgres' are per-connection server state, and savepoint
+ * behaviour is the kind of thing that is "obviously the same" right up until it
+ * is not.
+ */
+
+/** No argument, no knowledge of the transaction — the point of the feature. */
+async function createUserDeepInAService(email: string) {
+  return await recordAudit(email);
+}
+
+async function recordAudit(email: string) {
+  return await User.create({ data: { email } });
+}
+
+function suite(label: string, url?: string) {
+  describe(label, () => {
+    let workspace: string | undefined;
+    let database: DatabaseManager;
+    let raw: SQL;
+    let previous: Application | undefined;
+
+    beforeAll(async () => {
+      let target = url;
+      if (!target) {
+        workspace = mkdtempSync(join(tmpdir(), "gemi-orm-tx-"));
+        const path = join(workspace, "tx.db");
+        await applyMigrations(path);
+        target = `sqlite://${path}`;
+      }
+
+      database = new DatabaseManager({ url: target });
+      raw = new SQL(target);
+
+      previous = Application.getInstance();
+      const application = new Application();
+      application.instance(DatabaseManager, database as never);
+      Application.setInstance(application);
+    }, 120_000);
+
+    afterAll(async () => {
+      await raw?.close();
+      await database?.close();
+      if (previous) Application.setInstance(previous);
+      if (workspace) rmSync(workspace, { recursive: true, force: true });
+    });
+
+    // Every table, not just the three this suite writes to. On Postgres the
+    // whole run shares the one database `TEST_POSTGRES_URL` names, so a row
+    // another suite left in `SocialAccount` makes a `DELETE FROM "User"` here
+    // fail on a foreign key — and the failure lands in this suite, which never
+    // touched it. Children before parents, for the same reason.
+    const TABLES = [
+      "SocialAccount",
+      "Session",
+      "PasswordResetToken",
+      "MagicLinkToken",
+      "Account",
+      "User",
+      "OrganizationInvitation",
+      "Organization",
+    ];
+
+    beforeEach(async () => {
+      clearPlanCache();
+
+      if (url) {
+        await raw.unsafe(
+          `TRUNCATE ${TABLES.map((table) => `"${table}"`).join(", ")} ` +
+            `RESTART IDENTITY CASCADE`,
+        );
+        return;
+      }
+
+      for (const table of TABLES) {
+        await raw.unsafe(`DELETE FROM "${table}"`);
+      }
+    });
+
+    async function userCount(): Promise<number> {
+      const rows: any = await raw.unsafe(`SELECT "id" FROM "User"`);
+      return [...rows].length;
+    }
+
+    // --- criterion 1: commit and rollback ---------------------------------
+
+    test("returning normally commits", async () => {
+      const result = await Model.transaction(async () => {
+        await User.create({ data: { email: "commit@x.test" } });
+        return "done";
+      });
+
+      expect(result).toBe("done");
+      expect(await userCount()).toBe(1);
+    });
+
+    test("throwing rolls back and rethrows the original error", async () => {
+      const boom = new Error("boom");
+
+      await expect(
+        Model.transaction(async () => {
+          await User.create({ data: { email: "gone@x.test" } });
+          await User.create({ data: { email: "also-gone@x.test" } });
+          throw boom;
+        }),
+      ).rejects.toBe(boom);
+
+      expect(await userCount()).toBe(0);
+    });
+
+    // A rollback that only undoes the *last* statement would pass a one-write
+    // test. This one writes, reads its own write back, writes again, and fails.
+    test("everything in the callback rolls back, not just the last statement", async () => {
+      await expect(
+        Model.transaction(async () => {
+          const user = await User.create({ data: { email: "a@x.test" } });
+          const seen = await User.findUnique({ where: { id: user.id } });
+          expect(seen?.email).toBe("a@x.test");
+          await User.create({ data: { email: "b@x.test" } });
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      expect(await userCount()).toBe(0);
+    });
+
+    // --- criterion 2: arbitrary call depth --------------------------------
+
+    // Observed, not inferred: `currentTransaction()` returns the handle the
+    // statements actually run on, and it is the same object three frames down
+    // as it is at the boundary.
+    test("a query three calls deep runs on the same handle", async () => {
+      await Model.transaction(async () => {
+        const atBoundary = currentTransaction();
+        expect(atBoundary).toBeDefined();
+
+        await createUserDeepInAService("deep@x.test");
+
+        let inService: unknown;
+        await (async () => {
+          await (async () => {
+            inService = currentTransaction();
+          })();
+        })();
+
+        expect(inService).toBe(atBoundary);
+      });
+
+      expect(await userCount()).toBe(1);
+    });
+
+    test("a service that never heard of the transaction still rolls back", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await createUserDeepInAService("service@x.test");
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      expect(await userCount()).toBe(0);
+    });
+
+    // The relation reads are separate statements issued by `attachRelations`,
+    // one per node in the include tree. If any of them reached for the pool
+    // instead of the ambient handle it would not see the uncommitted parent —
+    // on Postgres it would return nothing, and on SQLite it would deadlock or
+    // read stale. Reading back a row written in the same transaction *through*
+    // an include is the assertion.
+    test("nested relation reads from an include join the transaction", async () => {
+      await Model.transaction(async () => {
+        const user = await User.create({ data: { email: "rel@x.test" } });
+        await AccountModel.create({ data: { userId: user.id } });
+
+        const withAccounts = await User.findUnique({
+          where: { id: user.id },
+          include: { accounts: true },
+        });
+
+        expect(withAccounts?.accounts).toHaveLength(1);
+      });
+
+      const rows: any = await raw.unsafe(`SELECT "id" FROM "Account"`);
+      expect([...rows]).toHaveLength(1);
+    });
+
+    // A nested write is two statements through `plan.before` / `plan.after`.
+    // Outside a transaction they are not atomic, which is recorded in
+    // `Model.$exec`; inside one they are, and that is the whole point of
+    // iteration 5 landing after iteration 4.
+    test("the extra statements of a nested write roll back with it", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await User.create({
+            data: {
+              email: "nested@x.test",
+              organization: { create: { name: "Acme" } },
+            },
+          });
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      const orgs: any = await raw.unsafe(`SELECT "id" FROM "Organization"`);
+      expect([...orgs]).toHaveLength(0);
+      expect(await userCount()).toBe(0);
+    });
+
+    // --- criterion 3: savepoints ------------------------------------------
+
+    test("a nested transaction is a savepoint, and its depth says so", async () => {
+      expect(transactionDepth()).toBeNull();
+
+      await Model.transaction(async () => {
+        expect(transactionDepth()).toBe(0);
+        await Model.transaction(async () => {
+          expect(transactionDepth()).toBe(1);
+          await Model.transaction(async () => {
+            expect(transactionDepth()).toBe(2);
+          });
+          expect(transactionDepth()).toBe(1);
+        });
+        expect(transactionDepth()).toBe(0);
+      });
+
+      expect(transactionDepth()).toBeNull();
+    });
+
+    test("an inner rollback leaves the outer transaction usable", async () => {
+      await Model.transaction(async () => {
+        await User.create({ data: { email: "outer@x.test" } });
+
+        await expect(
+          Model.transaction(async () => {
+            await User.create({ data: { email: "inner@x.test" } });
+            throw new Error("inner boom");
+          }),
+        ).rejects.toThrow("inner boom");
+
+        // The outer transaction survived the inner failure and can still write.
+        await User.create({ data: { email: "after@x.test" } });
+      });
+
+      const rows: any = await raw.unsafe(`SELECT "email" FROM "User" ORDER BY "id"`);
+      expect([...rows].map((row: any) => row.email)).toEqual([
+        "outer@x.test",
+        "after@x.test",
+      ]);
+    });
+
+    test("an inner success is undone when the outer rolls back", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await Model.transaction(async () => {
+            await User.create({ data: { email: "committed-inner@x.test" } });
+          });
+          throw new Error("outer boom");
+        }),
+      ).rejects.toThrow("outer boom");
+
+      expect(await userCount()).toBe(0);
+    });
+
+    // --- criterion 5: DB.transaction interop ------------------------------
+
+    test("DB.transaction still hands its callback the raw handle", async () => {
+      const value = await DB.transaction(async (tx) => {
+        const rows: any = await tx.unsafe(`SELECT 1 AS one`);
+        return [...rows][0].one;
+      });
+
+      expect(Number(value)).toBe(1);
+    });
+
+    test("an ORM call inside a DB.transaction joins it", async () => {
+      await expect(
+        DB.transaction(async () => {
+          await User.create({ data: { email: "mixed@x.test" } });
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      // If the ORM had reached for the pool it would have committed on its own
+      // connection and survived this rollback.
+      expect(await userCount()).toBe(0);
+    });
+
+    test("a raw query inside a Model.transaction can join it", async () => {
+      await Model.transaction(async () => {
+        const user = await User.create({ data: { email: "raw@x.test" } });
+
+        const tx = currentTransaction();
+        expect(tx).toBeDefined();
+        const rows: any = await tx!.unsafe(
+          `SELECT "email" FROM "User" WHERE "id" = ${
+            url ? "$1" : "?"
+          }`,
+          [user.id],
+        );
+        // Reads a row that is not committed yet, which only the transaction's
+        // own connection can see.
+        expect([...rows][0].email).toBe("raw@x.test");
+      });
+    });
+
+    test("a DB.transaction nested inside a Model.transaction is a savepoint", async () => {
+      // Bun refuses `begin` inside a transaction outright, so this would throw
+      // if DB.transaction still went straight to `sql.begin`.
+      await Model.transaction(async () => {
+        expect(transactionDepth()).toBe(0);
+        await DB.transaction(async () => {
+          expect(transactionDepth()).toBe(1);
+          await User.create({ data: { email: "db-nested@x.test" } });
+        });
+      });
+
+      expect(await userCount()).toBe(1);
+    });
+
+    // --- criterion 6: outside a transaction -------------------------------
+
+    test("outside any transaction there is no ambient handle", async () => {
+      expect(currentTransaction()).toBeUndefined();
+      await User.create({ data: { email: "pooled@x.test" } });
+      expect(await userCount()).toBe(1);
+    });
+
+    // The failure this guards: an implementation that stored the handle
+    // anywhere it outlived the callback. Bun's handle stays *callable* after
+    // its `begin` resolves — verified — so a leaked one would not error, it
+    // would silently run outside any transaction.
+    test("the scope does not outlive the callback", async () => {
+      await Model.transaction(async () => {
+        expect(currentTransaction()).toBeDefined();
+      });
+
+      expect(currentTransaction()).toBeUndefined();
+      expect(transactionDepth()).toBeNull();
+    });
+
+    test("a rolled-back transaction does not poison the next query", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await User.create({ data: { email: "doomed@x.test" } });
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      // On the pool again, and the connection the transaction reserved has been
+      // returned in a usable state.
+      await User.create({ data: { email: "after-rollback@x.test" } });
+      expect(await userCount()).toBe(1);
+    });
+
+    // --- criterion 4: concurrency -----------------------------------------
+
+    /**
+     * Two overlapping transactions against a real server, with awaits placed so
+     * each is suspended while the other runs.
+     *
+     * Postgres only, and not for want of trying: SQLite allows exactly one
+     * writer at a time, so two concurrent write transactions there serialise or
+     * fail with SQLITE_BUSY — the interleaving this needs cannot happen, and a
+     * test that "passes" because nothing overlapped proves nothing. The storage
+     * property itself is pinned dialect-free in
+     * `packages/gemi/orm/context.test.ts`, where a fake handle can produce the
+     * interleavings deterministically.
+     */
+    const concurrent = url ? test : test.skip;
+
+    concurrent("two concurrent transactions are isolated", async () => {
+      const pause = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
+
+      const [a, b] = await Promise.all([
+        Model.transaction(async () => {
+          await User.create({ data: { email: "tx-a@x.test" } });
+          await pause(40);
+          // Its own write is visible; the other transaction's is not, because
+          // that one has not committed yet.
+          const rows = await User.findMany({});
+          return rows.map((row: any) => row.email);
+        }),
+        Model.transaction(async () => {
+          await pause(15);
+          await User.create({ data: { email: "tx-b@x.test" } });
+          const rows = await User.findMany({});
+          await pause(40);
+          return rows.map((row: any) => row.email);
+        }),
+      ]);
+
+      expect(a).toEqual(["tx-a@x.test"]);
+      expect(b).toEqual(["tx-b@x.test"]);
+      expect(await userCount()).toBe(2);
+    });
+
+    concurrent("one concurrent transaction rolling back leaves the other", async () => {
+      const pause = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
+
+      const [kept] = await Promise.all([
+        Model.transaction(async () => {
+          await User.create({ data: { email: "survivor@x.test" } });
+          await pause(40);
+          return "kept";
+        }),
+        Model.transaction(async () => {
+          await pause(15);
+          await User.create({ data: { email: "doomed@x.test" } });
+          throw new Error("boom");
+        }).catch((error) => error.message),
+      ]);
+
+      expect(kept).toBe("kept");
+
+      const rows: any = await raw.unsafe(`SELECT "email" FROM "User"`);
+      expect([...rows].map((row: any) => row.email)).toEqual([
+        "survivor@x.test",
+      ]);
+    });
+
+    // --- criterion 7: plan cache ------------------------------------------
+
+    // The cache is keyed on dialect, model, operation and argument shape — not
+    // on connection, and it must stay that way: a plan compiled outside a
+    // transaction is valid inside one, and keying on the handle would mint a
+    // fresh plan per transaction and never hit.
+    test("transaction state does not touch the plan cache", async () => {
+      clearPlanCache();
+
+      await User.create({ data: { email: "cache-1@x.test" } });
+      const afterPool = planCacheStats();
+
+      await Model.transaction(async () => {
+        await User.create({ data: { email: "cache-2@x.test" } });
+      });
+      const afterTx = planCacheStats();
+
+      // Same shape, same plan: one more hit, no new entry.
+      expect(afterTx.size).toBe(afterPool.size);
+      expect(afterTx.hits).toBe(afterPool.hits + 1);
+    });
+  });
+}
+
+suite("transactions (sqlite)", undefined);
+
+if (POSTGRES_URL) {
+  suite("transactions (postgres)", POSTGRES_URL);
+} else {
+  describe("transactions (postgres)", () => {
+    // Loud, not silent: the SQLite pass proves nothing about savepoint
+    // behaviour on a real server, and a skipped dialect that reads as a passing
+    // one is how the three Postgres bugs in iteration 4 survived as long as
+    // they did.
+    test.skip("set TEST_POSTGRES_URL to run these against Postgres", () => {});
+  });
+}


### PR DESCRIPTION
`Model.transaction(cb)` — every query inside the callback joins it, at any call depth, with no `tx` threaded through anything.

```ts
await Model.transaction(async () => {
  const user = await User.create({ data: { email } })
  await audit(user)          // its queries are in the transaction too
})
```

This is one of the two features that justify the project. Prisma's `$transaction` hands back a distinct client, so every participating function must accept it — the transaction ends up in the signature of everything between the boundary and the query.

Stacked on #49. Review that one first.

## The integration is one line

```ts
const conn = currentTransaction() ?? db.sql
```

That covers every operation, both directions of nested write, the relation reads an `include` fans out into, and the one query with no model behind it (the implicit m-n join table) — but only because invariant 1 held through iterations 1–4. An operation that had acquired a private path to the database would show up here as a statement committing while its neighbours roll back. This suite is the test that would fail first.

## The open decision, now settled

The plan flagged this one as needing sign-off, and it has it. The transaction lives in a **second, ORM-owned `AsyncLocalStorage`** (`orm/context.ts`) holding `{ tx, depth }` and nothing else. `kernel/context.ts` keeps carrying only the Application — and now carries the reasoning too, so the "exactly one ALS" claim there does not silently become false.

Both alternatives are rejected on the record:

- **Re-entering the kernel store with a `{ app, tx }` wrapper.** Keeps the single-store claim literally true, at the cost of every reader of that store — `app()` above all — handling two shapes forever. A miss there is not a transaction bug, it is a service resolving off the wrong Application.
- **Hanging the handle off the Application.** One Application serves every concurrent request, so two overlapping transactions overwrite each other's handle and statements land in the wrong one. Silent data corruption, not a style question. It fails acceptance criterion 4 by construction.

The honest cost is two stores on the hot path of every query. The ORM's is shallow and entered only inside a transaction, so a query outside one pays a single `getStore()` returning `undefined`.

## Three spike findings that shaped the code

Verified against both dialects before building on them, per the plan's instruction not to assume Bun's semantics:

1. **`tx.begin` inside a transaction is refused outright** — *"cannot call begin inside a transaction use savepoint() instead"*. So nesting is a savepoint, which is the better semantics anyway: an inner failure rolls back to it and leaves the outer transaction usable.
2. **Bun hands the savepoint callback the same handle object** (`sp === tx`), so depth is the only thing that actually changes on the way in. The callback's argument is still what gets stored, so this keeps working if that stops being true.
3. **The handle stays callable after `begin` resolves.** Queries on a leaked one run on the pooled connection, outside any transaction, and *succeed* — no error to notice. This is the one that shaped the API: it is why `Model.transaction`'s callback takes no argument at all, why `currentTransaction()` is documented as read-and-use rather than something to store, and why there is a test asserting the scope does not outlive the callback.

## `DB.transaction` interop

It keeps its existing signature and still hands its callback the raw handle, but routes through the same `withTransaction`. Without that the two would be transaction systems that silently ignore each other: a `User.create` inside a `DB.transaction` would commit separately on a pooled connection and survive the rollback, and a `DB.transaction` nested inside a `Model.transaction` would throw on Bun's `begin` guard. Both directions are tested.

## Writes are atomic exactly when the caller asks

`$exec` does not open a transaction per call. It cannot know whether it is one step of a larger unit, and doing so would put a `BEGIN` around every query in the framework and turn a caller's transaction into a nest of savepoints they never asked for. The not-atomic note iteration 4 left in `Model.$exec` is rewritten to say that rather than deleted — outside a transaction, a nested write's later step failing still leaves the earlier rows written.

## Tests

**`packages/gemi/orm/context.test.ts`** — the storage property, with fake handles and no database. The one that earns its keep: two concurrent transactions with awaits interleaved between every step, asserting each one's *statements* landed on its own handle, not just that each one read the right value. That is the test that fails if the handle ever moves somewhere shared, and a fake makes the interleaving deterministic in a way a real database is not.

**`templates/saas-starter/app/models/transactions.test.ts`** — the rest, against both dialects: commit and rollback, rollback of everything rather than the last statement, a query three frames deep through a service that never heard of the transaction, an `include`'s nested relation reads, a nested write's extra `before`/`after` statements, savepoint nesting three deep with depth asserted at each level, inner-rollback-outer-survives and inner-success-outer-rollback, `DB.transaction` interop both ways, no ambient handle outside a transaction, a rolled-back transaction not poisoning the next query, and no plan-cache pollution.

The two real-database concurrency cases are **Postgres-only and say why**: SQLite allows one writer at a time, so two concurrent write transactions there serialise or fail with `SQLITE_BUSY`. The interleaving cannot happen, and a test that "passes" because nothing overlapped proves nothing.

## Verification

| | |
| --- | --- |
| `packages/gemi` | 472 passed, 7 failed |
| baseline (stashed) | 462 passed, 7 failed |
| `templates/saas-starter` (SQLite) | 234 passed |
| Postgres 16 (Docker, `--no-file-parallelism`) | 267 passed |
| `tsc --noEmit` | clean |
| `oxlint` | 2 warnings, both pre-existing in `facades/Auth.ts` |
| `bun run build:core` + `build:types` | clean |

The 7 failures are the same pre-existing router/i18n ones, byte-identical to the baseline — confirmed by stashing this branch's changes and re-running. On the Postgres pass the only failing files are the two differential suites that cannot run with a Postgres-generated client, which is documented behaviour in `differential.ts`.

## For the reviewer

- **Postgres runs need `--no-file-parallelism`.** Every suite points at the one database `TEST_POSTGRES_URL` names, and this suite truncates it between cases. The new suite truncates *all* tables rather than the three it writes to — a row another suite left in `SocialAccount` otherwise makes its `DELETE FROM "User"` fail on a foreign key, and the failure lands here.
- `applyMigrations` is now exported from `differential.ts` so the transaction suite can build a SQLite database without pulling in a Prisma client.
- I confirmed again that the generated artifacts are dialect-agnostic: flipping the datasource to `postgresql` and regenerating produced no diff under `app/models/generated/`.

## Not in scope

Isolation-level configuration, retry-on-serialization-failure, distributed transactions, and a unit-of-work model, all per the plan. Also left alone: the optional development-mode warning for long-lived transactions — cheap, but the plan marks it not required, and it wants a duration threshold that should come from a measurement rather than a guess.

One thing iteration 5 now *makes* fixable, recorded in `compileDelete` during the #49 review: a `delete` with an `include` on a cascading relation reads the children after the database has removed them. The fix is to read relations before the delete inside one transaction. It is not done here because the template schema declares no cascades, so there is nothing to test it against yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqZNWz1c22s3iLyKEKCyJg
