### PR TITLE
Per-parent `take` / `skip` inside a to-many, which needed the fold to recurse

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -148,14 +148,18 @@ them, and they return identical rows:
 
 - **`batched`** — one query per include node, with the children stitched onto the parents in
   process. Works on every dialect.
-- **`lateral`** — the children folded into the root statement with a `LATERAL` join and
-  `json_agg`. **Postgres only, and the default there.** One round trip instead of one per node.
+- **`lateral`** — the whole include tree folded into the root statement with `LATERAL` joins and
+  `json_agg`. **Postgres only, and the default there.** One round trip for the tree instead of one
+  per node.
 
 The lateral strategy **declines per node** rather than emitting SQL it cannot get right, falling
-back to batching for that node alone. It declines a node that has its own `include`, a relation
-inside a `select`, and an implicit many-to-many. A mixed include tree therefore uses both, which
-is fine — the results are the same either way, and there are tests asserting exactly that against
-Prisma across thirty relation shapes.
+back to batching for that node alone. It declines an implicit many-to-many, a self-relation (a
+relation onto the same table), a node carrying a `_count`, and any node with one of those below it
+— half a fold is not a thing, so a descendant that cannot be expressed declines its whole node. A
+declined node still runs under this strategy one level down, so a decline costs one statement, not
+the subtree. A mixed include tree therefore uses both, which is fine — the results are the same
+either way, and there are tests asserting exactly that against Prisma across thirty relation
+shapes.
 
 Override per call when you need to:
 
@@ -165,6 +169,45 @@ await User.findMany({ include: { accounts: true } }, { strategy: "batched" })
 
 Unlike `track`, `strategy` **does** reach the compiler and **is** part of the plan cache key: two
 strategies emit different SQL for the same arguments.
+
+### Paging a relation
+
+```ts
+await Store.findMany({
+  include: {
+    products: {
+      orderBy: { position: "asc" },
+      take: 10,                                       // ten products *per store*
+      include: { media: { take: 1, orderBy: { position: "asc" } } },
+    },
+  },
+})
+```
+
+`take` and `skip` inside a to-many are **per parent**, exactly as they are in Prisma — ten products
+for each store, not ten in total. A negative `take` means "the last N" and comes back in the order
+your `orderBy` describes, the same as at the root. Paginating without an `orderBy` orders by the
+child's primary key, because "the first ten" is otherwise only meaningful if the scan happens to be
+stable.
+
+**This needs the `lateral` strategy, so it needs Postgres.** The batched strategy serves every
+parent from one query, so the only `limit` it could emit would page every parent's children as a
+single set — plausible, and wrong. It refuses instead:
+
+```
+UnsupportedQueryError: gemi ORM does not support 'products.take' yet (Store.findMany).
+A 'take' inside a to-many relation is per parent, and the batched relation planner serves
+every parent from one query — so the only limit it could emit would page every parent's
+children as one set. Only the lateral join strategy can express it, by paginating inside a
+subquery that already runs once per parent row, and it needs Postgres: this node declined to
+fold (not postgres). Load 'products' as its own query, or narrow it with 'where'.
+```
+
+The tail of that message is the part to read: it says *why* this node reached a strategy that
+cannot page it — the dialect, an explicit `strategy: "batched"`, or a decline. There is no
+workaround that is both correct and affordable, which is why the refusal is loud: fetching every
+child and slicing in JavaScript reads the whole table, and one query per parent is the N+1 the
+`include` exists to avoid.
 
 ### Filtering on a relation
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -153,10 +153,17 @@ them, and they return identical rows:
   per node.
 
 The lateral strategy **declines per node** rather than emitting SQL it cannot get right, falling
