### PR TITLE
Catch the policied subclass nobody registered, before a query goes looking

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2774,6 +2774,22 @@ nothing, and the rows come back unscoped with no error. That is the shape a memb
 model usually has, and it is exactly the kind that carries a tenant scope. Write the line next to
 every subclass regardless — the guard is a backstop for the cases it can see, not a substitute.
 
+For the case it cannot see, there is an audit you can run once instead of trusting thirteen
+subclasses:
+
+```ts
+import { assertPoliciesRegistered } from "gemi/orm"
+import * as generated from "@/app/models/generated"
+import * as models from "@/app/models/User"
+
+assertPoliciesRegistered(generated, models)
+```
+
+Same rule, triggered differently: it reads the classes out of the module namespace, so a policied
+class that nothing queries is still visible. In a test it closes the hole for CI at no runtime cost;
+at boot it turns a deploy of the mistake into a failure to start rather than a quiet cross-tenant
+read. It can only see modules you hand it, so it does not replace the `register` line either.
+
 ## Querying
 
 Thirteen operations, with Prisma's argument types verbatim:

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -79,6 +79,22 @@ nothing, and the rows come back unscoped with no error. That is the shape a memb
 model usually has, and it is exactly the kind that carries a tenant scope. Write the line next to
 every subclass regardless — the guard is a backstop for the cases it can see, not a substitute.
 
+For the case it cannot see, there is an audit you can run once instead of trusting thirteen
+subclasses:
+
+```ts
+import { assertPoliciesRegistered } from "gemi/orm"
+import * as generated from "@/app/models/generated"
+import * as models from "@/app/models/User"
+
+assertPoliciesRegistered(generated, models)
+```
+
+Same rule, triggered differently: it reads the classes out of the module namespace, so a policied
+class that nothing queries is still visible. In a test it closes the hole for CI at no runtime cost;
+at boot it turns a deploy of the mistake into a failure to start rather than a quiet cross-tenant
+read. It can only see modules you hand it, so it does not replace the `register` line either.
+
 ## Querying
 
 Thirteen operations, with Prisma's argument types verbatim:

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -65,6 +65,8 @@ export {
   type OrmScope,
 } from "./context";
 
