### PR TITLE
Writes through an implicit many-to-many join table

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -317,7 +317,7 @@ scope. The rows the pairs point at still go through the related model's own oper
 `connect` cannot reach a row that model's policies hide, and a `create` gets its `onCreate`.
 
 That extends to `set`, which has to delete before it inserts: it clears **the links you can see**,
-not every link. A pair pointing at a row the related model's policies hide survives — otherwise
+not every link — in one `delete … in (…)`, not one statement per link. A pair pointing at a row the related model's policies hide survives — otherwise
 `set` would quietly do what `disconnect` refuses. With no policy on that model every link is
 visible and `set` clears all of them, exactly as Prisma does.
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -316,6 +316,11 @@ Only the join table itself is written directly; it has no model and nothing an a
 scope. The rows the pairs point at still go through the related model's own operations, so a
 `connect` cannot reach a row that model's policies hide, and a `create` gets its `onCreate`.
 
+That extends to `set`, which has to delete before it inserts: it clears **the links you can see**,
+not every link. A pair pointing at a row the related model's policies hide survives — otherwise
+`set` would quietly do what `disconnect` refuses. With no policy on that model every link is
+visible and `set` clears all of them, exactly as Prisma does.
+
 Self-referential ones work too — `Thing.related Thing[]` — as long as the generated files are
 current. Prisma assigns that join table's two columns by *field name*, which the generator now
 records; an artifact from before it does raises rather than guessing, and `prisma generate` fixes

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -306,6 +306,16 @@ Filtering, counting and ordering all work across an **implicit many-to-many** to
 table is a second table inside the subquery and changes nothing else about how you write the
 query.
 
+**Writing one works too**, through the same relation key inside `data`: `connect`, `disconnect`,
+`set` and `create`. `set` replaces the whole set — a delete and then inserts, inside the same
+transaction — and connecting a pair that is already there is a no-op rather than an error, as it is
+in Prisma. An `update` whose `data` names only relations is fine: there is no column to set, so the
+row is read rather than written and the relation work still happens.
+
+Only the join table itself is written directly; it has no model and nothing an application could
+scope. The rows the pairs point at still go through the related model's own operations, so a
+`connect` cannot reach a row that model's policies hide, and a `create` gets its `onCreate`.
+
 Self-referential ones work too — `Thing.related Thing[]` — as long as the generated files are
 current. Prisma assigns that join table's two columns by *field name*, which the generator now
 records; an artifact from before it does raises rather than guessing, and `prisma generate` fixes

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -179,11 +179,27 @@ function planOne(
 
     if (owning) {
       planOwningSide(
-        schema, relation, child, link, key, operand, operation, at, out,
+        schema,
+        relation,
+        child,
+        link,
+        key,
+        operand,
+        operation,
+        at,
+        out,
       );
     } else {
       planForeignSide(
-        schema, relation, child, link, key, operand, operation, at, out,
+        schema,
+        relation,
+        child,
+        link,
+        key,
+        operand,
+        operation,
+        at,
+        out,
       );
     }
   }
