### PR TITLE
`createMany({ skipDuplicates })`, on the dialect Prisma offers it

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -126,6 +126,27 @@ stepping stone: a `Pick<User, "id">` hydrated as a `User` would carry methods re
 query never fetched. See [Rows and entities](./orm-rows-and-entities.md) for the two opt-in levels
 above it — `track` + `save`, and `wrap`.
 
+### Importing a batch that may overlap
+
+```ts
+await Product.createMany({ data: rows, skipDuplicates: true })   // Postgres only
+```
+
+`ON CONFLICT DO NOTHING`, untargeted — so it covers every unique constraint and the primary key at
+once, which is what `skipDuplicates` means. The returned `{ count }` is the number of rows
+**inserted**, not the number supplied, so it answers "how many were new".
+
+The check and the insert being one statement is the whole point. Reading first to find out which
+rows exist is a second query *and* a race: between the read and the insert a concurrent importer
+writes one of them, and the insert fails on a unique violation anyway.
+
+**Postgres only, and that is Prisma's line rather than SQL's.** SQLite can express the same clause;
+Prisma rejects the argument there — for `false` as well as `true` — so gemi does too, rather than
+becoming a silent superset on the one dialect the differential harness could then no longer compare.
+On SQLite the error names the dialect and says so. If a batch is too large for one statement it is
+split inside a transaction, and `skipDuplicates` survives the split: the counts sum, and a conflict
+in a later chunk does not roll back an earlier one, because `do nothing` is not an error.
+
 ### Per-call options
 
 A second parameter, not a key inside `args` — intersecting Prisma's own arg types with a

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -185,6 +185,95 @@ describe("createMany", () => {
     ).toThrow(UnsupportedQueryError);
   });
 
