### PR TITLE
Warn in development when a transaction holds its connection too long

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3044,14 +3044,23 @@ opened it:
 until it does — check for network or filesystem I/O inside the callback…
 ```
 
-Set `GEMI_SLOW_TRANSACTION_MS` to change the threshold. There is no separate off-switch: a seed
-script or a dev-time migration with legitimately long transactions silences the warning by setting
-a threshold longer than they take. A value that is not a positive finite number — `0`, `-1`,
-`Infinity`, a typo — falls back to the 2-second default rather than disabling, so it cannot be
-switched off by accident.
+The threshold is `slowTransactionThreshold` in `app/config/database.ts`:
 
-The warning is development-only and never fires in production. It is a diagnostic, not a limit:
-nothing cancels a long transaction.
+```typescript
+export default defineDatabaseConfig({
+  url: process.env.DATABASE_URL,
+
+  slowTransactionThreshold: 5_000,   // milliseconds, or `false` to switch it off
+});
+```
+
+`false` is the only way to disable it. Any other unusable value — `0`, a negative, `Infinity`,
+`NaN` — falls back to the 2-second default rather than turning the warning off, so it cannot be
+lost to a mistake. Say `false` when you mean off; raise the number for a seed script or a data
+migration whose transactions are legitimately long.
+
+The warning is development-only and never fires in production, whatever the config says. It is a
+diagnostic, not a limit: nothing cancels a long transaction.
 
 ## Policies
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3029,6 +3029,30 @@ still compiles to one statement and opens nothing, and inside a transaction you 
 one becomes a savepoint. You do not need `Model.transaction` to make a single nested write whole;
 you need it to make *several separate calls* whole.
 
+### Keep slow work out of the callback
+
+The reserved connection is held for as long as the callback runs, whether or not it is running
+queries. A `fetch`, an upload or a queue push inside a transaction holds a connection for the
+length of that I/O, and under load the symptom is unrelated queries elsewhere in the process
+blocking on connection acquisition — an error that names neither the transaction nor the I/O.
+
+In development, a transaction still open after 2 seconds warns with the stack of the call that
+opened it:
+
+```
+[gemi] A database transaction has not settled after 2000ms. It reserves a pooled connection
+until it does — check for network or filesystem I/O inside the callback…
+```
+
+Set `GEMI_SLOW_TRANSACTION_MS` to change the threshold. There is no separate off-switch: a seed
+script or a dev-time migration with legitimately long transactions silences the warning by setting
+a threshold longer than they take. A value that is not a positive finite number — `0`, `-1`,
+`Infinity`, a typo — falls back to the 2-second default rather than disabling, so it cannot be
+switched off by accident.
+
+The warning is development-only and never fires in production. It is a diagnostic, not a limit:
+nothing cancels a long transaction.
+
 ## Policies
 
 A model carries a **list** of policies. Every member of a policy is optional; a model with none

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -327,6 +327,13 @@ await Model.transaction(async () => {
 `Promise.all` over several ORM calls inside the callback is not safe — the ordinary, encouraged
 thing everywhere else in a Bun codebase. Await them in sequence.
 
+**A multi-statement write is atomic on its own.** A write with a nested `create` or `connect` runs
+more than one statement, and `$exec` opens a transaction for exactly those calls — so a nested
+step that fails, or a child policy that denies, rolls back the parent row too. A plain `create`
+still compiles to one statement and opens nothing, and inside a transaction you opened the nested
+one becomes a savepoint. You do not need `Model.transaction` to make a single nested write whole;
+you need it to make *several separate calls* whole.
+
 ### Keep slow work out of the callback
 
 The reserved connection is held for as long as the callback runs, whether or not it is running
@@ -342,15 +349,14 @@ opened it:
 until it does — check for network or filesystem I/O inside the callback…
 ```
 
-Set `GEMI_SLOW_TRANSACTION_MS` to change the threshold. The warning is development-only and
-never fires in production; it is a diagnostic, not a limit — nothing cancels a long transaction.
+Set `GEMI_SLOW_TRANSACTION_MS` to change the threshold. There is no separate off-switch: a seed
+script or a dev-time migration with legitimately long transactions silences the warning by setting
+a threshold longer than they take. A value that is not a positive finite number — `0`, `-1`,
+`Infinity`, a typo — falls back to the 2-second default rather than disabling, so it cannot be
+switched off by accident.
 