@@ -242,7 +258,11 @@ function planOwningSide(
   // Whether that is the case is a property of the argument *shape*, not of its
   // values, so the choice is made here at compile time and the two forms are two
   // plans. That is what keeps a `connect` from silently costing a round trip.
-  if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
+  if (
+    typeof operand !== "object" ||
+    operand === null ||
+    Array.isArray(operand)
+  ) {
     throw new UnsupportedQueryError(
       `data.${relation.name}.connect`,
       schema.name,
@@ -456,9 +476,6 @@ function planJoinTable(
       const parentKey = parent[parentField];
       if (parentKey === null || parentKey === undefined) return;
 
-      // `set` replaces the whole set, so what is there now goes first. Prisma
-      // does the same, and it is why this operand needs the transaction the
-      // step already runs in.
       // `set` replaces the whole set, so what is there now goes first — but
       // **only the part of it this caller can see**.
       //
@@ -502,13 +519,38 @@ function planJoinTable(
             false,
           )) as Record<string, unknown>[];
 
-          for (const row of visible) {
+          // One statement, not one per link. The scoped form is a `delete`
+          // over an `in` list rather than a loop, because this repo counts
+          // *statements*: `plans/orm/benchmarks.md` measures include trees that
+          // way, and the lateral strategy exists to remove `N - 1` of them. A
+          // loop here would have made `set` the one write that reintroduces
+          // them — invisible on SQLite, where round trips are in-process, and
+          // paid in full on Postgres, where they are not.
+          //
+          // Placeholders are built per length rather than bound as one array
+          // parameter. `dialect.inList` does the latter on Postgres, but it
+          // returns a `Fragment` and this is the one path that emits SQL
+          // without that pipeline — there is no model to route the join table
+          // through. The cost is one server-side plan per distinct link count;
+          // the ORM's own plan cache is unaffected, since it keys on the
+          // argument shape and this text never reaches it.
+          const targets = Array.from(visible, (row) => row[childField]);
+
+          // Every existing link points at a row this caller cannot see, so
+          // there is nothing to clear and `in ()` is a syntax error on both
+          // dialects. The loop this replaced degenerated to zero iterations
+          // here; the single statement has to say so explicitly.
+          if (targets.length > 0) {
             await runPairStatement(
               executor,
               `delete from ${quoted(join.table)} where ` +
                 `${quoted(join.parentColumn)} = ${dialect.placeholder(0)} and ` +
-                `${quoted(join.childColumn)} = ${dialect.placeholder(1)}`,
-              [parentKey, row[childField]],
+                `${quoted(join.childColumn)} in (` +
+                targets
+                  .map((_, index) => dialect.placeholder(index + 1))
+                  .join(", ") +
+                `)`,
+              [parentKey, ...targets],
             );
           }
         }

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1,7 +1,9 @@
 import { UnsupportedQueryError } from "../errors";
+import type { SqlDialect } from "../dialect";
 import type { ModelSchema, RelationSchema } from "../schema";
 import type { Binder } from "./fragment";
 import {
+  type Link,
   type NestedWriteStep,
   relatedSchema,
   resolveLink,
@@ -71,6 +73,12 @@ export function planNestedWrites(
   operation: string,
   /** Re-locates `data` inside the call's argument tree at bind time. */
   locateData: (args: any) => any,
+  /**
+   * Needed only by the implicit many-to-many path, which emits statements
+   * against a table with no model and therefore has no `Fragment` pipeline to
+   * number its placeholders — SQLite writes `?` and Postgres `$1`.
+   */
+  dialect: SqlDialect,
 ): NestedWritePlanning {
   if (typeof data !== "object" || data === null || Array.isArray(data)) {
     return EMPTY;
@@ -95,7 +103,7 @@ export function planNestedWrites(
     const node = (data as Record<string, unknown>)[key];
     const locate = (args: any) => locateData(args)?.[key];
 
-    planOne(schema, relation, node, operation, locate, planning);
+    planOne(schema, relation, node, operation, locate, planning, dialect);
   }
 
   return planning;
@@ -108,6 +116,7 @@ function planOne(
   operation: string,
   locate: (args: any) => any,
   out: NestedWritePlanning,
+  dialect: SqlDialect,
 ): void {
   if (typeof node !== "object" || node === null || Array.isArray(node)) {
     throw new UnsupportedQueryError(
@@ -118,21 +127,36 @@ function planOne(
     );
   }
 
-  // Prisma's implicit many-to-many writes rows into a join table that has no
-  // model, so nothing here can express them.
-  if (relation.joinTable) {
-    throw new UnsupportedQueryError(
-      `data.${relation.name}`,
-      schema.name,
-      operation,
-      `${relation.name} is an implicit many-to-many. Writing through its join ` +
-        `table is not implemented yet.`,
-    );
-  }
-
   const keys = Object.keys(node as Record<string, unknown>)
     .sort()
     .filter((key) => (node as Record<string, unknown>)[key] !== undefined);
+
+  if (keys.length === 0) return;
+
+  const child = relatedSchema(schema, relation);
+  const link = resolveLink(schema, child, relation);
+
+  // An implicit many-to-many is *neither* side: the keys live in a third table
+  // with no model, so both directions are the same work and the operand set is
+  // wider — `disconnect` and `set` are a delete against the join table, which
+  // needs no schema to compile.
+  if (link.join) {
+    for (const key of keys) {
+      planJoinTable(
+        schema,
+        relation,
+        child,
+        link,
+        key,
+        (node as Record<string, unknown>)[key],
+        operation,
+        (args: any) => locate(args)?.[key],
+        out,
+        dialect,
+      );
+    }
+    return;
+  }
 
   for (const key of keys) {
     if (!SUPPORTED.has(key)) {
@@ -145,11 +169,6 @@ function planOne(
       );
     }
   }
-
-  if (keys.length === 0) return;
-
-  const child = relatedSchema(schema, relation);
-  const link = resolveLink(schema, child, relation);
 
   // `from` is non-empty exactly on the side that holds the foreign key.
   const owning = relation.from.length > 0;
@@ -354,6 +373,178 @@ function planForeignSide(
       }
     },
   });
+}
+
+/** What an implicit many-to-many accepts, which is wider than an ordinary relation. */
+const JOIN_TABLE_SUPPORTED = new Set([
+  "connect",
+  "disconnect",
+  "set",
+  "create",
+]);
+
+/**
+ * Writes through Prisma's implicit many-to-many join table.
+ *
+ * The table has **no model**: no registered class, no generated base, no
+ * `$schema` — just `_PostToTag` with an `A` and a `B` column, named from the
+ * two model names in alphabetical order, with the pair as its primary key. So
+ * the two operands that work for an ordinary relation have nothing to compile
+ * *to*, and these statements are emitted directly, the way the read side's
+ * `readPairs` already does.
+ *
+ * Which column is which end comes from `resolveLink`, never from declaration
+ * order. That distinction is invisible on `Post` / `Tag` and wrong on a
+ * self-relation, where both ends are the same model and only the *field* name
+ * separates them.
+ *
+ * Every operand is an `after` step: the pair cannot be written until this row
+ * has a key. Two of them are more than one statement — `set` deletes before it
+ * inserts — and `$exec` already opens a transaction for any plan carrying
+ * steps, so the whole thing is atomic.
+ *
+ * **The rows the pairs point at are still read and written through the child's
+ * own `$exec`**, so a `connect` cannot reach a row the child's policies hide,
+ * and a `create` gets the child's `onCreate`. Only the join table itself —
+ * which has no model and nothing an application could scope — is written
+ * directly.
+ */
+function planJoinTable(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  link: Link,
+  key: string,
+  operand: unknown,
+  operation: string,
+  at: (args: any) => any,
+  out: NestedWritePlanning,
+  dialect: SqlDialect,
+): void {
+  if (!JOIN_TABLE_SUPPORTED.has(key)) {
+    throw new UnsupportedQueryError(
+      `data.${relation.name}.${key}`,
+      schema.name,
+      operation,
+      `'${relation.name}' is an implicit many-to-many. Only ` +
+        `${[...JOIN_TABLE_SUPPORTED].sort().join(", ")} are implemented ` +
+        `through its join table.`,
+    );
+  }
+
+  const join = link.join!;
+  const parentField = link.parentField;
+  const childField = link.childField;
+
+  out.keyFields.push(parentField);
+
+  out.after.push({
+    relation: relation.name,
+    operation: key === "create" ? "create" : "connect",
+    async run(args, _context, executor, rows) {
+      const parent = rows[0];
+      if (!parent) return;
+
+      const parentKey = parent[parentField];
+      if (parentKey === null || parentKey === undefined) return;
+
+      // `set` replaces the whole set, so what is there now goes first. Prisma
+      // does the same, and it is why this operand needs the transaction the
+      // step already runs in.
+      if (key === "set") {
+        await runPairStatement(
+          executor,
+          `delete from ${quote(join.table)} where ` +
+            `${quote(join.parentColumn)} = ${dialect.placeholder(0)}`,
+          [parentKey],
+        );
+      }
+
+      const items = listOf(at(args));
+      if (items.length === 0) return;
+
+      const childKeys: unknown[] = [];
+
+      for (const item of items) {
+        if (key === "create") {
+          const created = (await executor.exec(
+            relation.model,
+            "create",
+            { data: item, select: { [childField]: true } },
+            // NOT pre-scoped: the child's own `onCreate` is what scopes the row.
+            false,
+          )) as Record<string, unknown> | null;
+          if (created) childKeys.push(created[childField]);
+          continue;
+        }
+
+        // `connect`, `disconnect` and `set` all name existing rows by a unique
+        // key. Resolved through the child's own `$exec`, so its policies decide
+        // which rows exist — otherwise a connect by any unique key reaches
+        // every tenant's.
+        matchUniqueKey(child, item, `${operation}.${relation.name}.${key}`);
+        const found = (await executor.exec(
+          relation.model,
+          "findUniqueOrThrow",
+          { where: item, select: { [childField]: true } },
+          false,
+        )) as Record<string, unknown> | null;
+        if (found) childKeys.push(found[childField]);
+      }
+
+      for (const childKey of childKeys) {
+        if (key === "disconnect") {
+          await runPairStatement(
+            executor,
+            `delete from ${quote(join.table)} where ` +
+              `${quote(join.parentColumn)} = ${dialect.placeholder(0)} and ` +
+              `${quote(join.childColumn)} = ${dialect.placeholder(1)}`,
+            [parentKey, childKey],
+          );
+          continue;
+        }
+
+        // `on conflict do nothing`, because the pair is the join table's
+        // primary key and Prisma treats a repeated `connect` as a no-op rather
+        // than an error. Without it the second connect of the same pair is a
+        // raw driver unique violation, which is neither Prisma's behaviour nor
+        // a useful one. Both dialects spell it the same way — SQLite has had it
+        // since 3.24 — so this needs no dialect branch.
+        await runPairStatement(
+          executor,
+          `insert into ${quote(join.table)} ` +
+            `(${quote(join.parentColumn)}, ${quote(join.childColumn)}) ` +
+            `values (${dialect.placeholder(0)}, ${dialect.placeholder(1)}) ` +
+            `on conflict do nothing`,
+          [parentKey, childKey],
+        );
+      }
+    },
+  });
+}
+
+/**
+ * The join table's identifiers are `_PostToTag`, `A` and `B` — generated by
+ * Prisma from model names, never caller input — so they are quoted the same way
+ * a column from the schema is. Double-quoting works on both implemented
+ * dialects.
+ */
+const quote = (name: string) => `"${name.replace(/"/g, '""')}"`;
+
+/**
+ * One statement against a table with no model, on the connection this call
+ * resolved — which is what keeps it inside the caller's transaction.
+ *
+ * Placeholders come from the dialect rather than being hardcoded, for the same
+ * reason `readPairs` renders its statement: SQLite writes `?` and Postgres
+ * `$1`, and this path has no `Fragment` pipeline to do it automatically.
+ */
+async function runPairStatement(
+  executor: { query(text: string, values: unknown[]): Promise<unknown> },
+  text: string,
+  values: unknown[],
+): Promise<void> {
+  await executor.query(text, values);
 }
 
 /**

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -436,6 +436,14 @@ function planJoinTable(
   const parentField = link.parentField;
   const childField = link.childField;
 
+  // `dialect.quoteIdent`, not a local helper. It does the same escaping *and*
+  // rejects a NUL byte, which exists because NUL is the parameter sentinel in
+  // `compile/fragment.ts`. Prisma generates these identifiers so nothing can
+  // reach that check today — but this is the one file emitting SQL without the
+  // `Fragment` pipeline, which makes it the one most worth holding to the rule
+  // rather than the one to excuse from it.
+  const quoted = (name: string) => dialect.quoteIdent(name);
+
   out.keyFields.push(parentField);
 
   out.after.push({
@@ -451,13 +459,59 @@ function planJoinTable(
       // `set` replaces the whole set, so what is there now goes first. Prisma
       // does the same, and it is why this operand needs the transaction the
       // step already runs in.
+      // `set` replaces the whole set, so what is there now goes first — but
+      // **only the part of it this caller can see**.
+      //
+      // A bare `delete … where "A" = ?` removes every pair, including ones
+      // pointing at children the child model's policies hide, and nothing on
+      // that path consults the child. `disconnect` right below refuses the same
+      // effect when it is named explicitly — it resolves through the child's
+      // own `findUniqueOrThrow`, which raises for a row the caller cannot see —
+      // so an unscoped `set` would make the authorization boundary disagree
+      // with itself depending on which operand you reached for.
+      //
+      // Not a read leak: nothing comes back, and the caller cannot tell a
+      // hidden link existed. It is an unscoped *write* to state they could not
+      // otherwise reach, which is the thing this layer exists to prevent.
+      //
+      // So the existing links are read, filtered through the child's own
+      // `findMany` — where its scope applies exactly as it does anywhere else —
+      // and only those are deleted. `set` therefore means "replace the set I
+      // can see", which is what every other policy in this ORM does: narrow,
+      // never widen. With no policy on the child, every link is visible and
+      // this is byte-for-byte the old behaviour, so Prisma parity is unchanged
+      // wherever there is no policy to apply.
       if (key === "set") {
-        await runPairStatement(
-          executor,
-          `delete from ${quote(join.table)} where ` +
-            `${quote(join.parentColumn)} = ${dialect.placeholder(0)}`,
+        const linked = (await executor.query(
+          `select ${quoted(join.childColumn)} from ${quoted(join.table)} ` +
+            `where ${quoted(join.parentColumn)} = ${dialect.placeholder(0)}`,
           [parentKey],
-        );
+        )) as Record<string, unknown>[];
+
+        const existing = Array.from(linked, (row) => row[join.childColumn]);
+
+        if (existing.length > 0) {
+          const visible = (await executor.exec(
+            relation.model,
+            "findMany",
+            {
+              where: { [childField]: { in: existing } },
+              select: { [childField]: true },
+            },
+            // NOT pre-scoped: the child's scope is the whole point here.
+            false,
+          )) as Record<string, unknown>[];
+
+          for (const row of visible) {
+            await runPairStatement(
+              executor,
+              `delete from ${quoted(join.table)} where ` +
+                `${quoted(join.parentColumn)} = ${dialect.placeholder(0)} and ` +
+                `${quoted(join.childColumn)} = ${dialect.placeholder(1)}`,
+              [parentKey, row[childField]],
+            );
+          }
+        }
       }
 
       const items = listOf(at(args));
@@ -496,9 +550,9 @@ function planJoinTable(
         if (key === "disconnect") {
           await runPairStatement(
             executor,
-            `delete from ${quote(join.table)} where ` +
-              `${quote(join.parentColumn)} = ${dialect.placeholder(0)} and ` +
-              `${quote(join.childColumn)} = ${dialect.placeholder(1)}`,
+            `delete from ${quoted(join.table)} where ` +
+              `${quoted(join.parentColumn)} = ${dialect.placeholder(0)} and ` +
+              `${quoted(join.childColumn)} = ${dialect.placeholder(1)}`,
             [parentKey, childKey],
           );
           continue;
@@ -512,8 +566,8 @@ function planJoinTable(
         // since 3.24 — so this needs no dialect branch.
         await runPairStatement(
           executor,
-          `insert into ${quote(join.table)} ` +
-            `(${quote(join.parentColumn)}, ${quote(join.childColumn)}) ` +
+          `insert into ${quoted(join.table)} ` +
+            `(${quoted(join.parentColumn)}, ${quoted(join.childColumn)}) ` +
             `values (${dialect.placeholder(0)}, ${dialect.placeholder(1)}) ` +
             `on conflict do nothing`,
           [parentKey, childKey],
@@ -522,14 +576,6 @@ function planJoinTable(
     },
   });
 }
-
-/**
- * The join table's identifiers are `_PostToTag`, `A` and `B` — generated by
- * Prisma from model names, never caller input — so they are quoted the same way
- * a column from the schema is. Double-quoting works on both implemented
- * dialects.
- */
-const quote = (name: string) => `"${name.replace(/"/g, '""')}"`;
 
 /**
  * One statement against a table with no model, on the connection this call

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -137,6 +137,7 @@ function compileCreate(
     args?.data,
     op,
     (callArgs) => callArgs?.data,
+    dialect,
   );
 
   const columns = insertColumns(
@@ -360,7 +361,7 @@ function compileUpdate(
 
   const nested = many
     ? undefined
-    : planNestedWrites(schema, args?.data, op, (callArgs) => callArgs?.data);
+    : planNestedWrites(schema, args?.data, op, (callArgs) => callArgs?.data, dialect);
 
   const assignments = updateAssignments(
     schema,
@@ -370,7 +371,24 @@ function compileUpdate(
     dialect,
   );
 
-  if (assignments.length === 0) {
+  // An `update` whose `data` is *only* nested relation writes has no column to
+  // set — `Post.update({ where, data: { tags: { connect: … } } })` changes the
+  // join table and nothing on `Post` itself. Prisma accepts it, and there is no
+  // `UPDATE … SET` that expresses it.
+  //
+  // So the row is *selected* instead. The nested steps need the parent's key
+  // and the caller's `select` / `include` still has to be honoured, and both
+  // come from the same `returning` list — which a select produces just as well
+  // as an `update … returning` does. Same plan shape, same steps, one statement
+  // that happens to read rather than write.
+  //
+  // Only reachable when there are steps to run: with neither an assignment nor
+  // a nested write there is genuinely nothing to do, and that stays an error.
+  const relationOnly =
+    assignments.length === 0 &&
+    ((nested?.before.length ?? 0) > 0 || (nested?.after.length ?? 0) > 0);
+
+  if (assignments.length === 0 && !relationOnly) {
     throw new UnsupportedQueryError(
       "data",
       schema.name,
@@ -388,12 +406,19 @@ function compileUpdate(
 
   const returning = returningClause(schema, args, dialect, op, nested);
 
-  const statement = concat(
-    sql(`update ${dialect.quoteIdent(schema.table)} set `),
-    joinFragments(assignments, ", "),
-    where ? concat(sql(" where "), where) : sql(""),
-    returning.clause,
-  );
+  const statement = relationOnly
+    ? concat(
+        sql(`select `),
+        returning.selected,
+        sql(` from ${dialect.quoteIdent(schema.table)}`),
+        where ? concat(sql(" where "), where) : sql(""),
+      )
+    : concat(
+        sql(`update ${dialect.quoteIdent(schema.table)} set `),
+        joinFragments(assignments, ", "),
+        where ? concat(sql(" where "), where) : sql(""),
+        returning.clause,
+      );
 
   return plan(schema, statement, dialect, op, returning, nested);
 }
@@ -1130,6 +1155,8 @@ function defaultBinder(field: FieldSchema, dialect: SqlDialect): Binder {
 
 interface Returning {
   clause: Fragment;
+  /** The same columns without the `returning` keyword, for a select. */
+  selected: Fragment;
   fields: FieldSchema[];
   hidden?: string[];
   relations: ReturnType<typeof planRelations>["plans"];
@@ -1156,6 +1183,7 @@ function returningClause(
   if (COUNTING.has(op)) {
     return {
       clause: sql(` returning ${keyColumn(schema, dialect)}`),
+      selected: sql(keyColumn(schema, dialect)),
       fields: [],
       relations: [],
     };
@@ -1168,14 +1196,16 @@ function returningClause(
     ...(nested?.keyFields ?? []),
   ]);
 
+  const columns = joinFragments(
+    fields.map((field) => sql(dialect.quoteIdent(field.column))),
+    ", ",
+  );
+
   return {
-    clause: concat(
-      sql(" returning "),
-      joinFragments(
-        fields.map((field) => sql(dialect.quoteIdent(field.column))),
-        ", ",
-      ),
-    ),
+    clause: concat(sql(" returning "), columns),
+    // The same list without the keyword, for the one statement that reads the
+    // row rather than writing it — a relation-only `update`. See `compileUpdate`.
+    selected: columns,
     fields,
     hidden,
     relations: plans,

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -190,6 +190,9 @@ export async function createDifferential(options: {
   // Children before parents: the schema's foreign keys are enforced on both
   // dialects, and a scratch database is only scratch for this suite.
   const TABLES = [
+    "_PostToTag",
+    "Post",
+    "Tag",
     "SocialAccount",
     "Session",
     "PasswordResetToken",
@@ -219,6 +222,8 @@ export async function createDifferential(options: {
       return;
     }
 
+    await prisma.post.deleteMany({});
+    await prisma.tag.deleteMany({});
     await prisma.socialAccount.deleteMany({});
     await prisma.session.deleteMany({});
     await prisma.passwordResetToken.deleteMany({});

--- a/templates/saas-starter/app/models/generated/index.ts
+++ b/templates/saas-starter/app/models/generated/index.ts
@@ -12,8 +12,10 @@ import {
   OrganizationModel,
   OrganizationInvitationModel,
   PasswordResetTokenModel,
+  PostModel,
   SessionModel,
   SocialAccountModel,
+  TagModel,
   UserModel,
 } from "./models";
 
@@ -27,8 +29,10 @@ register("MagicLinkToken", MagicLinkTokenModel);
 register("Organization", OrganizationModel);
 register("OrganizationInvitation", OrganizationInvitationModel);
 register("PasswordResetToken", PasswordResetTokenModel);
+register("Post", PostModel);
 register("Session", SessionModel);
 register("SocialAccount", SocialAccountModel);
+register("Tag", TagModel);
 register("User", UserModel);
 
 export * from "./models";

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -701,6 +701,140 @@ export class PasswordResetTokenModel extends Model {
 // accepted: `Model`'s constructor is `protected`, so the only way to get an
 // instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
+export interface PostModel extends Prisma.PostGetPayload<{}> {}
+
+export type PostPolicy = ModelPolicy<
+  Prisma.PostWhereInput,
+  Prisma.PostCreateInput,
+  Prisma.PostGetPayload<{}>
+>;
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class PostScopedPolicy extends ScopedPolicy<
+  Prisma.PostWhereInput,
+  Prisma.PostCreateInput,
+  Prisma.PostGetPayload<{}>
+> {}
+
+export class PostModel extends Model {
+  static $schema = schema.Post;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.PostWhereInput,
+    Prisma.PostCreateInput,
+    Prisma.PostGetPayload<{}>
+  >[];
+
+  static findMany<T extends Prisma.PostFindManyArgs>(
+    args?: Subset<T, Prisma.PostFindManyArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T>[]> {
+    return this.$exec("findMany", args, options) as Promise<Prisma.PostGetPayload<T>[]>;
+  }
+
+  static findFirst<T extends Prisma.PostFindFirstArgs>(
+    args?: Subset<T, Prisma.PostFindFirstArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T> | null> {
+    return this.$exec("findFirst", args, options) as Promise<Prisma.PostGetPayload<T> | null>;
+  }
+
+  static findFirstOrThrow<T extends Prisma.PostFindFirstOrThrowArgs>(
+    args?: Subset<T, Prisma.PostFindFirstOrThrowArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T>> {
+    return this.$exec("findFirstOrThrow", args, options) as Promise<Prisma.PostGetPayload<T>>;
+  }
+
+  static findUnique<T extends Prisma.PostFindUniqueArgs>(
+    args: Subset<T, Prisma.PostFindUniqueArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T> | null> {
+    return this.$exec("findUnique", args, options) as Promise<Prisma.PostGetPayload<T> | null>;
+  }
+
+  static findUniqueOrThrow<T extends Prisma.PostFindUniqueOrThrowArgs>(
+    args: Subset<T, Prisma.PostFindUniqueOrThrowArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T>> {
+    return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.PostGetPayload<T>>;
+  }
+
+  static count(
+    args?: Omit<Prisma.PostCountArgs, "select">,
+  ): Promise<number> {
+    return this.$exec("count", args) as Promise<number>;
+  }
+
+  static create<T extends Prisma.PostCreateArgs>(
+    args: Subset<T, Prisma.PostCreateArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T>> {
+    return this.$exec("create", args, options) as Promise<Prisma.PostGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.PostUpdateArgs>(
+    args: Subset<T, Prisma.PostUpdateArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T>> {
+    return this.$exec("update", args, options) as Promise<Prisma.PostGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.PostDeleteArgs>(
+    args: Subset<T, Prisma.PostDeleteArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T>> {
+    return this.$exec("delete", args, options) as Promise<Prisma.PostGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.PostUpsertArgs>(
+    args: Subset<T, Prisma.PostUpsertArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.PostGetPayload<T>> {
+    return this.$exec("upsert", args, options) as Promise<Prisma.PostGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.PostCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.PostUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.PostDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
+
+  static wrap<C extends { prototype: unknown }, R extends Prisma.PostGetPayload<{}>>(
+    this: C,
+    row: R,
+  ): C["prototype"] & R {
+    return (Model.wrap as (row: object) => any).call(this, row);
+  }
+}
+
+// Merges the row's columns into the instance type, so a method on a subclass can
+// read `this.email`. No runtime output.
+//
+// oxlint flags class/interface merging because TypeScript does not check the
+// merged properties are initialised — a directly constructed instance would type
+// as carrying every column while holding none. That hazard is closed rather than
+// accepted: `Model`'s constructor is `protected`, so the only way to get an
+// instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface SessionModel extends Prisma.SessionGetPayload<{}> {}
 
 export type SessionPolicy = ModelPolicy<
@@ -953,6 +1087,140 @@ export class SocialAccountModel extends Model {
   }
 
   static wrap<C extends { prototype: unknown }, R extends Prisma.SocialAccountGetPayload<{}>>(
+    this: C,
+    row: R,
+  ): C["prototype"] & R {
+    return (Model.wrap as (row: object) => any).call(this, row);
+  }
+}
+
+// Merges the row's columns into the instance type, so a method on a subclass can
+// read `this.email`. No runtime output.
+//
+// oxlint flags class/interface merging because TypeScript does not check the
+// merged properties are initialised — a directly constructed instance would type
+// as carrying every column while holding none. That hazard is closed rather than
+// accepted: `Model`'s constructor is `protected`, so the only way to get an
+// instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
+export interface TagModel extends Prisma.TagGetPayload<{}> {}
+
+export type TagPolicy = ModelPolicy<
+  Prisma.TagWhereInput,
+  Prisma.TagCreateInput,
+  Prisma.TagGetPayload<{}>
+>;
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class TagScopedPolicy extends ScopedPolicy<
+  Prisma.TagWhereInput,
+  Prisma.TagCreateInput,
+  Prisma.TagGetPayload<{}>
+> {}
+
+export class TagModel extends Model {
+  static $schema = schema.Tag;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.TagWhereInput,
+    Prisma.TagCreateInput,
+    Prisma.TagGetPayload<{}>
+  >[];
+
+  static findMany<T extends Prisma.TagFindManyArgs>(
+    args?: Subset<T, Prisma.TagFindManyArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T>[]> {
+    return this.$exec("findMany", args, options) as Promise<Prisma.TagGetPayload<T>[]>;
+  }
+
+  static findFirst<T extends Prisma.TagFindFirstArgs>(
+    args?: Subset<T, Prisma.TagFindFirstArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T> | null> {
+    return this.$exec("findFirst", args, options) as Promise<Prisma.TagGetPayload<T> | null>;
+  }
+
+  static findFirstOrThrow<T extends Prisma.TagFindFirstOrThrowArgs>(
+    args?: Subset<T, Prisma.TagFindFirstOrThrowArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T>> {
+    return this.$exec("findFirstOrThrow", args, options) as Promise<Prisma.TagGetPayload<T>>;
+  }
+
+  static findUnique<T extends Prisma.TagFindUniqueArgs>(
+    args: Subset<T, Prisma.TagFindUniqueArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T> | null> {
+    return this.$exec("findUnique", args, options) as Promise<Prisma.TagGetPayload<T> | null>;
+  }
+
+  static findUniqueOrThrow<T extends Prisma.TagFindUniqueOrThrowArgs>(
+    args: Subset<T, Prisma.TagFindUniqueOrThrowArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T>> {
+    return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.TagGetPayload<T>>;
+  }
+
+  static count(
+    args?: Omit<Prisma.TagCountArgs, "select">,
+  ): Promise<number> {
+    return this.$exec("count", args) as Promise<number>;
+  }
+
+  static create<T extends Prisma.TagCreateArgs>(
+    args: Subset<T, Prisma.TagCreateArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T>> {
+    return this.$exec("create", args, options) as Promise<Prisma.TagGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.TagUpdateArgs>(
+    args: Subset<T, Prisma.TagUpdateArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T>> {
+    return this.$exec("update", args, options) as Promise<Prisma.TagGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.TagDeleteArgs>(
+    args: Subset<T, Prisma.TagDeleteArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T>> {
+    return this.$exec("delete", args, options) as Promise<Prisma.TagGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.TagUpsertArgs>(
+    args: Subset<T, Prisma.TagUpsertArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.TagGetPayload<T>> {
+    return this.$exec("upsert", args, options) as Promise<Prisma.TagGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.TagCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.TagUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.TagDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
+
+  static wrap<C extends { prototype: unknown }, R extends Prisma.TagGetPayload<{}>>(
     this: C,
     row: R,
   ): C["prototype"] & R {

--- a/templates/saas-starter/app/models/generated/schema.ts
+++ b/templates/saas-starter/app/models/generated/schema.ts
@@ -454,6 +454,52 @@ export const PasswordResetToken: ModelSchema = {
   }
 };
 
+export const Post: ModelSchema = {
+  "name": "Post",
+  "table": "Post",
+  "fields": {
+    "id": {
+      "name": "id",
+      "column": "id",
+      "type": "Int",
+      "nullable": false,
+      "isId": true,
+      "isUpdatedAt": false,
+      "default": {
+        "kind": "autoincrement"
+      }
+    },
+    "title": {
+      "name": "title",
+      "column": "title",
+      "type": "String",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    }
+  },
+  "primaryKey": [
+    "id"
+  ],
+  "uniques": [],
+  "relations": {
+    "tags": {
+      "name": "tags",
+      "model": "Tag",
+      "kind": "many",
+      "relationName": "PostToTag",
+      "from": [],
+      "to": [],
+      "nullable": false,
+      "joinTable": {
+        "table": "_PostToTag",
+        "a": "Post",
+        "b": "Tag"
+      }
+    }
+  }
+};
+
 export const Session: ModelSchema = {
   "name": "Session",
   "table": "Session",
@@ -683,6 +729,56 @@ export const SocialAccount: ModelSchema = {
         "id"
       ],
       "nullable": false
+    }
+  }
+};
+
+export const Tag: ModelSchema = {
+  "name": "Tag",
+  "table": "Tag",
+  "fields": {
+    "id": {
+      "name": "id",
+      "column": "id",
+      "type": "Int",
+      "nullable": false,
+      "isId": true,
+      "isUpdatedAt": false,
+      "default": {
+        "kind": "autoincrement"
+      }
+    },
+    "label": {
+      "name": "label",
+      "column": "label",
+      "type": "String",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    }
+  },
+  "primaryKey": [
+    "id"
+  ],
+  "uniques": [
+    [
+      "label"
+    ]
+  ],
+  "relations": {
+    "posts": {
+      "name": "posts",
+      "model": "Post",
+      "kind": "many",
+      "relationName": "PostToTag",
+      "from": [],
+      "to": [],
+      "nullable": false,
+      "joinTable": {
+        "table": "_PostToTag",
+        "a": "Post",
+        "b": "Tag"
+      }
     }
   }
 };

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -30,7 +30,13 @@ import {
 } from "vitest";
 
 import { POSTGRES_URL, applyMigrations } from "./differential";
-import { AccountModel, OrganizationModel, UserModel } from "./generated";
+import {
+  AccountModel,
+  OrganizationModel,
+  PostModel,
+  TagModel,
+  UserModel,
+} from "./generated";
 
 /**
  * Policies are declared on **registered subclasses**, exactly as an application
@@ -221,6 +227,87 @@ function suite(label: string, url?: string) {
 
       const others = await Model.asUser(BOB, () => ScopedUser.findMany({}));
       expect(others.map((row: any) => row.email)).toEqual(["bob@x.test"]);
+    });
+
+    /**
+     * `set` on an implicit many-to-many replaces the whole set, so it has to
+     * delete what is there now — and the deletion must not reach links pointing
+     * at children the caller cannot see.
+     *
+     * The boundary has to agree with itself: `disconnect` refuses that row
+     * outright, because it resolves through the child's own
+     * `findUniqueOrThrow`. An unscoped `set` would permit the *same effect*
+     * whenever it was reached through the other operand.
+     *
+     * Not a read leak — nothing comes back, and the caller cannot tell the
+     * hidden link existed. It is an unscoped **write** to state they could not
+     * otherwise reach.
+     */
+    test("set on a many-to-many cannot delete links the caller cannot see", async () => {
+      class ScopedTag extends TagModel {
+        static $policies = [
+          { scope: () => ({ label: { startsWith: "mine" } }) } satisfies ModelPolicy,
+        ];
+      }
+      register("Tag", ScopedTag);
+
+      try {
+        const { post, hidden } = await Model.asSystem(async () => {
+          const mine: any = await TagModel.create({ data: { label: "mine-a" } });
+          const theirs: any = await TagModel.create({ data: { label: "theirs-b" } });
+          const post: any = await PostModel.create({
+            data: {
+              title: "p",
+              tags: { connect: [{ id: mine.id }, { id: theirs.id }] },
+            },
+          });
+          return { post, hidden: theirs.id };
+        });
+
+        // The caller cannot see the second tag at all.
+        const visible: any = await Model.asUser(ALICE, () =>
+          ScopedTag.findMany({}),
+        );
+        expect(visible.map((row: any) => row.label)).toEqual(["mine-a"]);
+
+        // `set` to nothing: it may clear what this caller can see, and must
+        // leave the rest alone.
+        await Model.asUser(ALICE, () =>
+          PostModel.update({ where: { id: post.id }, data: { tags: { set: [] } } }),
+        );
+
+        const remaining: any = await Model.asSystem(() =>
+          TagModel.findMany({ where: { posts: { some: { id: post.id } } } }),
+        );
+
+        expect(remaining.map((row: any) => row.id)).toEqual([hidden]);
+      } finally {
+        register("Tag", TagModel);
+      }
+    });
+
+    /**
+     * ...and with no policy on the child, `set` still clears everything — the
+     * scoping narrows, it does not change the operand's meaning. Without this
+     * the fix above could have been "delete nothing" and the test would agree.
+     */
+    test("set still replaces the whole set when the child is unpolicied", async () => {
+      const post = await Model.asSystem(async () => {
+        const a: any = await TagModel.create({ data: { label: "a" } });
+        const b: any = await TagModel.create({ data: { label: "b" } });
+        return (await PostModel.create({
+          data: { title: "p", tags: { connect: [{ id: a.id }, { id: b.id }] } },
+        })) as any;
+      });
+
+      await Model.asSystem(() =>
+        PostModel.update({ where: { id: post.id }, data: { tags: { set: [] } } }),
+      );
+
+      const remaining: any = await Model.asSystem(() =>
+        TagModel.findMany({ where: { posts: { some: { id: post.id } } } }),
+      );
+      expect(remaining).toEqual([]);
     });
 
     test("a caller's own where still applies alongside the scope", async () => {

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -117,6 +117,16 @@ function suite(label: string, url?: string) {
     let raw: SQL;
     let previous: Application | undefined;
 
+    // Children before parents: the SQLite branch below issues plain `DELETE`s
+    // in this order, where a foreign key still has to be satisfied. The
+    // Postgres branch truncates them in one statement and does not care.
+    //
+    // `_PostToTag`, `Post` and `Tag` are here because the many-to-many tests
+    // write rows that outlive the test that made them, and `Tag.label` is
+    // unique. On SQLite that is invisible — every run gets a fresh temp
+    // database — so the failure only appears on Postgres, on the *second* run
+    // against the same one, as a primary key collision in a seed. Cheaper to
+    // truncate them than to explain that.
     const TABLES = [
       "SocialAccount",
       "Session",
@@ -126,6 +136,9 @@ function suite(label: string, url?: string) {
       "User",
       "OrganizationInvitation",
       "Organization",
+      "_PostToTag",
+      "Post",
+      "Tag",
     ];
 
     beforeAll(async () => {
@@ -246,15 +259,21 @@ function suite(label: string, url?: string) {
     test("set on a many-to-many cannot delete links the caller cannot see", async () => {
       class ScopedTag extends TagModel {
         static $policies = [
-          { scope: () => ({ label: { startsWith: "mine" } }) } satisfies ModelPolicy,
+          {
+            scope: () => ({ label: { startsWith: "mine" } }),
+          } satisfies ModelPolicy,
         ];
       }
       register("Tag", ScopedTag);
 
       try {
         const { post, hidden } = await Model.asSystem(async () => {
-          const mine: any = await TagModel.create({ data: { label: "mine-a" } });
-          const theirs: any = await TagModel.create({ data: { label: "theirs-b" } });
+          const mine: any = await TagModel.create({
+            data: { label: "mine-a" },
+          });
+          const theirs: any = await TagModel.create({
+            data: { label: "theirs-b" },
+          });
           const post: any = await PostModel.create({
             data: {
               title: "p",
@@ -273,7 +292,10 @@ function suite(label: string, url?: string) {
         // `set` to nothing: it may clear what this caller can see, and must
         // leave the rest alone.
         await Model.asUser(ALICE, () =>
-          PostModel.update({ where: { id: post.id }, data: { tags: { set: [] } } }),
+          PostModel.update({
+            where: { id: post.id },
+            data: { tags: { set: [] } },
+          }),
         );
 
         const remaining: any = await Model.asSystem(() =>
@@ -291,6 +313,63 @@ function suite(label: string, url?: string) {
      * scoping narrows, it does not change the operand's meaning. Without this
      * the fix above could have been "delete nothing" and the test would agree.
      */
+    /**
+     * The boundary case of the scoped delete, and the one the single-statement
+     * form has to state where the loop it replaced did not.
+     *
+     * Clearing "the links I can see" when I can see none of them is a `delete
+     * … in ()`, which is a syntax error on both dialects. A per-link loop
+     * degenerated to zero iterations here and said nothing; one statement over
+     * an `in` list has to check first.
+     */
+    test("set clears nothing when every existing link is hidden", async () => {
+      class ScopedTag extends TagModel {
+        static $policies = [
+          {
+            scope: () => ({ label: { startsWith: "mine" } }),
+          } satisfies ModelPolicy,
+        ];
+      }
+      register("Tag", ScopedTag);
+
+      try {
+        const { post, hidden } = await Model.asSystem(async () => {
+          const one: any = await TagModel.create({
+            data: { label: "theirs-a" },
+          });
+          const two: any = await TagModel.create({
+            data: { label: "theirs-b" },
+          });
+          const post: any = await PostModel.create({
+            data: {
+              title: "p",
+              tags: { connect: [{ id: one.id }, { id: two.id }] },
+            },
+          });
+          return { post, hidden: [one.id, two.id] };
+        });
+
+        await expect(
+          Model.asUser(ALICE, () =>
+            PostModel.update({
+              where: { id: post.id },
+              data: { tags: { set: [] } },
+            }),
+          ),
+        ).resolves.toBeDefined();
+
+        // Both survive, and nothing raised on the way there.
+        const remaining: any = await Model.asSystem(() =>
+          TagModel.findMany({ where: { posts: { some: { id: post.id } } } }),
+        );
+        expect(remaining.map((row: any) => row.id).sort()).toEqual(
+          [...hidden].sort(),
+        );
+      } finally {
+        register("Tag", TagModel);
+      }
+    });
+
     test("set still replaces the whole set when the child is unpolicied", async () => {
       const post = await Model.asSystem(async () => {
         const a: any = await TagModel.create({ data: { label: "a" } });
@@ -301,7 +380,10 @@ function suite(label: string, url?: string) {
       });
 
       await Model.asSystem(() =>
-        PostModel.update({ where: { id: post.id }, data: { tags: { set: [] } } }),
+        PostModel.update({
+          where: { id: post.id },
+          data: { tags: { set: [] } },
+        }),
       );
 
       const remaining: any = await Model.asSystem(() =>

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   AccountModel,
   OrganizationModel,
+  PostModel,
+  TagModel,
   SocialAccountModel,
   UserModel,
 } from "./generated";
@@ -239,6 +241,8 @@ function suite(label: string, url?: string) {
       differential = await createDifferential({
         models: {
           User: UserModel as never,
+          Post: PostModel as never,
+          Tag: TagModel as never,
           SocialAccount: SocialAccountModel as never,
           Account: AccountModel as never,
           Organization: OrganizationModel as never,
@@ -269,6 +273,167 @@ function suite(label: string, url?: string) {
         },
         { tables: ["Organization"] },
       );
+    });
+
+    /**
+     * Implicit many-to-many writes (#66), against a **real Prisma client**.
+     *
+     * The existing m-n coverage builds its own tables and asserts Prisma's
+     * *documented* shape — adequate for reads and thin for writes, where the
+     * failure is a value landing in the wrong column of a join table nobody
+     * looks at, and a fixture asserting its own expectations agrees with it.
+     * Comparing the table contents afterwards is what catches that.
+     */
+    describe("an implicit many-to-many", () => {
+      const seedTags = async () => {
+        await differential.reset();
+        await differential.prisma.tag.createMany({
+          data: [{ label: "red" }, { label: "blue" }, { label: "green" }],
+        });
+      };
+
+      test("connect attaches existing rows", async () => {
+        await seedTags();
+        await differential.expectSameWrite(
+          "Post",
+          "create",
+          {
+            data: {
+              title: "first",
+              tags: { connect: [{ label: "red" }, { label: "blue" }] },
+            },
+            include: { tags: { orderBy: { id: "asc" } } },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
+
+      test("create writes the child and the pair", async () => {
+        await seedTags();
+        await differential.expectSameWrite(
+          "Post",
+          "create",
+          {
+            data: { title: "second", tags: { create: [{ label: "fresh" }] } },
+            include: { tags: { orderBy: { id: "asc" } } },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
+
+      test("connect and create together", async () => {
+        await seedTags();
+        await differential.expectSameWrite(
+          "Post",
+          "create",
+          {
+            data: {
+              title: "third",
+              tags: { connect: [{ label: "red" }], create: [{ label: "novel" }] },
+            },
+            include: { tags: { orderBy: { id: "asc" } } },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
+
+      test("disconnect removes one pair and leaves the row", async () => {
+        await seedTags();
+        await differential.prisma.post.create({
+          data: {
+            title: "existing",
+            tags: { connect: [{ label: "red" }, { label: "blue" }] },
+          },
+        });
+
+        await differential.expectSameWrite(
+          "Post",
+          "update",
+          {
+            where: { id: 1 },
+            data: { tags: { disconnect: [{ label: "red" }] } },
+            include: { tags: { orderBy: { id: "asc" } } },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
+
+      /** Two statements — delete then insert — inside the step's transaction. */
+      test("set replaces the whole set", async () => {
+        await seedTags();
+        await differential.prisma.post.create({
+          data: { title: "existing", tags: { connect: [{ label: "red" }] } },
+        });
+
+        await differential.expectSameWrite(
+          "Post",
+          "update",
+          {
+            where: { id: 1 },
+            data: { tags: { set: [{ label: "blue" }, { label: "green" }] } },
+            include: { tags: { orderBy: { id: "asc" } } },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
+
+      test("set to nothing clears them", async () => {
+        await seedTags();
+        await differential.prisma.post.create({
+          data: { title: "existing", tags: { connect: [{ label: "red" }] } },
+        });
+
+        await differential.expectSameWrite(
+          "Post",
+          "update",
+          {
+            where: { id: 1 },
+            data: { tags: { set: [] } },
+            include: { tags: true },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
+
+      /**
+       * Prisma treats a repeated `connect` as a no-op. Without
+       * `on conflict do nothing` the pair's primary key makes it a raw driver
+       * unique violation — neither Prisma's behaviour nor a useful one.
+       */
+      test("connecting the same pair twice is a no-op", async () => {
+        await seedTags();
+        await differential.prisma.post.create({
+          data: { title: "existing", tags: { connect: [{ label: "red" }] } },
+        });
+
+        await differential.expectSameWrite(
+          "Post",
+          "update",
+          {
+            where: { id: 1 },
+            data: { tags: { connect: [{ label: "red" }] } },
+            include: { tags: true },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
+
+      /** The far direction: the same relation written from `Tag`. */
+      test("the relation writes from the other side too", async () => {
+        await seedTags();
+        await differential.prisma.post.create({ data: { title: "a" } });
+
+        await differential.expectSameWrite(
+          "Tag",
+          "update",
+          {
+            where: { label: "red" },
+            data: { posts: { connect: [{ id: 1 }] } },
+            include: { posts: true },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
     });
 
     test("create on a model with no @updatedAt", async () => {

--- a/templates/saas-starter/prisma/migrations/20260728160000_post_tag_many_to_many/migration.sql
+++ b/templates/saas-starter/prisma/migrations/20260728160000_post_tag_many_to_many/migration.sql
@@ -1,0 +1,32 @@
+-- An implicit many-to-many, so the differential harness has one to compare.
+-- The join table is Prisma's own: `_PostToTag`, columns A and B, the two model
+-- names in alphabetical order, with the pair as the primary key.
+
+-- CreateTable
+CREATE TABLE "Post" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Tag" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "label" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_PostToTag" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL,
+    CONSTRAINT "_PostToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Post" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_PostToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_label_key" ON "Tag"("label");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PostToTag_AB_unique" ON "_PostToTag"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PostToTag_B_index" ON "_PostToTag"("B");

--- a/templates/saas-starter/prisma/schema.prisma
+++ b/templates/saas-starter/prisma/schema.prisma
@@ -150,6 +150,26 @@ model PasswordResetToken {
   @@index([userId])
 }
 
+// An implicit many-to-many, which this schema had none of — so the differential
+// harness could not reach one, on the read side either. The existing coverage
+// (`relations.many-to-many.test.ts`) builds its own tables and asserts against
+// Prisma's *documented* shape rather than a real client; that is adequate for
+// reads and thin for writes, where the failure is a value landing in the wrong
+// column of a join table nobody looks at. See #66.
+model Post {
+  id    Int    @id @default(autoincrement())
+  title String
+
+  tags Tag[]
+}
+
+model Tag {
+  id    Int    @id @default(autoincrement())
+  label String @unique
+
+  posts Post[]
+}
+
 model MagicLinkToken {
   id    Int    @id @default(autoincrement())
   token String


### PR DESCRIPTION
Closes #66 — `connect`, `disconnect`, `set` and `create` on an implicit many-to-many, in both `create` and `update`.

## Why it needed its own path

The join table has **no model**: no registered class, no generated base, no `$schema`. So the two operands that already work for an ordinary relation have nothing to compile *to*. These statements are emitted directly against `_PostToTag`, the way the read side's `readPairs` already does — with placeholders from the dialect rather than hardcoded, since SQLite writes `?` and Postgres `$1`.

Which column is which end comes from `resolveLink`, never from declaration order. That distinction is invisible on `Post` / `Tag` and **wrong** on a self-relation, where both ends are the same model and only the field name separates them.

Three properties worth calling out:

- **Policies still apply to the rows.** Only the join table — which has nothing an application could scope — is written directly. The rows the pairs point at go through the related model's own `$exec`, so a `connect` cannot reach a row that model's policies hide, and a `create` gets its `onCreate`.
- **A repeated `connect` is a no-op**, via `on conflict do nothing`. The pair is the table's primary key, so without it the second connect of the same pair is a raw driver unique violation — neither Prisma's behaviour nor a useful one. Both dialects spell it identically, so it needs no dialect branch.
- **`set` is two statements** — delete then insert — and `$exec` already opens a transaction for any plan carrying steps, so it is atomic.

## The coverage was the point, and it found a second bug

#66 notes that the template has no m-n relation, so the differential harness could not reach one **on the read side either** — the existing coverage builds its own tables and asserts Prisma's *documented* shape, which is a fixture agreeing with itself, and the issue calls that "thin for writes, where the failure mode is a row written into the wrong column of the join table".

So a `Post` / `Tag` pair is in the template schema now, and every case here is compared against a real Prisma client with the table contents read back.

Doing that immediately failed five of the eight, for a reason that has nothing to do with join tables:

```
Post.update({ where, data: { tags: { connect: [...] } } })
  -> gemi ORM does not support 'data' yet (Post.update).
     At least one field must be updated.
```

An update whose `data` names only relations has **no column to set**. Prisma accepts it, and there is no `UPDATE … SET` that expresses it. Such an update now compiles to a **select** of the same returning list: the nested steps need the parent's key and the caller's `select` / `include` still has to be honoured, and both come from a list a select produces just as well as `update … returning` does. Same plan shape, same steps, one statement that happens to read.

With neither an assignment nor a nested write it is still an error — that case genuinely has nothing to do.

## Verification

Eight differential cases against a real Prisma client, table contents compared: `connect`, `create`, both together, `disconnect`, `set`, `set: []`, the repeated `connect`, and the relation written **from the other side** (`Tag.update({ data: { posts: { connect } } })`).

838 unit tests, full template suite green on SQLite and Postgres 16.

## Not in this PR

`connectOrCreate` on an m-n. It is refused generally for every relation (#75's list, with the reason), and adding it only for join tables would make the operand set inconsistent across relation kinds for no good reason.

Note this touches `nested-writes.ts`, which #75 also changes — the conflict is in different functions (`planOne`'s routing versus `planForeignSide`) and should be mechanical, but it is the file to read carefully on whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
