### PR TITLE
`omit`, and the end of "yet" for `distinct` and `cursor`

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -141,7 +141,9 @@ later is included by default.
 It is a real projection: the omitted column never enters the `SELECT` list, so it is not read, not
 shaped and not decoded. `select` and `omit` together are refused, because one names what to keep and
 the other what to drop; Prisma rejects that pair too. It works on every operation that returns a
-payload, reads and writes alike.
+payload, reads and writes alike, and **inside an `include`** — which is where it usually matters,
+since a column you never want to leave the process is as likely to be on a related row as on the
+root one. Both relation strategies honour it.
 
 **It is not a substitute for a policy's `redact`.** `omit` is the caller choosing; `redact` is the
 model refusing, and a caller cannot opt out of it. Use `redact` for "nobody may read this", and

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -126,6 +126,27 @@ stepping stone: a `Pick<User, "id">` hydrated as a `User` would carry methods re
 query never fetched. See [Rows and entities](./orm-rows-and-entities.md) for the two opt-in levels
 above it — `track` + `save`, and `wrap`.
 
+### Returning everything except one column
+
+```ts
+const user = await User.findUnique({ where: { id }, omit: { password: true } })
+```
+
+`omit` is the complement of `select`, and the reason to have both is what happens when the model
+gains a column. With `select` the exclusion list has to be rewritten every time, and the day
+somebody forgets is the day the new column silently stops being returned. `omit` says the thing that
+is actually stable about the query — *this column must never leave the process* — so a column added
+later is included by default.
+
+It is a real projection: the omitted column never enters the `SELECT` list, so it is not read, not
+shaped and not decoded. `select` and `omit` together are refused, because one names what to keep and
+the other what to drop; Prisma rejects that pair too. It works on every operation that returns a
+payload, reads and writes alike.
+
+**It is not a substitute for a policy's `redact`.** `omit` is the caller choosing; `redact` is the
+model refusing, and a caller cannot opt out of it. Use `redact` for "nobody may read this", and
+`omit` for "I do not need this here".
+
 ### Per-call options
 
 A second parameter, not a key inside `args` — intersecting Prisma's own arg types with a
@@ -778,10 +799,21 @@ Stated so you can plan around them rather than discover them:
   an identity map is worse than none.
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
   touched.
-- **No `omit`.** Use `select`, or a policy's `redact`.
 - **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
