### PR TITLE
A nested `include` is scoped as a read, whatever encloses it

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -468,12 +468,21 @@ a shared model base can impose a policy a subclass can only narrow, never drop.
 | `before(ctx)` | First | Return `false` (or throw) to deny outright. |
 | `scope(ctx)` | Reads and row-matching writes | Returns a `where` fragment `AND`ed into `args.where`. A policy can only ever **narrow**. |
 | `onCreate(ctx, data)` | `create` / `createMany` / `upsert` | Defaults or validates the payload. An insert has no `where` for a scope to narrow. |
-
-A relation reached through `include` or `select` is always scoped as a **read**, whatever the
-statement around it is doing — so `User.create({ data, include: { accounts: true } })` applies
-`Account`'s `scope`, not its `onCreate`. The children are being read back, not written.
 | `onUpdate(ctx, data)` | `update` / `updateMany` / `upsert` | Defaults or validates the payload of a write to existing rows. |
 | `redact(ctx, row)` | Shaping | Removes fields from a fetched row. |
+
+**Anything that names another model is scoped as a read of that model**, whatever the statement
+around it is doing. That covers all four ways a query reaches a model it did not name — an
+`include` / `select` node, a `_count` entry, a relation filter in a `where`, and a relation
+ordering in an `orderBy` — and it means `context.operation` is `findMany` inside each of them:
+
+```ts
+User.create({ data, include: { accounts: true } })      // Account's scope, not its onCreate
+User.updateMany({ where: { accounts: { some: {} } } })  // Account's read scope, not its write one
+```
+
+The children are being *read back*; only the row named by the statement itself is being written.
+Nested writes under `data` are a different tree and scope themselves as writes.
 
 **A scope alone does not protect writes, and the ORM says so rather than assuming.** A `scope`
 narrows *which rows* a statement may touch and says nothing about the values written, so a

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -468,6 +468,10 @@ a shared model base can impose a policy a subclass can only narrow, never drop.
 | `before(ctx)` | First | Return `false` (or throw) to deny outright. |
 | `scope(ctx)` | Reads and row-matching writes | Returns a `where` fragment `AND`ed into `args.where`. A policy can only ever **narrow**. |
 | `onCreate(ctx, data)` | `create` / `createMany` / `upsert` | Defaults or validates the payload. An insert has no `where` for a scope to narrow. |
