### PR TITLE
Refuse MySQL and MariaDB explicitly, and say what still works

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -767,8 +767,24 @@ matters.
 that runs each query through both gemi and Prisma and compares the rows. `DatabaseManager` infers
 the dialect from `DATABASE_URL`.
 
-MySQL and MariaDB are **not** implemented. The dialect seam is there and `DatabaseManager` already
-recognises them, but nothing is built or tested behind it.
+MySQL and MariaDB are **not** implemented, and that is a statement about the supported matrix rather
+than a release that is coming. The dialect seam is there and `DatabaseManager` already recognises
+them, but nothing is built or tested behind it.
+
+**The connection still works, which is the part worth being precise about.** Bun's client speaks all
+four dialects, so pointed at MySQL an application connects, `DB.query` / `DB.sql` run, and
+transactions work. What is missing is a `SqlDialect` for the query *compiler*, so every model
+operation raises `UnsupportedDialectError` — with a message that says exactly that, rather than
+leaving you to conclude the database is unusable.
+
+In development the mismatch is reported **at boot** instead of on the first model query, since
+otherwise an application pointed at MySQL starts, passes a health check, and fails on the first
+`findMany`. `ormSupports(dialect)` is exported if you would rather assert it yourself:
+
+```ts
+import { ormSupports } from "gemi/orm"
+if (!ormSupports(DB.dialect)) throw new Error("this deployment needs Postgres")
+```
 
 ## Not in scope
 

--- a/packages/gemi/database/DatabaseServiceProvider.ts
+++ b/packages/gemi/database/DatabaseServiceProvider.ts
@@ -1,3 +1,4 @@
+import { ormSupports } from "../orm/dialect";
 import { ServiceProvider } from "../support/ServiceProvider";
 import { withDefaults } from "../support/withDefaults";
 import { databaseConfigDefaults, type DatabaseConfig } from "./config";
@@ -7,13 +8,49 @@ export class DatabaseServiceProvider extends ServiceProvider {
   register() {
     this.app.singleton(
       DatabaseManager,
-      () =>
-        new DatabaseManager(
+      () => {
+        const database = new DatabaseManager(
           withDefaults(
             databaseConfigDefaults(),
             this.app.config.get<DatabaseConfig>("database", {}),
           ),
-        ),
+        );
+
+        warnIfOrmUnavailable(database);
+        return database;
+      },
     );
   }
+}
+
+/**
+ * Say it at boot, not on the first model query.
+ *
+ * `DatabaseManager` connects to MySQL and MariaDB without complaint — Bun's
+ * client speaks them — and the ORM's compiler has no dialect for either. So a
+ * deploy pointed at one starts, passes a health check, serves whatever does not
+ * touch a model, and raises `UnsupportedDialectError` on the first `findMany`.
+ * That is the latest and most expensive moment to learn it.
+ *
+ * A **warning rather than a throw**, deliberately: raw SQL through `DB.query`
+ * and `DB.sql` genuinely works on those dialects, and so do transactions.
+ * Refusing to construct the manager would break code that is correct today to
+ * pre-empt an error the ORM already raises clearly. The supported set is a
+ * property of the query compiler, not of the connection.
+ *
+ * Development only, for the same reason the slow-transaction warning is: it is
+ * a diagnostic aimed at whoever is choosing the database, and it should not
+ * add noise to a production log every time the container starts.
+ */
+function warnIfOrmUnavailable(database: DatabaseManager): void {
+  if (process.env.NODE_ENV !== "development") return;
+  if (ormSupports(database.dialect)) return;
+
+  console.warn(
+    `[gemi] DATABASE_URL points at ${database.dialect}, which the gemi ORM ` +
+      `does not implement — only sqlite and postgres are. The connection ` +
+      `works, so raw SQL through DB.query / DB.sql and transactions are fine, ` +
+      `but every model operation will raise UnsupportedDialectError.\n` +
+      `(development only)`,
+  );
 }

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -183,14 +183,47 @@ export interface ConstraintViolation {
   constraint?: string;
 }
 
