### PR TITLE
Bytes is a Uint8Array on every dialect — correcting the fix I just shipped

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,10 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Forms](./forms.md)** — the `Form` component, surfacing validation errors, form status hooks.
 - **[Navigation](./navigation.md)** — `Link`, `useNavigate`, `useParams`, `useSearchParams`, and the `Redirect` component vs. facade.
 
+### Data
+- **[ORM](./orm.md)** — the Prisma-typed, gemi-executed query layer: models, relations, ambient transactions, policies, soft deletes.
+- **[Rows & Entities](./orm-rows-and-entities.md)** — plain objects by default, `track` + `save`, and `wrap`.
+
 ### Auth
 - **[Authentication](./authentication.md)** — `app/config/auth.ts`, adapters, sessions, magic links, OAuth, the `Auth` facade, and client auth hooks.
 - **[Authorization](./authorization.md)** — role-based middleware and authorization errors.

--- a/docs/index.html
+++ b/docs/index.html
@@ -107,6 +107,12 @@
         <a class="card" href="navigation.md"><span class="t">Navigation</span><span class="d">Link, useNavigate, params, search, Redirect.</span></a>
       </div>
 
+      <h2>Data</h2>
+      <div class="grid">
+        <a class="card" href="orm.md"><span class="t">ORM</span><span class="d">Models, relations, ambient transactions, policies, soft deletes.</span></a>
+        <a class="card" href="orm-rows-and-entities.md"><span class="t">Rows &amp; Entities</span><span class="d">POJOs by default, track + save, wrap.</span></a>
+      </div>
+
       <h2>Auth</h2>
       <div class="grid">
         <a class="card" href="authentication.md"><span class="t">Authentication</span><span class="d">app/config/auth.ts, adapters, sessions, magic links, OAuth, hooks.</span></a>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2766,9 +2766,13 @@ That `register` line is not bookkeeping. A relation read resolves its target thr
 by name, so whatever is registered under `"User"` is the class that runs inside every nested
 `include`. If that is the generated base while your policy lives on your subclass, the policy
 applies to root queries and is skipped inside includes — scoped one way, unscoped the other, with
-nothing to notice it. `Model.$exec` raises `UnregisteredPolicyClassError` if a class carrying
-policies is not the registered one, so forgetting the line fails loudly rather than leaking. Write
-it next to every subclass regardless.
+nothing to notice it. `Model.$exec` raises `UnregisteredPolicyClassError` when a class carrying
+policies is queried while a *different* class owns its name — but that guard is narrower than it
+sounds, and the gap runs the wrong way. **A model you only ever read through an `include` never
+trips it:** the include resolves the name to the unpolicied generated base, nothing diverges from
+nothing, and the rows come back unscoped with no error. That is the shape a membership or pivot
+model usually has, and it is exactly the kind that carries a tenant scope. Write the line next to
+every subclass regardless — the guard is a backstop for the cases it can see, not a substitute.
 
 ## Querying
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2693,6 +2693,552 @@ off-site URLs.
 
 ---
 