+  /**
+   * `skipDuplicates` — the check and the insert in one statement, which is the
+   * whole point: reading first to find out which rows exist is a second query
+   * *and* a race, since a concurrent importer can write one of them in between
+   * and the insert fails on a unique violation anyway.
+   */
+  describe("skipDuplicates", () => {
+    const rows = { data: [{ email: "a@b.c" }, { email: "d@e.f" }] };
+
+    test("true emits an untargeted conflict clause, before returning", () => {
+      const emitted = text("createMany", { ...rows, skipDuplicates: true }, postgres);
+
+      // Untargeted, so it covers every unique constraint and the primary key at
+      // once — which is what `skipDuplicates` means, and what Prisma emits. A
+      // targeted `on conflict (col)` would still fail on any other constraint.
+      expect(emitted).toContain(` on conflict do nothing returning "id"`);
+    });
+
+    test("false is the same statement as not asking", () => {
+      expect(text("createMany", { ...rows, skipDuplicates: false }, postgres)).toBe(
+        text("createMany", rows, postgres),
+      );
+    });
+
+    /**
+     * The count has to be the number *inserted*, not the number supplied —
+     * the part the issue flags as most likely to be got wrong. It falls out:
+     * a row a conflict skipped never reaches `RETURNING`.
+     */
+    test("the count is what was inserted, not what was offered", () => {
+      const plan = compileWrite(
+        user,
+        "createMany",
+        { ...rows, skipDuplicates: true },
+        postgres,
+      );
+
+      expect(plan.shape([{ id: 1 }])).toEqual({ count: 1 });
+      expect(plan.shape([])).toEqual({ count: 0 });
+    });
+
+    /**
+     * SQLite *can* express it, and Prisma still rejects the argument there —
+     * for `false` as well as `true`, verified against a generated 6.19 client.
+     * Accepting `false` because it happens to be a no-op would make the two
+     * dialects disagree about which calls are legal.
+     */
+    test.each([true, false])("%s is refused on sqlite, naming the dialect", (value) => {
+      expect(() =>
+        text("createMany", { ...rows, skipDuplicates: value }),
+      ).toThrow(/not available on sqlite/);
+      expect(() =>
+        text("createMany", { ...rows, skipDuplicates: value }),
+      ).toThrow(/Prisma does not offer it there either/);
+    });
+
+    /**
+     * Validation must not depend on how much data happened to be supplied. The
+     * empty-list shortcut returns before the statement is built, so the check
+     * has to come first or `createMany({ data: [], skipDuplicates: true })`
+     * succeeds on SQLite and the same call with one row throws.
+     */
+    test("an empty list is validated too", () => {
+      expect(() =>
+        text("createMany", { data: [], skipDuplicates: true }),
+      ).toThrow(/not available on sqlite/);
+      expect(() =>
+        compileWrite(user, "createMany", { data: [], skipDuplicates: true }, postgres),
+      ).not.toThrow();
+    });
+
+    test("a non-boolean is refused", () => {
+      expect(() =>
+        compileWrite(user, "createMany", { ...rows, skipDuplicates: "yes" }, postgres),
+      ).toThrow(/Expected true or false/);
+    });
+
+    test("it is only an argument of createMany", () => {
+      expect(() =>
+        compileWrite(
+          user,
+          "create",
+          { data: { email: "a@b.c" }, skipDuplicates: true },
+          postgres,
+        ),
+      ).toThrow(UnsupportedQueryError);
+    });
+  });
+
   // `default values` inserts exactly one row, and there is no portable
   // multi-row spelling of it — so this used to succeed and insert one row for
   // three, reporting `{ count: 1 }`.

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -66,7 +66,7 @@ import { compileWhere } from "./where";
 
 const WRITE_ARGS: Record<string, Set<string>> = {
   create: new Set(["data", "select", "include"]),
-  createMany: new Set(["data"]),
+  createMany: new Set(["data", "skipDuplicates"]),
   update: new Set(["data", "where", "select", "include"]),
   updateMany: new Set(["data", "where"]),
   delete: new Set(["where", "select", "include"]),
@@ -161,6 +161,13 @@ function compileCreateMany(
 ): QueryPlan {
   const rows = args?.data === undefined ? [] : listOf(args.data);
 
+  // Before the empty-list shortcut below, so that an unsupported argument is
+  // refused whether or not there was anything to write. Prisma rejects it on
+  // SQLite for an empty list too, and validation that depends on how much data
+  // happened to be supplied is the kind that passes in a test and fails in
+  // production.
+  const ignore = skipDuplicatesClause(schema, op, args, dialect);
+
   // Prisma returns `{ count: 0 }` for an empty list without touching the
   // database, but a plan must have a statement. A constant-false select is the
   // cheapest thing that yields zero rows on both dialects, and it keeps the
@@ -212,6 +219,7 @@ function compileCreateMany(
   const statement = concat(
     sql(`insert into ${dialect.quoteIdent(schema.table)}`),
     valuesClause(grid, dialect),
+    ignore ?? sql(""),
     returning.clause,
   );
 
@@ -219,8 +227,62 @@ function compileCreateMany(
   return {
     text,
     bind: bindValues(binders),
+    // The rows a conflict skipped never reach `RETURNING`, so this is the
+    // number *inserted* rather than the number supplied — which is what Prisma
+    // returns, and what makes the count usable for "how many were new".
     shape: (returned) => ({ count: returned.length }),
   };
+}
+
+/**
+ * `skipDuplicates`, or `null` when the caller did not ask for it.
+ *
+ * The whole point is that the check and the insert are one statement. Without
+ * it a caller reads first to find out which rows exist, which is a second query
+ * *and* a race: between the read and the insert a concurrent importer writes one
+ * of them, and the insert fails on a unique violation anyway.
+ *
+ * Refused on a dialect that does not offer it, naming the dialect rather than
+ * saying "yet" — the answer there is not "wait", it is "Prisma does not offer
+ * this on SQLite either, so neither do we". See `SqlDialect.ignoreConflicts`
+ * for why that is a parity decision rather than a gap.
+ */
+function skipDuplicatesClause(
+  schema: ModelSchema,
+  op: Operation,
+  args: any,
+  dialect: SqlDialect,
+): Fragment | null {
+  const requested = args?.skipDuplicates;
+  if (requested === undefined) return null;
+
+  if (typeof requested !== "boolean") {
+    throw new UnsupportedQueryError(
+      "skipDuplicates",
+      schema.name,
+      op,
+      `Expected true or false, got ${JSON.stringify(requested)}.`,
+    );
+  }
+
+  const clause = dialect.ignoreConflicts();
+  if (clause === null) {
+    // Refused whatever the value, which is exactly what Prisma does: on SQLite
+    // it reports `skipDuplicates` as an unknown argument for `false` as well as
+    // for `true`. Accepting `false` because it happens to be a no-op would make
+    // the two dialects disagree about which calls are legal.
+    throw new UnsupportedQueryError(
+      "skipDuplicates",
+      schema.name,
+      op,
+      `'skipDuplicates' is not available on ${dialect.name}. Prisma does not ` +
+        `offer it there either — it is a Postgres and MySQL argument. To ` +
+        `import a batch that may overlap, write the rows one at a time and ` +
+        `catch UniqueConstraintError, or move this model to Postgres.`,
+    );
+  }
+
+  return requested ? clause : null;
 }
 
 /**

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -138,6 +138,24 @@ export interface SqlDialect {
   paginate(take: Binder | null, skip: Binder | null): Fragment;
 
   /**
+   * The clause that makes an insert skip rows violating a unique constraint —
+   * `createMany({ skipDuplicates: true })` — or `null` where it is not offered.
+   *
+   * **`null` is a parity decision, not a missing feature**, and that is worth
+   * knowing before someone "fixes" SQLite by returning `insert or ignore`.
+   * SQLite has `on conflict do nothing` and has since 3.24; Prisma nonetheless
+   * rejects the *argument* on SQLite — `Unknown argument 'skipDuplicates'`,
+   * whatever its value, verified against a generated 6.19 client. Offering it
+   * here would make gemi a silent superset of Prisma on the one dialect the
+   * differential harness could then no longer compare, which is the trade this
+   * project has declined every other time it came up.
+   *
+   * A method rather than a boolean because the SQL differs where it exists, and
+   * a `Fragment` because everything the compiler emits is one.
+   */
+  ignoreConflicts(): Fragment | null;
+
+  /**
    * Recognise a driver error as a constraint violation, and say which columns
    * it names.
    *

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -84,6 +84,20 @@ export class PostgresDialect implements SqlDialect {
     );
   }
 
+  // `on conflict do nothing` with no target: it covers every unique constraint
+  // and the primary key at once, which is what `skipDuplicates` means — Prisma
+  // names no conflict target either. A targeted `on conflict (col)` would skip
+  // rows that collide on that column and still fail on any other constraint,
+  // which is the plausible wrong version.
+  //
+  // Rows it skips are absent from `RETURNING`, so the `{ count }` the compiler
+  // builds from the returned rows is the number *inserted* rather than the
+  // number supplied — which is the part the issue flags as most likely to be
+  // got wrong, and it falls out rather than needing a second count.
+  ignoreConflicts(): Fragment {
+    return sql(" on conflict do nothing");
+  }
+
   // Unlike SQLite, Postgres accepts `offset` on its own, so neither clause has
   // to be invented to satisfy the other.
   paginate(take: Binder | null, skip: Binder | null): Fragment {

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -123,6 +123,14 @@ export class SqliteDialect implements SqlDialect {
     return concat(sql(`${lhs} like `), param(pattern));
   }
 
+  // Not offered, and deliberately: see `SqlDialect.ignoreConflicts`. SQLite can
+  // express it — `on conflict do nothing` works here — but Prisma rejects the
+  // argument on this dialect, so implementing it would put gemi ahead of Prisma
+  // on the one dialect where the differential harness could no longer check it.
+  ignoreConflicts(): Fragment | null {
+    return null;
+  }
+
   // SQLite cannot parse `offset` without a preceding `limit`, so a bare `skip`
   // needs a limit anyway. `-1` is SQLite's "no limit", and it goes through a
   // parameter rather than into the text like everything else.

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -162,6 +162,13 @@ const LITERAL_KEYS = new Set([
   "include",
   "distinct",
   "mode",
+  // `skipDuplicates: true` emits `on conflict do nothing` and `false` does not,
+  // so the *value* is in the SQL text. Without it here both shape to `boolean`,
+  // share one entry, and whichever call compiled first decides whether the
+  // other one skips conflicts — an insert that raises where the caller asked it
+  // not to, or worse, one that silently swallows a duplicate the caller wanted
+  // to hear about.
+  "skipDuplicates",
 ]);
 
 export function canonicalShape(

--- a/packages/gemi/orm/plan.writes.discrimination.test.ts
+++ b/packages/gemi/orm/plan.writes.discrimination.test.ts
@@ -217,6 +217,39 @@ describe("plan cache discrimination — writes", () => {
     expect(planCacheStats().hits).toBe(3);
   });
 
+  /**
+   * `skipDuplicates` puts its *value* in the SQL text — `true` emits
+   * `on conflict do nothing` and `false` does not — so it is structural, for
+   * exactly the reason `select` is.
+   *
+   * Sharing an entry would be the dangerous direction twice over: whichever
+   * call compiled first would decide for the other, so an import asking to skip
+   * conflicts could raise, or an insert that wanted to hear about a duplicate
+   * could silently swallow it. On Postgres, since SQLite refuses the argument.
+   */
+  test("skipDuplicates discriminates, because its value is in the statement", () => {
+    const data = [{ email: "a@x" }];
+
+    const on = planKey(postgres, "User", "createMany", { data, skipDuplicates: true });
+    const off = planKey(postgres, "User", "createMany", { data, skipDuplicates: false });
+    const absent = planKey(postgres, "User", "createMany", { data });
+
+    expect(new Set([on, off, absent]).size).toBe(3);
+
+    // ...and they really do compile differently, which is why they must not
+    // share an entry.
+    const emitted = getOrCompile(
+      user,
+      "createMany",
+      { data, skipDuplicates: true },
+      postgres,
+    ).text;
+    expect(emitted).toContain("on conflict do nothing");
+    expect(
+      getOrCompile(user, "createMany", { data, skipDuplicates: false }, postgres).text,
+    ).not.toContain("on conflict");
+  });
+
   test("the same write on two dialects is two plans", () => {
     const args = { data: { email: "x" } };
     expect(planKey(sqlite, "User", "create", args)).not.toBe(

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -271,6 +271,167 @@ function suite(label: string, url?: string) {
       );
     });
 
+    /**
+     * `skipDuplicates` — Postgres only, and that is Prisma's line rather than
+     * SQL's: SQLite can express `on conflict do nothing`, and Prisma rejects
+     * the *argument* there for `false` as well as `true`. So these are guarded
+     * rather than listed in `CASES`, and the SQLite refusal is asserted in
+     * `write.test.ts` where it needs no database.
+     */
+    describe("skipDuplicates", () => {
+      test("skips the rows that exist and counts only the new ones", async () => {
+        if (!url) return;
+
+        await differential.expectSameWrite(
+          "User",
+          "createMany",
+          {
+            // `p1` is seeded, so it conflicts on `publicId`; the other two are
+            // new. A count of 3 would mean the conflict clause did nothing, and
+            // a count of 0 would mean the whole statement was skipped.
+            data: [
+              { publicId: "p1", email: "dup@example.dev" },
+              { publicId: "new-1", email: "new1@example.dev" },
+              { publicId: "new-2", email: "new2@example.dev" },
+            ],
+            skipDuplicates: true,
+          },
+          { tables: ["User"] },
+        );
+      });
+
+      test("without it, the same batch raises", async () => {
+        if (!url) return;
+        await differential.reset();
+
+        await expect(
+          UserModel.createMany({
+            data: [
+              { publicId: "p1", email: "dup@example.dev" },
+              { publicId: "new-3", email: "new3@example.dev" },
+            ],
+          }),
+        ).rejects.toThrow();
+      });
+
+      test("every row conflicting is a count of zero, not an error", async () => {
+        if (!url) return;
+
+        await differential.expectSameWrite(
+          "User",
+          "createMany",
+          {
+            data: [{ publicId: "p1", email: "a@example.dev" }],
+            skipDuplicates: true,
+          },
+          { tables: ["User"] },
+        );
+      });
+
+      test("false behaves as though it were absent", async () => {
+        if (!url) return;
+
+        await differential.expectSameWrite(
+          "User",
+          "createMany",
+          {
+            data: [{ publicId: "new-4", email: "new4@example.dev" }],
+            skipDuplicates: false,
+          },
+          { tables: ["User"] },
+        );
+      });
+
+      /**
+       * A conflict on a **composite** unique, not only a single column.
+       * `SocialAccount` carries `@@unique([username, provider])` and is the
+       * only model in the template that can reach one.
+       *
+       * The untargeted `on conflict do nothing` is what makes this work: it
+       * covers every constraint at once, where a targeted `on conflict (col)`
+       * would skip collisions on the named column and still raise here.
+       *
+       * Self-contained — the two conflicting rows are in the *same* call, which
+       * `do nothing` also deduplicates. Measured rather than assumed:
+       * `values ('x','1'),('x','1'),('y','2') on conflict do nothing` inserts
+       * two rows, not three and not one.
+       */
+      test("a conflict on a composite unique is skipped too", async () => {
+        if (!url) return;
+
+        const base = {
+          userId: 1,
+          accessToken: "t",
+          refreshToken: "r",
+          expiresAt: new Date(EPOCH),
+        };
+
+        await differential.expectSameWrite(
+          "SocialAccount",
+          "createMany",
+          {
+            data: [
+              { ...base, provider: "github", providerId: "gh-1", username: "ada" },
+              // Same (username, provider) as the row above, different
+              // providerId — so only the composite constraint catches it.
+              { ...base, provider: "github", providerId: "gh-2", username: "ada" },
+              { ...base, provider: "gitlab", providerId: "gl-1", username: "ada" },
+            ],
+            skipDuplicates: true,
+          },
+          { tables: ["SocialAccount"] },
+        );
+      });
+
+      /**
+       * The interaction the issue calls out: `createMany` splits itself across
+       * statements past the parameter ceiling, inside one transaction, and
+       * `skipDuplicates` has to survive that split — the counts sum, and a
+       * conflict in a later chunk must not roll back an earlier one, since
+       * `do nothing` is not an error.
+       *
+       * Postgres binds 65 535 parameters and `User` writes 6 columns per row,
+       * so ~11 000 rows is two statements. Not compared against Prisma: it
+       * chunks differently, and what is under test is *our* split.
+       */
+      test("a batch that splits across statements returns the total", async () => {
+        if (!url) return;
+        await differential.reset();
+
+        const rows = Array.from({ length: 11_000 }, (_, i) => ({
+          publicId: `bulk-${i}`,
+          email: `bulk-${i}@example.dev`,
+        }));
+        // One row in the *second* chunk collides with one in the first, so the
+        // conflict lands after a chunk has already been written.
+        rows[10_500] = { ...rows[0] };
+
+        // **Succeeding at all is the proof that it split.** `User` binds 6
+        // client-side columns per row, so this is 66 000 parameters against
+        // Postgres's 65 535 ceiling: unsplit, `render` raises
+        // `ParameterLimitError` rather than quietly running one statement.
+        //
+        // Asserted rather than left in prose, because the margin is thin — if
+        // the row count, the column count or the ceiling ever moved, the case
+        // would keep passing while silently no longer exercising the split.
+        // (`differential.queries()` cannot see it: the chunks run on a
+        // transaction handle, and the counting stand-in wraps the pool.)
+        expect(rows.length * 6).toBeGreaterThan(65_535);
+
+        const written = await UserModel.createMany({
+          data: rows,
+          skipDuplicates: true,
+        });
+
+        expect(written.count).toBe(10_999);
+
+        const stored = await UserModel.count({
+          where: { publicId: { startsWith: "bulk-" } },
+        });
+        expect(stored).toBe(10_999);
+      }, 120_000);
+    });
+
     test("create on a model with no @updatedAt", async () => {
       await differential.expectSameWrite(
         "Organization",

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -314,6 +314,33 @@ function suite(label: string, url?: string) {
         ).rejects.toThrow();
       });
 
+      /**
+       * A conflict against a row **this same statement is inserting**, rather
+       * than one already committed — which is a different thing for
+       * `on conflict do nothing` to resolve, and the shape a caller hits when
+       * their input list is simply not deduplicated.
+       *
+       * Measured before it was pinned: `values ('x','1'),('x','1'),('y','2')
+       * on conflict do nothing` inserts two rows, not three and not one.
+       */
+      test("two identical rows in one call insert once", async () => {
+        if (!url) return;
+
+        await differential.expectSameWrite(
+          "User",
+          "createMany",
+          {
+            data: [
+              { publicId: "dup-1", email: "dup1@example.dev" },
+              { publicId: "dup-1", email: "dup2@example.dev" },
+              { publicId: "dup-2", email: "dup3@example.dev" },
+            ],
+            skipDuplicates: true,
+          },
+          { tables: ["User"] },
+        );
+      });
+
       test("every row conflicting is a count of zero, not an error", async () => {
         if (!url) return;
 


### PR DESCRIPTION
Closes #69. Three call sites in a large production Prisma application, all importing a batch where some rows already exist.

The workaround is bad in a way worth restating: reading first to find out which rows exist is a second query **and** a race — between the read and the insert a concurrent importer writes one of them, and the insert fails on a unique violation anyway. The check and the insert being one statement is the entire point.

## What it emits

`on conflict do nothing`, **untargeted**. That covers every unique constraint and the primary key at once, which is what `skipDuplicates` means and what Prisma emits. A targeted `on conflict (col)` is the plausible wrong version — it skips collisions on the named column and still raises on any other, which is why the composite-unique test below exists.

The count needs no special handling: a row a conflict skipped never reaches `RETURNING`, so `{ count }` is the number **inserted** rather than the number supplied. The issue flags that as the part most likely to be got wrong; it falls out of the statement shape.

## Postgres only — Prisma's line, not SQL's

Measured rather than assumed. Prisma 6.19 reports `skipDuplicates` as an *unknown argument* on SQLite, for `false` as well as `true` — even though SQLite has had `on conflict do nothing` since 3.24. Implementing it there would make gemi a silent superset of Prisma on the one dialect the differential harness could then no longer compare, which is the trade this project has declined every other time it came up. The issue calls matching Prisma "the smaller surprise" and I agree.

The refusal names the dialect and says Prisma does not offer it either, rather than saying "yet":

```
gemi ORM does not support 'skipDuplicates' yet (User.createMany). 'skipDuplicates'
is not available on sqlite. Prisma does not offer it there either — it is a Postgres
and MySQL argument. To import a batch that may overlap, write the rows one at a time
and catch UniqueConstraintError, or move this model to Postgres.
```

It is a **dialect capability**, not a name check: `SqlDialect` gains `ignoreConflicts(): Fragment | null`, so no `if (dialect === "postgres")` enters the compiler. `null` is documented as a parity decision rather than a missing feature, so nobody later "fixes" SQLite by returning `insert or ignore`.

## No emitter change was needed, and that is a result rather than an omission

The generated bases use `Prisma.<M>CreateManyArgs` verbatim, and Prisma **omits `skipDuplicates` from that type on SQLite and includes it on Postgres** — 23 occurrences under `postgresql`, zero under `sqlite`, checked in the generated `index.d.ts`. So the type surface tracks the provider on its own, and compile-time behaviour matches Prisma on both dialects for free.

## Another plan-cache collision, same class as #74's

`skipDuplicates` puts its *value* in the SQL text — `true` emits the clause and `false` does not — so it is structural for the same reason `select` is, and it was not in `LITERAL_KEYS`. Both shaped to `boolean`, so whichever call compiled first decided for the other: an import asking to skip conflicts could raise, or an insert that wanted to hear about a duplicate could silently swallow it. Reproduced, fixed, and pinned in the writes discrimination suite.

## Acceptance — all four criteria

- **Verified against Prisma on Postgres**: skips the rows that exist and counts only the new ones, every row conflicting is `{ count: 0 }` rather than an error, `false` behaves as absent, and the same batch *without* it raises.
- **A batch that splits across statements returns the correct total.** 11 000 rows × 6 columns is 66 000 parameters against Postgres's 65 535 ceiling, so **succeeding is itself the proof that it split** — unsplit, `render` raises `ParameterLimitError`. Asserted arithmetically rather than left in prose, because the margin is thin enough that a moved constant would leave the case passing while no longer exercising the split. (`differential.queries()` cannot see it — the chunks run on a transaction handle and the counting stand-in wraps the pool.)
- **SQLite refuses, naming the dialect**, asserted in `write.test.ts` where it needs no database.
- **A conflict on a composite unique**, on the one model in the template carrying `@@unique([username, provider])`. Self-contained, after measuring that `do nothing` also deduplicates *within* one statement — `values ('x','1'),('x','1'),('y','2')` inserts two rows, not three and not one.

Plus 8 unit tests on the compiler. 749 unit tests and the full template suite green on SQLite and Postgres 16.

## A note on the build, since #74's review hit it

Regenerating the template with a `dist` built from a *different* branch silently rewrites `models.ts` from that branch's `emit.ts`. I hit it here too and rebuilt from this branch; the committed artifact is byte-identical to what this branch's generator produces, which is what `generated.test.ts` exists to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