+export { assertPoliciesRegistered } from "./registration";
+
 export {
   softDelete,
   softDeleteMany,

--- a/packages/gemi/orm/registration.test.ts
+++ b/packages/gemi/orm/registration.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { UnregisteredPolicyClassError } from "./errors";
+import { user } from "./fixtures";
+import type { ModelPolicy } from "./policy";
+import { assertPoliciesRegistered } from "./registration";
+import { clearRegistry, register } from "./registry";
+
+/**
+ * The audit that catches what `Model.$exec`'s guard structurally cannot.
+ *
+ * The guard's condition begins `registered !== this`, so it can only fire on a
+ * class somebody queries at the *root*. A policied subclass that is never
+ * registered and only ever read through an `include` resolves to the generated
+ * base, `this` **is** that base, and the comparison never runs. This function
+ * asks the same question of every class in a module namespace instead, which is
+ * where an unqueried class is still visible.
+ *
+ * The tests below are written as the *shapes* rather than as calls, because the
+ * two ways to get this wrong are opposite: too strict rejects a plain typed
+ * subclass, too narrow misses the leak. Both happened to the `$exec` guard
+ * during #51 — once in each direction.
+ */
+
+const scope: ModelPolicy = { scope: () => ({ organizationId: 7 }) };
+const other: ModelPolicy = { scope: () => ({ organizationId: 9 }) };
+
+class UserBase {
+  static $schema = user;
+}
+
+afterEach(() => {
+  clearRegistry();
+});
+
+describe("the case the $exec guard cannot see", () => {
+  /**
+   * The reviewer's reproduction from #51, as a unit test: a policied subclass
+   * that is never registered, never queried at its root, and therefore never
+   * seen. Rows come back unscoped with no error.
+   */
+  test("a policied subclass that was never registered is refused", () => {
+    class User extends UserBase {
+      static $policy = scope;
+    }
+
+    register("User", UserBase);
+
+    expect(() => assertPoliciesRegistered({ User })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+
+  test("the error names both classes and the fix", () => {
+    class Membership extends UserBase {
+      static $policy = scope;
+    }
+
+    register("User", UserBase);
+
+    try {
+      assertPoliciesRegistered({ Membership });
+      expect.unreachable("expected a throw");
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain("Membership");
+      expect(message).toContain("UserBase");
+      expect(message).toContain('register("User", Membership)');
+    }
+  });
+
+  test("registering the subclass is what makes it pass", () => {
+    class User extends UserBase {
+      static $policy = scope;
+    }
+
+    register("User", User);
+
+    expect(() => assertPoliciesRegistered({ User })).not.toThrow();
+  });
+});
+
+describe("what it must not reject", () => {
+  /**
+   * The over-strict direction. `class AdminUser extends User {}` is a typed
+   * view over the same rows carrying the same policies by inheritance — the
+   * shape that an identity comparison rejected, and the reason the guard
+   * compares policy *chains*.
+   */
+  test("a plain subclass of the registered class inherits and is fine", () => {
+    class User extends UserBase {
+      static $policy = scope;
+    }
+    class AdminUser extends User {}
+
+    register("User", User);
+
+    expect(() => assertPoliciesRegistered({ User, AdminUser })).not.toThrow();
+  });
+
+  test("an unregistered subclass with no policy of its own is fine", () => {
+    class Typed extends UserBase {}
+
+    register("User", UserBase);
+
+    expect(() => assertPoliciesRegistered({ Typed })).not.toThrow();
+  });
+
+  /**
+   * A module namespace holds whatever the author exported. Types erase, but
+   * constants, helpers and re-exported values do not, so everything that is not
+   * a model class has to be skipped rather than treated as an error.
+   */
+  test("non-model exports are ignored", () => {
+    register("User", UserBase);
+
+    expect(() =>
+      assertPoliciesRegistered({
+        UserBase,
+        DEFAULT_PAGE_SIZE: 20,
+        helper: () => "not a model",
+        nothing: undefined,
+        nullish: null,
+        shaped: { $schema: { name: "User" } },
+      }),
+    ).not.toThrow();
+  });
+
+  /**
+   * The generated `index.ts` registers every model, so an empty registry means
+   * it was never imported. That is a different mistake with its own error at
+   * the first query, and reporting it here would put a confusing second
+   * diagnosis in front of it.
+   */
+  test("a name nothing is registered under is left alone", () => {
+    class User extends UserBase {
+      static $policy = scope;
+    }
+
+    expect(() => assertPoliciesRegistered({ User })).not.toThrow();
+  });
+});
+
+describe("the other direction", () => {
+  /**
+   * Registered carries policies, the exported class does not. Querying the
+   * exported one would be unscoped where every include is scoped — the same
+   * policy applying to some queries and not others.
+   */
+  test("an exported base is refused when a policied class owns the name", () => {
+    class User extends UserBase {
+      static $policy = scope;
+    }
+
+    register("User", User);
+
+    try {
+      assertPoliciesRegistered({ UserBase });
+      expect.unreachable("expected a throw");
+    } catch (error) {
+      expect((error as UnregisteredPolicyClassError).carries).toBe(
+        "registered",
+      );
+    }
+  });
+
+  test("two different policies on the same name diverge", () => {
+    class Ours extends UserBase {
+      static $policy = scope;
+    }
+    class Theirs extends UserBase {
+      static $policy = other;
+    }
+
+    register("User", Theirs);
+
+    expect(() => assertPoliciesRegistered({ Ours })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+});
+
+describe("more than one module", () => {
+  test("every module handed over is checked", () => {
+    class Good extends UserBase {
+      static $policy = scope;
+    }
+    class Bad extends UserBase {
+      static $policy = other;
+    }
+
+    register("User", Good);
+
+    expect(() => assertPoliciesRegistered({ Good }, { Bad })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+
+  test("no modules at all is a no-op rather than an error", () => {
+    expect(() => assertPoliciesRegistered()).not.toThrow();
+  });
+});

--- a/packages/gemi/orm/registration.ts
+++ b/packages/gemi/orm/registration.ts
@@ -1,0 +1,112 @@
+import { UnregisteredPolicyClassError } from "./errors";
+import { policiesFor } from "./policy";
+import * as registry from "./registry";
+import type { ModelSchema } from "./schema";
+
+/**
+ * Checks that every policied model class an application defines is the one the
+ * registry resolves its name to — **ahead of any query**, rather than when one
+ * happens to be run.
+ *
+ * ### Why this exists
+ *
+ * `Model.$exec` already refuses a query whose class carries policies the
+ * registered class does not (`UnregisteredPolicyClassError`). That guard closed
+ * the two shapes found in #51, and it is the right check, but it can only fire
+ * on a class somebody actually queries **at the root**. Its condition begins
+ * `registered !== this`, and there is a case where that is false and the leak is
+ * real:
+ *
+ *     export class Membership extends MembershipModel {
+ *       static $policy = { scope: (ctx) => ({ orgId: ctx.user.orgId }) }
+ *     }
+ *     // ...and no `register("Membership", Membership)`
+ *
+ * If nothing ever calls `Membership.findMany()` — because memberships are only
+ * ever read through `include: { memberships: true }` — then the include resolves
+ * the name to the *generated base*, `this` **is** that base, the comparison
+ * never runs, and rows come back unscoped with no error. Not a policy chain that
+ * fails to diverge: a check that is never reached.
+ *
+ * A model reached only through includes is usually a membership or a pivot,
+ * which is exactly the kind that carries a tenant scope. So the residual runs
+ * the wrong way: the guard is weakest where the data is most sensitive.
+ *
+ * ### What this does about it
+ *
+ * The same rule, triggered differently. Instead of waiting for a root query,
+ * it takes the modules where an application's model classes live and applies the
+ * divergence comparison to every one of them:
+ *
+ *     import * as models from "@/app/models"
+ *     assertPoliciesRegistered(models)
+ *
+ * Reading a class out of a module namespace is what makes the unqueried case
+ * visible — the class exists and is exported whether or not anything queries it.
+ *
+ * Call it at boot, or from a test. A test is enough to close the hole for CI and
+ * costs nothing at runtime; booting with it turns a deploy of the mistake into a
+ * failure to start rather than a quiet cross-tenant read. Neither is a
+ * *substitute* for writing `register` next to the subclass, and this function
+ * cannot become one: it can only see modules it is handed.
+ */
+export function assertPoliciesRegistered(
+  ...modules: Array<Record<string, unknown>>
+): void {
+  for (const module of modules) {
+    for (const exported of Object.values(module)) {
+      const model = asModelClass(exported);
+      if (model === null) continue;
+
+      const name = model.$schema.name;
+      const registered = registry.has(name)
+        ? (registry.get<unknown>(name) as object)
+        : undefined;
+
+      // Nothing registered under the name at all. The generated `index.ts`
+      // registers every model, so reaching this means it was never imported —
+      // a different mistake, and one the first query reports clearly through
+      // `ModelNotRegisteredError`. Not this function's business.
+      if (registered === undefined || registered === model) continue;
+
+      const ours = policiesFor(model);
+      const theirs = policiesFor(registered);
+      const diverges =
+        ours.length !== theirs.length ||
+        ours.some((policy, index) => policy !== theirs[index]);
+
+      if (!diverges) continue;
+
+      throw new UnregisteredPolicyClassError(
+        name,
+        (registered as { name?: string }).name ?? String(registered),
+        (model as { name?: string }).name ?? String(model),
+        ours.length > 0 ? "queried" : "registered",
+      );
+    }
+  }
+}
+
+/**
+ * A model class, structurally.
+ *
+ * Structural rather than `instanceof Model` on purpose: this module sits below
+ * `Model.ts` in the import graph, and importing it here to answer a question
+ * about shape would put a cycle between the registry, the policy hook and the
+ * model base for no gain. `$schema` carrying a `name` is what every operation
+ * already relies on.
+ *
+ * A module namespace holds anything the author exported — types erase, but
+ * constants, helpers and re-exported values do not — so everything that is not
+ * a model class is skipped rather than treated as an error.
+ */
+function asModelClass(
+  value: unknown,
+): (object & { $schema: ModelSchema }) | null {
+  if (typeof value !== "function") return null;
+
+  const schema = (value as { $schema?: ModelSchema }).$schema;
+  if (schema === undefined || typeof schema.name !== "string") return null;
+
+  return value as unknown as object & { $schema: ModelSchema };
+}

--- a/plans/orm/06-policies.md
+++ b/plans/orm/06-policies.md
@@ -168,3 +168,52 @@ policy DSL. Keep policies as plain functions for now.
 - **Do not let policies see SQL.** The moment a policy can manipulate compiled
   text, invariant 2 is dead, the plan cache becomes unsound, and the relation
   strategies stop being interchangeable. Args in, args out.
+
+## Residual: an unregistered policied subclass, read only through includes
+
+**Recorded here because until now it lived only in a PR review thread.** It is a
+cross-tenant read path with no home in the durable record, which is the worst
+place for one to sit.
+
+`Model.$exec` raises `UnregisteredPolicyClassError` when a class carrying
+policies is queried while a different class owns its name. That closed the two
+shapes found in #51's review. Its condition begins `registered !== this`, and
+there is a third shape where that is false:
+
+```ts
+export class Membership extends MembershipModel {
+  static $policy = { scope: (ctx) => ({ orgId: ctx.user.orgId }) }
+}
+// ...and no register("Membership", Membership)
+```
+
+If nothing ever queries `Membership` **at its root** — because memberships are
+only read through `include: { memberships: true }` — the include resolves the
+name to the generated base, `this` *is* that base, and the comparison is never
+reached. Rows come back unscoped, with no error. Reproduced during #51's review:
+two organisations' accounts returned to a caller scoped to one.
+
+The residual runs the wrong way. A model reached only through includes is
+usually a membership or a pivot, which is exactly the kind that carries a tenant
+scope, so the guard is weakest where the data is most sensitive.
+
+**Partly closed** by `assertPoliciesRegistered(...modules)` — the same divergence
+comparison, applied to the classes in a module namespace rather than to the class
+of a query, so an unqueried class is still visible. Run it in a test or at boot.
+It is not a full closure and must not be described as one: it can only see
+modules it is handed.
+
+**Full closure needs the registration to stop being something an author writes.**
+The generator emits `register(...)` for the classes it generates; it cannot emit
+one for a subclass in application code it never sees. Options, none built:
+
+- Have the generator emit an application-side barrel that re-exports and
+  registers every `app/models/*.ts` subclass it finds. Codegen reading
+  application source is a new kind of coupling and wants its own decision.
+- Register on first *definition* rather than on first import. There is no hook:
+  `static $policy = …` in a subclass body is a [[Define]] on the subclass, so a
+  setter on the base is bypassed.
+- Make `$policy` a method call — `static $policy = policy(Membership, {…})` —
+  so declaring one registers it. Changes the documented shape of every policy,
+  and the `docs/authorization.md` examples with it.
+

--- a/plans/orm/06-policies.md
+++ b/plans/orm/06-policies.md
@@ -210,9 +210,27 @@ one for a subclass in application code it never sees. Options, none built:
 - Have the generator emit an application-side barrel that re-exports and
   registers every `app/models/*.ts` subclass it finds. Codegen reading
   application source is a new kind of coupling and wants its own decision.
-- Register on first *definition* rather than on first import. There is no hook:
-  `static $policy = …` in a subclass body is a [[Define]] on the subclass, so a
-  setter on the base is bypassed.
+- Register on first *definition* rather than on first import. There is no hook —
+  `static $policy = …` in a subclass body is a `[[DefineOwnProperty]]` on the
+  subclass, so a setter on the base is bypassed. Verified rather than reasoned
+  about: the setter does not fire and `Object.hasOwn(Child, "$policy")` is true.
+
+  **The dependency is worth naming, because the reason could expire.** Define
+  semantics are what ES2022 specifies and what Bun does, and this monorepo sets
+  `target: ES2022` in `@repo/typescript-config/base.json`. Under *assignment*
+  semantics — `useDefineForClassFields: false`, or an older target —
+  `static $policy = …` compiles to `Child.$policy = …` and an inherited setter
+  **would** fire.
+
+  That does not revive the option, and the reason it does not is the sharper
+  version of the point: **the subclass is application code**, compiled by the
+  application's toolchain, not by ours. A registration mechanism resting on a
+  setter would therefore work or silently not work depending on a consumer's
+  build configuration — and "silently not" here is an unscoped cross-tenant
+  read. A hook that is load-bearing for data access cannot be one that a
+  downstream `tsconfig.json` can turn off without any error. So: ruled out for
+  portability rather than for impossibility, which is the stronger reason and
+  the one that survives a change of target.
 - Make `$policy` a method call — `static $policy = policy(Membership, {…})` —
   so declaring one registers it. Changes the documented shape of every policy,
   and the `docs/authorization.md` examples with it.

--- a/templates/saas-starter/app/models/registration.test.ts
+++ b/templates/saas-starter/app/models/registration.test.ts
@@ -1,0 +1,106 @@
+import {
+  UnregisteredPolicyClassError,
+  assertPoliciesRegistered,
+  policiesFor,
+  register,
+  registry,
+} from "gemi/orm";
+import { afterEach, describe, expect, test } from "vitest";
+
+import * as generated from "./generated";
+import * as models from "./User";
+
+/**
+ * The registration audit, against the template's **real** generated classes.
+ *
+ * The unit tests in `packages/gemi/orm/registration.test.ts` cover the rule.
+ * What they cannot cover is whether it holds for a schema somebody actually
+ * generated — eight models, a registry populated by the generated `index.ts`,
+ * and an application subclass registered by hand in `User.ts`. That is the
+ * arrangement the audit exists to check, so it is worth checking on the real
+ * one.
+ *
+ * No database: the audit is a comparison of classes and policy chains, and
+ * keeping it that way means this runs on every `vitest` invocation rather than
+ * only when Postgres is up.
+ */
+
+describe("the template's own models", () => {
+  test("every policied class the template exports owns its name", () => {
+    expect(() => assertPoliciesRegistered(generated, models)).not.toThrow();
+  });
+
+  /**
+   * `User.ts` registers `User` over the generated base, which is the line the
+   * documentation tells every author to write. If that line is ever dropped
+   * the audit above is what fails, so this pins the arrangement it depends on.
+   */
+  test("User.ts has replaced the generated base in the registry", () => {
+    expect(models.User).not.toBe(generated.UserModel);
+    expect(Object.getPrototypeOf(models.User)).toBe(generated.UserModel);
+  });
+});
+
+/**
+ * The residual itself, reproduced against the real generated classes.
+ *
+ * This is the shape `Model.$exec`'s guard cannot see: a policied subclass that
+ * is never registered and never queried at its root. Every nested read of it
+ * resolves to the unpolicied generated base, so the policy simply does not
+ * exist as far as the query is concerned — and `$exec` raises nothing, because
+ * its check begins `registered !== this` and the class it is running on *is*
+ * the registered one.
+ */
+describe("the case the query-time guard cannot reach", () => {
+  const registered = generated.OrganizationModel;
+
+  afterEach(() => {
+    register("Organization", registered);
+  });
+
+  test("an unregistered policied subclass is invisible to the guard", () => {
+    class ScopedOrganization extends generated.OrganizationModel {
+      static $policy = {
+        scope: () => ({ id: -1 }),
+        onCreate: (_context: unknown, data: unknown) => data,
+      };
+    }
+
+    // Deliberately no `register("Organization", ScopedOrganization)` — that
+    // omission is the whole bug.
+
+    // The guard's own view, asserted as the condition rather than by running a
+    // query — every nested read of this model goes through the registered
+    // class, and the registered class is the one being run. `registered !==
+    // this` is false, so the policy comparison is never reached, and there is
+    // nothing to compare anyway: the base carries no policies.
+    //
+    // The executable half — a nested include returning another tenant's rows —
+    // is `policies.test.ts`, which needs a database. This is the structural
+    // statement of why it happens.
+    expect(registry.get("Organization")).toBe(generated.OrganizationModel);
+    expect(policiesFor(generated.OrganizationModel)).toEqual([]);
+    expect(policiesFor(ScopedOrganization)).toHaveLength(1);
+
+    // The audit sees it, because it reads the class out of the module rather
+    // than waiting for somebody to query it.
+    expect(() => assertPoliciesRegistered({ ScopedOrganization })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+
+  test("and writing the register line is what clears it", () => {
+    class ScopedOrganization extends generated.OrganizationModel {
+      static $policy = {
+        scope: () => ({ id: -1 }),
+        onCreate: (_context: unknown, data: unknown) => data,
+      };
+    }
+
+    register("Organization", ScopedOrganization);
+
+    expect(() =>
+      assertPoliciesRegistered({ ScopedOrganization }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Your review on #55 said "forgetting the line fails loudly rather than leaking" is stronger than the guard is. Narrowing that sentence was the right immediate fix. This closes as much of the gap as can be closed without changing how policies are declared, and writes down the rest.

Stacked on #55.

## The residual, checked against the code rather than taken on report

`Model.$exec`'s guard begins:

```ts
if (registered !== undefined && registered !== this) {
```

So it can only fire on a class somebody queries **at its root**. In your scenario `this` *is* the registered generated base — the comparison is never reached. Not a policy chain that fails to diverge; a check that never runs. That distinction matters for the fix, because no change to the comparison could have closed it.

And it runs the wrong way: a model read only through includes is usually a membership or a pivot, which is exactly the kind carrying a tenant scope. **The guard is weakest where the data is most sensitive.**

## `assertPoliciesRegistered(...modules)`

The same divergence comparison, triggered differently — it reads classes out of a module namespace instead of waiting for a query, which is how an unqueried class becomes visible at all:

```ts
import { assertPoliciesRegistered } from "gemi/orm"
import * as generated from "@/app/models/generated"
import * as models from "@/app/models/User"

assertPoliciesRegistered(generated, models)
```

In a test it closes the hole for CI at no runtime cost; at boot it turns a deploy of the mistake into a failure to start rather than a quiet cross-tenant read.

**It is not full closure and is not described as one** — in the JSDoc, the docs page, or the plan. It can only see modules it is handed. The `register` line is still the thing that actually matters, and the doc still says to write it regardless.

## Tests as the two opposite shapes

Because the `$exec` guard was wrong in *each* direction in turn during #51 — too strict rejected `class AdminUser extends User {}`, too narrow sat inside `if (policies.length > 0)`. I wrote these from the property rather than from the example in front of me, which is the specific thing I got wrong twice then:

- an unregistered policied subclass is refused
- a plain inheriting subclass is **not** (the over-strict direction)
- an exported base is refused when a policied class owns the name (the other direction)
- non-model exports in a namespace are skipped, not treated as errors
- a name nothing is registered under is left alone — that is `ModelNotRegisteredError`'s job, and a second diagnosis in front of it would confuse

The template suite runs the audit over the real eight-model generated set, no database, and pins the arrangement it depends on: that `User.ts` has in fact replaced the generated base in the registry.

## The part that should have happened in June

**The residual is now in `plans/orm/06-policies.md`.** It lived only in a PR review thread — a cross-tenant read path with no home in the durable record, which is the worst place for one to sit. The three candidate full closures are written down with what each costs:

- generator-emitted registration, which means codegen reading application source
- registration on definition — **no hook exists**: `static $policy = …` in a subclass body is a `[[Define]]` on the subclass, so a setter on the base is bypassed
- making `$policy` a call that registers, which changes the documented shape of every policy and the `docs/authorization.md` examples with it

| Verified at `5afeedf` | |
|---|---|
| `vitest run orm/` | 603 pass |
| template, SQLite | 329 pass, 26 skipped |
| `tsc --noEmit`, `oxlint` | clean |

## For the reviewer

- The claim I would check hardest is **"same rule, different trigger"** — that `assertPoliciesRegistered` and the `$exec` guard cannot disagree about a given pair of classes. They duplicate the divergence comparison rather than share it, because sharing it would mean either the registry importing `Model` or `Model` importing this. If you think the duplication is the wrong trade, say so now while there are only two copies.
- Second: whether an audit an author has to *call* is worth having at all, versus going straight for one of the three full closures. I think yes — it is available today and none of the three are — but it is a judgement call and you may read the ergonomics differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqZNWz1c22s3iLyKEKCyJg