-back to batching for that node alone. It declines an implicit many-to-many, a self-relation (a
-relation onto the same table), a node carrying a `_count`, and any node with one of those below it
-— half a fold is not a thing, so a descendant that cannot be expressed declines its whole node. A
-declined node still runs under this strategy one level down, so a decline costs one statement, not
+back to batching for that node alone. It declines:
+
+- an implicit many-to-many,
+- a self-relation (a relation onto the same table),
+- a node carrying a `_count`,
+- a node ordered by a *relation* — `orderBy: { user: { email: "asc" } }` or
+  `orderBy: { accounts: { _count: "desc" } }` — which compiles to a correlated subquery,
+- and any node with one of those below it: half a fold is not a thing, so a descendant that cannot
+  be expressed declines its whole node.
+
+A declined node still runs under this strategy one level down, so a decline costs one statement, not
 the subtree. A mixed include tree therefore uses both, which is fine — the results are the same
 either way, and there are tests asserting exactly that against Prisma across thirty relation
 shapes.

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -10,6 +10,7 @@ import {
   withTransaction,
 } from "./context";
 import {
+  type FoldedRelation,
   type NestedWriteStep,
   type RelationExecutor,
   type RelationStrategy,
@@ -817,7 +818,16 @@ export abstract class Model {
       if (plan.relations !== undefined && !system) {
         for (const relation of plan.relations) {
           if (relation.root === undefined) continue;
-          redactFolded(relation, result, op, system);
+          redactFolded(
+            {
+              as: relation.as,
+              model: relation.model,
+              folded: relation.root.folded,
+            },
+            result,
+            op,
+            system,
+          );
         }
       }
 
@@ -1006,39 +1016,58 @@ function findThenWrite(schema: ModelSchema, args: any, op: Operation): boolean {
 }
 
 /**
- * Runs a folded relation's own `redact` over the rows the strategy inlined.
+ * Runs a folded relation's own `redact` over the rows the strategy inlined, and
+ * then its descendants' over theirs.
  *
  * Only for a plan carrying `root` — a batched child came back through its own
  * `$exec` and has already redacted itself, and doing it twice is harmless but
  * pointless. Only outside `asSystem`, like every other policy.
+ *
+ * **Recursive, because the fold is.** A lateral node folds its whole subtree into
+ * one statement, so a grandchild's rows never enter its model's `$exec` either —
+ * and stopping at depth 1 would leave exactly the rows nobody thinks to check
+ * unredacted. `RootContribution.folded` is the shape of what was folded, which is
+ * the only thing that makes the walk possible.
  *
  * The child's policies are resolved through the registry by name, so this obeys
  * the same rule every nested read does: whatever is registered under that name
  * is the class whose policies apply.
  */
 function redactFolded(
-  relation: { as: string; model: string },
+  relation: { as: string; model: string; folded?: readonly FoldedRelation[] },
   result: unknown,
   op: Operation,
   system: boolean,
 ): void {
-  if (!registry.has(relation.model)) return;
+  const target = registry.has(relation.model)
+    ? registry.get<unknown>(relation.model)
+    : undefined;
+  const policies = target ? policiesFor(target) : [];
+  const nested = relation.folded ?? [];
 
-  const target = registry.get<unknown>(relation.model);
-  const policies = policiesFor(target);
-  if (policies.length === 0) return;
+  if (policies.length === 0 && nested.length === 0) return;
 
-  const schema = (target as { $schema?: { name?: string } }).$schema;
-  const context = policyContext(
-    schema?.name ?? relation.model,
-    op,
-    currentUser(),
-    system,
-  );
+  const context =
+    policies.length > 0
+      ? policyContext(
+          (target as { $schema?: { name?: string } }).$schema?.name ??
+            relation.model,
+          op,
+          currentUser(),
+          system,
+        )
+      : undefined;
+
+  // Collected whether or not *this* level redacts anything: an unpolicied model
+  // in the middle of the tree must not hide a policied one below it.
+  const children: Record<string, unknown>[] = [];
 
   for (const parent of rowsOf(result)) {
-    const children = parent?.[relation.as];
-    if (children === undefined || children === null) continue;
-    applyRedaction(policies, context, children);
+    const rows = parent?.[relation.as];
+    if (rows === undefined || rows === null) continue;
+    if (context) applyRedaction(policies, context, rows);
+    if (nested.length > 0) children.push(...rowsOf(rows));
   }
+
+  for (const child of nested) redactFolded(child, children, op, system);
 }

--- a/packages/gemi/orm/compile/lateral.test.ts
+++ b/packages/gemi/orm/compile/lateral.test.ts
@@ -240,6 +240,65 @@ describe("what it declines, falling back to batched", () => {
   });
 
   /**
+   * A relation ordering on a node compiles to a correlated subquery, and
+   * `foldNode` parses the node's `orderBy` with no `OrderContext` to build one
+   * with — so folding it raises rather than emitting anything.
+   *
+   * The depth-1 case is older than the recursive fold and was already broken:
+   * it folded, and threw. What recursion changed is *reach* — a node carrying a
+   * nested `include` used to decline for that reason and land on batched, where
+   * the ordering works, so making the fold recurse turned a working query into a
+   * throwing one. One decline covers both, which is why they are asserted
+   * together rather than as a regression and a fix.
+   */
+  test.each([
+    ["by a relation's field", { orderBy: { user: { email: "asc" } } }],
+    ["by a relation's count", { orderBy: { user: { _count: "desc" } } }],
+    [
+      "in the array form",
+      { orderBy: [{ organizationRole: "asc" }, { user: { email: "asc" } }] },
+    ],
+    [
+      "beneath a node that would otherwise fold",
+      {
+        orderBy: { user: { email: "asc" } },
+        include: { organization: true },
+      },
+    ],
+  ])("a node ordered %s declines", (_label, node) => {
+    const plan = compiled({ include: { accounts: node } });
+
+    expect(plan.strategies).toEqual(["batched"]);
+    expect(plan.text).not.toContain("lateral");
+  });
+
+  /**
+   * ...and an ordering by a *column* still folds, or the decline above would be
+   * matching every `orderBy` and nobody would notice.
+   */
+  test("an ordering by a column is unaffected", () => {
+    const plan = compiled({
+      include: { accounts: { orderBy: { organizationRole: "desc" } } },
+    });
+
+    expect(plan.strategies).toEqual(["lateral"]);
+    expect(plan.text).toContain(`order by "Account"."organizationRole" desc`);
+  });
+
+  /**
+   * The two declines meeting: batching cannot page per parent, so the query is
+   * refused rather than run — and the message says which of the two boundaries
+   * it hit.
+   */
+  test("a per-parent page under a relation ordering is refused, not silently batched", () => {
+    expect(() =>
+      compiled({
+        include: { accounts: { orderBy: { user: { email: "asc" } }, take: 2 } },
+      }),
+    ).toThrow(/declined to fold \(relation ordering on a folded node\)/);
+  });
+
+  /**
    * The correlation names both tables, so a relation onto the same table would
    * read `"Category"."parentId" = "Category"."id"` — which inside the subquery
    * compares its own row against itself rather than against the outer one.

--- a/packages/gemi/orm/compile/lateral.test.ts
+++ b/packages/gemi/orm/compile/lateral.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { PostgresDialect } from "../dialect/postgres";
 import { SqliteDialect } from "../dialect/sqlite";
-import { account, organization, post, tag, user } from "../fixtures";
+import { account, category, organization, post, tag, user } from "../fixtures";
 import * as registry from "../registry";
 import { lateralStrategy } from "./lateral";
 import { compileRead } from "./read";
@@ -108,36 +108,103 @@ describe("what it emits", () => {
  * per *node* is what lets a mixed tree work, and `strategies` reporting both names
  * is how that stays observable.
  */
-describe("what it declines, falling back to batched", () => {
-  test.each([
-    [
-      "a node with its own include",
-      { include: { accounts: { include: { organization: true } } } },
-    ],
-    [
-      "a node with a relation in its select",
-      { include: { accounts: { select: { organization: true } } } },
-    ],
-  ])("%s", (_label, args) => {
-    const plan = compiled(args);
+describe("folding a whole tree", () => {
+  test("a nested include folds into the same statement", () => {
+    const plan = compiled({
+      include: { accounts: { include: { organization: true } } },
+    });
 
-    expect(plan.strategies).toEqual(["batched"]);
-    expect(plan.text).not.toContain("lateral");
+    expect(plan.strategies).toEqual(["lateral"]);
+    // One statement, three levels: the point of recursing.
+    expect(plan.text.match(/left join lateral/g)).toHaveLength(2);
+    // The grandchild's correlation is against its *own* parent, not the root.
+    expect(plan.text).toContain(`"Organization"."id" = "Account"."organizationId"`);
+    // ...and it arrives as a key on the child's object rather than as a column.
+    expect(plan.text).toContain(`'organization', "__lat_organization_1"."data"`);
+  });
+
+  test("a relation inside a nested select folds too", () => {
+    const plan = compiled({
+      include: { accounts: { select: { id: true, organization: true } } },
+    });
+
+    expect(plan.strategies).toEqual(["lateral"]);
+    expect(plan.text).toContain(`'id', "Account"."id"`);
+    expect(plan.text).toContain(`'organization', "__lat_organization_1"."data"`);
+    // A `select` that names no other scalar selects no other scalar.
+    expect(plan.text).not.toContain(`'publicId', "Account"."publicId"`);
   });
 
   /**
-   * Pagination on a relation node needs no decline, because the *planner* refuses
-   * it before a strategy is consulted. Asserted here so the reason this strategy
-   * has no check for it is visible — `json_agg` being an aggregate means a `limit`
-   * beside it would cap the aggregate row rather than the children, so if
-   * per-relation pagination ever lands, this strategy must decline it.
+   * A nested alias carries an index, and this is the case that needs it: without
+   * one, the inner `__lat_accounts` would sit inside the outer `__lat_accounts`
+   * and silently shadow it.
    */
-  test("pagination on a node is refused upstream, so needs no decline here", () => {
-    expect(() => compiled({ include: { accounts: { take: 5 } } })).toThrow(
-      /take/,
+  test("a tree that reaches the same relation twice gets distinct aliases", () => {
+    const plan = compileRead(
+      organization,
+      "findMany",
+      { include: { users: { include: { accounts: { include: { user: true } } } } } },
+      postgres,
+      lateralStrategy,
     );
+
+    const aliases = [...plan.text.matchAll(/as ("__lat_\w+") on true/g)].map(
+      (match) => match[1],
+    );
+    expect(aliases).toHaveLength(3);
+    expect(new Set(aliases).size).toBe(3);
   });
 
+  test("a nested where's values are still parameters, located through the tree", () => {
+    const args = {
+      include: {
+        accounts: { include: { organization: { where: { name: "Acme" } } } },
+      },
+    };
+    const plan = compiled(args);
+
+    expect(plan.text).toContain(`"Organization"."name" = $`);
+    expect(plan.bind(args)).toEqual(["Acme"]);
+  });
+
+  test("the decoder recurses, so a nested DateTime is a Date too", () => {
+    const plan = compiled({
+      include: {
+        accounts: {
+          select: { id: true, organization: { select: { id: true } } },
+        },
+      },
+    });
+
+    const rows = plan.relations![0].root!.decode([
+      { id: 1, organization: { id: 9 } },
+      { id: 2, organization: null },
+    ]) as any[];
+
+    expect(rows[0].organization).toEqual({ id: 9 });
+    // A to-one with no row is `null`, not an empty object — the same contract
+    // the top level has, one level down.
+    expect(rows[1].organization).toBeNull();
+  });
+
+  test("the folded subtree is reported, so redaction can walk it", () => {
+    const plan = compiled({
+      include: { accounts: { include: { organization: true } } },
+    });
+
+    expect(plan.relations![0].root!.folded).toEqual([
+      { as: "organization", model: "Organization", kind: "one", folded: [] },
+    ]);
+  });
+});
+
+/**
+ * Every one of these is a correctness boundary rather than a to-do. Falling back
+ * per *node* is what lets a mixed tree work, and `strategies` reporting both names
+ * is how that stays observable.
+ */
+describe("what it declines, falling back to batched", () => {
   test("SQLite declines everything, since its round trips are in-process", () => {
     const plan = compiled({ include: { accounts: true } }, sqlite);
 
@@ -157,18 +224,234 @@ describe("what it declines, falling back to batched", () => {
     expect(plan.strategies).toEqual(["batched"]);
   });
 
-  /** A mixed tree: one node folds, the other does not. */
-  test("declining is per node, not per query", () => {
+  /**
+   * `_count` sits in the same container as the relation nodes and every walk over
+   * that container steps past it — so a node carrying one would fold *without* it
+   * and return rows missing a key the caller asked for.
+   */
+  test("a node carrying a _count declines", () => {
     const plan = compiled({
-      // `accounts` has a nested include and cannot fold; `organization` can.
       include: {
-        accounts: { include: { organization: true } },
-        organization: true,
+        organization: { include: { _count: { select: { users: true } } } },
       },
     });
 
-    expect(plan.strategies).toEqual(["batched", "lateral"]);
-    expect(plan.text).toContain("left join lateral");
+    expect(plan.strategies).toEqual(["batched"]);
+  });
+
+  /**
+   * The correlation names both tables, so a relation onto the same table would
+   * read `"Category"."parentId" = "Category"."id"` — which inside the subquery
+   * compares its own row against itself rather than against the outer one.
+   * Expressing it needs an alias in the `from` clause; batching already gets it
+   * right.
+   */
+  test("a self-relation declines", () => {
+    registry.register("Category", class { static $schema = category });
+
+    const plan = compileRead(
+      category,
+      "findMany",
+      { include: { children: true } },
+      postgres,
+      lateralStrategy,
+    );
+
+    expect(plan.strategies).toEqual(["batched"]);
+  });
+
+  /**
+   * Half a fold is not a thing: a folded node's children never enter the related
+   * model's `$exec`, so a descendant that cannot be expressed has nowhere to be
+   * loaded from. The whole node declines, and the strategy is applied again one
+   * level down — so a decline costs one statement, not the subtree.
+   */
+  test("a descendant that cannot fold declines the whole node", () => {
+    const plan = compileRead(
+      post,
+      "findMany",
+      { include: { tags: { include: { posts: true } } } },
+      postgres,
+      lateralStrategy,
+    );
+
+    expect(plan.strategies).toEqual(["batched"]);
+  });
+
+  /** A mixed tree: one node folds, the other does not. */
+  test("declining is per node, not per query", () => {
+    const plan = compileRead(
+      post,
+      "findMany",
+      // `tags` is an implicit m-n and cannot fold; there is nothing else on
+      // `Post`, so the mixed tree is built on `User` below.
+      { include: { tags: true } },
+      postgres,
+      lateralStrategy,
+    );
+    expect(plan.strategies).toEqual(["batched"]);
+
+    const mixed = compiled({
+      include: {
+        // `organization` carries a `_count` and cannot fold; `accounts` can.
+        organization: { include: { _count: { select: { users: true } } } },
+        accounts: true,
+      },
+    });
+
+    expect(mixed.strategies).toEqual(["batched", "lateral"]);
+    expect(mixed.text).toContain("left join lateral");
+  });
+});
+
+/**
+ * Per-parent `take` / `skip` — the shape the batched planner refuses, and the
+ * reason this strategy exists in the form it does.
+ *
+ * The trap the SQL has to avoid is a `limit` beside the `json_agg`: that caps the
+ * *aggregate's* single row, so it looks like it works and silently returns every
+ * child. The page has to be taken before the aggregate, which is why a paginated
+ * node gets a subquery the unpaginated one does not.
+ */
+describe("per-parent pagination", () => {
+  test("the limit is inside the page, not beside the aggregate", () => {
+    const args = {
+      include: { accounts: { take: 10, orderBy: { createdAt: "asc" } } },
+    };
+    const plan = compiled(args);
+
+    expect(plan.strategies).toEqual(["lateral"]);
+    // The page: an inner subquery that limits rows, aggregated afterwards.
+    expect(plan.text).toContain(`limit $1) as "__page_accounts"`);
+    expect(plan.text).toContain(
+      `json_agg("__page_accounts"."data" order by "__page_accounts"."__ord_0" asc)`,
+    );
+    // The ordering column is carried out of the page so the aggregate can
+    // re-apply it — aggregating over an ordered subquery and hoping the order
+    // survives is not something Postgres promises.
+    expect(plan.text).toContain(`"Account"."createdAt" as "__ord_0"`);
+    // A value, so a parameter.
+    expect(plan.bind(args)).toEqual([10]);
+  });
+
+  test("skip alongside take, and skip on its own", () => {
+    const both = { include: { accounts: { take: 5, skip: 2 } } };
+    expect(compiled(both).text).toContain("limit $1 offset $2");
+    expect(compiled(both).bind(both)).toEqual([5, 2]);
+
+    const only = { include: { accounts: { skip: 4 } } };
+    expect(compiled(only).text).toContain("offset $1");
+    expect(compiled(only).text).not.toContain("limit");
+    expect(compiled(only).bind(only)).toEqual([4]);
+  });
+
+  /**
+   * Paginating without an `orderBy` orders by the primary key, exactly as the
+   * root does. Without it "the first ten per parent" is only meaningful if the
+   * scan happens to be stable, which neither dialect promises.
+   */
+  test("paginating without an orderBy orders by the primary key", () => {
+    const plan = compiled({ include: { accounts: { take: 3 } } });
+    expect(plan.text).toContain(`"Account"."id" as "__ord_0"`);
+    expect(plan.text).toContain(`order by "__ord_0" asc limit $1`);
+  });
+
+  /**
+   * A negative `take` is "the last N": the page is taken in flipped order and
+   * the aggregate puts it back into the caller's. Both orderings are visible in
+   * the SQL, which is what makes the two halves checkable separately.
+   */
+  test("a negative take pages backwards and aggregates forwards", () => {
+    const args = {
+      include: { accounts: { take: -3, orderBy: { id: "asc" } } },
+    };
+    const plan = compiled(args);
+
+    expect(plan.text).toContain(`order by "__ord_0" desc limit $1`);
+    expect(plan.text).toContain(
+      `json_agg("__page_accounts"."data" order by "__page_accounts"."__ord_0" asc)`,
+    );
+    // `abs`, like the root's pagination — the sign is in the SQL, not the value.
+    expect(plan.bind(args)).toEqual([3]);
+  });
+
+  test("a node's own where is applied before the page, not after", () => {
+    const args = {
+      include: { accounts: { take: 2, where: { organizationRole: 0 } } },
+    };
+    const plan = compiled(args);
+
+    const page = plan.text.slice(plan.text.indexOf("from (select"));
+    expect(page).toContain(`"Account"."organizationRole" = $`);
+    expect(page.indexOf("organizationRole")).toBeLessThan(page.indexOf("limit"));
+    expect(plan.bind(args)).toEqual([0, 2]);
+  });
+
+  /**
+   * The issue's second acceptance criterion, and the shape the whole thing is
+   * for: ten users per organization, one account per user, in one statement.
+   */
+  test("a per-parent take under another per-parent take", () => {
+    const args = {
+      include: {
+        users: {
+          take: 10,
+          orderBy: { name: "asc" },
+          include: { accounts: { take: 1, orderBy: { createdAt: "desc" } } },
+        },
+      },
+    };
+    const plan = compileRead(
+      organization,
+      "findMany",
+      args,
+      postgres,
+      lateralStrategy,
+    );
+
+    expect(plan.strategies).toEqual(["lateral"]);
+    expect(plan.text).toContain(`) as "__page_users"`);
+    expect(plan.text).toContain(`) as "__page_accounts_1"`);
+    // Innermost first, because that is the order the text puts them in — and a
+    // mismatch here would page the wrong level by the other's number.
+    expect(plan.bind(args)).toEqual([1, 10]);
+  });
+
+  test("a to-one is not paginable, and says so as Prisma does", () => {
+    expect(() => compiled({ include: { organization: { take: 1 } } })).toThrow(
+      /Prisma does not accept 'take' on a to-one relation/,
+    );
+  });
+
+  test.each([
+    ["a non-integer take", { take: 1.5 }, /Expected an integer/],
+    ["a take that is not a number", { take: "5" }, /Expected an integer/],
+    ["a negative skip", { skip: -1 }, /cannot be negative/],
+  ])("%s is refused", (_label, node, message) => {
+    expect(() => compiled({ include: { accounts: node } })).toThrow(message);
+  });
+
+  /**
+   * The refusal, on a strategy that cannot express it. Its message has to name
+   * the strategy that *would* work rather than a future release — this is the
+   * message #61 holds up as the standard, so all four parts stay: what, why,
+   * when, and what to do instead.
+   */
+  test("declining to fold turns a per-parent page into a refusal", () => {
+    expect(() =>
+      compileRead(
+        post,
+        "findMany",
+        { include: { tags: { take: 2 } } },
+        postgres,
+        lateralStrategy,
+      ),
+    ).toThrow(/declined to fold \(implicit many-to-many\)/);
+
+    // SQLite has no lateral at all, and the message is the same one.
+    expect(() =>
+      compiled({ include: { accounts: { take: 2 } } }, sqlite),
+    ).toThrow(/per parent[\s\S]*lateral join strategy[\s\S]*not postgres/);
   });
 });
 

--- a/packages/gemi/orm/compile/lateral.ts
+++ b/packages/gemi/orm/compile/lateral.ts
@@ -176,6 +176,22 @@ function decline(
   // return rows missing a key the caller asked for.
   if (hasCount(args)) return "_count on a folded node";
 
+  // `orderBy: { user: { email: "asc" } }` on a node compiles to a correlated
+  // subquery, and `foldNode` parses the node's `orderBy` with no `OrderContext`
+  // to build one with — so `parseOrderBy` raises rather than emitting anything.
+  // Declining sends the node to the batched strategy, which compiles the
+  // ordering as part of the child's own query and gets it right.
+  //
+  // It reads like the `_count` case above and is the same shape: a node that
+  // would fold *without* something the caller asked for has to decline instead.
+  // Supporting it properly means threading an `OrderContext` down through
+  // `foldNode` so `order-relation.ts` can build the subquery against the child's
+  // qualifier — a bigger change than this one, and one that owes the
+  // differential harness its own coverage.
+  if (ordersByRelation(child, args.orderBy)) {
+    return "relation ordering on a folded node";
+  }
+
   for (const nested of relationNodes(child, args, operation)) {
     const reason = decline(
       child,
@@ -189,6 +205,28 @@ function decline(
   }
 
   return undefined;
+}
+
+/**
+ * Whether an `orderBy` sorts by a *relation* rather than by a column.
+ *
+ * Both of Prisma's relation-ordering forms name the relation as the key —
+ * `{ organization: { name: "asc" } }` and `{ accounts: { _count: "desc" } }` —
+ * so the check is the same one `parseOrderBy` makes, and both of its accepted
+ * containers (one object, or an array of them) are walked.
+ */
+function ordersByRelation(schema: ModelSchema, orderBy: unknown): boolean {
+  if (orderBy === undefined || orderBy === null) return false;
+
+  for (const entry of Array.isArray(orderBy) ? orderBy : [orderBy]) {
+    if (typeof entry !== "object" || entry === null) continue;
+    for (const [key, value] of Object.entries(entry)) {
+      if (value === undefined) continue;
+      if (key in schema.relations) return true;
+    }
+  }
+
+  return false;
 }
 
 function hasCount(args: Record<string, unknown>): boolean {

--- a/packages/gemi/orm/compile/lateral.ts
+++ b/packages/gemi/orm/compile/lateral.ts
@@ -1,20 +1,26 @@
 import type { SqlDialect } from "../dialect";
-import type { FieldSchema, ModelSchema } from "../schema";
-import { type Fragment, concat, sql } from "./fragment";
+import { COUNT_KEY } from "../relation-filters";
+import type { FieldSchema, ModelSchema, RelationSchema } from "../schema";
+import { type Binder, type Fragment, concat, sql } from "./fragment";
 import {
+  assertPaginable,
   batchedStrategy,
+  type FoldedRelation,
+  type Link,
   type RelationPlan,
   type RelationRequest,
   type RelationStrategy,
   relatedSchema,
+  relationNodes,
   resolveLink,
 } from "./plan-relations";
 import { resolveSelection } from "./select";
-import { compileOrderBy, parseOrderBy } from "./orderBy";
+import { compileOrderBy, parseOrderBy, reverse, type OrderTerm } from "./orderBy";
 import { compileWhere } from "./where";
 
 /**
- * `LATERAL` + `json_agg`: one round trip for a relation instead of one per node.
+ * `LATERAL` + `json_agg`: one round trip for a whole include *tree* instead of
+ * one per node.
  *
  * Iteration 9. The measured case for it, from `plans/orm/benchmarks.md`: an include
  * costs one statement per node — 1, 2, 3 for no-include, depth-2, depth-3, counted
@@ -29,16 +35,37 @@ import { compileWhere } from "./where";
  * - **Not Postgres.** SQLite has `json_group_array`, but its round trips are
  *   in-process and cost tens of microseconds; nothing measured asks for it, and the
  *   plan says to build it only if something does.
- * - **A node with its own `include` or `select` of a relation.** Folding a whole
- *   tree into one statement is the headline win and it needs recursion through this
- *   same builder; folding only the outer level of a depth-3 tree still saves one
- *   round trip of two, which is why this is worth shipping before that.
  * - **An implicit many-to-many.** The join table needs a second lateral, and the
  *   self-referential case cannot say which column is which end — see the note in
  *   `plan-relations.ts`.
+ * - **A self-relation**, where the child and the parent are the same table: the
+ *   correlation is written as `"T"."fk" = "T"."pk"`, which inside the subquery
+ *   refers to the subquery's own row rather than the outer one. Expressing it
+ *   needs an alias in the `from` clause, and the batched strategy already handles
+ *   it correctly.
+ * - **A `_count` on a node.** It projects a correlated subquery that
+ *   `planRelationCounts` owns at the *root* of a statement, and a folded node has
+ *   no root of its own.
+ *
+ * A node whose subtree contains any of those declines as a whole, because half a
+ * fold is not a thing: the children come back as JSON in the parent's row and
+ * never enter the related model's `$exec`, so a descendant that cannot fold has
+ * nowhere to be loaded from. Declining the node instead sends the *whole* subtree
+ * back through `$exec`, where the strategy is applied again one level down — so a
+ * decline costs one statement, not the subtree.
  *
  * Falling back per *node* rather than per query is what makes a mixed tree work:
  * `QueryPlan.strategies` then reports both names, which is why that field exists.
+ *
+ * ## Per-parent `take` / `skip`
+ *
+ * This is the strategy that can express them, and the only one. `json_agg` is an
+ * aggregate, so a `limit` beside it would cap the aggregate's single row rather
+ * than the children — the page has to happen *before* the aggregate, in a
+ * subquery of its own. The ordering terms are carried out of that subquery as
+ * `__ord_N` columns so the aggregate can re-apply them: aggregating over an
+ * ordered subquery and hoping the order survives is not something Postgres
+ * promises.
  *
  * ## Why the values are still parameters
  *
@@ -51,95 +78,59 @@ export const lateralStrategy: RelationStrategy = {
   name: "lateral",
 
   plan(request: RelationRequest): RelationPlan {
-    const batched = batchedStrategy.plan(request);
-    const declined = decline(request);
-    if (declined) return batched;
+    const declined = decline(
+      request.parent,
+      request.relation,
+      request.as,
+      request.node,
+      request.dialect,
+      request.operation,
+    );
 
-    const child = relatedSchema(request.parent, request.relation);
+    if (declined) {
+      // Raised here rather than left to the batched plan, because *why* this
+      // node reached a strategy that cannot page it is the actionable half of
+      // the message and only this function knows it.
+      assertPaginable(request, `this node declined to fold (${declined})`);
+      return batchedStrategy.plan(request);
+    }
+
+    const { dialect } = request;
+    const child = relatedSchema(request.parent, request.relation, request.as);
     const link = resolveLink(request.parent, child, request.relation);
-    const node = normalise(request.node);
 
-    const dialect = request.dialect;
-    const many = request.relation.kind === "many";
-
-    // An alias for the subquery, derived from the relation's key so two relations
-    // on one query cannot collide. Not user input: `as` is a key on the generated
-    // schema's `relations`, so it is an identifier the same way a column is.
-    const alias = dialect.quoteIdent(`__lat_${request.as}`);
-    const childTable = dialect.quoteIdent(child.table);
-    const childQualifier = `${childTable}.`;
-
-    const selected = resolveSelection(child, node, request.operation);
-    const object = jsonObject(selected, childQualifier, dialect);
-
-    // The correlation: the child's foreign key against the *parent's* column.
-    // This is the whole of "lateral" — the subquery references the outer row.
-    const correlation = sql(
-      `${childQualifier}${dialect.quoteIdent(
-        fieldOf(child, link.childField).column,
-      )} = ${dialect.quoteIdent(request.parent.table)}.${dialect.quoteIdent(
-        fieldOf(request.parent, link.parentField).column,
-      )}`,
-    );
-
-    // `orderBy` on a relation node, which most real includes carry.
-    //
-    // Inside an aggregate it belongs to the aggregate — `json_agg(x order by y)` —
-    // not to the subquery, because a bare `order by` beside an aggregate orders
-    // the one row the aggregate produces and the children come back in whatever
-    // order the scan found them. A to-one takes the ordinary clause, since it is
-    // not aggregating.
-    const terms = parseOrderBy(child, node?.orderBy, request.operation);
-    const ordering = compileOrderBy(terms, dialect, childQualifier);
-
-    const filter = compileWhere(
+    const fold = foldNode({
+      parent: request.parent,
       child,
-      node?.where,
-      { dialect, operation: request.operation, qualifier: childQualifier },
-      (args) => request.locate(args)?.where,
-    );
-
-    const payload = many
-      ? // `coalesce`, because `json_agg` over zero rows returns NULL and an empty
-        // to-many must shape to `[]`. Getting this wrong is the single most likely
-        // divergence in the whole strategy, and the differential harness compares
-        // key presence, so it would be caught — but it is cheaper to be right.
-        concat(
-          sql(`coalesce(json_agg(`),
-          object,
-          ordering ? concat(sql(" order by "), ordering) : sql(""),
-          sql(`), '[]'::json)`),
-        )
-      : object;
-
-    const subquery = concat(
-      sql(`select `),
-      payload,
-      sql(` as ${dialect.quoteIdent("data")} from ${childTable} where `),
-      correlation,
-      filter ? concat(sql(" and "), filter) : sql(""),
-      // A to-one must not aggregate, and must not return two rows into a scalar
-      // subquery position if the data violates the relation's cardinality. Its
-      // ordering is the ordinary clause; the aggregate's is inside `json_agg`
-      // above.
-      many || !ordering ? sql("") : concat(sql(" order by "), ordering),
-      many ? sql("") : sql(" limit 1"),
-    );
+      relation: request.relation,
+      as: request.as,
+      node: request.node,
+      locate: request.locate,
+      link,
+      dialect,
+      operation: request.operation,
+      depth: 1,
+      counter: { next: 0 },
+    });
 
     return {
-      ...batched,
+      as: request.as,
+      model: request.relation.model,
+      kind: request.relation.kind,
+      parentField: link.parentField,
       strategy: "lateral",
       root: {
         column: concat(
-          sql(`${alias}.${dialect.quoteIdent("data")} as `),
+          sql(`${fold.alias}.${dialect.quoteIdent("data")} as `),
           sql(dialect.quoteIdent(request.as)),
         ),
         join: concat(
           sql(` left join lateral (`),
-          subquery,
-          sql(`) as ${alias} on true`),
+          fold.subquery,
+          sql(`) as ${fold.alias} on true`),
         ),
-        decode: buildDecoder(selected, dialect, many),
+        decode: fold.decode,
+        folded: fold.folded,
       },
       // Unreachable: `attachRelations` skips a plan carrying `root`. Kept as a
       // loud failure rather than the batched loader, because reaching it would
@@ -155,34 +146,354 @@ export const lateralStrategy: RelationStrategy = {
   },
 };
 
-/** Why this node cannot fold, or `undefined` if it can. */
-function decline(request: RelationRequest): string | undefined {
-  if (request.dialect.name !== "postgres") return "not postgres";
+/**
+ * Why this node — or anything below it — cannot fold, or `undefined` if it can.
+ *
+ * Recursive, because folding is: a descendant that cannot be expressed has
+ * nowhere to be loaded from once its ancestors are JSON in a parent row.
+ */
+function decline(
+  parent: ModelSchema,
+  relation: RelationSchema,
+  as: string,
+  node: unknown,
+  dialect: SqlDialect,
+  operation: string,
+): string | undefined {
+  if (dialect.name !== "postgres") return "not postgres";
+  if (relation.joinTable) return "implicit many-to-many";
 
-  const relation = request.parent.relations[request.as];
-  if (relation?.joinTable) return "implicit many-to-many";
+  const child = relatedSchema(parent, relation, as);
+  // The correlation names both tables, so a relation onto the same table would
+  // compare the subquery's own row against itself.
+  if (child.table === parent.table) return "self-relation";
 
-  const node = normalise(request.node);
-  if (node === undefined) return undefined;
+  const args = normalise(node);
+  if (args === undefined) return undefined;
 
-  // No `take` / `skip` check: the planner refuses those on a relation node before
-  // a strategy is consulted (`assertNodeArgs`), so a decline for them would be
-  // dead code. Worth stating, because `json_agg` being an aggregate means a
-  // `limit` beside it would cap the aggregate row rather than the children — so
-  // if per-relation pagination is ever supported, this strategy must decline it
-  // or nest a second subselect.
-  if (node.include !== undefined) return "nested include";
+  // `_count` sits in the same container as the relation nodes and is skipped by
+  // every walk over it, so a node carrying one would fold *without* it and
+  // return rows missing a key the caller asked for.
+  if (hasCount(args)) return "_count on a folded node";
 
-  // A relation inside the node's own `select` is a nested tree by another name.
-  const select = node.select;
-  if (typeof select === "object" && select !== null) {
-    const child = relatedSchema(request.parent, request.relation);
-    for (const key of Object.keys(select)) {
-      if (key in child.relations && select[key]) return "nested select";
-    }
+  for (const nested of relationNodes(child, args, operation)) {
+    const reason = decline(
+      child,
+      nested.relation,
+      nested.as,
+      nested.node,
+      dialect,
+      operation,
+    );
+    if (reason) return `${nested.as}: ${reason}`;
   }
 
   return undefined;
+}
+
+function hasCount(args: Record<string, unknown>): boolean {
+  for (const container of ["include", "select"] as const) {
+    const tree = args[container];
+    if (typeof tree !== "object" || tree === null || Array.isArray(tree)) {
+      continue;
+    }
+    const count = (tree as Record<string, unknown>)[COUNT_KEY];
+    if (count !== undefined && count !== false) return true;
+  }
+  return false;
+}
+
+interface FoldInput {
+  /** The table the correlation compares against — one level out. */
+  parent: ModelSchema;
+  child: ModelSchema;
+  relation: RelationSchema;
+  as: string;
+  node: unknown;
+  /** Re-locates *this* node inside the whole call's argument tree. */
+  locate: (args: any) => any;
+  link: Link;
+  dialect: SqlDialect;
+  operation: string;
+  depth: number;
+  /**
+   * Hands out one index per node in this subtree, so a nested alias cannot
+   * shadow an ancestor's. Depth 1 keeps the bare `__lat_<relation>` form, which
+   * is the one a query log is read with.
+   */
+  counter: { next: number };
+}
+
+interface Fold {
+  /** Quoted, and unique within the statement it is emitted into. */
+  alias: string;
+  subquery: Fragment;
+  decode: (value: unknown) => unknown;
+  folded: FoldedRelation[];
+}
+
+/**
+ * One relation node as a correlated subquery, with everything below it folded in.
+ */
+function foldNode(input: FoldInput): Fold {
+  const { dialect, child, operation } = input;
+  const node = normalise(input.node);
+  const many = input.relation.kind === "many";
+
+  const index = input.counter.next++;
+  const alias = dialect.quoteIdent(suffixed("__lat_", input.as, input.depth, index));
+  const childTable = dialect.quoteIdent(child.table);
+  const childQualifier = `${childTable}.`;
+
+  const selected = resolveSelection(child, node, operation);
+
+  // Everything below this node, folded into the same subquery. Their joins go
+  // in this level's `from`, and their `data` columns into this level's object.
+  const nested = relationNodes(child, node, operation).map((relationNode) => {
+    const grandchild = relatedSchema(child, relationNode.relation, relationNode.as);
+    return {
+      as: relationNode.as,
+      relation: relationNode.relation,
+      fold: foldNode({
+        parent: child,
+        child: grandchild,
+        relation: relationNode.relation,
+        as: relationNode.as,
+        node: relationNode.node,
+        // Composed rather than captured: the plan is compiled once per argument
+        // *shape*, so a nested `where`'s values are read from the call through
+        // the whole chain of `locate`s.
+        locate: (args: any) => relationNode.locate(input.locate(args)),
+        link: resolveLink(child, grandchild, relationNode.relation),
+        dialect,
+        operation,
+        depth: input.depth + 1,
+        counter: input.counter,
+      }),
+    };
+  });
+
+  const object = jsonObject(
+    selected,
+    childQualifier,
+    dialect,
+    nested.map((entry) => ({ key: entry.as, alias: entry.fold.alias })),
+  );
+
+  const joins = concat(
+    ...nested.map((entry) =>
+      concat(
+        sql(` left join lateral (`),
+        entry.fold.subquery,
+        sql(`) as ${entry.fold.alias} on true`),
+      ),
+    ),
+  );
+
+  // The correlation: the child's foreign key against the *parent's* column.
+  // This is the whole of "lateral" — the subquery references the outer row.
+  const correlation = sql(
+    `${childQualifier}${dialect.quoteIdent(
+      fieldOf(child, input.link.childField).column,
+    )} = ${dialect.quoteIdent(input.parent.table)}.${dialect.quoteIdent(
+      fieldOf(input.parent, input.link.parentField).column,
+    )}`,
+  );
+
+  const filter = compileWhere(
+    child,
+    node?.where,
+    { dialect, operation, qualifier: childQualifier },
+    (args) => input.locate(args)?.where,
+  );
+
+  const scan = concat(
+    sql(` from ${childTable}`),
+    joins,
+    sql(` where `),
+    correlation,
+    filter ? concat(sql(" and "), filter) : sql(""),
+  );
+
+  const decode = buildDecoder(
+    selected,
+    dialect,
+    many,
+    nested.map((entry) => ({ key: entry.as, decode: entry.fold.decode })),
+  );
+
+  const folded: FoldedRelation[] = nested.map((entry) => ({
+    as: entry.as,
+    model: entry.relation.model,
+    kind: entry.relation.kind,
+    folded: entry.fold.folded,
+  }));
+
+  const terms = parseOrderBy(child, node?.orderBy, operation);
+
+  if (!many) {
+    // A to-one must not aggregate, and must not return two rows into a scalar
+    // subquery position if the data violates the relation's cardinality. It
+    // takes no `orderBy` — the planner refuses one — so there is nothing to
+    // order by either.
+    return {
+      alias,
+      folded,
+      decode,
+      subquery: concat(
+        sql(`select `),
+        object,
+        sql(` as ${dialect.quoteIdent("data")}`),
+        scan,
+        sql(" limit 1"),
+      ),
+    };
+  }
+
+  const page = pagination(input, node, terms, child);
+
+  if (!page) {
+    // `coalesce`, because `json_agg` over zero rows returns NULL and an empty
+    // to-many must shape to `[]`. Getting this wrong is the single most likely
+    // divergence in the whole strategy, and the differential harness compares
+    // key presence, so it would be caught — but it is cheaper to be right.
+    //
+    // The ordering belongs to the aggregate — `json_agg(x order by y)` — not to
+    // the subquery: a bare `order by` beside an aggregate orders the one row the
+    // aggregate produces, and the children come back in whatever order the scan
+    // found them.
+    const ordering = compileOrderBy(terms, dialect, childQualifier);
+    return {
+      alias,
+      folded,
+      decode,
+      subquery: concat(
+        sql(`select coalesce(json_agg(`),
+        object,
+        ordering ? concat(sql(" order by "), ordering) : sql(""),
+        sql(`), '[]'::json) as ${dialect.quoteIdent("data")}`),
+        scan,
+      ),
+    };
+  }
+
+  // Paginated: the page has to be taken *before* the aggregate, so the scan goes
+  // into a subquery of its own and the aggregate runs over its rows.
+  const pageAlias = dialect.quoteIdent(
+    suffixed("__page_", input.as, input.depth, index),
+  );
+
+  // The ordering columns, carried out of the page so the aggregate can re-apply
+  // them. Aliased rather than repeated, which also lets the inner `order by`
+  // name them — Postgres resolves an `order by` against the select list.
+  const carried = page.terms.map((term, position) =>
+    sql(
+      `, ${childQualifier}${dialect.quoteIdent(term.column)} as ` +
+        `${dialect.quoteIdent(orderAlias(position))}`,
+    ),
+  );
+
+  const inner = compileOrderBy(aliased(page.inner), dialect);
+  const outer = compileOrderBy(aliased(page.terms), dialect, `${pageAlias}.`);
+
+  return {
+    alias,
+    folded,
+    decode,
+    subquery: concat(
+      sql(`select coalesce(json_agg(${pageAlias}.${dialect.quoteIdent("data")}`),
+      outer ? concat(sql(" order by "), outer) : sql(""),
+      sql(`), '[]'::json) as ${dialect.quoteIdent("data")} from (select `),
+      object,
+      sql(` as ${dialect.quoteIdent("data")}`),
+      ...carried,
+      scan,
+      inner ? concat(sql(" order by "), inner) : sql(""),
+      page.clause,
+      sql(`) as ${pageAlias}`),
+    ),
+  };
+}
+
+/**
+ * The node's own `take` / `skip`, or `undefined` when it has neither.
+ *
+ * Mirrors the root's `pagination` in `read.ts`, including the two pieces of
+ * Prisma behaviour that are invisible until you read the SQL it emits:
+ *
+ * - Paginating without an `orderBy` orders by the primary key. Without it,
+ *   "the first ten" is only meaningful if the scan happens to be stable.
+ * - A *negative* `take` means "the last N": every ordering term is flipped and
+ *   `abs(take)` rows are taken. Here the page is put back into the caller's own
+ *   order by the aggregate rather than by reversing an array, since the
+ *   aggregate is already ordering — `inner` is the flipped order, `terms` is
+ *   the one the caller asked for.
+ */
+function pagination(
+  input: FoldInput,
+  node: Record<string, any> | undefined,
+  parsed: OrderTerm[],
+  child: ModelSchema,
+): { clause: Fragment; terms: OrderTerm[]; inner: OrderTerm[] } | undefined {
+  const take = node?.take;
+  const skip = node?.skip;
+  if (take === undefined && skip === undefined) return undefined;
+
+  const terms =
+    parsed.length > 0
+      ? parsed
+      : child.primaryKey.map((name) => ({
+          column: child.fields[name]?.column ?? name,
+          direction: "asc" as const,
+        }));
+
+  const takeBinder: Binder | null =
+    take === undefined
+      ? null
+      : (args: any) => Math.abs(Number(input.locate(args)?.take));
+
+  const skipBinder: Binder | null =
+    skip === undefined ? null : (args: any) => Number(input.locate(args)?.skip);
+
+  return {
+    clause: input.dialect.paginate(takeBinder, skipBinder),
+    terms,
+    inner: typeof take === "number" && take < 0 ? reverse(terms) : terms,
+  };
+}
+
+const orderAlias = (position: number) => `__ord_${position}`;
+
+/**
+ * The same terms, pointed at the carried `__ord_N` columns rather than at the
+ * child's own. Position is what ties the two together, so this must be mapped
+ * from the same array the columns were carried from.
+ */
+function aliased(terms: OrderTerm[]): OrderTerm[] {
+  return terms.map((term, position) => ({
+    ...term,
+    column: orderAlias(position),
+    expression: undefined,
+  }));
+}
+
+/**
+ * An alias derived from the relation's key, so two relations on one query cannot
+ * collide. Not user input: `as` is a key on the generated schema's `relations`,
+ * so it is an identifier the same way a column is.
+ *
+ * Below the first level it carries the node's index too. Without it a tree that
+ * reaches the same relation name twice — `accounts.user.accounts` — would emit
+ * one alias inside another of the same name, where the inner silently shadows
+ * the outer.
+ */
+function suffixed(
+  prefix: string,
+  as: string,
+  depth: number,
+  index: number,
+): string {
+  return depth === 1 ? `${prefix}${as}` : `${prefix}${as}_${index}`;
 }
 
 function normalise(node: unknown): any {
@@ -192,7 +503,8 @@ function normalise(node: unknown): any {
 }
 
 /**
- * `json_build_object('id', "Account"."id", …)` over the child's selected columns.
+ * `json_build_object('id', "Account"."id", …)` over the child's selected columns,
+ * followed by whatever relations folded below it.
  *
  * Keys are the *field* names, so the JSON arrives already shaped the way the
  * caller expects and the decoder does not have to map columns back. Both sides
@@ -202,6 +514,7 @@ function jsonObject(
   fields: readonly FieldSchema[],
   qualifier: string,
   dialect: SqlDialect,
+  nested: readonly { key: string; alias: string }[],
 ): Fragment {
   const parts = fields.map((field) => {
     const column = `${qualifier}${dialect.quoteIdent(field.column)}`;
@@ -219,6 +532,14 @@ function jsonObject(
     const expression = field.type === "BigInt" ? `${column}::text` : column;
     return `'${field.name}', ${expression}`;
   });
+
+  // A folded relation is already JSON — an array from its own `json_agg`, or an
+  // object from its own `json_build_object` — so it embeds as a value rather
+  // than being re-encoded.
+  for (const entry of nested) {
+    parts.push(`'${entry.key}', ${entry.alias}.${dialect.quoteIdent("data")}`);
+  }
+
   return sql(`json_build_object(${parts.join(", ")})`);
 }
 
@@ -236,11 +557,14 @@ function jsonObject(
  *
  * So the conversion is driven by the child's *schema*, per field, and it reuses the
  * dialect's own `decode` for anything the dialect already knows how to convert.
+ * A folded relation arrived nested inside this one's JSON, so its own decoder
+ * runs from here — the same recursion the SQL took, in the other direction.
  */
 function buildDecoder(
   fields: readonly FieldSchema[],
   dialect: SqlDialect,
   many: boolean,
+  nested: readonly { key: string; decode: (value: unknown) => unknown }[],
 ): (value: unknown) => unknown {
   const converters = fields
     .map((field) => ({ field, convert: jsonConverter(field) }))
@@ -254,6 +578,9 @@ function buildDecoder(
     const record = row as Record<string, unknown>;
     for (const { field, convert } of converters) {
       record[field.name] = convert(record[field.name]);
+    }
+    for (const child of nested) {
+      record[child.key] = child.decode(record[child.key]);
     }
     return record;
   };

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -37,13 +37,21 @@ import { resolveSelection } from "./select";
 
 /**
  * The keys a relation node accepts, which differ by kind. `take` / `skip` are
- * refused on both; see `assertNodeArgs`.
+ * a to-many's alone — on a to-one Prisma rejects them outright, since there is
+ * at most one row to page.
  *
  * Prisma's to-one include argument is `{ where?, select?, include? }` — it
  * takes a `where` (verified: it filters, and the relation comes back `null`
  * when nothing matches) but not an `orderBy`, since there is at most one row.
  */
-const RELATION_ARGS = new Set(["where", "orderBy", "select", "include"]);
+const RELATION_ARGS = new Set([
+  "where",
+  "orderBy",
+  "select",
+  "include",
+  "take",
+  "skip",
+]);
 const TO_ONE_ARGS = new Set(["where", "select", "include"]);
 
 /**
@@ -114,7 +122,7 @@ export interface RelationExecutor {
 }
 
 /** One relation as it appears in an `include` / `select` argument tree. */
-interface RelationNode {
+export interface RelationNode {
   /** The key on the parent's output object. */
   as: string;
   relation: RelationSchema;
@@ -224,6 +232,27 @@ export interface RelationPlan {
 }
 
 /**
+ * One relation a fold pulled in *below* the node itself, and what it pulled in
+ * turn.
+ *
+ * A folded tree is one statement, so nothing below the root ever reaches the
+ * related model's own `$exec` — and `redact` is the one policy capability that
+ * cannot ride along in the argument tree, because it is a row transform rather
+ * than a `where`. The parent runs it on the whole subtree's behalf, and it
+ * cannot do that without knowing the shape of what was folded. Depth-1 alone
+ * would leave a grandchild's redaction silently unapplied, which is the failure
+ * mode worth naming.
+ */
+export interface FoldedRelation {
+  as: string;
+  /** The related model's *name*, resolved through the registry at call time. */
+  model: string;
+  kind: "one" | "many";
+  /** What this relation folded in turn. Empty for a leaf. */
+  folded: FoldedRelation[];
+}
+
+/**
  * What a fold-into-the-root strategy adds to the root statement.
  *
  * Fragments rather than strings, like everything else the compiler emits, so a
@@ -236,6 +265,11 @@ export interface RootContribution {
   column: Fragment;
   /** Appended after the `from` clause — a `left join lateral (…) on true`. */
   join: Fragment;
+  /**
+   * The relations this one folded below itself. Empty when the node is a leaf,
+   * which is the common case.
+   */
+  folded: FoldedRelation[];
   /**
    * Turns the column's raw value into the shaped relation.
    *
@@ -367,7 +401,7 @@ export async function attachRelations(
  * *scalars*: `include` keeps them all, `select` keeps only what it names. What
  * they mean about relations is identical, so both funnel through here.
  */
-function relationNodes(
+export function relationNodes(
   schema: ModelSchema,
   args: any,
   operation: string,
@@ -488,6 +522,10 @@ function assertNodeArgs(
 
   for (const key of Object.keys(args).sort()) {
     if (args[key] === undefined) continue;
+    if (many && (key === "take" || key === "skip")) {
+      assertPageArgument(schema, node, operation, key, args[key]);
+      continue;
+    }
     if (many ? RELATION_ARGS.has(key) : TO_ONE_ARGS.has(key)) continue;
 
     // A to-one relation is at most one row, so ordering it is meaningless and
@@ -504,32 +542,93 @@ function assertNodeArgs(
       );
     }
 
-    // The decision recorded in the PR: `take` / `skip` on a to-many relation
-    // throw rather than being implemented under the batched strategy.
-    //
-    // `include: { accounts: { take: 5 } }` means five accounts *per user*, not
-    // five overall. Under batching, one query serves every parent, so a
-    // per-parent limit needs `row_number() over (partition by ...)` wrapped in
-    // a subquery — which cannot be expressed through `$exec` on the child's own
-    // model class, and so would need exactly the private query path invariant 1
-    // exists to prevent. It falls out for free from iteration 7's lateral
-    // strategy. The alternative — applying the limit globally — silently
-    // returns wrong data, which is worse than not supporting it.
+    // A to-one is at most one row, so there is nothing to page and Prisma says
+    // so. The to-many case is not refused here at all: whether a per-parent
+    // page can be expressed is a property of the *strategy*, not of the
+    // argument tree, and `assertPaginable` raises it where that is known.
     if (key === "take" || key === "skip") {
       throw new UnsupportedQueryError(
         `${node.as}.${key}`,
         schema.name,
         operation,
-        node.relation.kind === "many"
-          ? `A '${key}' inside a to-many relation is per parent, which the ` +
-            `batched relation planner cannot express. It arrives with the ` +
-            `lateral join strategy; until then, load '${node.as}' as its own ` +
-            `query, or narrow it with 'where'.`
-          : `Prisma does not accept '${key}' on a to-one relation.`,
+        `Prisma does not accept '${key}' on a to-one relation.`,
       );
     }
 
     throw new UnsupportedQueryError(`${node.as}.${key}`, schema.name, operation);
+  }
+}
+
+/**
+ * `take` / `skip` on a to-many node have to be numbers, and Prisma is stricter
+ * than "a number": a `skip` is a count of rows to pass over, so a negative one
+ * is meaningless and rejected rather than clamped.
+ *
+ * A *negative* `take` is not — it means "the last N", the same as at the root,
+ * and it changes the emitted SQL rather than a bound value. That is why the
+ * plan key records a `take`'s sign; see `shapeOfMember`.
+ */
+function assertPageArgument(
+  schema: ModelSchema,
+  node: RelationNode,
+  operation: string,
+  key: "take" | "skip",
+  value: unknown,
+): void {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new UnsupportedQueryError(
+      `${node.as}.${key}`,
+      schema.name,
+      operation,
+      `Expected an integer, got ${JSON.stringify(value)}.`,
+    );
+  }
+  if (key === "skip" && value < 0) {
+    throw new UnsupportedQueryError(
+      `${node.as}.skip`,
+      schema.name,
+      operation,
+      `A 'skip' counts rows to pass over, so it cannot be negative. Prisma ` +
+        `rejects one too.`,
+    );
+  }
+}
+
+/**
+ * Refuses a per-parent `take` / `skip` that the strategy about to plan this node
+ * cannot express, naming the one that can.
+ *
+ * `include: { accounts: { take: 5 } }` means five accounts *per user*, not five
+ * overall. The batched strategy serves every parent from one query, so the only
+ * `limit` it could emit would page the parents' children as a single set —
+ * plausible, and wrong. It refuses instead. The lateral strategy's subquery
+ * already runs once per parent row, so a `limit` inside it means exactly what
+ * Prisma means, which is why this is the one relation argument whose support is
+ * a property of the strategy rather than of the compiler.
+ *
+ * `why` says what put this node on a strategy that cannot page it — the dialect,
+ * a decline, or an explicit `strategy: "batched"` — because that is the part the
+ * caller can act on.
+ */
+export function assertPaginable(request: RelationRequest, why: string): void {
+  const node = request.node;
+  if (typeof node !== "object" || node === null || Array.isArray(node)) return;
+
+  for (const key of ["take", "skip"] as const) {
+    if ((node as Record<string, unknown>)[key] === undefined) continue;
+
+    throw new UnsupportedQueryError(
+      `${request.as}.${key}`,
+      request.parent.name,
+      request.operation,
+      `A '${key}' inside a to-many relation is per parent, and the batched ` +
+        `relation planner serves every parent from one query — so the only ` +
+        `limit it could emit would page every parent's children as one set. ` +
+        `Only the lateral join strategy can express it, by paginating inside ` +
+        `a subquery that already runs once per parent row, and it needs ` +
+        `Postgres: ${why}. Load '${request.as}' as its own query, or narrow ` +
+        `it with 'where'.`,
+    );
   }
 }
 
@@ -815,6 +914,10 @@ export const batchedStrategy: RelationStrategy = {
   name: BATCHED,
 
   plan(request: RelationRequest): RelationPlan {
+    // Before anything else, so that a node this strategy cannot serve fails at
+    // compile time rather than returning a page nobody asked for.
+    assertPaginable(request, `this query planned with the batched strategy`);
+
     const link = resolveLink(request.parent, request.child, request.relation);
 
     // Resolved at plan time so a stale artifact fails when the query is

--- a/packages/gemi/orm/fixtures.ts
+++ b/packages/gemi/orm/fixtures.ts
@@ -408,6 +408,69 @@ export const tag: ModelSchema = {
   },
 };
 
+/**
+ * A self-relation — the one topology where the parent and the child are the same
+ * table, which the template's schema has no example of.
+ *
+ * It exists for the lateral strategy's decline: a correlation is written as
+ * `"<child>"."<fk>" = "<parent>"."<pk>"`, and when both names are `"Category"`
+ * that compares the subquery's own row against itself rather than against the
+ * outer one. Batching is unaffected, because it stitches in JavaScript.
+ */
+export const category: ModelSchema = {
+  name: "Category",
+  table: "Category",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    name: {
+      name: "name",
+      column: "name",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    parentId: {
+      name: "parentId",
+      column: "parentId",
+      type: "Int",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    parent: {
+      name: "parent",
+      model: "Category",
+      kind: "one",
+      relationName: "CategoryTree",
+      from: ["parentId"],
+      to: ["id"],
+      nullable: true,
+    },
+    children: {
+      name: "children",
+      model: "Category",
+      kind: "many",
+      relationName: "CategoryTree",
+      from: [],
+      to: [],
+      nullable: false,
+    },
+  },
+};
+
 /** `@@map("audit_log")` with `@map`ped columns, plus every decoded scalar type. */
 export const mapped: ModelSchema = {
   name: "AuditLog",

--- a/packages/gemi/orm/plan.discrimination.test.ts
+++ b/packages/gemi/orm/plan.discrimination.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "vitest";
 
+import { lateralStrategy } from "./compile/lateral";
 import { PostgresDialect } from "./dialect/postgres";
 import { SqliteDialect } from "./dialect/sqlite";
 import { account, organization, user } from "./fixtures";
@@ -239,6 +240,84 @@ describe("plan cache discrimination", () => {
     expect(planKey(sqlite, "User", "findMany", { take: 10 })).not.toBe(
       planKey(sqlite, "User", "findMany", { take: -10 }),
     );
+  });
+
+  /**
+   * The same rule one level down, where it is easier to get wrong: a relation
+   * node's `take` / `skip` sit inside `include`, which is a *literal* subtree —
+   * every value there is recorded verbatim, because `"asc"` and `"desc"` have to
+   * be two keys. A number recorded verbatim would mint one plan entry per page,
+   * so both keys have to opt out of that, and only the `take`'s sign may stay.
+   *
+   * Compiled on Postgres because that is the only dialect that can page a
+   * relation at all; on SQLite these are refusals rather than plans.
+   */
+  describe("a relation node's take and skip", () => {
+    const key = (args: unknown) =>
+      planKey(postgres, "User", "findMany", args, "lateral");
+
+    test("magnitude shares a key, sign does not", () => {
+      expect(key({ include: { accounts: { take: 10 } } })).toBe(
+        key({ include: { accounts: { take: 20 } } }),
+      );
+      expect(key({ include: { accounts: { take: 10 } } })).not.toBe(
+        key({ include: { accounts: { take: -10 } } }),
+      );
+    });
+
+    test("a skip's value is a parameter, its presence is not", () => {
+      expect(key({ include: { accounts: { skip: 1 } } })).toBe(
+        key({ include: { accounts: { skip: 9 } } }),
+      );
+      expect(key({ include: { accounts: { skip: 1 } } })).not.toBe(
+        key({ include: { accounts: true } }),
+      );
+      expect(key({ include: { accounts: { skip: 1 } } })).not.toBe(
+        key({ include: { accounts: { take: 1 } } }),
+      );
+    });
+
+    test("and the shapes that share a key really do share a plan", () => {
+      const wide = getOrCompile(
+        user,
+        "findMany",
+        { include: { accounts: { take: 10, skip: 1 } } },
+        postgres,
+        lateralStrategy,
+      );
+      const narrow = getOrCompile(
+        user,
+        "findMany",
+        { include: { accounts: { take: 20, skip: 9 } } },
+        postgres,
+        lateralStrategy,
+      );
+
+      expect(narrow.text).toBe(wide.text);
+      expect(
+        narrow.bind({ include: { accounts: { take: 20, skip: 9 } } }),
+      ).toEqual([20, 9]);
+    });
+
+    test("...and the shapes that do not share a key compile differently", () => {
+      const forwards = getOrCompile(
+        user,
+        "findMany",
+        { include: { accounts: { take: 1, orderBy: { id: "asc" } } } },
+        postgres,
+        lateralStrategy,
+      );
+      const backwards = getOrCompile(
+        user,
+        "findMany",
+        { include: { accounts: { take: -1, orderBy: { id: "asc" } } } },
+        postgres,
+        lateralStrategy,
+      );
+
+      // The sign flips the page's ordering, which is why it is structural.
+      expect(backwards.text).not.toBe(forwards.text);
+    });
   });
 
   test("the operation is part of the key", () => {

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -251,6 +251,12 @@ function shapeOfMember(
   if (key === "take" && typeof value === "number") {
     return `number:${Math.sign(value)}`;
   }
+  // `skip` is a parameter with no structural half at all, and it needs saying
+  // because a *relation node's* `skip` sits inside `include` — a literal
+  // subtree, where a bare number would otherwise be recorded verbatim and mint
+  // one plan entry per page. The root's `skip` never had the problem, which is
+  // exactly why it went unnoticed until a node could carry one.
+  if (key === "skip" && typeof value === "number") return "number";
   if (collapseLists && LIST_KEYS.has(key) && Array.isArray(value)) {
     return collapsedList(value);
   }

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -289,6 +289,42 @@ const CASES: [string, string, unknown][] = [
   ["include to-many ordered desc", "findMany", {
     include: { accounts: { orderBy: { organizationRole: "desc" } } },
   }],
+  // Ordering an include by a *relation* rather than by a column. It compiles to
+  // a correlated subquery, which the lateral strategy has no `OrderContext` to
+  // build — so these are the shapes that must reach batching whichever strategy
+  // planned them, and the ones that would otherwise work on SQLite in
+  // development and throw on Postgres in production.
+  //
+  // **Every one carries an `id` tiebreaker, and it is not padding.** gemi orders
+  // by a correlated subquery and Prisma by a join, so the two statements are
+  // free to break a tie differently — and the fixture ties on purpose, since
+  // both of Ada's accounts point at the same user and therefore at the same
+  // email. Comparing an unspecified order would make these tests fail for a
+  // correct implementation, which is the failure mode a differential harness
+  // must not have.
+  ["include ordered by a relation field", "findMany", {
+    orderBy: { id: "asc" },
+    include: {
+      accounts: { orderBy: [{ user: { email: "asc" } }, { id: "asc" }] },
+    },
+  }],
+  ["include ordered by a relation, with a nested include", "findMany", {
+    orderBy: { id: "asc" },
+    include: {
+      accounts: {
+        orderBy: [{ user: { email: "asc" } }, { id: "asc" }],
+        include: { organization: true },
+      },
+    },
+  }],
+  ["include ordered by a column, then a relation", "findMany", {
+    orderBy: { id: "asc" },
+    include: {
+      accounts: {
+        orderBy: [{ organizationRole: "asc" }, { user: { email: "asc" } }],
+      },
+    },
+  }],
   ["include to-many with select", "findMany", {
     include: { accounts: { select: { publicId: true }, orderBy: { id: "asc" } } },
   }],

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient } from "@prisma/client";
+import { Model } from "gemi/orm";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 
 import {
@@ -562,6 +563,127 @@ const SQLITE_ONLY: [string, string, unknown][] = [
   ],
 ];
 
+/**
+ * Per-parent `take` / `skip` inside a to-many, which only the lateral strategy
+ * can express — so these are Postgres-only by construction rather than by
+ * convenience, and every one of them is compared against Prisma's own answer.
+ *
+ * The shapes here are the ones where a plausible-but-wrong implementation
+ * survives the obvious test: a limit applied to the parents' children as one set
+ * returns the *right rows for the first parent*, which is exactly why a fixture
+ * with several parents holding several children each is the discriminating one.
+ */
+const PER_PARENT: [string, string, unknown][] = [
+  [
+    "take inside a to-many is per parent",
+    "findMany",
+    { orderBy: { id: "asc" }, include: { accounts: { take: 1, orderBy: { id: "asc" } } } },
+  ],
+  [
+    "take larger than any parent's child count",
+    "findMany",
+    { orderBy: { id: "asc" }, include: { accounts: { take: 50, orderBy: { id: "asc" } } } },
+  ],
+  [
+    "take zero",
+    "findMany",
+    { orderBy: { id: "asc" }, include: { accounts: { take: 0, orderBy: { id: "asc" } } } },
+  ],
+  [
+    "skip inside a to-many is per parent",
+    "findMany",
+    { orderBy: { id: "asc" }, include: { accounts: { skip: 1, orderBy: { id: "asc" } } } },
+  ],
+  [
+    "take and skip together",
+    "findMany",
+    {
+      orderBy: { id: "asc" },
+      include: { accounts: { take: 1, skip: 1, orderBy: { id: "asc" } } },
+    },
+  ],
+  [
+    "a skip past the end leaves an empty array, not null",
+    "findMany",
+    { orderBy: { id: "asc" }, include: { accounts: { skip: 99, orderBy: { id: "asc" } } } },
+  ],
+  [
+    // The half a global limit gets right by accident is the first parent's page,
+    // so "the last N" in the caller's own order is the sharper case.
+    "a negative take is the last N, in the caller's order",
+    "findMany",
+    { orderBy: { id: "asc" }, include: { accounts: { take: -1, orderBy: { id: "asc" } } } },
+  ],
+  [
+    "a negative take under a descending orderBy",
+    "findMany",
+    { orderBy: { id: "asc" }, include: { accounts: { take: -2, orderBy: { id: "desc" } } } },
+  ],
+  [
+    "pagination with no orderBy falls back to the primary key",
+    "findMany",
+    { orderBy: { id: "asc" }, include: { accounts: { take: 1 } } },
+  ],
+  [
+    "a where narrows the set before the page is taken",
+    "findMany",
+    {
+      orderBy: { id: "asc" },
+      include: {
+        accounts: { where: { deletedAt: null }, take: 1, orderBy: { id: "asc" } },
+      },
+    },
+  ],
+  [
+    "a select alongside the page",
+    "findMany",
+    {
+      orderBy: { id: "asc" },
+      include: {
+        accounts: { select: { publicId: true }, take: 1, orderBy: { id: "asc" } },
+      },
+    },
+  ],
+  [
+    "a page on a single-row operation",
+    "findFirst",
+    { orderBy: { id: "asc" }, include: { accounts: { take: 1, orderBy: { id: "asc" } } } },
+  ],
+];
+
+/** The issue's second acceptance criterion: a page under a page. */
+const PER_PARENT_NESTED: [string, string, unknown][] = [
+  [
+    "Organization",
+    "findMany",
+    {
+      orderBy: { id: "asc" },
+      include: {
+        users: {
+          take: 2,
+          orderBy: { name: "asc" },
+          include: { accounts: { take: 1, orderBy: { id: "desc" } } },
+        },
+      },
+    },
+  ],
+  [
+    "Organization",
+    "findMany",
+    {
+      orderBy: { id: "asc" },
+      include: {
+        users: {
+          take: -1,
+          skip: 1,
+          orderBy: { id: "asc" },
+          include: { accounts: { take: 1, skip: 1, orderBy: { id: "asc" } } },
+        },
+      },
+    },
+  ],
+];
+
 const POSTGRES_ONLY: [string, string, unknown][] = [
   [
     "mode insensitive matches case-blind on postgres",
@@ -640,6 +762,32 @@ function suite(label: string, url?: string) {
         // A filter that silently matched nothing would make every case above
         // vacuous, and the suite would report a row of passes for no work.
         expect(RELATION_CASES.length).toBeGreaterThan(15);
+      });
+
+      test.each(PER_PARENT)("%s", async (_name, operation, args) => {
+        await differential.expectSame("User", operation, args);
+      });
+
+      test.each(PER_PARENT_NESTED)(
+        "per parent under per parent — %s.%o",
+        async (model, operation, args) => {
+          await differential.expectSame(model, operation, args);
+        },
+      );
+
+      /**
+       * The batched strategy still refuses, and it is worth pinning next to the
+       * cases that now work: the point is not that pagination landed, it is that
+       * the strategy that cannot express it still says so rather than computing
+       * a page that looks right for the first parent.
+       */
+      test("the same query under batched refuses rather than paging globally", async () => {
+        await expect(
+          UserModel.findMany(
+            { include: { accounts: { take: 1 } } },
+            { strategy: "batched" },
+          ),
+        ).rejects.toThrow(/per parent[\s\S]*lateral join strategy/);
       });
     }
 
@@ -743,11 +891,10 @@ function suite(label: string, url?: string) {
     /**
      * The lateral counterpart, and the reason the default flipped on Postgres.
      *
-     * Only the outer level folds here — `accounts` carries its own `include`, so
-     * the strategy declines that node — which still removes one statement of the
-     * four. Asserting the *specific* number rather than "fewer" is what would
-     * catch a regression in either direction: a node that stopped folding, or one
-     * that folded when it should have declined.
+     * The whole tree folds now that the strategy recurses, so four statements
+     * become one. Asserting the *specific* number rather than "fewer" is what
+     * would catch a regression in either direction: a node that stopped folding,
+     * or one that folded when it should have declined.
      */
     test("lateral: folding removes a statement per folded node", async () => {
       if (!url) return;
@@ -763,25 +910,32 @@ function suite(label: string, url?: string) {
         },
         lateral,
       );
-      // Two, and working out why is the useful part. `organization` folds into
-      // the root. `accounts` declines, because it carries its own include — but
-      // the strategy *propagates* to that nested `$exec`, so `accounts` runs as
-      // its own query with *its* `organization` folded in. So four becomes two,
-      // not three: the decline costs a statement, it does not cost the whole
-      // subtree.
-      //
-      // My first guess here was three, from assuming a declined node reverts its
-      // descendants to batching. It does not, and that is the propagation the
-      // batched case above proved was missing.
-      expect(differential.queries()).toBe(2);
+      // One. Every node folds, including the grandchild — a nested `include` is
+      // the same builder one level down rather than a decline.
+      expect(differential.queries()).toBe(1);
 
-      // A tree with nothing to decline collapses to one.
       differential.resetQueries();
       await UserModel.findMany(
         { include: { organization: true, accounts: true } },
         lateral,
       );
       expect(differential.queries()).toBe(1);
+
+      // A decline still costs exactly one statement, not the subtree: the node
+      // runs as its own query with *its* children folded in. `_count` on a node
+      // is the decline that is easiest to reach from the template's schema.
+      differential.resetQueries();
+      await UserModel.findMany(
+        {
+          include: {
+            organization: { include: { _count: { select: { users: true } } } },
+            accounts: { include: { organization: true } },
+          },
+        },
+        lateral,
+      );
+      // root + organization; `accounts` and its `organization` fold.
+      expect(differential.queries()).toBe(2);
     });
 
     // A node whose parents have no keys at all is not worth a round trip: the
@@ -854,17 +1008,80 @@ function suite(label: string, url?: string) {
       }
     });
 
-    test("take and skip inside a to-many relation throw rather than lie", async () => {
-      // Prisma implements these; gemi refuses them under the batched planner
-      // rather than applying the limit globally, which would return a
-      // plausible and wrong answer. See the iteration 7 note in
-      // plan-relations.ts.
+    /**
+     * The half of the fold that cannot ride along in the argument tree.
+     *
+     * `scope` survives folding because policies rewrite the arguments before the
+     * plan key, so a scoped `where` lands inside the subquery. `redact` cannot —
+     * it is a row transform in the shaping stage, with nothing to rewrite — so
+     * the parent runs it on the child's behalf. Now that a fold recurses, the
+     * parent has to run it for the *whole subtree*, and a grandchild is exactly
+     * the row nobody thinks to check.
+     *
+     * Not in `policies.test.ts` because that suite is SQLite, where the strategy
+     * declines everything and this path is unreachable.
+     */
+    test("lateral: a folded grandchild is still redacted", async () => {
+      if (!url) return;
+
+      const previous = (OrganizationModel as any).$policies;
+      (OrganizationModel as any).$policies = [
+        {
+          redact: (_context: unknown, row: Record<string, unknown>) => {
+            if ("description" in row) row.description = null;
+          },
+        },
+      ];
+
+      try {
+        const rows: any[] = await Model.asUser({ id: 1 }, () =>
+          UserModel.findMany(
+            { include: { accounts: { include: { organization: true } } } },
+            { strategy: "lateral" },
+          ),
+        );
+
+        const organizations = rows
+          .flatMap((row) => row.accounts)
+          .map((account: any) => account.organization)
+          .filter(Boolean);
+
+        // The fixture has to reach the grandchild at all, or this passes
+        // vacuously — which is precisely how the depth-1-only version looked.
+        expect(organizations.length).toBeGreaterThan(0);
+        expect(
+          organizations.every((org: any) => org.description === null),
+        ).toBe(true);
+      } finally {
+        (OrganizationModel as any).$policies = previous;
+      }
+    });
+
+    test("take and skip inside a to-many relation throw under batched rather than lie", async () => {
+      // The lateral strategy implements these — see the per-parent cases in the
+      // matrix above. Batched refuses rather than applying the limit to the
+      // combined set, which would return a plausible and wrong answer, and its
+      // message names the strategy that would work.
+      const batched = { strategy: "batched" } as const;
+
       await expect(
-        UserModel.findMany({ include: { accounts: { take: 1 } } }),
+        UserModel.findMany({ include: { accounts: { take: 1 } } }, batched),
       ).rejects.toThrow(/per parent/);
       await expect(
-        UserModel.findMany({ include: { accounts: { skip: 1 } } }),
+        UserModel.findMany({ include: { accounts: { skip: 1 } } }, batched),
       ).rejects.toThrow(/lateral join strategy/);
+
+      // And asking for lateral on a dialect that has none refuses too, rather
+      // than falling back and computing a page for the combined set. The
+      // message says which of the two it was.
+      if (!url) {
+        await expect(
+          UserModel.findMany(
+            { include: { accounts: { take: 1 } } },
+            { strategy: "lateral" },
+          ),
+        ).rejects.toThrow(/declined to fold \(not postgres\)/);
+      }
     });
 
     test("select and include together throw at any level", async () => {


### PR DESCRIPTION
Closes #62.

`include: { products: { take: 10 } }` means ten products **per store**. The batched planner serves every parent from one query, so the only `limit` it could emit pages the parents' children as a single set — plausible, and wrong — and it refused. The refusal lived in `assertNodeArgs`, *before* a strategy was chosen, so the one strategy that can express it never got the chance.

## What moved

Whether a per-parent page is expressible is a property of the **strategy**, not of the argument tree. So the refusal moves to where that is known — `assertPaginable`, called by the batched plan and by lateral when it declines. `assertNodeArgs` now only validates the argument (an integer; a `skip` cannot be negative) and still refuses `take` / `skip` on a to-one, as Prisma does.

The new message keeps #61's four parts and names the strategy that would work rather than a future release, plus *why this node reached one that cannot page it*:

```
gemi ORM does not support 'tags.take' yet (Post.findMany). A 'take' inside a
to-many relation is per parent, and the batched relation planner serves every
parent from one query — so the only limit it could emit would page every
parent's children as one set. Only the lateral join strategy can express it, by
paginating inside a subquery that already runs once per parent row, and it needs
Postgres: this node declined to fold (implicit many-to-many). Load 'tags' as its
own query, or narrow it with 'where'.
```

The tail varies: `not postgres`, `implicit many-to-many`, `this query planned with the batched strategy`.

## The page goes before the aggregate

`json_agg` is an aggregate, so a `limit` beside it caps the aggregate's **single row** and silently returns every child. That is the trap, and it is the shape that survives a careless test. A paginated node therefore gets a subquery of its own:

```sql
select coalesce(json_agg("__page_accounts"."data"
                order by "__page_accounts"."__ord_0" asc), '[]'::json) as "data"
from (select json_build_object(…) as "data", "Account"."createdAt" as "__ord_0"
      from "Account"
      where "Account"."userId" = "User"."id"
      order by "__ord_0" asc limit $1 offset $2) as "__page_accounts"
```

The ordering terms are carried out as `__ord_N` columns so the aggregate can re-apply them — aggregating over an ordered subquery and hoping the order survives is not something Postgres promises. A negative `take` pages in flipped order and the aggregate puts the page back into the caller's, so there is no array reversal to do. Paginating without an `orderBy` orders by the child's primary key, exactly as the root does.

An unpaginated node emits byte-identical SQL to before.

## The fold had to recurse

Acceptance criterion 2 is a page under a page, and it could not be met without this. A folded node's children never enter the related model's `$exec`, so a nested `include` under one has nowhere to be loaded from — the strategy declined the node instead. It now folds the **whole subtree**, and declines a node whose subtree contains anything it cannot express, because half a fold is not a thing. A decline still costs one statement rather than the subtree: the node runs as its own query with the strategy applied again one level down.

Side effect worth calling out for review: **a depth-3 tree on Postgres is now one statement rather than three.** That is the headline win iteration 9 deferred, and it changes what every existing nested include does there. The full nested differential matrix runs against it.

Declines are now: not Postgres, implicit many-to-many, self-relation, a `_count` on a node, or any of those below it.

### Two things had to follow the recursion

- **`redact` walks the subtree.** It is the one policy member that cannot ride along in the argument tree — `scope` becomes a `where` inside the subquery, `redact` is a row transform with nothing to rewrite — so the parent runs it on the child's behalf. At depth 1 only, a folded **grandchild came back unredacted**. `RootContribution` now carries the shape of what it folded and `redactFolded` recurses. Verified by deleting the recursive call and watching the new test fail.
- **A self-relation declines.** The correlation reads `"T"."fk" = "T"."pk"`, which inside the subquery compares its own row against itself rather than the outer one. Latent since iteration 9 and reachable at any depth once the fold recurses; batching handles it correctly, so declining is the whole fix. Expressing it properly needs an alias in the `from` clause — deliberately not in this PR.

### And one plan-cache fix

A relation node's `skip` sits inside `include`, which is a *literal* subtree in the plan key, so its value would have been recorded verbatim and minted one cache entry per page. The root's `skip` never had the problem, which is exactly why it went unnoticed until a node could carry one. A `take`'s sign stays structural, since it changes the SQL.

## Verification

Against **Prisma on real Postgres**, not asserted SQL:

- Twelve per-parent shapes: `take`, `skip`, both together, `take: 0`, a take larger than any parent's child count, a skip past the end (an empty array, not `null`), both negative-take orderings, no-`orderBy` fallback, a `where` narrowing before the page, a `select` alongside it, and a page on `findFirst`.
- Two nested shapes — `take` under `take`, and `take: -1, skip: 1` over `take: 1, skip: 1`.
- The fixture discriminates: one user has two accounts and another has one, so a limit applied to the combined set returns the right answer for the first parent and the wrong one for the second.
- The batched refusal, and the SQLite refusal, pinned next to the cases that now work.
- The full existing nested relation matrix, unchanged, under the recursive fold.

Plus 761 unit tests in `packages/gemi` (up 18) and the SQLite differential suite.

Pre-existing failures, unchanged by this branch and confirmed on the base commit: seven router/i18n tests in `packages/gemi`, and `generated.test.ts`'s generator-linkage probe in the template.

### Closes a `_count` divergence reported on #45 as a side effect

The new `_count on a folded node` decline also fixes the nested-`_count` bug reported against #45: an `include` carrying a `_count` used to fold *without* it and return rows missing the key the caller asked for. Confirmed by the same probe that reproduced it — it returned `[{"id":1}]` on the base branch and returns `_count` correctly here.

### Declines a node ordered by a relation

Added in review. A node's `orderBy` naming a relation compiles to a correlated subquery that `foldNode` has no `OrderContext` to build, so such a node cannot fold. The depth-1 case was already broken on `feat/orm`; recursion widened its reach to any node with a nested `include`, and one decline covers both.

## Not in this PR

`plans/orm/` is a historical record of each iteration rather than a living document, and iteration 9's plan does not state the nested-include decline as a permanent decision, so it is left alone. `docs/orm.md` — the user-facing page — gains a **Paging a relation** section and an updated decline list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