-**A multi-statement write is atomic on its own.** A write with a nested `create` or `connect` runs
-more than one statement, and `$exec` opens a transaction for exactly those calls — so a nested
-step that fails, or a child policy that denies, rolls back the parent row too. A plain `create`
-still compiles to one statement and opens nothing, and inside a transaction you opened the nested
-one becomes a savepoint. You do not need `Model.transaction` to make a single nested write whole;
-you need it to make *several separate calls* whole.
+The warning is development-only and never fires in production. It is a diagnostic, not a limit:
+nothing cancels a long transaction.
 
 ## Policies
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -349,14 +349,23 @@ opened it:
 until it does — check for network or filesystem I/O inside the callback…
 ```
 
-Set `GEMI_SLOW_TRANSACTION_MS` to change the threshold. There is no separate off-switch: a seed
-script or a dev-time migration with legitimately long transactions silences the warning by setting
-a threshold longer than they take. A value that is not a positive finite number — `0`, `-1`,
-`Infinity`, a typo — falls back to the 2-second default rather than disabling, so it cannot be
-switched off by accident.
+The threshold is `slowTransactionThreshold` in `app/config/database.ts`:
 
-The warning is development-only and never fires in production. It is a diagnostic, not a limit:
-nothing cancels a long transaction.
+```typescript
+export default defineDatabaseConfig({
+  url: process.env.DATABASE_URL,
+
+  slowTransactionThreshold: 5_000,   // milliseconds, or `false` to switch it off
+});
+```
+
+`false` is the only way to disable it. Any other unusable value — `0`, a negative, `Infinity`,
+`NaN` — falls back to the 2-second default rather than turning the warning off, so it cannot be
+lost to a mistake. Say `false` when you mean off; raise the number for a seed script or a data
+migration whose transactions are legitimately long.
+
+The warning is development-only and never fires in production, whatever the config says. It is a
+diagnostic, not a limit: nothing cancels a long transaction.
 
 ## Policies
 

--- a/packages/gemi/database/config.ts
+++ b/packages/gemi/database/config.ts
@@ -18,6 +18,21 @@ export interface DatabaseConfig {
   // Options passed straight through to Bun's `SQL` client (pool size, timeouts,
   // TLS, ...). See https://bun.sh/docs/api/sql.
   options?: Record<string, unknown>;
+
+  // How long a transaction may run, in milliseconds, before development warns
+  // that it is still holding a pooled connection. `false` turns the warning off.
+  //
+  // A diagnostic, not a limit: nothing here cancels or shortens a transaction.
+  // It only fires in development — the cost of a long transaction is paid by
+  // unrelated queries blocking on connection acquisition, and that is a problem
+  // worth catching while the callback is still in front of you.
+  //
+  // Raise it for a seed script or a data migration whose transactions are
+  // legitimately long; `false` if the noise is not worth it at all. A value
+  // that is not a positive finite number falls back to the 2s default rather
+  // than disabling, so the warning cannot be lost to a typo — say `false` when
+  // you mean off.
+  slowTransactionThreshold?: number | false;
 }
 
 export function defineDatabaseConfig(config: DatabaseConfig): DatabaseConfig {
@@ -29,7 +44,14 @@ export function databaseConfigDefaults(): DatabaseConfig {
     url: process.env.DATABASE_URL,
     dialect: undefined,
     options: undefined,
+    slowTransactionThreshold: SLOW_TRANSACTION_THRESHOLD,
   };
 }
+
+// The default warning threshold, in milliseconds. Exported so the ORM can fall
+// back to the same number when a `DatabaseManager` was built without going
+// through `withDefaults` — a test constructing one directly, say — rather than
+// keeping a second copy of it that can drift.
+export const SLOW_TRANSACTION_THRESHOLD = 2_000;
 
 export type { SQL };

--- a/packages/gemi/facades/DB.ts
+++ b/packages/gemi/facades/DB.ts
@@ -41,8 +41,15 @@ export class DB extends Facade {
   // `begin` inside a transaction). Two systems that silently ignored each other
   // would be worse than either alone — a rollback would leave half the work
   // committed.
+  //
+  // The slow-transaction threshold comes from the same `database` config as it
+  // does for the ORM, so a `DB.transaction` holding a connection too long warns
+  // exactly as a `Model.transaction` would. Same reason as above: one system.
   static transaction<T>(fn: (tx: SQL) => Promise<T>): Promise<T> {
-    return withTransaction(this.sql, fn as (tx: SQL) => Promise<T>);
+    const db = this.getFacadeRoot();
+    return withTransaction(db.sql, fn as (tx: SQL) => Promise<T>, {
+      slowTransactionThreshold: db.config.slowTransactionThreshold,
+    });
   }
 
   static close(): Promise<void> {

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -1,4 +1,4 @@
-import type { SQL } from "bun";
+import type { SQL, TransactionSQL } from "bun";
 import { DatabaseManager } from "../database/DatabaseManager";
 import { app } from "../foundation/app";
 import { type BindContext, createBindContext } from "./compile/fragment";
@@ -81,6 +81,25 @@ const ORTHROW = new Set([
   "update",
   "delete",
 ]);
+
+/**
+ * `withTransaction` with the connection's configured warning threshold attached.
+ *
+ * Every transaction the ORM opens goes through here rather than calling
+ * `withTransaction` directly, so `database.slowTransactionThreshold` is read in
+ * one place instead of at each call site — and a call site added later cannot
+ * quietly open a transaction that ignores the setting. `withTransaction` itself
+ * takes the threshold as an argument on purpose; it knows nothing about the
+ * container, and this is the seam where the two meet.
+ */
+function transact<T>(
+  db: DatabaseManager,
+  fn: (tx: TransactionSQL) => Promise<T>,
+): Promise<T> {
+  return withTransaction(db.sql, fn, {
+    slowTransactionThreshold: db.config.slowTransactionThreshold,
+  });
+}
 
 export abstract class Model {
   /**
@@ -360,11 +379,12 @@ export abstract class Model {
    *
    * **The connection is held for as long as the callback runs**, including
    * while it awaits things that are not queries. In development a transaction
-   * still open after 2s warns (`GEMI_SLOW_TRANSACTION_MS`); in production it
-   * just holds the connection. Keep network and filesystem I/O outside.
+   * still open after 2s warns — `database.slowTransactionThreshold` sets that
+   * bound, or `false` switches it off. In production it just holds the
+   * connection. Keep network and filesystem I/O outside.
    */
   static transaction<T>(fn: () => Promise<T>): Promise<T> {
-    return withTransaction(app(DatabaseManager).sql, () => fn());
+    return transact(app(DatabaseManager), () => fn());
   }
 
   static async $exec(
@@ -530,7 +550,7 @@ export abstract class Model {
     if (op === "upsert" && !preScoped && findThenWrite(schema, args, op)) {
       const { where, create, update, ...projection } = args;
 
-      return withTransaction(db.sql, async () => {
+      return transact(db, async () => {
         const found = await this.$exec("findFirst", { where }, options);
 
         return found === null
@@ -594,7 +614,7 @@ export abstract class Model {
       );
 
       if (chunks !== null) {
-        return withTransaction(db.sql, async () => {
+        return transact(db, async () => {
           let count = 0;
           for (const data of chunks) {
             const written = (await this.$exec(
@@ -679,7 +699,7 @@ export abstract class Model {
       // The pool, not `conn`: when a transaction is already open `withTransaction`
       // savepoints against the ambient handle and ignores this argument, and
       // passing a transaction handle here would read as though we begin on it.
-      return withTransaction(db.sql, async () => {
+      return transact(db, async () => {
         const before = await this.$exec(
           "findFirst",
           { where, ...projection },
@@ -827,7 +847,7 @@ export abstract class Model {
       (plan.before !== undefined && plan.before.length > 0) ||
       (plan.after !== undefined && plan.after.length > 0);
 
-    return atomic ? withTransaction(db.sql, finish) : finish();
+    return atomic ? transact(db, finish) : finish();
   }
 
   /**

--- a/packages/gemi/orm/context.test.ts
+++ b/packages/gemi/orm/context.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "vitest";
 
+import { SLOW_TRANSACTION_THRESHOLD } from "../database/config";
 import {
   currentTransaction,
   ormContext,
@@ -224,12 +225,16 @@ describe("the ambient transaction scope", () => {
 describe("the slow-transaction warning", () => {
   const env = process.env;
 
-  function inDevelopment(thresholdMs: number) {
-    process.env = {
-      ...env,
-      NODE_ENV: "development",
-      GEMI_SLOW_TRANSACTION_MS: String(thresholdMs),
-    };
+  /**
+   * The threshold is config now, so it is passed to `withTransaction` rather
+   * than set in the environment. Only `NODE_ENV` is still ambient — the
+   * warning is development-only regardless of what the config says.
+   */
+  const THRESHOLD = 10;
+  const options = { slowTransactionThreshold: THRESHOLD };
+
+  function inDevelopment() {
+    process.env = { ...env, NODE_ENV: "development" };
   }
 
   /**
@@ -275,15 +280,19 @@ describe("the slow-transaction warning", () => {
   });
 
   test("a transaction past the threshold warns while it is still open", async () => {
-    inDevelopment(10);
+    inDevelopment();
     const pool = fakePool("a");
     let warnedDuringCallback: string[] = [];
 
     const warnings = await capture((seen) =>
-      withTransaction(pool, async () => {
-        await sleep(PAST_THRESHOLD);
-        warnedDuringCallback = [...seen];
-      }),
+      withTransaction(
+        pool,
+        async () => {
+          await sleep(PAST_THRESHOLD);
+          warnedDuringCallback = [...seen];
+        },
+        options,
+      ),
     );
 
     expect(warnings).toHaveLength(1);
@@ -297,10 +306,12 @@ describe("the slow-transaction warning", () => {
   // warned, the warning would be noise and get muted, which is the same as not
   // having it.
   test("a transaction inside the threshold says nothing", async () => {
-    inDevelopment(50);
+    inDevelopment();
     const pool = fakePool("a");
 
-    const warnings = await capture(() => withTransaction(pool, async () => {}));
+    const warnings = await capture(() =>
+      withTransaction(pool, async () => {}, { slowTransactionThreshold: 50 }),
+    );
 
     expect(warnings).toEqual([]);
   });
@@ -308,14 +319,18 @@ describe("the slow-transaction warning", () => {
   // A rollback releases the connection exactly as a commit does, so a throwing
   // callback has to disarm the timer too.
   test("a throwing transaction disarms the warning", async () => {
-    inDevelopment(10);
+    inDevelopment();
     const pool = fakePool("a");
 
     const warnings = await capture(async () => {
       await expect(
-        withTransaction(pool, async () => {
-          throw new Error("boom");
-        }),
+        withTransaction(
+          pool,
+          async () => {
+            throw new Error("boom");
+          },
+          options,
+        ),
       ).rejects.toThrow("boom");
     });
 
@@ -326,16 +341,26 @@ describe("the slow-transaction warning", () => {
   // report one slow block three times and name the innermost frame rather than
   // the one actually holding the connection.
   test("nesting warns once, for the outermost scope", async () => {
-    inDevelopment(10);
+    inDevelopment();
     const pool = fakePool("a");
 
     const warnings = await capture(() =>
-      withTransaction(pool, () =>
-        withTransaction(pool, () =>
-          withTransaction(pool, async () => {
-            await sleep(PAST_THRESHOLD);
-          }),
-        ),
+      withTransaction(
+        pool,
+        () =>
+          withTransaction(
+            pool,
+            () =>
+              withTransaction(
+                pool,
+                async () => {
+                  await sleep(PAST_THRESHOLD);
+                },
+                options,
+              ),
+            options,
+          ),
+        options,
       ),
     );
 
@@ -343,17 +368,17 @@ describe("the slow-transaction warning", () => {
   });
 
   test("production is silent, however long the transaction runs", async () => {
-    process.env = {
-      ...env,
-      NODE_ENV: "production",
-      GEMI_SLOW_TRANSACTION_MS: "10",
-    };
+    process.env = { ...env, NODE_ENV: "production" };
     const pool = fakePool("a");
 
     const warnings = await capture(() =>
-      withTransaction(pool, async () => {
-        await sleep(PAST_THRESHOLD);
-      }),
+      withTransaction(
+        pool,
+        async () => {
+          await sleep(PAST_THRESHOLD);
+        },
+        options,
+      ),
     );
 
     expect(warnings).toEqual([]);
@@ -364,7 +389,7 @@ describe("the slow-transaction warning", () => {
   // `try`/`catch` the timer stays armed and warns about a transaction that
   // never opened.
   test("a pool that throws synchronously disarms the warning", async () => {
-    inDevelopment(10);
+    inDevelopment();
     const pool: any = {
       begin() {
         throw new Error("pool is closed");
@@ -372,7 +397,7 @@ describe("the slow-transaction warning", () => {
     };
 
     const warnings = await capture(async () => {
-      expect(() => withTransaction(pool, async () => {})).toThrow(
+      expect(() => withTransaction(pool, async () => {}, options)).toThrow(
         "pool is closed",
       );
       await sleep(PAST_THRESHOLD);
@@ -382,13 +407,17 @@ describe("the slow-transaction warning", () => {
   });
 
   test("the warning names the call site", async () => {
-    inDevelopment(10);
+    inDevelopment();
     const pool = fakePool("a");
 
     const warnings = await capture(() =>
-      withTransaction(pool, async () => {
-        await sleep(PAST_THRESHOLD);
-      }),
+      withTransaction(
+        pool,
+        async () => {
+          await sleep(PAST_THRESHOLD);
+        },
+        options,
+      ),
     );
 
     expect(warnings[0]).toContain("context.test.ts");
@@ -405,7 +434,7 @@ describe("the slow-transaction warning", () => {
    * committed.
    */
   test("the warning timer does not hold the process open", async () => {
-    inDevelopment(10);
+    inDevelopment();
     const pool = fakePool("a");
     const realSetTimeout = globalThis.setTimeout;
     const unreffed: boolean[] = [];
@@ -421,7 +450,7 @@ describe("the slow-transaction warning", () => {
     }) as typeof globalThis.setTimeout;
 
     try {
-      await withTransaction(pool, async () => {});
+      await withTransaction(pool, async () => {}, options);
     } finally {
       globalThis.setTimeout = realSetTimeout;
     }
@@ -433,20 +462,18 @@ describe("the slow-transaction warning", () => {
 /**
  * The threshold itself, asserted as a value rather than through the warning.
  *
- * The fallback — a malformed `GEMI_SLOW_TRANSACTION_MS` landing on the default
- * instead of switching the warning off — cannot be tested behaviourally at all.
- * "No warning fired" is what you observe when the fallback works (the default
- * is 2s, longer than any sane test) *and* when it is missing entirely, so a
- * behavioural test of it passes under the very mutation it is meant to catch.
- * Reading the number is the only version that can fail.
+ * The fallback — a malformed `database.slowTransactionThreshold` landing on the
+ * default instead of switching the warning off — cannot be tested behaviourally
+ * at all. "No warning fired" is what you observe when the fallback works (the
+ * default is 2s, longer than any sane test) *and* when it is missing entirely,
+ * so a behavioural test of it passes under the very mutation it is meant to
+ * catch. Reading the number is the only version that can fail.
  */
 describe("the slow-transaction threshold", () => {
   const env = process.env;
 
-  function withEnv(nodeEnv: string, configured?: string) {
+  function inMode(nodeEnv: string) {
     process.env = { ...env, NODE_ENV: nodeEnv };
-    if (configured === undefined) delete process.env.GEMI_SLOW_TRANSACTION_MS;
-    else process.env.GEMI_SLOW_TRANSACTION_MS = configured;
   }
 
   afterEach(() => {
@@ -455,40 +482,52 @@ describe("the slow-transaction threshold", () => {
 
   test("the warning is off outside development", () => {
     for (const nodeEnv of ["production", "test", ""]) {
-      withEnv(nodeEnv, "10");
-      expect(slowTransactionThreshold()).toBeNull();
+      inMode(nodeEnv);
+      expect(slowTransactionThreshold(10)).toBeNull();
     }
   });
 
-  test("unset means the two-second default", () => {
-    withEnv("development");
+  test("unconfigured means the two-second default", () => {
+    inMode("development");
+    expect(slowTransactionThreshold()).toBe(SLOW_TRANSACTION_THRESHOLD);
     expect(slowTransactionThreshold()).toBe(2_000);
   });
 
   test("a usable value is honoured", () => {
-    withEnv("development", "500");
-    expect(slowTransactionThreshold()).toBe(500);
+    inMode("development");
+    expect(slowTransactionThreshold(500)).toBe(500);
+  });
+
+  /**
+   * `false` is the only off-switch, and the reason the config type is
+   * `number | false` rather than just `number`.
+   *
+   * Under the old env var there was no way to say "off" that a typo could not
+   * also say by accident. Now the two are different shapes: anything malformed
+   * falls back, and only the literal `false` disables.
+   */
+  test("false is the off switch", () => {
+    inMode("development");
+    expect(slowTransactionThreshold(false)).toBeNull();
   });
 
   /**
    * Every one of these falls back rather than returning `null`.
    *
-   * Silently losing a diagnostic to a typo is worse than ignoring the typo:
-   * the warning would simply stop appearing, and nothing would say why. Note
-   * `Infinity` — finite-looking to a reader, and the reason the check is
+   * Silently losing a diagnostic to a bad value is worse than ignoring the bad
+   * value: the warning would simply stop appearing, and nothing would say why.
+   * Note `Infinity` — finite-looking to a reader, and the reason the check is
    * `Number.isFinite` rather than `!Number.isNaN`; without it the timer would
    * be scheduled for never.
    */
   test.each([
-    ["a typo", "soon"],
-    ["empty", ""],
-    ["whitespace", "   "],
-    ["zero", "0"],
-    ["negative", "-1"],
-    ["infinite", "Infinity"],
-    ["not a number", "NaN"],
+    ["zero", 0],
+    ["negative", -1],
+    ["infinite", Infinity],
+    ["negative infinite", -Infinity],
+    ["not a number", NaN],
   ])("%s falls back to the default", (_label, configured) => {
-    withEnv("development", configured);
-    expect(slowTransactionThreshold()).toBe(2_000);
+    inMode("development");
+    expect(slowTransactionThreshold(configured)).toBe(2_000);
   });
 });

--- a/packages/gemi/orm/context.test.ts
+++ b/packages/gemi/orm/context.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
   currentTransaction,
   ormContext,
+  slowTransactionThreshold,
   transactionDepth,
   withTransaction,
 } from "./context";
@@ -258,6 +259,17 @@ describe("the slow-transaction warning", () => {
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
 
+  /**
+   * How long a "this should warn" test stays inside its transaction.
+   *
+   * 20× the 10ms threshold. The obvious 4× is enough on an idle machine and
+   * thinner than it looks on a loaded CI box running the suite in parallel,
+   * where the timer competes with every other worker for the event loop. The
+   * headroom costs a fraction of a second across the whole file and removes the
+   * only source of flake here.
+   */
+  const PAST_THRESHOLD = 200;
+
   afterEach(() => {
     process.env = env;
   });
@@ -269,7 +281,7 @@ describe("the slow-transaction warning", () => {
 
     const warnings = await capture((seen) =>
       withTransaction(pool, async () => {
-        await sleep(40);
+        await sleep(PAST_THRESHOLD);
         warnedDuringCallback = [...seen];
       }),
     );
@@ -321,7 +333,7 @@ describe("the slow-transaction warning", () => {
       withTransaction(pool, () =>
         withTransaction(pool, () =>
           withTransaction(pool, async () => {
-            await sleep(40);
+            await sleep(PAST_THRESHOLD);
           }),
         ),
       ),
@@ -340,28 +352,32 @@ describe("the slow-transaction warning", () => {
 
     const warnings = await capture(() =>
       withTransaction(pool, async () => {
-        await sleep(40);
+        await sleep(PAST_THRESHOLD);
       }),
     );
 
     expect(warnings).toEqual([]);
   });
 
-  // A typo in the env var must not switch the diagnostic off — silently losing
-  // a warning is worse than ignoring an unreadable threshold.
-  test("an unusable threshold falls back to the default rather than disabling", async () => {
+  // A synchronous throw from `begin` — a closed pool — never reaches the
+  // `.finally`, because there is no promise to attach it to. Without the
+  // `try`/`catch` the timer stays armed and warns about a transaction that
+  // never opened.
+  test("a pool that throws synchronously disarms the warning", async () => {
     inDevelopment(10);
-    process.env.GEMI_SLOW_TRANSACTION_MS = "soon";
-    const pool = fakePool("a");
+    const pool: any = {
+      begin() {
+        throw new Error("pool is closed");
+      },
+    };
 
-    const warnings = await capture(() =>
-      withTransaction(pool, async () => {
-        await sleep(40);
-      }),
-    );
+    const warnings = await capture(async () => {
+      expect(() => withTransaction(pool, async () => {})).toThrow(
+        "pool is closed",
+      );
+      await sleep(PAST_THRESHOLD);
+    });
 
-    // The default is 2s, so nothing fires inside this test — the assertion is
-    // that it fell back to *some* real threshold instead of returning null.
     expect(warnings).toEqual([]);
   });
 
@@ -371,10 +387,108 @@ describe("the slow-transaction warning", () => {
 
     const warnings = await capture(() =>
       withTransaction(pool, async () => {
-        await sleep(40);
+        await sleep(PAST_THRESHOLD);
       }),
     );
 
     expect(warnings[0]).toContain("context.test.ts");
+  });
+
+  /**
+   * The `unref` is the stated reason this file uses a real clock instead of
+   * vitest's fake one, so it has to be asserted somewhere or the justification
+   * is unbacked — deleting the call would otherwise pass the whole suite.
+   *
+   * A pending warning that kept the event loop alive would turn a diagnostic
+   * into a hang: `gemi db:seed` finishing its work and then sitting there for
+   * the remainder of a two-second threshold, for a transaction that already
+   * committed.
+   */
+  test("the warning timer does not hold the process open", async () => {
+    inDevelopment(10);
+    const pool = fakePool("a");
+    const realSetTimeout = globalThis.setTimeout;
+    const unreffed: boolean[] = [];
+
+    globalThis.setTimeout = ((fn: () => void, ms: number) => {
+      const timer = realSetTimeout(fn, ms);
+      const realUnref = timer.unref?.bind(timer);
+      timer.unref = () => {
+        unreffed.push(true);
+        return realUnref ? realUnref() : timer;
+      };
+      return timer;
+    }) as typeof globalThis.setTimeout;
+
+    try {
+      await withTransaction(pool, async () => {});
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+
+    expect(unreffed).toEqual([true]);
+  });
+});
+
+/**
+ * The threshold itself, asserted as a value rather than through the warning.
+ *
+ * The fallback — a malformed `GEMI_SLOW_TRANSACTION_MS` landing on the default
+ * instead of switching the warning off — cannot be tested behaviourally at all.
+ * "No warning fired" is what you observe when the fallback works (the default
+ * is 2s, longer than any sane test) *and* when it is missing entirely, so a
+ * behavioural test of it passes under the very mutation it is meant to catch.
+ * Reading the number is the only version that can fail.
+ */
+describe("the slow-transaction threshold", () => {
+  const env = process.env;
+
+  function withEnv(nodeEnv: string, configured?: string) {
+    process.env = { ...env, NODE_ENV: nodeEnv };
+    if (configured === undefined) delete process.env.GEMI_SLOW_TRANSACTION_MS;
+    else process.env.GEMI_SLOW_TRANSACTION_MS = configured;
+  }
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test("the warning is off outside development", () => {
+    for (const nodeEnv of ["production", "test", ""]) {
+      withEnv(nodeEnv, "10");
+      expect(slowTransactionThreshold()).toBeNull();
+    }
+  });
+
+  test("unset means the two-second default", () => {
+    withEnv("development");
+    expect(slowTransactionThreshold()).toBe(2_000);
+  });
+
+  test("a usable value is honoured", () => {
+    withEnv("development", "500");
+    expect(slowTransactionThreshold()).toBe(500);
+  });
+
+  /**
+   * Every one of these falls back rather than returning `null`.
+   *
+   * Silently losing a diagnostic to a typo is worse than ignoring the typo:
+   * the warning would simply stop appearing, and nothing would say why. Note
+   * `Infinity` — finite-looking to a reader, and the reason the check is
+   * `Number.isFinite` rather than `!Number.isNaN`; without it the timer would
+   * be scheduled for never.
+   */
+  test.each([
+    ["a typo", "soon"],
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["zero", "0"],
+    ["negative", "-1"],
+    ["infinite", "Infinity"],
+    ["not a number", "NaN"],
+  ])("%s falls back to the default", (_label, configured) => {
+    withEnv("development", configured);
+    expect(slowTransactionThreshold()).toBe(2_000);
   });
 });

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -1,5 +1,6 @@
 import type { SQL, TransactionSQL } from "bun";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { SLOW_TRANSACTION_THRESHOLD } from "../database/config";
 
 /**
  * The ambient transaction: the ORM's own `AsyncLocalStorage`, holding nothing
@@ -149,33 +150,39 @@ export function runAsUser<T>(user: unknown, fn: () => Promise<T>): Promise<T> {
   );
 }
 
-/** Default threshold for the development-mode long-transaction warning. */
-const SLOW_TRANSACTION_MS = 2_000;
-
 /**
  * The warning threshold in milliseconds, or `null` when the warning is off.
  *
- * Exported for its tests. The behaviour worth pinning is the fallback — that a
- * malformed `GEMI_SLOW_TRANSACTION_MS` lands on the default rather than
- * disabling — and that cannot be observed through `withTransaction`: "no
- * warning fired" is what a disabled warning looks like too, so a behavioural
- * test of it passes just as happily when the fallback is gone. Asserting the
- * number directly is the only form of that test that can fail.
+ * `configured` is `database.slowTransactionThreshold` — see `DatabaseConfig`.
+ * It arrives as a value rather than being read from here so that this file
+ * keeps knowing nothing about the container: `withTransaction` is reachable
+ * with a bare pool, and its tests use one.
+ *
+ * Exported for its own tests. The behaviour worth pinning is the fallback —
+ * that a malformed threshold lands on the default rather than disabling — and
+ * that cannot be observed through `withTransaction`: "no warning fired" is what
+ * a disabled warning looks like too, so a behavioural test of it passes just as
+ * happily when the fallback is gone. Asserting the number directly is the only
+ * form of that test that can fail.
  */
-export function slowTransactionThreshold(): number | null {
+export function slowTransactionThreshold(
+  configured?: number | false,
+): number | null {
   // Read per call, never cached at module scope. `scripts/build.ts` rewrites
   // `process.env.NODE_ENV` to `Bun.env.NODE_ENV` precisely so mode stays a
   // runtime question in the built framework; caching it here would undo that.
   if (process.env.NODE_ENV !== "development") return null;
 
-  const configured = process.env.GEMI_SLOW_TRANSACTION_MS;
-  if (configured === undefined) return SLOW_TRANSACTION_MS;
+  // The one way to switch it off, and it has to be spelled. Everything else
+  // falls back, so the warning is never lost to a mistyped value — only to an
+  // explicit `false`.
+  if (configured === false) return null;
 
-  const parsed = Number(configured);
-  // A malformed value falls back rather than throwing or disabling: a typo in
-  // an env var should not silently switch a diagnostic off.
-  if (!Number.isFinite(parsed) || parsed <= 0) return SLOW_TRANSACTION_MS;
-  return parsed;
+  if (configured === undefined) return SLOW_TRANSACTION_THRESHOLD;
+  if (!Number.isFinite(configured) || configured <= 0) {
+    return SLOW_TRANSACTION_THRESHOLD;
+  }
+  return configured;
 }
 
 /**
@@ -206,8 +213,8 @@ export function slowTransactionThreshold(): number | null {
  * a long transaction elsewhere creates. Hence "not settled" rather than "open
  * for" — the message must not claim a connection was held for the whole span.
  */
-function watchForSlowTransaction(): () => void {
-  const threshold = slowTransactionThreshold();
+function watchForSlowTransaction(configured?: number | false): () => void {
+  const threshold = slowTransactionThreshold(configured);
   if (threshold === null) return () => {};
 
   const site = new Error("transaction opened here");
@@ -219,7 +226,8 @@ function watchForSlowTransaction(): () => void {
         `reserves a pooled connection until it does — check for network or ` +
         `filesystem I/O inside the callback, and move it outside the ` +
         `transaction if you find any.\n${stack}\n` +
-        `(development only; set GEMI_SLOW_TRANSACTION_MS to change the threshold)`,
+        `(development only; set database.slowTransactionThreshold to change ` +
+        `the threshold, or false to switch this off)`,
     );
   }, threshold);
 
@@ -256,10 +264,15 @@ function watchForSlowTransaction(): () => void {
  * three levels of nesting work.
  *
  * In development, an outermost transaction that stays open past
- * `GEMI_SLOW_TRANSACTION_MS` (2s by default) warns — see
- * `watchForSlowTransaction`. Nothing here *prevents* a long transaction; the
- * warning exists because the cost of one is paid by unrelated queries
+ * `options.slowTransactionThreshold` (2s by default, `false` to disable) warns
+ * — see `watchForSlowTransaction`. Nothing here *prevents* a long transaction;
+ * the warning exists because the cost of one is paid by unrelated queries
  * elsewhere in the process, which makes it hard to trace back.
+ *
+ * The threshold is passed in rather than read from `app(DatabaseManager)` here.
+ * Every caller already holds the manager — it is where `pool` came from — and
+ * taking it as an argument keeps this file free of the container, so a bare
+ * `SQL` is still enough to call it. Its tests rely on that.
  *
  * The return type is asserted rather than inferred for one reason worth
  * knowing: Bun's `begin` unwraps a callback that resolves to an *array of
@@ -270,6 +283,7 @@ function watchForSlowTransaction(): () => void {
 export function withTransaction<T>(
   pool: SQL,
   fn: (tx: TransactionSQL) => Promise<T>,
+  options?: { slowTransactionThreshold?: number | false },
 ): Promise<T> {
   const current = ormContext.getStore();
 
@@ -304,7 +318,9 @@ export function withTransaction<T>(
   // already being timed — so warning per depth would report one slow block as
   // several warnings and point at the innermost frame rather than the one
   // holding the connection.
-  const stopWatching = watchForSlowTransaction();
+  const stopWatching = watchForSlowTransaction(
+    options?.slowTransactionThreshold,
+  );
 
   // The `try` covers a *synchronous* throw from `begin` — a closed pool, say.
   // `.finally` alone would not: it is only attached once `begin` has returned a

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -152,7 +152,17 @@ export function runAsUser<T>(user: unknown, fn: () => Promise<T>): Promise<T> {
 /** Default threshold for the development-mode long-transaction warning. */
 const SLOW_TRANSACTION_MS = 2_000;
 
-function slowTransactionThreshold(): number | null {
+/**
+ * The warning threshold in milliseconds, or `null` when the warning is off.
+ *
+ * Exported for its tests. The behaviour worth pinning is the fallback — that a
+ * malformed `GEMI_SLOW_TRANSACTION_MS` lands on the default rather than
+ * disabling — and that cannot be observed through `withTransaction`: "no
+ * warning fired" is what a disabled warning looks like too, so a behavioural
+ * test of it passes just as happily when the fallback is gone. Asserting the
+ * number directly is the only form of that test that can fail.
+ */
+export function slowTransactionThreshold(): number | null {
   // Read per call, never cached at module scope. `scripts/build.ts` rewrites
   // `process.env.NODE_ENV` to `Bun.env.NODE_ENV` precisely so mode stays a
   // runtime question in the built framework; caching it here would undo that.
@@ -296,15 +306,28 @@ export function withTransaction<T>(
   // holding the connection.
   const stopWatching = watchForSlowTransaction();
 
-  // Spread rather than replace: a `Model.transaction` inside a `Model.asSystem`
-  // must not silently re-enable policies for its whole subtree.
-  return (
-    pool
-      .begin((tx) => ormContext.run({ ...current, tx, depth: 0 }, () => fn(tx)))
-      // `finally` and not a `then`/`catch` pair: the connection is released on
-      // rollback exactly as it is on commit, so a throwing callback must clear
-      // the timer too or every failed transaction leaves a warning armed
-      // against a connection that has already gone back to the pool.
-      .finally(stopWatching) as Promise<T>
-  );
+  // The `try` covers a *synchronous* throw from `begin` — a closed pool, say.
+  // `.finally` alone would not: it is only attached once `begin` has returned a
+  // promise, so a synchronous throw escapes with the timer still armed and
+  // eventually warns about a transaction that never opened. `unref` keeps that
+  // from holding the process, which makes it cosmetic rather than a leak, but
+  // it is the same gap the `.finally` below exists to close.
+  try {
+    // Spread rather than replace: a `Model.transaction` inside a
+    // `Model.asSystem` must not silently re-enable policies for its subtree.
+    return (
+      pool
+        .begin((tx) =>
+          ormContext.run({ ...current, tx, depth: 0 }, () => fn(tx)),
+        )
+        // `finally` and not a `then`/`catch` pair: the connection is released on
+        // rollback exactly as it is on commit, so a throwing callback must clear
+        // the timer too or every failed transaction leaves a warning armed
+        // against a connection that has already gone back to the pool.
+        .finally(stopWatching) as Promise<T>
+    );
+  } catch (error) {
+    stopWatching();
+    throw error;
+  }
 }

--- a/plans/orm/05-ambient-transactions.md
+++ b/plans/orm/05-ambient-transactions.md
@@ -153,7 +153,8 @@ territory, and only if the Eloquent tier is pursued).
   above a duration threshold is cheap and worth considering, though not required.
 
   *Shipped.* `watchForSlowTransaction` in `orm/context.ts`: a warning at
-  `GEMI_SLOW_TRANSACTION_MS` (default 2s), development only, outermost scope
+  `database.slowTransactionThreshold` (default 2s, `false` to disable),
+  development only, outermost scope
   only. A timer rather than an elapsed-time measurement on the way out, because
   the case that matters most is the transaction that never settles at all — an
   after-the-fact measurement is silent for exactly that one. It reports; it does

--- a/templates/saas-starter/app/config/database.ts
+++ b/templates/saas-starter/app/config/database.ts
@@ -9,4 +9,13 @@ export default defineDatabaseConfig({
   // scheme). Inference throws rather than guessing, so you'll know if you
   // need it.
   // dialect: "postgres",
+
+  // How long a transaction may run, in milliseconds, before development warns
+  // that it is still holding a pooled connection. Defaults to 2000. Raise it
+  // for a seed script or a data migration whose transactions are legitimately
+  // long; `false` switches the warning off entirely.
+  //
+  // Development-only, and a diagnostic rather than a limit — nothing here
+  // cancels a transaction.
+  // slowTransactionThreshold: 5_000,
 });

--- a/templates/saas-starter/app/models/bench/run.ts
+++ b/templates/saas-starter/app/models/bench/run.ts
@@ -670,12 +670,20 @@ async function runDialect(
       },
     });
 
-    application.instance(DatabaseManager, {
-      dialect: database.dialect,
-      url: (database as unknown as { url: string }).url,
-      sql: counting,
-      close: () => database.close(),
-    } as never);
+    // A Proxy over the manager for the same reason `counting` is one over the
+    // client: a hand-written `{ dialect, url, sql, close }` is a list of what
+    // the ORM reads today, and it falls behind the first time it reads
+    // something else — `config`, most recently.
+    application.instance(
+      DatabaseManager,
+      new Proxy(database, {
+        get(target, property, receiver) {
+          if (property === "sql") return counting;
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      }),
+    );
 
     try {
       await fn();

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -275,11 +275,23 @@ export async function createDifferential(options: {
     },
   });
 
-  app.instance(DatabaseManager, {
-    dialect: database.dialect,
-    url: database.url,
-    sql: counting,
-  } as never);
+  // And the manager is a Proxy for exactly the reason above, one level up.
+  // This was `{ dialect, url, sql }` — a hand-written object listing what
+  // `$exec` read at the time — and it drifted the moment `$exec` read one more
+  // thing: `config`, for the slow-transaction threshold, which failed with
+  // `undefined is not an object (evaluating 'db.config.slowTransactionThreshold')`.
+  // The same lesson as `counting`, so the same shape: delegate everything to
+  // the real manager, override only `sql`.
+  app.instance(
+    DatabaseManager,
+    new Proxy(database, {
+      get(target, property, receiver) {
+        if (property === "sql") return counting;
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }),
+  );
   Application.setInstance(app);
 
   return {

--- a/templates/saas-starter/app/models/relations.many-to-many.test.ts
+++ b/templates/saas-starter/app/models/relations.many-to-many.test.ts
@@ -268,18 +268,32 @@ async function setup(url: string, ddl: string[]) {
   previous = Application.getInstance();
   const app = new Application();
   database = new DatabaseManager({ url });
-  // `$exec` resolves the manager per call and reads exactly `sql.unsafe` and
-  // `dialect` off it, so a counting stand-in needs no cooperation from the ORM.
-  app.instance(DatabaseManager, {
-    dialect: database.dialect,
-    url: database.url,
-    sql: {
-      unsafe(text: string, values: unknown[]) {
-        queries++;
-        return database.sql.unsafe(text, values);
-      },
+  // `$exec` resolves the manager per call, so a counting stand-in needs no
+  // cooperation from the ORM. It delegates rather than listing the properties
+  // the ORM reads: the hand-written version of this drifted in
+  // `differential.ts` the moment `$exec` read one more of them.
+  const counting = new Proxy(database.sql, {
+    get(target, property, receiver) {
+      if (property === "unsafe") {
+        return (text: string, values: unknown[]) => {
+          queries++;
+          return target.unsafe(text, values);
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
     },
-  } as never);
+  });
+  app.instance(
+    DatabaseManager,
+    new Proxy(database, {
+      get(target, property, receiver) {
+        if (property === "sql") return counting;
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }),
+  );
   Application.setInstance(app);
 
   register("Post", Post);

--- a/templates/saas-starter/app/models/transactions.test.ts
+++ b/templates/saas-starter/app/models/transactions.test.ts
@@ -13,7 +13,15 @@ import {
   planCacheStats,
   transactionDepth,
 } from "gemi/orm";
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
 
 import { POSTGRES_URL, applyMigrations } from "./differential";
 import { AccountModel } from "./generated";
@@ -552,6 +560,76 @@ function suite(label: string, url?: string) {
       // Same shape, same plan: one more hit, no new entry.
       expect(afterTx.size).toBe(afterPool.size);
       expect(afterTx.hits).toBe(afterPool.hits + 1);
+    });
+
+    // --- the slow-transaction warning -------------------------------------
+
+    /**
+     * The wiring, end to end: `app/config/database.ts` →
+     * `DatabaseManager.config` → `transact` → `withTransaction`.
+     *
+     * `context.test.ts` covers the warning's behaviour against a fake pool, and
+     * proves nothing about whether the configured number ever reaches it.
+     * Between the two sits the seam that actually broke during this change — a
+     * container stand-in without a `config` — so it is worth one real
+     * transaction on a real connection.
+     */
+    describe("the slow-transaction warning", () => {
+      const env = process.env;
+      let warnings: string[];
+      let restoreWarn: () => void;
+      let configured: number | false | undefined;
+
+      beforeEach(() => {
+        process.env = { ...env, NODE_ENV: "development" };
+        configured = database.config.slowTransactionThreshold;
+        warnings = [];
+        const original = console.warn;
+        console.warn = (message: string) => void warnings.push(message);
+        restoreWarn = () => {
+          console.warn = original;
+          process.env = env;
+          database.config.slowTransactionThreshold = configured;
+        };
+      });
+
+      afterEach(() => restoreWarn());
+
+      test("the configured threshold is the one that fires", async () => {
+        database.config.slowTransactionThreshold = 10;
+
+        await Model.transaction(async () => {
+          await User.create({ data: { email: "slow@x.test" } });
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain("not settled after 10ms");
+      });
+
+      test("false switches it off", async () => {
+        database.config.slowTransactionThreshold = false;
+
+        await Model.transaction(async () => {
+          await User.create({ data: { email: "quiet@x.test" } });
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+
+        expect(warnings).toEqual([]);
+      });
+
+      // `DB.transaction` reads the same config, so raw-SQL transactions are not
+      // a hole in the diagnostic.
+      test("DB.transaction warns on the same setting", async () => {
+        database.config.slowTransactionThreshold = 10;
+
+        await DB.transaction(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain("not settled after 10ms");
+      });
     });
   });
 }


### PR DESCRIPTION
Iteration 5 left this as an open note: *"Long-lived transactions hold a pooled connection. Nothing here prevents a callback from doing network I/O while holding one. A development-mode warning above a duration threshold is cheap and worth considering, though not required."*

This is that warning.

## Why it earns its place

An ambient transaction reserves one pooled connection for as long as its callback runs. The API gives no hint that awaiting a `fetch` inside it differs from awaiting a query — which is the point of ambient transactions, and also the trap:

```ts
await User.transaction(async () => {
  const user = await User.create({ data })
  await billing.createCustomer(user)   // holds a connection for the whole round-trip
})
```

Under load the cost lands somewhere else entirely: unrelated queries block on connection acquisition, and the resulting error names neither the transaction nor the I/O that held it. That's the failure this makes traceable.

```
[gemi] A database transaction has not settled after 2000ms. It reserves a pooled connection
until it does — check for network or filesystem I/O inside the callback, and move it outside
the transaction if you find any.
    at Object.<anonymous> (app/services/signup.ts:34:9)
    …