+/**
+ * The ORM was asked to compile against a dialect it does not implement.
+ *
+ * **The split this message has to convey**, because it is the surprising part:
+ * `DatabaseManager` connects to MySQL and MariaDB perfectly well — Bun's client
+ * speaks all four — so raw SQL through `DB.query` / `DB.sql` works, and
+ * transactions work. What does not exist is a `SqlDialect` for them, so
+ * everything that *compiles* a statement stops here.
+ *
+ * A caller who reads only "not supported" reasonably concludes the connection
+ * is unusable, which is wrong and is the more expensive misreading: it is the
+ * ORM that is unavailable, not the database.
+ */
 export class UnsupportedDialectError extends Error {
   constructor(dialect: Dialect) {
     super(
-      `The gemi ORM does not support the '${dialect}' dialect yet. ` +
-        `Only sqlite and postgres are implemented.`,
+      `The gemi ORM does not support the '${dialect}' dialect. Only sqlite ` +
+        `and postgres are implemented — see the supported matrix in ` +
+        `docs/orm.md.\n\n` +
+        `The *connection* is fine: Bun's client speaks ${dialect}, so raw SQL ` +
+        `through DB.query / DB.sql and transactions all work. It is the query ` +
+        `compiler that has no ${dialect} dialect, so every model operation ` +
+        `raises this.\n\n` +
+        `Point DATABASE_URL at Postgres or SQLite to use the ORM, or keep ` +
+        `using Prisma's own client for this database.`,
     );
     this.name = "UnsupportedDialectError";
   }
+}
+
+/**
+ * Whether the ORM can compile for this dialect at all.
+ *
+ * Exported so an application can find out at **boot** rather than on its first
+ * query. That is the whole gap this closes: `DatabaseManager` constructs
+ * happily against MySQL, so a deploy pointed at one starts, passes a health
+ * check, serves traffic, and fails on the first model read — which is the
+ * latest and most expensive moment to learn it.
+ */
+export function ormSupports(dialect: Dialect): boolean {
+  return dialect === "sqlite" || dialect === "postgres";
 }
 
 const sqlite = new SqliteDialect();

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -223,11 +223,45 @@ export class UnsupportedDialectError extends Error {
  * latest and most expensive moment to learn it.
  */
 export function ormSupports(dialect: Dialect): boolean {
-  return dialect === "sqlite" || dialect === "postgres";
+  return COMPILERS[dialect] !== null;
 }
 
-const sqlite = new SqliteDialect();
-const postgres = new PostgresDialect();
+/** Every dialect `Dialect` names, for anything that has to walk them all. */
+export function everyDialect(): Dialect[] {
+  return Object.keys(COMPILERS) as Dialect[];
+}
+
+/**
+ * The compiler for each dialect, or `null` where the ORM has none.
+ *
+ * **One map rather than two lists, and `satisfies` rather than a lookup.** The
+ * supported set used to be written three times — `ormSupports`' `||` chain,
+ * `dialectFor`'s `if` chain, and a test enumerating a hand-written copy of the
+ * `Dialect` union — so adding a fifth member to that union changed nothing
+ * anywhere: `tsc` clean, tests green, the new dialect silently reported as
+ * unsupported by one function and unknown to the other.
+ *
+ * That moment is exactly what the guard exists for. Adding a dialect to the
+ * union is the *first step of implementing one*, and it is the step where a
+ * half-added dialect would disagree with itself.
+ *
+ * `satisfies Record<Dialect, …>` makes it a compile error in a file the build
+ * actually checks. It has to live here rather than in a test: `tsconfig.json`
+ * excludes test files and vitest transpiles without type-checking, so an
+ * exhaustiveness check written there is a type error nothing ever evaluates.
+ *
+ * The sixth thing in this codebase made `tsc`'s job rather than a convention's
+ * — see the note on `resolveLink`'s `operation`.
+ */
+const COMPILERS = {
+  sqlite: new SqliteDialect(),
+  postgres: new PostgresDialect(),
+  // Bun's client speaks both; the ORM has no compiler for either. See
+  // `UnsupportedDialectError`, which is careful to say that the *connection*
+  // still works.
+  mysql: null,
+  mariadb: null,
+} satisfies Record<Dialect, SqlDialect | null>;
 
 /**
  * Resolved per call from `DatabaseManager.dialect`, never baked into a
@@ -235,9 +269,9 @@ const postgres = new PostgresDialect();
  * the one `prisma generate` saw.
  */
 export function dialectFor(dialect: Dialect): SqlDialect {
-  if (dialect === "sqlite") return sqlite;
-  if (dialect === "postgres") return postgres;
-  throw new UnsupportedDialectError(dialect);
+  const compiler = COMPILERS[dialect];
+  if (compiler === null) throw new UnsupportedDialectError(dialect);
+  return compiler;
 }
 
 export { PostgresDialect, SqliteDialect };

--- a/packages/gemi/orm/dialect/unsupported.test.ts
+++ b/packages/gemi/orm/dialect/unsupported.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+
+import { UnsupportedDialectError, dialectFor, ormSupports } from "./index";
+
+/**
+ * MySQL and MariaDB: refused explicitly, which is #71's option (2) and the
+ * minimum that should ship whichever way the long-term decision goes.
+ *
+ * The property worth pinning is not "it throws" — it already did — but **what
+ * the refusal says**, because the obvious reading of "not supported" is wrong
+ * in the expensive direction. `DatabaseManager` connects to both perfectly
+ * well; Bun's client speaks all four dialects. Raw SQL and transactions work.
+ * What does not exist is a `SqlDialect`, so only the *compiler* stops.
+ *
+ * A caller who concludes the connection is unusable will migrate a database
+ * they did not need to.
+ */
+
+describe("a dialect the ORM does not implement", () => {
+  test.each(["mysql", "mariadb"])("%s is refused", (dialect) => {
+    expect(() => dialectFor(dialect as never)).toThrow(UnsupportedDialectError);
+  });
+
+  test.each(["sqlite", "postgres"])("%s resolves", (dialect) => {
+    expect(dialectFor(dialect as never).name).toBe(dialect);
+  });
+
+  /**
+   * The three things the message owes the reader: what is unavailable, what
+   * still works, and what to do. #61's rule.
+   */
+  test("the message separates the compiler from the connection", () => {
+    const run = () => dialectFor("mysql" as never);
+
+    expect(run).toThrow(/does not support the 'mysql' dialect/);
+    // What still works — the half a bare "not supported" hides.
+    expect(run).toThrow(/The \*connection\* is fine/);
+    expect(run).toThrow(/DB\.query/);
+    // What to do.
+    expect(run).toThrow(/Point DATABASE_URL at Postgres or SQLite/);
+  });
+
+  /**
+   * It no longer says "yet". The word is the one #68 made load-bearing:
+   * `distinct` and `cursor` say "a decision rather than a gap", genuinely
+   * unimplemented arguments say "yet", and this is neither — it is a
+   * *supported-matrix* statement, and "yet" invited a reader to wait for a
+   * release that is not planned.
+   */
+  test("it states the supported set rather than promising more", () => {
+    expect(() => dialectFor("mysql" as never)).toThrow(
+      /Only sqlite and postgres are implemented/,
+    );
+    expect(() => dialectFor("mysql" as never)).not.toThrow(/dialect yet/);
+  });
+
+  /**
+   * The predicate exists so an application can ask at boot instead of finding
+   * out on its first model query — which is what `DatabaseServiceProvider`
+   * uses it for.
+   */
+  test("ormSupports answers without throwing", () => {
+    expect(ormSupports("sqlite")).toBe(true);
+    expect(ormSupports("postgres")).toBe(true);
+    expect(ormSupports("mysql")).toBe(false);
+    expect(ormSupports("mariadb")).toBe(false);
+  });
+
+  /**
+   * The two have to agree, or the boot check and the query-time failure would
+   * disagree about which databases work — the check would be worse than none.
+   */
+  test("the predicate and the resolver cannot disagree", () => {
+    for (const dialect of ["sqlite", "postgres", "mysql", "mariadb"] as const) {
+      let resolved = true;
+      try {
+        dialectFor(dialect);
+      } catch {
+        resolved = false;
+      }
+      expect(resolved, dialect).toBe(ormSupports(dialect));
+    }
+  });
+});

--- a/packages/gemi/orm/dialect/unsupported.test.ts
+++ b/packages/gemi/orm/dialect/unsupported.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { UnsupportedDialectError, dialectFor, ormSupports } from "./index";
+import {
+  UnsupportedDialectError,
+  dialectFor,
+  everyDialect,
+  ormSupports,
+} from "./index";
 
 /**
  * MySQL and MariaDB: refused explicitly, which is #71's option (2) and the
@@ -69,9 +74,21 @@ describe("a dialect the ORM does not implement", () => {
   /**
    * The two have to agree, or the boot check and the query-time failure would
    * disagree about which databases work — the check would be worse than none.
+   *
+   * Walked from `everyDialect()` rather than a hand-written list. The list this
+   * used to carry was a *copy* of the `Dialect` union, so it only covered the
+   * members someone had remembered to add — and adding a fifth changed nothing
+   * anywhere, which is precisely the moment the guard exists for.
+   *
+   * The exhaustiveness itself is `tsc`'s now, via the `satisfies` on
+   * `COMPILERS`; this checks the two functions agree in *behaviour*, which a
+   * type cannot.
    */
   test("the predicate and the resolver cannot disagree", () => {
-    for (const dialect of ["sqlite", "postgres", "mysql", "mariadb"] as const) {
+    const dialects = everyDialect();
+    expect(dialects.length).toBeGreaterThan(1);
+
+    for (const dialect of dialects) {
       let resolved = true;
       try {
         dialectFor(dialect);

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -147,6 +147,7 @@ export {
   SqliteDialect,
   UnsupportedDialectError,
   dialectFor,
+  everyDialect,
   ormSupports,
   type ConstraintViolation,
   type SqlDialect,

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -147,6 +147,7 @@ export {
   SqliteDialect,
   UnsupportedDialectError,
   dialectFor,
+  ormSupports,
   type ConstraintViolation,
   type SqlDialect,
 } from "./dialect";


### PR DESCRIPTION
Closes #71 at its **option (2)** — the one the issue names as *"the minimum that should ship with the ORM, whichever of the three is chosen long-term."* Building a third dialect, or shipping a documented partial, remain open decisions and are not pre-empted here.

## Measured first

A MySQL URL today:

```
inferDialect        -> mysql
new DatabaseManager -> ok, dialect = mysql
dialectFor          -> THREW
```

`dialectFor` is called by `Model.$exec` **per query**. So an application pointed at MySQL starts, passes a health check, serves everything that does not touch a model, and raises on the first `findMany`. The refusal existed; it arrived at the latest and most expensive moment.

## The message separates the compiler from the connection

It said *"does not support the 'mysql' dialect **yet**"*, which invites the reading that the database is unusable. It is not — and this is the part worth being precise about:

**Bun's client speaks all four dialects.** Pointed at MySQL, the connection works, `DB.query` / `DB.sql` run, and transactions work. What is missing is a `SqlDialect` for the query *compiler*. A reader who concludes the connection is dead migrates a database they did not need to.

The message now says what is unavailable, what still works, and what to do:

```
The gemi ORM does not support the 'mysql' dialect. Only sqlite and postgres are
implemented — see the supported matrix in docs/orm.md.

The *connection* is fine: Bun's client speaks mysql, so raw SQL through
DB.query / DB.sql and transactions all work. It is the query compiler that has
no mysql dialect, so every model operation raises this.

Point DATABASE_URL at Postgres or SQLite to use the ORM, or keep using Prisma's
own client for this database.
```

It also **stops saying "yet"**. That word became load-bearing in #78/#68: `distinct` and `cursor` say *"a decision rather than a gap"*, genuinely unimplemented arguments say *"yet"*, and this is neither — it is a supported-matrix statement, and "yet" promised a release that is not planned.

## `ormSupports(dialect)`, and a boot-time warning

Exported, so an application can assert it at startup rather than discover it on the first query:

```ts
import { ormSupports } from "gemi/orm"
if (!ormSupports(DB.dialect)) throw new Error("this deployment needs Postgres")
```

`DatabaseServiceProvider` warns in development when the configured dialect has no compiler.

**A warning rather than a throw, deliberately.** Refusing to construct the manager would break raw SQL that works correctly today, in order to pre-empt an error the ORM already raises clearly. The supported set is a property of the compiler, not of the connection — and the change should not contradict the message it just wrote.

A test pins that `ormSupports` and `dialectFor` **cannot disagree**: a boot check that differed from the query-time failure about which databases work would be worse than no check at all.

## Verification

8 new tests; 859 orm/database tests pass. Full template suite green on SQLite. Pre-existing and unchanged: the six router/i18n files in `packages/gemi` (7 tests), confirmed against the base commit, and `generated.test.ts`'s generator-linkage probe.

Not run against a live MySQL server — nothing here connects to one, and the behaviour under test is dialect *resolution*, which is a pure function of the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
