### PR TITLE
A multi-field relation refuses on every surface, and says which one

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -779,6 +779,12 @@ Stated so you can plan around them rather than discover them:
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
   touched.
 - **No `omit`.** Use `select`, or a policy's `redact`.
+- **No multi-field relations.** `@relation(fields: [a, b], references: [c, d])` is refused wherever
+  a relation is correlated — `include` under either strategy, a relation filter, `_count`, an
+  `orderBy` through a relation, and nested writes — rather than joining on the first field and
+  returning plausible wrong rows. The error names the fields on both sides and the operation it came
+  from. This one *is* pending rather than declined; it needs a composite key comparison on both
+  sides (a tuple `in` for the batched strategy, a conjunction for the lateral one).
 - **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
 - **No `groupBy`, `aggregate`, `distinct` or cursor pagination.** These land in
   [Raw SQL](#raw-sql), which exists so that "not implemented" has an answer rather than a shrug.

--- a/packages/gemi/orm/compile/composite-relations.test.ts
+++ b/packages/gemi/orm/compile/composite-relations.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { PostgresDialect } from "../dialect/postgres";
+import { SqliteDialect } from "../dialect/sqlite";
+import { UnsupportedQueryError } from "../errors";
+import { ledger, ledgerEntry } from "../fixtures";
+import * as registry from "../registry";
+import { lateralStrategy } from "./lateral";
+import { compileRead } from "./read";
+import { compileWrite } from "./write";
+
+/**
+ * Multi-field relations — `@relation(fields: [a, b], references: [c, d])`.
+ *
+ * Not implemented (#67), and the point of this file is the *shape* of the
+ * refusal rather than the feature:
+ *
+ * 1. **Every surface refuses.** A one-field assumption reached by any path
+ *    would join on the first field and silently return the wrong rows — the
+ *    worst failure available here, because the query succeeds. Seven surfaces
+ *    correlate over a relation, and each has its own compiler; they are safe
+ *    only because all seven resolve their link through one function. That is a
+ *    property to hold, not a coincidence to rediscover.
+ *
+ * 2. **Each names the operation it came from.** They all used to report
+ *    `(Model.include)` — a composite relation named in a `where`, in an
+ *    `orderBy`, or in a nested `connect` on a `create` sent the reader to an
+ *    `include` they had not written.
+ *
+ * When the feature lands this file inverts: the refusals become assertions
+ * about emitted SQL, and the list of surfaces is already here.
+ */
+
+const sqlite = new SqliteDialect();
+const postgres = new PostgresDialect();
+
+beforeEach(() => {
+  registry.clearRegistry();
+  registry.register("Ledger", class { static $schema = ledger });
+  registry.register("LedgerEntry", class { static $schema = ledgerEntry });
+});
+
+afterEach(() => registry.clearRegistry());
+
+/** `[surface, run, model, operation]` — the seven paths that correlate. */
+const SURFACES: [string, () => unknown, string, string][] = [
+  [
+    "include, to-many",
+    () => compileRead(ledger, "findMany", { include: { entries: true } }, sqlite),
+    "Ledger",
+    "findMany",
+  ],
+  [
+    "include, to-one",
+    () => compileRead(ledgerEntry, "findMany", { include: { ledger: true } }, sqlite),
+    "LedgerEntry",
+    "findMany",
+  ],
+  [
+    "include under the lateral strategy",
+    () =>
+      compileRead(
+        ledger,
+        "findMany",
+        { include: { entries: true } },
+        postgres,
+        lateralStrategy,
+      ),
+    "Ledger",
+    "findMany",
+  ],
+  [
+    "a relation filter",
+    () =>
+      compileRead(
+        ledger,
+        "findMany",
+        { where: { entries: { some: { amount: 1 } } } },
+        sqlite,
+      ),
+    "Ledger",
+    "findMany",
+  ],
+  [
+    "_count",
+    () =>
+      compileRead(
+        ledger,
+        "findMany",
+        { include: { _count: { select: { entries: true } } } },
+        sqlite,
+      ),
+    "Ledger",
+    "findMany",
+  ],
+  [
+    "an orderBy through a relation",
+    () =>
+      compileRead(
+        ledgerEntry,
+        "findMany",
+        { orderBy: { ledger: { title: "asc" } } },
+        sqlite,
+      ),
+    "LedgerEntry",
+    "findMany",
+  ],
+  [
+    "a nested write",
+    () =>
+      compileWrite(
+        ledger,
+        "create",
+        {
+          data: {
+            tenantId: 1,
+            code: "a",
+            title: "t",
+            entries: { create: { amount: 1 } },
+          },
+        },
+        sqlite,
+      ),
+    "Ledger",
+    "create",
+  ],
+];
+
+describe("a multi-field relation is refused, everywhere", () => {
+  test.each(SURFACES)("%s", (_label, run) => {
+    expect(run).toThrow(UnsupportedQueryError);
+    expect(run).toThrow(/joins on 2 fields/);
+  });
+
+  /**
+   * The half that was wrong: a refusal has to name where it came from, or it
+   * sends the reader to a query they did not write. `#61`'s rule.
+   */
+  test.each(SURFACES)("%s names its own operation", (_label, run, model, operation) => {
+    expect(run).toThrow(`(${model}.${operation})`);
+  });
+
+  /** And says what to do instead, rather than only what it will not do. */
+  test("the message offers a way through", () => {
+    const run = () =>
+      compileRead(ledger, "findMany", { include: { entries: true } }, sqlite);
+
+    expect(run).toThrow(/composite key comparison/);
+    expect(run).toThrow(/DB\.query/);
+  });
+
+  /**
+   * Both sides, because the two are resolved differently: the owning side reads
+   * `from` / `to` off its own relation, and the other side has to find its
+   * counterpart through `relationName` first.
+   */
+  test("it is refused from the referenced side as well as the owning one", () => {
+    expect(() =>
+      compileRead(ledger, "findMany", { include: { entries: true } }, sqlite),
+    ).toThrow(/to: tenantId, code/);
+
+    expect(() =>
+      compileRead(ledgerEntry, "findMany", { include: { ledger: true } }, sqlite),
+    ).toThrow(/from: tenantId, ledgerCode/);
+  });
+
+  /**
+   * A single-field relation on the same models still compiles — otherwise this
+   * suite would pass for a compiler that refused every relation.
+   */
+  test("a single-field relation is unaffected", () => {
+    registry.register("Ledger", class { static $schema = ledger });
+    const single = {
+      ...ledgerEntry,
+      relations: {
+        ledger: { ...ledgerEntry.relations.ledger, from: ["ledgerCode"], to: ["code"] },
+      },
+    };
+    registry.register("LedgerEntry", class { static $schema = single });
+
+    expect(() =>
+      compileRead(single, "findMany", { include: { ledger: true } }, sqlite),
+    ).not.toThrow();
+  });
+});

--- a/packages/gemi/orm/compile/correlate.ts
+++ b/packages/gemi/orm/compile/correlate.ts
@@ -54,12 +54,14 @@ export function correlate(
   alias: string,
   /** How the outer row is named: the parent's table, or an enclosing alias. */
   parentQualifier: string,
+  /** The caller's operation, so a refused link names where it came from. */
+  operation = "include",
 ): Correlated {
   const child = relatedSchema(parent, relation);
   // Throws for a self-referential implicit m-n, where the artifact cannot say
   // which join column is which end. That refusal is the planner's and predates
   // this; it is reached here rather than duplicated.
-  const link = resolveLink(parent, child, relation);
+  const link = resolveLink(parent, child, relation, operation);
 
   const quoted = dialect.quoteIdent(alias);
   const qualifier = `${quoted}.`;

--- a/packages/gemi/orm/compile/correlate.ts
+++ b/packages/gemi/orm/compile/correlate.ts
@@ -54,8 +54,11 @@ export function correlate(
   alias: string,
   /** How the outer row is named: the parent's table, or an enclosing alias. */
   parentQualifier: string,
-  /** The caller's operation, so a refused link names where it came from. */
-  operation = "include",
+  /**
+   * The caller's operation, so a refused link names where it came from.
+   * Required for the same reason `resolveLink`'s is — see the note there.
+   */
+  operation: string,
 ): Correlated {
   const child = relatedSchema(parent, relation);
   // Throws for a self-referential implicit m-n, where the artifact cannot say

--- a/packages/gemi/orm/compile/lateral.ts
+++ b/packages/gemi/orm/compile/lateral.ts
@@ -97,7 +97,12 @@ export const lateralStrategy: RelationStrategy = {
 
     const { dialect } = request;
     const child = relatedSchema(request.parent, request.relation, request.as);
-    const link = resolveLink(request.parent, child, request.relation);
+    const link = resolveLink(
+      request.parent,
+      child,
+      request.relation,
+      request.operation,
+    );
 
     const fold = foldNode({
       parent: request.parent,
@@ -302,7 +307,7 @@ function foldNode(input: FoldInput): Fold {
         // *shape*, so a nested `where`'s values are read from the call through
         // the whole chain of `locate`s.
         locate: (args: any) => relationNode.locate(input.locate(args)),
-        link: resolveLink(child, grandchild, relationNode.relation),
+        link: resolveLink(child, grandchild, relationNode.relation, operation),
         dialect,
         operation,
         depth: input.depth + 1,

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -149,7 +149,7 @@ function planOne(
   if (keys.length === 0) return;
 
   const child = relatedSchema(schema, relation);
-  const link = resolveLink(schema, child, relation);
+  const link = resolveLink(schema, child, relation, operation);
 
   // `from` is non-empty exactly on the side that holds the foreign key.
   const owning = relation.from.length > 0;

--- a/packages/gemi/orm/compile/order-relation.ts
+++ b/packages/gemi/orm/compile/order-relation.ts
@@ -91,6 +91,7 @@ export function relationOrderExpression(
     dialect,
     `_o${index}`,
     `${dialect.quoteIdent(schema.table)}.`,
+    operation,
   );
 
   const selected = projection(

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -697,13 +697,19 @@ export function resolveLink(
   parent: ModelSchema,
   child: ModelSchema,
   relation: RelationSchema,
+  /**
+   * The operation the link is being resolved for, so a refusal names where it
+   * came from. Defaulted for the callers that predate it; every call site in
+   * the compiler passes a real one.
+   */
+  operation = "include",
 ): Link {
   if (relation.joinTable) return joinTableLink(parent, child, relation);
 
   if (relation.from.length > 0) {
     return {
-      parentField: single(parent, relation, relation.from, "from"),
-      childField: single(parent, relation, relation.to, "to"),
+      parentField: single(parent, relation, relation.from, "from", operation),
+      childField: single(parent, relation, relation.to, "to", operation),
     };
   }
 
@@ -718,8 +724,8 @@ export function resolveLink(
   }
 
   return {
-    parentField: single(parent, relation, other.to, "to"),
-    childField: single(parent, relation, other.from, "from"),
+    parentField: single(parent, relation, other.to, "to", operation),
+    childField: single(parent, relation, other.from, "from", operation),
   };
 }
 
@@ -752,24 +758,40 @@ function otherSide(
 }
 
 /**
- * Multi-field relations (`@relation(fields: [a, b], references: [c, d])`) would
- * need a row-value `in`, which the two dialects spell differently and neither
- * indexes well. Refused rather than quietly matching on the first field.
+ * Multi-field relations — `@relation(fields: [a, b], references: [c, d])` —
+ * refused rather than quietly matching on the first field.
+ *
+ * **Refused everywhere, which is the property that matters**, and it is a
+ * property rather than a coincidence: every surface that correlates over a
+ * relation resolves its link through here. `include` under either strategy, a
+ * relation filter, a `_count`, an `orderBy` through a relation, and every
+ * nested write all arrive at this function, so none of them can reach a
+ * one-field assumption. There is a test walking all seven.
+ *
+ * The `operation` argument exists because they do not all arrive from an
+ * `include`, and this used to say so anyway: a composite relation named in a
+ * `where` reported `(Order.include)`, and so did a nested `connect` on a
+ * `create`. A refusal that misnames where it came from sends the reader to a
+ * query they did not write — see #61.
  */
 function single(
   parent: ModelSchema,
   relation: RelationSchema,
   fields: string[],
   side: string,
+  operation: string,
 ): string {
   if (fields.length !== 1) {
     throw new UnsupportedQueryError(
       relation.name,
       parent.name,
-      "include",
+      operation,
       `${relation.name} joins on ${fields.length} fields (${side}: ` +
-        `${fields.join(", ") || "none"}). Multi-field relations are not ` +
-        `implemented yet.`,
+        `${fields.join(", ") || "none"}). A multi-field relation needs a ` +
+        `composite key comparison on both sides — a tuple 'in' for the ` +
+        `batched strategy, a conjunction for the lateral one — which is not ` +
+        `implemented. Query the two models separately and join them in ` +
+        `process, or write the join with 'sql' and 'DB.query'.`,
     );
   }
   return fields[0];
@@ -918,7 +940,12 @@ export const batchedStrategy: RelationStrategy = {
     // compile time rather than returning a page nobody asked for.
     assertPaginable(request, `this query planned with the batched strategy`);
 
-    const link = resolveLink(request.parent, request.child, request.relation);
+    const link = resolveLink(
+      request.parent,
+      request.child,
+      request.relation,
+      request.operation,
+    );
 
     // Resolved at plan time so a stale artifact fails when the query is
     // compiled rather than after the root query has already run.

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -699,10 +699,24 @@ export function resolveLink(
   relation: RelationSchema,
   /**
    * The operation the link is being resolved for, so a refusal names where it
-   * came from. Defaulted for the callers that predate it; every call site in
-   * the compiler passes a real one.
+   * came from.
+   *
+   * **Required, and deliberately so.** The bug this argument exists to fix *is*
+   * a wrongly-defaulted operation: `single` hardcoded `"include"`, so a
+   * composite relation named in a `where` or in a nested `connect` reported a
+   * query the caller had not written. A default here would reintroduce exactly
+   * that, one call site later — the next surface to correlate over a relation
+   * would inherit `include` by omission, silently, and the seven-surface test
+   * cannot catch it because it only knows about the seven that exist.
+   *
+   * It is the fifth parameter in this codebase made required for this reason,
+   * after `render`'s `origin`, `changedFields`' `schema` and
+   * `RelationExecutor.exec`'s `preScoped`. The rule they share: where omitting
+   * an argument silently produces the *wrong* behaviour rather than an error,
+   * requiring it is the difference between a convention and something `tsc`
+   * enforces.
    */
-  operation = "include",
+  operation: string,
 ): Link {
   if (relation.joinTable) return joinTableLink(parent, child, relation);
 

--- a/packages/gemi/orm/compile/relation-count.ts
+++ b/packages/gemi/orm/compile/relation-count.ts
@@ -106,6 +106,7 @@ function countPlan(
     dialect,
     `_c${index}`,
     `${dialect.quoteIdent(schema.table)}.`,
+    operation,
   );
 
   const where = node === true ? undefined : (node as any)?.where;

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -216,6 +216,7 @@ function compileRelationFilter(
     dialect,
     `_r${depth}`,
     parentQualifier,
+    context.operation,
   );
   const child = source.child;
   const correlation = sql(source.correlation);

--- a/packages/gemi/orm/fixtures.ts
+++ b/packages/gemi/orm/fixtures.ts
@@ -409,6 +409,118 @@ export const tag: ModelSchema = {
 };
 
 /**
+ * A **multi-field relation** — `@relation(fields: [tenantId, ledgerCode],
+ * references: [tenantId, code])` — which the template's schema has no example
+ * of and Prisma allows.
+ *
+ * The shape is not exotic: it is what a tenant-scoped schema looks like when
+ * every table carries `tenantId` and every relation joins on
+ * `(tenantId, parentId)`. An application written that way cannot use `include`
+ * at all today, which is what #67 is about.
+ *
+ * These exist so the *refusal* can be tested on every surface that correlates
+ * over a relation. Until the feature lands, the property worth holding is that
+ * none of them quietly joins on the first field.
+ */
+export const ledger: ModelSchema = {
+  name: "Ledger",
+  table: "Ledger",
+  fields: {
+    tenantId: {
+      name: "tenantId",
+      column: "tenantId",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+    },
+    code: {
+      name: "code",
+      column: "code",
+      type: "String",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+    },
+    title: {
+      name: "title",
+      column: "title",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["tenantId", "code"],
+  uniques: [],
+  relations: {
+    entries: {
+      name: "entries",
+      model: "LedgerEntry",
+      kind: "many",
+      relationName: "LedgerToEntry",
+      from: [],
+      to: [],
+      nullable: false,
+    },
+  },
+};
+
+/** The owning side of {@link ledger}'s two-field relation. */
+export const ledgerEntry: ModelSchema = {
+  name: "LedgerEntry",
+  table: "LedgerEntry",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    tenantId: {
+      name: "tenantId",
+      column: "tenantId",
+      type: "Int",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    ledgerCode: {
+      name: "ledgerCode",
+      column: "ledgerCode",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    amount: {
+      name: "amount",
+      column: "amount",
+      type: "Int",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    ledger: {
+      name: "ledger",
+      model: "Ledger",
+      kind: "one",
+      relationName: "LedgerToEntry",
+      from: ["tenantId", "ledgerCode"],
+      to: ["tenantId", "code"],
+      nullable: false,
+    },
+  },
+};
+
+/**
  * A self-relation — the one topology where the parent and the child are the same
  * table, which the template's schema has no example of.
  *


### PR DESCRIPTION
**Groundwork for #67, not the feature** — and I want to be plain about that split rather than dress it up.

The feature is a composite key comparison on both sides: a tuple `in` for the batched strategy, a conjunction for the lateral one, a composite stitch key that cannot collide, and a template schema that actually has a two-field relation so the differential harness can compare it. That touches four compilers and wants the coverage the issue asks for (both directions, both strategies, both dialects, plus relation filters, `_count`, `orderBy`, and plan discrimination). It deserves its own PR.

What this does is establish what is true today — and the audit turned up one thing that was wrong.

## The safety property holds, and is now pinned

Seven surfaces correlate over a relation, each with its own compiler:

| surface | before | after |
| --- | --- | --- |
| `include`, to-many | refused | refused |
| `include`, to-one | refused | refused |
| `include` under `lateral` | refused | refused |
| a relation filter | refused | refused |
| `_count` | refused | refused |
| `orderBy` through a relation | refused | refused |
| a nested write | refused | refused |

All seven resolve their link through one function, so none can reach a one-field assumption and join on `fields[0]` — which would return **plausible wrong rows from a query that succeeds**, the worst failure available here.

That was already true. It was not tested, and "all seven happen to go through one function" is exactly the kind of property that stops being true quietly when the eighth surface arrives.

## The message was wrong about where it came from

`single()` hardcoded `"include"` as the operation. So a composite relation named in a `where` reported `(Ledger.include)`, and a nested `connect` on a `create` reported `(LedgerEntry.include)` — sending the reader to a query they had not written. Measured before and after:

```
relation filter (some)      (Ledger.include)   ->  (Ledger.findMany)
_count                      (Ledger.include)   ->  (Ledger.findMany)
orderBy a relation field    (Entry.include)    ->  (Entry.findMany)
nested write: connect       (Entry.include)    ->  (Entry.create)
nested write: child create  (Ledger.include)   ->  (Ledger.create)
```

The fix is one argument threaded from five call sites. The message now also names what the shape needs and offers a way through, instead of only naming what it will not do:

```
gemi ORM does not support 'entries' yet (Ledger.findMany). entries joins on 2
fields (to: tenantId, code). A multi-field relation needs a composite key
comparison on both sides — a tuple 'in' for the batched strategy, a conjunction
for the lateral one — which is not implemented. Query the two models separately
and join them in process, or write the join with 'sql' and 'DB.query'.
```

## The fixture

A `ledger` / `ledgerEntry` pair carrying `@relation(fields: [tenantId, ledgerCode], references: [tenantId, code])` — the tenant-scoped shape the issue names, where every table has `tenantId` and every relation joins on `(tenantId, parentId)`. The template's schema has no example of one.

17 tests walk the seven surfaces, both directions of the relation (they resolve differently — the owning side reads `from`/`to` off its own relation, the other has to find its counterpart through `relationName`), and **one single-field relation on the same models**, so the suite cannot pass for a compiler that refused every relation.

`docs/orm.md` gains the entry, marked *pending* rather than declined — unlike `distinct` and `cursor` in #78, this one is a gap and should say so.

When the feature lands, this file inverts: the refusals become assertions about emitted SQL, and the list of surfaces is already written down.

855 unit tests, full template suite green on SQLite and Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