-- **No `groupBy`, `aggregate`, `distinct` or cursor pagination.** These land in
-  [Raw SQL](#raw-sql), which exists so that "not implemented" has an answer rather than a shrug.
+- **No `groupBy` or `aggregate`.** These land in [Raw SQL](#raw-sql), which exists so that "not
+  implemented" has an answer rather than a shrug.
+- **No `distinct`, and this one is deliberate rather than pending.** Prisma applies it **in
+  memory** — its query log shows no `DISTINCT` at all, so `take` neither reduces the rows pulled
+  nor paginates by group. Reproducing that faithfully would mean reading the whole result set and
+  deduplicating in JavaScript behind an argument that reads like a database operation; emitting a
+  real `DISTINCT ON` instead would silently diverge from Prisma. Write it as SQL.
+- **No `cursor`, also deliberate.** It is only correct under a *total* ordering, which Prisma does
+  not enforce — under a non-unique `orderBy` it skips or repeats rows at the page boundary. Use
+  `take` with a `where` on the last row's sort key, or compose the keyset comparison with `sql`.
+
+Both of the last two throw `UnsupportedByDesignError`, which says *"and this is a decision rather
+than a gap"* rather than *"yet"* — so a refusal you can plan around reads differently from one that
+might lift next release.
 
 ## See also
 

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -48,11 +48,12 @@ const RELATION_ARGS = new Set([
   "where",
   "orderBy",
   "select",
+  "omit",
   "include",
   "take",
   "skip",
 ]);
-const TO_ONE_ARGS = new Set(["where", "select", "include"]);
+const TO_ONE_ARGS = new Set(["where", "select", "omit", "include"]);
 
 /**
  * How deep an include tree may nest. Not a modelling limit — a legal tree can
@@ -1162,6 +1163,25 @@ function childQuery(
 
   if (relationArgs.orderBy !== undefined) args.orderBy = relationArgs.orderBy;
   if (relationArgs.include !== undefined) args.include = relationArgs.include;
+
+  // `omit` gets the same treatment as `select`, and it has to: the lateral
+  // strategy resolves a node's selection directly, so a node's `omit` already
+  // narrowed its columns there. Not forwarding it here would drop the omission
+  // on the batched path only — the same query returning the column under one
+  // strategy and not the other, decided by the dialect.
+  const omit = relationArgs.omit as Record<string, unknown> | undefined;
+  if (omit !== undefined) {
+    if (omit[childField] !== true) {
+      args.omit = omit;
+    } else {
+      // The stitch key cannot be omitted from the *query* — nothing could
+      // match the children to their parents without it. So it is fetched and
+      // then deleted, exactly as a `select` that leaves it out is.
+      const { [childField]: _dropped, ...rest } = omit;
+      args.omit = rest;
+      return { args, hidden: true };
+    }
+  }
 
   const select = relationArgs.select as Record<string, unknown> | undefined;
   if (select === undefined) return { args, hidden: false };

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -5,6 +5,7 @@ import { SqliteDialect } from "../dialect/sqlite";
 import {
   ParameterLimitError,
   UnknownFieldError,
+  UnsupportedByDesignError,
   UnsupportedQueryError,
 } from "../errors";
 import { USER_COLUMNS, account, mapped, user } from "../fixtures";
@@ -481,13 +482,43 @@ describe("postgres", () => {
   });
 });
 
-describe("unimplemented arguments still throw", () => {
+/**
+ * `cursor` and `distinct` are **decisions, not gaps**, and the error says so.
+ *
+ * The distinction is one a caller can act on: "yet" means wait for a release,
+ * "will not" means change the code. They shared one error until #68, which is
+ * how `docs/orm.md` came to list an argument under *Not in scope* while the
+ * runtime said "yet".
+ */
+describe("arguments refused by design", () => {
   test.each([
     ["cursor", { cursor: { id: 1 } }],
     ["distinct", { distinct: ["email"] }],
-  ])("%s", (argument, args) => {
+  ])("%s says it is a decision, not a gap", (argument, args) => {
+    expect(() => text(args)).toThrow(UnsupportedByDesignError);
     expect(() => text(args)).toThrow(
-      `gemi ORM does not support '${argument}' yet (User.findMany).`,
+      `gemi ORM does not implement '${argument}' (User.findMany), and this is ` +
+        `a decision rather than a gap.`,
+    );
+    // Still an `UnsupportedQueryError`, so a caller that does not care which
+    // kind it is keeps working.
+    expect(() => text(args)).toThrow(UnsupportedQueryError);
+  });
+
+  /** Each names what to reach for instead — #61's rule. */
+  test("distinct explains why Prisma's own version is the problem", () => {
+    expect(() => text({ distinct: ["email"] })).toThrow(/in memory/);
+    expect(() => text({ distinct: ["email"] })).toThrow(/DB\.query/);
+  });
+
+  test("cursor names the failure it would have", () => {
+    expect(() => text({ cursor: { id: 1 } })).toThrow(/total.* ordering/);
+    expect(() => text({ cursor: { id: 1 } })).toThrow(/skips or repeats rows/);
+  });
+
+  test("an argument that really is unimplemented still says 'yet'", () => {
+    expect(() => text({ nonsense: 1 } as never)).toThrow(
+      `gemi ORM does not support 'nonsense' yet (User.findMany).`,
     );
   });
 

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -24,7 +24,7 @@ import { assertUniqueWhere } from "./unique";
 import { compileWhere } from "./where";
 
 /** Every read operation, and what each accepts. */
-const READ_ARGS: Record<string, Set<string>> = {
+export const READ_ARGS: Record<string, Set<string>> = {
   findMany: new Set(["where", "orderBy", "skip", "take", "select", "include", "omit"]),
   findFirst: new Set(["where", "orderBy", "skip", "take", "select", "include", "omit"]),
   findFirstOrThrow: new Set([

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -1,5 +1,5 @@
 import type { SqlDialect } from "../dialect";
-import { UnsupportedQueryError } from "../errors";
+import { UnsupportedByDesignError, UnsupportedQueryError } from "../errors";
 import type { Operation, QueryPlan } from "../plan";
 import type { ModelSchema } from "../schema";
 import { buildRowShaper } from "../shape";
@@ -25,8 +25,8 @@ import { compileWhere } from "./where";
 
 /** Every read operation, and what each accepts. */
 const READ_ARGS: Record<string, Set<string>> = {
-  findMany: new Set(["where", "orderBy", "skip", "take", "select", "include"]),
-  findFirst: new Set(["where", "orderBy", "skip", "take", "select", "include"]),
+  findMany: new Set(["where", "orderBy", "skip", "take", "select", "include", "omit"]),
+  findFirst: new Set(["where", "orderBy", "skip", "take", "select", "include", "omit"]),
   findFirstOrThrow: new Set([
     "where",
     "orderBy",
@@ -34,14 +34,43 @@ const READ_ARGS: Record<string, Set<string>> = {
     "take",
     "select",
     "include",
+    "omit",
   ]),
-  findUnique: new Set(["where", "select", "include"]),
-  findUniqueOrThrow: new Set(["where", "select", "include"]),
+  findUnique: new Set(["where", "select", "include", "omit"]),
+  findUniqueOrThrow: new Set(["where", "select", "include", "omit"]),
   // No `select`: Prisma's `count` uses it to return an object of per-field
   // counts, which is aggregate territory and is not emitted onto the generated
   // bases. Accepting it here and then ignoring it would return the plain total
   // under a shape the caller did not ask for.
   count: new Set(["where", "orderBy", "skip", "take"]),
+};
+
+/**
+ * The two read arguments that are **not coming**, and what to reach for.
+ *
+ * Both are decisions rather than gaps, and both were made against measurements
+ * of what Prisma actually does rather than against its documentation.
+ *
+ * `docs/orm.md` says the same. An argument that says "yet" while the docs say
+ * "not in scope" is the contradiction #68 exists to end — a caller cannot plan
+ * around a refusal that might lift next release.
+ */
+const PERMANENTLY_REFUSED: Record<string, string> = {
+  distinct:
+    `Prisma's 'distinct' is applied **in memory**, not in SQL — its query log ` +
+    `shows no DISTINCT at all, and 'take' therefore does not reduce the rows ` +
+    `pulled or paginate by group. Reproducing that faithfully would mean ` +
+    `reading the whole result set and deduplicating in JavaScript behind an ` +
+    `argument that reads like a database operation. Implementing it as a real ` +
+    `'DISTINCT ON' instead would be a silent divergence from Prisma. Write it ` +
+    `as SQL instead, with 'sql' and 'DB.query' — where what runs is what you ` +
+    `wrote, and 'distinct on' means what the database means by it.`,
+  cursor:
+    `'cursor' is only correct under a *total* ordering, which Prisma does not ` +
+    `enforce — under a non-unique 'orderBy' it silently skips or repeats rows ` +
+    `at the page boundary. For a stable page use 'take' with a 'where' on the ` +
+    `last row's sort key, or compose the keyset comparison with 'sql' and ` +
+    `'DB.query'.`,
 };
 
 export function isReadOperation(op: Operation): boolean {
@@ -345,9 +374,14 @@ function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
   const allowed = READ_ARGS[op];
   for (const key of Object.keys(args).sort()) {
     if (args[key] === undefined) continue;
-    if (!allowed.has(key)) {
-      throw new UnsupportedQueryError(key, schema.name, op);
+    if (allowed.has(key)) continue;
+
+    const permanent = PERMANENTLY_REFUSED[key];
+    if (permanent) {
+      throw new UnsupportedByDesignError(key, schema.name, op, permanent);
     }
+
+    throw new UnsupportedQueryError(key, schema.name, op);
   }
 }
 

--- a/packages/gemi/orm/compile/select.ts
+++ b/packages/gemi/orm/compile/select.ts
@@ -21,6 +21,7 @@ export function resolveSelection(
   operation: string,
 ): FieldSchema[] {
   const select = args?.select;
+  const omit = args?.omit;
 
   // Prisma rejects using both, because the result shape would be ambiguous.
   if (select !== undefined && args?.include !== undefined) {
@@ -32,10 +33,26 @@ export function resolveSelection(
     );
   }
 
+  // ...and rejects `select` with `omit` for the same reason: one names what to
+  // keep and the other what to drop, so together they describe two different
+  // column lists. Verified against a generated client, which raises rather
+  // than picking one.
+  if (select !== undefined && omit !== undefined) {
+    throw new UnsupportedQueryError(
+      "select + omit",
+      schema.name,
+      operation,
+      `'select' names what to keep and 'omit' what to drop, so the two ` +
+        `describe different column lists. Prisma allows only one of them on ` +
+        `the same query. Drop the 'omit' — a 'select' already excludes ` +
+        `everything it does not name.`,
+    );
+  }
+
   // `include` keeps every scalar and adds relations beside them, which is
   // precisely the default column list.
   if (select === undefined || select === null) {
-    return Object.values(schema.fields);
+    return omitted(schema, omit, operation);
   }
 
   if (typeof select !== "object" || Array.isArray(select)) {
@@ -112,6 +129,97 @@ export function resolveSelection(
   // because the relation's own key column is added by the caller of this
   // function and then hidden again from the result.
   return selected;
+}
+
+/**
+ * The default column list minus whatever `omit` names.
+ *
+ * **The complement of `select`, and the reason to have both.** With `select`
+ * the exclusion list is rewritten every time the model gains a column, and the
+ * day somebody forgets is the day the new column silently stops being
+ * returned. `omit: { password: true }` says the thing that is actually stable
+ * about the query — *this one column must never leave the process* — so a
+ * column added later is included by default, which is the safer direction for
+ * everything except the field you named.
+ *
+ * A real projection, not a post-filter: the omitted column never enters the
+ * `select` list, so it is not read, not shaped and not decoded. Prisma does the
+ * same — verified from its query log, where the column is simply absent.
+ *
+ * Note this deliberately does *not* replace a policy's `redact`. `omit` is the
+ * caller choosing; `redact` is the model refusing, and a caller cannot opt out
+ * of it. See `docs/orm.md`.
+ */
+function omitted(
+  schema: ModelSchema,
+  omit: unknown,
+  operation: string,
+): FieldSchema[] {
+  if (omit === undefined || omit === null) return Object.values(schema.fields);
+
+  if (typeof omit !== "object" || Array.isArray(omit)) {
+    throw new UnsupportedQueryError(
+      "omit",
+      schema.name,
+      operation,
+      "Expected an object of fields.",
+    );
+  }
+
+  const dropped = new Set<string>();
+
+  for (const key of Object.keys(omit as Record<string, unknown>)) {
+    const value = (omit as Record<string, unknown>)[key];
+    if (value === undefined) continue;
+
+    // A relation cannot be omitted — it is not a column, and it is absent
+    // unless an `include` asked for it. Named separately from the unknown-field
+    // case, which would send the caller looking for a typo.
+    if (key in schema.relations) {
+      throw new UnsupportedQueryError(
+        `omit.${key}`,
+        schema.name,
+        operation,
+        `'${key}' is a relation, not a column. A relation is already absent ` +
+          `unless an 'include' asks for it.`,
+      );
+    }
+
+    if (!(key in schema.fields)) {
+      throw new UnknownFieldError(key, schema.name, Object.keys(schema.fields));
+    }
+
+    if (typeof value !== "boolean") {
+      throw new UnsupportedQueryError(
+        `omit.${key}`,
+        schema.name,
+        operation,
+        "Expected true or false.",
+      );
+    }
+
+    // `false` means keep it, exactly as it does in a `select`.
+    if (value) dropped.add(key);
+  }
+
+  const kept = Object.values(schema.fields).filter(
+    (field) => !dropped.has(field.name),
+  );
+
+  if (kept.length === 0) {
+    // Prisma raises rather than returning rows of empty objects, and a
+    // `select ... from` with no columns is not valid SQL either way — the same
+    // reasoning as an empty `select`.
+    throw new UnsupportedQueryError(
+      "omit",
+      schema.name,
+      operation,
+      `It omits every field on ${schema.name}, which leaves no column to ` +
+        `select. Prisma rejects that too.`,
+    );
+  }
+
+  return kept;
 }
 
 /**

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -72,14 +72,18 @@ import { compileWhere } from "./where";
  * is refused with an error naming the column, rather than silently written wrong.
  */
 
+// `omit` rides along wherever a payload comes back, which is every write but
+// the three that return a count — Prisma types it the same way. It is resolved
+// by `resolveSelection`, so the `RETURNING` list narrows exactly as a read's
+// column list does and the omitted column is never read.
 const WRITE_ARGS: Record<string, Set<string>> = {
-  create: new Set(["data", "select", "include"]),
+  create: new Set(["data", "select", "include", "omit"]),
   createMany: new Set(["data"]),
-  update: new Set(["data", "where", "select", "include"]),
+  update: new Set(["data", "where", "select", "include", "omit"]),
   updateMany: new Set(["data", "where"]),
-  delete: new Set(["where", "select", "include"]),
+  delete: new Set(["where", "select", "include", "omit"]),
   deleteMany: new Set(["where"]),
-  upsert: new Set(["where", "create", "update", "select", "include"]),
+  upsert: new Set(["where", "create", "update", "select", "include", "omit"]),
 };
 
 /** The writes that return one row, and raise when they match none. */

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -76,7 +76,7 @@ import { compileWhere } from "./where";
 // the three that return a count — Prisma types it the same way. It is resolved
 // by `resolveSelection`, so the `RETURNING` list narrows exactly as a read's
 // column list does and the omitted column is never read.
-const WRITE_ARGS: Record<string, Set<string>> = {
+export const WRITE_ARGS: Record<string, Set<string>> = {
   create: new Set(["data", "select", "include", "omit"]),
   createMany: new Set(["data"]),
   update: new Set(["data", "where", "select", "include", "omit"]),

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -22,6 +22,36 @@ export class UnsupportedQueryError extends Error {
 }
 
 /**
+ * An argument the ORM has **decided not to implement**, as opposed to one it has
+ * not implemented yet.
+ *
+ * The distinction is the whole point, and it is a distinction a caller can act
+ * on: "yet" means wait for a release, "will not" means change the code. Sharing
+ * one error for both meant `docs/orm.md` could list `omit` under *Not in scope*
+ * while the runtime said "yet" — a contradiction a reader has no way to
+ * resolve, and the one #68 exists to end.
+ *
+ * A subclass rather than a sibling, so `catch (e) { if (e instanceof
+ * UnsupportedQueryError) … }` keeps working for callers that do not care which
+ * kind it is.
+ */
+export class UnsupportedByDesignError extends UnsupportedQueryError {
+  constructor(
+    argument: string,
+    model: string,
+    operation: string,
+    /** What to use instead. Required — see #61: a refusal owes the caller a next step. */
+    reason: string,
+  ) {
+    super(argument, model, operation);
+    this.name = "UnsupportedByDesignError";
+    this.message =
+      `gemi ORM does not implement '${argument}' (${model}.${operation}), ` +
+      `and this is a decision rather than a gap. ${reason}`;
+  }
+}
+
+/**
  * Thrown when an argument names something that is not a field on the model. A
  * `where` key with no matching field is an error, never a passthrough — that is
  * the rule that keeps user input out of the identifier positions in the SQL.

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -30,6 +30,7 @@ export {
   UnknownRelationError,
   UnregisteredPolicyClassError,
   UnregisteredRelationTargetError,
+  UnsupportedByDesignError,
   UnsupportedQueryError,
 } from "./errors";
 

--- a/packages/gemi/orm/plan.coverage.test.ts
+++ b/packages/gemi/orm/plan.coverage.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { READ_ARGS } from "./compile/read";
+import { WRITE_ARGS } from "./compile/write";
+import { SqliteDialect } from "./dialect/sqlite";
+import { account, organization, user } from "./fixtures";
+import { clearPlanCache, getOrCompile, planKey, type Operation } from "./plan";
+import * as registry from "./registry";
+
+/**
+ * A rule, rather than another row.
+ *
+ * Three separate changes have now shipped the same bug: an argument whose
+ * *value* reaches the SQL text, left out of `LITERAL_KEYS`, so two calls that
+ * compile differently share one cache entry and the second caller runs the
+ * first one's statement.
+ *
+ *   - `aggregate`'s `_count` / `_sum` / … — `{ email: true }` against
+ *     `{ email: false }` counted a column the caller switched off.
+ *   - `createMany`'s `skipDuplicates` — `true` against `false` decided whether
+ *     conflicts raise.
+ *   - `findMany`'s `omit` — `{ password: true }` against `{ password: false }`,
+ *     where the *permissive* call warms the cache and the one asking to hide
+ *     the column gets it back.
+ *
+ * Each was caught by someone thinking to look. That is not a mechanism, so this
+ * file is the mechanism: it walks **every argument every operation accepts**,
+ * compiles two calls that differ only in that argument's literal content, and
+ * asserts the plan key separates them whenever the SQL does.
+ *
+ * The property is exactly the cache's contract, stated once:
+ *
+ *     two argument shapes that compile to different statements
+ *     must not share a plan key.
+ *
+ * Its value is in the *coverage* check below rather than in any single case: an
+ * argument added to `READ_ARGS` or `WRITE_ARGS` without a probe here fails this
+ * suite, so the fourth instance of the bug is a failing test at the time it is
+ * written instead of a review comment afterwards.
+ */
+
+const sqlite = new SqliteDialect();
+
+beforeEach(() => {
+  clearPlanCache();
+  registry.clearRegistry();
+  registry.register("User", class { static $schema = user });
+  registry.register("Account", class { static $schema = account });
+  registry.register("Organization", class { static $schema = organization });
+});
+
+/**
+ * Two argument trees per key that differ **only** in that key's literal
+ * content — never in a bound value, which is what the cache is allowed to
+ * share. Where an argument cannot change the statement at all, the pair is
+ * identical and the assertion below tolerates it.
+ */
+const PROBES: Record<string, [unknown, unknown]> = {
+  // Values, so these legitimately share a plan.
+  where: [{ where: { email: "a" } }, { where: { email: "b" } }],
+  data: [{ data: { email: "a" } }, { data: { email: "b" } }],
+  take: [{ take: 1 }, { take: 2 }],
+  skip: [{ skip: 1 }, { skip: 2 }],
+
+  // Structure: each of these changes the statement.
+  orderBy: [{ orderBy: { id: "asc" } }, { orderBy: { id: "desc" } }],
+  select: [{ select: { id: true } }, { select: { email: true } }],
+  omit: [{ omit: { password: true } }, { omit: { password: false } }],
+  include: [{ include: { accounts: true } }, { include: { organization: true } }],
+  skipDuplicates: [
+    { data: [{ email: "a" }], skipDuplicates: true },
+    { data: [{ email: "a" }], skipDuplicates: false },
+  ],
+  create: [{ create: { email: "a" } }, { create: { email: "a", name: "n" } }],
+  update: [{ update: { name: "a" } }, { update: { name: "a", locale: "l" } }],
+  cursor: [{ cursor: { id: 1 } }, { cursor: { id: 2 } }],
+  distinct: [{ distinct: ["email"] }, { distinct: ["name"] }],
+};
+
+/** What each operation needs beside the argument under test to compile at all. */
+const BASE: Record<string, Record<string, unknown>> = {
+  findUnique: { where: { id: 1 } },
+  findUniqueOrThrow: { where: { id: 1 } },
+  create: { data: { email: "base" } },
+  createMany: { data: [{ email: "base" }] },
+  update: { where: { id: 1 }, data: { name: "base" } },
+  updateMany: { where: { id: 1 }, data: { name: "base" } },
+  delete: { where: { id: 1 } },
+  deleteMany: { where: { id: 1 } },
+  upsert: {
+    where: { id: 1 },
+    create: { email: "base" },
+    update: { name: "base" },
+  },
+};
+
+const OPERATIONS: [string, Set<string>][] = [
+  ...Object.entries(READ_ARGS),
+  ...Object.entries(WRITE_ARGS),
+];
+
+describe("the plan key separates every argument that changes the statement", () => {
+  /**
+   * The guard that makes this a rule: an argument the compiler accepts and this
+   * file does not probe is a hole exactly the size of the last three bugs.
+   */
+  test("every accepted argument has a probe", () => {
+    const missing: string[] = [];
+    for (const [operation, allowed] of OPERATIONS) {
+      for (const key of allowed) {
+        if (!(key in PROBES)) missing.push(`${operation}.${key}`);
+      }
+    }
+
+    expect(
+      missing,
+      `add a two-value probe to PROBES for: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  test.each(OPERATIONS)("%s", (operation, allowed) => {
+    for (const key of allowed) {
+      const [a, b] = PROBES[key];
+      const base = BASE[operation] ?? {};
+
+      // The probe replaces the base's own value for that key, so `data` and
+      // `where` are tested rather than shadowed.
+      const argsA = { ...base, ...(a as object) };
+      const argsB = { ...base, ...(b as object) };
+
+      let textA: string;
+      let textB: string;
+      try {
+        // **Compiled in isolation, and this is the whole trick.** Sharing the
+        // cache here would make the test agree with the bug: when the two keys
+        // collide, the second call is a cache *hit*, so both plans are the same
+        // object, the texts match, and the check below skips the very case it
+        // exists to catch. Clearing between them forces two real compiles, so
+        // "the statements differ" is a fact about the compiler rather than
+        // about what the cache happened to return.
+        clearPlanCache();
+        textA = getOrCompile(user, operation as Operation, argsA, sqlite).text;
+        clearPlanCache();
+        textB = getOrCompile(user, operation as Operation, argsB, sqlite).text;
+      } catch {
+        // The argument is refused for this operation — `distinct` on a write,
+        // say. A refusal cannot mis-cache.
+        continue;
+      }
+
+      if (textA === textB) continue;
+
+      expect(
+        planKey(sqlite, "User", operation as Operation, argsA),
+        `${operation}.${key} compiles to two different statements but shares ` +
+          `one plan key — add it to LITERAL_KEYS in plan.ts`,
+      ).not.toBe(planKey(sqlite, "User", operation as Operation, argsB));
+    }
+  });
+
+  /**
+   * The converse, so the rule cannot be satisfied by making everything
+   * structural: an argument that only carries *values* must still share a plan,
+   * or the cache stops being a cache.
+   */
+  test("arguments that only carry values still share one plan", () => {
+    for (const [a, b] of [PROBES.where, PROBES.take, PROBES.skip]) {
+      const argsA = { ...(a as object) };
+      const argsB = { ...(b as object) };
+      expect(
+        getOrCompile(user, "findMany", argsA, sqlite).text,
+        JSON.stringify(argsA),
+      ).toBe(getOrCompile(user, "findMany", argsB, sqlite).text);
+      expect(planKey(sqlite, "User", "findMany", argsA)).toBe(
+        planKey(sqlite, "User", "findMany", argsB),
+      );
+    }
+  });
+});

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -159,6 +159,14 @@ let evictions = 0;
 const LITERAL_KEYS = new Set([
   "orderBy",
   "select",
+  // `omit` is `select`'s complement and decides the same thing — which columns
+  // the statement asks for — so it fails the same way and in the worse
+  // direction. `omit: { password: true }` and `{ password: false }` both shape
+  // to `boolean`, so whichever compiled first decided for the other: an admin
+  // screen that keeps the column warms the cache, and the public endpoint that
+  // asked to hide it gets the column back. The reverse order is harmless, which
+  // is exactly the wrong asymmetry.
+  "omit",
   "include",
   "distinct",
   "mode",

--- a/templates/saas-starter/app/models/User.test.ts
+++ b/templates/saas-starter/app/models/User.test.ts
@@ -154,16 +154,36 @@ describe("User.findMany()", () => {
     expect(planCacheStats()).toMatchObject({ compiles: 1, hits: 1 });
   });
 
-  // Signatures accept the full Prisma argument type from iteration 1; anything
-  // not implemented yet has to say so rather than silently returning the wrong
-  // rows.
-  test("throws on an argument that is not implemented yet", async () => {
+  // Signatures accept the full Prisma argument type from iteration 1, so an
+  // argument the ORM does not run has to say so rather than silently returning
+  // the wrong rows — and has to say *which kind* of refusal it is, since "wait
+  // for a release" and "change the code" are different answers.
+  test("throws on an argument refused by design, and says it is a decision", async () => {
     await expect(User.findMany({ cursor: { id: 1 } })).rejects.toThrow(
       UnsupportedQueryError,
     );
     await expect(User.findMany({ cursor: { id: 1 } })).rejects.toThrow(
-      "gemi ORM does not support 'cursor' yet (User.findMany).",
+      "gemi ORM does not implement 'cursor' (User.findMany), and this is a " +
+        "decision rather than a gap.",
     );
+    // ...and it names what to reach for instead.
+    await expect(User.findMany({ cursor: { id: 1 } })).rejects.toThrow(
+      /DB\.query/,
+    );
+  });
+
+  /** The other half of the same decision: `omit` runs now. */
+  test("omit drops a column from the payload without a select", async () => {
+    const [user]: any = await User.findMany({
+      where: { email: SEEDED.email },
+      omit: { password: true },
+    });
+
+    expect("password" in user).toBe(false);
+    // Everything else is still there, which is the difference from `select`:
+    // a column added to the model later is included rather than forgotten.
+    expect(user.email).toBe(SEEDED.email);
+    expect("locale" in user).toBe(true);
   });
 
   // The relation is loaded through the *generated* artifact's topology: this

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -575,6 +575,48 @@ const CASES: [string, string, unknown][] = [
     where: { publicId: "p4" }, include: { organization: true },
   }],
 
+  // --- omit ---------------------------------------------------------------
+  //
+  // The complement of `select`, and a real projection: the omitted column never
+  // enters the SELECT list, which Prisma's query log confirms. The cases that
+  // discriminate are the ones where `omit` and `select` would *differ* — a
+  // model gaining a column is included by an `omit` and dropped by a `select`.
+  ["omit one column", "findMany", { omit: { password: true } }],
+  ["omit several", "findMany", {
+    omit: { password: true, verificationToken: true, locale: true },
+  }],
+  // `false` means keep it, exactly as in a `select`.
+  ["omit false keeps the column", "findMany", { omit: { password: false } }],
+  ["omit mixed true and false", "findMany", {
+    omit: { password: true, locale: false },
+  }],
+  ["omit an empty object", "findMany", { omit: {} }],
+  ["omit a nullable column", "findMany", { omit: { deletedAt: true } }],
+  ["omit the primary key", "findMany", { omit: { id: true } }],
+  ["omit beside a where", "findMany", {
+    where: { globalRole: 2 }, omit: { password: true },
+  }],
+  ["omit beside an orderBy and take", "findMany", {
+    orderBy: { id: "asc" }, take: 2, omit: { password: true },
+  }],
+  ["omit on findFirst", "findFirst", {
+    orderBy: { id: "asc" }, omit: { password: true },
+  }],
+  ["omit on findUnique", "findUnique", {
+    where: { publicId: "p1" }, omit: { password: true },
+  }],
+  // With an `include`, the omission applies to the parent's own columns and
+  // leaves the relation alone.
+  ["omit beside an include", "findMany", {
+    omit: { password: true }, include: { accounts: { orderBy: { id: "asc" } } },
+  }],
+  // ...and the omitted column is the *stitch key*, which the planner has to
+  // fetch anyway and then hide again — the same path a `select` without the key
+  // takes.
+  ["omit the key an include stitches on", "findMany", {
+    omit: { id: true }, include: { accounts: { orderBy: { id: "asc" } } },
+  }],
+
   // --- count ------------------------------------------------------------
   ["count", "count", undefined],
   ["count with where", "count", { where: { deletedAt: null } }],

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -617,6 +617,29 @@ const CASES: [string, string, unknown][] = [
     omit: { id: true }, include: { accounts: { orderBy: { id: "asc" } } },
   }],
 
+  // Nested, which is where the motivating shape actually bites: a column you
+  // never want to leave the process is as likely to be on an *included*
+  // relation as on the root. Both strategies have to agree — the lateral one
+  // resolves the node's selection directly, the batched one forwards the
+  // argument to the child's own query.
+  ["omit inside an include", "findMany", {
+    orderBy: { id: "asc" },
+    include: { accounts: { omit: { organizationRole: true }, orderBy: { id: "asc" } } },
+  }],
+  ["omit the column an include stitches on", "findMany", {
+    orderBy: { id: "asc" },
+    include: { accounts: { omit: { userId: true }, orderBy: { id: "asc" } } },
+  }],
+  ["omit on a to-one include", "findMany", {
+    orderBy: { id: "asc" },
+    include: { organization: { omit: { logoUrl: true } } },
+  }],
+  ["omit at both levels", "findMany", {
+    orderBy: { id: "asc" },
+    omit: { password: true },
+    include: { accounts: { omit: { organizationRole: true }, orderBy: { id: "asc" } } },
+  }],
+
   // --- count ------------------------------------------------------------
   ["count", "count", undefined],
   ["count with where", "count", { where: { deletedAt: null } }],


### PR DESCRIPTION
Closes #68, which asks for **three decisions** rather than three features. Each was made against a measurement of what Prisma actually does, not against its documentation.

## `omit` — implemented

7 call sites, all the same shape: every column except the password hash.

```ts
const user = await User.findUnique({ where: { id }, omit: { password: true } })
```

It is a **real projection** in Prisma — read off its query log, the column is simply absent from the `SELECT` list rather than filtered afterwards — and it is the complement of `select` for a reason worth writing down: with `select` the exclusion list is rewritten every time the model gains a column, and the day somebody forgets is the day the new column silently stops being returned. `omit` says the thing that is actually stable about the query.

Implemented in `resolveSelection`, which reads, writes and relation nodes all share — so a write's `RETURNING` list narrows exactly as a read's column list does, with no second implementation to drift.

Behaviours reproduced from the probe rather than assumed: `omit: { x: false }` keeps the column; `select` + `omit` together is refused (Prisma raises); omitting *every* field is refused.

## `distinct` — refused permanently

The issue suspected Prisma's version was in-memory. It is — the query log for `findMany({ distinct: ["name"], take: 1 })` is:

```sql
SELECT `User`.`id`, `User`.`name` FROM `User` WHERE 1=1 ORDER BY `User`.`id` ASC LIMIT ? OFFSET ?
```

No `DISTINCT` anywhere, and `take` did not reduce the rows pulled. Reproducing that faithfully would mean reading the whole result set and deduplicating in JavaScript behind an argument that reads like a database operation. Emitting a real `DISTINCT ON` instead would silently diverge from Prisma, and the differential harness would be right to call it a divergence.

Neither is worth doing now that composed SQL has somewhere to go (#73, merged).

## `cursor` — refused permanently

Only correct under a *total* ordering, which Prisma does not enforce — under a non-unique `orderBy` it skips or repeats rows at the page boundary. The real demand behind it is keyset pagination, which `sql` + `DB.query` express directly and honestly.

## The criterion that made this more than three edits

> The refusal and `docs/orm.md` agree — no argument says "yet" while the docs say "not in scope".

They *could not* agree, because every refusal used one error whose message says "yet". So the docs listed `omit` under **Not in scope** while the runtime promised it was coming — a contradiction a reader has no way to resolve.

`UnsupportedByDesignError` says **"and this is a decision rather than a gap"**, and each of the two carries what to reach for instead (#61's rule). It **subclasses** `UnsupportedQueryError`, so `catch (e instanceof UnsupportedQueryError)` keeps working for callers that do not care which kind it is. An argument that genuinely is unimplemented still says "yet", and there is a test holding the two apart — otherwise the next refusal added would quietly inherit the wrong word.

## Verification

13 differential cases for `omit` against Prisma on both dialects: one column, several, `false`, mixed true/false, an empty object, a nullable column, the primary key, beside a `where`, beside `orderBy` + `take`, on `findFirst` and `findUnique`, beside an `include`, and — the one I most wanted — **omitting the very key the include stitches on**, which the planner has to fetch anyway and then hide again.

841 unit tests, and the full template suite green on SQLite and Postgres 16. Pre-existing and unchanged: `generated.test.ts`'s generator-linkage probe.

Branched after #72 and #73 merged, so it needs no rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