+## ORM
+
+gemi's ORM keeps Prisma's developer experience — including full `select` / `include` type
+narrowing — while executing every query itself through Bun's native `SQL` client. There is no
+Prisma query engine at runtime, no serialization boundary, and no Prisma client in your bundle.
+
+Two things justify it, and both are things Prisma structurally cannot give you:
+
+- **Ambient transactions.** `Model.transaction(fn)` puts every query inside `fn` — including
+  queries in code `fn` calls, three layers down, that knows nothing about transactions — on one
+  connection inside one transaction. No `tx` parameter threaded through your call stack.
+- **First-class policies that apply to nested reads.** A tenant scope on `Account` applies to
+  `Account.findMany()` *and* to the `accounts` inside `User.findMany({ include: { accounts: true } })`.
+
+## Division of labour
+
+Prisma is still here. It owns everything about your schema; gemi owns everything about running
+queries against it.
+
+| Concern | Owner |
+| --- | --- |
+| Schema definition (`schema.prisma`) | Prisma |
+| Migrations (`prisma migrate`) | Prisma |
+| Query argument and result **types** | Prisma (`prisma generate`, imported type-only) |
+| Runtime model metadata | gemi (a Prisma generator block, run by `prisma generate`) |
+| SQL compilation, execution, result shaping | gemi |
+| Transactions, policies, hooks | gemi |
+
+`@prisma/client` is generated and imported **type-only**. It never appears in a runtime import
+and never ships in a bundle.
+
+## Setup
+
+Add the gemi generator to `schema.prisma`, *after* the `client` block — the emitted bases
+type-import `@prisma/client`, and Prisma runs generators in declaration order.
+
+```prisma
+generator client {
+  provider = "prisma-client-js"
+}
+
+generator gemi {
+  provider = "gemi-orm-generator"
+  output   = "../app/models/generated"
+}
+```
+
+Then `bunx prisma generate`. You get three files under `app/models/generated/`:
+
+- `schema.ts` — runtime metadata: tables, columns, types, defaults, relations.
+- `models.ts` — a typed base class per model, carrying the thirteen operations.
+- `index.ts` — registers every model by name.
+
+**The output is committed on purpose.** Diffs stay reviewable and CI needs no codegen step.
+
+### Your model class
+
+The generated base is not the class you write code on. Subclass it, and **re-register it**:
+
+```ts
+// app/models/User.ts
+import { register } from "gemi/orm"
+import { UserModel } from "./generated"
+
+export class User extends UserModel {}
+
+register("User", User)
+```
+
+That `register` line is not bookkeeping. A relation read resolves its target through the registry
+by name, so whatever is registered under `"User"` is the class that runs inside every nested
+`include`. If that is the generated base while your policy lives on your subclass, the policy
+applies to root queries and is skipped inside includes — scoped one way, unscoped the other, with
+nothing to notice it. `Model.$exec` raises `UnregisteredPolicyClassError` if a class carrying
+policies is not the registered one, so forgetting the line fails loudly rather than leaking. Write
+it next to every subclass regardless.
+
+## Querying
+
+Thirteen operations, with Prisma's argument types verbatim:
+
+```
+findMany   findFirst   findFirstOrThrow   findUnique   findUniqueOrThrow   count
+create     createMany  update             updateMany   upsert              delete   deleteMany
+```
+
+```ts
+const users = await User.findMany({
+  where: { organizationId, email: { contains: "@example.com" } },
+  orderBy: { createdAt: "desc" },
+  take: 20,
+})
+
+const user = await User.findUniqueOrThrow({
+  where: { id },
+  select: { id: true, email: true, accounts: { select: { provider: true } } },
+})
+```
+
+`select` and `include` narrow the **return type**, exactly as they do in Prisma — `user.email`
+type-checks, `user.name` does not. A key outside the operation's argument type collapses to
+`never` rather than being quietly accepted.
+
+Queries return **plain objects**, never class instances. That is the default and it is not a
+stepping stone: a `Pick<User, "id">` hydrated as a `User` would carry methods reading fields the
+query never fetched. See [Rows and entities](./orm-rows-and-entities.md) for the two opt-in levels
+above it — `track` + `save`, and `wrap`.
+
+### Per-call options
+
+A second parameter, not a key inside `args` — intersecting Prisma's own arg types with a
+gemi-specific key would mean `Prisma.UserFindManyArgs` no longer describes what the operation
+accepts.
+
+```ts
+await User.findMany({ where }, { track: true, strategy: "batched" })
+```
+
+| Option | What it does |
+| --- | --- |
+| `track` | Record where each row came from so `Model.save(row)` can update it. Off by default; it costs a `WeakMap` insert and a snapshot clone per row. |
+| `strategy` | Which relation strategy loads the `include` tree. See below. |
+
+## Relations
+
+`include` and nested `select` work at any depth up to `MAX_RELATION_DEPTH` (10). Two strategies load
+them, and they return identical rows:
+
+- **`batched`** — one query per include node, with the children stitched onto the parents in
+  process. Works on every dialect.
+- **`lateral`** — the children folded into the root statement with a `LATERAL` join and
+  `json_agg`. **Postgres only, and the default there.** One round trip instead of one per node.
+
+The lateral strategy **declines per node** rather than emitting SQL it cannot get right, falling
+back to batching for that node alone. It declines a node that has its own `include`, a relation
+inside a `select`, and an implicit many-to-many. A mixed include tree therefore uses both, which
+is fine — the results are the same either way, and there are tests asserting exactly that against
+Prisma across thirty relation shapes.
+
+Override per call when you need to:
+
+```ts
+await User.findMany({ include: { accounts: true } }, { strategy: "batched" })
+```
+
+Unlike `track`, `strategy` **does** reach the compiler and **is** part of the plan cache key: two
+strategies emit different SQL for the same arguments.
+
+**Not implemented yet:** filtering on a relation (`where: { accounts: { some: … } }`) and ordering
+by one. Both raise `UnsupportedQueryError` rather than being silently ignored.
+
+## Transactions
+
+```ts
+await User.transaction(async () => {
+  const user = await User.create({ data: { email } })
+  await audit(user)          // its queries are in the transaction too
+})
+```
+
+`audit` needs no transaction parameter and no awareness that one is open. The scope is carried in
+an `AsyncLocalStorage`, so every ORM query in the async subtree joins it. Commit on return,
+rollback on throw.
+
+Nesting is a **savepoint**: an inner failure rolls back to the savepoint and leaves the outer
+transaction usable.
+
+### Two things that will bite you
+
+**Catching an error inside a transaction, on Postgres.** Any failed statement aborts the whole
+Postgres transaction block, so catching it and carrying on loses everything. SQLite does not care
+— which means this is a bug that passes in development and takes out the transaction in
+production:
+
+```ts
+await Model.transaction(async () => {
+  try { await User.create({ data: { email } }) }
+  catch (e) { if (!(e instanceof UniqueConstraintError)) throw e }
+  await Audit.create({ … })   // fine on SQLite; on Postgres: "current transaction is aborted"
+})
+```
+
+The fix is to make the fallible statement its own savepoint, which works on both dialects:
+
+```ts
+await Model.transaction(async () => {
+  try {
+    await Model.transaction(() => User.create({ data: { email } }))
+  } catch (e) { if (!(e instanceof UniqueConstraintError)) throw e }
+  await Audit.create({ … })   // fine on both
+})
+```
+
+**One statement at a time.** Every query in scope runs on one reserved connection, so
+`Promise.all` over several ORM calls inside the callback is not safe — the ordinary, encouraged
+thing everywhere else in a Bun codebase. Await them in sequence.
+
+## Policies
+
+A policy is a plain object on the model class. Every member is optional; a model with none pays a
+single `undefined` check per query.
+
+```ts
+export class Account extends AccountModel {
+  static $policy = {
+    scope: (ctx) => ({ organizationId: ctx.user.organizationId }),
+    onCreate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
+  }
+}
+
+register("Account", Account)
+```
+
+| Member | When it runs | What it does |
+| --- | --- | --- |
+| `before(ctx)` | First | Return `false` (or throw) to deny outright. |
+| `scope(ctx)` | Reads and row-matching writes | Returns a `where` fragment `AND`ed into `args.where`. A policy can only ever **narrow**. |
+| `onCreate(ctx, data)` | `create` / `createMany` / `upsert` | Defaults or validates the payload. An insert has no `where` for a scope to narrow. |
+| `redact(ctx, row)` | Shaping | Removes fields from a fetched row. |
+
+**Policies rewrite the argument tree, never SQL.** That is what makes a scope two lines instead of
+string surgery, what keeps the two relation strategies interchangeable, and what keeps the plan
+cache sound — policies run *before* the plan key is computed, so two differently-scoped users
+never share a plan.
+
+Because the rewrite happens on the arg tree, a nested read is scoped too:
+
+```ts
+await User.findMany({ include: { accounts: true } })
+// the accounts subquery carries Account's scope, under either strategy
+```
+
+### `ctx.user` denies by default
+
+Reading `ctx.user` when there is no user raises `PolicyDeniedError`. Not returning `null` —
+raising. A scope built from a null user would be `{ organizationId: undefined }`, and an undefined
+value is an *absent* filter, so the scope would silently vanish and the read would be unscoped.
+The leak is the quiet version of this error.
+
+Check `ctx.hasUser` first if a policy genuinely wants to handle both cases.
+
+The user is read **synchronously** off the request store, because this hook runs once per query
+per node of an include tree and an awaited user would be a round trip per node. The consequence:
+**a route without the `auth` middleware sees no user even when the request carries a valid
+cookie.** That is the correct reading — the route did not ask to authenticate — but it makes
+middleware configuration load-bearing for data access.
+
+### Outside a request
+
+Cron ticks, queue workers, seed scripts and tests never enter a request scope, so there is no
+ambient user. Two escapes:
+
+```ts
+await Model.asSystem(async () => { … })   // no actor; ctx.user reads null instead of raising
+await Model.asUser(actor, async () => { … })  // act as a specific user
+```
+
+`asSystem` is what the framework's own auth adapter uses: authentication runs *before* there is an
+authenticated user, so a policy scoping by `ctx.user` could not be satisfied and deny-by-default
+would turn "wrong password" into a 500.
+
+### A `scope` with no `onCreate` is refused
+
+If a policy scopes reads but says nothing about creates, `create` raises rather than writing a row
+into whatever tenant the caller named. Add an `onCreate` that sets the scoped column — or, if
+unscoped creates really are intended, say so with a pass-through `onCreate`.
+
+### Soft deletes
+
+Ships as a policy, which is the proof the hook is expressive enough to be worth having:
+
+```ts
+import { softDelete, softDeleteMany, softDeletes } from "gemi/orm"
+
+export class User extends UserModel {
+  static $policy = softDeletes()          // reads skip rows with a deletedAt
+  static delete = softDelete(User)        // delete becomes an update
+  static deleteMany = softDeleteMany(User)
+}
+```
+
+`deletedAt` must be a nullable `DateTime` on the model (`field` overrides the column name). The
+read half applies to nested reads for the same reason every policy does — a deleted `Account` does
+not appear under `User.findMany({ include: { accounts: true } })` without anything being written at
+the include site, which is the half ORM-level soft deletes usually get wrong.
+
+A class has one `$policy`, so composing with your own means composing the objects. The base-class
+route is usually cleaner and gets the ordering right for free (`policiesFor` walks base to
+derived, so the soft-delete scope applies first and yours narrows further):
+
+```ts
+class SoftDeleted extends UserModel { static $policy = softDeletes() }
+export class User extends SoftDeleted { static $policy = { …mine } }
+```
+
+## Errors
+
+Every failure is a typed error from `gemi/orm`, not a driver string.
+
+| Error | Raised when |
+| --- | --- |
+| `RecordNotFoundError` | An `…OrThrow` operation matched nothing. |
+| `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. |
+| `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
+| `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
+| `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
+| `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |
+| `RelationDepthExceededError` | An include tree past `MAX_RELATION_DEPTH`. |
+| `ParameterLimitError` | A statement exceeding the dialect's parameter ceiling. |
+| `StaleSchemaArtifactError` | Generated files predate the running gemi. Re-run `prisma generate`. |
+
+## Performance
+
+**Compilation is split from binding.** `compile` is a pure function of the argument *shape* and
+produces SQL where every value is a placeholder (`?` on SQLite, `$1` on Postgres); `bind` is the
+only stage that sees a value.
+So the same query shape produces byte-identical SQL, which makes it cacheable — and it makes SQL
+injection structurally impossible rather than carefully avoided, since identifiers can only come
+from the generated schema and values can only ever be parameters.
+
+Compiled plans are cached on `dialect:strategy:model:operation:canonicalShape`, in an LRU bounded
+at 1000 entries. `planCacheStats()` reports `size`, `compiles`, `hits`, `evictions` and
+`capacity`; `clearPlanCache()` empties it, which tests want and applications should not need.
+
+Measured numbers, the methodology, and the reasoning behind the lateral default live in
+`plans/orm/benchmarks.md` in the repository — deliberately not here, because they are tied to a
+machine and a dataset and would go stale as documentation.
+
+## Dialects
+
+**SQLite and Postgres** are built and tested, on every operation, against a differential harness
+that runs each query through both gemi and Prisma and compares the rows. `DatabaseManager` infers
+the dialect from `DATABASE_URL`.
+
+MySQL and MariaDB are **not** implemented. The dialect seam is there and `DatabaseManager` already
+recognises them, but nothing is built or tested behind it.
+
+## Not in scope
+
+Stated so you can plan around them rather than discover them:
+
+- **No identity map and no unit of work.** Two queries for the same row give you two objects. Half
+  an identity map is worse than none.
+- **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
+  touched.
+- **No `omit`.** Use `select`, or a policy's `redact`.
+- **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
+
+## See also
+
+- **[Rows and entities](./orm-rows-and-entities.md)** — POJOs, `track` + `save`, and `wrap`.
+- **[Authentication](./authentication.md)** — `app/config/auth.ts` and the user provider seam.
+  `OrmAuthenticationAdapter` (exported from `gemi/kernel`, beside the Prisma one) implements all
+  twenty-two methods of `IAuthenticationAdapter` on this ORM and can be selected in its place. The
+  starter template still points at the Prisma adapter; switching it is a per-application call.
+- **[Authorization](./authorization.md)** — route-level authorization, which policies complement
+  rather than replace.
+
+---
+
+## Rows and Entities
+
+Queries return **plain objects**. That is the default, it is not a stepping stone, and most
+applications should never need anything else.
+
+Beyond it there are two further levels, both opt-in. They exist because "mutate an object and
+save it" is genuinely convenient and "call a method on a record" sometimes is too — but each one
+buys that convenience with something, and the price is worth knowing before you pay it.
+
+These are **three deliberate levels, not one unfinished abstraction.**
+
+| Level | What you get | What it costs |
+| --- | --- | --- |
+| POJOs *(default)* | Plain objects, full `select` narrowing | Nothing |
+| `track` + `save` | Mutate and persist, only changed columns | ~2× read time when on; provenance tied to object identity |
+| `wrap` | Methods on a record | Requires a complete row |
+
+## Level 1 — plain objects
+
+```ts
+const users = await User.findMany({ where: { organizationId }, select: { id: true, email: true } })
+users[0].email
+```
+
+Exactly what Prisma returns, including `select` and `include` narrowing the type. Nothing is
+hydrated, nothing is proxied, and `users[0]` is a plain object you can spread, serialise, or
+hand to a view without thinking about it.
+
+This is the level `select` works properly at, and that is the reason it is the default: a
+narrowed row is a narrowed *type*, so there is nothing on it that could read a field the query
+did not fetch.
+
+## Level 2 — `track` and `save`
+
+To mutate a row and persist it, ask for provenance when you read it:
+
+```ts
+const user = await User.findUnique({ where: { id } }, { track: true })
+user.name = "New name"
+await User.save(user)      // update "User" set "name" = ?, "updatedAt" = ? where "id" = ?
+```
+
+`save` diffs against the values that came back and writes **only what changed**. An unchanged
+row is a no-op: no statement, and no `@updatedAt` stamp.
+
+`track` is a **second argument**, not a key inside the query, so `Prisma.UserFindManyArgs` keeps
+describing exactly what the operation accepts.
+
+### It is off by default, and that is a measurement
+
+Provenance costs a `WeakMap` insert and a snapshot clone per row. On a 1 000-row read that is
+**about +100% on SQLite and +40% on Postgres** — see `plans/orm/benchmarks.md`. So it is not a
+flag to set out of habit; on a large read it is a real decision.
+
+### Provenance is tied to object identity
+
+This is the first thing you will hit, so it is worth reading before you hit it.
+
+```ts
+const user = await User.findUnique({ where: { id } }, { track: true })
+const copy = { ...user }
+await User.save(copy)     // throws: this object carries no provenance
+```
+
+Provenance lives in a `WeakMap` keyed on the object, which is what stops it leaking — the entry
+goes when the row does. The consequence is that any *copy* is a different object with none:
+spreading, cloning, `structuredClone`, or a JSON round trip through a queue or an HTTP boundary
+all lose it.
+
+`save` raises there rather than guessing. The guess would be "write every column", and writing a
+column that was never fetched is how a partial `select` silently reverts data.
+
+### A partial row can be saved — and assigning to an unfetched column is refused
+
+```ts
+const user = await User.findUnique({ where: { id }, select: { id: true, name: true } }, { track: true })
+user.name = "Renamed"
+await User.save(user)             // update "User" set "name" = ? …
+```
+
+A partial row saves the columns it read. It cannot write the ones it did not, because there is
+nothing to compare them against and writing them blind would overwrite whatever the column
+actually holds.
+
+Assigning to one is an **error**, not a silent no-op:
+
+```ts
+user.email = "nope@example.com"   // never fetched
+await User.save(user)             // ✗ 'email' was not fetched by the query this row came from
+```
+
+Two ways forward, and the error names both: select the column, or update it explicitly with
+`User.update({ where, data: { email } })`.
+
+The row must also carry its **primary key** — a `select` without it leaves nothing to identify
+which row to update, and `save` says so rather than failing further down with a confusing
+`where` error.
+
+### The row is refreshed after a save
+
+`save` copies the database's version of the row back over yours, so `user.updatedAt` is the
+instant the update happened rather than the one you fetched. Anything else the database rewrote
+comes back too.
+
+### Everything else still applies
+
+`save` compiles through the same path as any other write, so [policies](./authorization.md)
+scope it, `@updatedAt` stamps it, an open transaction contains it, and two saves touching the
+same columns share one cached plan.
+
+## Level 3 — `wrap`, for behaviour
+
+When a record genuinely wants methods:
+
+```ts
+export class User extends UserModel {
+  get displayName() {
+    return this.name ?? this.email ?? "anonymous"
+  }
+}
+
+const user = User.wrap(await User.findUniqueOrThrow({ where: { id } }))
+user.displayName
+await user.save()
+```
+
+`wrap` requires a **complete** row. A partial one is a compile error:
+
+```ts
+const partial = await User.findUnique({ where: { id }, select: { id: true } })
+User.wrap(partial)   // ✗ Type error: missing properties
+```
+
+That single constraint is what lets instances and `select` coexist. `displayName` reads
+`this.email`, so it is only safe if `email` was fetched — and the type system, not a runtime
+check, is what guarantees it. Narrowing and behaviour never meet.
+
+It is also why `wrap` needs no `track`: a complete row is one that can be snapshotted in full,
+so the instance is tracked and `save()` works on it. The type constraint and the save capability
+are the same constraint.
+
+### `wrap` is explicit on purpose
+
+Queries do not hydrate by default and will not. The moment they did, `select: { id: true }`
+would produce an instance whose methods can read fields the query never fetched — a runtime
+crash the type system cannot see, because the operation's return type still describes a narrowed
+payload.
+
+There is an `ActiveRecordModel` base in the ORM that makes every query return instances by
+overriding one method. It ships as a **documented example rather than a supported tier**, for
+exactly the reason above plus one more: the return *types* do not change, so the methods are
+invisible to TypeScript at the call site even though they exist at runtime. Fixing that means
+conditional return types across all twelve operations, which is the complexity the plain-object
+default was chosen to avoid.
+
+Use it if you want to see the seam work. Reach for `wrap` if you want the guarantee.
+
+## What this is not
+
+There is **no identity map, no unit of work, no deferred flush, and no lazy relation loading on
+instances** — deliberately, and not as a gap to be filled later without a plan.
+
+Full Doctrine- or Hibernate-style active record brings flush ordering across foreign keys,
+cascade semantics, stale-instance invalidation, and a request-scoped identity map that is a
+memory leak if scoped too widely and a cross-tenant data leak if scoped wrongly. **Half an
+identity map is worse than none**, because code starts relying on guarantees it only sometimes
+has.
+
+So: two objects read from the same row in the same request are two objects, and mutating one does
+not change the other. `save` writes when you call it and not before. If you need a transaction
+around several saves, open one:
+
+```ts
+await Model.transaction(async () => {
+  await User.save(user)
+  await Account.save(account)
+})
+```
+
+If this tier is ever pursued properly it gets its own plan and its own decision about whether
+the ORM is the product rather than one part of the framework. Until then, the levels above are
+what there is, and they are complete as described.
+
+
+---
+
 ## Authentication
 
 gemi ships a full authentication system — email/password, passwordless magic-link (PIN),

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2848,6 +2848,23 @@ strategies emit different SQL for the same arguments.
 **Not implemented yet:** filtering on a relation (`where: { accounts: { some: … } }`) and ordering
 by one. Both raise `UnsupportedQueryError` rather than being silently ignored.
 
+### One value that will surprise you
+
+A `Bytes` column comes back as a plain `Uint8Array`, on every dialect and under either strategy —
+which is what Prisma returns, so it is parity rather than a gemi choice. The surprise is that
+`Uint8Array.prototype.toString` **ignores its argument**:
+
+```ts
+row.blob.toString("hex")                 // "1,2,255" — not an error, just wrong
+Buffer.from(row.blob).toString("hex")    // "0102ff"
+```
+
+Worth knowing because the wrong form looks right and throws nothing. It is also the reason the
+container is asserted rather than only the contents in the coercion tests: `Buffer` is a
+`Uint8Array` subclass, so the two compare equal element by element while behaving differently here.
+Postgres' driver hands back a `Buffer` and the dialect normalises it, so this stays one answer
+across dialects.
+
 ## Transactions
 
 ```ts

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -26,6 +26,11 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Forms](https://nstfkc.github.io/gemi/forms.md): the Form component, surfacing validation errors, form-status hooks.
 - [Navigation](https://nstfkc.github.io/gemi/navigation.md): Link, useNavigate, useParams, useSearchParams, and the Redirect component vs facade.
 
+## Data
+
+- [ORM](https://nstfkc.github.io/gemi/orm.md): the Prisma-typed, gemi-executed query layer — the Prisma generator block, the thirteen operations, relations and the batched/lateral strategies, ambient transactions, policies that apply to nested reads, soft deletes.
+- [Rows & Entities](https://nstfkc.github.io/gemi/orm-rows-and-entities.md): plain objects by default, opt-in provenance with track + save, and wrap for methods on a record.
+
 ## Auth
 
 - [Authentication](https://nstfkc.github.io/gemi/authentication.md): app/config/auth.ts, adapters, sessions, magic links, OAuth, the Auth facade, and client auth hooks.

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -71,9 +71,13 @@ That `register` line is not bookkeeping. A relation read resolves its target thr
 by name, so whatever is registered under `"User"` is the class that runs inside every nested
 `include`. If that is the generated base while your policy lives on your subclass, the policy
 applies to root queries and is skipped inside includes — scoped one way, unscoped the other, with
-nothing to notice it. `Model.$exec` raises `UnregisteredPolicyClassError` if a class carrying
-policies is not the registered one, so forgetting the line fails loudly rather than leaking. Write
-it next to every subclass regardless.
+nothing to notice it. `Model.$exec` raises `UnregisteredPolicyClassError` when a class carrying
+policies is queried while a *different* class owns its name — but that guard is narrower than it
+sounds, and the gap runs the wrong way. **A model you only ever read through an `include` never
+trips it:** the include resolves the name to the unpolicied generated base, nothing diverges from
+nothing, and the rows come back unscoped with no error. That is the shape a membership or pivot
+model usually has, and it is exactly the kind that carries a tenant scope. Write the line next to
+every subclass regardless — the guard is a backstop for the cases it can see, not a substitute.
 
 ## Querying
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -153,6 +153,23 @@ strategies emit different SQL for the same arguments.
 **Not implemented yet:** filtering on a relation (`where: { accounts: { some: … } }`) and ordering
 by one. Both raise `UnsupportedQueryError` rather than being silently ignored.
 
+### One value that will surprise you
+
+A `Bytes` column comes back as a plain `Uint8Array`, on every dialect and under either strategy —
+which is what Prisma returns, so it is parity rather than a gemi choice. The surprise is that
+`Uint8Array.prototype.toString` **ignores its argument**:
+
+```ts
+row.blob.toString("hex")                 // "1,2,255" — not an error, just wrong
+Buffer.from(row.blob).toString("hex")    // "0102ff"
+```
+
+Worth knowing because the wrong form looks right and throws nothing. It is also the reason the
+container is asserted rather than only the contents in the coercion tests: `Buffer` is a
+`Uint8Array` subclass, so the two compare equal element by element while behaving differently here.
+Postgres' driver hands back a `Buffer` and the dialect normalises it, so this stays one answer
+across dialects.
+
 ## Transactions
 
 ```ts

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1,0 +1,357 @@
+# ORM
+
+gemi's ORM keeps Prisma's developer experience — including full `select` / `include` type
+narrowing — while executing every query itself through Bun's native `SQL` client. There is no
+Prisma query engine at runtime, no serialization boundary, and no Prisma client in your bundle.
+
+Two things justify it, and both are things Prisma structurally cannot give you:
+
+- **Ambient transactions.** `Model.transaction(fn)` puts every query inside `fn` — including
+  queries in code `fn` calls, three layers down, that knows nothing about transactions — on one
+  connection inside one transaction. No `tx` parameter threaded through your call stack.
+- **First-class policies that apply to nested reads.** A tenant scope on `Account` applies to
+  `Account.findMany()` *and* to the `accounts` inside `User.findMany({ include: { accounts: true } })`.
+
+## Division of labour
+
+Prisma is still here. It owns everything about your schema; gemi owns everything about running
+queries against it.
+
+| Concern | Owner |
+| --- | --- |
+| Schema definition (`schema.prisma`) | Prisma |
+| Migrations (`prisma migrate`) | Prisma |
+| Query argument and result **types** | Prisma (`prisma generate`, imported type-only) |
+| Runtime model metadata | gemi (a Prisma generator block, run by `prisma generate`) |
+| SQL compilation, execution, result shaping | gemi |
+| Transactions, policies, hooks | gemi |
+
+`@prisma/client` is generated and imported **type-only**. It never appears in a runtime import
+and never ships in a bundle.
+
+## Setup
+
+Add the gemi generator to `schema.prisma`, *after* the `client` block — the emitted bases
+type-import `@prisma/client`, and Prisma runs generators in declaration order.
+
+```prisma
+generator client {
+  provider = "prisma-client-js"
+}
+
+generator gemi {
+  provider = "gemi-orm-generator"
+  output   = "../app/models/generated"
+}
+```
+
+Then `bunx prisma generate`. You get three files under `app/models/generated/`:
+
+- `schema.ts` — runtime metadata: tables, columns, types, defaults, relations.
+- `models.ts` — a typed base class per model, carrying the thirteen operations.
+- `index.ts` — registers every model by name.
+
+**The output is committed on purpose.** Diffs stay reviewable and CI needs no codegen step.
+
+### Your model class
+
+The generated base is not the class you write code on. Subclass it, and **re-register it**:
+
+```ts
+// app/models/User.ts
+import { register } from "gemi/orm"
+import { UserModel } from "./generated"
+
+export class User extends UserModel {}
+
+register("User", User)
+```
+
+That `register` line is not bookkeeping. A relation read resolves its target through the registry
+by name, so whatever is registered under `"User"` is the class that runs inside every nested
+`include`. If that is the generated base while your policy lives on your subclass, the policy
+applies to root queries and is skipped inside includes — scoped one way, unscoped the other, with
+nothing to notice it. `Model.$exec` raises `UnregisteredPolicyClassError` if a class carrying
+policies is not the registered one, so forgetting the line fails loudly rather than leaking. Write
+it next to every subclass regardless.
+
+## Querying
+
+Thirteen operations, with Prisma's argument types verbatim:
+
+```
+findMany   findFirst   findFirstOrThrow   findUnique   findUniqueOrThrow   count
+create     createMany  update             updateMany   upsert              delete   deleteMany
+```
+
+```ts
+const users = await User.findMany({
+  where: { organizationId, email: { contains: "@example.com" } },
+  orderBy: { createdAt: "desc" },
+  take: 20,
+})
+
+const user = await User.findUniqueOrThrow({
+  where: { id },
+  select: { id: true, email: true, accounts: { select: { provider: true } } },
+})
+```
+
+`select` and `include` narrow the **return type**, exactly as they do in Prisma — `user.email`
+type-checks, `user.name` does not. A key outside the operation's argument type collapses to
+`never` rather than being quietly accepted.
+
+Queries return **plain objects**, never class instances. That is the default and it is not a
+stepping stone: a `Pick<User, "id">` hydrated as a `User` would carry methods reading fields the
+query never fetched. See [Rows and entities](./orm-rows-and-entities.md) for the two opt-in levels
+above it — `track` + `save`, and `wrap`.
+
+### Per-call options
+
+A second parameter, not a key inside `args` — intersecting Prisma's own arg types with a
+gemi-specific key would mean `Prisma.UserFindManyArgs` no longer describes what the operation
+accepts.
+
+```ts
+await User.findMany({ where }, { track: true, strategy: "batched" })
+```
+
+| Option | What it does |
+| --- | --- |
+| `track` | Record where each row came from so `Model.save(row)` can update it. Off by default; it costs a `WeakMap` insert and a snapshot clone per row. |
+| `strategy` | Which relation strategy loads the `include` tree. See below. |
+
+## Relations
+
+`include` and nested `select` work at any depth up to `MAX_RELATION_DEPTH` (10). Two strategies load
+them, and they return identical rows:
+
+- **`batched`** — one query per include node, with the children stitched onto the parents in
+  process. Works on every dialect.
+- **`lateral`** — the children folded into the root statement with a `LATERAL` join and
+  `json_agg`. **Postgres only, and the default there.** One round trip instead of one per node.
+
+The lateral strategy **declines per node** rather than emitting SQL it cannot get right, falling
+back to batching for that node alone. It declines a node that has its own `include`, a relation
+inside a `select`, and an implicit many-to-many. A mixed include tree therefore uses both, which
+is fine — the results are the same either way, and there are tests asserting exactly that against
+Prisma across thirty relation shapes.
+
+Override per call when you need to:
+
+```ts
+await User.findMany({ include: { accounts: true } }, { strategy: "batched" })
+```
+
+Unlike `track`, `strategy` **does** reach the compiler and **is** part of the plan cache key: two
+strategies emit different SQL for the same arguments.
+
+**Not implemented yet:** filtering on a relation (`where: { accounts: { some: … } }`) and ordering
+by one. Both raise `UnsupportedQueryError` rather than being silently ignored.
+
+## Transactions
+
+```ts
+await User.transaction(async () => {
+  const user = await User.create({ data: { email } })
+  await audit(user)          // its queries are in the transaction too
+})
+```
+
+`audit` needs no transaction parameter and no awareness that one is open. The scope is carried in
+an `AsyncLocalStorage`, so every ORM query in the async subtree joins it. Commit on return,
+rollback on throw.
+
+Nesting is a **savepoint**: an inner failure rolls back to the savepoint and leaves the outer
+transaction usable.
+
+### Two things that will bite you
+
+**Catching an error inside a transaction, on Postgres.** Any failed statement aborts the whole
+Postgres transaction block, so catching it and carrying on loses everything. SQLite does not care
+— which means this is a bug that passes in development and takes out the transaction in
+production:
+
+```ts
+await Model.transaction(async () => {
+  try { await User.create({ data: { email } }) }
+  catch (e) { if (!(e instanceof UniqueConstraintError)) throw e }
+  await Audit.create({ … })   // fine on SQLite; on Postgres: "current transaction is aborted"
+})
+```
+
+The fix is to make the fallible statement its own savepoint, which works on both dialects:
+
+```ts
+await Model.transaction(async () => {
+  try {
+    await Model.transaction(() => User.create({ data: { email } }))
+  } catch (e) { if (!(e instanceof UniqueConstraintError)) throw e }
+  await Audit.create({ … })   // fine on both
+})
+```
+
+**One statement at a time.** Every query in scope runs on one reserved connection, so
+`Promise.all` over several ORM calls inside the callback is not safe — the ordinary, encouraged
+thing everywhere else in a Bun codebase. Await them in sequence.
+
+## Policies
+
+A policy is a plain object on the model class. Every member is optional; a model with none pays a
+single `undefined` check per query.
+
+```ts
+export class Account extends AccountModel {
+  static $policy = {
+    scope: (ctx) => ({ organizationId: ctx.user.organizationId }),
+    onCreate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
+  }
+}
+
+register("Account", Account)
+```
+
+| Member | When it runs | What it does |
+| --- | --- | --- |
+| `before(ctx)` | First | Return `false` (or throw) to deny outright. |
+| `scope(ctx)` | Reads and row-matching writes | Returns a `where` fragment `AND`ed into `args.where`. A policy can only ever **narrow**. |
+| `onCreate(ctx, data)` | `create` / `createMany` / `upsert` | Defaults or validates the payload. An insert has no `where` for a scope to narrow. |
+| `redact(ctx, row)` | Shaping | Removes fields from a fetched row. |
+
+**Policies rewrite the argument tree, never SQL.** That is what makes a scope two lines instead of
+string surgery, what keeps the two relation strategies interchangeable, and what keeps the plan
+cache sound — policies run *before* the plan key is computed, so two differently-scoped users
+never share a plan.
+
+Because the rewrite happens on the arg tree, a nested read is scoped too:
+
+```ts
+await User.findMany({ include: { accounts: true } })
+// the accounts subquery carries Account's scope, under either strategy
+```
+
+### `ctx.user` denies by default
+
+Reading `ctx.user` when there is no user raises `PolicyDeniedError`. Not returning `null` —
+raising. A scope built from a null user would be `{ organizationId: undefined }`, and an undefined
+value is an *absent* filter, so the scope would silently vanish and the read would be unscoped.
+The leak is the quiet version of this error.
+
+Check `ctx.hasUser` first if a policy genuinely wants to handle both cases.
+
+The user is read **synchronously** off the request store, because this hook runs once per query
+per node of an include tree and an awaited user would be a round trip per node. The consequence:
+**a route without the `auth` middleware sees no user even when the request carries a valid
+cookie.** That is the correct reading — the route did not ask to authenticate — but it makes
+middleware configuration load-bearing for data access.
+
+### Outside a request
+
+Cron ticks, queue workers, seed scripts and tests never enter a request scope, so there is no
+ambient user. Two escapes:
+
+```ts
+await Model.asSystem(async () => { … })   // no actor; ctx.user reads null instead of raising
+await Model.asUser(actor, async () => { … })  // act as a specific user
+```
+
+`asSystem` is what the framework's own auth adapter uses: authentication runs *before* there is an
+authenticated user, so a policy scoping by `ctx.user` could not be satisfied and deny-by-default
+would turn "wrong password" into a 500.
+
+### A `scope` with no `onCreate` is refused
+
+If a policy scopes reads but says nothing about creates, `create` raises rather than writing a row
+into whatever tenant the caller named. Add an `onCreate` that sets the scoped column — or, if
+unscoped creates really are intended, say so with a pass-through `onCreate`.
+
+### Soft deletes
+
+Ships as a policy, which is the proof the hook is expressive enough to be worth having:
+
+```ts
+import { softDelete, softDeleteMany, softDeletes } from "gemi/orm"
+
+export class User extends UserModel {
+  static $policy = softDeletes()          // reads skip rows with a deletedAt
+  static delete = softDelete(User)        // delete becomes an update
+  static deleteMany = softDeleteMany(User)
+}
+```
+
+`deletedAt` must be a nullable `DateTime` on the model (`field` overrides the column name). The
+read half applies to nested reads for the same reason every policy does — a deleted `Account` does
+not appear under `User.findMany({ include: { accounts: true } })` without anything being written at
+the include site, which is the half ORM-level soft deletes usually get wrong.
+
+A class has one `$policy`, so composing with your own means composing the objects. The base-class
+route is usually cleaner and gets the ordering right for free (`policiesFor` walks base to
+derived, so the soft-delete scope applies first and yours narrows further):
+
+```ts
+class SoftDeleted extends UserModel { static $policy = softDeletes() }
+export class User extends SoftDeleted { static $policy = { …mine } }
+```
+
+## Errors
+
+Every failure is a typed error from `gemi/orm`, not a driver string.
+
+| Error | Raised when |
+| --- | --- |
+| `RecordNotFoundError` | An `…OrThrow` operation matched nothing. |
+| `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. |
+| `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
+| `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
+| `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
+| `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |
+| `RelationDepthExceededError` | An include tree past `MAX_RELATION_DEPTH`. |
+| `ParameterLimitError` | A statement exceeding the dialect's parameter ceiling. |
+| `StaleSchemaArtifactError` | Generated files predate the running gemi. Re-run `prisma generate`. |
+
+## Performance
+
+**Compilation is split from binding.** `compile` is a pure function of the argument *shape* and
+produces SQL where every value is a placeholder (`?` on SQLite, `$1` on Postgres); `bind` is the
+only stage that sees a value.
+So the same query shape produces byte-identical SQL, which makes it cacheable — and it makes SQL
+injection structurally impossible rather than carefully avoided, since identifiers can only come
+from the generated schema and values can only ever be parameters.
+
+Compiled plans are cached on `dialect:strategy:model:operation:canonicalShape`, in an LRU bounded
+at 1000 entries. `planCacheStats()` reports `size`, `compiles`, `hits`, `evictions` and
+`capacity`; `clearPlanCache()` empties it, which tests want and applications should not need.
+
+Measured numbers, the methodology, and the reasoning behind the lateral default live in
+`plans/orm/benchmarks.md` in the repository — deliberately not here, because they are tied to a
+machine and a dataset and would go stale as documentation.
+
+## Dialects
+
+**SQLite and Postgres** are built and tested, on every operation, against a differential harness
+that runs each query through both gemi and Prisma and compares the rows. `DatabaseManager` infers
+the dialect from `DATABASE_URL`.
+
+MySQL and MariaDB are **not** implemented. The dialect seam is there and `DatabaseManager` already
+recognises them, but nothing is built or tested behind it.
+
+## Not in scope
+
+Stated so you can plan around them rather than discover them:
+
+- **No identity map and no unit of work.** Two queries for the same row give you two objects. Half
+  an identity map is worse than none.
+- **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
+  touched.
+- **No `omit`.** Use `select`, or a policy's `redact`.
+- **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
+
+## See also
+
+- **[Rows and entities](./orm-rows-and-entities.md)** — POJOs, `track` + `save`, and `wrap`.
+- **[Authentication](./authentication.md)** — `app/config/auth.ts` and the user provider seam.
+  `OrmAuthenticationAdapter` (exported from `gemi/kernel`, beside the Prisma one) implements all
+  twenty-two methods of `IAuthenticationAdapter` on this ORM and can be selected in its place. The
+  starter template still points at the Prisma adapter; switching it is a per-application call.
+- **[Authorization](./authorization.md)** — route-level authorization, which policies complement
+  rather than replace.

--- a/packages/gemi/orm/compile/lateral.ts
+++ b/packages/gemi/orm/compile/lateral.ts
@@ -317,25 +317,29 @@ function jsonConverter(
     case "Bytes":
       // Postgres renders `bytea` into JSON as `\x` followed by hex.
       //
-      // **`Buffer`, not `Uint8Array`**, and the container matters as much as the
-      // contents. The driver gives the batched path a `Buffer`, and this
-      // codebase's rule is that a strategy must be invisible to callers — so
-      // returning a bare `Uint8Array` here made `row.digest.toString("hex")`
-      // return `"1,2,255"` instead of `"0102ff"`. A wrong answer with no error,
-      // because `Uint8Array.prototype.toString` ignores its argument.
-      // `Buffer.isBuffer` and the rest of that surface went the same way.
+      // **`Uint8Array`, not `Buffer`**, and the container matters as much as
+      // the contents — see `PostgresDialect.decode`, which normalises the
+      // driver's `Buffer` to the same thing for the batched path. Prisma 6
+      // returns `Uint8Array` on every dialect; that is the contract, and
+      // `Buffer.prototype.toString("hex")` versus
+      // `Uint8Array.prototype.toString("hex")` is the observable difference.
       //
-      // My own coercion fixture missed this: it compared `[...folded]` against
-      // `[...fetched]`, which spreads both to plain arrays and so passes for two
-      // different containers holding the same bytes. Contents were equal; the
-      // type was not.
+      // `Buffer.from(text, "hex")` for the parse — it is the parser the driver
+      // would have used, and faster than a manual nibble loop — then a view
+      // over the same bytes. No copy.
       return (value) => {
         if (value === null || value === undefined) return null;
-        if (Buffer.isBuffer(value)) return value;
-        if (ArrayBuffer.isView(value)) return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
-        // `Buffer.from(text, "hex")` rather than a manual loop — same result,
-        // and it is the parser the driver would have used.
-        return Buffer.from(String(value).replace(/^\\?x/, ""), "hex");
+        if (ArrayBuffer.isView(value)) {
+          return Buffer.isBuffer(value)
+            ? new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+            : value;
+        }
+        const buffer = Buffer.from(String(value).replace(/^\\?x/, ""), "hex");
+        return new Uint8Array(
+          buffer.buffer,
+          buffer.byteOffset,
+          buffer.byteLength,
+        );
       };
 
     default:

--- a/packages/gemi/orm/dialect/postgres.test.ts
+++ b/packages/gemi/orm/dialect/postgres.test.ts
@@ -186,12 +186,53 @@ describe("decoding the types the template schema cannot reach", () => {
     expect(postgres.decode({ a: 1 }, field("Json") as any)).toEqual({ a: 1 });
   });
 
-  test.each(["Int", "String", "Boolean", "Float", "DateTime", "Bytes"])(
+  test.each(["Int", "String", "Boolean", "Float", "DateTime"])(
     "%s needs no decoding",
     (type) => {
       expect(postgres.needsDecode(field(type) as any)).toBe(false);
     },
   );
+
+  /**
+   * `Bytes` used to be on that list, and the driver's `Buffer` went straight
+   * through. Prisma 6 returns a `Uint8Array` on every dialect, and so does this
+   * ORM on SQLite, where the driver's own value already is one — so passing the
+   * `Buffer` through diverged from Prisma and from our other dialect at once.
+   *
+   * It stayed invisible because `Buffer` *is* a `Uint8Array`: it satisfies the
+   * generated type, passes `ArrayBuffer.isView`, and compares equal element by
+   * element. `toString` is where they part company.
+   */
+  test("Bytes is normalised to a Uint8Array, not the driver's Buffer", () => {
+    expect(postgres.needsDecode(field("Bytes") as any)).toBe(true);
+
+    const buffer = Buffer.from([1, 2, 255]);
+    const decoded = postgres.decode(buffer, field("Bytes") as any) as Uint8Array;
+
+    expect(Buffer.isBuffer(decoded)).toBe(false);
+    expect(decoded.constructor.name).toBe("Uint8Array");
+    expect([...decoded]).toEqual([1, 2, 255]);
+
+    // The observable difference, and the reason the container is worth a test:
+    // `Buffer.prototype.toString` takes an encoding, `Uint8Array`'s ignores it.
+    expect(buffer.toString("hex")).toBe("0102ff");
+    expect(decoded.toString("hex")).toBe("1,2,255");
+  });
+
+  /** A view over the driver's bytes, so a large row costs no copy. */
+  test("the normalised Bytes shares memory with the driver's buffer", () => {
+    const buffer = Buffer.from([7, 8, 9]);
+    const decoded = postgres.decode(buffer, field("Bytes") as any) as Uint8Array;
+
+    expect(decoded.buffer).toBe(buffer.buffer);
+    expect(decoded.byteOffset).toBe(buffer.byteOffset);
+  });
+
+  /** A driver that already hands back a plain view is left alone. */
+  test("a Uint8Array from the driver passes through untouched", () => {
+    const bytes = new Uint8Array([4, 5]);
+    expect(postgres.decode(bytes, field("Bytes") as any)).toBe(bytes);
+  });
 
   test("a value that cannot be decoded raises rather than returning nonsense", () => {
     expect(() => postgres.decode("not json", field("Json") as any)).toThrow();

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -164,15 +164,24 @@ export class PostgresDialect implements SqlDialect {
   //   boolean            -> boolean     ✓
   //   text               -> string      ✓
   //   timestamp(3)       -> Date        ✓ (but see the protocol note below)
-  //   bytea              -> Buffer      ✓ (a Uint8Array, which is what Prisma gives)
+  //   bytea              -> Buffer      ✗ where Prisma gives a plain Uint8Array
   //   bigint             -> "123"       ✗ string, where Prisma gives 123n
   //   jsonb / json       -> '{"a":1}'   ✗ unparsed text, where Prisma gives an object
+  //
+  // The `bytea` line carried a ✓ and the parenthetical "a Uint8Array, which is
+  // what Prisma gives". Both halves are true and the conclusion was still wrong:
+  // a `Buffer` *is* a `Uint8Array`, so the type checks out, but it is not the
+  // one Prisma returns and it does not behave the same. Checked against a
+  // generated Prisma 6 client on both dialects rather than reasoned about —
+  // Prisma returns a plain `Uint8Array` for `Bytes` everywhere.
   //
   // `numeric` also arrives as a string, which is the correct thing for it to
   // do — but `Decimal` is refused at *generation* time (iteration 1), so no
   // such field can reach this.
   needsDecode(field: FieldSchema): boolean {
-    return field.type === "BigInt" || field.type === "Json";
+    return (
+      field.type === "BigInt" || field.type === "Json" || field.type === "Bytes"
+    );
   }
 
   decode(value: unknown, field: FieldSchema): unknown {
@@ -195,6 +204,25 @@ export class PostgresDialect implements SqlDialect {
         } catch {
           throw new DecodeError(field, value);
         }
+      case "Bytes":
+        // The driver hands back a `Buffer`; Prisma 6 returns a `Uint8Array`,
+        // on **every** dialect, and so does this ORM on SQLite where the
+        // driver's own value already is one. Returning the `Buffer` verbatim
+        // therefore diverged from Prisma and from our own SQLite path at the
+        // same time — and `Buffer` being a `Uint8Array` subclass is exactly
+        // what made it invisible: it satisfies the generated type, survives
+        // `ArrayBuffer.isView`, and compares equal element by element.
+        //
+        // What it does not survive is `toString`. `Buffer.prototype.toString`
+        // takes an encoding; `Uint8Array.prototype.toString` ignores its
+        // argument and joins with commas. So `row.digest.toString("hex")` read
+        // `"0102ff"` in production on Postgres and `"1,2,255"` in development
+        // on SQLite, with no error on either.
+        //
+        // A view, not a copy: same bytes, same lifetime, no allocation.
+        return Buffer.isBuffer(value)
+          ? new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+          : value;
       default:
         return value;
     }

--- a/plans/orm/README.md
+++ b/plans/orm/README.md
@@ -398,6 +398,31 @@ Iterations 5 and 6 are the reason the project exists, but they are cheap *once
 the choke point exists*, which is why they come after the query engine rather
 than before it.
 
+**All nine have shipped.** What remains on this plan is not another vehicle: it
+is the two entries under [Open decisions](#open-decisions) that are decisions
+rather than work, and whatever the ORM's first real users find.
+
+### Documentation
+
+`docs/orm.md` is the user-facing page — setup through the Prisma generator
+block, the thirteen operations, relations and the two strategies, ambient
+transactions, policies, soft deletes, the typed errors, and an explicit
+*not in scope* section. It sits beside `docs/orm-rows-and-entities.md`, which
+iteration 8 wrote and which nothing linked to: neither page was reachable from
+`docs/README.md`, `docs/index.html`, `docs/llms.txt` or `docs/llms-full.txt`
+until the doc pass. Both are now in all four.
+
+Two deliberate omissions, so the next person does not read them as oversights:
+
+- **No measured numbers.** They live in `plans/orm/benchmarks.md`, generated
+  from `benchmarks.json`. Copying them into `docs/` would produce prose that
+  drifts from its own source — which happened three times inside the benchmark
+  document itself before the numbers were derived rather than written.
+- **Nothing about internals.** `$exec`, the plan key, `Fragment`/`Binder`, the
+  strategy seam and the six invariants are all in this directory. An
+  application author does not need them, and documenting them in `docs/` would
+  make them a compatibility surface.
+
 ## Picking up an iteration
 
 0. Confirm you are on a branch descended from `feat/database-layer` (see

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -123,7 +123,16 @@ function normalize(value: unknown, volatile?: Set<string>): unknown {
   if (value === null) return null;
   if (value instanceof Date) return `date:${value.toISOString()}`;
   if (typeof value === "bigint") return `bigint:${value.toString()}`;
-  if (ArrayBuffer.isView(value)) return `bytes:${[...(value as any)].join(",")}`;
+  // The constructor name is part of the comparison, not decoration. `Buffer`
+  // is a `Uint8Array` subclass, so a divergence between the two survives
+  // `ArrayBuffer.isView`, the generated type, and any element-wise comparison —
+  // and spreading to an array, which is what this line used to do, erased the
+  // one thing that distinguishes them. `.toString("hex")` returns `"0102ff"`
+  // from one and `"1,2,255"` from the other, so it is a real divergence that
+  // this harness could not see. See the `Bytes` case in `PostgresDialect`.
+  if (ArrayBuffer.isView(value)) {
+    return `bytes:${value.constructor.name}:${[...(value as any)].join(",")}`;
+  }
   if (Array.isArray(value)) return value.map((item) => normalize(item, volatile));
   if (typeof value === "object") {
     const out: Record<string, unknown> = {};

--- a/templates/saas-starter/app/models/lateral.coercion.test.ts
+++ b/templates/saas-starter/app/models/lateral.coercion.test.ts
@@ -258,19 +258,25 @@ RUN("every scalar through a relation, lateral vs batched", () => {
     expect([...folded]).toEqual([...VALUES.blob]);
     expect([...folded]).toEqual([...fetched]);
 
-    // The *container*, not just the contents — and this is the assertion the
-    // first version of this test was missing. `[...x]` spreads a `Buffer` and a
+    // The *container*, not just the contents. `[...x]` spreads a `Buffer` and a
     // `Uint8Array` to the same plain array, so a content-only comparison passes
-    // for two different types. The difference is observable and bites the
-    // ordinary things a caller does with a `bytea`.
-    expect(Buffer.isBuffer(folded)).toBe(true);
-    expect(Buffer.isBuffer(fetched)).toBe(true);
+    // for two different types — which is how the first version of this test
+    // missed a real divergence it was written to catch.
+    //
+    // `Uint8Array` on both sides, because that is what Prisma 6 returns on
+    // every dialect and what this ORM returns on SQLite. The first fix here
+    // converged both Postgres paths on `Buffer` instead, which made the two
+    // strategies agree with each other and with nothing else.
+    expect(Buffer.isBuffer(folded)).toBe(false);
+    expect(Buffer.isBuffer(fetched)).toBe(false);
+    expect(folded.constructor.name).toBe("Uint8Array");
+    expect(fetched.constructor.name).toBe("Uint8Array");
 
-    // The specific way it bit: `Uint8Array.prototype.toString` ignores its
-    // argument, so this returned "0,1,2,253,254,255" instead of hex — a wrong
-    // answer with no error.
+    // The call that made the difference observable rather than academic.
+    // `Uint8Array.prototype.toString` ignores its argument, so this is the
+    // comma form on both paths — the same answer a caller gets from Prisma.
     expect(folded.toString("hex")).toBe(fetched.toString("hex"));
-    expect(folded.toString("hex")).toBe("000102fdfeff");
+    expect(folded.toString("hex")).toBe("0,1,2,253,254,255");
   });
 
   /** ISO text out of the aggregate, where the driver would have given a `Date`. */
@@ -308,6 +314,9 @@ RUN("every scalar through a relation, lateral vs batched", () => {
     expect([...lateral[0].items[0].blob]).toEqual([
       ...batched[0].items[0].blob,
     ]);
+    expect(lateral[0].items[0].blob.constructor.name).toBe(
+      batched[0].items[0].blob.constructor.name,
+    );
   });
 
   /** The to-one direction, which takes the non-aggregate path in the strategy. */

--- a/templates/saas-starter/app/models/writes.coercion.test.ts
+++ b/templates/saas-starter/app/models/writes.coercion.test.ts
@@ -123,6 +123,29 @@ class EverythingModel extends Model {
 
 const WHEN = new Date("2021-03-04T05:06:07.008Z");
 
+/**
+ * A `Bytes` value, asserted by **container** as well as contents.
+ *
+ * Contents alone cannot see the divergence that matters here. `Buffer` is a
+ * `Uint8Array` subclass, so `[...a]` and `toEqual` treat the two as identical
+ * — and until this helper existed, every assertion in this file did exactly
+ * that. What the two do not share is `toString`: `Buffer.prototype.toString`
+ * takes an encoding, `Uint8Array.prototype.toString` ignores its argument. So
+ * `row.blob.toString("hex")` returned `"0102ff"` on Postgres and `"1,2,255"`
+ * on SQLite, from the same schema, with nothing failing.
+ *
+ * `Uint8Array` is the contract because it is what Prisma 6 returns, on every
+ * dialect — verified against a generated client rather than assumed. This
+ * helper runs in both dialects' suites, which is what makes it a cross-dialect
+ * pin rather than two independent checks.
+ */
+function expectBytes(actual: unknown, expected: ArrayLike<number>) {
+  expect(ArrayBuffer.isView(actual)).toBe(true);
+  expect(Buffer.isBuffer(actual)).toBe(false);
+  expect((actual as object).constructor.name).toBe("Uint8Array");
+  expect([...(actual as Uint8Array)]).toEqual(Array.from(expected));
+}
+
 function suite(label: string, url?: string) {
   describe(label, () => {
     let workspace: string | undefined;
@@ -186,7 +209,7 @@ function suite(label: string, url?: string) {
       expect(created.count).toBe(9007199254740991n);
       expect(created.ratio).toBe(1.5);
       expect(created.payload).toEqual(values.payload);
-      expect([...created.blob]).toEqual([...values.blob]);
+      expectBytes(created.blob, values.blob);
       expect(created.when).toBeInstanceOf(Date);
       expect(created.when.getTime()).toBe(WHEN.getTime());
       expect(created.optional).toBeNull();
@@ -201,7 +224,7 @@ function suite(label: string, url?: string) {
       expect(read.count).toBe(9007199254740991n);
       expect(read.ratio).toBe(1.5);
       expect(read.payload).toEqual(values.payload);
-      expect([...read.blob]).toEqual([...values.blob]);
+      expectBytes(read.blob, values.blob);
       expect(read.when.getTime()).toBe(WHEN.getTime());
       expect(read.optional).toBeNull();
     });
@@ -291,7 +314,7 @@ function suite(label: string, url?: string) {
       expect(updated.flag).toBe(false);
       expect(updated.count).toBe(-42n);
       expect(updated.payload).toEqual([1, "two", null]);
-      expect([...updated.blob]).toEqual([9, 8, 7]);
+      expectBytes(updated.blob, [9, 8, 7]);
       expect(updated.when.toISOString()).toBe("1999-12-31T23:59:59.999Z");
       expect(updated.optional).toBe("now set");
     });
@@ -350,7 +373,7 @@ function suite(label: string, url?: string) {
         where: { id: created.id },
       });
       expect(deleted.count).toBe(9007199254740991n);
-      expect([...deleted.blob]).toEqual([...values.blob]);
+      expectBytes(deleted.blob, values.blob);
 
       expect(await EverythingModel.$exec("count", {})).toBe(0);
     });


### PR DESCRIPTION
**This corrects the fix I shipped in `a8778ed` and reported as closed on #54.** The container was wrong, and the reason it was wrong is more useful than the bug.

Stacked on #54.

## What I did yesterday, and why it was wrong

You found `bytea` coming back as `Uint8Array` under lateral against `Buffer` under batched, and argued: *"this codebase's rule is to match what the shipped path already returns, so `Buffer` is the one that keeps `lateral` invisible to callers."* I agreed and made lateral return `Buffer`.

The principle is right. The application of it was not — I took *the shipped Postgres path* as the reference without checking it, and it is the outlier. Checked this time against a generated Prisma 6 client with a `Bytes` column on both dialects:

```
prisma  postgres  Uint8Array   isBuffer=false
prisma  sqlite    Uint8Array   isBuffer=false
gemi    sqlite    Uint8Array   isBuffer=false   <- driver's own value
gemi    postgres  Buffer       isBuffer=true    <- the outlier
```

So I converged the two Postgres paths on the value that matches neither Prisma nor our own SQLite, and closed the finding.

## The bug is bigger than the strategy

**The same defect exists between dialects, in the shipped read path, and predates the lateral work entirely.** From one schema:

| | `row.blob` | `row.blob.toString("hex")` |
|---|---|---|
| development, SQLite | `Uint8Array` | `"1,2,255"` |
| production, Postgres | `Buffer` | `"0102ff"` |

`Buffer.prototype.toString` takes an encoding; `Uint8Array.prototype.toString` ignores its argument. No error on either side.

It hid because **`Buffer` *is* a `Uint8Array`** — it satisfies the generated type, passes `ArrayBuffer.isView`, and compares equal element by element. The comment in `dialect/postgres.ts` recorded `bytea -> Buffer` with a ✓ and the parenthetical *"a Uint8Array, which is what Prisma gives"*. Both halves true, conclusion wrong, and it sat there through nine iterations.

`PostgresDialect` now normalises `Bytes` to a plain `Uint8Array` — a view over the driver's bytes, no copy — and the lateral decoder returns the same. All four combinations agree with each other and with Prisma.

## The harness was blind by construction

`differential.ts` normalised every typed array with:

```ts
if (ArrayBuffer.isView(value)) return `bytes:${[...(value as any)].join(",")}`;
```

Spreading erases exactly the distinction at issue. **That harness is the primary correctness guarantee for this ORM** — every operation, gemi against Prisma, both dialects — and it could not have reported a container divergence in any of them. It now carries the constructor name.

That is your general point earning its keep: `[...a]` and `JSON.stringify` are both container-erasing, so a decoder test needs at least one assertion that is not. I went looking for the shape rather than fixing the one instance, and it was in the harness.

## Tests

Every `Bytes` assertion in `writes.coercion.test.ts` now goes through a shared `expectBytes` checking container *and* contents, and that suite runs on **both** dialects — a cross-dialect pin rather than two independent checks. `lateral.coercion.test.ts` asserts `Uint8Array` on both strategies. Three unit tests on `PostgresDialect`: the normalisation, that it is a view rather than a copy, and that a driver already returning a plain view is left alone.

**And I checked they fail without the fix**, since that is the entire lesson from the last round: disabling the `Bytes` branch in `needsDecode` fails three cases in `writes.coercion` on Postgres. Before this commit it failed none.

| Verified at `b2a3f3a` | |
|---|---|
| `vitest run orm/` | 593 pass |
| template, SQLite | 325 pass, 26 skipped |
| template, Postgres 16 | 498 pass |
| `tsc --noEmit`, `oxlint` | clean |

## For the reviewer

- The claim I would check hardest is **`Uint8Array` being the right target**, since I got the target wrong once already. The evidence is a generated Prisma 6 client, not the docs — `.probe/` schemas with a `Bytes` model, pushed and queried on both dialects. Worth reproducing if you disagree, because everything else follows from it.
- Second: the view rather than a copy. `new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)` shares memory with the driver's `Buffer`. I believe that is safe — a `Buffer` is already a view, and the new one keeps the same `ArrayBuffer` alive — but it is the kind of thing that is fine until a driver starts pooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqZNWz1c22s3iLyKEKCyJg
