### PR TITLE
Policies become a list, and the write halves stop being optional

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3022,28 +3022,81 @@ await Model.transaction(async () => {
 `Promise.all` over several ORM calls inside the callback is not safe — the ordinary, encouraged
 thing everywhere else in a Bun codebase. Await them in sequence.
 
+**A multi-statement write is atomic on its own.** A write with a nested `create` or `connect` runs
+more than one statement, and `$exec` opens a transaction for exactly those calls — so a nested
+step that fails, or a child policy that denies, rolls back the parent row too. A plain `create`
+still compiles to one statement and opens nothing, and inside a transaction you opened the nested
+one becomes a savepoint. You do not need `Model.transaction` to make a single nested write whole;
+you need it to make *several separate calls* whole.
+
 ## Policies
 
-A policy is a plain object on the model class. Every member is optional; a model with none pays a
-single `undefined` check per query.
+A model carries a **list** of policies. Every member of a policy is optional; a model with none
+pays a single `undefined` check per query.
 
 ```ts
+import { AccountPolicy } from "./generated"
+
 export class Account extends AccountModel {
-  static $policy = {
-    scope: (ctx) => ({ organizationId: ctx.user.organizationId }),
-    onCreate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
-  }
+  static $policies: AccountPolicy[] = [
+    {
+      scope: (ctx) => ({ organizationId: ctx.user.organizationId }),
+      onCreate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
+      onUpdate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
+    },
+  ]
 }
 
 register("Account", Account)
 ```
+
+The `AccountPolicy` annotation is not decoration. TypeScript does not contextually type an
+initializer from an inherited static declaration, so without it `ctx` and `data` are implicitly
+`any` — the generator emits one of these per model so you never write the generic form by hand.
+
+Policies compose by listing them, in the order they apply:
+
+```ts
+static $policies: AccountPolicy[] = [softDeletes<Account>(), new TenantPolicy()]
+```
+
+Entries may be objects or classes. A class is instantiated once, and extending the generated
+`AccountScopedPolicy` makes `scope`, `onCreate` and `onUpdate` abstract members — so a policy that
+scopes reads but forgets the write halves is a compile error rather than a runtime refusal:
+
+```ts
+class TenantPolicy extends AccountScopedPolicy {
+  scope(ctx: PolicyContext) { return { organizationId: (ctx.user as User).organizationId } }
+  onCreate(ctx: PolicyContext, data: Prisma.AccountCreateInput) { … }
+  onUpdate(ctx: PolicyContext, data: Partial<Prisma.AccountCreateInput>) { … }
+}
+```
+
+Each level of the prototype chain contributes its own array and they concatenate **base first**, so
+a shared model base can impose a policy a subclass can only narrow, never drop.
 
 | Member | When it runs | What it does |
 | --- | --- | --- |
 | `before(ctx)` | First | Return `false` (or throw) to deny outright. |
 | `scope(ctx)` | Reads and row-matching writes | Returns a `where` fragment `AND`ed into `args.where`. A policy can only ever **narrow**. |
 | `onCreate(ctx, data)` | `create` / `createMany` / `upsert` | Defaults or validates the payload. An insert has no `where` for a scope to narrow. |
+| `onUpdate(ctx, data)` | `update` / `updateMany` / `upsert` | Defaults or validates the payload of a write to existing rows. |
 | `redact(ctx, row)` | Shaping | Removes fields from a fetched row. |
+
+**A scope alone does not protect writes, and the ORM says so rather than assuming.** A `scope`
+narrows *which rows* a statement may touch and says nothing about the values written, so a
+tenant-scoped `update` could hand one of your own rows to another tenant — after which you can
+neither read it back nor put it right. Two guards, each asked of the policy that carries the scope
+rather than of the list as a whole:
+
+- a `create` under a policy with `scope` and no `onCreate` is refused;
+- an `update` writing a column that policy's own `scope` selects on is refused with
+  `ScopeEscapeError` unless it has an `onUpdate`.
+
+`onUpdate: (_ctx, data) => data` is a complete and legitimate answer. The point is that the policy
+says which. The guard reads scope-owned columns off the top level of the returned fragment, so
+`{ organizationId: 7 }` is understood and a combinator scope such as `{ OR: [...] }` is not
+attributed to any column and is not checked.
 
 **Policies rewrite the argument tree, never SQL.** That is what makes a scope two lines instead of
 string surgery, what keeps the two relation strategies interchangeable, and what keeps the plan
@@ -3144,8 +3197,8 @@ Ships as a policy, which is the proof the hook is expressive enough to be worth 
 import { softDelete, softDeleteMany, softDeletes } from "gemi/orm"
 
 export class User extends UserModel {
-  static $policy = softDeletes()          // reads skip rows with a deletedAt
-  static delete = softDelete(User)        // delete becomes an update
+  static $policies = [softDeletes<User>()]  // reads skip rows with a deletedAt
+  static delete = softDelete(User)          // delete becomes an update
   static deleteMany = softDeleteMany(User)
 }
 ```
@@ -3155,14 +3208,18 @@ read half applies to nested reads for the same reason every policy does — a de
 not appear under `User.findMany({ include: { accounts: true } })` without anything being written at
 the include site, which is the half ORM-level soft deletes usually get wrong.
 
-A class has one `$policy`, so composing with your own means composing the objects. The base-class
-route is usually cleaner and gets the ordering right for free (`policiesFor` walks base to
-derived, so the soft-delete scope applies first and yours narrows further):
+Composing it with your own is one list:
 
 ```ts
-class SoftDeleted extends UserModel { static $policy = softDeletes() }
-export class User extends SoftDeleted { static $policy = { …mine } }
+static $policies: UserPolicy[] = [softDeletes<User>(), new TenantPolicy()]
 ```
+
+`softDeletes()` carries an `onUpdate` pass-through, because `softDelete()` writes the very column
+the policy scopes on and something has to say that is intended. That permission is **per policy**:
+a tenant policy sitting beside it in the same list still has to answer for its own column.
+
+`field` is constrained to the model's own keys, so pointing it at a column that does not exist is a
+compile error rather than a `no such column` on the first read.
 
 ## Errors
 
@@ -3173,6 +3230,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `RecordNotFoundError` | An `…OrThrow` operation matched nothing. |
 | `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. |
 | `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
+| `ScopeEscapeError` | An `update` wrote a column its own policy's `scope` selects on, with no `onUpdate`. |
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
 | `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -327,6 +327,24 @@ await Model.transaction(async () => {
 `Promise.all` over several ORM calls inside the callback is not safe — the ordinary, encouraged
 thing everywhere else in a Bun codebase. Await them in sequence.
 
+### Keep slow work out of the callback
+
+The reserved connection is held for as long as the callback runs, whether or not it is running
+queries. A `fetch`, an upload or a queue push inside a transaction holds a connection for the
+length of that I/O, and under load the symptom is unrelated queries elsewhere in the process
+blocking on connection acquisition — an error that names neither the transaction nor the I/O.
+
+In development, a transaction still open after 2 seconds warns with the stack of the call that
+opened it:
+
+```
+[gemi] A database transaction has not settled after 2000ms. It reserves a pooled connection
+until it does — check for network or filesystem I/O inside the callback…
+```
+
+Set `GEMI_SLOW_TRANSACTION_MS` to change the threshold. The warning is development-only and
+never fires in production; it is a diagnostic, not a limit — nothing cancels a long transaction.
+
 **A multi-statement write is atomic on its own.** A write with a nested `create` or `connect` runs
 more than one statement, and `$exec` opens a transaction for exactly those calls — so a nested
 step that fails, or a child policy that denies, rolls back the parent row too. A plain `create`

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -327,28 +327,81 @@ await Model.transaction(async () => {
 `Promise.all` over several ORM calls inside the callback is not safe — the ordinary, encouraged
 thing everywhere else in a Bun codebase. Await them in sequence.
 
+**A multi-statement write is atomic on its own.** A write with a nested `create` or `connect` runs
+more than one statement, and `$exec` opens a transaction for exactly those calls — so a nested
+step that fails, or a child policy that denies, rolls back the parent row too. A plain `create`
+still compiles to one statement and opens nothing, and inside a transaction you opened the nested
+one becomes a savepoint. You do not need `Model.transaction` to make a single nested write whole;
+you need it to make *several separate calls* whole.
+
 ## Policies
 
-A policy is a plain object on the model class. Every member is optional; a model with none pays a
-single `undefined` check per query.
+A model carries a **list** of policies. Every member of a policy is optional; a model with none
+pays a single `undefined` check per query.
 
 ```ts
+import { AccountPolicy } from "./generated"
+
 export class Account extends AccountModel {
-  static $policy = {
-    scope: (ctx) => ({ organizationId: ctx.user.organizationId }),
-    onCreate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
-  }
+  static $policies: AccountPolicy[] = [
+    {
+      scope: (ctx) => ({ organizationId: ctx.user.organizationId }),
+      onCreate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
+      onUpdate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
+    },
+  ]
 }
 
 register("Account", Account)
 ```
+
+The `AccountPolicy` annotation is not decoration. TypeScript does not contextually type an
+initializer from an inherited static declaration, so without it `ctx` and `data` are implicitly
+`any` — the generator emits one of these per model so you never write the generic form by hand.
+
+Policies compose by listing them, in the order they apply:
+
+```ts
+static $policies: AccountPolicy[] = [softDeletes<Account>(), new TenantPolicy()]
+```
+
+Entries may be objects or classes. A class is instantiated once, and extending the generated
+`AccountScopedPolicy` makes `scope`, `onCreate` and `onUpdate` abstract members — so a policy that
+scopes reads but forgets the write halves is a compile error rather than a runtime refusal:
+
+```ts
+class TenantPolicy extends AccountScopedPolicy {
+  scope(ctx: PolicyContext) { return { organizationId: (ctx.user as User).organizationId } }
+  onCreate(ctx: PolicyContext, data: Prisma.AccountCreateInput) { … }
+  onUpdate(ctx: PolicyContext, data: Partial<Prisma.AccountCreateInput>) { … }
+}
+```
+
+Each level of the prototype chain contributes its own array and they concatenate **base first**, so
+a shared model base can impose a policy a subclass can only narrow, never drop.
 
 | Member | When it runs | What it does |
 | --- | --- | --- |
 | `before(ctx)` | First | Return `false` (or throw) to deny outright. |
 | `scope(ctx)` | Reads and row-matching writes | Returns a `where` fragment `AND`ed into `args.where`. A policy can only ever **narrow**. |
 | `onCreate(ctx, data)` | `create` / `createMany` / `upsert` | Defaults or validates the payload. An insert has no `where` for a scope to narrow. |
+| `onUpdate(ctx, data)` | `update` / `updateMany` / `upsert` | Defaults or validates the payload of a write to existing rows. |
 | `redact(ctx, row)` | Shaping | Removes fields from a fetched row. |
+
+**A scope alone does not protect writes, and the ORM says so rather than assuming.** A `scope`
+narrows *which rows* a statement may touch and says nothing about the values written, so a
+tenant-scoped `update` could hand one of your own rows to another tenant — after which you can
+neither read it back nor put it right. Two guards, each asked of the policy that carries the scope
+rather than of the list as a whole:
+
+- a `create` under a policy with `scope` and no `onCreate` is refused;
+- an `update` writing a column that policy's own `scope` selects on is refused with
+  `ScopeEscapeError` unless it has an `onUpdate`.
+
+`onUpdate: (_ctx, data) => data` is a complete and legitimate answer. The point is that the policy
+says which. The guard reads scope-owned columns off the top level of the returned fragment, so
+`{ organizationId: 7 }` is understood and a combinator scope such as `{ OR: [...] }` is not
+attributed to any column and is not checked.
 
 **Policies rewrite the argument tree, never SQL.** That is what makes a scope two lines instead of
 string surgery, what keeps the two relation strategies interchangeable, and what keeps the plan
@@ -449,8 +502,8 @@ Ships as a policy, which is the proof the hook is expressive enough to be worth 
 import { softDelete, softDeleteMany, softDeletes } from "gemi/orm"
 
 export class User extends UserModel {
-  static $policy = softDeletes()          // reads skip rows with a deletedAt
-  static delete = softDelete(User)        // delete becomes an update
+  static $policies = [softDeletes<User>()]  // reads skip rows with a deletedAt
+  static delete = softDelete(User)          // delete becomes an update
   static deleteMany = softDeleteMany(User)
 }
 ```
@@ -460,14 +513,18 @@ read half applies to nested reads for the same reason every policy does — a de
 not appear under `User.findMany({ include: { accounts: true } })` without anything being written at
 the include site, which is the half ORM-level soft deletes usually get wrong.
 
-A class has one `$policy`, so composing with your own means composing the objects. The base-class
-route is usually cleaner and gets the ordering right for free (`policiesFor` walks base to
-derived, so the soft-delete scope applies first and yours narrows further):
+Composing it with your own is one list:
 
 ```ts
-class SoftDeleted extends UserModel { static $policy = softDeletes() }
-export class User extends SoftDeleted { static $policy = { …mine } }
+static $policies: UserPolicy[] = [softDeletes<User>(), new TenantPolicy()]
 ```
+
+`softDeletes()` carries an `onUpdate` pass-through, because `softDelete()` writes the very column
+the policy scopes on and something has to say that is intended. That permission is **per policy**:
+a tenant policy sitting beside it in the same list still has to answer for its own column.
+
+`field` is constrained to the model's own keys, so pointing it at a column that does not exist is a
+compile error rather than a `no such column` on the first read.
 
 ## Errors
 
@@ -478,6 +535,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `RecordNotFoundError` | An `…OrThrow` operation matched nothing. |
 | `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. |
 | `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
+| `ScopeEscapeError` | An `update` wrote a column its own policy's `scope` selects on, with no `onUpdate`. |
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
 | `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |

--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -434,7 +434,8 @@ describe("emitArtifacts()", () => {
     const models = files["models.ts"];
 
     expect(models).toContain("options?: ExecOptions,");
-    expect(models).toContain('import { Model, type ExecOptions } from "gemi/orm";');
+    expect(models).toContain("type ExecOptions,");
+    expect(models).toMatch(/^} from "gemi\/orm";$/m);
 
     // The args type is Prisma's, unintersected.
     expect(models).toMatch(

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -471,18 +471,22 @@ export interface ${model}Model extends Prisma.${model}GetPayload<{}> {}
  * declaration, but the author gets no help writing the body. Naming the type is
  * what turns the hook into a typed one.
  *
- * `${model}Policy` is a class rather than a `type` so that it serves both uses:
- * a class is also a type, its members are all optional through `Policy`'s merged
- * interface, and it carries no private members — so an object literal satisfies
- * it structurally and `extends` works for anyone who prefers methods.
+ * `${model}Policy` is a `type` and `${model}ScopedPolicy` is a class, which is
+ * the split their uses actually want. The scoped one *has* to be a class —
+ * abstract members are the entire mechanism. The plain one is only ever an
+ * annotation (`static $policies: UserPolicy[] = [...]`), and emitting it as a
+ * class would put two runtime declarations plus a value import of `Policy` into
+ * every generated `models.ts`, once per model, to serve a use nobody has: an
+ * author who wants methods without the mandatory write halves extends
+ * `Policy<…>` from `gemi/orm` directly.
  */
 function policyTypes(model: string): string {
   return `
-export abstract class ${model}Policy extends Policy<
+export type ${model}Policy = ModelPolicy<
   Prisma.${model}WhereInput,
   Prisma.${model}CreateInput,
   Prisma.${model}GetPayload<{}>
-> {}
+>;
 
 // The same shape with \`scope\`, \`onCreate\` and \`onUpdate\` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those
@@ -600,9 +604,9 @@ export function emitModelsFile(schemas: ModelSchema[]): string {
     `\nimport type { Prisma } from "@prisma/client";\n`,
     `import {
   Model,
-  Policy,
   ScopedPolicy,
   type ExecOptions,
+  type ModelPolicy,
   type PolicyEntry,
 } from "gemi/orm";\n`,
     `\nimport * as schema from "./schema";\n`,

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -454,6 +454,48 @@ export interface ${model}Model extends Prisma.${model}GetPayload<{}> {}
 `;
 }
 
+/**
+ * The model's policy types, emitted so an application never writes
+ * `ModelPolicy<Prisma.UserWhereInput, Prisma.UserCreateInput, …>` by hand.
+ *
+ * Two names because the two authoring forms need different things, and one name
+ * cannot be both a class to extend and a plain type alias:
+ *
+ *   static $policies: UserPolicy[] = [{ scope: (ctx) => … }]   // object form
+ *   class Tenant extends UserScopedPolicy { … }                // class form
+ *
+ * The annotation on the object form is load-bearing rather than decorative.
+ * TypeScript does not contextually type an initializer from an inherited static
+ * declaration, so a bare `static $policies = [{ scope: (ctx) => … }]` leaves
+ * `ctx` an implicit `any` — the return type is still checked against the base's
+ * declaration, but the author gets no help writing the body. Naming the type is
+ * what turns the hook into a typed one.
+ *
+ * `${model}Policy` is a class rather than a `type` so that it serves both uses:
+ * a class is also a type, its members are all optional through `Policy`'s merged
+ * interface, and it carries no private members — so an object literal satisfies
+ * it structurally and `extends` works for anyone who prefers methods.
+ */
+function policyTypes(model: string): string {
+  return `
+export abstract class ${model}Policy extends Policy<
+  Prisma.${model}WhereInput,
+  Prisma.${model}CreateInput,
+  Prisma.${model}GetPayload<{}>
+> {}
+
+// The same shape with \`scope\`, \`onCreate\` and \`onUpdate\` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it \`TS2515\` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class ${model}ScopedPolicy extends ScopedPolicy<
+  Prisma.${model}WhereInput,
+  Prisma.${model}CreateInput,
+  Prisma.${model}GetPayload<{}>
+> {}
+`;
+}
+
 function operation(model: string, op: ReadOperation): string {
   const argsType = `Prisma.${model}${op.args}`;
   const returns = op.returns(model);
@@ -556,7 +598,13 @@ export function emitModelsFile(schemas: ModelSchema[]): string {
   const parts = [
     HEADER,
     `\nimport type { Prisma } from "@prisma/client";\n`,
-    `import { Model, type ExecOptions } from "gemi/orm";\n`,
+    `import {
+  Model,
+  Policy,
+  ScopedPolicy,
+  type ExecOptions,
+  type PolicyEntry,
+} from "gemi/orm";\n`,
     `\nimport * as schema from "./schema";\n`,
     `
 // Copied from Prisma's own generated client. It is what makes \`select\` and
@@ -571,9 +619,19 @@ type Subset<T, U> = {
 
   for (const schema of schemas) {
     parts.push(instanceShape(schema.name));
+    parts.push(policyTypes(schema.name));
     parts.push(`
 export class ${schema.name}Model extends Model {
   static $schema = schema.${schema.name};
+
+  // Narrowed from \`Model\`'s \`PolicyEntry[]\` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.${schema.name}WhereInput,
+    Prisma.${schema.name}CreateInput,
+    Prisma.${schema.name}GetPayload<{}>
+  >[];
 ${READ_OPERATIONS.map((op) => operation(schema.name, op)).join("")}${countOperation(
       schema.name,
     )}${WRITE_OPERATIONS.map((op) => operation(schema.name, op)).join(

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -42,7 +42,7 @@ import {
   markPreScoped,
   policiesFor,
   policyContext,
-  type ModelPolicy,
+  type PolicyEntry,
   type PolicyContext,
 } from "./policy";
 import {
@@ -103,11 +103,25 @@ export abstract class Model {
   static $schema: ModelSchema;
 
   /**
-   * The model's own policy. Optional, inherited through the prototype chain so
-   * a shared base can contribute one to every subclass — see `policiesFor` for
-   * the order, which is base first and narrowing-only.
+   * The model's own policies, in the order they should apply.
+   *
+   * A list rather than the single `$policy` this replaced, because composition
+   * is the normal case and the two ways of expressing it against one slot were
+   * both bad. Spreading (`{ ...softDeletes(), ...mine }`) silently drops
+   * whichever `scope` came first, and an intermediate base class per combination
+   * means one throwaway class for every model a shared policy applies to — the
+   * generated bases all differ, so a `TenantScoped` used on three models needed
+   * three of them.
+   *
+   * Each level of the prototype chain contributes its own array and they
+   * concatenate base first, so a shared model base can still impose a policy
+   * that a subclass can only narrow. See `policiesFor`.
+   *
+   * Entries may be policy objects or classes; a class is instantiated once. The
+   * generated `<Model>Policy` type gives an object literal here full contextual
+   * typing, which a bare `$policies = [...]` does not get on its own.
    */
-  static $policy?: ModelPolicy;
+  static $policies?: readonly PolicyEntry[];
 
   /**
    * Runs `fn` with policies suspended, for code that has no user and knows it:
@@ -366,7 +380,11 @@ export abstract class Model {
     // operation that acquired a private path to the database would show up
     // here as a statement silently running outside the transaction, committed
     // while its neighbours roll back.
-    const conn = currentTransaction() ?? db.sql;
+    // `let`, because a multi-statement write opens a transaction of its own
+    // further down and every statement after that point — including the
+    // `executor.query` closure below, which captures this binding rather than
+    // its value — has to run on the new handle rather than back on the pool.
+    let conn = currentTransaction() ?? db.sql;
 
     // POLICIES, AND THE ORDER MATTERS MORE HERE THAN ANYWHERE ELSE IN THE ORM.
     //
@@ -677,107 +695,134 @@ export abstract class Model {
       });
     }
 
-    // A write with a nested `create` / `connect` runs more than one statement.
-    // Atomic exactly when the caller wrapped the call in `Model.transaction` —
-    // *not* implicitly. A write does not open its own transaction, because
-    // `$exec` cannot know whether it is one step of a larger unit; opening one
-    // per call would put a `BEGIN` around every query in the framework and turn
-    // a caller's transaction into a nest of savepoints it never asked for.
-    // Outside one, a failing later step still leaves the earlier rows written.
-    await runSteps(plan.before, effective, context, executor, []);
-
-    // `unsafe` despite the name. Bun's tagged template cannot express a query
-    // whose *shape* is dynamic, which every ORM query is. Safety here does not
-    // come from the template syntax: it comes from the compiler's two rules —
-    // identifiers only ever come from the generated schema, and every value is
-    // a bound parameter. Do not "fix" this into a tagged template.
-    const rows = await execute(
-      conn,
-      dialect,
-      schema,
-      op,
-      plan.text,
-      plan.bind(effective, context),
-    );
-
-    const result = this.$shape(plan, rows as unknown[]);
-
-    // The plan shapes a single-row operation to `null` when nothing matched;
-    // turning that into an error belongs here rather than in the plan, because
-    // this is where the model's name is in scope for the message.
-    if (result === null && ORTHROW.has(op)) {
-      throw new RecordNotFoundError(schema.name, op);
-    }
-
-    // Rows that could not exist until this one did: the far side of a relation
-    // whose foreign key lives on the child. Run before relations are attached,
-    // so an `include` on the same call sees what was just written.
-    await runSteps(plan.after, effective, context, executor, rowsOf(result));
-
-    // Relations are loaded after the root rows are shaped, one query per node
-    // in the include tree. Each of those queries is `$exec` on the *related
-    // model's own class*, recursively — not a private helper — so a nested read
-    // is subject to everything a top-level read is.
+    // A write with a nested `create` / `connect` runs more than one statement,
+    // and those statements are one unit: the parent row and the children it was
+    // asked for either all land or none do.
     //
-    // The planner is handed the database rather than reaching for it: that is
-    // what keeps `compile/` free of a runtime import, and it is why the one
-    // query with no model behind it — the implicit m-n join table — still runs
-    // on the connection this call resolved.
-    if (plan.relations !== undefined) {
-      await attachRelations(
-        plan.relations,
-        plan.hidden,
-        result,
-        effective,
-        executor,
+    // This used to be left to the caller — "atomic exactly when the caller
+    // wrapped the call in `Model.transaction`, *not* implicitly" — on the
+    // reasoning that `$exec` cannot know whether it is one step of a larger unit
+    // and that opening one per call would put a `BEGIN` around every query in
+    // the framework. The second half of that is right and is why the condition
+    // below is what it is; the first half does not survive contact with
+    // policies. A nested write step runs the *child's* `$exec`, so the child's
+    // policies are consulted mid-sequence, after the parent row is already
+    // written. A child that denies therefore left a half-written parent behind,
+    // and "your policy stopped the write" and "your policy stopped half the
+    // write" are not the same promise.
+    //
+    // So: implicit, but only for the calls that are actually multi-statement.
+    // A plain `create` still compiles to one statement and opens nothing, which
+    // is what keeps the `BEGIN`-around-everything objection answered — and
+    // inside a caller's own transaction `withTransaction` takes a savepoint
+    // rather than nesting a second one.
+    const finish = async (): Promise<unknown> => {
+      // Re-resolved rather than reused: if the branch below opened a
+      // transaction, every statement from here on belongs to it. Outside one
+      // this is the same handle it already was.
+      conn = currentTransaction() ?? conn;
+
+      await runSteps(plan.before, effective, context, executor, []);
+
+      // `unsafe` despite the name. Bun's tagged template cannot express a query
+      // whose *shape* is dynamic, which every ORM query is. Safety here does not
+      // come from the template syntax: it comes from the compiler's two rules —
+      // identifiers only ever come from the generated schema, and every value is
+      // a bound parameter. Do not "fix" this into a tagged template.
+      const rows = await execute(
+        conn,
+        dialect,
+        schema,
+        op,
+        plan.text,
+        plan.bind(effective, context),
       );
-    } else if (plan.hidden !== undefined && plan.hidden.length > 0) {
-      // A write can hide a key column without having any relation to attach:
-      // a nested `after` step needs the parent's key returned, but the caller's
-      // `select` never asked for it.
-      for (const row of rowsOf(result)) {
-        for (const key of plan.hidden) delete row[key];
+
+      const result = this.$shape(plan, rows as unknown[]);
+
+      // The plan shapes a single-row operation to `null` when nothing matched;
+      // turning that into an error belongs here rather than in the plan, because
+      // this is where the model's name is in scope for the message.
+      if (result === null && ORTHROW.has(op)) {
+        throw new RecordNotFoundError(schema.name, op);
       }
-    }
 
-    // A **folded** relation's rows never entered the child's `$exec`, so nothing
-    // has run the child's `redact` over them. The comment below — "a related row
-    // was shaped by its own model's `$exec`" — is true of the batched strategy
-    // and false of the lateral one, which is precisely the kind of assumption
-    // iteration 9 had to revisit for `scope`.
-    //
-    // `scope` survived the fold because policies rewrite the *argument tree*
-    // before planning, and a scoped `where` lands inside the subquery. `redact`
-    // cannot: it is a row transform in the shaping stage, with no argument to
-    // rewrite. So the parent runs it on the child's behalf, which is the only
-    // place that can.
-    if (plan.relations !== undefined && !system) {
-      for (const relation of plan.relations) {
-        if (relation.root === undefined) continue;
-        redactFolded(relation, result, op, system);
+      // Rows that could not exist until this one did: the far side of a relation
+      // whose foreign key lives on the child. Run before relations are attached,
+      // so an `include` on the same call sees what was just written.
+      await runSteps(plan.after, effective, context, executor, rowsOf(result));
+
+      // Relations are loaded after the root rows are shaped, one query per node
+      // in the include tree. Each of those queries is `$exec` on the *related
+      // model's own class*, recursively — not a private helper — so a nested read
+      // is subject to everything a top-level read is.
+      //
+      // The planner is handed the database rather than reaching for it: that is
+      // what keeps `compile/` free of a runtime import, and it is why the one
+      // query with no model behind it — the implicit m-n join table — still runs
+      // on the connection this call resolved.
+      if (plan.relations !== undefined) {
+        await attachRelations(
+          plan.relations,
+          plan.hidden,
+          result,
+          effective,
+          executor,
+        );
+      } else if (plan.hidden !== undefined && plan.hidden.length > 0) {
+        // A write can hide a key column without having any relation to attach:
+        // a nested `after` step needs the parent's key returned, but the caller's
+        // `select` never asked for it.
+        for (const row of rowsOf(result)) {
+          for (const key of plan.hidden) delete row[key];
+        }
       }
-    }
 
-    // Redaction last, on the shaped result. After relations, not before: a
-    // related row was shaped by its own model's `$exec` and has already been
-    // through its own policy's `redact` — this one only owns its own rows.
-    if (policy) applyRedaction(policies, policy, result);
+      // A **folded** relation's rows never entered the child's `$exec`, so nothing
+      // has run the child's `redact` over them. The comment below — "a related row
+      // was shaped by its own model's `$exec`" — is true of the batched strategy
+      // and false of the lateral one, which is precisely the kind of assumption
+      // iteration 9 had to revisit for `scope`.
+      //
+      // `scope` survived the fold because policies rewrite the *argument tree*
+      // before planning, and a scoped `where` lands inside the subquery. `redact`
+      // cannot: it is a row transform in the shaping stage, with no argument to
+      // rewrite. So the parent runs it on the child's behalf, which is the only
+      // place that can.
+      if (plan.relations !== undefined && !system) {
+        for (const relation of plan.relations) {
+          if (relation.root === undefined) continue;
+          redactFolded(relation, result, op, system);
+        }
+      }
 
-    // Provenance, after redaction so a redacted field is not snapshotted as its
-    // original value and then written back by `save`.
-    //
-    // Here rather than inside `$shape`, which is where the plan sketched it, for
-    // one reason: `$shape` is the seam an `ActiveRecordModel` overrides to
-    // return instances, and tracking there would make every such override
-    // responsible for reimplementing it. Doing it at the choke point means an
-    // override gets provenance for free — which is the same argument that put
-    // everything else in `$exec`.
-    if (options?.track === true) {
-      const relationKeys = (plan.relations ?? []).map((relation) => relation.as);
-      for (const row of rowsOf(result)) track(row, schema, relationKeys);
-    }
+      // Redaction last, on the shaped result. After relations, not before: a
+      // related row was shaped by its own model's `$exec` and has already been
+      // through its own policy's `redact` — this one only owns its own rows.
+      if (policy) applyRedaction(policies, policy, result);
 
-    return result;
+      // Provenance, after redaction so a redacted field is not snapshotted as its
+      // original value and then written back by `save`.
+      //
+      // Here rather than inside `$shape`, which is where the plan sketched it, for
+      // one reason: `$shape` is the seam an `ActiveRecordModel` overrides to
+      // return instances, and tracking there would make every such override
+      // responsible for reimplementing it. Doing it at the choke point means an
+      // override gets provenance for free — which is the same argument that put
+      // everything else in `$exec`.
+      if (options?.track === true) {
+        const relationKeys = (plan.relations ?? []).map((relation) => relation.as);
+        for (const row of rowsOf(result)) track(row, schema, relationKeys);
+      }
+
+      return result;
+    };
+
+    const atomic =
+      (plan.before !== undefined && plan.before.length > 0) ||
+      (plan.after !== undefined && plan.after.length > 0);
+
+    return atomic ? withTransaction(db.sql, finish) : finish();
   }
 
   /**

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -357,6 +357,11 @@ export abstract class Model {
    * not safe here — the ordinary, encouraged thing everywhere else in a Bun
    * codebase. Await them in sequence. (`$exec` already runs its own nested
    * writes and relation reads sequentially for this reason.)
+   *
+   * **The connection is held for as long as the callback runs**, including
+   * while it awaits things that are not queries. In development a transaction
+   * still open after 2s warns (`GEMI_SLOW_TRANSACTION_MS`); in production it
+   * just holds the connection. Keep network and filesystem I/O outside.
    */
   static transaction<T>(fn: () => Promise<T>): Promise<T> {
     return withTransaction(app(DatabaseManager).sql, () => fn());

--- a/packages/gemi/orm/context.test.ts
+++ b/packages/gemi/orm/context.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 
 import {
   currentTransaction,
@@ -208,5 +208,173 @@ describe("the ambient transaction scope", () => {
     await withTransaction(pool, async () => {
       expect(ormContext.getStore()).toEqual({ tx: pool.handle, depth: 0 });
     });
+  });
+});
+
+/**
+ * The development-mode warning for a transaction that holds its connection too
+ * long.
+ *
+ * Driven with a real timer against a tiny threshold rather than vitest's fake
+ * clock, because the thing under test is partly *which* clock: the timer is
+ * `unref`'d so a pending warning cannot keep a short-lived process alive, and a
+ * fake clock replaces the very object that behaviour lives on.
+ */
+describe("the slow-transaction warning", () => {
+  const env = process.env;
+
+  function inDevelopment(thresholdMs: number) {
+    process.env = {
+      ...env,
+      NODE_ENV: "development",
+      GEMI_SLOW_TRANSACTION_MS: String(thresholdMs),
+    };
+  }
+
+  /**
+   * Collects warnings for the duration of `fn`, restoring `console.warn`.
+   *
+   * `fn` receives the live array, so a test can also assert on what had been
+   * warned at a given moment *during* the transaction.
+   */
+  async function capture(
+    fn: (warnings: string[]) => Promise<unknown>,
+  ): Promise<string[]> {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (message: string) => void warnings.push(message);
+    try {
+      await fn(warnings);
+      // The warning fires from a timer, so it can land in the tick after the
+      // transaction settles. Give it one before concluding it never came —
+      // otherwise "did not warn" would pass for the wrong reason.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    } finally {
+      console.warn = original;
+    }
+    return warnings;
+  }
+
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test("a transaction past the threshold warns while it is still open", async () => {
+    inDevelopment(10);
+    const pool = fakePool("a");
+    let warnedDuringCallback: string[] = [];
+
+    const warnings = await capture((seen) =>
+      withTransaction(pool, async () => {
+        await sleep(40);
+        warnedDuringCallback = [...seen];
+      }),
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("not settled after 10ms");
+    // The point of a timer over an elapsed-time measurement: the report arrives
+    // while the connection is still held, not in the post-mortem.
+    expect(warnedDuringCallback).toHaveLength(1);
+  });
+
+  // The realistic transaction settles in single-digit milliseconds. If those
+  // warned, the warning would be noise and get muted, which is the same as not
+  // having it.
+  test("a transaction inside the threshold says nothing", async () => {
+    inDevelopment(50);
+    const pool = fakePool("a");
+
+    const warnings = await capture(() => withTransaction(pool, async () => {}));
+
+    expect(warnings).toEqual([]);
+  });
+
+  // A rollback releases the connection exactly as a commit does, so a throwing
+  // callback has to disarm the timer too.
+  test("a throwing transaction disarms the warning", async () => {
+    inDevelopment(10);
+    const pool = fakePool("a");
+
+    const warnings = await capture(async () => {
+      await expect(
+        withTransaction(pool, async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  // Savepoints reserve no connection of their own. Warning per depth would
+  // report one slow block three times and name the innermost frame rather than
+  // the one actually holding the connection.
+  test("nesting warns once, for the outermost scope", async () => {
+    inDevelopment(10);
+    const pool = fakePool("a");
+
+    const warnings = await capture(() =>
+      withTransaction(pool, () =>
+        withTransaction(pool, () =>
+          withTransaction(pool, async () => {
+            await sleep(40);
+          }),
+        ),
+      ),
+    );
+
+    expect(warnings).toHaveLength(1);
+  });
+
+  test("production is silent, however long the transaction runs", async () => {
+    process.env = {
+      ...env,
+      NODE_ENV: "production",
+      GEMI_SLOW_TRANSACTION_MS: "10",
+    };
+    const pool = fakePool("a");
+
+    const warnings = await capture(() =>
+      withTransaction(pool, async () => {
+        await sleep(40);
+      }),
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  // A typo in the env var must not switch the diagnostic off — silently losing
+  // a warning is worse than ignoring an unreadable threshold.
+  test("an unusable threshold falls back to the default rather than disabling", async () => {
+    inDevelopment(10);
+    process.env.GEMI_SLOW_TRANSACTION_MS = "soon";
+    const pool = fakePool("a");
+
+    const warnings = await capture(() =>
+      withTransaction(pool, async () => {
+        await sleep(40);
+      }),
+    );
+
+    // The default is 2s, so nothing fires inside this test — the assertion is
+    // that it fell back to *some* real threshold instead of returning null.
+    expect(warnings).toEqual([]);
+  });
+
+  test("the warning names the call site", async () => {
+    inDevelopment(10);
+    const pool = fakePool("a");
+
+    const warnings = await capture(() =>
+      withTransaction(pool, async () => {
+        await sleep(40);
+      }),
+    );
+
+    expect(warnings[0]).toContain("context.test.ts");
   });
 });

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -149,6 +149,78 @@ export function runAsUser<T>(user: unknown, fn: () => Promise<T>): Promise<T> {
   );
 }
 
+/** Default threshold for the development-mode long-transaction warning. */
+const SLOW_TRANSACTION_MS = 2_000;
+
+function slowTransactionThreshold(): number | null {
+  // Read per call, never cached at module scope. `scripts/build.ts` rewrites
+  // `process.env.NODE_ENV` to `Bun.env.NODE_ENV` precisely so mode stays a
+  // runtime question in the built framework; caching it here would undo that.
+  if (process.env.NODE_ENV !== "development") return null;
+
+  const configured = process.env.GEMI_SLOW_TRANSACTION_MS;
+  if (configured === undefined) return SLOW_TRANSACTION_MS;
+
+  const parsed = Number(configured);
+  // A malformed value falls back rather than throwing or disabling: a typo in
+  // an env var should not silently switch a diagnostic off.
+  if (!Number.isFinite(parsed) || parsed <= 0) return SLOW_TRANSACTION_MS;
+  return parsed;
+}
+
+/**
+ * Warn, in development only, about a transaction that has been open too long.
+ *
+ * The risk is structural rather than occasional: an open transaction holds one
+ * reserved connection for as long as its callback runs, and nothing about
+ * `Model.transaction(async () => { ... })` stops that callback from awaiting a
+ * `fetch`, an S3 upload or a slow queue push. Under concurrency that drains the
+ * pool, and the symptom — every unrelated query in the process blocking on
+ * connection acquisition — names neither the callback nor the I/O in it.
+ *
+ * A timer rather than measuring elapsed time on the way out, for one reason:
+ * the worst case is the transaction that *never* settles (a hung request, a
+ * lock wait, a deadlock). After-the-fact measurement is silent for exactly that
+ * case; a timer fires while it is still open and still holding the connection.
+ *
+ * The `Error` is constructed up front and read only if the timer fires — V8
+ * formats `.stack` lazily on first access, so an ordinary fast transaction pays
+ * for an object allocation and nothing else.
+ *
+ * The clock starts at the `begin` call, not at the moment a connection is
+ * acquired, and stops when `begin` settles rather than when the callback
+ * returns — so it spans the pool wait and the commit round-trip as well as the
+ * callback. That is deliberate: all three are time this transaction is in
+ * flight, and a warning that only covered the callback would stay silent for a
+ * transaction stuck waiting on an exhausted pool, which is the exact situation
+ * a long transaction elsewhere creates. Hence "not settled" rather than "open
+ * for" — the message must not claim a connection was held for the whole span.
+ */
+function watchForSlowTransaction(): () => void {
+  const threshold = slowTransactionThreshold();
+  if (threshold === null) return () => {};
+
+  const site = new Error("transaction opened here");
+
+  const timer = setTimeout(() => {
+    const stack = site.stack?.split("\n").slice(1).join("\n") ?? "";
+    console.warn(
+      `[gemi] A database transaction has not settled after ${threshold}ms. It ` +
+        `reserves a pooled connection until it does — check for network or ` +
+        `filesystem I/O inside the callback, and move it outside the ` +
+        `transaction if you find any.\n${stack}\n` +
+        `(development only; set GEMI_SLOW_TRANSACTION_MS to change the threshold)`,
+    );
+  }, threshold);
+
+  // Otherwise the warning timer is itself a reason the process stays alive,
+  // which would turn a diagnostic into a hang in short-lived commands and
+  // scripts.
+  timer.unref?.();
+
+  return () => clearTimeout(timer);
+}
+
 /**
  * Run `fn` inside a transaction, entering the ambient scope for its whole async
  * subtree.
@@ -172,6 +244,12 @@ export function runAsUser<T>(user: unknown, fn: () => Promise<T>): Promise<T> {
  * because Bun types a savepoint handle as plain `SQL` — without `savepoint` on
  * it — while the runtime object does carry the method, which is what makes
  * three levels of nesting work.
+ *
+ * In development, an outermost transaction that stays open past
+ * `GEMI_SLOW_TRANSACTION_MS` (2s by default) warns — see
+ * `watchForSlowTransaction`. Nothing here *prevents* a long transaction; the
+ * warning exists because the cost of one is paid by unrelated queries
+ * elsewhere in the process, which makes it hard to trace back.
  *
  * The return type is asserted rather than inferred for one reason worth
  * knowing: Bun's `begin` unwraps a callback that resolves to an *array of
@@ -211,9 +289,22 @@ export function withTransaction<T>(
     }) as Promise<T>;
   }
 
+  // Only the outermost scope is watched. A savepoint reserves no connection of
+  // its own — its lifetime is bounded by the transaction it sits in, which is
+  // already being timed — so warning per depth would report one slow block as
+  // several warnings and point at the innermost frame rather than the one
+  // holding the connection.
+  const stopWatching = watchForSlowTransaction();
+
   // Spread rather than replace: a `Model.transaction` inside a `Model.asSystem`
   // must not silently re-enable policies for its whole subtree.
-  return pool.begin((tx) =>
-    ormContext.run({ ...current, tx, depth: 0 }, () => fn(tx)),
-  ) as Promise<T>;
+  return (
+    pool
+      .begin((tx) => ormContext.run({ ...current, tx, depth: 0 }, () => fn(tx)))
+      // `finally` and not a `then`/`catch` pair: the connection is released on
+      // rollback exactly as it is on commit, so a throwing callback must clear
+      // the timer too or every failed transaction leaves a warning armed
+      // against a connection that has already gone back to the pool.
+      .finally(stopWatching) as Promise<T>
+  );
 }

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -175,6 +175,58 @@ export class PolicyDeniedError extends Error {
 }
 
 /**
+ * Thrown when an `update` writes to a column its own policy's `scope` selects on,
+ * and the policy has no `onUpdate` saying what that should mean.
+ *
+ * The shape it catches:
+ *
+ *     scope: (ctx) => ({ organizationId: ctx.user.organizationId })
+ *     // ...and then
+ *     User.update({ where: { id }, data: { organizationId: 999 } })
+ *
+ * The scope did its job — only rows in the caller's own tenant could be selected
+ * — and the statement still hands one of them to another tenant. Afterwards the
+ * row is outside the scope, so it cannot be read back and cannot be put right by
+ * the same caller: a one-way door rather than a visible failure. The usual way in
+ * is not malice but mass assignment, a handler forwarding request fields into
+ * `data`.
+ *
+ * This is `assertCreateCovered`'s question asked of the other write. There it is
+ * "you scoped reads but never said what an insert means"; here it is "you scoped
+ * reads but never said whether an update may move a row out". Both are answered
+ * by writing the hook, including when the answer is "allow it" —
+ * `onUpdate: (_ctx, data) => data` is a complete and legitimate answer, and
+ * saying it out loud is the point.
+ *
+ * **What it cannot see.** The scope-owned columns are read off the top level of
+ * the fragment the policy returned, so `{ organizationId: 7 }` is understood and
+ * `{ OR: [...] }` is not — a scope built from combinators is not attributed to
+ * any column and an update through it is not checked. Narrowing that would mean
+ * either interpreting arbitrary `where` grammar or refusing every update on such
+ * a model, and neither is worth it: the guard is a rail on the common shape, not
+ * a proof.
+ */
+export class ScopeEscapeError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly operation: string,
+    public readonly fields: readonly string[],
+  ) {
+    const named = fields.map((field) => `'${field}'`).join(", ");
+    super(
+      `${model}.${operation} writes ${named}, which ${model}'s policy also ` +
+        `scopes on — so this update can move a row outside the scope that ` +
+        `selected it, where the caller can no longer read or repair it.\n\n` +
+        `Add an onUpdate to that policy. It may reassert the column ` +
+        `(data => ({ ...data, ${fields[0]}: ctx.user.${fields[0]} })), reject ` +
+        `the write, or allow it explicitly with (_ctx, data) => data — all ` +
+        `three are fine, and the point is that the policy says which.`,
+    );
+    this.name = "ScopeEscapeError";
+  }
+}
+
+/**
  * Thrown when a model class carries policies but is not the class the registry
  * resolves its name to.
  *
@@ -183,7 +235,7 @@ export class PolicyDeniedError extends Error {
  * AccountModel)` — while an application authors its policy on a subclass:
  *
  *     export class Account extends AccountModel {
- *       static $policy = { scope: (ctx) => ({ organizationId: … }) }
+ *       static $policies = [{ scope: (ctx) => ({ organizationId: … }) }]
  *     }
  *
  * A root query goes through `Account`, so `policiesFor(this)` finds the policy

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -24,6 +24,7 @@ export {
   RecordNotFoundError,
   RelationDepthExceededError,
   ReturningUnsupportedError,
+  ScopeEscapeError,
   UniqueConstraintError,
   UnknownFieldError,
   UnknownRelationError,
@@ -75,6 +76,8 @@ export {
 } from "./soft-deletes";
 
 export {
+  Policy,
+  ScopedPolicy,
   applyPolicies,
   applyRedaction,
   currentUser,
@@ -83,6 +86,7 @@ export {
   redactNullable,
   type ModelPolicy,
   type PolicyContext,
+  type PolicyEntry,
 } from "./policy";
 
 export {

--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import { PolicyDeniedError, UnsupportedQueryError } from "./errors";
+import {
+  PolicyDeniedError,
+  ScopeEscapeError,
+  UnsupportedQueryError,
+} from "./errors";
 import { organization, user } from "./fixtures";
 import {
   applyNestedPolicies,
@@ -43,7 +47,7 @@ describe("dispatch through the prototype chain", () => {
   test("a model's own policy is found", () => {
     const own: ModelPolicy = { scope: () => ({ a: 1 }) };
     class Owner {
-      static $policy = own;
+      static $policies = [own];
     }
     expect(policiesFor(Owner)).toEqual([own]);
   });
@@ -57,10 +61,10 @@ describe("dispatch through the prototype chain", () => {
     const derived: ModelPolicy = { scope: () => ({ organizationId: 7 }) };
 
     class Base {
-      static $policy = base;
+      static $policies = [base];
     }
     class Derived extends Base {
-      static $policy = derived;
+      static $policies = [derived];
     }
 
     expect(policiesFor(Derived)).toEqual([base, derived]);
@@ -72,24 +76,24 @@ describe("dispatch through the prototype chain", () => {
     const c: ModelPolicy = { before: () => true };
 
     class A {
-      static $policy = a;
+      static $policies = [a];
     }
     class B extends A {
-      static $policy = b;
+      static $policies = [b];
     }
     class C extends B {
-      static $policy = c;
+      static $policies = [c];
     }
 
     expect(policiesFor(C)).toEqual([a, b, c]);
   });
 
-  // A plain property read would find the base's `$policy` at every level of the
+  // A plain property read would find the base's `$policies` at every level of the
   // chain and collect it once per level.
   test("an inherited policy is not counted twice", () => {
     const base: ModelPolicy = { scope: () => ({ a: 1 }) };
     class Base {
-      static $policy = base;
+      static $policies = [base];
     }
     class Derived extends Base {}
     class Grandchild extends Derived {}
@@ -985,5 +989,231 @@ describe("relation filters in where", () => {
     );
 
     expect(out.where).toBe(where);
+  });
+});
+
+/**
+ * Composition, which is the whole reason `$policies` is a list.
+ *
+ * The single `$policy` it replaced left two ways to combine policies and both
+ * were traps. Spreading two objects that each carry a `scope` silently keeps
+ * only the last — no error, no warning, and the dropped one is usually the
+ * shared guard rather than the local rule. The alternative was an intermediate
+ * model class per combination, which does not compose across models at all
+ * because every generated base is a different class.
+ */
+describe("$policies as a list", () => {
+  test("entries apply in array order", () => {
+    const first: ModelPolicy = { scope: () => ({ a: 1 }) };
+    const second: ModelPolicy = { scope: () => ({ b: 2 }) };
+    class Model {
+      static $policies = [first, second];
+    }
+
+    expect(policiesFor(Model)).toEqual([first, second]);
+  });
+
+  test("a base's list comes before a derived one's, so a base can only be narrowed", () => {
+    const shared: ModelPolicy = { scope: () => ({ tenant: 1 }) };
+    const local: ModelPolicy = { scope: () => ({ own: 2 }) };
+    class Base {
+      static $policies = [shared];
+    }
+    class Derived extends Base {
+      static $policies = [local];
+    }
+
+    expect(policiesFor(Derived)).toEqual([shared, local]);
+  });
+
+  test("both scopes reach the where, rather than one replacing the other", () => {
+    const out = applyPolicies(
+      [{ scope: () => ({ deletedAt: null }) }, { scope: () => ({ orgId: 7 }) }],
+      context(),
+      { where: { name: "a" } },
+    );
+
+    expect(out.where).toEqual({
+      name: "a",
+      AND: [{ deletedAt: null }, { orgId: 7 }],
+    });
+  });
+
+  /**
+   * A class entry is instantiated once and the *same* instance comes back on
+   * every call. Not a performance point: `$exec`'s divergence guard and
+   * `assertPoliciesRegistered` both compare two chains element by element, so a
+   * fresh instance per call would make a class-form policy fail that comparison
+   * against itself.
+   */
+  test("a class entry is instantiated once, with stable identity", () => {
+    class Tenant {
+      scope() {
+        return { orgId: 1 };
+      }
+    }
+    class Owner {
+      static $policies = [Tenant];
+    }
+
+    const first = policiesFor(Owner);
+    const second = policiesFor(Owner);
+
+    expect(first[0]).toBeInstanceOf(Tenant);
+    expect(first[0]).toBe(second[0]);
+  });
+});
+
+/**
+ * The create guard, asked of one policy rather than of the chain.
+ *
+ * It used to pass when *any* policy in the list had an `onCreate`, and
+ * `softDeletes()` ships a pass-through one so that its own scope does not trip
+ * the check. Composing the two therefore disarmed the guard for the tenant
+ * policy, and the insert ran with the scoped column unset — the exact outcome
+ * the error message describes, produced by the guard meant to prevent it.
+ */
+describe("assertCreateCovered is per policy", () => {
+  const tenant: ModelPolicy = { scope: (ctx: any) => ({ orgId: ctx.user.id }) };
+  const passThrough: ModelPolicy = {
+    scope: () => ({ deletedAt: null }),
+    onCreate: (_ctx, data) => data,
+  };
+
+  test("a scope with no onCreate is still refused on its own", () => {
+    expect(() =>
+      applyPolicies([tenant], context({ operation: "create" as any }), {
+        data: { name: "a" },
+      }),
+    ).toThrow(UnsupportedQueryError);
+  });
+
+  test("another policy's onCreate no longer covers for it", () => {
+    expect(() =>
+      applyPolicies(
+        [passThrough, tenant],
+        context({ operation: "create" as any }),
+        { data: { name: "a" } },
+      ),
+    ).toThrow(UnsupportedQueryError);
+  });
+
+  test("a policy that answers for itself passes, beside one that does not need to", () => {
+    const covered: ModelPolicy = {
+      scope: (ctx: any) => ({ orgId: ctx.user.id }),
+      onCreate: (ctx: any, data) => ({ ...data, orgId: ctx.user.id }),
+    };
+
+    const out = applyPolicies(
+      [passThrough, covered],
+      context({ operation: "create" as any }),
+      { data: { name: "a" } },
+    );
+
+    expect(out.data).toEqual({ name: "a", orgId: 1 });
+  });
+});
+
+/**
+ * The update half of the same question. A scope says which rows may be touched
+ * and nothing about the values written, so a tenant-scoped update could hand one
+ * of its own rows to another tenant — after which the caller can neither read it
+ * back nor put it right.
+ */
+describe("scope escape on update", () => {
+  const tenant: ModelPolicy = {
+    scope: (ctx: any) => ({ orgId: ctx.user.organizationId }),
+    onCreate: (_ctx, data) => data,
+  };
+
+  test("an ordinary update is untouched", () => {
+    const out = applyPolicies([tenant], context({ operation: "update" as any }), {
+      where: { id: 1 },
+      data: { name: "x" },
+    });
+
+    expect(out.data).toEqual({ name: "x" });
+    expect(out.where).toEqual({ id: 1, AND: [{ orgId: 7 }] });
+  });
+
+  test("writing the scoped column is refused", () => {
+    expect(() =>
+      applyPolicies([tenant], context({ operation: "update" as any }), {
+        where: { id: 1 },
+        data: { orgId: 999 },
+      }),
+    ).toThrow(ScopeEscapeError);
+  });
+
+  test("updateMany too, where there is no where at all to look at", () => {
+    expect(() =>
+      applyPolicies([tenant], context({ operation: "updateMany" as any }), {
+        data: { orgId: 999 },
+      }),
+    ).toThrow(ScopeEscapeError);
+  });
+
+  test("an onUpdate takes responsibility and the write proceeds", () => {
+    const owning: ModelPolicy = {
+      ...tenant,
+      onUpdate: (ctx: any, data) => ({ ...data, orgId: ctx.user.organizationId }),
+    };
+
+    const out = applyPolicies([owning], context({ operation: "update" as any }), {
+      where: { id: 1 },
+      data: { orgId: 999 },
+    });
+
+    // Reasserted rather than accepted, which is what this policy chose to mean.
+    expect(out.data).toEqual({ orgId: 7 });
+  });
+
+  /**
+   * Per policy, like the create guard. Soft deletes writes its own scoped column
+   * on purpose and says so with a pass-through `onUpdate`; that must not become
+   * permission for the tenant policy's column.
+   */
+  test("one policy's onUpdate does not cover another's column", () => {
+    const soft: ModelPolicy = {
+      scope: () => ({ deletedAt: null }),
+      onCreate: (_ctx, data) => data,
+      onUpdate: (_ctx, data) => data,
+    };
+
+    expect(() =>
+      applyPolicies([soft, tenant], context({ operation: "update" as any }), {
+        where: { id: 1 },
+        data: { orgId: 999 },
+      }),
+    ).toThrow(ScopeEscapeError);
+
+    // ...and the soft-delete write itself is allowed, by the policy that owns it.
+    expect(() =>
+      applyPolicies([soft, tenant], context({ operation: "update" as any }), {
+        where: { id: 1 },
+        data: { deletedAt: new Date() },
+      }),
+    ).not.toThrow();
+  });
+
+  /**
+   * The documented limit. A scope built from combinators is not attributed to
+   * any column, so the guard cannot fire — stated as a test so that changing it
+   * is a decision rather than an accident.
+   */
+  test("a combinator scope is not attributed, and is not guarded", () => {
+    const complex: ModelPolicy = {
+      scope: (ctx: any) => ({
+        OR: [{ orgId: ctx.user.organizationId }, { public: true }],
+      }),
+      onCreate: (_ctx, data) => data,
+    };
+
+    expect(() =>
+      applyPolicies([complex], context({ operation: "update" as any }), {
+        where: { id: 1 },
+        data: { orgId: 999 },
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -1217,3 +1217,83 @@ describe("scope escape on update", () => {
     ).not.toThrow();
   });
 });
+
+/**
+ * The gap review found in the first version of the guard: it inspected the
+ * caller's `data` from inside the scope loop, which runs *before* any `onUpdate`
+ * rewrites it. A policy carrying only an `onUpdate` could therefore write a
+ * column a different policy scopes on, and the check had already run against a
+ * payload that did not contain it.
+ *
+ * The same shape as the `assertCreateCovered` bug — one policy acting on
+ * another's behalf — arriving through the rewrite instead of through a `some()`.
+ * Fixed by asking the question last, of what will actually be written.
+ */
+describe("scope escape via another policy's onUpdate", () => {
+  const injector: ModelPolicy = {
+    onUpdate: (_context, data) => ({ ...data, orgId: 999 }),
+  };
+  const tenant: ModelPolicy = {
+    scope: (ctx: any) => ({ orgId: ctx.user.organizationId }),
+    onCreate: (_context, data) => data,
+  };
+
+  test("an injected write to an unguarded scoped column is refused", () => {
+    expect(() =>
+      applyPolicies([injector, tenant], context({ operation: "update" as any }), {
+        where: { id: 1 },
+        data: { name: "x" },
+      }),
+    ).toThrow(ScopeEscapeError);
+  });
+
+  test("order in the list does not matter — the check runs after every rewrite", () => {
+    expect(() =>
+      applyPolicies([tenant, injector], context({ operation: "update" as any }), {
+        where: { id: 1 },
+        data: { name: "x" },
+      }),
+    ).toThrow(ScopeEscapeError);
+  });
+
+  test("but the owning policy's own onUpdate is still free to write it", () => {
+    const owning: ModelPolicy = {
+      ...tenant,
+      onUpdate: (_context, data) => ({ ...data, orgId: 999 }),
+    };
+
+    const out = applyPolicies(
+      [injector, owning],
+      context({ operation: "update" as any }),
+      { where: { id: 1 }, data: { name: "x" } },
+    );
+
+    expect(out.data).toEqual({ name: "x", orgId: 999 });
+  });
+});
+
+/**
+ * The rename tripwire. `Model` no longer declares `$policy`, so a class still
+ * carrying it compiles clean and is simply never read — the model is unpolicied
+ * with nothing to notice it.
+ */
+describe("the old $policy name", () => {
+  test("is refused rather than silently ignored", () => {
+    class Legacy {
+      static $policy = { scope: () => ({ orgId: 7 }) };
+    }
+
+    expect(() => policiesFor(Legacy)).toThrow(/\$policies/);
+  });
+
+  test("is caught on a base class too, not just the one queried", () => {
+    class Base {
+      static $policy = { scope: () => ({ orgId: 7 }) };
+    }
+    class Derived extends Base {
+      static $policies = [{ scope: () => ({ a: 1 }) }];
+    }
+
+    expect(() => policiesFor(Derived)).toThrow(/\$policies/);
+  });
+});

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -327,6 +327,15 @@ const INSERTING = new Set<string>(["create", "createMany"]);
  * call would make every comparison fail — every query on a class-form policy
  * would raise `UnregisteredPolicyClassError` against itself. Keyed on the
  * constructor, which is as stable as the class object.
+ *
+ * Keyed on the constructor and nothing else, so a policy class listed in two
+ * models' `$policies` is **one instance shared across both** — once per process,
+ * not once per model. Correct for every policy that exists today, all of which
+ * are stateless, and the reason the class form is documented as a place for
+ * behaviour rather than for state: a policy that memoised anything per model
+ * would silently serve one model's cache to the other. A policy that genuinely
+ * needs per-model state should be a factory returning a fresh object, which is
+ * what `PolicyEntry`'s other half is for.
  */
 const instantiated = new WeakMap<object, ModelPolicy>();
 
@@ -369,6 +378,25 @@ export function policiesFor(model: unknown): readonly ModelPolicy[] {
 
   let current = model as PolicedModel | null;
   while (current && current !== Function.prototype) {
+    // The rename tripwire, and it earns its keep because the failure it catches
+    // is silent in both directions: `Model` no longer declares `$policy`, so a
+    // class still carrying it neither fails to compile nor gets read — the model
+    // is simply unpolicied, and a tenant scope stops applying with nothing to
+    // notice it. Every call site in this repository is migrated; the window this
+    // covers is a branch rebased across the rename, or a stack still on the old
+    // name. Same argument `UnregisteredPolicyClassError` makes one function over:
+    // a policy that is present but not in effect has to be loud.
+    //
+    // Delete once `feat/orm` merges and nothing can still be carrying it.
+    if (Object.hasOwn(current, "$policy")) {
+      throw new Error(
+        `${(current as { name?: string }).name ?? "This model"} declares ` +
+          `\`$policy\`, which is now \`$policies\` and takes a list. The old ` +
+          `name is not read, so this model is currently unpolicied — every ` +
+          `scope, onCreate and redact on it is being skipped.`,
+      );
+    }
+
     if (Object.hasOwn(current, "$policies") && current.$policies) {
       const level = current.$policies;
       if (level.length > 0) {
@@ -418,6 +446,13 @@ export function applyPolicies(
 
   let out = args;
 
+  /**
+   * Scope-owned columns whose policy has no `onUpdate`, so nobody has said what
+   * writing them should mean. Accumulated during the scope loop and checked once
+   * at the end, against the payload as it will actually be written.
+   */
+  let unguarded: string[] | undefined;
+
   for (const policy of policies) {
     if (policy.before) {
       const verdict = policy.before(context);
@@ -445,12 +480,12 @@ export function applyPolicies(
 
     assertScopable(context);
 
-    // Checked against *this* policy's own fragment, which is why it lives inside
-    // the loop rather than beside `assertCreateCovered`'s call: the question is
-    // whether the columns this scope constrains are being written, and only this
-    // iteration knows what they are.
-    if (UPDATING.has(context.operation)) {
-      assertNoScopeEscape(policy, scope, context, out);
+    // Collected from *this* policy's own fragment — only this iteration knows
+    // what its scope constrains — but checked after the rewrites below rather
+    // than here. See `unguarded` and `assertNoScopeEscape`.
+    if (UPDATING.has(context.operation) && !policy.onUpdate) {
+      const owned = scopeOwnedFields(scope);
+      if (owned.length > 0) (unguarded ??= []).push(...owned);
     }
 
     out = withScope(out, scope);
@@ -466,6 +501,28 @@ export function applyPolicies(
     for (const policy of policies) {
       if (policy.onUpdate) out = withUpdated(out, context, policy);
     }
+  }
+
+  // **After the `onUpdate` pass, not before it**, and that ordering is the whole
+  // point of hoisting the check out of the scope loop.
+  //
+  // Checking the caller's `data` where the fragment is computed is the obvious
+  // placement and it leaves a gap the same shape as the `assertCreateCovered`
+  // bug this guard was written alongside: one policy acting on another's behalf.
+  // There it was a `some()` over the list; here it is the rewrite. A policy
+  // carrying only an `onUpdate` can write a column that a *different* policy
+  // scopes on, and if that policy has no `onUpdate` of its own then nobody has
+  // taken responsibility for the column — yet the value lands anyway, because
+  // the check already ran against a `data` that did not contain it.
+  //
+  //     [{ onUpdate: (_c, d) => ({ ...d, orgId: 999 }) },
+  //      { scope: () => ({ orgId: 7 }) }]
+  //
+  // Running last means the question is asked of what will actually be written,
+  // whoever put it there — which is the only version of the question worth
+  // asking.
+  if (unguarded !== undefined) {
+    assertNoScopeEscape(unguarded, context, out);
   }
 
   return out;
@@ -567,35 +624,32 @@ function withUpdated(
 }
 
 /**
- * Refuses an update that writes a column this policy's own `scope` selects on,
- * unless the policy has an `onUpdate` that has taken responsibility for it.
+ * Refuses an update whose payload writes a scope-owned column that no policy has
+ * taken responsibility for.
  *
  * See {@link ScopeEscapeError} for what the shape is and why it is dangerous.
- * The check is deliberately narrow — it fires only when the update actually
+ * The check is deliberately narrow — it fires only when the payload actually
  * names such a column — so an ordinary `update({ data: { name } })` on a
  * tenant-scoped model costs one `Object.keys` and passes, and nobody has to
  * write an `onUpdate` they do not need.
+ *
+ * `unguarded` is already filtered to policies without an `onUpdate`: a policy
+ * that has one owns its columns, and whatever it does with them is its business.
  */
 function assertNoScopeEscape(
-  policy: ModelPolicy,
-  scope: unknown,
+  unguarded: readonly string[],
   context: PolicyContext,
   args: any,
 ): void {
-  // The policy has said what an update means. Whatever it does with the column
-  // is its business from here.
-  if (policy.onUpdate) return;
-
-  const owned = scopeOwnedFields(scope);
-  if (owned.length === 0) return;
-
   const data = args?.data;
   if (typeof data !== "object" || data === null) return;
 
-  const escaping = owned.filter((field) => field in data);
+  const escaping = unguarded.filter((field) => field in data);
   if (escaping.length === 0) return;
 
-  throw new ScopeEscapeError(context.model, context.operation, escaping);
+  throw new ScopeEscapeError(context.model, context.operation, [
+    ...new Set(escaping),
+  ]);
 }
 
 /**

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -1,6 +1,10 @@
 import { RequestContext } from "../http/requestContext";
 import { currentActor } from "./context";
-import { PolicyDeniedError, UnsupportedQueryError } from "./errors";
+import {
+  PolicyDeniedError,
+  ScopeEscapeError,
+  UnsupportedQueryError,
+} from "./errors";
 import type { Operation } from "./plan";
 import {
   COUNT_KEY,
@@ -122,7 +126,7 @@ export function policyContext(
  * What a model contributes. Every member is optional; a model with none is
  * unpolicied and pays a single `undefined` check per query.
  */
-export interface ModelPolicy {
+export interface ModelPolicy<TWhere = any, TCreate = any, TRow = any> {
   /**
    * Runs first, and may throw to deny outright. Return `false` to deny with the
    * framework's own message.
@@ -136,7 +140,7 @@ export interface ModelPolicy {
    * replacement for it, so a caller's own filters always still apply and a
    * policy can only ever *narrow*. Returning `undefined` means no scope.
    */
-  scope?(context: PolicyContext): unknown;
+  scope?(context: PolicyContext): TWhere | undefined;
 
   /**
    * Defaults or validates the payload of a `create`. Separate from `scope`
@@ -144,22 +148,127 @@ export interface ModelPolicy {
    * on an insert, and "restrict which rows are affected" has no meaning for one
    * that does not exist yet. Receives and returns plain `data`.
    */
-  onCreate?(context: PolicyContext, data: any): any;
+  onCreate?(context: PolicyContext, data: TCreate): TCreate;
+
+  /**
+   * The same job for an `update`, and the reason it is a separate hook rather
+   * than something `scope` covers.
+   *
+   * A scope narrows *which rows* an update may touch. It says nothing about the
+   * values being written — so a tenant-scoped model could only ever update its
+   * own rows, and could set `organizationId` on one of them to any tenant it
+   * liked. Read-scoped, write-open: the row leaves the caller's scope and cannot
+   * be read back, which makes it a one-way door rather than a visible error.
+   *
+   * That is the same hole `onCreate` exists to close, arriving through `data`
+   * instead of through a missing `where`, and `plans/orm/06-policies.md` §5 asked
+   * for exactly this — "define what `scope` means per operation rather than
+   * assuming the read semantics generalise" — for every write. It was answered
+   * for `create` and `delete` and left open for `update`.
+   *
+   * Receives and returns plain `data`. A policy that does not define it is not
+   * penalised on ordinary updates; it is only required when an update actually
+   * names a column the policy's own scope constrains. See `assertNoScopeEscape`.
+   */
+  onUpdate?(context: PolicyContext, data: Partial<TCreate>): Partial<TCreate>;
 
   /**
    * Removes fields from a row after it is fetched. Runs in the shaping stage.
    *
    * The one policy capability that deliberately makes gemi's result differ from
    * Prisma's, so the differential harness must compare against the
-   * *pre-redaction* payload. It also has a type-honesty problem — the generated
-   * type says the field is there — which is why `redactable` below restricts it.
+   * *pre-redaction* payload.
+   *
+   * `Partial<TRow>` rather than `TRow`, because redaction's whole problem is that
+   * it makes the generated type a lie — the type says the field is there and the
+   * value is gone. A `redact` also runs over rows shaped by a `select`, where
+   * most fields genuinely are absent. `redactNullable` is the guard rail that
+   * keeps the lie out of the *caller's* type; this keeps it out of the policy's.
    */
-  redact?(context: PolicyContext, row: any): void;
+  redact?(context: PolicyContext, row: Partial<TRow>): void;
 }
 
-/** A model class carrying an optional policy, as seen from here. */
+/**
+ * A policy as it may be written in a `$policies` array: the object itself, or a
+ * class to be instantiated once.
+ *
+ * Both forms are accepted because neither dominates. A class gets contextual
+ * *return* checking against {@link Policy} and — through {@link ScopedPolicy} —
+ * lets `scope`/`onCreate`/`onUpdate` be abstract members, so the pairing this
+ * file otherwise enforces at runtime becomes a compile error. An object comes
+ * out of a factory, which is the only form that can carry configuration and be
+ * reused across models: `softDeletes<User>({ field })` cannot be a bare
+ * constructor, because a constructor in an array has nowhere to put arguments
+ * or type parameters.
+ */
+export type PolicyEntry<TWhere = any, TCreate = any, TRow = any> =
+  | ModelPolicy<TWhere, TCreate, TRow>
+  | (new () => ModelPolicy<TWhere, TCreate, TRow>);
+
+/**
+ * The optional base class for the class-authoring form.
+ *
+ * The members are declared through an interface merged with the class rather
+ * than in the class body, and that is not a style choice. A class *field*
+ * declaration — `scope?: (ctx) => T` — emits `Object.defineProperty(this,
+ * "scope", { value: undefined })` under `useDefineForClassFields`, which is the
+ * default at this target. That own property would shadow the derived class's
+ * prototype method and every policy written this way would silently do nothing.
+ * Declaration merging gives the instance type the same members and emits no
+ * field at all.
+ *
+ * Extending this is optional in both directions: a plain object satisfies
+ * `ModelPolicy` structurally, and an instance of a subclass satisfies it the
+ * same way. Nothing in the runtime checks for it.
+ *
+ * Note what it does *not* buy: TypeScript never contextually types an
+ * overriding method's parameters from its base, so `scope(ctx)` in a subclass is
+ * an implicit `any`. Write `scope(ctx: PolicyContext)`. What it does buy is the
+ * return type being checked against the model's `WhereInput`.
+ */
+// Both suppressions are the merge described above, seen from the linter's side.
+//
+// `no-unsafe-declaration-merging` fires because merging a class with an
+// interface lets the interface claim members the constructor never initialises.
+// That is exactly what is wanted here and it is safe for the same reason the
+// generated model bases' merge is: every member is optional, so "not
+// initialised" is a value the type already permits. The unsafe version of this
+// pattern declares *required* members.
+//
+// `no-unused-vars` fires because the type parameters appear only on the
+// interface half. Dropping them from the class is not an option — `ScopedPolicy`
+// extends it with the same three — and renaming them to `_TWhere` would put the
+// underscores in every author's hover text.
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging, eslint/no-unused-vars
+export abstract class Policy<TWhere = any, TCreate = any, TRow = any> {}
+export interface Policy<TWhere = any, TCreate = any, TRow = any>
+  extends ModelPolicy<TWhere, TCreate, TRow> {}
+
+/**
+ * A policy that scopes, with the write halves made mandatory by the type system.
+ *
+ * `assertCreateCovered` and `assertNoScopeEscape` enforce this at runtime, and
+ * have to: an object literal can always omit a key. Extending this class moves
+ * the same rule to compile time for the authors who want it — a missing
+ * `onCreate` becomes `TS2515` at the class declaration rather than an error on
+ * the first `create` that reaches production.
+ */
+export abstract class ScopedPolicy<
+  TWhere = any,
+  TCreate = any,
+  TRow = any,
+> extends Policy<TWhere, TCreate, TRow> {
+  abstract scope(context: PolicyContext): TWhere | undefined;
+  abstract onCreate(context: PolicyContext, data: TCreate): TCreate;
+  abstract onUpdate(
+    context: PolicyContext,
+    data: Partial<TCreate>,
+  ): Partial<TCreate>;
+}
+
+/** A model class carrying optional policies, as seen from here. */
 export interface PolicedModel {
-  $policy?: ModelPolicy;
+  $policies?: readonly PolicyEntry[];
   $schema?: ModelSchema;
 }
 
@@ -189,6 +298,20 @@ const SCOPABLE = new Set<string>([
 const CREATING = new Set<string>(["create", "createMany", "upsert"]);
 
 /**
+ * Operations whose payload an `onUpdate` applies to. `upsert` is here and absent
+ * from {@link UPDATING} below for the same reason it is in `CREATING`: it has an
+ * update payload to default, but a scope can never reach it (see
+ * `assertScopable`), so there is nothing for the scope-escape guard to check.
+ */
+const MUTATING = new Set<string>(["update", "updateMany", "upsert"]);
+
+/**
+ * Operations that write to existing rows *and* carry a scope, so an update can
+ * move a row out of the scope that selected it.
+ */
+const UPDATING = new Set<string>(["update", "updateMany"]);
+
+/**
  * Operations that write a new row and have no `where` at all, so a `scope`
  * cannot apply to them even in principle. `upsert` is not here: it *has* a
  * where, it just cannot carry a predicate — a different problem with a
@@ -197,32 +320,87 @@ const CREATING = new Set<string>(["create", "createMany", "upsert"]);
 const INSERTING = new Set<string>(["create", "createMany"]);
 
 /**
+ * Instances made from constructor entries, so identity is stable across calls.
+ *
+ * Not an optimisation. `$exec`'s divergence guard and `assertPoliciesRegistered`
+ * both compare two policy chains element by element, and a fresh instance per
+ * call would make every comparison fail — every query on a class-form policy
+ * would raise `UnregisteredPolicyClassError` against itself. Keyed on the
+ * constructor, which is as stable as the class object.
+ */
+const instantiated = new WeakMap<object, ModelPolicy>();
+
+function resolveEntry(entry: PolicyEntry): ModelPolicy {
+  if (typeof entry !== "function") return entry;
+
+  const existing = instantiated.get(entry);
+  if (existing !== undefined) return existing;
+
+  const made = new (entry as new () => ModelPolicy)();
+  instantiated.set(entry, made);
+  return made;
+}
+
+/**
  * Every policy that applies to a model class, base first.
  *
  * Walks the prototype chain so a `TenantModel` or `SoftDeletes` base
- * contributes to every subclass. The order is **base to derived**, and it is
- * chosen rather than incidental: a subclass's `scope` is `AND`ed after its
- * base's, so a base can only ever be narrowed further, never widened. A derived
- * policy that could drop its base's scope would make a shared tenant guard
- * unenforceable, which is the opposite of why a base class would carry one.
+ * contributes to every subclass, and concatenates each level's `$policies`.
+ * The order is **base to derived**, and it is chosen rather than incidental: a
+ * subclass's `scope` is `AND`ed after its base's, so a base can only ever be
+ * narrowed further, never widened. A derived policy that could drop its base's
+ * scope would make a shared tenant guard unenforceable, which is the opposite of
+ * why a base class would carry one. Within one level, array order is the
+ * author's and is preserved.
  *
- * `Object.hasOwn` rather than a property read: an inherited `$policy` would
+ * `Object.hasOwn` rather than a property read: an inherited `$policies` would
  * otherwise be collected once per level of the chain.
+ *
+ * **Deliberately uncached.** This runs per query per node of an include tree, so
+ * a cache is tempting — but `$policies` is an ordinary static that tests and
+ * feature flags reassign at runtime, and a cache keyed on the class would serve
+ * the stale chain with no way to notice. The single-level fast path below is
+ * what keeps the common case free: one `Object.hasOwn` per level and no
+ * allocation at all when nothing needs instantiating.
  */
-export function policiesFor(model: unknown): ModelPolicy[] {
-  const found: ModelPolicy[] = [];
+export function policiesFor(model: unknown): readonly ModelPolicy[] {
+  let found: ModelPolicy[] | undefined;
+  let only: readonly PolicyEntry[] | undefined;
 
   let current = model as PolicedModel | null;
   while (current && current !== Function.prototype) {
-    if (Object.hasOwn(current, "$policy") && current.$policy) {
-      // Unshifted, so the walk's derived-to-base order comes back base-first.
-      found.unshift(current.$policy);
+    if (Object.hasOwn(current, "$policies") && current.$policies) {
+      const level = current.$policies;
+      if (level.length > 0) {
+        if (only === undefined && found === undefined) {
+          // First contributing level, walking derived to base. Held rather than
+          // copied, in case it turns out to be the only one.
+          only = level;
+        } else {
+          // A second level exists, so the held one has to be materialised.
+          // Unshifted, so the walk's derived-to-base order comes back
+          // base-first.
+          found ??= (only as readonly PolicyEntry[]).map(resolveEntry);
+          only = undefined;
+          found.unshift(...level.map(resolveEntry));
+        }
+      }
     }
     current = Object.getPrototypeOf(current);
   }
 
-  return found;
+  if (found !== undefined) return found;
+  if (only === undefined) return EMPTY;
+
+  // The overwhelmingly common shape: policies on exactly one class. Returned
+  // without copying when every entry is already an object, which is every
+  // factory-authored policy.
+  return only.some((entry) => typeof entry === "function")
+    ? only.map(resolveEntry)
+    : (only as readonly ModelPolicy[]);
 }
+
+const EMPTY: readonly ModelPolicy[] = Object.freeze([]);
 
 /**
  * Applies every policy to the argument tree, returning a new tree.
@@ -258,7 +436,7 @@ export function applyPolicies(
     // an author who expressed an intent this operation cannot honour, and
     // running it would write a row into whatever tenant the caller named.
     if (INSERTING.has(context.operation)) {
-      assertCreateCovered(policies, context);
+      assertCreateCovered(policy, context);
       continue;
     }
 
@@ -266,12 +444,27 @@ export function applyPolicies(
     if (scope === undefined || scope === null) continue;
 
     assertScopable(context);
+
+    // Checked against *this* policy's own fragment, which is why it lives inside
+    // the loop rather than beside `assertCreateCovered`'s call: the question is
+    // whether the columns this scope constrains are being written, and only this
+    // iteration knows what they are.
+    if (UPDATING.has(context.operation)) {
+      assertNoScopeEscape(policy, scope, context, out);
+    }
+
     out = withScope(out, scope);
   }
 
   if (CREATING.has(context.operation)) {
     for (const policy of policies) {
       if (policy.onCreate) out = withCreated(out, context, policy);
+    }
+  }
+
+  if (MUTATING.has(context.operation)) {
+    for (const policy of policies) {
+      if (policy.onUpdate) out = withUpdated(out, context, policy);
     }
   }
 
@@ -352,18 +545,104 @@ function withCreated(args: any, context: PolicyContext, policy: ModelPolicy): an
 }
 
 /**
+ * Runs an `onUpdate` over whichever shape the operation's payload takes.
+ *
+ * The same shallow copy as `withCreated`, for the same reason, and the same
+ * split for `upsert` — there the update branch is `args.update` rather than
+ * `args.data`, and the create branch is `onCreate`'s.
+ */
+function withUpdated(
+  args: any,
+  context: PolicyContext,
+  policy: ModelPolicy,
+): any {
+  const key = context.operation === "upsert" ? "update" : "data";
+  const payload = args?.[key];
+
+  // Nothing to default. An `update` with no `data` is the compiler's error to
+  // report, and manufacturing `{}` here would turn it into a silent no-op write.
+  if (payload === undefined || payload === null) return args;
+
+  return { ...args, [key]: policy.onUpdate!(context, { ...payload }) };
+}
+
+/**
+ * Refuses an update that writes a column this policy's own `scope` selects on,
+ * unless the policy has an `onUpdate` that has taken responsibility for it.
+ *
+ * See {@link ScopeEscapeError} for what the shape is and why it is dangerous.
+ * The check is deliberately narrow — it fires only when the update actually
+ * names such a column — so an ordinary `update({ data: { name } })` on a
+ * tenant-scoped model costs one `Object.keys` and passes, and nobody has to
+ * write an `onUpdate` they do not need.
+ */
+function assertNoScopeEscape(
+  policy: ModelPolicy,
+  scope: unknown,
+  context: PolicyContext,
+  args: any,
+): void {
+  // The policy has said what an update means. Whatever it does with the column
+  // is its business from here.
+  if (policy.onUpdate) return;
+
+  const owned = scopeOwnedFields(scope);
+  if (owned.length === 0) return;
+
+  const data = args?.data;
+  if (typeof data !== "object" || data === null) return;
+
+  const escaping = owned.filter((field) => field in data);
+  if (escaping.length === 0) return;
+
+  throw new ScopeEscapeError(context.model, context.operation, escaping);
+}
+
+/**
+ * The columns a scope fragment constrains, as far as they can be known.
+ *
+ * Top-level keys only, and combinators excluded: `{ organizationId: 7 }` names
+ * a column, `{ OR: [...] }` names a structure whose columns cannot be attributed
+ * to this policy without interpreting the whole `where` grammar. Returning
+ * nothing for those is the permissive answer and is the documented limit of the
+ * guard rather than an oversight.
+ */
+function scopeOwnedFields(scope: unknown): string[] {
+  if (typeof scope !== "object" || scope === null || Array.isArray(scope)) {
+    return [];
+  }
+
+  const owned: string[] = [];
+  for (const key of Object.keys(scope as Record<string, unknown>)) {
+    if (key === "AND" || key === "OR" || key === "NOT") continue;
+    owned.push(key);
+  }
+  return owned;
+}
+
+/**
  * Refuses a `create` whose policy scopes reads but says nothing about writes.
  *
  * The natural tenant policy carries both `scope` and `onCreate`, and for it this
  * is a no-op. The dangerous shape is `scope` alone: reads are confined to the
  * caller's tenant and an insert can name any tenant it likes, which is a policy
  * that looks complete and is half of one. Refused with the missing piece named.
+ *
+ * **Asks about one policy, not the chain.** It used to take the whole list and
+ * pass if *any* member had an `onCreate`, which meant one policy could satisfy
+ * the check on another's behalf — and `softDeletes()` ships a pass-through
+ * `onCreate` precisely so that its own scope does not trip this. So adding soft
+ * deletes to a model disarmed the guard for that model's tenant policy, and the
+ * insert ran with the scoped column unset: the exact outcome the message below
+ * describes, produced by the guard meant to prevent it. Composition is the
+ * normal case now that `$policies` is a list, so the question has to be asked of
+ * the policy that carries the scope.
  */
 function assertCreateCovered(
-  policies: readonly ModelPolicy[],
+  policy: ModelPolicy,
   context: PolicyContext,
 ): void {
-  if (policies.some((policy) => policy.onCreate)) return;
+  if (policy.onCreate) return;
 
   throw new UnsupportedQueryError(
     context.operation,

--- a/packages/gemi/orm/registration.test.ts
+++ b/packages/gemi/orm/registration.test.ts
@@ -41,7 +41,7 @@ describe("the case the $exec guard cannot see", () => {
    */
   test("a policied subclass that was never registered is refused", () => {
     class User extends UserBase {
-      static $policy = scope;
+      static $policies = [scope];
     }
 
     register("User", UserBase);
@@ -53,7 +53,7 @@ describe("the case the $exec guard cannot see", () => {
 
   test("the error names both classes and the fix", () => {
     class Membership extends UserBase {
-      static $policy = scope;
+      static $policies = [scope];
     }
 
     register("User", UserBase);
@@ -71,7 +71,7 @@ describe("the case the $exec guard cannot see", () => {
 
   test("registering the subclass is what makes it pass", () => {
     class User extends UserBase {
-      static $policy = scope;
+      static $policies = [scope];
     }
 
     register("User", User);
@@ -89,7 +89,7 @@ describe("what it must not reject", () => {
    */
   test("a plain subclass of the registered class inherits and is fine", () => {
     class User extends UserBase {
-      static $policy = scope;
+      static $policies = [scope];
     }
     class AdminUser extends User {}
 
@@ -134,7 +134,7 @@ describe("what it must not reject", () => {
    */
   test("a name nothing is registered under is left alone", () => {
     class User extends UserBase {
-      static $policy = scope;
+      static $policies = [scope];
     }
 
     expect(() => assertPoliciesRegistered({ User })).not.toThrow();
@@ -149,7 +149,7 @@ describe("the other direction", () => {
    */
   test("an exported base is refused when a policied class owns the name", () => {
     class User extends UserBase {
-      static $policy = scope;
+      static $policies = [scope];
     }
 
     register("User", User);
@@ -166,10 +166,10 @@ describe("the other direction", () => {
 
   test("two different policies on the same name diverge", () => {
     class Ours extends UserBase {
-      static $policy = scope;
+      static $policies = [scope];
     }
     class Theirs extends UserBase {
-      static $policy = other;
+      static $policies = [other];
     }
 
     register("User", Theirs);
@@ -183,10 +183,10 @@ describe("the other direction", () => {
 describe("more than one module", () => {
   test("every module handed over is checked", () => {
     class Good extends UserBase {
-      static $policy = scope;
+      static $policies = [scope];
     }
     class Bad extends UserBase {
-      static $policy = other;
+      static $policies = [other];
     }
 
     register("User", Good);

--- a/packages/gemi/orm/registration.ts
+++ b/packages/gemi/orm/registration.ts
@@ -18,7 +18,7 @@ import type { ModelSchema } from "./schema";
  * real:
  *
  *     export class Membership extends MembershipModel {
- *       static $policy = { scope: (ctx) => ({ orgId: ctx.user.orgId }) }
+ *       static $policies = [{ scope: (ctx) => ({ orgId: ctx.user.orgId }) }]
  *     }
  *     // ...and no `register("Membership", Membership)`
  *

--- a/packages/gemi/orm/soft-deletes.ts
+++ b/packages/gemi/orm/soft-deletes.ts
@@ -14,25 +14,36 @@ import type { ModelPolicy } from "./policy";
  * Usage — `deletedAt` must be a nullable `DateTime` on the model:
  *
  *     export class User extends UserModel {
- *       static $policy = softDeletes()
+ *       static $policies = [softDeletes<User>()]
  *     }
  *
  *     await User.findMany({})        // deleted rows are not there
  *     await User.delete({ where })   // sets deletedAt, does not remove the row
  *
- * Composing it with a policy of your own means composing the objects, since a
- * class has one `$policy`. The base-class route is usually cleaner:
+ * Composing it with a policy of your own is now just a longer list, in the order
+ * they should apply:
  *
- *     class SoftDeleted extends UserModel { static $policy = softDeletes() }
- *     export class User extends SoftDeleted { static $policy = { ...mine } }
+ *     static $policies = [softDeletes<User>(), new TenantPolicy()]
  *
- * ...which also gets the ordering right for free: `policiesFor` walks base to
- * derived, so the soft-delete scope is applied first and yours narrows further.
+ * That ordering is the author's, and within a class it is the array's. Across
+ * classes `policiesFor` still walks base to derived, so a `$policies` on a
+ * shared base is applied before a subclass's and can only be narrowed further.
+ *
+ * It stays a **factory** rather than a class because it takes configuration and
+ * a model type parameter, and a bare constructor in a `$policies` array has
+ * nowhere to put either. `PolicyEntry` accepts both forms for exactly this
+ * reason.
  */
 
-export interface SoftDeleteOptions {
-  /** The timestamp column. Defaults to `deletedAt`, which the template uses. */
-  field?: string;
+export interface SoftDeleteOptions<M> {
+  /**
+   * The timestamp column. Defaults to `deletedAt`, which the template uses.
+   *
+   * Constrained to the model's own keys, so a typo or a model that has no such
+   * column is a compile error instead of a `no such column` from the database on
+   * the first read.
+   */
+  field?: keyof M & string;
 }
 
 /**
@@ -44,7 +55,9 @@ export interface SoftDeleteOptions {
  * under `User.findMany({ include: { accounts: true } })` without anything being
  * written at the include site.
  */
-export function softDeletes(options: SoftDeleteOptions = {}): ModelPolicy {
+export function softDeletes<M = any>(
+  options: SoftDeleteOptions<M> = {},
+): ModelPolicy<any, any, M> {
   const field = options.field ?? "deletedAt";
 
   return {
@@ -56,6 +69,19 @@ export function softDeletes(options: SoftDeleteOptions = {}): ModelPolicy {
     // combination is a half-written policy. Here the pass-through *is* the
     // correct behaviour, so it is stated rather than implied.
     onCreate: (_context, data) => data,
+
+    // The same statement for updates, and here it is doing real work rather than
+    // satisfying a formality. This policy scopes on `deletedAt`, and
+    // `softDelete()` below turns a delete into an update that *writes*
+    // `deletedAt` — which is precisely the "an update moves a row out of the
+    // scope that selected it" shape `ScopeEscapeError` refuses. It is also
+    // exactly what soft deleting means, so this policy is the one that gets to
+    // say the write is intended.
+    //
+    // Note it does not authorise anything else: the guard is per policy, so a
+    // tenant policy sitting beside this one in `$policies` still has to answer
+    // for its own column. That separation is the point of the per-policy check.
+    onUpdate: (_context, data) => data,
   };
 }
 
@@ -70,7 +96,7 @@ export function softDeletes(options: SoftDeleteOptions = {}): ModelPolicy {
  * a much larger claim than scoping a `where`.
  *
  *     export class User extends UserModel {
- *       static $policy = softDeletes()
+ *       static $policies = [softDeletes<User>()]
  *       static delete = softDelete(User)
  *       static deleteMany = softDeleteMany(User)
  *     }
@@ -81,9 +107,9 @@ export function softDeletes(options: SoftDeleteOptions = {}): ModelPolicy {
  * `delete({ where })` naming an already-deleted row finds nothing, exactly as
  * a hard delete of a missing row would.
  */
-export function softDelete<T>(
+export function softDelete<T, M = any>(
   model: { update(args: any): Promise<T> },
-  options: SoftDeleteOptions = {},
+  options: SoftDeleteOptions<M> = {},
 ): (args: any) => Promise<T> {
   const field = options.field ?? "deletedAt";
 
@@ -96,9 +122,9 @@ export function softDelete<T>(
   };
 }
 
-export function softDeleteMany<T>(
+export function softDeleteMany<T, M = any>(
   model: { updateMany(args: any): Promise<T> },
-  options: SoftDeleteOptions = {},
+  options: SoftDeleteOptions<M> = {},
 ): (args: any) => Promise<T> {
   const field = options.field ?? "deletedAt";
 

--- a/plans/orm/05-ambient-transactions.md
+++ b/plans/orm/05-ambient-transactions.md
@@ -151,6 +151,13 @@ territory, and only if the Eloquent tier is pursued).
 - **Long-lived transactions hold a pooled connection.** Nothing here prevents a
   callback from doing network I/O while holding one. A development-mode warning
   above a duration threshold is cheap and worth considering, though not required.
+
+  *Shipped.* `watchForSlowTransaction` in `orm/context.ts`: a warning at
+  `GEMI_SLOW_TRANSACTION_MS` (default 2s), development only, outermost scope
+  only. A timer rather than an elapsed-time measurement on the way out, because
+  the case that matters most is the transaction that never settles at all — an
+  after-the-fact measurement is silent for exactly that one. It reports; it does
+  not cancel.
 - **ALS has a real cost** under heavy concurrency. It is already used per request
   by the kernel, so the marginal cost of a second, shallower store should be
   small — but iteration 7 should measure it rather than assume, since this is on

--- a/plans/orm/06-policies.md
+++ b/plans/orm/06-policies.md
@@ -54,7 +54,7 @@ Attached to the model class, inherited through the prototype chain so a
 ```ts
 // sketch
 export class Account extends AccountModel {
-  static $policy = {
+  static $policies = [{
     // deny outright
     before(ctx) { if (!ctx.user) throw new ForbiddenError(); },
     // rewrite the arg tree — this is the part extensions cannot do
@@ -63,7 +63,7 @@ export class Account extends AccountModel {
     },
     // post-fetch field removal
     redact(ctx, row) { ... },
-  };
+  }];
 }
 ```
 
@@ -195,7 +195,7 @@ there is a third shape where that is false:
 
 ```ts
 export class Membership extends MembershipModel {
-  static $policy = { scope: (ctx) => ({ orgId: ctx.user.orgId }) }
+  static $policies = [{ scope: (ctx) => ({ orgId: ctx.user.orgId }) }]
 }
 // ...and no register("Membership", Membership)
 ```
@@ -224,16 +224,17 @@ one for a subclass in application code it never sees. Options, none built:
   registers every `app/models/*.ts` subclass it finds. Codegen reading
   application source is a new kind of coupling and wants its own decision.
 - Register on first *definition* rather than on first import. There is no hook —
-  `static $policy = …` in a subclass body is a `[[DefineOwnProperty]]` on the
+  `static $policies = …` in a subclass body is a `[[DefineOwnProperty]]` on the
   subclass, so a setter on the base is bypassed. Verified rather than reasoned
-  about: the setter does not fire and `Object.hasOwn(Child, "$policy")` is true.
+  about: the setter does not fire and `Object.hasOwn(Child, "$policies")` is
+  true.
 
   **The dependency is worth naming, because the reason could expire.** Define
   semantics are what ES2022 specifies and what Bun does, and this monorepo sets
   `target: ES2022` in `@repo/typescript-config/base.json`. Under *assignment*
   semantics — `useDefineForClassFields: false`, or an older target —
-  `static $policy = …` compiles to `Child.$policy = …` and an inherited setter
-  **would** fire.
+  `static $policies = …` compiles to `Child.$policies = …` and an inherited
+  setter **would** fire.
 
   That does not revive the option, and the reason it does not is the sharper
   version of the point: **the subclass is application code**, compiled by the
@@ -244,9 +245,9 @@ one for a subclass in application code it never sees. Options, none built:
   downstream `tsconfig.json` can turn off without any error. So: ruled out for
   portability rather than for impossibility, which is the stronger reason and
   the one that survives a change of target.
-- Make `$policy` a method call — `static $policy = policy(Membership, {…})` —
-  so declaring one registers it. Changes the documented shape of every policy,
-  and the `docs/authorization.md` examples with it.
+- Make the declaration a method call — `static $policies = policies(Membership,
+  […])` — so declaring one registers it. Changes the documented shape of every
+  policy, and the `docs/authorization.md` examples with it.
 
 ## Found by audit: nested writes were unscoped
 

--- a/plans/orm/06-policies.md
+++ b/plans/orm/06-policies.md
@@ -116,6 +116,19 @@ affected; scoping a `create` means validating or defaulting the tenant column.
 Define what `scope` means per operation rather than assuming the read semantics
 generalise.
 
+**Answered, and one part of it was missed the first time.** `create` got `onCreate`
+plus a guard refusing a scope that has none; `delete`/`deleteMany` scope their
+`where` like a read. `update` scoped its `where` and left `data` untouched — so a
+tenant-scoped update could move a row to another tenant, which is this section's
+own question left unanswered for the one operation where it is least visible.
+Closed by `onUpdate` and `ScopeEscapeError`.
+
+The guards are asked of **the policy that carries the scope**, not of the list.
+Asking the list was a real hole rather than a nicety: `softDeletes()` ships a
+pass-through `onCreate` so its own scope does not trip the create guard, which
+meant adding soft deletes to a model disarmed that guard for the model's tenant
+policy — and the insert ran with the scoped column unset.
+
 ### 6. Redaction
 
 Post-fetch field removal in the shaping stage. Note that this is the one policy

--- a/templates/saas-starter/app/models/User.ts
+++ b/templates/saas-starter/app/models/User.ts
@@ -9,6 +9,24 @@ import { UserModel } from "./generated";
 // Queries return plain objects, never instances of this class — `select` makes
 // that unavoidable, since a `Pick<User, "id">` hydrated as a `User` would carry
 // methods reading fields the query never fetched.
+// Policies go in `$policies`, which is a list so that composition needs no
+// intermediate class and no object spread:
+//
+//   import { softDeletes } from "gemi/orm"
+//   import { UserPolicy } from "./generated"
+//
+//   export class User extends UserModel {
+//     static $policies: UserPolicy[] = [
+//       softDeletes<User>(),
+//       { scope: (ctx) => ({ organizationId: ctx.user.organizationId }),
+//         onCreate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
+//         onUpdate: (_ctx, data) => data },
+//     ]
+//   }
+//
+// The `UserPolicy` annotation is what types `ctx`, `data` and the returned
+// `where` against this model — without it the entries are inferred from the
+// literal and the parameters are implicitly `any`.
 export class User extends UserModel {}
 
 // Re-registers the name against *this* class, replacing the generated base that

--- a/templates/saas-starter/app/models/bench/run.ts
+++ b/templates/saas-starter/app/models/bench/run.ts
@@ -374,7 +374,7 @@ async function microbenchmarks(): Promise<string> {
       `Walks the prototype chain and finds nothing. Paid by every model. |`,
   );
 
-  (UserModel as any).$policy = { scope: () => ({ deletedAt: null }) };
+  (UserModel as any).$policies = [{ scope: () => ({ deletedAt: null }) }];
   try {
     const policed = await time(() => policiesFor(UserModel), {
       runs: 200,
@@ -385,7 +385,7 @@ async function microbenchmarks(): Promise<string> {
         `Same walk, one \`Object.hasOwn\` hit. |`,
     );
   } finally {
-    delete (UserModel as any).$policy;
+    delete (UserModel as any).$policies;
   }
 
   // §5 also asks whether the plan cache's bound is the right one. The answer is
@@ -1168,7 +1168,7 @@ async function runDialect(
       onCreate: (_context, data) => data,
     };
 
-    (UserModel as any).$policy = scopedPolicy;
+    (UserModel as any).$policies = [scopedPolicy];
     try {
       results.push(
         await scenario({
@@ -1193,7 +1193,7 @@ async function runDialect(
         }),
       );
     } finally {
-      delete (UserModel as any).$policy;
+      delete (UserModel as any).$policies;
     }
 
     return results;

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -6,9 +6,9 @@
 import type { Prisma } from "@prisma/client";
 import {
   Model,
-  Policy,
   ScopedPolicy,
   type ExecOptions,
+  type ModelPolicy,
   type PolicyEntry,
 } from "gemi/orm";
 
@@ -33,11 +33,11 @@ type Subset<T, U> = {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface AccountModel extends Prisma.AccountGetPayload<{}> {}
 
-export abstract class AccountPolicy extends Policy<
+export type AccountPolicy = ModelPolicy<
   Prisma.AccountWhereInput,
   Prisma.AccountCreateInput,
   Prisma.AccountGetPayload<{}>
-> {}
+>;
 
 // The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those
@@ -167,11 +167,11 @@ export class AccountModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface MagicLinkTokenModel extends Prisma.MagicLinkTokenGetPayload<{}> {}
 
-export abstract class MagicLinkTokenPolicy extends Policy<
+export type MagicLinkTokenPolicy = ModelPolicy<
   Prisma.MagicLinkTokenWhereInput,
   Prisma.MagicLinkTokenCreateInput,
   Prisma.MagicLinkTokenGetPayload<{}>
-> {}
+>;
 
 // The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those
@@ -301,11 +301,11 @@ export class MagicLinkTokenModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface OrganizationModel extends Prisma.OrganizationGetPayload<{}> {}
 
-export abstract class OrganizationPolicy extends Policy<
+export type OrganizationPolicy = ModelPolicy<
   Prisma.OrganizationWhereInput,
   Prisma.OrganizationCreateInput,
   Prisma.OrganizationGetPayload<{}>
-> {}
+>;
 
 // The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those
@@ -435,11 +435,11 @@ export class OrganizationModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface OrganizationInvitationModel extends Prisma.OrganizationInvitationGetPayload<{}> {}
 
-export abstract class OrganizationInvitationPolicy extends Policy<
+export type OrganizationInvitationPolicy = ModelPolicy<
   Prisma.OrganizationInvitationWhereInput,
   Prisma.OrganizationInvitationCreateInput,
   Prisma.OrganizationInvitationGetPayload<{}>
-> {}
+>;
 
 // The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those
@@ -569,11 +569,11 @@ export class OrganizationInvitationModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface PasswordResetTokenModel extends Prisma.PasswordResetTokenGetPayload<{}> {}
 
-export abstract class PasswordResetTokenPolicy extends Policy<
+export type PasswordResetTokenPolicy = ModelPolicy<
   Prisma.PasswordResetTokenWhereInput,
   Prisma.PasswordResetTokenCreateInput,
   Prisma.PasswordResetTokenGetPayload<{}>
-> {}
+>;
 
 // The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those
@@ -703,11 +703,11 @@ export class PasswordResetTokenModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface SessionModel extends Prisma.SessionGetPayload<{}> {}
 
-export abstract class SessionPolicy extends Policy<
+export type SessionPolicy = ModelPolicy<
   Prisma.SessionWhereInput,
   Prisma.SessionCreateInput,
   Prisma.SessionGetPayload<{}>
-> {}
+>;
 
 // The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those
@@ -837,11 +837,11 @@ export class SessionModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface SocialAccountModel extends Prisma.SocialAccountGetPayload<{}> {}
 
-export abstract class SocialAccountPolicy extends Policy<
+export type SocialAccountPolicy = ModelPolicy<
   Prisma.SocialAccountWhereInput,
   Prisma.SocialAccountCreateInput,
   Prisma.SocialAccountGetPayload<{}>
-> {}
+>;
 
 // The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those
@@ -971,11 +971,11 @@ export class SocialAccountModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface UserModel extends Prisma.UserGetPayload<{}> {}
 
-export abstract class UserPolicy extends Policy<
+export type UserPolicy = ModelPolicy<
   Prisma.UserWhereInput,
   Prisma.UserCreateInput,
   Prisma.UserGetPayload<{}>
-> {}
+>;
 
 // The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
 // that scopes cannot omit the write halves. The runtime refuses those

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -4,7 +4,13 @@
 // It is committed on purpose: diffs stay reviewable and CI needs no codegen step.
 
 import type { Prisma } from "@prisma/client";
-import { Model, type ExecOptions } from "gemi/orm";
+import {
+  Model,
+  Policy,
+  ScopedPolicy,
+  type ExecOptions,
+  type PolicyEntry,
+} from "gemi/orm";
 
 import * as schema from "./schema";
 
@@ -27,8 +33,33 @@ type Subset<T, U> = {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface AccountModel extends Prisma.AccountGetPayload<{}> {}
 
+export abstract class AccountPolicy extends Policy<
+  Prisma.AccountWhereInput,
+  Prisma.AccountCreateInput,
+  Prisma.AccountGetPayload<{}>
+> {}
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class AccountScopedPolicy extends ScopedPolicy<
+  Prisma.AccountWhereInput,
+  Prisma.AccountCreateInput,
+  Prisma.AccountGetPayload<{}>
+> {}
+
 export class AccountModel extends Model {
   static $schema = schema.Account;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.AccountWhereInput,
+    Prisma.AccountCreateInput,
+    Prisma.AccountGetPayload<{}>
+  >[];
 
   static findMany<T extends Prisma.AccountFindManyArgs>(
     args?: Subset<T, Prisma.AccountFindManyArgs>,
@@ -136,8 +167,33 @@ export class AccountModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface MagicLinkTokenModel extends Prisma.MagicLinkTokenGetPayload<{}> {}
 
+export abstract class MagicLinkTokenPolicy extends Policy<
+  Prisma.MagicLinkTokenWhereInput,
+  Prisma.MagicLinkTokenCreateInput,
+  Prisma.MagicLinkTokenGetPayload<{}>
+> {}
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class MagicLinkTokenScopedPolicy extends ScopedPolicy<
+  Prisma.MagicLinkTokenWhereInput,
+  Prisma.MagicLinkTokenCreateInput,
+  Prisma.MagicLinkTokenGetPayload<{}>
+> {}
+
 export class MagicLinkTokenModel extends Model {
   static $schema = schema.MagicLinkToken;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.MagicLinkTokenWhereInput,
+    Prisma.MagicLinkTokenCreateInput,
+    Prisma.MagicLinkTokenGetPayload<{}>
+  >[];
 
   static findMany<T extends Prisma.MagicLinkTokenFindManyArgs>(
     args?: Subset<T, Prisma.MagicLinkTokenFindManyArgs>,
@@ -245,8 +301,33 @@ export class MagicLinkTokenModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface OrganizationModel extends Prisma.OrganizationGetPayload<{}> {}
 
+export abstract class OrganizationPolicy extends Policy<
+  Prisma.OrganizationWhereInput,
+  Prisma.OrganizationCreateInput,
+  Prisma.OrganizationGetPayload<{}>
+> {}
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class OrganizationScopedPolicy extends ScopedPolicy<
+  Prisma.OrganizationWhereInput,
+  Prisma.OrganizationCreateInput,
+  Prisma.OrganizationGetPayload<{}>
+> {}
+
 export class OrganizationModel extends Model {
   static $schema = schema.Organization;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.OrganizationWhereInput,
+    Prisma.OrganizationCreateInput,
+    Prisma.OrganizationGetPayload<{}>
+  >[];
 
   static findMany<T extends Prisma.OrganizationFindManyArgs>(
     args?: Subset<T, Prisma.OrganizationFindManyArgs>,
@@ -354,8 +435,33 @@ export class OrganizationModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface OrganizationInvitationModel extends Prisma.OrganizationInvitationGetPayload<{}> {}
 
+export abstract class OrganizationInvitationPolicy extends Policy<
+  Prisma.OrganizationInvitationWhereInput,
+  Prisma.OrganizationInvitationCreateInput,
+  Prisma.OrganizationInvitationGetPayload<{}>
+> {}
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class OrganizationInvitationScopedPolicy extends ScopedPolicy<
+  Prisma.OrganizationInvitationWhereInput,
+  Prisma.OrganizationInvitationCreateInput,
+  Prisma.OrganizationInvitationGetPayload<{}>
+> {}
+
 export class OrganizationInvitationModel extends Model {
   static $schema = schema.OrganizationInvitation;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.OrganizationInvitationWhereInput,
+    Prisma.OrganizationInvitationCreateInput,
+    Prisma.OrganizationInvitationGetPayload<{}>
+  >[];
 
   static findMany<T extends Prisma.OrganizationInvitationFindManyArgs>(
     args?: Subset<T, Prisma.OrganizationInvitationFindManyArgs>,
@@ -463,8 +569,33 @@ export class OrganizationInvitationModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface PasswordResetTokenModel extends Prisma.PasswordResetTokenGetPayload<{}> {}
 
+export abstract class PasswordResetTokenPolicy extends Policy<
+  Prisma.PasswordResetTokenWhereInput,
+  Prisma.PasswordResetTokenCreateInput,
+  Prisma.PasswordResetTokenGetPayload<{}>
+> {}
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class PasswordResetTokenScopedPolicy extends ScopedPolicy<
+  Prisma.PasswordResetTokenWhereInput,
+  Prisma.PasswordResetTokenCreateInput,
+  Prisma.PasswordResetTokenGetPayload<{}>
+> {}
+
 export class PasswordResetTokenModel extends Model {
   static $schema = schema.PasswordResetToken;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.PasswordResetTokenWhereInput,
+    Prisma.PasswordResetTokenCreateInput,
+    Prisma.PasswordResetTokenGetPayload<{}>
+  >[];
 
   static findMany<T extends Prisma.PasswordResetTokenFindManyArgs>(
     args?: Subset<T, Prisma.PasswordResetTokenFindManyArgs>,
@@ -572,8 +703,33 @@ export class PasswordResetTokenModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface SessionModel extends Prisma.SessionGetPayload<{}> {}
 
+export abstract class SessionPolicy extends Policy<
+  Prisma.SessionWhereInput,
+  Prisma.SessionCreateInput,
+  Prisma.SessionGetPayload<{}>
+> {}
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class SessionScopedPolicy extends ScopedPolicy<
+  Prisma.SessionWhereInput,
+  Prisma.SessionCreateInput,
+  Prisma.SessionGetPayload<{}>
+> {}
+
 export class SessionModel extends Model {
   static $schema = schema.Session;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.SessionWhereInput,
+    Prisma.SessionCreateInput,
+    Prisma.SessionGetPayload<{}>
+  >[];
 
   static findMany<T extends Prisma.SessionFindManyArgs>(
     args?: Subset<T, Prisma.SessionFindManyArgs>,
@@ -681,8 +837,33 @@ export class SessionModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface SocialAccountModel extends Prisma.SocialAccountGetPayload<{}> {}
 
+export abstract class SocialAccountPolicy extends Policy<
+  Prisma.SocialAccountWhereInput,
+  Prisma.SocialAccountCreateInput,
+  Prisma.SocialAccountGetPayload<{}>
+> {}
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class SocialAccountScopedPolicy extends ScopedPolicy<
+  Prisma.SocialAccountWhereInput,
+  Prisma.SocialAccountCreateInput,
+  Prisma.SocialAccountGetPayload<{}>
+> {}
+
 export class SocialAccountModel extends Model {
   static $schema = schema.SocialAccount;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.SocialAccountWhereInput,
+    Prisma.SocialAccountCreateInput,
+    Prisma.SocialAccountGetPayload<{}>
+  >[];
 
   static findMany<T extends Prisma.SocialAccountFindManyArgs>(
     args?: Subset<T, Prisma.SocialAccountFindManyArgs>,
@@ -790,8 +971,33 @@ export class SocialAccountModel extends Model {
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface UserModel extends Prisma.UserGetPayload<{}> {}
 
+export abstract class UserPolicy extends Policy<
+  Prisma.UserWhereInput,
+  Prisma.UserCreateInput,
+  Prisma.UserGetPayload<{}>
+> {}
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class UserScopedPolicy extends ScopedPolicy<
+  Prisma.UserWhereInput,
+  Prisma.UserCreateInput,
+  Prisma.UserGetPayload<{}>
+> {}
+
 export class UserModel extends Model {
   static $schema = schema.User;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.UserWhereInput,
+    Prisma.UserCreateInput,
+    Prisma.UserGetPayload<{}>
+  >[];
 
   static findMany<T extends Prisma.UserFindManyArgs>(
     args?: Subset<T, Prisma.UserFindManyArgs>,

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -127,12 +127,12 @@ const tenant = (): ModelPolicy => ({
 
 class Folder extends Model {
   static $schema = folderSchema;
-  static $policy = tenant();
+  static $policies = [tenant()];
 }
 
 class Note extends Model {
   static $schema = noteSchema;
-  static $policy = tenant();
+  static $policies = [tenant()];
 }
 
 const OURS = { orgId: 7 };
@@ -299,5 +299,125 @@ describe("policies on nested writes", () => {
 
     const notes: any = await raw.unsafe(`SELECT * FROM "Note"`);
     expect(notes[0].folderId).toBe(1);
+  });
+});
+
+/**
+ * Atomicity of a multi-statement write, which is what makes the policies above
+ * mean anything on the write side.
+ *
+ * A nested write runs the *child's* `$exec`, so the child's policies are
+ * consulted mid-sequence — after the parent row has already been inserted. When
+ * the child denies, "your policy stopped the write" has to mean the whole write,
+ * not the half that ran before the hook was reached. `$exec` therefore opens a
+ * transaction for exactly the calls that are multi-statement, which it can tell
+ * from the compiled plan's `before`/`after` steps.
+ *
+ * Deliberately observed through the raw connection rather than through the ORM:
+ * a scoped read would hide a leftover row belonging to another tenant, which is
+ * the very thing being checked for.
+ */
+describe("a denied nested write leaves nothing behind", () => {
+  let workspace: string;
+  let database: DatabaseManager;
+  let raw: SQL;
+  let previous: Application | undefined;
+
+  beforeAll(async () => {
+    workspace = mkdtempSync(join(tmpdir(), "gemi-orm-atomic-"));
+    const url = `sqlite://${join(workspace, "atomic.db")}`;
+
+    database = new DatabaseManager({ url });
+    raw = new SQL(url);
+    for (const statement of DDL) await raw.unsafe(statement);
+
+    previous = Application.getInstance();
+    const application = new Application();
+    application.instance(DatabaseManager, database as never);
+    Application.setInstance(application);
+  }, 120_000);
+
+  afterAll(async () => {
+    await raw?.unsafe(`DROP TABLE IF EXISTS "Note"`).catch(() => {});
+    await raw?.unsafe(`DROP TABLE IF EXISTS "Folder"`).catch(() => {});
+    await raw?.close();
+    await database?.close();
+    if (previous) Application.setInstance(previous);
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    clearPlanCache();
+    await raw.unsafe(`DELETE FROM "Note"`);
+    await raw.unsafe(`DELETE FROM "Folder"`);
+  });
+
+  test("the parent insert is rolled back when the child's policy denies", async () => {
+    class OpenFolder extends Model {
+      static $schema = folderSchema;
+    }
+    class RefusingNote extends Model {
+      static $schema = noteSchema;
+      static $policies = [{ before: () => false }];
+    }
+    register("Folder", OpenFolder);
+    register("Note", RefusingNote);
+
+    await expect(
+      Model.asUser(OURS, () =>
+        OpenFolder.$exec("create", {
+          data: { code: "ours", notes: { create: { label: "n" } } },
+        }),
+      ),
+    ).rejects.toThrow();
+
+    // The parent was written before the nested step ran, so this is the
+    // assertion that the transaction is real.
+    const folders: any = await raw.unsafe(`SELECT * FROM "Folder"`);
+    const notes: any = await raw.unsafe(`SELECT * FROM "Note"`);
+    expect([...folders]).toHaveLength(0);
+    expect([...notes]).toHaveLength(0);
+  });
+
+  test("a single-statement write still opens no transaction", async () => {
+    class OpenFolder extends Model {
+      static $schema = folderSchema;
+    }
+    register("Folder", OpenFolder);
+
+    const statements: string[] = [];
+    const counted = new Proxy(database, {
+      get(target: any, key) {
+        if (key !== "sql") return target[key];
+        return new Proxy(target.sql, {
+          get(sql: any, method) {
+            if (method !== "unsafe") return sql[method];
+            return (text: string, values?: unknown[]) => {
+              statements.push(text);
+              return sql.unsafe(text, values);
+            };
+          },
+        });
+      },
+    });
+
+    const application = new Application();
+    application.instance(DatabaseManager, counted as never);
+    Application.setInstance(application);
+
+    await Model.asSystem(() =>
+      OpenFolder.$exec("create", { data: { code: "plain" } }),
+    );
+
+    Application.setInstance(
+      (() => {
+        const app = new Application();
+        app.instance(DatabaseManager, database as never);
+        return app;
+      })(),
+    );
+
+    expect(statements.some((text) => /^\s*begin/i.test(text))).toBe(false);
+    expect(statements).toHaveLength(1);
   });
 });

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -401,21 +401,22 @@ describe("a denied nested write leaves nothing behind", () => {
       },
     });
 
-    const application = new Application();
-    application.instance(DatabaseManager, counted as never);
-    Application.setInstance(application);
+    const proxied = new Application();
+    proxied.instance(DatabaseManager, counted as never);
 
-    await Model.asSystem(() =>
-      OpenFolder.$exec("create", { data: { code: "plain" } }),
-    );
-
-    Application.setInstance(
-      (() => {
-        const app = new Application();
-        app.instance(DatabaseManager, database as never);
-        return app;
-      })(),
-    );
+    // `finally`, and restoring the instance `beforeAll` built rather than a
+    // fresh one. A throw here is precisely what a regression in the atomicity
+    // change looks like, and leaving the counting proxy installed would surface
+    // it as an unrelated failure in whatever test ran next.
+    const before = Application.getInstance();
+    try {
+      Application.setInstance(proxied);
+      await Model.asSystem(() =>
+        OpenFolder.$exec("create", { data: { code: "plain" } }),
+      );
+    } finally {
+      Application.setInstance(before!);
+    }
 
     expect(statements.some((text) => /^\s*begin/i.test(text))).toBe(false);
     expect(statements).toHaveLength(1);

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -15,10 +15,19 @@ import {
   softDeleteMany,
   register,
   softDeletes,
+  ScopeEscapeError,
   UnregisteredPolicyClassError,
   type ModelPolicy,
 } from "gemi/orm";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
 
 import { POSTGRES_URL, applyMigrations } from "./differential";
 import { AccountModel, OrganizationModel, UserModel } from "./generated";
@@ -84,6 +93,16 @@ const tenantScoped: ModelPolicy = {
     organizationId: (context.user as { organizationId: number }).organizationId,
   }),
 };
+
+/**
+ * Soft deletes and a tenant scope on one model, which is the composition the
+ * per-policy write guards exist to keep separate.
+ */
+class GuardedUser extends UserModel {
+  static $policies = [softDeletes<GuardedUser>(), tenantScoped];
+
+  static softDelete = softDelete(GuardedUser);
+}
 
 function suite(label: string, url?: string) {
   describe(label, () => {
@@ -185,7 +204,9 @@ function suite(label: string, url?: string) {
     // --- criterion 1: deny, scope, redact on a root query -----------------
 
     test("before denies", async () => {
-      (ScopedUser as any).$policies = [{ before: () => false } satisfies ModelPolicy];
+      (ScopedUser as any).$policies = [
+        { before: () => false } satisfies ModelPolicy,
+      ];
 
       await expect(
         Model.asUser(ALICE, () => ScopedUser.findMany({})),
@@ -213,11 +234,13 @@ function suite(label: string, url?: string) {
     });
 
     test("redact removes a field from the result", async () => {
-      (ScopedUser as any).$policies = [{
-        redact: (_context, row) => {
-          if ("email" in row) row.email = null;
-        },
-      } satisfies ModelPolicy];
+      (ScopedUser as any).$policies = [
+        {
+          redact: (_context, row) => {
+            if ("email" in row) row.email = null;
+          },
+        } satisfies ModelPolicy,
+      ];
 
       const rows = await Model.asUser(ALICE, () => ScopedUser.findMany({}));
       expect(rows).toHaveLength(2);
@@ -330,10 +353,12 @@ function suite(label: string, url?: string) {
       (ScopedAccount as any).$policies = [tenantScoped];
 
       class Narrower extends ScopedAccount {
-        static $policies: ModelPolicy[] = [{
-          scope: () => ({ deletedAt: null }),
-          onCreate: (_c, data) => data,
-        }];
+        static $policies: ModelPolicy[] = [
+          {
+            scope: () => ({ deletedAt: null }),
+            onCreate: (_c, data) => data,
+          },
+        ];
       }
 
       await expect(
@@ -393,7 +418,9 @@ function suite(label: string, url?: string) {
     });
 
     test("a deny on the related model denies the whole include", async () => {
-      (ScopedAccount as any).$policies = [{ before: () => false } satisfies ModelPolicy];
+      (ScopedAccount as any).$policies = [
+        { before: () => false } satisfies ModelPolicy,
+      ];
 
       await expect(
         Model.asUser(ALICE, () =>
@@ -414,13 +441,15 @@ function suite(label: string, url?: string) {
      */
     test("a nested scope applies exactly once, not twice", async () => {
       let scopeCalls = 0;
-      (ScopedAccount as any).$policies = [{
-        scope: (context: any) => {
-          scopeCalls++;
-          return { organizationId: context.user.organizationId };
-        },
-        onCreate: (_c: any, data: any) => data,
-      } satisfies ModelPolicy];
+      (ScopedAccount as any).$policies = [
+        {
+          scope: (context: any) => {
+            scopeCalls++;
+            return { organizationId: context.user.organizationId };
+          },
+          onCreate: (_c: any, data: any) => data,
+        } satisfies ModelPolicy,
+      ];
 
       const rows = await Model.asUser(ALICE, () =>
         ScopedUser.findMany({ include: { accounts: true } }),
@@ -462,7 +491,9 @@ function suite(label: string, url?: string) {
         static $policies = [tenantScoped];
       }
       class Named extends Tenanted {
-        static $policies: ModelPolicy[] = [{ scope: () => ({ email: "alice@x.test" }) }];
+        static $policies: ModelPolicy[] = [
+          { scope: () => ({ email: "alice@x.test" }) },
+        ];
       }
 
       // The leaf carries a policy, so the leaf owns the name — the same rule
@@ -518,12 +549,16 @@ function suite(label: string, url?: string) {
     test("differently-shaped scopes get different plans", async () => {
       const ADMIN = { ...ALICE, admin: true };
 
-      (ScopedUser as any).$policies = [{
-        scope: (context) => {
-          const user = context.user as any;
-          return user.admin ? undefined : { organizationId: user.organizationId };
-        },
-      } satisfies ModelPolicy];
+      (ScopedUser as any).$policies = [
+        {
+          scope: (context) => {
+            const user = context.user as any;
+            return user.admin
+              ? undefined
+              : { organizationId: user.organizationId };
+          },
+        } satisfies ModelPolicy,
+      ];
 
       clearPlanCache();
 
@@ -625,7 +660,10 @@ function suite(label: string, url?: string) {
       (ScopedUser as any).$policies = [tenantScoped];
 
       const updated: any = await Model.asUser(ALICE, () =>
-        ScopedUser.update({ where: { id: ALICE.id }, data: { name: "renamed" } }),
+        ScopedUser.update({
+          where: { id: ALICE.id },
+          data: { name: "renamed" },
+        }),
       );
       expect(updated.name).toBe("renamed");
     });
@@ -730,6 +768,80 @@ function suite(label: string, url?: string) {
       );
       expect(rows).toHaveLength(2);
     });
+
+    /**
+     * The update guard, through the real `$exec` rather than through
+     * `applyPolicies`.
+     *
+     * `packages/gemi/orm/policy.test.ts` pins the rule as a pure function, which
+     * is where it belongs. What that cannot show is that the refusal survives the
+     * path a caller actually takes — the plan cache, the compiler, `softDelete`'s
+     * operation rewrite. The differential harness cannot see it either: a guard
+     * that throws before any SQL is emitted produces no statement to compare
+     * against Prisma, so this is the only place the behaviour is observable
+     * against a real database.
+     *
+     * The arrangement mirrors the create-guard bug this iteration fixed — soft
+     * deletes beside a tenant scope. Soft deletes writes the column it scopes on
+     * and says so with an `onUpdate`; that permission must not extend to the
+     * tenant policy's column sitting next to it in the same list.
+     */
+    describe("scope escape", () => {
+      beforeEach(() => {
+        register("User", GuardedUser);
+      });
+
+      afterEach(() => {
+        register("User", UserModel);
+      });
+
+      test("an ordinary update goes through", async () => {
+        await expect(
+          Model.asUser(ALICE, () =>
+            GuardedUser.update({
+              where: { id: ALICE.id },
+              data: { name: "renamed" },
+            }),
+          ),
+        ).resolves.toBeTruthy();
+      });
+
+      test("writing the tenant column is refused, and nothing is written", async () => {
+        await expect(
+          Model.asUser(ALICE, () =>
+            GuardedUser.update({
+              where: { id: ALICE.id },
+              data: { organizationId: -1 } as never,
+            }),
+          ),
+        ).rejects.toThrow(ScopeEscapeError);
+
+        const rows: any = await raw.unsafe(
+          `SELECT "organizationId" FROM "User" WHERE "id" = ${ALICE.id}`,
+        );
+        expect([...rows][0].organizationId).toBe(ALICE.organizationId);
+      });
+
+      /**
+       * The interaction the per-policy split exists for. `softDelete` issues
+       * `update({ data: { deletedAt } })` — a write to a scope-owned column — and
+       * it has to succeed, because the policy owning that column has an
+       * `onUpdate`. Under the old chain-wide check this would have been
+       * indistinguishable from the case above.
+       */
+      test("softDelete writes its own scoped column without tripping the guard", async () => {
+        await expect(
+          Model.asUser(ALICE, () =>
+            GuardedUser.softDelete({ where: { id: ALICE.id } }),
+          ),
+        ).resolves.toBeTruthy();
+
+        const rows: any = await raw.unsafe(
+          `SELECT "deletedAt" FROM "User" WHERE "id" = ${ALICE.id}`,
+        );
+        expect([...rows][0].deletedAt).not.toBeNull();
+      });
+    });
   });
 }
 
@@ -788,9 +900,7 @@ function softDeleteSuite(label: string, url?: string) {
       register("User", SoftUser);
       register("Account", SoftAccount);
       if (url) {
-        await raw.unsafe(
-          `TRUNCATE "Account", "User" RESTART IDENTITY CASCADE`,
-        );
+        await raw.unsafe(`TRUNCATE "Account", "User" RESTART IDENTITY CASCADE`);
       } else {
         await raw.unsafe(`DELETE FROM "Account"`);
         await raw.unsafe(`DELETE FROM "User"`);
@@ -842,8 +952,12 @@ function softDeleteSuite(label: string, url?: string) {
         `SELECT "email", "deletedAt" FROM "User" ORDER BY "id"`,
       );
       const rows = [...stored];
-      expect(rows.find((row: any) => row.email === "alice@x.test").deletedAt).toBeNull();
-      expect(rows.find((row: any) => row.email === "bob@x.test").deletedAt).not.toBeNull();
+      expect(
+        rows.find((row: any) => row.email === "alice@x.test").deletedAt,
+      ).toBeNull();
+      expect(
+        rows.find((row: any) => row.email === "bob@x.test").deletedAt,
+      ).not.toBeNull();
     });
 
     /**
@@ -913,10 +1027,12 @@ function softDeleteSuite(label: string, url?: string) {
         static $policies = [softDeletes()];
       }
       class Restricted extends SoftDeleted {
-        static $policies: ModelPolicy[] = [{
-          scope: () => ({ email: { contains: "alice" } }),
-          onCreate: (_c, data) => data,
-        }];
+        static $policies: ModelPolicy[] = [
+          {
+            scope: () => ({ email: { contains: "alice" } }),
+            onCreate: (_c, data) => data,
+          },
+        ];
       }
 
       // One class owns the name — the leaf, which is the one carrying a policy

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -25,12 +25,12 @@ import { AccountModel, OrganizationModel, UserModel } from "./generated";
 
 /**
  * Policies are declared on **registered subclasses**, exactly as an application
- * declares them — not by assigning `$policy` onto the generated base.
+ * declares them — not by assigning `$policies` onto the generated base.
  *
  * That distinction is load-bearing, and getting it wrong is how a cross-tenant
  * leak passed review here: `generated/index.ts` registers the generated base, a
  * nested relation read resolves through the registry, and a policy sitting on a
- * subclass is therefore invisible to every `include`. Attaching `$policy` to
+ * subclass is therefore invisible to every `include`. Attaching `$policies` to
  * `AccountModel` made the headline test green while the documented pattern
  * leaked. These subclasses are registered in `beforeEach`, so the tests exercise
  * the same wiring an application does.
@@ -176,8 +176,8 @@ function suite(label: string, url?: string) {
 
     afterEach(() => {
       // A static on a class shared across the file, so it outlives the test.
-      delete (ScopedUser as any).$policy;
-      delete (ScopedAccount as any).$policy;
+      delete (ScopedUser as any).$policies;
+      delete (ScopedAccount as any).$policies;
       register("User", UserModel);
       register("Account", AccountModel);
     });
@@ -185,7 +185,7 @@ function suite(label: string, url?: string) {
     // --- criterion 1: deny, scope, redact on a root query -----------------
 
     test("before denies", async () => {
-      (ScopedUser as any).$policy = { before: () => false } satisfies ModelPolicy;
+      (ScopedUser as any).$policies = [{ before: () => false } satisfies ModelPolicy];
 
       await expect(
         Model.asUser(ALICE, () => ScopedUser.findMany({})),
@@ -193,7 +193,7 @@ function suite(label: string, url?: string) {
     });
 
     test("scope narrows a root read", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const rows = await Model.asUser(ALICE, () => ScopedUser.findMany({}));
       expect(rows.map((row: any) => row.email)).toEqual(["alice@x.test"]);
@@ -203,7 +203,7 @@ function suite(label: string, url?: string) {
     });
 
     test("a caller's own where still applies alongside the scope", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       // Bob's row, asked for by Alice — the scope must win.
       const rows = await Model.asUser(ALICE, () =>
@@ -213,11 +213,11 @@ function suite(label: string, url?: string) {
     });
 
     test("redact removes a field from the result", async () => {
-      (ScopedUser as any).$policy = {
+      (ScopedUser as any).$policies = [{
         redact: (_context, row) => {
           if ("email" in row) row.email = null;
         },
-      } satisfies ModelPolicy;
+      } satisfies ModelPolicy];
 
       const rows = await Model.asUser(ALICE, () => ScopedUser.findMany({}));
       expect(rows).toHaveLength(2);
@@ -244,7 +244,7 @@ function suite(label: string, url?: string) {
      * scope the accounts is `Account`'s own policy firing on a nested read.
      */
     test("a scope on the related model applies to a nested include", async () => {
-      (ScopedAccount as any).$policy = tenantScoped;
+      (ScopedAccount as any).$policies = [tenantScoped];
 
       const rows = await Model.asUser(ALICE, () =>
         ScopedUser.findMany({ include: { accounts: true } }),
@@ -268,7 +268,7 @@ function suite(label: string, url?: string) {
      * The regression guard for the wiring itself, not for the mechanism.
      *
      * The headline test above was green while the *documented* pattern leaked:
-     * it attached `$policy` to the generated base, which is what
+     * it attached `$policies` to the generated base, which is what
      * `generated/index.ts` registers, so the nested read found it. An
      * application declares its policy on a subclass — and if that subclass does
      * not own the model's name, the nested read resolves to the generated base
@@ -281,7 +281,7 @@ function suite(label: string, url?: string) {
      */
     test("a policy on an unregistered subclass raises instead of leaking", async () => {
       class Unregistered extends AccountModel {
-        static $policy = tenantScoped;
+        static $policies = [tenantScoped];
       }
       // Deliberately *not* registered: "Account" still resolves to the
       // generated base, exactly as it would in an application that declared a
@@ -310,7 +310,7 @@ function suite(label: string, url?: string) {
      * about policies it had not written.
      */
     test("a subclass adding no policy of its own is allowed", async () => {
-      (ScopedAccount as any).$policy = tenantScoped;
+      (ScopedAccount as any).$policies = [tenantScoped];
 
       // A typed view over the registered, policied class.
       class AdminAccount extends ScopedAccount {}
@@ -327,13 +327,13 @@ function suite(label: string, url?: string) {
     // ...and the divergent case is still refused, which is the half that
     // distinguishes "stricter than the risk" from "matching the risk".
     test("a subclass adding its own policy must own the name", async () => {
-      (ScopedAccount as any).$policy = tenantScoped;
+      (ScopedAccount as any).$policies = [tenantScoped];
 
       class Narrower extends ScopedAccount {
-        static $policy: ModelPolicy = {
+        static $policies: ModelPolicy[] = [{
           scope: () => ({ deletedAt: null }),
           onCreate: (_c, data) => data,
-        };
+        }];
       }
 
       await expect(
@@ -356,7 +356,7 @@ function suite(label: string, url?: string) {
      * test in this file used to do.
      */
     test("querying the generated base when a policied class owns the name raises", async () => {
-      (ScopedAccount as any).$policy = tenantScoped;
+      (ScopedAccount as any).$policies = [tenantScoped];
 
       await expect(
         Model.asUser(ALICE, () => AccountModel.findMany({})),
@@ -374,14 +374,14 @@ function suite(label: string, url?: string) {
     // correct and must not raise. Without this the guard would break every
     // seeded fixture in the repo.
     test("asSystem may query the generated base without raising", async () => {
-      (ScopedAccount as any).$policy = tenantScoped;
+      (ScopedAccount as any).$policies = [tenantScoped];
 
       const rows = await Model.asSystem(() => AccountModel.findMany({}));
       expect(rows).toHaveLength(2);
     });
 
     test("the same include for the other tenant sees only theirs", async () => {
-      (ScopedAccount as any).$policy = tenantScoped;
+      (ScopedAccount as any).$policies = [tenantScoped];
 
       const rows = await Model.asUser(BOB, () =>
         ScopedUser.findMany({ include: { accounts: true } }),
@@ -393,7 +393,7 @@ function suite(label: string, url?: string) {
     });
 
     test("a deny on the related model denies the whole include", async () => {
-      (ScopedAccount as any).$policy = { before: () => false } satisfies ModelPolicy;
+      (ScopedAccount as any).$policies = [{ before: () => false } satisfies ModelPolicy];
 
       await expect(
         Model.asUser(ALICE, () =>
@@ -414,13 +414,13 @@ function suite(label: string, url?: string) {
      */
     test("a nested scope applies exactly once, not twice", async () => {
       let scopeCalls = 0;
-      (ScopedAccount as any).$policy = {
+      (ScopedAccount as any).$policies = [{
         scope: (context: any) => {
           scopeCalls++;
           return { organizationId: context.user.organizationId };
         },
         onCreate: (_c: any, data: any) => data,
-      } satisfies ModelPolicy;
+      } satisfies ModelPolicy];
 
       const rows = await Model.asUser(ALICE, () =>
         ScopedUser.findMany({ include: { accounts: true } }),
@@ -459,10 +459,10 @@ function suite(label: string, url?: string) {
 
     test("a base class policy applies to a subclass, and narrows further", async () => {
       class Tenanted extends ScopedUser {
-        static $policy = tenantScoped;
+        static $policies = [tenantScoped];
       }
       class Named extends Tenanted {
-        static $policy: ModelPolicy = { scope: () => ({ email: "alice@x.test" }) };
+        static $policies: ModelPolicy[] = [{ scope: () => ({ email: "alice@x.test" }) }];
       }
 
       // The leaf carries a policy, so the leaf owns the name — the same rule
@@ -492,7 +492,7 @@ function suite(label: string, url?: string) {
      * plan, and each user still gets only their own rows.
      */
     test("same shape, different users: one plan, no leak", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
       clearPlanCache();
 
       const alice = await Model.asUser(ALICE, () => ScopedUser.findMany({}));
@@ -518,12 +518,12 @@ function suite(label: string, url?: string) {
     test("differently-shaped scopes get different plans", async () => {
       const ADMIN = { ...ALICE, admin: true };
 
-      (ScopedUser as any).$policy = {
+      (ScopedUser as any).$policies = [{
         scope: (context) => {
           const user = context.user as any;
           return user.admin ? undefined : { organizationId: user.organizationId };
         },
-      } satisfies ModelPolicy;
+      } satisfies ModelPolicy];
 
       clearPlanCache();
 
@@ -544,7 +544,7 @@ function suite(label: string, url?: string) {
     // --- criterion 5: writes ----------------------------------------------
 
     test("onCreate defaults the tenant column", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const created: any = await Model.asUser(BOB, () =>
         ScopedUser.create({ data: { email: "new@x.test" } }),
@@ -553,7 +553,7 @@ function suite(label: string, url?: string) {
     });
 
     test("scope restricts which rows an updateMany affects", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const result: any = await Model.asUser(ALICE, () =>
         ScopedUser.updateMany({ data: { name: "renamed" } }),
@@ -573,7 +573,7 @@ function suite(label: string, url?: string) {
     test("scope restricts which rows a deleteMany affects", async () => {
       // Accounts reference users, so clear the children first.
       await Model.asSystem(() => ScopedAccount.deleteMany({}));
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const result: any = await Model.asUser(ALICE, () =>
         ScopedUser.deleteMany({}),
@@ -595,7 +595,7 @@ function suite(label: string, url?: string) {
      */
     test("a scoped delete of another tenant's row finds nothing", async () => {
       await Model.asSystem(() => ScopedAccount.deleteMany({}));
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       await expect(
         Model.asUser(ALICE, () => ScopedUser.delete({ where: { id: BOB.id } })),
@@ -610,7 +610,7 @@ function suite(label: string, url?: string) {
     // unique key being unreachable.
     test("a scoped delete of the caller's own row succeeds", async () => {
       await Model.asSystem(() => ScopedAccount.deleteMany({}));
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const deleted: any = await Model.asUser(ALICE, () =>
         ScopedUser.delete({ where: { id: ALICE.id } }),
@@ -622,7 +622,7 @@ function suite(label: string, url?: string) {
     });
 
     test("a scoped update of the caller's own row succeeds", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const updated: any = await Model.asUser(ALICE, () =>
         ScopedUser.update({ where: { id: ALICE.id }, data: { name: "renamed" } }),
@@ -633,21 +633,21 @@ function suite(label: string, url?: string) {
     // --- criteria 6 and 7: no user, and system access ---------------------
 
     test("a policied model with no user is denied, not left unscoped", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       await expect(ScopedUser.findMany({})).rejects.toThrow(PolicyDeniedError);
       await expect(ScopedUser.findMany({})).rejects.toThrow(/no user in scope/);
     });
 
     test("asSystem is the explicit opt-out, and returns everything", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const rows = await Model.asSystem(() => ScopedUser.findMany({}));
       expect(rows).toHaveLength(2);
     });
 
     test("asSystem suspends policies rather than widening the user's scope", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       // Even with a user in scope, asSystem is unscoped — a script that has
       // said it is a script is not then re-scoped to whoever is around.
@@ -669,7 +669,7 @@ function suite(label: string, url?: string) {
      * this whole iteration is arranged against.
      */
     test("asUser inside asSystem narrows back to the user", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const rows = await Model.asSystem(() =>
         Model.asUser(ALICE, () => ScopedUser.findMany({})),
@@ -681,7 +681,7 @@ function suite(label: string, url?: string) {
     // The reverse nesting is unchanged and correct: naming the system inside a
     // user scope suspends policies, because that is what asSystem means.
     test("asSystem inside asUser still suspends", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const rows = await Model.asUser(ALICE, () =>
         Model.asSystem(() => ScopedUser.findMany({})),
@@ -696,7 +696,7 @@ function suite(label: string, url?: string) {
       ["undefined", undefined],
       ["null", null],
     ])("asUser(%s) is denied, not unscoped", async (_label, absent) => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       await expect(
         Model.asUser(absent, () => ScopedUser.findMany({})),
@@ -711,7 +711,7 @@ function suite(label: string, url?: string) {
     // --- interaction with iteration 5 -------------------------------------
 
     test("a scope survives inside a transaction", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const rows = await Model.asUser(ALICE, () =>
         Model.transaction(() => ScopedUser.findMany({})),
@@ -723,7 +723,7 @@ function suite(label: string, url?: string) {
     // a transaction inside `asSystem` must not silently re-enable policies for
     // its whole subtree.
     test("a transaction inside asSystem stays system", async () => {
-      (ScopedUser as any).$policy = tenantScoped;
+      (ScopedUser as any).$policies = [tenantScoped];
 
       const rows = await Model.asSystem(() =>
         Model.transaction(() => ScopedUser.findMany({})),
@@ -806,8 +806,8 @@ function softDeleteSuite(label: string, url?: string) {
     });
 
     afterEach(() => {
-      delete (SoftUser as any).$policy;
-      delete (SoftAccount as any).$policy;
+      delete (SoftUser as any).$policies;
+      delete (SoftAccount as any).$policies;
     });
 
     // No user is needed: the soft-delete scope does not read one, so
@@ -815,13 +815,13 @@ function softDeleteSuite(label: string, url?: string) {
     // that forced every query in the application through `asUser` would make
     // the recipe unusable for anything but request-scoped code.
     test("the scope works with no user in scope", async () => {
-      (SoftUser as any).$policy = softDeletes();
+      (SoftUser as any).$policies = [softDeletes()];
       const rows = await SoftUser.findMany({});
       expect(rows).toHaveLength(2);
     });
 
     test("a soft-deleted row disappears from reads", async () => {
-      (SoftUser as any).$policy = softDeletes();
+      (SoftUser as any).$policies = [softDeletes()];
       const remove = softDelete(SoftUser);
 
       await remove({ where: { id: bobId } });
@@ -835,7 +835,7 @@ function softDeleteSuite(label: string, url?: string) {
     });
 
     test("the timestamp is set, not the row removed", async () => {
-      (SoftUser as any).$policy = softDeletes();
+      (SoftUser as any).$policies = [softDeletes()];
       await softDelete(SoftUser)({ where: { id: bobId } });
 
       const stored: any = await raw.unsafe(
@@ -852,7 +852,7 @@ function softDeleteSuite(label: string, url?: string) {
      * nothing is written at the include site to make that true.
      */
     test("a soft-deleted row disappears from a nested include too", async () => {
-      (SoftAccount as any).$policy = softDeletes();
+      (SoftAccount as any).$policies = [softDeletes()];
 
       const before = await SoftUser.findMany({ include: { accounts: true } });
       expect(before.flatMap((row: any) => row.accounts)).toHaveLength(1);
@@ -871,7 +871,7 @@ function softDeleteSuite(label: string, url?: string) {
     // deleting an already-deleted row matches nothing, exactly as a hard delete
     // of a missing row would.
     test("soft-deleting an already-deleted row finds nothing", async () => {
-      (SoftUser as any).$policy = softDeletes();
+      (SoftUser as any).$policies = [softDeletes()];
       const remove = softDelete(SoftUser);
 
       await remove({ where: { id: bobId } });
@@ -879,7 +879,7 @@ function softDeleteSuite(label: string, url?: string) {
     });
 
     test("softDeleteMany reports a count and respects a where", async () => {
-      (SoftUser as any).$policy = softDeletes();
+      (SoftUser as any).$policies = [softDeletes()];
 
       const result: any = await softDeleteMany(SoftUser)({
         where: { email: "bob@x.test" },
@@ -891,14 +891,14 @@ function softDeleteSuite(label: string, url?: string) {
     // Synchronously, before any query is built — the rewrite validates its own
     // arguments rather than handing a contradictory pair to `update`.
     test("a data argument is refused rather than overwritten", () => {
-      (SoftUser as any).$policy = softDeletes();
+      (SoftUser as any).$policies = [softDeletes()];
       expect(() =>
         softDelete(SoftUser)({ where: { id: aliceId }, data: { name: "x" } }),
       ).toThrow(/takes no 'data'/);
     });
 
     test("a custom field name is honoured", async () => {
-      (SoftUser as any).$policy = softDeletes({ field: "deletedAt" });
+      (SoftUser as any).$policies = [softDeletes({ field: "deletedAt" })];
       await softDelete(SoftUser, { field: "deletedAt" })({
         where: { id: bobId },
       });
@@ -910,13 +910,13 @@ function softDeleteSuite(label: string, url?: string) {
     // and the subclass's narrows further.
     test("composes with another policy via a base class", async () => {
       class SoftDeleted extends SoftUser {
-        static $policy = softDeletes();
+        static $policies = [softDeletes()];
       }
       class Restricted extends SoftDeleted {
-        static $policy: ModelPolicy = {
+        static $policies: ModelPolicy[] = [{
           scope: () => ({ email: { contains: "alice" } }),
           onCreate: (_c, data) => data,
-        };
+        }];
       }
 
       // One class owns the name — the leaf, which is the one carrying a policy

--- a/templates/saas-starter/app/models/redact-strategies.test.ts
+++ b/templates/saas-starter/app/models/redact-strategies.test.ts
@@ -127,12 +127,12 @@ class Book extends Model {
   static $schema = bookSchema;
   // A policy on the *to-one* side, so the fold can be checked in the direction
   // where the folded value is a single object rather than an array.
-  static $policy = hideNote;
+  static $policies = [hideNote];
 }
 
 class Ledger extends Model {
   static $schema = ledgerSchema;
-  static $policy = hideSecret;
+  static $policies = [hideSecret];
 }
 
 const RUN = POSTGRES_URL ? describe : describe.skip;

--- a/templates/saas-starter/app/models/registration.test.ts
+++ b/templates/saas-starter/app/models/registration.test.ts
@@ -60,10 +60,12 @@ describe("the case the query-time guard cannot reach", () => {
 
   test("an unregistered policied subclass is invisible to the guard", () => {
     class ScopedOrganization extends generated.OrganizationModel {
-      static $policy = {
-        scope: () => ({ id: -1 }),
-        onCreate: (_context: unknown, data: unknown) => data,
-      };
+      static $policies = [
+        {
+          scope: () => ({ id: -1 }),
+          onCreate: (_context: unknown, data: unknown) => data,
+        },
+      ];
     }
 
     // Deliberately no `register("Organization", ScopedOrganization)` — that
@@ -91,10 +93,12 @@ describe("the case the query-time guard cannot reach", () => {
 
   test("and writing the register line is what clears it", () => {
     class ScopedOrganization extends generated.OrganizationModel {
-      static $policy = {
-        scope: () => ({ id: -1 }),
-        onCreate: (_context: unknown, data: unknown) => data,
-      };
+      static $policies = [
+        {
+          scope: () => ({ id: -1 }),
+          onCreate: (_context: unknown, data: unknown) => data,
+        },
+      ];
     }
 
     register("Organization", ScopedOrganization);

--- a/templates/saas-starter/app/models/registration.test.ts
+++ b/templates/saas-starter/app/models/registration.test.ts
@@ -60,10 +60,14 @@ describe("the case the query-time guard cannot reach", () => {
 
   test("an unregistered policied subclass is invisible to the guard", () => {
     class ScopedOrganization extends generated.OrganizationModel {
-      static $policies = [
+      // Typed through the generated alias, which is what an application would
+      // write. It is also what catches the loose version of this: an `onCreate`
+      // returning `unknown` is not an `OrganizationCreateInput`, and the
+      // narrowed `$policies` on the generated base says so.
+      static $policies: generated.OrganizationPolicy[] = [
         {
           scope: () => ({ id: -1 }),
-          onCreate: (_context: unknown, data: unknown) => data,
+          onCreate: (_context, data) => data,
         },
       ];
     }
@@ -93,10 +97,14 @@ describe("the case the query-time guard cannot reach", () => {
 
   test("and writing the register line is what clears it", () => {
     class ScopedOrganization extends generated.OrganizationModel {
-      static $policies = [
+      // Typed through the generated alias, which is what an application would
+      // write. It is also what catches the loose version of this: an `onCreate`
+      // returning `unknown` is not an `OrganizationCreateInput`, and the
+      // narrowed `$policies` on the generated base says so.
+      static $policies: generated.OrganizationPolicy[] = [
         {
           scope: () => ({ id: -1 }),
-          onCreate: (_context: unknown, data: unknown) => data,
+          onCreate: (_context, data) => data,
         },
       ];
     }

--- a/templates/saas-starter/app/models/relation-filter-policies.test.ts
+++ b/templates/saas-starter/app/models/relation-filter-policies.test.ts
@@ -133,7 +133,7 @@ class Person extends Model {
 
 class Acct extends Model {
   static $schema = acctSchema;
-  static $policy = tenant;
+  static $policies = [tenant];
 }
 
 const ALICE = { id: 1, orgId: 1 };

--- a/templates/saas-starter/app/models/save.test.ts
+++ b/templates/saas-starter/app/models/save.test.ts
@@ -77,7 +77,7 @@ function suite(label: string, url?: string) {
     });
 
     afterEach(() => {
-      delete (SaveUser as any).$policy;
+      delete (SaveUser as any).$policies;
       register("User", UserModel);
     });
 
@@ -203,10 +203,10 @@ function suite(label: string, url?: string) {
       const bob = rows.find((row) => row.email === "b@x.test");
 
       // Scoped to Alice's row only. Bob's save has to find nothing.
-      (SaveUser as any).$policy = {
+      (SaveUser as any).$policies = [{
         scope: () => ({ email: "a@x.test" }),
         onCreate: (_c: any, data: any) => data,
-      } satisfies ModelPolicy;
+      } satisfies ModelPolicy];
 
       bob.name = "Robert";
       await expect(


### PR DESCRIPTION
Stacked on `feat/orm` (#45), like #58 was.

## `$policy` → `$policies`

A model now carries a list. The single slot left two ways to compose and both were traps: spreading two objects that each carry a `scope` silently keeps only the last, and the intermediate-base-class route needs one throwaway class *per model*, because every generated base is a different class.

```ts
static $policies: UserPolicy[] = [softDeletes<User>(), new TenantPolicy()]
```

Each level of the prototype chain contributes its own array and they concatenate **base first**, so a shared base can still impose a policy a subclass can only narrow.

Entries may be objects or classes — a class is instantiated once, with stable identity, because `$exec`'s divergence guard and `assertPoliciesRegistered` compare chains element by element.

## Typed policies

`ModelPolicy<TWhere, TCreate, TRow>` is generic, and the generator emits `<Model>Policy` and `<Model>ScopedPolicy` per model off Prisma's own types. The annotation is load-bearing rather than cosmetic: TypeScript does not contextually type an initializer from an inherited static declaration, so a bare `static $policies = [{ scope: (ctx) => … }]` leaves `ctx` an implicit `any`. Extending `<Model>ScopedPolicy` makes `scope`/`onCreate`/`onUpdate` abstract members, so a half-written policy is `TS2515` at the declaration.

## Two write guards, asked per policy

**The create guard was defeatable.** `assertCreateCovered` was a `some()` over the whole chain, so one policy could satisfy it on another's behalf — and `softDeletes()` ships a pass-through `onCreate` precisely so its own scope does not trip it. Adding soft deletes to a model therefore disarmed the guard for that model's tenant policy and the insert ran with the scoped column unset: the exact outcome the error message describes, produced by the guard meant to prevent it.

| policies on `create` | before | after |
| --- | --- | --- |
| `[tenantScope]` | throws | throws |
| `[softDeletes(), tenantScope]` | **passes, column unset** | throws |

**`onUpdate` closes the same hole on the other write.** A `scope` narrows *which rows* an update may touch and says nothing about the values written, so a tenant-scoped update could hand one of its own rows to another tenant — after which the caller can neither read it back nor put it right. Writing a column the policy's own `scope` selects on now raises `ScopeEscapeError` unless the policy has an `onUpdate`. `onUpdate: (_ctx, data) => data` is a complete answer; the point is that the policy says which.

Scope-owned columns are read off the top level of the returned fragment, so `{ organizationId: 7 }` is understood and `{ OR: [...] }` is not attributed to any column and is not checked. That limit is documented and pinned by a test so changing it is a decision.

`plans/orm/06-policies.md` §5 asked for exactly this — *"define what `scope` means per operation rather than assuming the read semantics generalise"* — and it was answered for `create` and `delete` and left open for `update`.

## Multi-statement writes are atomic on their own

A nested write step runs the *child's* `$exec`, so a child policy is consulted mid-sequence, after the parent row is already written. A denial used to leave the parent behind — "your policy stopped the write" and "your policy stopped half the write" are not the same promise.

`$exec` now opens a transaction for exactly the calls whose compiled plan has `before`/`after` steps. A plain `create` still compiles to one statement and opens nothing (asserted), and inside a caller's own transaction it takes a savepoint. The rollback test fails without the change — verified by disabling the flag.

## Also

`softDeletes<M>()` is generic, so `field` is constrained to the model's own keys: pointing it at a column that does not exist is a compile error rather than `no such column` on the first read.

## Verification

- sqlite: **401 passed**, 31 skipped
- Postgres via `app/models/postgres.sh`: **601 passed** — the 2 failures are the dialect guard refusing to run the sqlite differential against a Postgres-generated client, which is by design
- `tsc --noEmit`: clean on the package; template app has the same 45 pre-existing errors before and after
- `oxlint`: 90 warnings before and after
- The 7 failing router/translation tests in the package suite are pre-existing on `feat/orm` (confirmed against a stashed tree)

## Breaking

`static $policy` is gone rather than kept as sugar — #45 is unmerged, so it costs nothing now and could not be done later. All call sites in the package, the template suite and the benchmark harness are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)