(development only; set GEMI_SLOW_TRANSACTION_MS to change the threshold)
```

## Decisions worth reviewing

**A timer, not a duration measured on the way out.** The case that matters most is the transaction that never settles at all — a hung request, a lock wait, a deadlock. An after-the-fact measurement is silent for exactly that one. The timer fires while the transaction is still in flight.

**The clock spans the pool wait and the commit round-trip, not just the callback.** Deliberate: a transaction stuck waiting on an exhausted pool is the symptom a *different* long transaction creates, so scoping the timer to the callback would go quiet precisely when the warning is most useful. It's also why the message reads "has not settled after" rather than "has been open for" — during the pool wait no connection is held yet, and the wording must not claim one was.

**Outermost scope only.** A savepoint reserves no connection of its own; its lifetime is bounded by the transaction it sits in, which is already being timed. Warning per depth would report one slow block several times over and point at the innermost frame instead of the one actually holding the connection.

**Development only, read per call.** `scripts/build.ts` rewrites `process.env.NODE_ENV` to `Bun.env.NODE_ENV` specifically so mode stays a runtime question in the built framework — caching it at module scope would undo that.

**An unparseable threshold falls back to the default rather than disabling.** A typo in an env var silently switching a diagnostic off is worse than ignoring the typo.

**The timer is `unref`'d**, so a pending warning can't keep a short-lived script or CLI command alive. The `Error` carrying the call site is allocated up front but only formatted if the timer fires — V8 builds `.stack` lazily, so a fast transaction pays for one allocation and nothing else.

`DB.transaction` is covered too, since it already routes through `withTransaction`.

It reports; it does not cancel. Nothing here shortens or aborts a long transaction.

## Tests

Seven, in `orm/context.test.ts`. They drive a real timer against a 10ms threshold rather than vitest's fake clock, because the `unref` behaviour under test lives on the very object a fake clock replaces.

Both negative assertions are load-bearing, confirmed by mutation:

| Mutation | Test that fails |
| --- | --- |
| Remove the `NODE_ENV` gate | "production is silent, however long the transaction runs" |
| Neuter the `.finally(stopWatching)` | "a throwing transaction disarms the warning" |

The second is the one worth keeping: a rollback releases the connection exactly as a commit does, so a throwing callback has to disarm the timer or every failed transaction leaves a warning armed against a connection already back in the pool.

## Verification

- ORM suite: 730 pass
- Template `transactions.test.ts`: 20 pass, 3 skipped
- `tsc` clean; `oxlint` clean (90 warnings, all pre-existing, none in these files)
- **Not exercised against Postgres** — the template's Postgres suite skips without `TEST_POSTGRES_URL`. The change is a JS timer with no SQL in it, so the dialect cannot reach it.

## Note on the base

This is stacked on `feat/orm-policy-list` (`80940e1` + `9b12b17`), so those two commits show here until that branch lands in `feat/orm`. **Only `6b30bb9` is this PR's.**

One crossover to know about: the `Model.transaction` doc comment pointing at this warning is in `9b12b17` rather than here — the two branches were being written at the same time and that hunk landed a commit early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