+
+A relation reached through `include` or `select` is always scoped as a **read**, whatever the
+statement around it is doing — so `User.create({ data, include: { accounts: true } })` applies
+`Account`'s `scope`, not its `onCreate`. The children are being read back, not written.
 | `onUpdate(ctx, data)` | `update` / `updateMany` / `upsert` | Defaults or validates the payload of a write to existing rows. |
 | `redact(ctx, row)` | Shaping | Removes fields from a fetched row. |
 

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -506,7 +506,6 @@ export abstract class Model {
       effective = applyNestedPolicies(
         schema,
         effective,
-        op,
         currentUser(),
         system,
         (model) => {

--- a/packages/gemi/orm/compile/order-relation.test.ts
+++ b/packages/gemi/orm/compile/order-relation.test.ts
@@ -200,7 +200,6 @@ describe("policies", () => {
     const out = applyNestedPolicies(
       root,
       { orderBy: { accounts: { _count: "desc" } } },
-      "findMany" as any,
       { organizationId: 7 },
       false,
       lookup([tenant]),
@@ -216,7 +215,6 @@ describe("policies", () => {
     const out = applyNestedPolicies(
       root,
       { orderBy: [{ email: "asc" }, { accounts: { _count: "desc" } }] },
-      "findMany" as any,
       { organizationId: 7 },
       false,
       lookup([tenant]),
@@ -232,7 +230,6 @@ describe("policies", () => {
       applyNestedPolicies(
         root,
         args,
-        "findMany" as any,
         { organizationId: 7 },
         true,
         lookup([tenant]),
@@ -243,7 +240,7 @@ describe("policies", () => {
   test("an unpolicied ordering is returned unchanged, identically", () => {
     const args = { orderBy: { accounts: { _count: "desc" } } };
     expect(
-      applyNestedPolicies(root, args, "findMany" as any, {}, false, lookup([])),
+      applyNestedPolicies(root, args, {}, false, lookup([])),
     ).toBe(args);
   });
 

--- a/packages/gemi/orm/compile/relation-count.test.ts
+++ b/packages/gemi/orm/compile/relation-count.test.ts
@@ -229,7 +229,6 @@ describe("policies", () => {
     const out = applyNestedPolicies(
       root,
       { include: { _count: { select: { accounts: true } } } },
-      "findMany" as any,
       { organizationId: 7 },
       false,
       lookup([tenant]),
@@ -248,7 +247,6 @@ describe("policies", () => {
           _count: { select: { accounts: { where: { organizationRole: 1 } } } },
         },
       },
-      "findMany" as any,
       { organizationId: 7 },
       false,
       lookup([tenant]),
@@ -265,7 +263,6 @@ describe("policies", () => {
     const out = applyNestedPolicies(
       root,
       args,
-      "findMany" as any,
       { organizationId: 7 },
       true,
       lookup([tenant]),
@@ -280,7 +277,6 @@ describe("policies", () => {
     const out = applyNestedPolicies(
       root,
       args,
-      "findMany" as any,
       {},
       false,
       lookup([]),

--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -658,7 +658,6 @@ describe("applyNestedPolicies", () => {
     const out = applyNestedPolicies(
       relations({ accounts: "Account" }),
       { include: { accounts: true } },
-      "findMany" as any,
       USER,
       false,
       lookup({ Account: [tenant] }),
@@ -672,7 +671,6 @@ describe("applyNestedPolicies", () => {
     const out = applyNestedPolicies(
       relations({ accounts: "Account" }),
       { include: { accounts: { where: { organizationRole: 0 } } } },
-      "findMany" as any,
       USER,
       false,
       lookup({ Account: [tenant] }),
@@ -688,7 +686,6 @@ describe("applyNestedPolicies", () => {
     const out = applyNestedPolicies(
       relations({ accounts: "Account" }),
       { include: { accounts: { include: { organization: true } } } },
-      "findMany" as any,
       USER,
       false,
       lookup({ Organization: [tenant] }),
@@ -704,7 +701,6 @@ describe("applyNestedPolicies", () => {
     const out = applyNestedPolicies(
       relations({ accounts: "Account" }),
       { select: { id: true, accounts: true } },
-      "findMany" as any,
       USER,
       false,
       lookup({ Account: [tenant] }),
@@ -720,7 +716,6 @@ describe("applyNestedPolicies", () => {
     const out = applyNestedPolicies(
       relations({ accounts: "Account" }),
       args,
-      "findMany" as any,
       USER,
       false,
       lookup({}),
@@ -738,7 +733,6 @@ describe("applyNestedPolicies", () => {
     applyNestedPolicies(
       relations({ accounts: "Account" }),
       args,
-      "findMany" as any,
       USER,
       false,
       lookup({ Account: [tenant] }),
@@ -752,7 +746,6 @@ describe("applyNestedPolicies", () => {
     const out = applyNestedPolicies(
       relations({ accounts: "Account" }),
       args,
-      "findMany" as any,
       null,
       true,
       lookup({ Account: [tenant] }),
@@ -770,7 +763,6 @@ describe("applyNestedPolicies", () => {
       applyNestedPolicies(
         relations({ accounts: "Account" }),
         { include: { accounts: true } },
-        "findMany" as any,
         null,
         false,
         lookup({ Account: [tenant] }),
@@ -778,12 +770,61 @@ describe("applyNestedPolicies", () => {
     ).toThrow(PolicyDeniedError);
   });
 
+  /**
+   * **The rule, stated once over all four node types.**
+   *
+   * The walk touches an `include` / `select` node, a `_count` entry, a relation
+   * filter and a relation ordering, and each of them reads another model. It
+   * used to take the root operation as a parameter and pass it to all four, so
+   * the wrong value was expressible four times over — and two of the four were
+   * getting it. The parameter is gone; this pins what replaced it.
+   *
+   * The scope reads `context.operation` straight into the filter, so the
+   * assertion names the value rather than inferring it from a side effect. Any
+   * node that starts being told something else fails here by showing what.
+   */
+  test("every node is scoped as a read, and says so", () => {
+    const reportsOperation: ModelPolicy = {
+      scope: (context) => ({ seenOperation: context.operation }),
+    };
+
+    const out = applyNestedPolicies(
+      {
+        relations: {
+          accounts: { model: "Account", kind: "many" as const },
+        },
+      },
+      {
+        include: {
+          accounts: true,
+          _count: { select: { accounts: true } },
+        },
+        where: { accounts: { some: {} } },
+        orderBy: { accounts: { _count: "asc" } },
+      },
+      USER,
+      false,
+      (model: string) =>
+        model === "Account"
+          ? {
+              policies: [reportsOperation],
+              schema: { name: "Account", relations: {} },
+            }
+          : undefined,
+    );
+
+    const seen = { seenOperation: "findMany" };
+    expect(out.include.accounts).toEqual({ where: seen });
+    expect(out.include._count.select.accounts).toEqual({ where: seen });
+    expect(out.where.accounts.some).toEqual({ AND: [seen] });
+    expect(out.orderBy.accounts).toEqual({ _count: "asc", where: seen });
+  });
+
   test("an unregistered relation target is left for the planner to report", () => {
     const args = { include: { unknown: true } };
     const out = applyNestedPolicies(
       relations({ unknown: "Missing" }),
       args,
-      "findMany" as any,
       USER,
       false,
       lookup({}),
@@ -846,7 +887,6 @@ describe("relation filters in where", () => {
     return applyNestedPolicies(
       root,
       { where },
-      "findMany" as any,
       USER,
       false,
       lookup(policies),
@@ -963,7 +1003,6 @@ describe("relation filters in where", () => {
     const out = applyNestedPolicies(
       root,
       { where: { accounts: { some: {} } } },
-      "findMany" as any,
       USER,
       true,
       lookup({ Account: [tenant] }),
@@ -982,7 +1021,6 @@ describe("relation filters in where", () => {
     const out = applyNestedPolicies(
       root,
       { where },
-      "findMany" as any,
       USER,
       false,
       lookup({}),

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -916,6 +916,18 @@ export type PolicyLookup = (model: string) => {
  * arg tree before planning — *true*, where before it was true only of the
  * strategy that happened to recurse.
  */
+/**
+ * The operation a nested `include` / `select` node is scoped as.
+ *
+ * `findMany` because that is what a relation node *is* — one query for the
+ * children of the rows in hand — and because a policy reading
+ * `context.operation` should see the read it is being asked about rather than
+ * the statement that happens to enclose it. It is also in `SCOPABLE`, which an
+ * insert operation is not, and that mismatch is what produced the bug this
+ * constant exists to prevent.
+ */
+const NESTED_READ: Operation = "findMany";
+
 export function applyNestedPolicies(
   schema: {
     relations: Record<string, { model: string; kind: "one" | "many" }>;
@@ -982,10 +994,31 @@ export function applyNestedPolicies(
 
       // Depth first, so a grandchild's scope is in place before its parent's
       // node is rewritten around it.
+      //
+      // **`NESTED_READ`, not the root's operation.** An `include` / `select`
+      // node is a *read* whatever the statement around it is doing, and passing
+      // the root operation down scoped it as an insert under a root `create`.
+      // Two ways that went wrong, and the quiet one was worse:
+      //
+      //   User.create({ data, include: { accounts: true } })
+      //
+      // - A child with a `scope` and no `onCreate` raised
+      //   `Account has a policy that scopes reads but no 'onCreate'` — naming
+      //   an operation the caller never asked for, about a row being read back
+      //   rather than written.
+      // - A child with both took `applyPolicies`' inserting branch, which skips
+      //   `withScope` and then runs `onCreate` over the include node. The node
+      //   came out carrying `data: {}` where its `where` should have been, so
+      //   the child's read scope — a tenant filter, or `softDeletes`' own
+      //   `deletedAt: null` — silently disappeared from the nested read.
+      //
+      // Nested *write* nodes under `data` are a different path entirely
+      // (`planNestedWrites`), and they already scope themselves as writes. This
+      // walk only ever sees the read tree.
       const deeper = applyNestedPolicies(
         target.schema,
         nodeArgs,
-        operation,
+        NESTED_READ,
         user,
         system,
         lookup,
@@ -997,7 +1030,7 @@ export function applyNestedPolicies(
         !system && target.policies.length > 0
           ? applyPolicies(
               target.policies,
-              policyContext(target.schema.name, operation, user, system),
+              policyContext(target.schema.name, NESTED_READ, user, system),
               deeper,
             )
           : deeper;

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -893,6 +893,26 @@ export type PolicyLookup = (model: string) => {
 } | undefined;
 
 /**
+ * The operation every node this walk touches is scoped as.
+ *
+ * `findMany` because that is what each of them *is* — one query for rows of
+ * another model, named from inside somebody else's arguments — and because a
+ * policy reading `context.operation` should see the read it is being asked
+ * about rather than the statement that happens to enclose it. It is also in
+ * `SCOPABLE`, which an inserting operation is not, and that mismatch is what
+ * produced the bug this constant exists to prevent.
+ *
+ * **It is a constant rather than a parameter, and that is the fix.** The walk
+ * used to take the root operation and pass it down; every node type then had
+ * its own opportunity to be scoped as the enclosing statement instead of as
+ * the read it is, and two of the four took it. Threading the right value
+ * through four call sites leaves the wrong value expressible at all four. Not
+ * accepting one at all is what makes it unrepresentable — the same reason #79
+ * made `resolveLink`'s `operation` required rather than defaulted.
+ */
+const NESTED_READ: Operation = "findMany";
+
+/**
  * Applies every *nested* model's policies to its own node in the argument tree,
  * recursively, returning a new tree.
  *
@@ -915,25 +935,49 @@ export type PolicyLookup = (model: string) => {
  * claim — that scoping applies under every strategy because policies rewrite the
  * arg tree before planning — *true*, where before it was true only of the
  * strategy that happened to recurse.
- */
-/**
- * The operation a nested `include` / `select` node is scoped as.
  *
- * `findMany` because that is what a relation node *is* — one query for the
- * children of the rows in hand — and because a policy reading
- * `context.operation` should see the read it is being asked about rather than
- * the statement that happens to enclose it. It is also in `SCOPABLE`, which an
- * insert operation is not, and that mismatch is what produced the bug this
- * constant exists to prevent.
+ * **Every node it touches is a read.** There are four kinds — an `include` /
+ * `select` node, a `_count` entry, a relation filter in a `where`, a relation
+ * ordering in an `orderBy` — and each names *another model's rows*, whatever
+ * the statement around it is doing. So each is scoped as {@link NESTED_READ}
+ * rather than as the enclosing operation.
+ *
+ * Passing the root operation down broke two of the four, and only the ones
+ * reachable from an insert were visible:
+ *
+ *   User.create({ data, include: { accounts: true } })
+ *   User.create({ data, include: { _count: { select: { accounts: true } } } })
+ *
+ * - A child with a `scope` and no `onCreate` **raised**, with
+ *   `Account has a policy that scopes reads but no 'onCreate'` — naming an
+ *   operation the caller never asked for, about rows being read back rather
+ *   than written. That is a legal policy: a model can scope reads and never
+ *   create rows.
+ * - A child with both took `applyPolicies`' inserting branch, which skips
+ *   `withScope` and then runs `onCreate` over the node. It came out carrying
+ *   `data: {}` where its `where` should have been, so the child's read scope —
+ *   a tenant filter, or `softDeletes`' own `deletedAt: null` — silently
+ *   disappeared from the nested read.
+ *
+ * The other two are not reachable from an insert, and the reason is worth
+ * recording so the asymmetry is not rediscovered: `create` accepts only
+ * `data` / `select` / `include` and `createMany` only `data`, so neither has a
+ * `where` or an `orderBy` for a relation to be named in. They were still
+ * wrong, just more quietly — under a root `update` a policy whose `scope`
+ * reads `context.operation` saw `"update"` for what is a read, and answered
+ * the question it was not asked.
+ *
+ * Nested *write* nodes under `data` are a different path entirely
+ * (`planNestedWrites`), and already scope themselves as writes. This walk only
+ * ever sees the read tree, which is why it can take the operation as a
+ * constant at all.
  */
-const NESTED_READ: Operation = "findMany";
 
 export function applyNestedPolicies(
   schema: {
     relations: Record<string, { model: string; kind: "one" | "many" }>;
   },
   args: any,
-  operation: Operation,
   user: unknown,
   system: boolean,
   lookup: PolicyLookup,
@@ -961,7 +1005,6 @@ export function applyNestedPolicies(
         const scopedCounts = scopeCounts(
           schema,
           (tree as Record<string, unknown>)[key],
-          operation,
           user,
           system,
           lookup,
@@ -994,31 +1037,9 @@ export function applyNestedPolicies(
 
       // Depth first, so a grandchild's scope is in place before its parent's
       // node is rewritten around it.
-      //
-      // **`NESTED_READ`, not the root's operation.** An `include` / `select`
-      // node is a *read* whatever the statement around it is doing, and passing
-      // the root operation down scoped it as an insert under a root `create`.
-      // Two ways that went wrong, and the quiet one was worse:
-      //
-      //   User.create({ data, include: { accounts: true } })
-      //
-      // - A child with a `scope` and no `onCreate` raised
-      //   `Account has a policy that scopes reads but no 'onCreate'` — naming
-      //   an operation the caller never asked for, about a row being read back
-      //   rather than written.
-      // - A child with both took `applyPolicies`' inserting branch, which skips
-      //   `withScope` and then runs `onCreate` over the include node. The node
-      //   came out carrying `data: {}` where its `where` should have been, so
-      //   the child's read scope — a tenant filter, or `softDeletes`' own
-      //   `deletedAt: null` — silently disappeared from the nested read.
-      //
-      // Nested *write* nodes under `data` are a different path entirely
-      // (`planNestedWrites`), and they already scope themselves as writes. This
-      // walk only ever sees the read tree.
       const deeper = applyNestedPolicies(
         target.schema,
         nodeArgs,
-        NESTED_READ,
         user,
         system,
         lookup,
@@ -1053,7 +1074,6 @@ export function applyNestedPolicies(
   const ordered = scopeRelationOrderings(
     schema,
     out.orderBy,
-    operation,
     user,
     system,
     lookup,
@@ -1066,7 +1086,6 @@ export function applyNestedPolicies(
   const filtered = scopeRelationFilters(
     schema,
     out.where,
-    operation,
     user,
     system,
     lookup,
@@ -1096,7 +1115,6 @@ export function applyNestedPolicies(
 function scopeRelationOrderings(
   schema: { relations: Record<string, { model: string; kind: "one" | "many" }> },
   orderBy: unknown,
-  operation: Operation,
   user: unknown,
   system: boolean,
   lookup: PolicyLookup,
@@ -1110,7 +1128,6 @@ function scopeRelationOrderings(
       const scoped = scopeRelationOrderings(
         schema,
         entry,
-        operation,
         user,
         system,
         lookup,
@@ -1139,7 +1156,7 @@ function scopeRelationOrderings(
 
     const scoped = applyPolicies(
       target.policies,
-      policyContext(target.schema.name, operation, user, system),
+      policyContext(target.schema.name, NESTED_READ, user, system),
       node,
     );
 
@@ -1162,7 +1179,6 @@ function scopeRelationOrderings(
 function scopeCounts(
   schema: { relations: Record<string, { model: string; kind: "one" | "many" }> },
   node: unknown,
-  operation: Operation,
   user: unknown,
   system: boolean,
   lookup: PolicyLookup,
@@ -1200,7 +1216,7 @@ function scopeCounts(
 
     const scoped = applyPolicies(
       target.policies,
-      policyContext(target.schema.name, operation, user, system),
+      policyContext(target.schema.name, NESTED_READ, user, system),
       nodeArgs,
     );
 
@@ -1231,7 +1247,6 @@ function scopeCounts(
 function scopeRelationFilters(
   schema: { relations: Record<string, { model: string; kind: "one" | "many" }> },
   where: unknown,
-  operation: Operation,
   user: unknown,
   system: boolean,
   lookup: PolicyLookup,
@@ -1244,7 +1259,6 @@ function scopeRelationFilters(
       const scoped = scopeRelationFilters(
         schema,
         entry,
-        operation,
         user,
         system,
         lookup,
@@ -1268,7 +1282,6 @@ function scopeRelationFilters(
       const scoped = scopeRelationFilters(
         schema,
         value,
-        operation,
         user,
         system,
         lookup,
@@ -1286,7 +1299,6 @@ function scopeRelationFilters(
     const scoped = scopeRelationNode(
       relation,
       value,
-      operation,
       user,
       system,
       lookup,
@@ -1304,7 +1316,6 @@ function scopeRelationFilters(
 function scopeRelationNode(
   relation: { model: string; kind: "one" | "many" },
   value: unknown,
-  operation: Operation,
   user: unknown,
   system: boolean,
   lookup: PolicyLookup,
@@ -1336,7 +1347,6 @@ function scopeRelationNode(
     const deeper = scopeRelationFilters(
       target.schema,
       argument,
-      operation,
       user,
       system,
       lookup,
@@ -1346,7 +1356,7 @@ function scopeRelationNode(
       !system && target.policies.length > 0
         ? applyPolicies(
             target.policies,
-            policyContext(target.schema.name, operation, user, system),
+            policyContext(target.schema.name, NESTED_READ, user, system),
             { where: deeper },
           ).where
         : deeper;

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -322,6 +322,78 @@ function suite(label: string, url?: string) {
       ).resolves.toBeDefined();
     });
 
+    /**
+     * **The same bug, one node type over.** `applyNestedPolicies` handles four
+     * kinds of node and the first fix reached only one of them. A `_count`
+     * entry counts another model's rows, so it is as much a read as an
+     * `include` is, and it was still scoped as the enclosing statement.
+     *
+     * This is the loud half again, on the same legal policy: a model that
+     * scopes reads and never creates rows. Before the fix this raised
+     * `Account has a policy that scopes reads but no 'onCreate'` from a
+     * `create` on `User`.
+     *
+     * **What it cannot assert is the count**, and the reason is a gap rather
+     * than an oversight: `planRelationCounts` is called from `compile/read.ts`
+     * only, so a `_count` in a *write's* `include` is dropped and the returned
+     * row has no `_count` key at all. An unknown relation name in the same
+     * position raises `UnknownRelationError`, so this one key is the exception.
+     * Filed separately — it is a Prisma divergence, not a policy bug, and the
+     * quiet half of this finding becomes reachable the day it is fixed.
+     */
+    test("a _count under a create is scoped as a read too", async () => {
+      (ScopedAccount as any).$policies = [
+        { scope: () => ({ organizationId: ALICE.organizationId }) } satisfies ModelPolicy,
+      ];
+
+      await expect(
+        Model.asUser(ALICE, () =>
+          ScopedUser.create({
+            data: { email: "counted@x.test" },
+            include: { _count: { select: { accounts: true } } },
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    /**
+     * The third node type, and the one that shows why the operation stopped
+     * being a *parameter* of the walk rather than being passed correctly at
+     * each of its call sites.
+     *
+     * A relation filter is not reachable from an insert — `create` accepts no
+     * `where` — so it never appeared in #85. It was still being scoped as the
+     * enclosing statement, and under a root `update` that is an operation a
+     * policy is perfectly entitled to answer differently for.
+     *
+     * The scope below is the shape that makes it observable: read scope and
+     * write scope disagree, so the subquery over `Account` gives different
+     * answers depending on which one it is asked for. Reading is what the
+     * filter does, so the read scope is the correct one.
+     */
+    test("a relation filter under an update is scoped as a read", async () => {
+      (ScopedAccount as any).$policies = [
+        {
+          scope: (context) =>
+            context.operation === "findMany"
+              ? { organizationId: ALICE.organizationId }
+              : // No account is ever in organisation -1, so if the filter is
+                // scoped as the enclosing `update` it matches nothing and no
+                // user is touched.
+                { organizationId: -1 },
+        } satisfies ModelPolicy,
+      ];
+
+      const touched = await Model.asUser(ALICE, () =>
+        ScopedUser.updateMany({
+          where: { accounts: { some: {} } },
+          data: { name: "has-an-account" },
+        }),
+      );
+
+      expect(touched.count).toBeGreaterThan(0);
+    });
+
     test("a caller's own where still applies alongside the scope", async () => {
       (ScopedUser as any).$policies = [tenantScoped];
 

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -223,6 +223,105 @@ function suite(label: string, url?: string) {
       expect(others.map((row: any) => row.email)).toEqual(["bob@x.test"]);
     });
 
+    /**
+     * A nested `include` is a **read**, whatever the statement around it is
+     * doing. It used to be scoped as the root operation, so under a `create`
+     * the child was scoped as an insert — see #85.
+     *
+     * Two failures, and the second is the one a careless test misses: it is
+     * silent. Asserting only that the call does not throw would pass against
+     * the bug, because the bug *is* the scope quietly not being applied.
+     */
+    test("an include under a create applies the child's read scope", async () => {
+      (ScopedAccount as any).$policies = [tenantScoped];
+
+      const created: any = await Model.asUser(ALICE, () =>
+        ScopedUser.create({
+          data: { email: "fresh@x.test", organizationId: ALICE.organizationId },
+          include: { accounts: true },
+        }),
+      );
+
+      // The new row has no accounts, so the interesting assertion is not the
+      // count — it is that the read was *scoped at all*, which the next test
+      // pins directly.
+      expect(created.accounts).toEqual([]);
+    });
+
+    /**
+     * **The silent half, and the only shape that can show it.**
+     *
+     * Under a root `create` the included children belong to a row that has just
+     * been made, so they are empty whether the scope was applied or dropped —
+     * which is why #85 calls the blast radius small *today*. `upsert` is in the
+     * same inserting branch and can land on a row that **already has
+     * children**, so a dropped scope is visible as rows that should not be
+     * there.
+     *
+     * Without the fix this returns both accounts; with it, one.
+     */
+    test("...and the scope actually filters, rather than being skipped", async () => {
+      (ScopedAccount as any).$policies = [tenantScoped];
+
+      // An account in Alice's org, and one in Bob's, both pointing at the user
+      // about to be created — so only the scope can tell them apart.
+      const fresh: any = await Model.asSystem(() =>
+        UserModel.create({ data: { email: "target@x.test", organizationId: ALICE.organizationId } }),
+      );
+      await Model.asSystem(async () => {
+        await AccountModel.create({
+          data: { userId: fresh.id, organizationId: ALICE.organizationId },
+        });
+        await AccountModel.create({
+          data: { userId: fresh.id, organizationId: BOB.organizationId },
+        });
+      });
+
+      // The baseline: a plain read, which was never affected.
+      const read: any = await Model.asUser(ALICE, () =>
+        ScopedUser.findUniqueOrThrow({
+          where: { id: fresh.id },
+          include: { accounts: true },
+        }),
+      );
+      expect(read.accounts).toHaveLength(1);
+
+      // The same include reached through an *inserting* operation that lands on
+      // the existing row. `upsert` is in the branch that used to drop the
+      // scope, and unlike `create` it can see children.
+      const upserted: any = await Model.asUser(ALICE, () =>
+        ScopedUser.upsert({
+          where: { id: fresh.id },
+          create: { id: fresh.id, email: "target@x.test" },
+          update: { name: "renamed" },
+          include: { accounts: true },
+        }),
+      );
+
+      expect(upserted.accounts).toHaveLength(1);
+      expect(upserted.accounts[0].organizationId).toBe(ALICE.organizationId);
+    });
+
+    /**
+     * The hard failure from #85(a): a child that scopes reads and declares no
+     * `onCreate` is a legal policy — it simply never creates rows — and
+     * including it from a `create` raised about an operation nobody asked for.
+     */
+    test("a child that scopes but never creates can still be included from a write", async () => {
+      (ScopedAccount as any).$policies = [
+        { scope: () => ({ organizationId: ALICE.organizationId }) } satisfies ModelPolicy,
+      ];
+
+      await expect(
+        Model.asUser(ALICE, () =>
+          ScopedUser.create({
+            data: { email: "nothrow@x.test" },
+            include: { accounts: true },
+          }),
+        ),
+      ).resolves.toBeDefined();
+    });
+
     test("a caller's own where still applies alongside the scope", async () => {
       (ScopedUser as any).$policies = [tenantScoped];
 


### PR DESCRIPTION
Closes #85 — finding 1 on #45, which was untracked until I filed it this iteration along with #84.

## The bug

`applyNestedPolicies` passed the **root** operation down to every nested node. An `include` / `select` node is always a *read*, so under a root `create` the child was scoped as an insert and `applyPolicies` took its `INSERTING` branch. Two failures, and the second is the one that matters:

**(a) A child that scopes reads and declares no `onCreate` raised.**

```
UnsupportedQueryError: gemi ORM does not support 'create' yet (Account.create).
Account has a policy that scopes reads but no 'onCreate' …
```

That is a legal policy — a model can scope reads and never create rows — and nothing was being created on `Account`. It was being read back on the new row. The error named an operation the caller never asked for.

**(b) A child with both silently lost its read scope.**

The inserting branch skips `withScope`, then the creating pass runs `onCreate` over the include node, so it came out carrying `data: {}` where its `where` should have been:

```
findMany     include: {"accounts":{"where":{"organizationId":7}}}
create       include: {"accounts":{"data":{}}}            <- scope gone
softDeletes  include: {"accounts":{"data":{}}}            <- deletedAt: null gone
```

No error. A `softDeletes` scope vanishing from a nested read is precisely the class of thing this layer exists to make impossible.

## The fix

The recursion and the policy context both use `findMany` rather than the enclosing operation. Nested *write* nodes under `data` are a separate path (`planNestedWrites`) and already scope themselves as writes — this walk only ever sees the read tree, so there is no case where the root operation was the right answer.

`findMany` is also in `SCOPABLE`, which an inserting operation is not; that mismatch is what produced the bug, and the constant carries the reason.

## Testing the silent half was the hard part

Under a root `create` the included children belong to a row that has **just been made**, so they come back empty whether the scope was applied or dropped. A test there passes against the bug — which is why #85's own acceptance criterion says so.

`upsert` is in the same inserting branch and can land on a row that **already has children**. So the discriminating test seeds two accounts on one user, in two different organisations, and upserts with an include: without the fix both come back, with it one.

All three tests were verified by reverting the two lines and watching them fail — 3 failed / 45 passed against the bug, 48 passed with it. The same discipline as the `LITERAL_KEYS` guard on #78 and the `satisfies` map on #82: a check that has not been seen to go red is not a check.

## Also filed this iteration

**#84** — `take` / `skip` are not validated, and `take: "-2"` from a query string silently returns the *first* two rows ascending instead of the last two. That is finding 3 on #45, which I deferred on #74 because the fix is a behaviour change to every read operation; it now has an issue rather than depending on either of us remembering it.

838 unit tests, 48 policy tests, full template suite green on SQLite and Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
