### PR TITLE
`aggregate`, and `count`'s per-field form

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -48,7 +48,7 @@ generator gemi {
 Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 - `schema.ts` — runtime metadata: tables, columns, types, defaults, relations.
-- `models.ts` — a typed base class per model, carrying the thirteen operations.
+- `models.ts` — a typed base class per model, carrying the fourteen operations.
 - `index.ts` — registers every model by name.
 
 **The output is committed on purpose.** Diffs stay reviewable and CI needs no codegen step.
@@ -97,10 +97,10 @@ read. It can only see modules you hand it, so it does not replace the `register`
 
 ## Querying
 
-Thirteen operations, with Prisma's argument types verbatim:
+Fourteen operations, with Prisma's argument types verbatim:
 
 ```
-findMany   findFirst   findFirstOrThrow   findUnique   findUniqueOrThrow   count
+findMany   findFirst   findFirstOrThrow   findUnique   findUniqueOrThrow   count   aggregate
 create     createMany  update             updateMany   upsert              delete   deleteMany
 ```
 
@@ -125,6 +125,55 @@ Queries return **plain objects**, never class instances. That is the default and
 stepping stone: a `Pick<User, "id">` hydrated as a `User` would carry methods reading fields the
 query never fetched. See [Rows and entities](./orm-rows-and-entities.md) for the two opt-in levels
 above it — `track` + `save`, and `wrap`.
+
+### Aggregates
+
+```ts
+const { _max } = await Post.aggregate({
+  where: { boardId },
+  _max: { position: true },
+})
+const next = (_max.position ?? 0) + 1
+```
+
+That is the shape most reaches for `aggregate`: the next sort index when reordering a list, not
+analytics. All five of Prisma's functions are here, and they compose into one statement:
+
+```ts
+await User.aggregate({
+  where: { globalRole: { gt: 0 } },
+  _count: { _all: true, email: true },
+  _sum: { globalRole: true },
+  _avg: { globalRole: true },
+  _min: { createdAt: true },
+  _max: { createdAt: true },
+})
+```
+
+Three behaviours are Prisma's and are easy to get wrong in the other direction:
+
+- **`_count` has two shapes.** `_count: true` returns a number; `_count: { _all: true, email: true }`
+  returns an object — and a **per-field count counts rows where that column is not null**, which is
+  a different number from `_all` and the reason to ask per field.
+- **The empty set is not zeroes.** Over no matching rows `_count` is `0`, but `_sum`, `_avg`, `_min`
+  and `_max` are each `null`, per field.
+- **`take` / `skip` page the rows being aggregated**, not the one row that comes back — so
+  `take: 2` with `orderBy: { position: "asc" }` sums the first two rows, not the whole table.
+  (`orderBy` on its own, with no pagination, changes nothing and is dropped.)
+
+`count` gains Prisma's per-field form for the same reason:
+
+```ts
+await User.count()                                   // 3
+await User.count({ select: { _all: true, email: true } })  // { _all: 3, email: 2 }
+```
+
+Results are typed by Prisma's own mapped types, so `_max: { position: true }` narrows to
+`{ _max: { position: number | null } }` and nothing else.
+
+**`groupBy` is not implemented.** `having` is a predicate compiler over aggregate expressions rather
+than columns, which is its own piece of work; shipping half of it typed as though it worked would be
+worse than not shipping it.
 
 ### Per-call options
 

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -520,17 +520,53 @@ function operation(model: string, op: ReadOperation): string {
 }
 
 /**
- * `count` is the one read whose return type is not a payload. Prisma's own
- * `count` also accepts a `select` that turns the result into an object of
- * per-field counts; that is aggregate territory, so it is omitted and the
- * return type is plainly `number`.
+ * `count`, whose result depends on whether it was given a `select`.
+ *
+ * Without one it is a plain `number`. With one it is Prisma's object of
+ * per-field counts — `{ _all: 3, email: 2 }`, where each field's number is the
+ * rows whose column is *not null*. Both spellings are Prisma's, so the overload
+ * is what keeps the return type exact rather than widening it to
+ * `number | object` for every caller.
+ *
+ * `GetScalarType` is Prisma's own mapper for this: it turns the caller's select
+ * into the shape of the payload it produces, which is how `count({ select: {
+ * email: true } })` narrows to `{ email: number }` and not to the whole model.
  */
 function countOperation(model: string): string {
   return `
-  static count(
-    args?: Omit<Prisma.${model}CountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.${model}CountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.${model}CountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.${model}CountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.${model}CountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+`;
+}
+
+/**
+ * `aggregate` — `_count`, `_avg`, `_sum`, `_min`, `_max` over a filtered set.
+ *
+ * The payload type is Prisma's `GetXAggregateType<T>`, which is what makes
+ * `_max: { position: true }` narrow to `{ _max: { position: number | null } }`
+ * rather than to every field of every function. Same rule as everywhere else
+ * here: the types are Prisma's own, so narrowing stays exact and there is no
+ * second definition of the shape to drift.
+ *
+ * `groupBy` is deliberately not beside it. `having` is a predicate compiler over
+ * aggregate expressions rather than columns, and shipping half of it typed as
+ * though it worked would be worse than not shipping it.
+ */
+function aggregateOperation(model: string): string {
+  return `
+  static aggregate<T extends Prisma.${model}AggregateArgs>(
+    args: Prisma.Subset<T, Prisma.${model}AggregateArgs>,
+  ): Promise<Prisma.Get${model}AggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.Get${model}AggregateType<T>
+    >;
   }
 `;
 }
@@ -638,7 +674,7 @@ export class ${schema.name}Model extends Model {
   >[];
 ${READ_OPERATIONS.map((op) => operation(schema.name, op)).join("")}${countOperation(
       schema.name,
-    )}${WRITE_OPERATIONS.map((op) => operation(schema.name, op)).join(
+    )}${aggregateOperation(schema.name)}${WRITE_OPERATIONS.map((op) => operation(schema.name, op)).join(
       "",
     )}${BATCH_OPERATIONS.map((op) => batchOperation(schema.name, op)).join(
       "",

--- a/packages/gemi/orm/compile/aggregate.test.ts
+++ b/packages/gemi/orm/compile/aggregate.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { PostgresDialect } from "../dialect/postgres";
+import { SqliteDialect } from "../dialect/sqlite";
+import { UnknownFieldError, UnsupportedQueryError } from "../errors";
+import { account, mapped, organization, reading, user } from "../fixtures";
+import * as registry from "../registry";
+import { compileAggregate } from "./aggregate";
+import { compileRead } from "./read";
+
+/**
+ * `aggregate`, and the `select` form of `count`.
+ *
+ * The differential harness covers the shapes the template's schema can reach —
+ * `Int`, `String`, `DateTime` — against Prisma on both dialects, which is the
+ * stronger test and the one that owns "does it match Prisma". What it *cannot*
+ * reach is the rest of the type table: the template has no `BigInt`, `Float`,
+ * `Decimal`, `Json` or `Bytes` column, so the coercion rules for those are only
+ * checkable here. That is the division of labour, and the `BigInt` case below is
+ * the one that would otherwise be silently wrong in production.
+ */
+
+const postgres = new PostgresDialect();
+const sqlite = new SqliteDialect();
+
+beforeEach(() => {
+  registry.clearRegistry();
+  registry.register("User", class { static $schema = user });
+  registry.register("Account", class { static $schema = account });
+  registry.register("Organization", class { static $schema = organization });
+});
+
+afterEach(() => registry.clearRegistry());
+
+const plan = (args: any, dialect = postgres, schema = user) =>
+  compileAggregate(schema, "aggregate", args, dialect);
+
+const text = (args: any, dialect = postgres, schema = user) =>
+  plan(args, dialect, schema).text;
+
+describe("what it emits", () => {
+  test("one function per requested field", () => {
+    expect(text({ _sum: { globalRole: true } })).toBe(
+      `select sum("globalRole") as "_sum_0" from "User"`,
+    );
+    expect(text({ _avg: { globalRole: true } })).toContain(`avg("globalRole")`);
+    expect(text({ _min: { globalRole: true } })).toContain(`min("globalRole")`);
+    expect(text({ _max: { globalRole: true } })).toContain(`max("globalRole")`);
+  });
+
+  /**
+   * The distinction the whole per-field form exists for: `count(*)` counts
+   * rows, `count("email")` counts rows where the column is not null. Emitting
+   * the first for both would be plausible and would return a different number.
+   */
+  test("_count counts rows, and a field counts non-nulls", () => {
+    expect(text({ _count: true })).toContain(`count(*)`);
+    expect(text({ _count: { _all: true } })).toContain(`count(*)`);
+    expect(text({ _count: { email: true } })).toContain(`count("email")`);
+  });
+
+  test("several functions share one statement", () => {
+    const emitted = text({
+      _count: { _all: true },
+      _sum: { globalRole: true },
+      _min: { createdAt: true },
+    });
+
+    expect(emitted.match(/select /g)).toHaveLength(1);
+    expect(emitted).toContain(`count(*)`);
+    expect(emitted).toContain(`sum("globalRole")`);
+    expect(emitted).toContain(`min("createdAt")`);
+  });
+
+  test("a where binds its values", () => {
+    const args = { where: { globalRole: 2 }, _count: true };
+    const compiled = plan(args);
+
+    expect(compiled.text).toContain(`where "globalRole" = $1`);
+    expect(compiled.bind(args)).toEqual([2]);
+  });
+
+  test("the column list respects @map", () => {
+    expect(text({ _max: { occurredAt: true } }, postgres, mapped)).toContain(
+      `max("occurred_at")`,
+    );
+  });
+
+  /**
+   * Aliases are positional rather than named after the field. A model could
+   * carry a field called `_all`, and `"_count_" + fieldName` would then collide
+   * with `_count`'s own alias — two aggregates arriving under one key, with the
+   * second silently winning.
+   */
+  test("two aggregates over the same field get distinct aliases", () => {
+    const emitted = text({
+      _min: { globalRole: true },
+      _max: { globalRole: true },
+    });
+
+    const aliases = [...emitted.matchAll(/as "(_\w+_\d+)"/g)].map((m) => m[1]);
+    expect(aliases).toHaveLength(2);
+    expect(new Set(aliases).size).toBe(2);
+  });
+});
+
+/**
+ * `take` / `skip` describe the rows being aggregated, not the one row the
+ * aggregate produces. A `limit` beside the aggregate would cap the *result*,
+ * which is always one row, and quietly report the unpaginated total.
+ */
+describe("pagination", () => {
+  test("a paginated aggregate wraps its rows in a subquery", () => {
+    const args = { orderBy: { globalRole: "asc" }, take: 2, _sum: { globalRole: true } };
+    const compiled = plan(args);
+
+    expect(compiled.text).toBe(
+      `select sum("globalRole") as "_sum_0" from (select "globalRole" from ` +
+        `"User" order by "globalRole" asc limit $1) as "sub"`,
+    );
+    expect(compiled.bind(args)).toEqual([2]);
+  });
+
+  test("the subquery selects every column an aggregate names", () => {
+    const emitted = text({
+      take: 1,
+      _sum: { globalRole: true },
+      _max: { createdAt: true },
+    });
+
+    expect(emitted).toContain(`select "globalRole", "createdAt" from "User"`);
+  });
+
+  /**
+   * With only `count(*)` there is no column to carry, so it selects the primary
+   * key — the narrowest thing that keeps a row identity, and what the paginated
+   * `count` does for the same reason.
+   */
+  test("a paginated count(*) selects the primary key", () => {
+    expect(text({ take: 2, _count: true })).toContain(`select "id" from "User"`);
+  });
+
+  test("paginating without an orderBy orders by the primary key", () => {
+    expect(text({ take: 2, _count: true })).toContain(`order by "id" asc`);
+  });
+
+  test("an unpaginated aggregate has no subquery at all", () => {
+    expect(text({ _count: true })).toBe(`select count(*) as "_count_0" from "User"`);
+  });
+
+  test("a negative take flips the order and binds its magnitude", () => {
+    const args = { orderBy: { globalRole: "asc" }, take: -2, _sum: { globalRole: true } };
+    const compiled = plan(args);
+
+    expect(compiled.text).toContain(`order by "globalRole" desc`);
+    expect(compiled.bind(args)).toEqual([2]);
+  });
+});
+
+/**
+ * The coercion table, which is where this operation earns or loses its
+ * correctness: `sum(integer)` is `bigint` in Postgres and `avg(integer)` is
+ * `numeric`, and Bun hands both back as strings.
+ */
+describe("turning the driver's values into Prisma's", () => {
+  const shape = (args: any, row: Record<string, unknown>, schema = user) =>
+    plan(args, postgres, schema).shape([row]) as any;
+
+  test("_count is a number, even though the driver says string", () => {
+    expect(shape({ _count: true }, { _count_0: "3" })._count).toBe(3);
+    expect(shape({ _count: { _all: true } }, { _count_0: "3" })._count).toEqual({
+      _all: 3,
+    });
+  });
+
+  test("_avg is a number, even for an integer column", () => {
+    expect(
+      shape({ _avg: { globalRole: true } }, { _avg_0: "2.0000000000000000" }),
+    ).toEqual({ _avg: { globalRole: 2 } });
+  });
+
+  test("_sum over an Int column is a number", () => {
+    expect(shape({ _sum: { globalRole: true } }, { _sum_0: "15" })).toEqual({
+      _sum: { globalRole: 15 },
+    });
+  });
+
+  /**
+   * The one that would be silently wrong. `sum(bigint)` crosses as an exact
+   * string, and `Number()` on 9007199254740995 drops the low bits — in a value
+   * whose entire reason for being a `BigInt` is that it does not fit a double.
+   * Same trap the lateral strategy's `::text` cast exists for.
+   */
+  test("_sum over a BigInt column keeps every bit", () => {
+    const result = shape({ _sum: { size: true } }, { _sum_0: "9007199254740995" }, mapped);
+
+    expect(result._sum.size).toBe(9007199254740995n);
+    // Compared as text, because the loss this guards against is invisible to a
+    // numeric comparison: the *literal* 9007199254740995 is already
+    // 9007199254740996 by the time it reaches the assertion, so `not.toBe` a
+    // number would pass for the broken implementation too.
+    expect(String(result._sum.size)).toBe("9007199254740995");
+    expect(String(Number("9007199254740995"))).toBe("9007199254740996");
+  });
+
+  test("_sum over a Float column is a number", () => {
+    expect(shape({ _sum: { value: true } }, { _sum_0: 4.5 }, reading)).toEqual({
+      _sum: { value: 4.5 },
+    });
+  });
+
+  test("_min and _max decode as values of their column", () => {
+    // Postgres hands a `bigint` back as text; the column's own decoder is what
+    // knows to make it a BigInt rather than a number.
+    expect(
+      shape({ _max: { size: true } }, { _max_0: "9007199254740993" }, mapped)._max,
+    ).toEqual({ size: 9007199254740993n });
+
+    // ...and on SQLite a DateTime is integer milliseconds.
+    const dates = compileAggregate(user, "aggregate", { _min: { createdAt: true } }, sqlite)
+      .shape([{ _min_0: 1600000000000 }]) as any;
+    expect(dates._min.createdAt).toBeInstanceOf(Date);
+    expect(dates._min.createdAt.toISOString()).toBe("2020-09-13T12:26:40.000Z");
+  });
+
+  /**
+   * `_count` over no rows is `0`; every other function is `null`, per field.
+   * Coalescing them all to `0` would look right in every test that has rows.
+   */
+  test("an empty set is zero for counts and null for everything else", () => {
+    const result = shape(
+      {
+        _count: { _all: true, email: true },
+        _sum: { globalRole: true },
+        _avg: { globalRole: true },
+        _min: { globalRole: true },
+        _max: { createdAt: true },
+      },
+      { _count_0: "0", _count_1: "0", _sum_2: null, _avg_3: null, _min_4: null, _max_5: null },
+    );
+
+    expect(result).toEqual({
+      _count: { _all: 0, email: 0 },
+      _sum: { globalRole: null },
+      _avg: { globalRole: null },
+      _min: { globalRole: null },
+      _max: { createdAt: null },
+    });
+  });
+
+  test("a bare _count is a number rather than an object", () => {
+    expect(shape({ _count: true }, { _count_0: "7" })).toEqual({ _count: 7 });
+  });
+});
+
+describe("what it refuses", () => {
+  test("an aggregate with no functions", () => {
+    expect(() => plan({})).toThrow(/at least one of/);
+    expect(() => plan(undefined)).toThrow(/at least one of/);
+    expect(() => plan({ where: { globalRole: 1 } })).toThrow(/at least one of/);
+  });
+
+  test("an unknown field", () => {
+    expect(() => plan({ _sum: { nope: true } })).toThrow(UnknownFieldError);
+  });
+
+  /**
+   * A relation named here is a plausible mistake — `_count: { accounts: true }`
+   * reads like counting the relation — and the default "unknown field" message
+   * would send the caller looking for a typo.
+   */
+  test("a relation, with a message that says what to do instead", () => {
+    expect(() => plan({ _count: { accounts: true } })).toThrow(
+      /'accounts' is a relation/,
+    );
+    expect(() => plan({ _count: { accounts: true } })).toThrow(/_count' inside an 'include'/);
+  });
+
+  test.each([
+    ["_sum", "email"],
+    ["_avg", "email"],
+    ["_sum", "createdAt"],
+  ])("%s over a non-numeric column (%s)", (kind, field) => {
+    expect(() => plan({ [kind]: { [field]: true } })).toThrow(
+      /needs a number/,
+    );
+  });
+
+  test.each([
+    ["_min", "payload"],
+    ["_max", "payload"],
+  ])("%s over a Json column (%s)", (kind, field) => {
+    expect(() => plan({ [kind]: { [field]: true } }, postgres, mapped)).toThrow(
+      /no ordering the two/,
+    );
+  });
+
+  test("_min over a Bytes column", () => {
+    expect(() => plan({ _min: { digest: true } }, postgres, reading)).toThrow(
+      /no ordering the two/,
+    );
+  });
+
+  test("select and include, which an aggregate has no use for", () => {
+    expect(() => plan({ _count: true, select: { id: true } })).toThrow(
+      /nothing to select/,
+    );
+    expect(() => plan({ _count: true, include: { accounts: true } })).toThrow(
+      /nothing to include/,
+    );
+  });
+
+  test("an unknown argument", () => {
+    expect(() => plan({ _count: true, cursor: { id: 1 } })).toThrow(
+      UnsupportedQueryError,
+    );
+  });
+
+  test("a malformed function value", () => {
+    expect(() => plan({ _sum: true })).toThrow(/Expected an object of fields/);
+    expect(() => plan({ _count: 3 })).toThrow(/Expected true or an object/);
+  });
+
+  test("an orderBy is validated whether or not it paginates", () => {
+    expect(() => plan({ _count: true, orderBy: { nope: "asc" } })).toThrow(
+      UnknownFieldError,
+    );
+    expect(() =>
+      plan({ _count: true, orderBy: { nope: "asc" }, take: 1 }),
+    ).toThrow(UnknownFieldError);
+  });
+});
+
+/**
+ * `count({ select })` is the same statement with a flatter result: no `_count`
+ * wrapper, because the operation already says what the numbers are. It routes
+ * through this compiler rather than reimplementing the per-field rule.
+ */
+describe("count with a select", () => {
+  const counted = (args: any) => compileRead(user, "count", args, postgres);
+
+  test("returns a flat object of counts", () => {
+    const compiled = counted({ select: { _all: true, email: true } });
+
+    expect(compiled.text).toContain(`count(*)`);
+    expect(compiled.text).toContain(`count("email")`);
+    expect(compiled.shape([{ _count_0: "5", _count_1: "3" }])).toEqual({
+      _all: 5,
+      email: 3,
+    });
+  });
+
+  test("a count with no select is still a plain number", () => {
+    const compiled = counted({});
+    expect(compiled.shape([{ _count: 4 }])).toBe(4);
+  });
+
+  test("a select naming nothing is refused", () => {
+    expect(() => counted({ select: {} })).toThrow(/at least one field/);
+    expect(() => counted({ select: { email: false } })).toThrow(/at least one field/);
+  });
+
+  test("a where and pagination still apply", () => {
+    const args = { where: { globalRole: 2 }, take: 2, select: { _all: true } };
+    const compiled = counted(args);
+
+    expect(compiled.text).toContain(`) as "sub"`);
+    expect(compiled.bind(args)).toEqual([2, 2]);
+  });
+});

--- a/packages/gemi/orm/compile/aggregate.ts
+++ b/packages/gemi/orm/compile/aggregate.ts
@@ -1,0 +1,465 @@
+import type { SqlDialect } from "../dialect";
+import { UnknownFieldError, UnsupportedQueryError } from "../errors";
+import type { QueryPlan } from "../plan";
+import type { FieldSchema, ModelSchema, ScalarType } from "../schema";
+import { type Fragment, bindValues, concat, joinFragments, render, sql } from "./fragment";
+import { compileOrderBy, parseOrderBy } from "./orderBy";
+import { pagination } from "./paginate";
+import { compileWhere } from "./where";
+
+/**
+ * `aggregate`, and the `select` form of `count`.
+ *
+ * The fourteenth operation, and the first read whose result is neither rows nor
+ * a bare number. Its shape is Prisma's, verified against a generated client
+ * rather than inferred from the docs — every claim in this file's comments is a
+ * line of that probe's output.
+ *
+ * ## Why it is not just `count` with more functions
+ *
+ * Three things differ, and each one is a place a plausible implementation is
+ * wrong:
+ *
+ * 1. **`_count` has two shapes.** `_count: true` returns a *number*;
+ *    `_count: { _all: true, email: true }` returns an object, and a per-field
+ *    count is `count("email")` — the number of rows where that column is **not
+ *    null**, which is a different number from `count(*)` and is the whole point
+ *    of asking per field.
+ * 2. **The empty set is not zeroes.** `_count` over no rows is `0`, but `_sum`,
+ *    `_avg`, `_min` and `_max` are all `null` — per field, inside their objects.
+ *    An implementation that coalesced to `0` would be wrong in the direction
+ *    nobody checks.
+ * 3. **The driver's types are not the column's types.** `sum(integer)` is
+ *    `bigint` in Postgres and `avg(integer)` is `numeric`, and Bun hands both
+ *    back as *strings*. So the coercion cannot be `dialect.decode(value, field)`
+ *    — that decodes a value of the column's type, and an aggregate is not one.
+ *    See `coerce` below, where each rule is a measurement.
+ *
+ * ## Pagination
+ *
+ * `take` / `skip` describe the rows being aggregated, not the one row the
+ * aggregate produces — exactly as they do for `count`, and for the same reason:
+ * `limit` beside an aggregate caps the result, which is always one row. So a
+ * paginated aggregate wraps its row query in a subquery, the same shape
+ * `compileRead` uses. Verified against Prisma: `take: 2` with
+ * `orderBy: { globalRole: "asc" }` over rows 0, 5, 10 sums to 5, not 15.
+ */
+
+/** The aggregate functions Prisma exposes, in the order it returns them. */
+const KINDS = ["_count", "_avg", "_sum", "_min", "_max"] as const;
+type Kind = (typeof KINDS)[number];
+
+const AGGREGATE_ARGS = new Set<string>([
+  "where",
+  "orderBy",
+  "take",
+  "skip",
+  ...KINDS,
+]);
+
+/** `_sum` and `_avg` need arithmetic, so Prisma restricts them to these. */
+const NUMERIC = new Set<ScalarType>(["Int", "Float", "BigInt", "Decimal"]);
+
+/**
+ * `_min` / `_max` need an ordering. `Json` has none in either dialect, and
+ * `Bytes` orders bytewise in a way Prisma does not expose — both are refused
+ * rather than emitted and left to disagree.
+ */
+const UNORDERABLE = new Set<ScalarType>(["Json", "Bytes"]);
+
+/** The SQL function each kind compiles to. */
+const FUNCTION: Record<Kind, string> = {
+  _count: "count",
+  _avg: "avg",
+  _sum: "sum",
+  _min: "min",
+  _max: "max",
+};
+
+interface Term {
+  kind: Kind;
+  /** Absent for `_count`'s `_all`, which is `count(*)`. */
+  field?: FieldSchema;
+  /** The key this term is written to inside its kind's object. */
+  as: string;
+  /** The column alias it comes back under. Positional, so it cannot collide. */
+  alias: string;
+}
+
+export function isAggregateOperation(op: string): boolean {
+  return op === "aggregate";
+}
+
+/**
+ * `aggregate`, and `count({ select })` — which is the same statement with a
+ * flatter result.
+ *
+ * Prisma's `count({ select: { _all: true, email: true } })` returns
+ * `{ _all: 3, email: 2 }`: no `_count` wrapper, because the operation already
+ * says what the numbers are. It was refused here until now as "aggregate
+ * territory", which was the right call while there was no aggregate to put it
+ * beside; the two decisions belong together and this is the together.
+ */
+export function compileAggregate(
+  schema: ModelSchema,
+  op: string,
+  args: any,
+  dialect: SqlDialect,
+): QueryPlan {
+  const flat = op === "count";
+  assertArgs(schema, op, args, flat);
+
+  const terms = flat
+    ? countSelectTerms(schema, op, args?.select)
+    : aggregateTerms(schema, op, args);
+
+  if (terms.length === 0) {
+    throw new UnsupportedQueryError(
+      op,
+      schema.name,
+      op,
+      flat
+        ? `A 'select' on a count must name at least one field, or '_all'.`
+        : `An aggregate needs at least one of ${KINDS.join(", ")}. Prisma ` +
+          `rejects an empty one too.`,
+    );
+  }
+
+  const where = compileWhere(schema, args?.where, { dialect, operation: op }, (a) => a?.where);
+  const whereClause = where ? concat(sql(" where "), where) : sql("");
+  const from = sql(` from ${dialect.quoteIdent(schema.table)}`);
+
+  const projection = joinFragments(
+    terms.map((term) =>
+      sql(
+        `${FUNCTION[term.kind]}(${
+          term.field ? dialect.quoteIdent(term.field.column) : "*"
+        }) as ${dialect.quoteIdent(term.alias)}`,
+      ),
+    ),
+    ", ",
+  );
+
+  // Parsed unconditionally, so that validation does not depend on whether a
+  // *different* argument was also supplied — the same rule `count` follows.
+  const parsed = parseOrderBy(schema, args?.orderBy, op, {
+    dialect,
+    locate: (a: any) => a?.orderBy,
+  });
+  const paginating = args?.take !== undefined || args?.skip !== undefined;
+
+  let statement: Fragment;
+
+  if (!paginating) {
+    statement = concat(sql("select "), projection, from, whereClause);
+  } else {
+    const { clause, terms: order } = pagination(schema, args, dialect, parsed);
+    const ordering = compileOrderBy(order, dialect);
+
+    // The subquery selects every column an aggregate names — an `order by` may
+    // reference columns beyond them, which is fine, since it is resolved
+    // against the table rather than against the select list.
+    //
+    // With only `count(*)` there is no such column, so it selects the primary
+    // key: the narrowest thing that keeps a row identity, which is what
+    // `compileRead`'s paginated count does for the same reason.
+    const columns = new Map<string, string>();
+    for (const term of terms) {
+      if (term.field) columns.set(term.field.column, term.field.column);
+    }
+    if (columns.size === 0) {
+      const key = schema.primaryKey[0] ?? Object.keys(schema.fields)[0];
+      const column = schema.fields[key]?.column ?? key;
+      columns.set(column, column);
+    }
+
+    statement = concat(
+      sql("select "),
+      projection,
+      sql(
+        ` from (select ${[...columns.values()]
+          .map((column) => dialect.quoteIdent(column))
+          .join(", ")}`,
+      ),
+      from,
+      whereClause,
+      ordering ? concat(sql(" order by "), ordering) : sql(""),
+      clause,
+      sql(`) as ${dialect.quoteIdent("sub")}`),
+    );
+  }
+
+  const { text, binders } = render(statement, dialect, {
+    model: schema.name,
+    operation: op,
+  });
+
+  return {
+    text,
+    bind: bindValues(binders),
+    shape(rows) {
+      const row = (rows as Record<string, unknown>[])[0] ?? {};
+
+      if (flat) {
+        const out: Record<string, unknown> = {};
+        for (const term of terms) out[term.as] = coerce(term, row[term.alias], dialect);
+        return out;
+      }
+
+      const out: Record<string, unknown> = {};
+      for (const term of terms) {
+        // `_count: true` is a number rather than an object, and it is the only
+        // aggregate that can be either.
+        if (term.kind === "_count" && term.as === BARE) {
+          out._count = coerce(term, row[term.alias], dialect);
+          continue;
+        }
+        const bucket = (out[term.kind] ??= {}) as Record<string, unknown>;
+        bucket[term.as] = coerce(term, row[term.alias], dialect);
+      }
+      return out;
+    },
+  };
+}
+
+/** The `as` a bare `_count: true` carries, which no field name can be. */
+const BARE = "";
+
+function aggregateTerms(
+  schema: ModelSchema,
+  op: string,
+  args: any,
+): Term[] {
+  const terms: Term[] = [];
+
+  for (const kind of KINDS) {
+    const requested = args?.[kind];
+    if (requested === undefined || requested === false) continue;
+
+    if (kind === "_count" && requested === true) {
+      terms.push({ kind, as: BARE, alias: alias(kind, terms.length) });
+      continue;
+    }
+
+    if (typeof requested !== "object" || requested === null || Array.isArray(requested)) {
+      throw new UnsupportedQueryError(
+        kind,
+        schema.name,
+        op,
+        kind === "_count"
+          ? `Expected true or an object of fields.`
+          : `Expected an object of fields.`,
+      );
+    }
+
+    for (const key of Object.keys(requested).sort()) {
+      const wanted = (requested as Record<string, unknown>)[key];
+      if (wanted === undefined || wanted === false) continue;
+
+      if (kind === "_count" && key === "_all") {
+        terms.push({ kind, as: "_all", alias: alias(kind, terms.length) });
+        continue;
+      }
+
+      const field = resolveField(schema, op, kind, key);
+      assertAggregable(schema, op, kind, field);
+      terms.push({ kind, field, as: key, alias: alias(kind, terms.length) });
+    }
+  }
+
+  return terms;
+}
+
+/** `count({ select: { _all: true, email: true } })` — every term a `count`. */
+function countSelectTerms(schema: ModelSchema, op: string, select: any): Term[] {
+  if (typeof select !== "object" || select === null || Array.isArray(select)) {
+    throw new UnsupportedQueryError(
+      "select",
+      schema.name,
+      op,
+      `Expected an object of fields.`,
+    );
+  }
+
+  const terms: Term[] = [];
+  for (const key of Object.keys(select).sort()) {
+    const wanted = select[key];
+    if (wanted === undefined || wanted === false) continue;
+
+    if (key === "_all") {
+      terms.push({ kind: "_count", as: "_all", alias: alias("_count", terms.length) });
+      continue;
+    }
+
+    const field = resolveField(schema, op, "_count", key);
+    terms.push({ kind: "_count", field, as: key, alias: alias("_count", terms.length) });
+  }
+  return terms;
+}
+
+/**
+ * Positional, so two terms can never collide however the model is named — a
+ * field called `_all` would otherwise produce the same alias as `_count`'s own.
+ * The kind stays in the name because a query log is read by a person.
+ */
+const alias = (kind: Kind, index: number) => `${kind}_${index}`;
+
+function resolveField(
+  schema: ModelSchema,
+  op: string,
+  kind: Kind,
+  name: string,
+): FieldSchema {
+  const field = schema.fields[name];
+  if (!field) {
+    // A relation named here is a plausible mistake with an unhelpful default
+    // message, so it gets its own.
+    if (name in schema.relations) {
+      throw new UnsupportedQueryError(
+        `${kind}.${name}`,
+        schema.name,
+        op,
+        `'${name}' is a relation. Aggregate its own model instead, or use ` +
+          `'_count' inside an 'include' to count it per row.`,
+      );
+    }
+    throw new UnknownFieldError(name, schema.name, Object.keys(schema.fields));
+  }
+  return field;
+}
+
+function assertAggregable(
+  schema: ModelSchema,
+  op: string,
+  kind: Kind,
+  field: FieldSchema,
+): void {
+  if ((kind === "_sum" || kind === "_avg") && !NUMERIC.has(field.type)) {
+    throw new UnsupportedQueryError(
+      `${kind}.${field.name}`,
+      schema.name,
+      op,
+      `'${field.name}' is a ${field.type}, and ${kind} needs a number. ` +
+        `Prisma does not offer it on this field either.`,
+    );
+  }
+
+  if ((kind === "_min" || kind === "_max") && UNORDERABLE.has(field.type)) {
+    throw new UnsupportedQueryError(
+      `${kind}.${field.name}`,
+      schema.name,
+      op,
+      `'${field.name}' is a ${field.type}, which has no ordering the two ` +
+        `dialects agree on.`,
+    );
+  }
+}
+
+/**
+ * The driver's value for one aggregate, as the value Prisma returns.
+ *
+ * **Every line here is a measurement**, taken through Bun against Postgres 16
+ * and SQLite, because the obvious rule — "decode it as the column's type" — is
+ * wrong for three of the five kinds. What Postgres returns:
+ *
+ *   count(*)             "2"                    string
+ *   count(text)          "2"                    string
+ *   sum(integer)         "4"                    string   <- bigint
+ *   sum(bigint)          "9007199254740995"     string
+ *   sum(double)          4                      number
+ *   avg(integer)         "2.0000000000000000"   string   <- numeric
+ *   avg(double)          2                      number
+ *   min(integer)         1                      number
+ *   max(text)            "b"                    string
+ *   min(timestamp)       Date                   object
+ *   max(bigint)          "9007199254740993"     string
+ *
+ * ...and over an empty set every one of them is `null` except the counts, which
+ * are `"0"`.
+ *
+ * So:
+ *
+ * - **`_count` is always a number**, and always present. `Number("0")` rather
+ *   than a coalesce, because the driver gives a string and `?? 0` would leave it
+ *   one.
+ * - **`_avg` is always a number**, whatever the column is — Prisma returns a
+ *   float for the average of an `Int`, and Postgres hands back `numeric` text.
+ * - **`_sum` keeps the column's type**, so it is the one kind where a `BigInt`
+ *   column matters: `sum(bigint)` crosses as an exact string, and `Number()` on
+ *   9007199254740995 would silently drop the low bits. Same trap the lateral
+ *   strategy's `::text` cast exists for.
+ * - **`_min` / `_max` are values of the column**, so here — and only here — the
+ *   dialect's own `decode` is exactly right. It is what turns SQLite's integer
+ *   milliseconds back into a `Date`.
+ */
+function coerce(term: Term, value: unknown, dialect: SqlDialect): unknown {
+  if (term.kind === "_count") return Number(value ?? 0);
+
+  // Every other aggregate is null over an empty set, and per field.
+  if (value === null || value === undefined) return null;
+
+  if (term.kind === "_avg") return Number(value);
+
+  if (term.kind === "_sum") {
+    const type = term.field?.type;
+    if (type === "BigInt") return BigInt(String(value));
+    // `Decimal` is left as the driver gave it. The template's schema has no
+    // Decimal column, so nothing here has ever been compared against Prisma's
+    // `Decimal` instance — claiming a conversion that has not been measured
+    // would be worse than passing the value through and saying so.
+    if (type === "Decimal") return value;
+    return Number(value);
+  }
+
+  // `_min` / `_max` are values *of the column*, so here — and only here — the
+  // dialect's own `decode` is exactly right. It is what turns SQLite's integer
+  // milliseconds back into a `Date`, and Postgres's `bigint` text into a
+  // `BigInt`. Without it a `_max: { createdAt: true }` comes back as
+  // 1600000004000 where Prisma returns a `Date`, on SQLite only — which is the
+  // shape of every bug this file's coercion table exists to prevent.
+  return term.field ? dialect.decode(value, term.field) : value;
+}
+
+function assertArgs(
+  schema: ModelSchema,
+  op: string,
+  args: any,
+  flat: boolean,
+): void {
+  if (args === undefined || args === null) {
+    if (flat) return;
+    throw new UnsupportedQueryError(
+      op,
+      schema.name,
+      op,
+      `An aggregate needs at least one of ${KINDS.join(", ")}.`,
+    );
+  }
+
+  if (typeof args !== "object" || Array.isArray(args)) {
+    throw new UnsupportedQueryError(String(args), schema.name, op, "Expected an object.");
+  }
+
+  if (flat) return;
+
+  for (const key of Object.keys(args).sort()) {
+    if (args[key] === undefined) continue;
+    if (AGGREGATE_ARGS.has(key)) continue;
+
+    // `select` and `include` are the two a caller reaches for by habit, and
+    // neither means anything here: an aggregate's shape is decided entirely by
+    // which functions were asked for.
+    if (key === "select" || key === "include") {
+      throw new UnsupportedQueryError(
+        key,
+        schema.name,
+        op,
+        `An aggregate returns the functions it was given, so there is nothing ` +
+          `to ${key === "select" ? "select" : "include"}. Prisma does not ` +
+          `accept it either.`,
+      );
+    }
+
+    throw new UnsupportedQueryError(key, schema.name, op);
+  }
+}

--- a/packages/gemi/orm/compile/aggregate.ts
+++ b/packages/gemi/orm/compile/aggregate.ts
@@ -57,7 +57,12 @@ const AGGREGATE_ARGS = new Set<string>([
   ...KINDS,
 ]);
 
-/** `_sum` and `_avg` need arithmetic, so Prisma restricts them to these. */
+/**
+ * `_sum` and `_avg` need arithmetic, so Prisma restricts them to these.
+ *
+ * `Decimal` is listed for completeness and cannot occur: `emit.ts` refuses a
+ * Decimal field at generation time, so no generated schema has one.
+ */
 const NUMERIC = new Set<ScalarType>(["Int", "Float", "BigInt", "Decimal"]);
 
 /**
@@ -99,6 +104,12 @@ export function isAggregateOperation(op: string): boolean {
  * says what the numbers are. It was refused here until now as "aggregate
  * territory", which was the right call while there was no aggregate to put it
  * beside; the two decisions belong together and this is the together.
+ *
+ * **No `ExecOptions`**, unlike every neighbouring read, and that is deliberate
+ * rather than an omission: `strategy` chooses how an include tree loads and an
+ * aggregate has no relations, `track` records where a row came from so `save`
+ * can update it and an aggregate returns no rows. Accepting either and ignoring
+ * it would be worse than not accepting it.
  */
 export function compileAggregate(
   schema: ModelSchema,
@@ -403,10 +414,17 @@ function coerce(term: Term, value: unknown, dialect: SqlDialect): unknown {
   if (term.kind === "_sum") {
     const type = term.field?.type;
     if (type === "BigInt") return BigInt(String(value));
-    // `Decimal` is left as the driver gave it. The template's schema has no
-    // Decimal column, so nothing here has ever been compared against Prisma's
-    // `Decimal` instance — claiming a conversion that has not been measured
-    // would be worse than passing the value through and saying so.
+    // `Decimal` is **unreachable**, not merely untested: `emit.ts`'s
+    // `UNSUPPORTED_SCALARS` refuses a Decimal field at generation time, so no
+    // generated schema can carry one and neither this branch nor `Decimal`'s
+    // membership of `NUMERIC` can be entered.
+    //
+    // Kept, and kept as a pass-through, because the day Decimal becomes
+    // supported is the day this needs a real decision — Postgres returns
+    // `sum(numeric)` as text, and whether that becomes a `Prisma.Decimal`, a
+    // string or a number is the same question the generator declined to answer.
+    // Silently `Number()`-ing it would answer it wrongly and lose exactly the
+    // precision the type exists to keep.
     if (type === "Decimal") return value;
     return Number(value);
   }

--- a/packages/gemi/orm/compile/index.ts
+++ b/packages/gemi/orm/compile/index.ts
@@ -3,6 +3,7 @@ import { UnsupportedQueryError } from "../errors";
 import type { Operation, QueryPlan } from "../plan";
 import type { RelationStrategy } from "./plan-relations";
 import type { ModelSchema } from "../schema";
+import { compileAggregate, isAggregateOperation } from "./aggregate";
 import { compileRead, isReadOperation } from "./read";
 import { compileWrite, isWriteOperation } from "./write";
 
@@ -26,6 +27,10 @@ export function compile(
    */
   strategy?: RelationStrategy,
 ): QueryPlan {
+  // Before the read check, because `aggregate` is a read whose result is
+  // neither rows nor a number and so shares none of `compileRead`'s shaping.
+  if (isAggregateOperation(op)) return compileAggregate(schema, op, args, dialect);
+
   if (isReadOperation(op)) {
     return compileRead(schema, op, args, dialect, strategy);
   }
@@ -34,6 +39,7 @@ export function compile(
 }
 
 export { compileRead, isReadOperation };
+export { compileAggregate, isAggregateOperation } from "./aggregate";
 export { compileWrite, isWriteOperation };
 export {
   planNestedWrites,

--- a/packages/gemi/orm/compile/paginate.ts
+++ b/packages/gemi/orm/compile/paginate.ts
@@ -1,0 +1,62 @@
+import type { SqlDialect } from "../dialect";
+import type { ModelSchema } from "../schema";
+import type { Binder, Fragment } from "./fragment";
+import { reverse, type OrderTerm } from "./orderBy";
+
+/**
+ * `skip` / `take`, plus the two pieces of Prisma behaviour around them that are
+ * invisible until you read the SQL it emits:
+ *
+ * - Paginating without an `orderBy` injects `order by <primary key> asc`.
+ *   Without it, "page 2" is only meaningful if the storage engine happens to
+ *   return a stable order, which is not guaranteed on either dialect.
+ * - A *negative* `take` means "the last N": Prisma flips every ordering term,
+ *   takes `abs(take)`, and then reverses the result set so the caller still
+ *   sees their own ordering. `reversed` carries that last part out to `shape`.
+ */
+export function pagination(
+  schema: ModelSchema,
+  args: any,
+  dialect: SqlDialect,
+  parsed: OrderTerm[],
+  /**
+   * Whether the operation returns at most one row, which pins `take` to 1
+   * whatever the arguments say. Passed rather than derived from the operation
+   * name, so this module needs to know nothing about which operations exist —
+   * which is also what keeps `read.ts` and `aggregate.ts` from importing each
+   * other to share it.
+   */
+  single = false,
+): { clause: Fragment; terms: OrderTerm[]; reversed: boolean } {
+  const take = single ? 1 : args?.take;
+  const skip = args?.skip;
+
+  let terms = parsed;
+  const paginating = take !== undefined || skip !== undefined;
+
+  if (paginating && terms.length === 0 && !single) {
+    terms = schema.primaryKey.map((name) => ({
+      column: schema.fields[name]?.column ?? name,
+      direction: "asc" as const,
+    }));
+  }
+
+  const negative = typeof take === "number" && take < 0;
+  if (negative) terms = reverse(terms);
+
+  const takeBinder: Binder | null =
+    take === undefined
+      ? null
+      : single
+        ? () => 1
+        : (callArgs: any) => Math.abs(Number(callArgs?.take));
+
+  const skipBinder: Binder | null =
+    skip === undefined ? null : (callArgs: any) => Number(callArgs?.skip);
+
+  return {
+    clause: dialect.paginate(takeBinder, skipBinder),
+    terms,
+    reversed: negative,
+  };
+}

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -503,9 +503,25 @@ describe("unimplemented arguments still throw", () => {
     );
   });
 
-  test("count rejects select rather than ignoring it", () => {
-    expect(() => text({ select: { id: true } }, "count")).toThrow(
-      "gemi ORM does not support 'select' yet (User.count).",
+  /**
+   * `count({ select })` used to be refused as aggregate territory, and that was
+   * the right call while there was no aggregate to put it beside. It is a
+   * per-field count now — `count("email")`, the rows where the column is not
+   * null — and it routes through `compileAggregate` so the two cannot disagree
+   * about what that means.
+   */
+  test("count with a select is a per-field count, not the plain total", () => {
+    expect(text({ select: { email: true } }, "count")).toContain(
+      `count("email")`,
+    );
+    expect(text({ select: { _all: true } }, "count")).toContain(`count(*)`);
+    // ...and a count with no select is still the plain total.
+    expect(text({}, "count")).toContain(`count(*) as "_count"`);
+  });
+
+  test("a select naming nothing is refused rather than counted as everything", () => {
+    expect(() => text({ select: {} }, "count")).toThrow(
+      /must name at least one field/,
     );
   });
 

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -4,7 +4,6 @@ import type { Operation, QueryPlan } from "../plan";
 import type { ModelSchema } from "../schema";
 import { buildRowShaper } from "../shape";
 import {
-  type Binder,
   type Fragment,
   bindValues,
   concat,
@@ -12,7 +11,7 @@ import {
   render,
   sql,
 } from "./fragment";
-import { compileOrderBy, parseOrderBy, reverse, type OrderTerm } from "./orderBy";
+import { compileOrderBy, parseOrderBy } from "./orderBy";
 import {
   planRelations,
   strategiesOf,
@@ -21,6 +20,8 @@ import {
 import { planRelationCounts } from "./relation-count";
 import { resolveSelection, withKeyFields } from "./select";
 import { assertUniqueWhere } from "./unique";
+import { compileAggregate } from "./aggregate";
+import { pagination } from "./paginate";
 import { compileWhere } from "./where";
 
 /** Every read operation, and what each accepts. */
@@ -37,11 +38,11 @@ const READ_ARGS: Record<string, Set<string>> = {
   ]),
   findUnique: new Set(["where", "select", "include"]),
   findUniqueOrThrow: new Set(["where", "select", "include"]),
-  // No `select`: Prisma's `count` uses it to return an object of per-field
-  // counts, which is aggregate territory and is not emitted onto the generated
-  // bases. Accepting it here and then ignoring it would return the plain total
-  // under a shape the caller did not ask for.
-  count: new Set(["where", "orderBy", "skip", "take"]),
+  // `select` on a count returns an object of per-field counts rather than a
+  // number — `{ _all: 3, email: 2 }`. It was refused here while there was no
+  // aggregate to put it beside; now there is, and `compileAggregate` owns it,
+  // so this only has to let it through.
+  count: new Set(["where", "orderBy", "skip", "take", "select"]),
 };
 
 export function isReadOperation(op: Operation): boolean {
@@ -73,6 +74,14 @@ export function compileRead(
   strategy?: RelationStrategy,
 ): QueryPlan {
   assertArgs(schema, op, args);
+
+  // A count with a `select` is an aggregate wearing a count's name: same
+  // statement, flatter result. Routed rather than reimplemented, so the two
+  // cannot disagree about what a per-field count means (rows where the column
+  // is not null).
+  if (op === "count" && args?.select !== undefined && args.select !== null) {
+    return compileAggregate(schema, op, args, dialect);
+  }
 
   // Relations are planned *before* the `where` is compiled, because whether any
   // strategy folds children into the root statement decides whether the root's
@@ -124,7 +133,7 @@ export function compileRead(
     if (!paginated) {
       statement = concat(counted, from, whereClause);
     } else {
-      const { clause, terms } = pagination(schema, op, args, dialect, parsed);
+      const { clause, terms } = pagination(schema, args, dialect, parsed, SINGLE_ROW.has(op));
       const order = compileOrderBy(terms, dialect);
       // One column, not `*`: the subquery exists to be counted, so the narrowest
       // thing that keeps a row identity is right.
@@ -185,13 +194,13 @@ export function compileRead(
     reversed,
   } = pagination(
     schema,
-    op,
     args,
     dialect,
     parseOrderBy(schema, args?.orderBy, op, {
       dialect,
       locate: (a: any) => a?.orderBy,
     }),
+    SINGLE_ROW.has(op),
   );
   const order = compileOrderBy(terms, dialect, qualifier);
 
@@ -264,58 +273,6 @@ export function compileRead(
       // where the model's name is in scope for the message.
       return single ? (shaped[0] ?? null) : shaped;
     },
-  };
-}
-
-/**
- * `skip` / `take`, plus the two pieces of Prisma behaviour around them that are
- * invisible until you read the SQL it emits:
- *
- * - Paginating without an `orderBy` injects `order by <primary key> asc`.
- *   Without it, "page 2" is only meaningful if the storage engine happens to
- *   return a stable order, which is not guaranteed on either dialect.
- * - A *negative* `take` means "the last N": Prisma flips every ordering term,
- *   takes `abs(take)`, and then reverses the result set so the caller still
- *   sees their own ordering. `reversed` carries that last part out to `shape`.
- */
-function pagination(
-  schema: ModelSchema,
-  op: Operation,
-  args: any,
-  dialect: SqlDialect,
-  parsed: OrderTerm[],
-): { clause: Fragment; terms: OrderTerm[]; reversed: boolean } {
-  const single = SINGLE_ROW.has(op);
-  const take = single ? 1 : args?.take;
-  const skip = args?.skip;
-
-  let terms = parsed;
-  const paginating = take !== undefined || skip !== undefined;
-
-  if (paginating && terms.length === 0 && !single) {
-    terms = schema.primaryKey.map((name) => ({
-      column: schema.fields[name]?.column ?? name,
-      direction: "asc" as const,
-    }));
-  }
-
-  const negative = typeof take === "number" && take < 0;
-  if (negative) terms = reverse(terms);
-
-  const takeBinder: Binder | null =
-    take === undefined
-      ? null
-      : single
-        ? () => 1
-        : (callArgs: any) => Math.abs(Number(callArgs?.take));
-
-  const skipBinder: Binder | null =
-    skip === undefined ? null : (callArgs: any) => Number(callArgs?.skip);
-
-  return {
-    clause: dialect.paginate(takeBinder, skipBinder),
-    terms,
-    reversed: negative,
   };
 }
 

--- a/packages/gemi/orm/plan.discrimination.test.ts
+++ b/packages/gemi/orm/plan.discrimination.test.ts
@@ -241,6 +241,118 @@ describe("plan cache discrimination", () => {
     );
   });
 
+  /**
+   * An aggregate's functions decide the projection, so they are structural for
+   * exactly the reason `select` is — and a collision here is the dangerous
+   * direction: a caller who switched a field *off* would get the statement that
+   * counts it, and the extra key in the result would look like data.
+   *
+   * Its own describe rather than rows in `DISTINCT_SHAPES`, because that table
+   * is compiled as `findMany` and these are only meaningful as `aggregate`.
+   */
+  describe("aggregate", () => {
+    const AGGREGATE_SHAPES: [string, unknown][] = [
+      ["count bare", { _count: true }],
+      ["count off", { _count: false }],
+      ["count _all", { _count: { _all: true } }],
+      ["count a field", { _count: { email: true } }],
+      ["count that field off", { _count: { email: false } }],
+      ["count another field", { _count: { name: true } }],
+      ["count two fields", { _count: { email: true, name: true } }],
+      ["sum", { _sum: { globalRole: true } }],
+      ["sum another field", { _sum: { id: true } }],
+      ["avg", { _avg: { globalRole: true } }],
+      ["min", { _min: { globalRole: true } }],
+      ["max", { _max: { globalRole: true } }],
+      ["min and max", { _min: { globalRole: true }, _max: { globalRole: true } }],
+      ["sum with a take", { _sum: { globalRole: true }, take: 1 }],
+      ["sum with a skip", { _sum: { globalRole: true }, skip: 1 }],
+      ["sum with an orderBy", { _sum: { globalRole: true }, orderBy: { id: "asc" } }],
+    ];
+
+    test("every shape gets its own key", () => {
+      const keys = new Map<string, string>();
+      for (const [label, args] of AGGREGATE_SHAPES) {
+        const key = planKey(sqlite, "User", "aggregate", args);
+        const clash = keys.get(key);
+        expect(clash, `"${label}" collides with "${clash}"`).toBeUndefined();
+        keys.set(key, label);
+      }
+      expect(keys.size).toBe(AGGREGATE_SHAPES.length);
+    });
+
+    test("...and its own plan", () => {
+      const plans = new Map<string, string>();
+      for (const [label, args] of AGGREGATE_SHAPES) {
+        // `_count: false` leaves nothing to aggregate, which is a refusal
+        // rather than a plan — it earns its own *key*, which is what matters.
+        if (label === "count off" || label === "count that field off") continue;
+        // See the benign-duplicate test below.
+        if (label === "sum with an orderBy") continue;
+
+        const plan = getOrCompile(user, "aggregate", args, sqlite);
+        // The shaper is part of a plan's identity here, and it has to be:
+        // `_count: true` and `_count: { _all: true }` emit *the same*
+        // `count(*)` and differ only in whether the result is a number or an
+        // object. Comparing text and binders alone would report that as a
+        // collision, which it is not — the same widening `identityOf` above
+        // needed when `_count` relations arrived.
+        const identity = [
+          plan.text,
+          JSON.stringify(plan.bind(args)),
+          JSON.stringify(plan.shape([])),
+        ].join(" ");
+        const clash = plans.get(identity);
+        expect(
+          clash,
+          `"${label}" is indistinguishable from "${clash}":\n  ${identity}`,
+        ).toBeUndefined();
+        plans.set(identity, label);
+      }
+    });
+
+    /**
+     * The benign duplicate, pinned so it cannot quietly become the dangerous
+     * kind: an **unpaginated** aggregate drops its `orderBy`, because ordering
+     * the single row an aggregate produces means nothing. So it shares a plan
+     * with the same aggregate that had no `orderBy` at all — while still
+     * earning its own cache key, which costs a spare entry and never a wrong
+     * statement.
+     *
+     * It is still *parsed*, so a misspelled column is an error either way. That
+     * is the half worth keeping: validation must not depend on whether a
+     * different argument happened to be supplied.
+     */
+    test("an unpaginated orderBy is dropped, sharing a plan but not a key", () => {
+      const plain = { _sum: { globalRole: true } };
+      const ordered = { _sum: { globalRole: true }, orderBy: { id: "asc" } };
+
+      expect(getOrCompile(user, "aggregate", ordered, sqlite).text).toBe(
+        getOrCompile(user, "aggregate", plain, sqlite).text,
+      );
+      expect(planKey(sqlite, "User", "aggregate", ordered)).not.toBe(
+        planKey(sqlite, "User", "aggregate", plain),
+      );
+
+      // ...and paginating puts it back, which is what makes the drop safe.
+      expect(
+        getOrCompile(user, "aggregate", { ...ordered, take: 1 }, sqlite).text,
+      ).toContain(`order by "id" asc`);
+    });
+
+    // A count's `select` is the same rule under a different operation, and it
+    // already worked — pinned so that a change to `LITERAL_KEYS` cannot break
+    // one without the other noticing.
+    test("a count's select discriminates too", () => {
+      expect(planKey(sqlite, "User", "count", { select: { email: true } })).not.toBe(
+        planKey(sqlite, "User", "count", { select: { email: false } }),
+      );
+      expect(planKey(sqlite, "User", "count", { select: { email: true } })).not.toBe(
+        planKey(sqlite, "User", "count", {}),
+      );
+    });
+  });
+
   test("the operation is part of the key", () => {
     const args = { where: { id: 1 } };
     const keys = new Set(

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -6,10 +6,15 @@ import type { RelationStrategy } from "./compile/plan-relations";
 import type { ModelSchema } from "./schema";
 
 /**
- * The public operations. `aggregate`, `groupBy` and the raw operations are
- * deliberately not among them: they are excluded at the operation level rather
- * than narrowed out of the argument types, because narrowing Prisma's recursive
- * where-inputs with `Omit` is miserable.
+ * The public operations. `groupBy` and the raw operations are deliberately not
+ * among them: they are excluded at the operation level rather than narrowed out
+ * of the argument types, because narrowing Prisma's recursive where-inputs with
+ * `Omit` is miserable.
+ *
+ * `aggregate` joined the list once there was a measured account of what Prisma
+ * returns for one — see `compile/aggregate.ts`. `groupBy` did not follow it in
+ * the same change: `having` is a second predicate compiler over aggregate
+ * expressions rather than columns, which is its own piece of work.
  */
 export type Operation =
   | "findUnique"
@@ -18,6 +23,7 @@ export type Operation =
   | "findFirstOrThrow"
   | "findMany"
   | "count"
+  | "aggregate"
   | "create"
   | "createMany"
   | "update"
@@ -162,6 +168,17 @@ const LITERAL_KEYS = new Set([
   "include",
   "distinct",
   "mode",
+  // An aggregate's functions decide the *projection*, so they are structural
+  // for exactly the reason `select` is — and they fail the same way. Without
+  // them, `_count: { email: true }` and `_count: { email: false }` both shape to
+  // `{_count:{email:boolean}}`, share one entry, and the second caller gets the
+  // first one's statement: a column they switched off, counted anyway. `_count:
+  // true` against `_count: false` is the same collision one level up.
+  "_count",
+  "_avg",
+  "_sum",
+  "_min",
+  "_max",
 ]);
 
 export function canonicalShape(

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -280,6 +280,14 @@ export interface PolicedModel {
  * refuses a `where` carrying anything beside that key. A scoped upsert is
  * therefore not expressible at all, and is refused by name rather than run
  * unscoped — see `assertScopable`.
+ *
+ * **Every other operation with a `where` has to be in here, and adding one is
+ * the step that is easy to forget.** `assertScopable` is written for `upsert`,
+ * so an operation missing from this set does not run unscoped — it fails, with
+ * `upsert`'s reason about `on conflict` targets, which sends the reader
+ * somewhere unrelated. That is the safe direction and a confusing one, and it
+ * takes the operation away from exactly the models the ORM's headline
+ * capability is for: anything carrying `softDeletes()` has a `scope`.
  */
 const SCOPABLE = new Set<string>([
   "findMany",
@@ -288,6 +296,10 @@ const SCOPABLE = new Set<string>([
   "findUnique",
   "findUniqueOrThrow",
   "count",
+  // Its `where` is an ordinary predicate over the rows being aggregated, so a
+  // scope narrows it exactly as it narrows a `count` — which is the same
+  // statement with one function in it.
+  "aggregate",
   "update",
   "updateMany",
   "delete",

--- a/templates/saas-starter/app/models/aggregate.test-d.ts
+++ b/templates/saas-starter/app/models/aggregate.test-d.ts
@@ -1,0 +1,105 @@
+import { expectTypeOf, test, describe } from "vitest";
+
+import { UserModel } from "./generated";
+
+/**
+ * `aggregate` and `count({ select })`, at the type level.
+ *
+ * A `.test-d.ts` file, run with `vitest --typecheck`. Nothing here executes.
+ *
+ * The property under test is the one this operation shares with every other:
+ * **the result narrows to what was asked for**, using Prisma's own mapped types
+ * rather than a second definition that can drift from them. It is only checkable
+ * here — a runtime test would pass for a signature returning `any`, which is
+ * exactly the shortcut worth ruling out for an operation whose result shape is
+ * decided entirely by its arguments.
+ */
+
+describe("aggregate narrows to the functions it was given", () => {
+  test("one function over one field", async () => {
+    const result = await UserModel.aggregate({ _max: { globalRole: true } });
+
+    expectTypeOf(result._max.globalRole).toEqualTypeOf<number | null>();
+    // The next-position case from the issue: a `_max` over a list's sort index,
+    // which is ordinary CRUD rather than analytics.
+    expectTypeOf(result).not.toHaveProperty("_sum");
+    expectTypeOf(result).not.toHaveProperty("_min");
+  });
+
+  test("several functions at once, each carrying only its own fields", async () => {
+    const result = await UserModel.aggregate({
+      _sum: { globalRole: true },
+      _min: { createdAt: true },
+    });
+
+    expectTypeOf(result._sum.globalRole).toEqualTypeOf<number | null>();
+    expectTypeOf(result._min.createdAt).toEqualTypeOf<Date | null>();
+    expectTypeOf(result._sum).not.toHaveProperty("createdAt");
+    expectTypeOf(result._min).not.toHaveProperty("globalRole");
+  });
+
+  /**
+   * `_count` is the only one with two shapes, and the type has to follow the
+   * value: a number for `true`, an object for the per-field form.
+   */
+  test("_count is a number when bare and an object when not", async () => {
+    const bare = await UserModel.aggregate({ _count: true });
+    expectTypeOf(bare._count).toEqualTypeOf<number>();
+
+    const perField = await UserModel.aggregate({
+      _count: { _all: true, email: true },
+    });
+    expectTypeOf(perField._count._all).toEqualTypeOf<number>();
+    expectTypeOf(perField._count.email).toEqualTypeOf<number>();
+  });
+
+  test("a nullable column's min is nullable, like every aggregate over no rows", async () => {
+    const result = await UserModel.aggregate({ _min: { deletedAt: true } });
+    expectTypeOf(result._min.deletedAt).toEqualTypeOf<Date | null>();
+  });
+
+  test("where, orderBy, take and skip are accepted", async () => {
+    const result = await UserModel.aggregate({
+      where: { globalRole: 2 },
+      orderBy: { createdAt: "desc" },
+      take: 10,
+      skip: 1,
+      _avg: { globalRole: true },
+    });
+
+    expectTypeOf(result._avg.globalRole).toEqualTypeOf<number | null>();
+  });
+
+  test("a field the model does not have is rejected", () => {
+    // @ts-expect-error — `nope` is not a field on User.
+    UserModel.aggregate({ _sum: { nope: true } });
+  });
+
+  test("a non-numeric field is rejected for _sum, as Prisma rejects it", () => {
+    // @ts-expect-error — `email` is a String, and `_sum` needs a number.
+    UserModel.aggregate({ _sum: { email: true } });
+  });
+});
+
+/**
+ * `count` keeps both of Prisma's spellings, which is why the emitted method is
+ * an overload rather than one signature widened to `number | object`.
+ */
+describe("count narrows on its select", () => {
+  test("without a select it is a plain number", async () => {
+    expectTypeOf(await UserModel.count()).toEqualTypeOf<number>();
+    expectTypeOf(
+      await UserModel.count({ where: { globalRole: 2 } }),
+    ).toEqualTypeOf<number>();
+  });
+
+  test("with a select it is an object of exactly the named counts", async () => {
+    const result = await UserModel.count({
+      select: { _all: true, email: true },
+    });
+
+    expectTypeOf(result._all).toEqualTypeOf<number>();
+    expectTypeOf(result.email).toEqualTypeOf<number>();
+    expectTypeOf(result).not.toHaveProperty("name");
+  });
+});

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -546,6 +546,86 @@ const CASES: [string, string, unknown][] = [
   ["count with skip", "count", { skip: 2 }],
   ["count with take and skip", "count", { take: 2, skip: 1 }],
   ["count with orderBy", "count", { orderBy: { name: "asc" } }],
+
+  // --- count's per-field form ---------------------------------------------
+  //
+  // `{ _all: 3, email: 2 }` rather than a number, and the per-field entries
+  // count rows where the column is **not null** — which the fixture makes
+  // discriminating, since `email` and `name` are null on different rows.
+  ["count select _all", "count", { select: { _all: true } }],
+  ["count select a field", "count", { select: { email: true } }],
+  ["count select two fields", "count", { select: { email: true, name: true } }],
+  ["count select _all and a field", "count", { select: { _all: true, email: true } }],
+  ["count select with where", "count", {
+    where: { globalRole: 2 }, select: { _all: true, email: true },
+  }],
+  ["count select matching nothing", "count", {
+    where: { globalRole: 99 }, select: { _all: true, email: true },
+  }],
+
+  // --- aggregate ----------------------------------------------------------
+  //
+  // The empty-set row is the one that discriminates hardest: `_count` is 0 but
+  // every other function is `null`, per field, and an implementation that
+  // coalesced to 0 would look right everywhere else.
+  ["aggregate _count true", "aggregate", { _count: true }],
+  ["aggregate _count _all", "aggregate", { _count: { _all: true } }],
+  ["aggregate _count per field", "aggregate", { _count: { email: true, name: true } }],
+  ["aggregate _count mixed", "aggregate", { _count: { _all: true, email: true } }],
+  ["aggregate _sum", "aggregate", { _sum: { globalRole: true } }],
+  ["aggregate _avg", "aggregate", { _avg: { globalRole: true } }],
+  ["aggregate _min", "aggregate", { _min: { globalRole: true } }],
+  ["aggregate _max", "aggregate", { _max: { globalRole: true } }],
+  ["aggregate every function at once", "aggregate", {
+    _count: { _all: true, email: true },
+    _sum: { globalRole: true },
+    _avg: { globalRole: true },
+    _min: { globalRole: true },
+    _max: { globalRole: true },
+  }],
+  // A string and a DateTime through min/max, which come back as values of the
+  // column rather than as numbers — the DateTime is the one SQLite stores as
+  // integer milliseconds and therefore has to decode.
+  ["aggregate min/max on a string", "aggregate", {
+    _min: { email: true }, _max: { name: true },
+  }],
+  ["aggregate min/max on a DateTime", "aggregate", {
+    _min: { createdAt: true }, _max: { createdAt: true },
+  }],
+  ["aggregate min/max on a nullable DateTime", "aggregate", {
+    _min: { deletedAt: true }, _max: { deletedAt: true },
+  }],
+  ["aggregate with where", "aggregate", {
+    where: { globalRole: { gt: 0 } }, _sum: { globalRole: true }, _count: true,
+  }],
+  ["aggregate over no rows", "aggregate", {
+    where: { globalRole: 99 },
+    _count: true,
+    _sum: { globalRole: true },
+    _avg: { globalRole: true },
+    _min: { globalRole: true },
+    _max: { createdAt: true },
+  }],
+  ["aggregate over no rows, _count object", "aggregate", {
+    where: { globalRole: 99 }, _count: { _all: true, email: true },
+  }],
+  // `take` / `skip` describe the rows being aggregated, not the one row the
+  // aggregate produces — so these sum a *page* rather than the whole set.
+  ["aggregate with take", "aggregate", {
+    orderBy: { globalRole: "asc" }, take: 2, _sum: { globalRole: true }, _count: true,
+  }],
+  ["aggregate with skip", "aggregate", {
+    orderBy: { globalRole: "asc" }, skip: 1, _sum: { globalRole: true }, _count: true,
+  }],
+  ["aggregate with take and skip", "aggregate", {
+    orderBy: { globalRole: "asc" }, skip: 1, take: 2, _sum: { globalRole: true },
+  }],
+  ["aggregate with a negative take", "aggregate", {
+    orderBy: { globalRole: "asc" }, take: -2, _sum: { globalRole: true },
+  }],
+  ["aggregate paginating with no orderBy", "aggregate", {
+    take: 2, _count: true,
+  }],
 ];
 
 /**

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -96,10 +96,22 @@ export class AccountModel extends Model {
     return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.AccountGetPayload<T>>;
   }
 
-  static count(
-    args?: Omit<Prisma.AccountCountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.AccountCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.AccountCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.AccountCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.AccountCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.AccountAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.AccountAggregateArgs>,
+  ): Promise<Prisma.GetAccountAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetAccountAggregateType<T>
+    >;
   }
 
   static create<T extends Prisma.AccountCreateArgs>(
@@ -230,10 +242,22 @@ export class MagicLinkTokenModel extends Model {
     return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.MagicLinkTokenGetPayload<T>>;
   }
 
-  static count(
-    args?: Omit<Prisma.MagicLinkTokenCountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.MagicLinkTokenCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.MagicLinkTokenCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.MagicLinkTokenCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.MagicLinkTokenCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.MagicLinkTokenAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.MagicLinkTokenAggregateArgs>,
+  ): Promise<Prisma.GetMagicLinkTokenAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetMagicLinkTokenAggregateType<T>
+    >;
   }
 
   static create<T extends Prisma.MagicLinkTokenCreateArgs>(
@@ -364,10 +388,22 @@ export class OrganizationModel extends Model {
     return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.OrganizationGetPayload<T>>;
   }
 
-  static count(
-    args?: Omit<Prisma.OrganizationCountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.OrganizationCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.OrganizationCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.OrganizationCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.OrganizationCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.OrganizationAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.OrganizationAggregateArgs>,
+  ): Promise<Prisma.GetOrganizationAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetOrganizationAggregateType<T>
+    >;
   }
 
   static create<T extends Prisma.OrganizationCreateArgs>(
@@ -498,10 +534,22 @@ export class OrganizationInvitationModel extends Model {
     return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.OrganizationInvitationGetPayload<T>>;
   }
 
-  static count(
-    args?: Omit<Prisma.OrganizationInvitationCountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.OrganizationInvitationCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.OrganizationInvitationCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.OrganizationInvitationCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.OrganizationInvitationCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.OrganizationInvitationAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.OrganizationInvitationAggregateArgs>,
+  ): Promise<Prisma.GetOrganizationInvitationAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetOrganizationInvitationAggregateType<T>
+    >;
   }
 
   static create<T extends Prisma.OrganizationInvitationCreateArgs>(
@@ -632,10 +680,22 @@ export class PasswordResetTokenModel extends Model {
     return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.PasswordResetTokenGetPayload<T>>;
   }
 
-  static count(
-    args?: Omit<Prisma.PasswordResetTokenCountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.PasswordResetTokenCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.PasswordResetTokenCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.PasswordResetTokenCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.PasswordResetTokenCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.PasswordResetTokenAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.PasswordResetTokenAggregateArgs>,
+  ): Promise<Prisma.GetPasswordResetTokenAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetPasswordResetTokenAggregateType<T>
+    >;
   }
 
   static create<T extends Prisma.PasswordResetTokenCreateArgs>(
@@ -766,10 +826,22 @@ export class SessionModel extends Model {
     return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.SessionGetPayload<T>>;
   }
 
-  static count(
-    args?: Omit<Prisma.SessionCountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.SessionCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.SessionCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.SessionCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.SessionCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.SessionAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.SessionAggregateArgs>,
+  ): Promise<Prisma.GetSessionAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetSessionAggregateType<T>
+    >;
   }
 
   static create<T extends Prisma.SessionCreateArgs>(
@@ -900,10 +972,22 @@ export class SocialAccountModel extends Model {
     return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.SocialAccountGetPayload<T>>;
   }
 
-  static count(
-    args?: Omit<Prisma.SocialAccountCountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.SocialAccountCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.SocialAccountCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.SocialAccountCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.SocialAccountCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.SocialAccountAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.SocialAccountAggregateArgs>,
+  ): Promise<Prisma.GetSocialAccountAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetSocialAccountAggregateType<T>
+    >;
   }
 
   static create<T extends Prisma.SocialAccountCreateArgs>(
@@ -1034,10 +1118,22 @@ export class UserModel extends Model {
     return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.UserGetPayload<T>>;
   }
 
-  static count(
-    args?: Omit<Prisma.UserCountArgs, "select">,
-  ): Promise<number> {
-    return this.$exec("count", args) as Promise<number>;
+  static count(args?: Omit<Prisma.UserCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.UserCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.UserCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.UserCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.UserAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.UserAggregateArgs>,
+  ): Promise<Prisma.GetUserAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetUserAggregateType<T>
+    >;
   }
 
   static create<T extends Prisma.UserCreateArgs>(

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -223,6 +223,42 @@ function suite(label: string, url?: string) {
       expect(others.map((row: any) => row.email)).toEqual(["bob@x.test"]);
     });
 
+    /**
+     * An aggregate's `where` is an ordinary predicate over the rows being
+     * aggregated, so a scope narrows it exactly as it narrows a `count`.
+     *
+     * Worth its own test because the failure is not a leak: an operation
+     * missing from `SCOPABLE` *throws*, with `upsert`'s reason about `on
+     * conflict` targets — so the feature disappears on every policied model
+     * while the message points somewhere unrelated. `softDeletes()` is what
+     * makes that broad rather than niche: it ships with the framework and it
+     * carries a `scope`.
+     */
+    test("scope narrows an aggregate, not just a read", async () => {
+      (ScopedUser as any).$policies = [tenantScoped];
+
+      const mine = await Model.asUser(ALICE, () =>
+        ScopedUser.aggregate({ _count: true }),
+      );
+      expect(mine._count).toBe(1);
+
+      // The whole table is two rows, so an unscoped aggregate would say 2 —
+      // which is what makes this discriminating rather than vacuous.
+      const everything = await Model.asSystem(() =>
+        ScopedUser.aggregate({ _count: true }),
+      );
+      expect(everything._count).toBe(2);
+    });
+
+    test("scope narrows count's per-field form too", async () => {
+      (ScopedUser as any).$policies = [tenantScoped];
+
+      const counts = await Model.asUser(ALICE, () =>
+        ScopedUser.count({ select: { _all: true, email: true } }),
+      );
+      expect(counts).toEqual({ _all: 1, email: 1 });
+    });
+
     test("a caller's own where still applies alongside the scope", async () => {
       (ScopedUser as any).$policies = [tenantScoped];
 


### PR DESCRIPTION
Closes #64, for the half the issue says to ship first.

`_max: { position: true }` to find the next sort index is **ordinary CRUD, not analytics** — so this is a floor rather than a call-site count: any list-reordering feature reaches for it on the way in. It was also the one gap on the list with no partial workaround inside the ORM at all.

`groupBy` is deliberately not beside it, as the issue suggests. `having` is a predicate compiler over aggregate expressions rather than columns, and shipping half of it typed as though it worked would be worse than not shipping it.

## Prisma's behaviour was measured first

Before any compiler code, against a generated client. Every claim in `compile/aggregate.ts`'s comments is a line of that probe's output. Three findings shaped the implementation, and each is a place a plausible implementation is wrong:

- **`_count` has two shapes.** `_count: true` returns a *number*; `_count: { _all: true, email: true }` returns an object — and a per-field count is `count("email")`, the rows where that column is **not null**. That is a different number from `count(*)` and the whole reason to ask per field.
- **The empty set is not zeroes.** `_count` over no rows is `0`, but `_sum`, `_avg`, `_min` and `_max` are each `null`, per field. An implementation that coalesced to `0` would look right in every test that has rows.
- **The driver's types are not the column's types.** Measured through Bun against Postgres 16:

| | returns | as |
| --- | --- | --- |
| `count(*)`, `count(text)` | `"2"` | **string** |
| `sum(integer)` | `"4"` | **string** (bigint) |
| `sum(bigint)` | `"9007199254740995"` | **string** |
| `avg(integer)` | `"2.0000000000000000"` | **string** (numeric) |
| `sum(double)`, `avg(double)`, `min(integer)` | number | number |
| `min(timestamp)` | `Date` | object |

  So the coercion **cannot** be `dialect.decode(value, field)` — that decodes a value of the column's type, and an aggregate is not one. `_min` / `_max` are the exception, and there `decode` is exactly right: it is what turns SQLite's integer milliseconds back into a `Date`.

## `count({ select })` ships with it

It was refused as "aggregate territory", which was the right call while there was no aggregate to put it beside. The issue asks for the two decisions together, and this is the together — it routes through the same compiler, so the two cannot disagree about what a per-field count means.

```ts
await User.count()                                        // 3
await User.count({ select: { _all: true, email: true } })  // { _all: 3, email: 2 }
```

The emitted `count` is an **overload** rather than a return type widened to `number | object`, so both spellings stay exact for every caller.

## Two things found while building it

- **A plan-cache collision.** An aggregate's functions decide the projection, so they are structural for exactly the reason `select` is — and they were not in `LITERAL_KEYS`. `_count: { email: true }` and `_count: { email: false }` shaped to the same key, so the second caller would have got the first's statement: a column they switched off, counted anyway. Reproduced, fixed, and sixteen shapes now go through the discrimination suite. Its plan-identity check needed widening too, since `_count: true` and `_count: { _all: true }` emit the same `count(*)` and differ only in the shaper.
- **`read.ts` and `aggregate.ts` both need `pagination`**, which would have been an import cycle. It moves to `compile/paginate.ts` and takes `single` as a parameter rather than deriving it from the operation name, so it needs to know nothing about which operations exist.

## Verification

**27 new differential cases, against Prisma on both dialects** — every function at once, `min`/`max` over a string and over a nullable `DateTime`, the empty set (both `_count` shapes), and `take` / `skip` / negative-`take` paging the rows being *aggregated* rather than the row that comes back.

**Unit tests for the type table the template's schema cannot reach** — it has no `BigInt`, `Float`, `Decimal`, `Json` or `Bytes` column. The `BigInt` sum is the one that would otherwise be silently wrong in production: `sum(bigint)` crosses as an exact string and `Number()` drops the low bits, the same trap the lateral strategy's `::text` cast exists for. That test compares as *text*, because the literal `9007199254740995` is already rounded by the time a numeric assertion sees it — `not.toBe` a number would have passed for the broken implementation.

**Nine type-level assertions** (`aggregate.test-d.ts`) pin the narrowing: `_max: { position: true }` to `{ _max: { position: number | null } }`, `_count` as number-or-object, and `@ts-expect-error` on an unknown field and on `_sum` over a String.

`Decimal` is passed through rather than converted, and says so: the template has no Decimal column, so nothing here has been compared against Prisma's `Decimal` instance, and claiming an unmeasured conversion would be worse.

Suites: 784 unit tests, full template suite green on SQLite and Postgres 16. Pre-existing and unchanged: `generated.test.ts`'s generator-linkage probe, the by-design one-dialect-at-a-time differential guard, and two `where.ts` lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
