### PR TITLE
Composable SQL fragments — `sql` / `join` / `empty`, `unsafeSql`, and rowcount from raw writes

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -593,6 +593,101 @@ Measured numbers, the methodology, and the reasoning behind the lateral default 
 `plans/orm/benchmarks.md` in the repository — deliberately not here, because they are tied to a
 machine and a dataset and would go stale as documentation.
 
+## Raw SQL
+
+The ORM does not implement every SQL shape, and that is deliberate. What it owes you is somewhere
+for the rest to go — not just a way to run one hand-written statement, but a way to *compose* SQL,
+because a predicate built conditionally and passed around is the shape raw SQL actually takes in an
+application.
+
+```ts
+import { DB } from "gemi/facades"
+import { sql, join, empty } from "gemi/orm"
+
+const filters = []
+if (q) filters.push(sql`"name" ilike ${`%${q}%`}`)
+if (organizationId) filters.push(sql`"organizationId" = ${organizationId}`)
+
+const where = filters.length ? sql`where ${join(filters, " and ")}` : empty
+
+const rows = await DB.query<Product>(
+  sql`select * from "Product" ${where} order by "position" limit ${20}`,
+)
+```
+
+| | |
+| --- | --- |
+| `` sql`…` `` | A fragment. Every `${value}` is **bound**; a `${fragment}` is spliced in, carrying its own parameters. Nests to any depth. |
+| `join(items, sep)` | Fragments *or* values, joined. `join(ids)` is `$1, $2, $3`. An empty list is `empty`, not a dangling separator. |
+| `empty` | The fragment that contributes nothing, so a conditional predicate stays a value instead of becoming a branch. |
+| `DB.query(fragment)` | The rows. |
+| `DB.execute(fragment)` | How many rows the statement **touched**. |
+
+Three properties worth knowing, because they are the reason this is not just `DB.sql`:
+
+- **Placeholders are assigned at assembly, not at authoring.** SQLite writes `?` and Postgres
+  writes `$1`; a fragment does not know where it will land, so the numbering happens once the whole
+  statement exists. The same fragment can be nested, reused twice in one statement, or built before
+  the dialect is known.
+- **It runs on the ambient transaction.** A `DB.query` inside `Model.transaction` joins it, exactly
+  as a `User.create` does. A raw statement that quietly committed while its neighbours rolled back
+  would be worse than no raw statement at all.
+- **A plain string is refused.** Accepting one would make an interpolated template literal the path
+  of least resistance, which is the injection everything else here exists to prevent.
+
+**Policies do not apply here, and cannot.** A policy scopes a *model's* queries by rewriting the
+argument tree; a raw statement has no argument tree and no model behind it, so nothing scopes it and
+nothing redacts its rows. That is not a gap to be closed later — it is what "raw" means. If the
+statement reads a policied model, the tenant predicate is yours to write, and
+[`Every path that reaches another model carries that model's policies`](#every-path-that-reaches-another-model-carries-that-models-policies)
+stops at this door.
+
+Values are handed to the driver as they arrive, with two exceptions that exist so a fragment means
+the same thing on both dialects: a `Date` binds as milliseconds on SQLite — which is what the ORM
+stores — and a boolean as `0`/`1`. A plain object is **not** JSON-encoded for you; the compiler only
+knows to do that because a field says `Json`, and guessing from the value would turn a mistyped
+parameter into a successfully-written string.
+
+### The rowcount is a primitive, not a diagnostic
+
+```ts
+const won = await DB.execute(
+  sql`update "Reservation" set "status" = 'claimed'
+      where "id" = ${id} and "status" = 'reserved'`,
+)
+if (won === 0) throw new AlreadyClaimed()
+```
+
+`1` means this caller won the compare-and-swap and `0` means it lost. That is the whole concurrency
+control for a large class of code, so an API that discarded the number could not express it.
+
+### `unsafeSql` — the one door into the SQL text
+
+```ts
+import { unsafeSql } from "gemi/orm"
+
+// A literal in this file. Never a request, a form, a header or a database row.
+const REAPER = unsafeSql(`'reaper'`)
+
+await DB.query(sql`
+  select … from "Job" where "name" is distinct from ${REAPER} …
+`)
+```
+
+**Never give it a value that came from outside the program.** There is no escaping and there will
+not be — escaping that is "usually right" is worse than none, because it survives review.
+
+It exists because plan quality can depend on *not* parameterising. A partial index declared
+`where "name" is distinct from 'reaper'` is only usable if the planner can prove the query's
+predicate matches the index's, and a bound parameter is opaque at plan time — so `$1` there means a
+sequential scan of the whole table instead of an index hit. The constant has to be in the text. The
+same applies to identifiers and sort directions, which cannot be parameters in SQL at all; the rule
+is the same for those, and it is about where the value came from, not what it is.
+
+`DB.sql` is unchanged and still Bun's own tagged template, for a single self-contained statement
+that needs none of this. It does **not** join the ambient transaction — use `DB.query` when that
+matters.
+
 ## Dialects
 
 **SQLite and Postgres** are built and tested, on every operation, against a differential harness
@@ -612,6 +707,8 @@ Stated so you can plan around them rather than discover them:
   touched.
 - **No `omit`.** Use `select`, or a policy's `redact`.
 - **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
+- **No `groupBy`, `aggregate`, `distinct` or cursor pagination.** These land in
+  [Raw SQL](#raw-sql), which exists so that "not implemented" has an answer rather than a shrug.
 
 ## See also
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -644,9 +644,18 @@ stops at this door.
 
 Values are handed to the driver as they arrive, with two exceptions that exist so a fragment means
 the same thing on both dialects: a `Date` binds as milliseconds on SQLite — which is what the ORM
-stores — and a boolean as `0`/`1`. A plain object is **not** JSON-encoded for you; the compiler only
-knows to do that because a field says `Json`, and guessing from the value would turn a mistyped
-parameter into a successfully-written string.
+stores — and a boolean as `0`/`1`.
+
+A plain object is **not** JSON-encoded for you. The compiler only knows to do that because a field
+says `Json`, and guessing from the value would turn a mistyped parameter into a successfully-written
+string. What the driver then does with it differs: Bun binds an object into a Postgres `jsonb`
+column correctly, and on SQLite binds it to something no row matches. Stringify it yourself if the
+column is JSON and you want the same answer on both.
+
+**Only a fragment built by `sql`, `join`, `unsafeSql` or `empty` is spliced.** Anything else in an
+interpolation slot is bound — including an object that merely *looks* like a fragment, which is what
+a parsed request body can be made to contain. That check is membership, not shape, precisely so that
+`{"text": "…", "binders": []}` arriving from outside the program is a parameter and not a statement.
 
 ### The rowcount is a primitive, not a diagnostic
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -618,7 +618,7 @@ const rows = await DB.query<Product>(
 | | |
 | --- | --- |
 | `` sql`…` `` | A fragment. Every `${value}` is **bound**; a `${fragment}` is spliced in, carrying its own parameters. Nests to any depth. |
-| `join(items, sep)` | Fragments *or* values, joined. `join(ids)` is `$1, $2, $3`. An empty list is `empty`, not a dangling separator. |
+| `join(items, sep)` | Fragments *or* values, joined. `join(ids)` is `$1, $2, $3`. An empty list is `empty`, not a dangling separator. The separator is **glue only** — see below. |
 | `empty` | The fragment that contributes nothing, so a conditional predicate stays a value instead of becoming a branch. |
 | `DB.query(fragment)` | The rows. |
 | `DB.execute(fragment)` | How many rows the statement **touched**. |
@@ -651,6 +651,20 @@ says `Json`, and guessing from the value would turn a mistyped parameter into a 
 string. What the driver then does with it differs: Bun binds an object into a Postgres `jsonb`
 column correctly, and on SQLite binds it to something no row matches. Stringify it yourself if the
 column is JSON and you want the same answer on both.
+
+**The separator `join` takes is written into the SQL**, so it is not a free string: whitespace,
+commas, or `and` / `or`, and nothing else. Anything more expressive is legitimate but has to say so
+with `unsafeSql`, which keeps that the only door:
+
+```ts
+join(filters, " and ")               // fine
+join(parts, unsafeSql(") and ("))    // fine, and visibly a decision
+join(ids, req.query.sep)             // refused
+```
+
+That is an allowlist rather than a blocklist on purpose. The obvious blocklist — reject quotes,
+semicolons and comment markers — lets `") or 1=1 union select password from Users where 1=(1"`
+through, which has none of them and is still an injection.
 
 **Only a fragment built by `sql`, `join`, `unsafeSql` or `empty` is spliced.** Anything else in an
 interpolation slot is bound — including an object that merely *looks* like a fragment, which is what

--- a/packages/gemi/facades/DB.ts
+++ b/packages/gemi/facades/DB.ts
@@ -1,7 +1,9 @@
 import type { SQL } from "bun";
 import { DatabaseManager } from "../database/DatabaseManager";
 import type { Dialect } from "../database/dialect";
-import { withTransaction } from "../orm/context";
+import { currentTransaction, withTransaction } from "../orm/context";
+import { dialectFor } from "../orm/dialect";
+import { renderFragment, type SqlFragment } from "../orm/sql";
 import { Facade } from "./Facade";
 
 // Access to the app's database connection. Bun's `SQL` client is a tagged
@@ -27,6 +29,73 @@ export class DB extends Facade {
   // autoincrement, boolean and timestamp types).
   static get dialect(): Dialect {
     return this.getFacadeRoot().dialect;
+  }
+
+  // Runs a composed fragment and returns its rows.
+  //
+  //   const where = filters.length ? sql`where ${join(filters, " and ")}` : empty
+  //   const rows = await DB.query(sql`select * from "Product" ${where}`)
+  //
+  // Two things it does that `DB.sql` does not, and they are the reason it
+  // exists rather than being sugar:
+  //
+  // - It takes a **fragment**, so a predicate can be built as a value and
+  //   passed around. See `orm/sql.ts` for why that shape is the one raw SQL
+  //   actually needs.
+  // - It runs on the **ambient transaction** when there is one. A raw statement
+  //   that quietly escapes `Model.transaction` and commits while its neighbours
+  //   roll back is worse than no raw statement at all — so this resolves the
+  //   handle exactly as `Model.$exec` does, through `currentTransaction()`.
+  //
+  // A plain string is refused. That is deliberate: accepting one would make an
+  // interpolated template the path of least resistance, which is the injection
+  // this whole mechanism exists to keep closed. `unsafeSql` is the door, and it
+  // is named so that using it is a decision.
+  //
+  // `async` rather than returning the driver's promise directly, so that a
+  // rejected fragment — a plain string, a parameter count over the ceiling —
+  // *rejects* instead of throwing synchronously. An API that does one sometimes
+  // and the other otherwise is a footgun: `DB.query(...).catch(…)` would miss
+  // exactly the errors this refuses to run.
+  static async query<T = any>(fragment: SqlFragment): Promise<T[]> {
+    return (await this.run(fragment, "query")) as T[];
+  }
+
+  // The same, for a statement whose answer is *how many rows it touched*.
+  //
+  //   const won = await DB.execute(
+  //     sql`update "Reservation" set status = 'claimed'
+  //         where id = ${id} and status = 'reserved'`,
+  //   )
+  //   if (won === 0) { /* somebody else claimed it first */ }
+  //
+  // The count is the concurrency primitive there, not a diagnostic: 1 means this
+  // caller won the compare-and-swap and 0 means it lost, and an API that
+  // discarded it could not express that at all.
+  //
+  // **Where the number comes from.** Bun puts it on `count`, and leaves
+  // `affectedRows` null — measured on both dialects rather than read from a
+  // changelog, for `update`, `delete`, `insert`, a statement matching nothing,
+  // and one with `returning`. `compile/write.ts` records the same measurement
+  // from the other side: the *ORM's* counts come from `RETURNING` instead,
+  // because there the statement shape is ours to choose and an exact count that
+  // depends on nothing undocumented is worth a key column per row. Here the
+  // statement is the caller's, so there is nothing to add a `RETURNING` to.
+  static async execute(fragment: SqlFragment): Promise<number> {
+    const result = await this.run(fragment, "execute");
+    return Number((result as { count?: unknown })?.count ?? 0);
+  }
+
+  private static run(fragment: SqlFragment, operation: string) {
+    const db = this.getFacadeRoot();
+    // Per call, never captured: the same rule `Model.$exec` follows, and what
+    // keeps the connection swappable in tests.
+    const { text, values } = renderFragment(
+      fragment,
+      dialectFor(db.dialect),
+      operation,
+    );
+    return (currentTransaction() ?? db.sql).unsafe(text, values);
   }
 
   // Runs the callback inside a transaction, committing when it resolves and

--- a/packages/gemi/facades/DB.ts
+++ b/packages/gemi/facades/DB.ts
@@ -76,7 +76,14 @@ export class DB extends Facade {
   // **Where the number comes from.** Bun puts it on `count`, and leaves
   // `affectedRows` null — measured on both dialects rather than read from a
   // changelog, for `update`, `delete`, `insert`, a statement matching nothing,
-  // and one with `returning`. `compile/write.ts` records the same measurement
+  // and one with `returning`.
+  //
+  // `result.count` on what is otherwise an *array* reads like a bug, so: Bun
+  // returns an array with `count`, `command` and `lastInsertRowid` hung off it,
+  // on every statement including the ones that return no rows at all. A write
+  // without `returning` is therefore a zero-length array whose `count` is the
+  // number of rows it touched, and a write *with* one is an array of the rows
+  // whose `count` matches their number. `compile/write.ts` records the same measurement
   // from the other side: the *ORM's* counts come from `RETURNING` instead,
   // because there the statement shape is ours to choose and an exact count that
   // depends on nothing undocumented is worth a key column per row. Here the

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -42,12 +42,20 @@ import { compileWhere } from "./where";
  *
  * **1. Row counts come from `RETURNING`, not from driver metadata.**
  * `updateMany` and `deleteMany` return `{ count }`, and the obvious source is
- * whatever the driver reports about the statement. Measured, that source is not
- * portable: Bun's SQLite driver leaves `affectedRows` **null** on every
- * statement and puts the number on a `count` property instead, and neither is
- * documented or verifiable against Postgres from here. So the count is the
- * number of rows a `RETURNING <primary key>` gives back — one statement shape on
- * every dialect, exact by construction, and dependent on nothing undocumented.
+ * whatever the driver reports about the statement. Measured, that source is
+ * undocumented: Bun's SQLite driver leaves `affectedRows` **null** on every
+ * statement and puts the number on a `count` property instead. So the count is
+ * the number of rows a `RETURNING <primary key>` gives back — one statement
+ * shape on every dialect, exact by construction, and dependent on nothing
+ * undocumented.
+ *
+ * `count` has since been measured on Postgres too, and it agrees: same property,
+ * same value, `affectedRows` null on both, across `update`, `delete`, `insert`,
+ * a statement matching nothing and one carrying `returning`. That does not
+ * change the decision here — `RETURNING` is still exact and still asks the
+ * driver for nothing — but it is what lets `DB.execute` report a *raw* write's
+ * rowcount, where the statement is the caller's and there is no `RETURNING` to
+ * add. See `facades/DB.ts`.
  * It costs one key column per affected row on the wire, which is a real cost on
  * a very large `deleteMany`; iteration 7 owns performance and can revisit it
  * with a benchmark rather than a guess.

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -105,6 +105,27 @@ export interface SqlDialect {
    */
   encode(value: unknown, field: FieldSchema): unknown;
 
+  /**
+   * The same, for a value with **no declared column type** — a parameter
+   * interpolated into a composed raw fragment, where there is no schema to ask.
+   *
+   * It exists because "raw" cannot mean "unportable". Bun's SQLite driver
+   * rejects a `Date` outright (`Binding expected string, TypedArray, boolean,
+   * number, bigint or null`) while Postgres takes one, so
+   * ``sql`where "createdAt" > ${date}` `` would work on one dialect and throw on
+   * the other — and the caller has no dialect-independent value to reach for
+   * instead, because milliseconds are only correct if that is what the ORM
+   * stored. Which it is: this converts to exactly what `encode` writes for a
+   * `DateTime`, so a raw statement compares against ORM-written rows correctly.
+   *
+   * Deliberately narrow. It normalises the JavaScript types whose SQL form the
+   * ORM has already decided — a `Date`, a boolean — and touches nothing else. A
+   * plain object is *not* JSON-encoded here: the compiler only knows to do that
+   * because a field says `Json`, and guessing from the value would turn a
+   * mistyped parameter into a successfully-written string.
+   */
+  encodeUntyped(value: unknown): unknown;
+
   /** Driver value -> the value Prisma would have returned for this field. */
   decode(value: unknown, field: FieldSchema): unknown;
 

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -154,6 +154,15 @@ export class PostgresDialect implements SqlDialect {
     return value;
   }
 
+  // Nothing to do without a field: the only conversion `encode` makes here is
+  // the JSON one, and that is precisely the one that needs the column's
+  // declared type to be legitimate. `Date`, `boolean`, `bigint` and arrays all
+  // bind natively, which is why a raw fragment is portable across the two
+  // dialects even though only SQLite has to normalise anything.
+  encodeUntyped(value: unknown): unknown {
+    return value;
+  }
+
   // Postgres returns real `timestamptz`, `boolean` and `double precision`, so
   // most columns need nothing. Two do, and neither is reachable from the
   // template's schema — which is why they went unnoticed until a fixture with

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -197,6 +197,18 @@ export class SqliteDialect implements SqlDialect {
     }
   }
 
+  // The two conversions above that do not need a field to decide: a `Date` is
+  // milliseconds and a boolean is 0/1, which is what the ORM writes and
+  // therefore what a raw statement has to compare against. Everything else is
+  // handed to the driver as it arrived — including a plain object, which the
+  // driver rejects, because a value that should have been JSON is a mistake
+  // worth hearing about rather than guessing at.
+  encodeUntyped(value: unknown): unknown {
+    if (value instanceof Date) return value.getTime();
+    if (typeof value === "boolean") return value ? 1 : 0;
+    return value;
+  }
+
   needsDecode(field: FieldSchema): boolean {
     switch (field.type) {
       case "DateTime":

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -199,10 +199,23 @@ export class SqliteDialect implements SqlDialect {
 
   // The two conversions above that do not need a field to decide: a `Date` is
   // milliseconds and a boolean is 0/1, which is what the ORM writes and
-  // therefore what a raw statement has to compare against. Everything else is
-  // handed to the driver as it arrived — including a plain object, which the
-  // driver rejects, because a value that should have been JSON is a mistake
-  // worth hearing about rather than guessing at.
+  // therefore what a raw statement has to compare against.
+  //
+  // Everything else is handed to the driver as it arrived, **including a plain
+  // object**, and that is a decision rather than an omission. Measured, since
+  // the obvious guesses are both wrong: Bun binds a plain object without
+  // complaint on *both* dialects, and on Postgres it lands correctly in a
+  // `jsonb` column — an object bound into one comes back as the object. So
+  // refusing them here would break the legitimate case to catch the mistaken
+  // one. On SQLite the same value binds to something no row matches, silently;
+  // stringify it yourself if the column is JSON.
+  //
+  // Guessing from the value is the other tempting fix and is worse: the
+  // compiler only JSON-encodes because a field says `Json`, and encoding on
+  // sight would turn a mistyped parameter into a successfully-written string.
+  // (An *array* is the one Bun does reject on SQLite, with
+  // `SQLite query expected 1 values, received 2` — a confusing message for a
+  // real mistake, but a loud one.)
   encodeUntyped(value: unknown): unknown {
     if (value instanceof Date) return value.getTime();
     if (typeof value === "boolean") return value ? 1 : 0;

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -66,6 +66,17 @@ export {
   type OrmScope,
 } from "./context";
 
+// Composable raw SQL. `DB.query` / `DB.execute` run what these build — the
+// place every shape the ORM declines is supposed to land.
+export {
+  empty,
+  join,
+  renderFragment,
+  sql,
+  unsafeSql,
+  type SqlFragment,
+} from "./sql";
+
 export { assertPoliciesRegistered } from "./registration";
 
 export {

--- a/packages/gemi/orm/sql.test.ts
+++ b/packages/gemi/orm/sql.test.ts
@@ -146,6 +146,98 @@ describe("the dialects renumber differently, which is the whole reason for rende
 });
 
 /**
+ * Whether a value is a fragment decides whether it reaches the *statement* or a
+ * *parameter*, so answering it by shape makes that decision available to
+ * anything that can name two properties — and `{"text": …, "binders": []}` is
+ * two lines of JSON.
+ *
+ * These are the cases that were a live SQL injection through the intended call
+ * site with the intended safe value:
+ *
+ *   const body = await request.json()
+ *   DB.query(sql`select "email" from "User" where "email" = ${body.email}`)
+ */
+describe("only fragments this module made are spliced", () => {
+  const forged = { text: `'' or 1=1`, binders: [] };
+
+  test("a forged fragment binds as a value rather than splicing", () => {
+    const { text, values } = render(sql`where "email" = ${forged}`);
+
+    expect(text).toBe(`where "email" = $1`);
+    expect(text).not.toContain("or 1=1");
+    expect(values).toEqual([forged]);
+  });
+
+  test("...including one that would have leaked another column", () => {
+    const attack = {
+      text: `'' union select "password" from "User"`,
+      binders: [],
+    };
+    const { text, values } = render(sql`where "email" = ${attack}`);
+
+    expect(text).toBe(`where "email" = $1`);
+    expect(text).not.toContain("password");
+    expect(values).toEqual([attack]);
+  });
+
+  /**
+   * `join` is the same door and slightly wider: `join(body.filters)` maps over
+   * an array the caller never inspected.
+   */
+  test("join does not splice forged entries either", () => {
+    const { text, values } = render(sql`where ${join([forged], " and ")}`);
+
+    expect(text).toBe(`where $1`);
+    expect(values).toEqual([forged]);
+  });
+
+  test("a forged fragment cannot be executed directly", () => {
+    expect(() => render(forged)).toThrow(/built with 'sql'/);
+  });
+
+  /**
+   * The brand has to survive composition, or the fix would trade an injection
+   * for a mechanism that silently stopped nesting. `concat` and `joinFragments`
+   * return *fresh* objects, which is why the registration is of what comes out
+   * rather than a property on what goes in.
+   */
+  test("every constructor's output is spliceable, including through composition", () => {
+    const nested = sql`"a" = ${1}`;
+    const joined = join([sql`"b" = ${2}`, sql`"c" = ${3}`], " and ");
+    const literal = unsafeSql("true");
+
+    const { text, values } = render(
+      sql`where ${nested} and ${joined} and ${literal} and ${empty}`,
+    );
+
+    expect(text).toBe(`where "a" = $1 and "b" = $2 and "c" = $3 and true and `);
+    expect(values).toEqual([1, 2, 3]);
+  });
+
+  test("a fragment nested two levels deep still splices", () => {
+    const inner = sql`"a" = ${1}`;
+    const middle = sql`(${inner} or "b" = ${2})`;
+    const { text, values } = render(sql`where ${middle}`);
+
+    expect(text).toBe(`where ("a" = $1 or "b" = $2)`);
+    expect(values).toEqual([1, 2]);
+  });
+
+  /**
+   * A structurally-perfect copy of a real fragment — same text, same binders,
+   * cloned rather than forged by hand. Shape cannot tell it from the original;
+   * membership can.
+   */
+  test("a structural clone of a real fragment does not splice", () => {
+    const real = sql`"a" = ${1}`;
+    const clone = { text: real.text, binders: [...real.binders] };
+
+    expect(render(sql`where ${real}`).text).toBe(`where "a" = $1`);
+    expect(render(sql`where ${clone}`).text).toBe(`where $1`);
+  });
+});
+
+/**
  * A fragment's parameters have no declared column type, so there is no `encode`
  * to run — and doing nothing at all would make the escape hatch work on one
  * dialect and throw on the other, which is the one thing "raw" must not mean.

--- a/packages/gemi/orm/sql.test.ts
+++ b/packages/gemi/orm/sql.test.ts
@@ -331,6 +331,78 @@ describe("join", () => {
   test("something that is not an array is refused", () => {
     expect(() => (join as any)("a and b")).toThrow(/Expected an array/);
   });
+
+  /**
+   * The separator goes between the fragments *in the statement*, which makes it
+   * the one other place a string could reach the SQL — and the module's whole
+   * claim is that `unsafeSql` is the door. So it is glue or it is a fragment.
+   */
+  describe("the separator is text, so it is not a free string", () => {
+    test.each([
+      ["the default", undefined, `$1, $2`],
+      ["a comma", ",", `$1,$2`],
+      ["and", " and ", `$1 and $2`],
+      ["or", " or ", `$1 or $2`],
+      ["AND, cased differently", " AND ", `$1 AND $2`],
+      ["a space", " ", `$1 $2`],
+      ["nothing at all", "", `$1$2`],
+      ["a newline and indentation", "\n  ", `$1\n  $2`],
+    ])("%s is glue", (_label, separator, expected) => {
+      const fragment =
+        separator === undefined ? join([1, 2]) : join([1, 2], separator);
+      expect(render(fragment).text).toBe(expected);
+    });
+
+    /**
+     * The reported payload, and the reason this is an allowlist rather than a
+     * blocklist: the second case carries no quote and no comment marker, so
+     * "reject the dangerous characters" would have let it through.
+     */
+    test.each([
+      [`) or 1=1 union select "password" from "User" -- `],
+      [`) or 1=1 union select password from Users where 1=(1`],
+      [`; drop table "User"; --`],
+      [` union all select `],
+    ])("%s is refused", (separator) => {
+      expect(() => join([1, 2], separator)).toThrow(/may only be glue/);
+      expect(() => join([1, 2], separator)).toThrow(/unsafeSql/);
+    });
+
+    test("a fragment separator is accepted, and is the escape hatch", () => {
+      const { text, values } = render(
+        join([sql`"a" = ${1}`, sql`"b" = ${2}`], unsafeSql(") and (")),
+      );
+
+      expect(text).toBe(`"a" = $1) and ("b" = $2`);
+      expect(values).toEqual([1, 2]);
+    });
+
+    test("a fragment separator carries its own parameters, once per gap", () => {
+      const { text, values } = render(join([sql`a`, sql`b`, sql`c`], sql` ${0} `));
+
+      expect(text).toBe(`a $1 b $2 c`);
+      expect(values).toEqual([0, 0]);
+    });
+
+    /**
+     * A forged object is not a fragment, so it does not take the fragment path
+     * — and it is not a string either, so it cannot pretend to be glue.
+     */
+    test("a forged fragment separator is refused rather than spliced", () => {
+      expect(() =>
+        join([1, 2], { text: ` or 1=1 -- `, binders: [] } as any),
+      ).toThrow(/Expected a separator string or a fragment/);
+    });
+
+    test.each([
+      ["a number", 7],
+      ["null", null],
+    ])("%s is refused", (_label, separator) => {
+      expect(() => join([1, 2], separator as any)).toThrow(
+        /Expected a separator string or a fragment/,
+      );
+    });
+  });
 });
 
 describe("empty", () => {

--- a/packages/gemi/orm/sql.test.ts
+++ b/packages/gemi/orm/sql.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, test } from "vitest";
+
+import { PostgresDialect } from "./dialect/postgres";
+import { SqliteDialect } from "./dialect/sqlite";
+import { ParameterLimitError, UnsupportedQueryError } from "./errors";
+import { empty, join, renderFragment, sql, unsafeSql } from "./sql";
+
+/**
+ * Composable SQL fragments.
+ *
+ * The property that matters is not that `sql` produces a string — it is that a
+ * value *never* reaches the text, however deeply the fragments nest and however
+ * many times one is reused. So every case here asserts the emitted text and the
+ * bound values together: a test that checked only the text would pass for an
+ * implementation that interpolated, which is the one failure this exists to
+ * prevent.
+ */
+
+const postgres = new PostgresDialect();
+const sqlite = new SqliteDialect();
+
+const render = (fragment: any, dialect = postgres) =>
+  renderFragment(fragment, dialect);
+
+describe("sql", () => {
+  test("a value becomes a placeholder, not text", () => {
+    const { text, values } = render(sql`select * from "User" where "id" = ${7}`);
+
+    expect(text).toBe(`select * from "User" where "id" = $1`);
+    expect(values).toEqual([7]);
+  });
+
+  test("the value is never in the text, even when it looks like SQL", () => {
+    const injected = `1; drop table "User"; --`;
+    const { text, values } = render(sql`where "name" = ${injected}`);
+
+    expect(text).toBe(`where "name" = $1`);
+    expect(text).not.toContain("drop table");
+    expect(values).toEqual([injected]);
+  });
+
+  test("fragments nest, and the placeholders renumber across them", () => {
+    const a = sql`"a" = ${1}`;
+    const b = sql`"b" = ${2}`;
+    const { text, values } = render(sql`where ${a} and ${b} and "c" = ${3}`);
+
+    expect(text).toBe(`where "a" = $1 and "b" = $2 and "c" = $3`);
+    expect(values).toEqual([1, 2, 3]);
+  });
+
+  test("nesting is not depth-limited", () => {
+    let fragment = sql`${0}`;
+    for (let i = 1; i < 20; i++) fragment = sql`(${fragment} + ${i})`;
+
+    const { values } = render(fragment);
+    expect(values).toHaveLength(20);
+    expect(values[0]).toBe(0);
+    expect(values[19]).toBe(19);
+  });
+
+  /**
+   * The hard case from the issue: one fragment built once and interpolated
+   * twice, in different clauses. Its parameters have to appear at *both*
+   * positions, in the right order — a fragment that cached its own placeholder
+   * numbers would get the second occurrence wrong.
+   */
+  test("a fragment reused twice binds twice, in position", () => {
+    const window = sql`"createdAt" > ${100}`;
+    const { text, values } = render(
+      sql`select array_agg("id") filter (where ${window}) from "Job" where ${window}`,
+    );
+
+    expect(text).toBe(
+      `select array_agg("id") filter (where "createdAt" > $1) from "Job" ` +
+        `where "createdAt" > $2`,
+    );
+    expect(values).toEqual([100, 100]);
+  });
+
+  test("an array binds as one value rather than expanding", () => {
+    const { text, values } = render(sql`where "id" = any(${[1, 2, 3]})`);
+
+    expect(text).toBe(`where "id" = any($1)`);
+    expect(values).toEqual([[1, 2, 3]]);
+  });
+
+  // `undefined` is the one that is not itself on the way out — it binds as
+  // `null`, since a driver has no other reading of it. The rest are values.
+  test.each([
+    ["null", null, null],
+    ["undefined", undefined, null],
+    ["a date", new Date(0), new Date(0)],
+    ["false", false, false],
+    ["zero", 0, 0],
+    ["an empty string", "", ""],
+  ])("%s is a bound value like any other", (_label, value, bound) => {
+    const { text, values } = render(sql`where "x" = ${value}`);
+
+    expect(text).toBe(`where "x" = $1`);
+    expect(values).toEqual([bound]);
+  });
+
+  test("called as a function rather than a tag, it says so", () => {
+    expect(() => (sql as any)(`select 1`)).toThrow(UnsupportedQueryError);
+    expect(() => (sql as any)(`select 1`)).toThrow(/tagged template/);
+    // ...and points at the thing the caller was probably reaching for.
+    expect(() => (sql as any)(`select 1`)).toThrow(/unsafeSql/);
+  });
+});
+
+describe("the dialects renumber differently, which is the whole reason for render", () => {
+  test("postgres numbers, sqlite does not", () => {
+    const fragment = sql`where "a" = ${1} and "b" = ${2}`;
+
+    expect(render(fragment, postgres).text).toBe(`where "a" = $1 and "b" = $2`);
+    expect(render(fragment, sqlite).text).toBe(`where "a" = ? and "b" = ?`);
+  });
+
+  /**
+   * The same fragment object rendered for both dialects, in that order. A
+   * fragment that memoised its rendered text — an obvious optimisation — would
+   * hand the second caller the first one's placeholders, and on SQLite `$1` is
+   * a syntax error rather than a wrong answer, which is at least loud. The
+   * reverse order is not.
+   */
+  test("a fragment can be rendered for both dialects, in either order", () => {
+    const fragment = sql`where "a" = ${1}`;
+
+    expect(render(fragment, sqlite).text).toBe(`where "a" = ?`);
+    expect(render(fragment, postgres).text).toBe(`where "a" = $1`);
+    expect(render(fragment, sqlite).text).toBe(`where "a" = ?`);
+  });
+
+  test("the parameter ceiling applies, and names the dialect", () => {
+    const many = Array.from({ length: 40_000 }, (_, i) => i);
+    expect(() => render(sql`where "id" in (${join(many)})`, sqlite)).toThrow(
+      ParameterLimitError,
+    );
+    // Postgres has the same ceiling shape at a different number; 40 000 clears
+    // SQLite's 32 766 and not Postgres's 65 535, which is why this pair
+    // discriminates rather than just asserting "it throws".
+    expect(() =>
+      render(sql`where "id" in (${join(many)})`, postgres),
+    ).not.toThrow();
+  });
+});
+
+/**
+ * A fragment's parameters have no declared column type, so there is no `encode`
+ * to run — and doing nothing at all would make the escape hatch work on one
+ * dialect and throw on the other, which is the one thing "raw" must not mean.
+ */
+describe("values with no column type behind them", () => {
+  const at = new Date(1_700_000_000_000);
+
+  test("a Date binds as milliseconds on sqlite and as itself on postgres", () => {
+    const fragment = sql`where "createdAt" > ${at}`;
+
+    // Exactly what `SqliteDialect.encode` writes for a DateTime, so a raw
+    // statement compares against ORM-written rows rather than against nothing.
+    expect(render(fragment, sqlite).values).toEqual([at.getTime()]);
+    // Bun's Postgres driver binds a `Date` natively; converting would be wrong.
+    expect(render(fragment, postgres).values).toEqual([at]);
+  });
+
+  test("a boolean is 0/1 on sqlite and a boolean on postgres", () => {
+    const fragment = sql`where "flag" = ${true} or "flag" = ${false}`;
+
+    expect(render(fragment, sqlite).values).toEqual([1, 0]);
+    expect(render(fragment, postgres).values).toEqual([true, false]);
+  });
+
+  test.each([
+    ["a string", "x"],
+    ["a number", 7],
+    ["a bigint", 9007199254740993n],
+    ["null", null],
+  ])("%s is handed to the driver as it arrived", (_label, value) => {
+    expect(render(sql`${value}`, sqlite).values).toEqual([value]);
+    expect(render(sql`${value}`, postgres).values).toEqual([value]);
+  });
+
+  /**
+   * Deliberately *not* converted. The compiler only JSON-encodes because a
+   * field says `Json`; guessing from the value would turn a mistyped parameter
+   * into a successfully-written string, which is worse than the driver
+   * rejecting it.
+   */
+  test("a plain object is not JSON-encoded on the caller's behalf", () => {
+    const payload = { a: 1 };
+
+    expect(render(sql`${payload}`, sqlite).values).toEqual([payload]);
+    expect(render(sql`${payload}`, postgres).values).toEqual([payload]);
+  });
+
+  test("undefined becomes null rather than reaching the driver", () => {
+    expect(render(sql`${undefined}`, sqlite).values).toEqual([null]);
+    expect(render(sql`${undefined}`, postgres).values).toEqual([null]);
+  });
+});
+
+describe("join", () => {
+  test("fragments joined by a separator", () => {
+    const filters = [sql`"a" = ${1}`, sql`"b" = ${2}`, sql`"c" = ${3}`];
+    const { text, values } = render(sql`where ${join(filters, " and ")}`);
+
+    expect(text).toBe(`where "a" = $1 and "b" = $2 and "c" = $3`);
+    expect(values).toEqual([1, 2, 3]);
+  });
+
+  test("plain values are bound, one placeholder each", () => {
+    const { text, values } = render(sql`where "id" in (${join([1, 2, 3])})`);
+
+    expect(text).toBe(`where "id" in ($1, $2, $3)`);
+    expect(values).toEqual([1, 2, 3]);
+  });
+
+  test("the default separator is a comma", () => {
+    expect(render(sql`${join([sql`a`, sql`b`])}`).text).toBe(`a, b`);
+  });
+
+  /**
+   * The case the caller forgets. `join([])` has to be `empty` rather than a
+   * separator or a throw, or a conditional filter list that turned out to be
+   * empty emits `where ` and fails at the database instead of composing.
+   */
+  test("an empty list is empty, not a dangling separator", () => {
+    expect(render(join([])).text).toBe("");
+    expect(render(join([], " and ")).text).toBe("");
+  });
+
+  test("a mixed list of fragments and values works", () => {
+    const { text, values } = render(join([sql`"a" = ${1}`, 2], " and "));
+
+    expect(text).toBe(`"a" = $1 and $2`);
+    expect(values).toEqual([1, 2]);
+  });
+
+  test("something that is not an array is refused", () => {
+    expect(() => (join as any)("a and b")).toThrow(/Expected an array/);
+  });
+});
+
+describe("empty", () => {
+  test("contributes nothing and binds nothing", () => {
+    const { text, values } = render(sql`select 1 ${empty}`);
+
+    expect(text).toBe(`select 1 `);
+    expect(values).toEqual([]);
+  });
+
+  /**
+   * The shape the whole thing is for: a conditional predicate is a *value*, so
+   * both branches are the same expression rather than two statements.
+   */
+  test("a conditional predicate is one expression either way", () => {
+    const build = (q?: string) =>
+      sql`select * from "Product" ${q ? sql`where "name" = ${q}` : empty}`;
+
+    expect(render(build("axle")).values).toEqual(["axle"]);
+    expect(render(build()).values).toEqual([]);
+    expect(render(build()).text).toBe(`select * from "Product" `);
+  });
+
+  test("it is frozen, since every caller shares the one object", () => {
+    expect(Object.isFrozen(empty)).toBe(true);
+    // And composing with it does not mutate it, which is the failure freezing
+    // is there to make loud rather than the reason it matters.
+    render(sql`${empty} ${empty}`);
+    expect(empty.text).toBe("");
+    expect(empty.binders).toHaveLength(0);
+  });
+});
+
+describe("unsafeSql", () => {
+  test("text lands in the statement, with no parameter around it", () => {
+    const { text, values } = render(
+      sql`where "name" is distinct from ${unsafeSql(`'reaper'`)}`,
+    );
+
+    expect(text).toBe(`where "name" is distinct from 'reaper'`);
+    expect(values).toEqual([]);
+  });
+
+  test("it composes like any other fragment", () => {
+    const direction = unsafeSql("desc");
+    const { text, values } = render(
+      sql`select * from "Job" where "id" > ${1} order by "createdAt" ${direction}`,
+    );
+
+    expect(text).toBe(
+      `select * from "Job" where "id" > $1 order by "createdAt" desc`,
+    );
+    expect(values).toEqual([1]);
+  });
+
+  /**
+   * It is a plain call, never a tag. As a tagged template it would take
+   * `${value}` interpolations and put them straight into the SQL text, which is
+   * precisely the one thing it must not offer — and the mistake is invisible at
+   * the call site, since both spellings read the same.
+   */
+  test("used as a tagged template, it refuses", () => {
+    expect(() => (unsafeSql as any)`select ${1}`).toThrow(
+      UnsupportedQueryError,
+    );
+    expect(() => (unsafeSql as any)`select ${1}`).toThrow(/not a tagged template/);
+  });
+
+  test.each([
+    ["a number", 1],
+    ["an object", {}],
+    ["null", null],
+    ["undefined", undefined],
+  ])("%s is refused", (_label, value) => {
+    expect(() => (unsafeSql as any)(value)).toThrow(/Expected a string literal/);
+  });
+});
+
+describe("renderFragment", () => {
+  /**
+   * A plain string is refused rather than accepted as "obviously safe SQL".
+   * Accepting one would make an interpolated template literal the path of least
+   * resistance into `DB.query`, and that path is the injection every other rule
+   * in the compiler exists to keep closed.
+   */
+  test.each([
+    ["a string", `select 1`],
+    ["a number", 1],
+    ["null", null],
+    ["undefined", undefined],
+    ["a plain object", { text: 1 }],
+  ])("%s is not a fragment", (_label, value) => {
+    expect(() => render(value)).toThrow(UnsupportedQueryError);
+    expect(() => render(value)).toThrow(/built with 'sql'/);
+  });
+
+  test("the operation name reaches the error", () => {
+    expect(() => renderFragment("nope" as any, postgres, "execute")).toThrow(
+      /DB\.execute/,
+    );
+  });
+});

--- a/packages/gemi/orm/sql.ts
+++ b/packages/gemi/orm/sql.ts
@@ -1,0 +1,276 @@
+import type { SqlDialect } from "./dialect";
+import { UnsupportedQueryError } from "./errors";
+import {
+  type Fragment,
+  bindValues,
+  concat,
+  joinFragments,
+  param,
+  render,
+  sql as text,
+} from "./compile/fragment";
+
+/**
+ * SQL fragments as first-class values: `sql`, `join`, `empty`, and one door out.
+ *
+ * The ORM deliberately does not implement every SQL shape — `distinct`, cursor
+ * pagination, `groupBy`, window functions, recursive CTEs. That is the right
+ * call, but it is only half a decision: the shapes it declines have to have
+ * somewhere to go, and "drop to raw SQL" is not an answer if raw SQL cannot be
+ * *composed*.
+ *
+ * `DB.sql` — Bun's tagged template — covers a single self-contained statement,
+ * and that is genuinely all it covers. The shape it cannot express is the common
+ * one: a predicate list built conditionally, passed around as a value, and
+ * interpolated into a larger statement.
+ *
+ * ```ts
+ * const filters = []
+ * if (q) filters.push(sql`name ilike ${`%${q}%`}`)
+ * if (organizationId) filters.push(sql`"organizationId" = ${organizationId}`)
+ *
+ * const where = filters.length ? sql`where ${join(filters, " and ")}` : empty
+ * const rows = await DB.query(sql`select * from "Product" ${where} limit ${20}`)
+ * ```
+ *
+ * ## This is the compiler's own `Fragment`, made public
+ *
+ * Not a parallel mechanism. `compile/fragment.ts` has held exactly this shape
+ * since iteration 1 — text plus positional binders, composable, never
+ * concatenating a value into the text — because that is what invariant 2 needs
+ * internally. Reusing it means a public fragment binds by the same rule the
+ * compiler's own SQL does, and it means the parameter ceiling, the placeholder
+ * numbering and the dialect split are all already handled rather than
+ * reimplemented one door down.
+ *
+ * **Placeholders are assigned at assembly, not at authoring.** SQLite writes
+ * `?` and Postgres writes `$1`, `$2`, and a fragment does not know where in the
+ * final statement it will land — so `sql` records a *position* and `render`
+ * turns it into a placeholder once the whole statement exists. That is what lets
+ * the same fragment be nested, reused twice in one statement, or built before
+ * the dialect is even known.
+ */
+
+/**
+ * A composable piece of SQL. Its values are bound parameters, never text.
+ *
+ * Opaque on purpose: an application builds one with `sql`, combines it with
+ * `join`, and hands it to `DB.query` / `DB.execute`. Reading `.text` off it is
+ * not part of the contract — it holds parameter *markers* rather than the
+ * dialect's placeholders, so it is not the statement that runs.
+ */
+export type SqlFragment = Fragment;
+
+/**
+ * A SQL fragment. Every `${value}` is bound as a parameter; a `${fragment}` is
+ * spliced in, carrying its own parameters with it.
+ *
+ * ```ts
+ * sql`where "id" = ${id}`                       // "id" = $1, with id bound
+ * sql`where ${sql`"a" = ${1}`} and ${sql`"b" = ${2}`}`   // nests to any depth
+ * ```
+ *
+ * An interpolated **array** is bound as one value, not expanded — that is what
+ * Postgres's `= any($1)` wants, and it is the only reading that does not depend
+ * on the dialect. For a comma-separated list of placeholders, say so with
+ * `join`.
+ */
+export function sql(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): SqlFragment {
+  // A defensive check rather than a type error, because the interesting misuse
+  // is `sql(userInput)` — a plain call with a string, which would otherwise
+  // reach `strings.raw` as `undefined` and produce a fragment of `undefined`
+  // text rather than an error. It is also the shape somebody reaches for when
+  // they want the escape hatch and have not found `unsafeSql`.
+  if (!Array.isArray(strings) || !("raw" in (strings as object))) {
+    throw new UnsupportedQueryError(
+      "sql",
+      "DB",
+      "sql",
+      `'sql' is a tagged template — write sql\`select 1\`, not sql("select 1"). ` +
+        `To put text that is not a value into a statement, use 'unsafeSql', ` +
+        `and read what it says first.`,
+    );
+  }
+
+  const parts: Fragment[] = [];
+
+  for (let i = 0; i < strings.length; i++) {
+    parts.push(text(strings[i]));
+    if (i < values.length) parts.push(interpolate(values[i]));
+  }
+
+  return concat(...parts);
+}
+
+/**
+ * Fragments — or values — joined by a separator, the way `Array.join` reads.
+ *
+ * ```ts
+ * join(filters, " and ")            // a and b and c
+ * join([sql`"a" asc`, sql`"b" desc`])   // "a" asc, "b" desc
+ * join(ids)                         // $1, $2, $3 — each bound
+ * ```
+ *
+ * An **empty list produces `empty`**, not a separator and not a syntax error, so
+ * `join` composes with a list that turned out to have nothing in it. That is the
+ * case a caller forgets, and it is the one that would otherwise emit `where ` and
+ * fail at the database rather than here.
+ */
+export function join(
+  values: readonly unknown[],
+  separator = ", ",
+): SqlFragment {
+  if (!Array.isArray(values)) {
+    throw new UnsupportedQueryError(
+      "join",
+      "DB",
+      "sql",
+      `Expected an array of fragments or values, got ${typeof values}.`,
+    );
+  }
+  if (values.length === 0) return empty;
+
+  return joinFragments(values.map(interpolate), separator);
+}
+
+/**
+ * The fragment that contributes nothing.
+ *
+ * The point of it is that `where ${empty}` and `where ${filter}` are the same
+ * expression — a conditional predicate is a value, not a branch around the
+ * statement. Frozen, because it is shared by every caller and a fragment is read
+ * as immutable everywhere else.
+ */
+export const empty: SqlFragment = Object.freeze({
+  text: "",
+  binders: Object.freeze([]) as [],
+});
+
+/**
+ * **Text straight into the SQL, with no parameter around it.** The one door in
+ * this ORM through which a value reaches the statement text.
+ *
+ * Everything else in the compiler exists to make this impossible — identifiers
+ * come from the generated schema, values are bound — so reaching for it should
+ * feel like reaching for it. **Never give it a value that came from a request, a
+ * form, a URL, a header, a queue payload or a database row.** There is no
+ * escaping here and there will not be: escaping that is "usually right" is worse
+ * than none, because it survives review.
+ *
+ * ## Why it exists at all, since that is the fair question
+ *
+ * Plan quality can depend on *not* parameterising. A partial index declared as
+ *
+ * ```sql
+ * create index … on "Job" (…) where "name" is distinct from 'reaper'
+ * ```
+ *
+ * is only usable if the planner can prove the query's predicate matches the
+ * index's. A bound parameter is opaque at plan time, so `where "name" is
+ * distinct from $1` does not match — and the query falls back to a sequential
+ * scan over the whole table. The constant has to be *in the text*:
+ *
+ * ```ts
+ * const REAPER = unsafeSql(`'reaper'`)   // a literal in this file, never input
+ * await DB.query(sql`
+ *   select … from "Job" where "name" is distinct from ${REAPER} …
+ * `)
+ * ```
+ *
+ * A builder with no escape hatch cannot express that at any price, and the
+ * workaround — hand-writing the whole statement — loses composition for every
+ * other part of it.
+ *
+ * The same applies to the other things that cannot be parameters in SQL:
+ * identifiers, a sort direction, a table name chosen from a fixed set in code.
+ * All of them share the rule above — the value is written in the source file, or
+ * chosen from a set written in the source file, never passed in.
+ */
+export function unsafeSql(literal: string): SqlFragment {
+  if (typeof literal !== "string") {
+    throw new UnsupportedQueryError(
+      "unsafeSql",
+      "DB",
+      "sql",
+      `Expected a string literal, got ${
+        Array.isArray(literal) ? "an array" : typeof literal
+      }. 'unsafeSql' is a plain call, not a tagged template — a template would ` +
+        `interpolate values into the SQL text, which is the one thing it must ` +
+        `never do.`,
+    );
+  }
+  return text(literal);
+}
+
+/**
+ * A fragment as the statement a driver can run: the dialect's placeholders in
+ * the text, and the values in the order they appear.
+ *
+ * Separate from the executing, and exported, because it is the half that is a
+ * pure function of `(fragment, dialect)` — so a test can assert what a
+ * composition emits on both dialects without a database anywhere near it, which
+ * is exactly how the rest of the compiler is tested.
+ *
+ * `render` also applies the parameter ceiling here, which matters more for a
+ * hand-built fragment than for a compiled plan: `join(ids)` over a
+ * request-derived list is one placeholder per element on SQLite, and 40 000 of
+ * them is a driver error rather than a clear one.
+ */
+export function renderFragment(
+  fragment: SqlFragment,
+  dialect: SqlDialect,
+  operation = "query",
+): { text: string; values: unknown[] } {
+  if (!isFragment(fragment)) {
+    throw new UnsupportedQueryError(
+      operation,
+      "DB",
+      operation,
+      `Expected a fragment built with 'sql', got ${
+        fragment === null ? "null" : typeof fragment
+      }. A plain string is not accepted here on purpose — it would be the one ` +
+        `path into the SQL text that nobody had to think about.`,
+    );
+  }
+
+  const rendered = render(fragment, dialect, { model: "DB", operation });
+  return {
+    text: rendered.text,
+    // `encodeUntyped` and not `encode`: there is no field here to ask, which is
+    // the whole difference between a fragment's parameters and a compiled
+    // plan's. It normalises the two JavaScript types whose SQL form the ORM has
+    // already decided — a `Date` and a boolean — so a raw statement compares
+    // against ORM-written rows on both dialects rather than only on Postgres.
+    values: bindValues(rendered.binders)(undefined).map((value) =>
+      value === null || value === undefined
+        ? (value ?? null)
+        : dialect.encodeUntyped(value),
+    ),
+  };
+}
+
+/** Whether a value is a fragment, so it splices rather than binds. */
+function isFragment(value: unknown): value is Fragment {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Fragment).text === "string" &&
+    Array.isArray((value as Fragment).binders)
+  );
+}
+
+/**
+ * One interpolated slot: a fragment splices, anything else binds.
+ *
+ * The binder ignores both its arguments. A compiled plan's binders read the
+ * *call's* argument tree, because one plan serves many calls; a fragment is
+ * built per call and closes over the value it was given, which is the whole
+ * difference between the compiler's fragments and these.
+ */
+function interpolate(value: unknown): Fragment {
+  if (isFragment(value)) return value;
+  return param(() => value);
+}

--- a/packages/gemi/orm/sql.ts
+++ b/packages/gemi/orm/sql.ts
@@ -161,10 +161,33 @@ export function sql(
  * `join` composes with a list that turned out to have nothing in it. That is the
  * case a caller forgets, and it is the one that would otherwise emit `where ` and
  * fail at the database rather than here.
+ *
+ * ## The separator is text, so it is not a free string
+ *
+ * It goes between the fragments *in the statement*, which makes it the one other
+ * place a string could reach the SQL — and this module's whole claim is that
+ * `unsafeSql` is **the** door. So a plain-string separator has to be glue and
+ * nothing else: whitespace, commas, or a boolean connective. Anything more
+ * expressive is legitimate and has to say so:
+ *
+ * ```ts
+ * join(filters, " and ")                 // fine
+ * join(parts, unsafeSql(") and ("))      // fine, and visibly a decision
+ * join(ids, request.query.sep)           // refused
+ * ```
+ *
+ * A **blocklist would not do**, which is why this is an allowlist. The obvious
+ * one — reject quotes, semicolons and comment markers — lets this through:
+ *
+ *     join([1, 2], ") or 1=1 union select password from Users where 1=(1")
+ *
+ * No quote, no `--`, still an injection. There is no sound way to say "this
+ * arbitrary text is safe glue", so the rule is that glue is a small closed set
+ * and everything else is a fragment somebody built on purpose.
  */
 export function join(
   values: readonly unknown[],
-  separator = ", ",
+  separator: string | SqlFragment = ", ",
 ): SqlFragment {
   if (!Array.isArray(values)) {
     throw new UnsupportedQueryError(
@@ -176,7 +199,48 @@ export function join(
   }
   if (values.length === 0) return empty;
 
-  return brand(joinFragments(values.map(interpolate), separator));
+  const parts = values.map(interpolate);
+
+  if (isFragment(separator)) {
+    const woven: Fragment[] = [];
+    for (let i = 0; i < parts.length; i++) {
+      if (i > 0) woven.push(separator);
+      woven.push(parts[i]);
+    }
+    return brand(concat(...woven));
+  }
+
+  assertGlue(separator);
+  return brand(joinFragments(parts, separator));
+}
+
+/**
+ * Whitespace and commas, or a boolean connective surrounded by whitespace.
+ *
+ * Deliberately small. Every separator a composed statement actually needs is in
+ * here — `", "`, `" and "`, `" or "`, `" "` — and everything outside it is
+ * expressive enough to change what the statement *does*, which is the property
+ * that makes it a `unsafeSql` decision rather than a string argument.
+ */
+const GLUE = /^[\s,]*$|^\s*(?:and|or)\s*$/i;
+
+function assertGlue(separator: unknown): void {
+  if (typeof separator === "string" && GLUE.test(separator)) return;
+
+  throw new UnsupportedQueryError(
+    "join",
+    "DB",
+    "sql",
+    typeof separator === "string"
+      ? `A separator is written into the SQL text, so it may only be glue: ` +
+        `whitespace, commas, or 'and' / 'or'. Got ` +
+        `${JSON.stringify(separator)}. If that is deliberate, say so with ` +
+        `unsafeSql(...) — and never build one from anything that came from ` +
+        `outside the program.`
+      : `Expected a separator string or a fragment, got ${
+          separator === null ? "null" : typeof separator
+        }.`,
+  );
 }
 
 /**

--- a/packages/gemi/orm/sql.ts
+++ b/packages/gemi/orm/sql.ts
@@ -62,6 +62,49 @@ import {
 export type SqlFragment = Fragment;
 
 /**
+ * Every fragment this module has produced.
+ *
+ * **Identity, not shape, and the difference is a SQL injection.** `interpolate`
+ * splices a fragment as text and binds everything else, so "is this a fragment"
+ * decides whether a value reaches the statement or a parameter. Asking the
+ * *shape* — a `text` string and a `binders` array — makes that decision
+ * answerable by anything that can name two properties, and `{"text": "…",
+ * "binders": []}` is two lines of JSON:
+ *
+ * ```ts
+ * const body = await request.json()
+ * await DB.query(sql`select "email" from "User" where "email" = ${body.email}`)
+ * // body.email = { text: `'' union select "password" from "User"`, binders: [] }
+ * // -> select "email" from "User" where "email" = '' union select "password" from "User"
+ * ```
+ *
+ * That is the intended call site with the intended safe value, and it returned
+ * the password column out of a statement selecting only `email`. The internal
+ * `Fragment` never had the problem because nothing outside `compile/` could
+ * construct one; making the type public is what turned "text plus binders" from
+ * an implementation detail into a shape an attacker can name. `unsafeSql` is
+ * built so that reaching for the escape hatch is a decision — a structural check
+ * is a second, unmarked door beside it.
+ *
+ * A `WeakSet` the module owns cannot be forged: membership is granted only by
+ * the constructors below. It registers the *returned* object rather than
+ * stamping a property, because `concat` and `joinFragments` return fresh objects
+ * — a marker property on the inputs would not survive them, and the version that
+ * cannot drift is the one that brands what actually comes out.
+ */
+const FRAGMENTS = new WeakSet<object>();
+
+function brand(fragment: Fragment): SqlFragment {
+  FRAGMENTS.add(fragment);
+  return fragment;
+}
+
+/** Whether a value is a fragment *this module made*, so it splices rather than binds. */
+function isFragment(value: unknown): value is Fragment {
+  return typeof value === "object" && value !== null && FRAGMENTS.has(value);
+}
+
+/**
  * A SQL fragment. Every `${value}` is bound as a parameter; a `${fragment}` is
  * spliced in, carrying its own parameters with it.
  *
@@ -102,7 +145,7 @@ export function sql(
     if (i < values.length) parts.push(interpolate(values[i]));
   }
 
-  return concat(...parts);
+  return brand(concat(...parts));
 }
 
 /**
@@ -133,7 +176,7 @@ export function join(
   }
   if (values.length === 0) return empty;
 
-  return joinFragments(values.map(interpolate), separator);
+  return brand(joinFragments(values.map(interpolate), separator));
 }
 
 /**
@@ -144,10 +187,9 @@ export function join(
  * statement. Frozen, because it is shared by every caller and a fragment is read
  * as immutable everywhere else.
  */
-export const empty: SqlFragment = Object.freeze({
-  text: "",
-  binders: Object.freeze([]) as [],
-});
+export const empty: SqlFragment = brand(
+  Object.freeze({ text: "", binders: Object.freeze([]) as [] }),
+);
 
 /**
  * **Text straight into the SQL, with no parameter around it.** The one door in
@@ -202,7 +244,7 @@ export function unsafeSql(literal: string): SqlFragment {
         `never do.`,
     );
   }
-  return text(literal);
+  return brand(text(literal));
 }
 
 /**
@@ -250,16 +292,6 @@ export function renderFragment(
         : dialect.encodeUntyped(value),
     ),
   };
-}
-
-/** Whether a value is a fragment, so it splices rather than binds. */
-function isFragment(value: unknown): value is Fragment {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as Fragment).text === "string" &&
-    Array.isArray((value as Fragment).binders)
-  );
 }
 
 /**

--- a/templates/saas-starter/app/models/raw-sql.test.ts
+++ b/templates/saas-starter/app/models/raw-sql.test.ts
@@ -124,6 +124,60 @@ function suite(label: string, url?: string) {
       ]);
     });
 
+    /**
+     * A parsed request body reaching an interpolation slot, which is the
+     * intended call site with the intended safe value:
+     *
+     *   const body = await request.json()
+     *   DB.query(sql`select "email" from "User" where "email" = ${body.email}`)
+     *
+     * When "is this a fragment" was answered by *shape*, `{"text": …,
+     * "binders": []}` in that body was spliced into the statement as text.
+     * These run the forged bodies through the public facade against a real
+     * database, because the assertion that matters is not what the compiler
+     * emits — it is what comes back.
+     */
+    test("a forged fragment in a request body cannot splice into the statement", async () => {
+      const search = (email: unknown) =>
+        DB.query<{ email: string }>(
+          sql`select "email" from "User" where "email" = ${email}`,
+        );
+
+      expect(await search("ada@x.test")).toHaveLength(1);
+
+      // `'' or 1=1` would have returned every row.
+      expect(await search({ text: `'' or 1=1`, binders: [] })).toHaveLength(0);
+
+      // ...and this one returned the password column out of a statement that
+      // selects only `email`.
+      const leak = await search({
+        text: `'' union select "password" from "User"`,
+        binders: [],
+      });
+      expect(leak).toHaveLength(0);
+
+      // A structural clone of a real fragment is the same attack without the
+      // hand-written text: shape cannot tell it apart, membership can.
+      const real = sql`x`;
+      expect(
+        await search({ text: real.text, binders: [...real.binders] }),
+      ).toHaveLength(0);
+
+      // The table is intact and the honest query still works, so the guard is
+      // not simply refusing everything.
+      expect(await emails()).toHaveLength(3);
+    });
+
+    test("a forged fragment inside join binds too", async () => {
+      const rows = await DB.query(
+        sql`select "email" from "User" where "email" in (${join([
+          { text: `'' or 1=1`, binders: [] },
+        ])})`,
+      );
+
+      expect(rows).toHaveLength(0);
+    });
+
     test("a value that looks like SQL is data, not SQL", async () => {
       const injected = `x' or 1=1; drop table "User"; --`;
       const rows = await DB.query(

--- a/templates/saas-starter/app/models/raw-sql.test.ts
+++ b/templates/saas-starter/app/models/raw-sql.test.ts
@@ -1,0 +1,336 @@
+import { SQL } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join as joinPath } from "node:path";
+
+import { DB } from "gemi/facades";
+import { DatabaseManager } from "gemi/database";
+import { Application } from "gemi/foundation";
+import { Model, clearPlanCache, empty, join, sql, unsafeSql } from "gemi/orm";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+
+import { POSTGRES_URL, applyMigrations } from "./differential";
+import { User } from "./User";
+
+/**
+ * Composed raw SQL against a real database.
+ *
+ * `sql.test.ts` in the framework covers what a fragment *emits*, with no
+ * database anywhere near it. What it cannot cover is the half that only a
+ * driver can answer, and that half is where the surprises live:
+ *
+ * - **The rowcount.** Bun reports it on `count` and leaves `affectedRows` null,
+ *   on both dialects. That is measured behaviour rather than documented
+ *   behaviour, so it belongs in a test that would notice it changing.
+ * - **The ambient transaction.** A raw statement that quietly runs on a pooled
+ *   connection while `Model.transaction` holds a reserved one commits while its
+ *   neighbours roll back — the worst outcome available here, and invisible in
+ *   any test that does not deliberately roll back.
+ *
+ * Both dialects, because the two agree about neither for free.
+ */
+
+function suite(label: string, url?: string) {
+  describe(label, () => {
+    let workspace: string | undefined;
+    let database: DatabaseManager;
+    let raw: SQL;
+    let previous: Application | undefined;
+
+    beforeAll(async () => {
+      let target = url;
+      if (!target) {
+        workspace = mkdtempSync(joinPath(tmpdir(), "gemi-orm-raw-"));
+        const path = joinPath(workspace, "raw.db");
+        await applyMigrations(path);
+        target = `sqlite://${path}`;
+      }
+
+      database = new DatabaseManager({ url: target });
+      raw = new SQL(target);
+
+      previous = Application.getInstance();
+      const application = new Application();
+      application.instance(DatabaseManager, database as never);
+      Application.setInstance(application);
+    }, 120_000);
+
+    afterAll(async () => {
+      await raw?.close();
+      await database?.close();
+      if (previous) Application.setInstance(previous);
+      if (workspace) rmSync(workspace, { recursive: true, force: true });
+    });
+
+    // Children before parents, and every table rather than the ones this suite
+    // writes to: on Postgres the whole run shares one database, so a row another
+    // suite left behind fails a delete here that never touched it.
+    const TABLES = [
+      "SocialAccount",
+      "Session",
+      "PasswordResetToken",
+      "MagicLinkToken",
+      "Account",
+      "User",
+      "OrganizationInvitation",
+      "Organization",
+    ];
+
+    beforeEach(async () => {
+      clearPlanCache();
+
+      if (url) {
+        await raw.unsafe(
+          `TRUNCATE ${TABLES.map((table) => `"${table}"`).join(", ")} ` +
+            `RESTART IDENTITY CASCADE`,
+        );
+      } else {
+        for (const table of TABLES) {
+          await raw.unsafe(`DELETE FROM "${table}"`);
+        }
+      }
+
+      await Model.asSystem(async () => {
+        await User.create({ data: { email: "ada@x.test", globalRole: 0 } });
+        await User.create({ data: { email: "grace@x.test", globalRole: 1 } });
+        await User.create({ data: { email: "hopper@x.test", globalRole: 1 } });
+      });
+    });
+
+    async function emails(): Promise<string[]> {
+      const rows: any = await raw.unsafe(
+        `SELECT "email" FROM "User" ORDER BY "id"`,
+      );
+      return [...rows].map((row: any) => row.email);
+    }
+
+    // --- reading ----------------------------------------------------------
+
+    test("query returns rows, with the value bound", async () => {
+      const rows = await DB.query<{ email: string }>(
+        sql`select "email" from "User" where "globalRole" = ${1} order by "id"`,
+      );
+
+      expect(rows.map((row) => row.email)).toEqual([
+        "grace@x.test",
+        "hopper@x.test",
+      ]);
+    });
+
+    test("a value that looks like SQL is data, not SQL", async () => {
+      const injected = `x' or 1=1; drop table "User"; --`;
+      const rows = await DB.query(
+        sql`select "email" from "User" where "email" = ${injected}`,
+      );
+
+      expect(rows).toHaveLength(0);
+      // The table is still there, which is the assertion that would have
+      // caught an implementation that concatenated.
+      expect(await emails()).toHaveLength(3);
+    });
+
+    /**
+     * The shape the whole mechanism is for: predicates built conditionally, as
+     * values, and composed into one statement.
+     */
+    test("a conditional filter list composes", async () => {
+      const search = async (q?: string, role?: number) => {
+        const filters = [];
+        if (q) filters.push(sql`"email" like ${`%${q}%`}`);
+        if (role !== undefined) filters.push(sql`"globalRole" = ${role}`);
+
+        const where = filters.length
+          ? sql`where ${join(filters, " and ")}`
+          : empty;
+
+        const rows = await DB.query<{ email: string }>(
+          sql`select "email" from "User" ${where} order by "id"`,
+        );
+        return rows.map((row) => row.email);
+      };
+
+      expect(await search()).toHaveLength(3);
+      expect(await search("ada")).toEqual(["ada@x.test"]);
+      expect(await search(undefined, 1)).toEqual([
+        "grace@x.test",
+        "hopper@x.test",
+      ]);
+      expect(await search("hopper", 1)).toEqual(["hopper@x.test"]);
+      expect(await search("hopper", 0)).toEqual([]);
+    });
+
+    test("join over a list of values becomes an in-list", async () => {
+      const rows = await DB.query<{ email: string }>(
+        sql`select "email" from "User"
+            where "email" in (${join(["ada@x.test", "hopper@x.test"])})
+            order by "id"`,
+      );
+
+      expect(rows.map((row) => row.email)).toEqual([
+        "ada@x.test",
+        "hopper@x.test",
+      ]);
+    });
+
+    test("unsafeSql puts text in the statement, and it runs", async () => {
+      const direction = unsafeSql("desc");
+      const rows = await DB.query<{ email: string }>(
+        sql`select "email" from "User" where "globalRole" >= ${0}
+            order by "id" ${direction}`,
+      );
+
+      expect(rows[0].email).toBe("hopper@x.test");
+    });
+
+    // --- writing ----------------------------------------------------------
+
+    test("execute returns the number of rows a write touched", async () => {
+      expect(
+        await DB.execute(
+          sql`update "User" set "locale" = ${"tr-TR"} where "globalRole" = ${1}`,
+        ),
+      ).toBe(2);
+
+      expect(
+        await DB.execute(
+          sql`update "User" set "locale" = ${"tr-TR"} where "globalRole" = ${9}`,
+        ),
+      ).toBe(0);
+
+      expect(
+        await DB.execute(sql`delete from "User" where "email" = ${"ada@x.test"}`),
+      ).toBe(1);
+
+      expect(await emails()).toEqual(["grace@x.test", "hopper@x.test"]);
+    });
+
+    /**
+     * The reason the rowcount is not a diagnostic. `UPDATE … WHERE status =
+     * 'reserved'` returning 1 means this caller won the race and 0 means it
+     * lost; an API that discarded the number could not express it at all.
+     */
+    test("the rowcount is usable as a compare-and-swap", async () => {
+      const claim = () =>
+        DB.execute(
+          sql`update "User" set "verificationToken" = ${"claimed"}
+              where "email" = ${"ada@x.test"} and "verificationToken" is null`,
+        );
+
+      expect(await claim()).toBe(1);
+      // The second caller loses, because the row no longer matches.
+      expect(await claim()).toBe(0);
+    });
+
+    test("execute on an insert counts the row it wrote", async () => {
+      expect(
+        await DB.execute(
+          sql`insert into "User" ("publicId", "email", "globalRole",
+                                  "createdAt", "updatedAt")
+              values (${"raw-1"}, ${"raw@x.test"}, ${2},
+                      ${new Date()}, ${new Date()})`,
+        ),
+      ).toBe(1);
+
+      expect(await emails()).toHaveLength(4);
+    });
+
+    // --- the ambient transaction -----------------------------------------
+
+    /**
+     * The failure this guards is silent in every other test: a raw statement
+     * that runs on a pooled connection commits while the transaction around it
+     * rolls back, so the callback throws, the ORM's writes vanish, and the raw
+     * one stays.
+     */
+    test("a raw write inside a transaction rolls back with it", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await DB.execute(sql`delete from "User" where "globalRole" = ${1}`);
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+
+      expect(await emails()).toHaveLength(3);
+    });
+
+    test("...and commits with it", async () => {
+      await Model.transaction(async () => {
+        await DB.execute(sql`delete from "User" where "globalRole" = ${1}`);
+      });
+
+      expect(await emails()).toEqual(["ada@x.test"]);
+    });
+
+    /**
+     * The other direction, and the one that proves it is the *same* connection
+     * rather than merely a second one that also committed: a raw read sees a
+     * write the transaction has not committed yet. Nothing outside the
+     * transaction can see it, so a `DB.query` on the pool would return two rows
+     * here rather than three.
+     */
+    test("a raw read inside a transaction sees the transaction's own writes", async () => {
+      await Model.asSystem(() =>
+        Model.transaction(async () => {
+          await User.create({ data: { email: "inside@x.test" } });
+
+          const rows = await DB.query(
+            sql`select "email" from "User" where "email" = ${"inside@x.test"}`,
+          );
+          expect(rows).toHaveLength(1);
+        }),
+      );
+
+      expect(await emails()).toHaveLength(4);
+    });
+
+    test("a raw write inside a savepoint rolls back to it, leaving the outer alive", async () => {
+      await Model.transaction(async () => {
+        await expect(
+          Model.transaction(async () => {
+            await DB.execute(sql`delete from "User"`);
+            throw new Error("inner");
+          }),
+        ).rejects.toThrow("inner");
+
+        // The outer transaction is still usable, and the delete is gone.
+        const rows = await DB.query(sql`select "id" from "User"`);
+        expect(rows).toHaveLength(3);
+      });
+
+      expect(await emails()).toHaveLength(3);
+    });
+
+    // --- what did not change ---------------------------------------------
+
+    test("DB.sql is untouched, and still Bun's own tagged template", async () => {
+      const rows: any = await DB.sql`select "email" from "User" where "globalRole" = ${0}`;
+
+      expect([...rows]).toHaveLength(1);
+    });
+
+    test("a plain string is refused rather than run", async () => {
+      await expect(
+        DB.query(`select * from "User"` as never),
+      ).rejects.toThrow(/built with 'sql'/);
+    });
+  });
+}
+
+suite("raw sql (sqlite)", undefined);
+
+if (POSTGRES_URL) {
+  suite("raw sql (postgres)", POSTGRES_URL);
+} else {
+  describe("raw sql (postgres)", () => {
+    // Loud rather than silent: the rowcount and the savepoint behaviour are
+    // exactly the two things a SQLite pass proves nothing about.
+    test.skip("set TEST_POSTGRES_URL to run these against Postgres", () => {});
+  });
+}


### PR DESCRIPTION
Closes #63.

The ORM declines plenty of SQL shapes on purpose, and every one of them has *"drop to raw SQL"* as its stated workaround — `distinct` and cursor pagination (#68), `groupBy` (#64), window functions, recursive CTEs. That workaround had nowhere to land. `DB.sql` runs one self-contained statement; it cannot express a predicate built conditionally, held as a value, and interpolated into a larger query — which is what raw SQL actually looks like in an application.

```ts
import { DB } from "gemi/facades"
import { sql, join, empty } from "gemi/orm"

const filters = []
if (q) filters.push(sql`"name" ilike ${`%${q}%`}`)
if (organizationId) filters.push(sql`"organizationId" = ${organizationId}`)

const where = filters.length ? sql`where ${join(filters, " and ")}` : empty
const rows = await DB.query(sql`select * from "Product" ${where} limit ${20}`)
```

## It is the compiler's own `Fragment`, made public

Not a parallel mechanism. `compile/fragment.ts` has held exactly this shape since iteration 1 — text plus positional binders, composable, never concatenating a value into the text — because that is what invariant 2 needs internally. Reusing it means a public fragment binds by the same rule the compiler's own SQL does, and the parameter ceiling, the placeholder numbering and the dialect split are handled rather than reimplemented one door down.

Placeholders are assigned **at assembly, not at authoring**, which is what lets a fragment nest, be reused twice in one statement, or be built before the dialect is known. There is a test that renders one fragment for SQLite, then Postgres, then SQLite again — a fragment that memoised its rendered text would fail it in the direction that is *not* a syntax error.

## The two capabilities, neither free

### Rowcount from a write

`compile/write.ts` already recorded that driver metadata was not portable, and that the ORM's own `{ count }` therefore comes from `RETURNING <pk>`. I measured it again, on **both dialects**, across `update`, `delete`, `insert`, a statement matching nothing, and one carrying `returning`:

| | `count` | `affectedRows` |
| --- | --- | --- |
| SQLite | correct, every case | `null` |
| Postgres | correct, every case | `null` |

So `DB.execute` can report it. That matters because the count *is* the concurrency primitive, not a diagnostic:

```ts
const won = await DB.execute(
  sql`update "Reservation" set "status" = 'claimed'
      where "id" = ${id} and "status" = 'reserved'`,
)
if (won === 0) throw new AlreadyClaimed()
```

The ORM's own choice is unchanged — `RETURNING` is still exact and still asks the driver for nothing — but its note claimed `count` was "not verifiable against Postgres from here", which is no longer true, so that half is corrected and pointed at the new measurement.

### `unsafeSql`

The one door through which text reaches the SQL. It exists for something a builder cannot otherwise express: a partial index declared `where "name" is distinct from 'reaper'` is only usable if the planner can prove the query's predicate matches it, and a bound parameter is opaque at plan time — so `$1` there means a sequential scan of the whole table instead of an index hit. The constant has to be *in the text*.

It refuses a non-string, and it refuses **tagged-template use** — as a tag it would interpolate values straight into the SQL, which is the one thing it must never offer, and both spellings read identically at the call site. `sql("…")` called as a plain function is also refused, with a message pointing at `unsafeSql` since that is what the caller was reaching for.

## Two things found while building it

- **A `Date` was not portable through a fragment.** Bun's SQLite driver rejects one outright (`Binding expected string, TypedArray, boolean, number, bigint or null`); Postgres takes it. `SqlDialect` gains `encodeUntyped`, for a value with no declared column type: a `Date` becomes milliseconds and a boolean `0`/`1` on SQLite, which is *exactly* what `encode` writes for those columns — so a raw statement compares against ORM-written rows rather than against nothing. A plain object is deliberately **not** JSON-encoded: the compiler only knows to do that because a field says `Json`, and guessing from the value would turn a mistyped parameter into a successfully-written string.
- **`DB.query` threw synchronously** for a rejected fragment while returning a promise otherwise, so `DB.query(...).catch(…)` would miss precisely the errors it refuses to run. Both entry points are `async`.

## The ambient transaction

`DB.query` / `DB.execute` resolve the handle through the same `currentTransaction()` that `Model.$exec` uses. A raw statement that quietly ran on a pooled connection would commit while its neighbours rolled back — the worst outcome available here, and invisible in any test that does not deliberately roll back. Covered on both dialects: a raw write rolls back with the transaction, a raw read sees that transaction's *uncommitted* writes (which is what proves it is the same connection rather than a second one that also committed), and a savepoint rolls back to itself leaving the outer transaction usable.

`DB.sql` is untouched and still Bun's own tagged template, with a regression test saying so. It still does not join the ambient transaction; the docs now say which to reach for.

## Also documented

**Policies do not apply to raw SQL, and cannot** — a policy scopes a model's queries by rewriting the argument tree, and a raw statement has neither. Worth stating explicitly next to a page that otherwise says "every path that reaches another model carries that model's policies", because that sentence stops at this door.

### Only fragments this module made are spliced

Added in review, and it was a live SQL injection. `isFragment` asked whether a value had a string `text` and an array `binders` — so `{"text": "…", "binders": []}` arriving in a parsed request body was spliced into the statement as text, through the intended call site with the intended safe value. One of the reproduced payloads returned the password column out of a statement selecting only `email`.

Membership in a `WeakSet` this module owns, granted only by `sql`, `join`, `unsafeSql` and `empty`, registering what each constructor *returns* (since `concat`/`joinFragments` return fresh objects). Six tests cover it, all of which fail against the structural check — including a structural *clone* of a real fragment, which shape cannot tell apart.

The internal `Fragment` never had this problem, because nothing outside `compile/` could construct one. Making the type public is what turned "text plus binders" into a shape an attacker can name.

## Verification

- 46 unit tests in `packages/gemi/orm/sql.test.ts`, with no database anywhere near them. Every case asserts the emitted text **and** the bound values — a test that checked only the text would pass for an implementation that interpolated, which is the one failure this exists to prevent.
- 14 integration tests in `templates/saas-starter/app/models/raw-sql.test.ts`, run against **both dialects** (28 total with `TEST_POSTGRES_URL` set, all green) — rowcounts, the compare-and-swap, transaction and savepoint rollback, a value that looks like SQL staying data, and the composition example end to end.
- Full template suite green on SQLite and on Postgres.

Pre-existing failures, unchanged and confirmed on the base commit: seven router/i18n tests in `packages/gemi`, and `generated.test.ts`'s generator-linkage probe in the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

