### PR TITLE
`take` and `skip` are validated, at the one place that reads them

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -117,6 +117,25 @@ const user = await User.findUniqueOrThrow({
 })
 ```
 
+**`take` and `skip` must be integers, and are refused rather than coerced.** They are the only
+arguments whose *sign* decides the SQL — a negative `take` means "the last N", which flips every
+ordering term — so a `take` arriving as a string does not merely have the wrong type, it takes the
+wrong branch: `take: "-2"` used to return the **first** two rows, in the opposite order, with no
+error. A query string is exactly where a string `take` comes from, so parse it before you pass it:
+
+```
+UnsupportedQueryError: gemi ORM does not support 'take' yet (User.findMany).
+Expected an integer, got "-2".
+```
+
+A negative `skip` is refused too — it counts rows to pass over — and both rules are the ones that
+already applied inside an `include`.
+
+> **Divergence from Prisma, on purpose.** Prisma accepts a *fractional* `take` and truncates toward
+> zero; this refuses it. Binding one instead is a `datatype mismatch` error from SQLite and a
+> silently different row count on Postgres, which rounds — so the fraction has no single meaning to
+> match. One rule at both levels, failing loudly, beats three behaviours.
+
 `select` and `include` narrow the **return type**, exactly as they do in Prisma — `user.email`
 type-checks, `user.name` does not. A key outside the operation's argument type collapses to
 `never` rather than being quietly accepted.

--- a/packages/gemi/orm/compile/aggregate.test.ts
+++ b/packages/gemi/orm/compile/aggregate.test.ts
@@ -155,6 +155,22 @@ describe("pagination", () => {
     expect(compiled.text).toContain(`order by "globalRole" desc`);
     expect(compiled.bind(args)).toEqual([2]);
   });
+
+  /**
+   * #84 reaches here because `aggregate` pages, and it validates its arguments
+   * in a different file from `read.ts`. The check lives in `paginate.ts` — the
+   * one place that *reads* these two — rather than in each caller's allowlist,
+   * so this passes without `aggregate.ts` knowing the rule exists.
+   */
+  test("a take that is not an integer is refused here too", () => {
+    expect(() => plan({ take: "-2", _count: true })).toThrow(
+      /Expected an integer, got "-2"/,
+    );
+    expect(() => plan({ skip: -1, _count: true })).toThrow(
+      /'skip' counts rows to pass over/,
+    );
+    expect(() => plan({ take: "-2", _count: true })).toThrow(/User\.aggregate/);
+  });
 });
 
 /**

--- a/packages/gemi/orm/compile/aggregate.ts
+++ b/packages/gemi/orm/compile/aggregate.ts
@@ -2,7 +2,14 @@ import type { SqlDialect } from "../dialect";
 import { UnknownFieldError, UnsupportedQueryError } from "../errors";
 import type { QueryPlan } from "../plan";
 import type { FieldSchema, ModelSchema, ScalarType } from "../schema";
-import { type Fragment, bindValues, concat, joinFragments, render, sql } from "./fragment";
+import {
+  type Fragment,
+  bindValues,
+  concat,
+  joinFragments,
+  render,
+  sql,
+} from "./fragment";
 import { compileOrderBy, parseOrderBy } from "./orderBy";
 import { pagination } from "./paginate";
 import { compileWhere } from "./where";
@@ -132,11 +139,16 @@ export function compileAggregate(
       flat
         ? `A 'select' on a count must name at least one field, or '_all'.`
         : `An aggregate needs at least one of ${KINDS.join(", ")}. Prisma ` +
-          `rejects an empty one too.`,
+            `rejects an empty one too.`,
     );
   }
 
-  const where = compileWhere(schema, args?.where, { dialect, operation: op }, (a) => a?.where);
+  const where = compileWhere(
+    schema,
+    args?.where,
+    { dialect, operation: op },
+    (a) => a?.where,
+  );
   const whereClause = where ? concat(sql(" where "), where) : sql("");
   const from = sql(` from ${dialect.quoteIdent(schema.table)}`);
 
@@ -164,7 +176,13 @@ export function compileAggregate(
   if (!paginating) {
     statement = concat(sql("select "), projection, from, whereClause);
   } else {
-    const { clause, terms: order } = pagination(schema, args, dialect, parsed);
+    const { clause, terms: order } = pagination(
+      schema,
+      op,
+      args,
+      dialect,
+      parsed,
+    );
     const ordering = compileOrderBy(order, dialect);
 
     // The subquery selects every column an aggregate names — an `order by` may
@@ -213,7 +231,8 @@ export function compileAggregate(
 
       if (flat) {
         const out: Record<string, unknown> = {};
-        for (const term of terms) out[term.as] = coerce(term, row[term.alias], dialect);
+        for (const term of terms)
+          out[term.as] = coerce(term, row[term.alias], dialect);
         return out;
       }
 
@@ -236,11 +255,7 @@ export function compileAggregate(
 /** The `as` a bare `_count: true` carries, which no field name can be. */
 const BARE = "";
 
-function aggregateTerms(
-  schema: ModelSchema,
-  op: string,
-  args: any,
-): Term[] {
+function aggregateTerms(schema: ModelSchema, op: string, args: any): Term[] {
   const terms: Term[] = [];
 
   for (const kind of KINDS) {
@@ -252,7 +267,11 @@ function aggregateTerms(
       continue;
     }
 
-    if (typeof requested !== "object" || requested === null || Array.isArray(requested)) {
+    if (
+      typeof requested !== "object" ||
+      requested === null ||
+      Array.isArray(requested)
+    ) {
       throw new UnsupportedQueryError(
         kind,
         schema.name,
@@ -282,7 +301,11 @@ function aggregateTerms(
 }
 
 /** `count({ select: { _all: true, email: true } })` — every term a `count`. */
-function countSelectTerms(schema: ModelSchema, op: string, select: any): Term[] {
+function countSelectTerms(
+  schema: ModelSchema,
+  op: string,
+  select: any,
+): Term[] {
   if (typeof select !== "object" || select === null || Array.isArray(select)) {
     throw new UnsupportedQueryError(
       "select",
@@ -298,12 +321,21 @@ function countSelectTerms(schema: ModelSchema, op: string, select: any): Term[] 
     if (wanted === undefined || wanted === false) continue;
 
     if (key === "_all") {
-      terms.push({ kind: "_count", as: "_all", alias: alias("_count", terms.length) });
+      terms.push({
+        kind: "_count",
+        as: "_all",
+        alias: alias("_count", terms.length),
+      });
       continue;
     }
 
     const field = resolveField(schema, op, "_count", key);
-    terms.push({ kind: "_count", field, as: key, alias: alias("_count", terms.length) });
+    terms.push({
+      kind: "_count",
+      field,
+      as: key,
+      alias: alias("_count", terms.length),
+    });
   }
   return terms;
 }
@@ -455,7 +487,12 @@ function assertArgs(
   }
 
   if (typeof args !== "object" || Array.isArray(args)) {
-    throw new UnsupportedQueryError(String(args), schema.name, op, "Expected an object.");
+    throw new UnsupportedQueryError(
+      String(args),
+      schema.name,
+      op,
+      "Expected an object.",
+    );
   }
 
   if (flat) return;

--- a/packages/gemi/orm/compile/paginate.ts
+++ b/packages/gemi/orm/compile/paginate.ts
@@ -47,6 +47,23 @@ import { reverse, type OrderTerm } from "./orderBy";
  *
  * `argument` is the name to report: `take` at the root, `accounts.take` on a
  * relation node.
+ *
+ * **The error type is wrong here, and deliberately left wrong until #78 lands.**
+ * `UnsupportedQueryError` spells "does not support 'take' *yet*", and there is
+ * no future in which `take: "-2"` becomes supported — the word promises
+ * something nobody intends. For the fraction it contradicts this file's own
+ * comment, which calls the refusal deliberate. That word is load-bearing in
+ * this codebase: #78 adds `UnsupportedByDesignError` for "a decision rather
+ * than a gap", and #82 removed "yet" from the dialect message for exactly this
+ * reason.
+ *
+ * Validation is a fourth category again — not unimplemented, not a design
+ * refusal of a feature, but invalid input — so the fix is a category, not a
+ * reworded string, and inventing one here while #78 is in flight would be the
+ * second copy this function exists to avoid. When #78 merges: the fraction
+ * refusal moves to the by-design category it is already documented as, and the
+ * type-mismatch messages lose the word. The two branches merge clean today, so
+ * this is an order note rather than a conflict.
  */
 export function assertPageArgument(
   model: string,

--- a/packages/gemi/orm/compile/paginate.ts
+++ b/packages/gemi/orm/compile/paginate.ts
@@ -1,7 +1,78 @@
 import type { SqlDialect } from "../dialect";
+import { UnsupportedQueryError } from "../errors";
 import type { ModelSchema } from "../schema";
 import type { Binder, Fragment } from "./fragment";
 import { reverse, type OrderTerm } from "./orderBy";
+
+/**
+ * `take` / `skip` have to be integers, and Prisma is stricter than "a number":
+ * a `skip` counts rows to pass over, so a negative one is meaningless and is
+ * rejected rather than clamped. A negative *`take`* is not — it means "the last
+ * N".
+ *
+ * **Why refusing rather than coercing**, which is the cheaper fix and the wrong
+ * one. The sign of a `take` decides the *SQL*: it flips every ordering term and
+ * reverses the result set. Everything else about these two arguments is a bound
+ * value. So a `take` that is a string does not merely arrive in the wrong type —
+ * it takes the wrong branch, because the branch is `typeof take === "number" &&
+ * take < 0` and a string is not a number:
+ *
+ *     { take: -2 }    ->  order flipped, bind 2   the last two rows
+ *     { take: "-2" }  ->  order as written, bind 2   the *first* two rows
+ *
+ * `Math.abs(Number(...))` then binds `2` either way, so the statement is valid,
+ * the result set is the right size, and the rows are wrong. No error anywhere.
+ *
+ * Coercing early would fix that one case — `Number("-2")` is negative — and
+ * would keep accepting `take: "abc"`, which binds `NaN`. Prisma types these as
+ * `number` and rejects a string outright, and #72 already chose refusal for the
+ * same arguments on a *relation* node. This is that decision reaching the root,
+ * where it should have been in the first place.
+ *
+ * **A fraction is the one deliberate divergence, and it is deliberate because
+ * of what the alternative measures at.** Prisma accepts `take: 1.5` and
+ * truncates toward zero. Binding it, which is what this did, does not:
+ *
+ *     prisma    take: 1.5   ->  1 row     truncates
+ *     sqlite    limit ? = 1.5   ->  SQLiteError: datatype mismatch (SQLITE_MISMATCH)
+ *     postgres  limit $1 = 1.5  ->  2 rows    rounds to nearest
+ *
+ * Measured through Bun against both engines. So the status quo is an opaque
+ * driver error on one dialect and a silent disagreement with Prisma *and* with
+ * the other dialect on the second — from one argument, with no line naming
+ * `take`. Matching Prisma would mean truncating here and also changing #72's
+ * relation-node rule, which refuses fractions today; refusing keeps one rule at
+ * both levels and fails in the loud direction. `docs/orm.md` records it as a
+ * divergence rather than leaving it to be discovered.
+ *
+ * `argument` is the name to report: `take` at the root, `accounts.take` on a
+ * relation node.
+ */
+export function assertPageArgument(
+  model: string,
+  operation: string,
+  argument: string,
+  key: "take" | "skip",
+  value: unknown,
+): void {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new UnsupportedQueryError(
+      argument,
+      model,
+      operation,
+      `Expected an integer, got ${JSON.stringify(value)}.`,
+    );
+  }
+  if (key === "skip" && value < 0) {
+    throw new UnsupportedQueryError(
+      argument,
+      model,
+      operation,
+      `A 'skip' counts rows to pass over, so it cannot be negative. Prisma ` +
+        `rejects one too.`,
+    );
+  }
+}
 
 /**
  * `skip` / `take`, plus the two pieces of Prisma behaviour around them that are
@@ -13,9 +84,22 @@ import { reverse, type OrderTerm } from "./orderBy";
  * - A *negative* `take` means "the last N": Prisma flips every ordering term,
  *   takes `abs(take)`, and then reverses the result set so the caller still
  *   sees their own ordering. `reversed` carries that last part out to `shape`.
+ *
+ * **Validation happens here rather than in each caller's argument check.** Three
+ * operations page — `findMany` and friends, `count`, `aggregate` — and they
+ * validate their arguments in two different files. Putting the check at the one
+ * place that *reads* `take` and `skip` means a fourth pager cannot be added
+ * without it, which is the same reason invariant 1 puts every query through one
+ * door.
  */
 export function pagination(
   schema: ModelSchema,
+  /**
+   * The operation being compiled, for the error message. Required rather than
+   * defaulted: this exists to report which call was refused, and a default
+   * would name the wrong one on every caller that forgot it.
+   */
+  operation: string,
   args: any,
   dialect: SqlDialect,
   parsed: OrderTerm[],
@@ -28,6 +112,17 @@ export function pagination(
    */
   single = false,
 ): { clause: Fragment; terms: OrderTerm[]; reversed: boolean } {
+  // Against the caller's own arguments, before `single` pins anything. A
+  // `findFirst` ignores the value of `take` — but it still accepts the
+  // argument, and Prisma still rejects a string there, so refusing what was
+  // written beats refusing what survived.
+  if (args?.take !== undefined) {
+    assertPageArgument(schema.name, operation, "take", "take", args.take);
+  }
+  if (args?.skip !== undefined) {
+    assertPageArgument(schema.name, operation, "skip", "skip", args.skip);
+  }
+
   const take = single ? 1 : args?.take;
   const skip = args?.skip;
 

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -7,6 +7,7 @@ import {
   UnregisteredRelationTargetError,
   UnsupportedQueryError,
 } from "../errors";
+import { assertPageArgument } from "./paginate";
 import { COUNT_KEY } from "../relation-filters";
 import * as registry from "../registry";
 import type { FieldSchema, ModelSchema, RelationSchema } from "../schema";
@@ -523,7 +524,7 @@ function assertNodeArgs(
   for (const key of Object.keys(args).sort()) {
     if (args[key] === undefined) continue;
     if (many && (key === "take" || key === "skip")) {
-      assertPageArgument(schema, node, operation, key, args[key]);
+      assertNodePageArgument(schema, node, operation, key, args[key]);
       continue;
     }
     if (many ? RELATION_ARGS.has(key) : TO_ONE_ARGS.has(key)) continue;
@@ -555,43 +556,34 @@ function assertNodeArgs(
       );
     }
 
-    throw new UnsupportedQueryError(`${node.as}.${key}`, schema.name, operation);
+    throw new UnsupportedQueryError(
+      `${node.as}.${key}`,
+      schema.name,
+      operation,
+    );
   }
 }
 
 /**
- * `take` / `skip` on a to-many node have to be numbers, and Prisma is stricter
- * than "a number": a `skip` is a count of rows to pass over, so a negative one
- * is meaningless and rejected rather than clamped.
+ * The relation-node spelling of the root check, which lives in `paginate.ts`
+ * beside the code that reads these two arguments.
  *
- * A *negative* `take` is not — it means "the last N", the same as at the root,
- * and it changes the emitted SQL rather than a bound value. That is why the
- * plan key records a `take`'s sign; see `shapeOfMember`.
+ * One function rather than two with the same body: #84 was the root path *not*
+ * having this check, and the fix landing as a second copy is how the two drift
+ * — a `take` refused inside an `include` and coerced at the root is a worse
+ * story than either rule alone. The only difference is the name reported, and
+ * that is a parameter.
+ *
+ * That is also why the plan key records a `take`'s sign; see `shapeOfMember`.
  */
-function assertPageArgument(
+function assertNodePageArgument(
   schema: ModelSchema,
   node: RelationNode,
   operation: string,
   key: "take" | "skip",
   value: unknown,
 ): void {
-  if (typeof value !== "number" || !Number.isInteger(value)) {
-    throw new UnsupportedQueryError(
-      `${node.as}.${key}`,
-      schema.name,
-      operation,
-      `Expected an integer, got ${JSON.stringify(value)}.`,
-    );
-  }
-  if (key === "skip" && value < 0) {
-    throw new UnsupportedQueryError(
-      `${node.as}.skip`,
-      schema.name,
-      operation,
-      `A 'skip' counts rows to pass over, so it cannot be negative. Prisma ` +
-        `rejects one too.`,
-    );
-  }
+  assertPageArgument(schema.name, operation, `${node.as}.${key}`, key, value);
 }
 
 /**
@@ -744,7 +736,7 @@ function otherSide(
       candidates.length === 0
         ? `${child.name} declares no relation named '${relation.relationName}'.`
         : `${child.name} declares ${candidates.length} relations named ` +
-          `'${relation.relationName}'.`,
+            `'${relation.relationName}'.`,
     );
   }
 
@@ -922,8 +914,16 @@ export const batchedStrategy: RelationStrategy = {
 
     // Resolved at plan time so a stale artifact fails when the query is
     // compiled rather than after the root query has already run.
-    const parentKeyField = field(request.parent, request.relation, link.parentField);
-    const childKeyField = field(request.child, request.relation, link.childField);
+    const parentKeyField = field(
+      request.parent,
+      request.relation,
+      link.parentField,
+    );
+    const childKeyField = field(
+      request.child,
+      request.relation,
+      link.childField,
+    );
     assertKeyable(request.parent, request.relation, parentKeyField);
     assertKeyable(request.child, request.relation, childKeyField);
 

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -254,6 +254,81 @@ describe("skip and take", () => {
     const rows = plan.shape([{ id: 1 }, { id: 2 }, { id: 3 }]) as any[];
     expect(rows.map((row) => row.id)).toEqual([1, 2, 3]);
   });
+
+  /**
+   * #84. These two arguments are the only ones whose *sign* decides the SQL, so
+   * a wrong type here does not fail — it takes the other branch.
+   *
+   * `take: "-2"` asks for the last two rows. `typeof take === "number"` is
+   * false for a string, so the order is not flipped; `Math.abs(Number(...))`
+   * then binds `2`. The statement is valid, the page is the right size, and the
+   * rows are the first two in the opposite order. Nothing raises.
+   *
+   * A query string is exactly where a string `take` comes from — `?take=-2` —
+   * and the ORM's own types say `number`, so nothing in between has a reason to
+   * coerce it.
+   */
+  test("a string take is refused, rather than silently paging the wrong end", () => {
+    expect(() => text({ take: "-2" })).toThrow(UnsupportedQueryError);
+    expect(() => text({ take: "-2" })).toThrow(/Expected an integer, got "-2"/);
+
+    // The shape of the bug, pinned so a future coercion cannot reintroduce it
+    // quietly: with a real -2 the order flips, which is what "-2" did not do.
+    expect(text({ take: -2 })).toBe(`${SELECT_USER} order by "id" desc limit ?`);
+    expect(text({ take: 2 })).toBe(`${SELECT_USER} order by "id" asc limit ?`);
+  });
+
+  /**
+   * The one place this is deliberately *stricter* than Prisma, which accepts a
+   * fraction and truncates toward zero. Binding it does not, and the three
+   * behaviours are the argument for refusing rather than picking one:
+   *
+   *     prisma           take: 1.5  ->  1 row   truncates
+   *     sqlite   limit ? = 1.5      ->  SQLiteError: datatype mismatch
+   *     postgres limit $1 = 1.5     ->  2 rows  rounds to nearest
+   *
+   * Measured through Bun against both engines rather than reasoned about.
+   */
+  test("a fractional take is refused, which Prisma would have truncated", () => {
+    expect(() => text({ take: 1.5 })).toThrow(/Expected an integer, got 1.5/);
+    expect(() => text({ skip: 1.5 })).toThrow(/Expected an integer, got 1.5/);
+  });
+
+  // Quieter than the `take` case and still not a number the caller meant:
+  // `Number("x")` is `NaN`, which binds as `null` and offsets nothing.
+  test("a non-numeric skip is refused rather than bound as null", () => {
+    expect(() => text({ skip: "x" })).toThrow(/Expected an integer, got "x"/);
+  });
+
+  // Already the rule inside an `include` since #72. A `skip` counts rows to
+  // pass over, so there is no reading of a negative one.
+  test("a negative skip is refused, as it already was on a relation node", () => {
+    expect(() => text({ skip: -1 })).toThrow(
+      /'skip' counts rows to pass over/,
+    );
+  });
+
+  test("the refusal names the operation that was asked for", () => {
+    for (const op of ["findMany", "findFirst", "count"]) {
+      expect(() => text({ take: "5" }, op)).toThrow(
+        new RegExp(`User\\.${op}`),
+      );
+    }
+  });
+
+  /**
+   * `findFirst` pins `take` to 1 and never reads the caller's value, so this is
+   * the one operation where the argument could have been ignored rather than
+   * refused. It is refused: Prisma rejects a string there too, and refusing
+   * what was *written* rather than what survived is what keeps the rule one
+   * sentence long.
+   */
+  test("a single-row operation refuses it too, though it ignores the value", () => {
+    expect(() => text({ take: "1" }, "findFirst")).toThrow(
+      UnsupportedQueryError,
+    );
+    expect(text({ take: 1 }, "findFirst")).toBe(`${SELECT_USER} limit ?`);
+  });
 });
 
 describe("select", () => {

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -90,7 +90,10 @@ export function compileRead(
   // unplanned path and pays nothing.
   const relations =
     op === "count"
-      ? { plans: [] as ReturnType<typeof planRelations>["plans"], keyFields: [] }
+      ? {
+          plans: [] as ReturnType<typeof planRelations>["plans"],
+          keyFields: [],
+        }
       : planRelations(schema, args, dialect, op, strategy);
 
   const folded = relations.plans.some((plan) => plan.root !== undefined);
@@ -133,7 +136,14 @@ export function compileRead(
     if (!paginated) {
       statement = concat(counted, from, whereClause);
     } else {
-      const { clause, terms } = pagination(schema, args, dialect, parsed, SINGLE_ROW.has(op));
+      const { clause, terms } = pagination(
+        schema,
+        op,
+        args,
+        dialect,
+        parsed,
+        SINGLE_ROW.has(op),
+      );
       const order = compileOrderBy(terms, dialect);
       // One column, not `*`: the subquery exists to be counted, so the narrowest
       // thing that keeps a row identity is right.
@@ -149,7 +159,10 @@ export function compileRead(
       );
     }
 
-    const { text, binders } = render(statement, dialect, { model: schema.name, operation: op });
+    const { text, binders } = render(statement, dialect, {
+      model: schema.name,
+      operation: op,
+    });
     return {
       text,
       bind: bindValues(binders),
@@ -194,6 +207,7 @@ export function compileRead(
     reversed,
   } = pagination(
     schema,
+    op,
     args,
     dialect,
     parseOrderBy(schema, args?.orderBy, op, {
@@ -214,7 +228,10 @@ export function compileRead(
     paginationClause,
   );
 
-  const { text, binders } = render(statement, dialect, { model: schema.name, operation: op });
+  const { text, binders } = render(statement, dialect, {
+    model: schema.name,
+    operation: op,
+  });
   const shaper = buildRowShaper(
     fields,
     dialect,
@@ -307,4 +324,3 @@ function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
     }
   }
 }
-


### PR DESCRIPTION
Closes #84.

## The failure

`take` and `skip` reached `pagination()` unvalidated, and they are the only two arguments whose **sign decides the SQL** rather than a bound value — a negative `take` means "the last N", which flips every ordering term. The sign is read as `typeof take === "number" && take < 0`, so a string does not merely arrive in the wrong type. It takes the other branch:

```
{ take: -2 }    order flipped, bind 2      the last two rows
{ take: "-2" }  order as written, bind 2   the *first* two rows
```

`Math.abs(Number(...))` binds `2` either way, so the statement is valid, the page is the right size, and the rows are wrong. Nothing raises. `?take=-2` from a query string is exactly where a string `take` comes from, and the generated types say `number`, so nothing in between has a reason to coerce it.

## The fix

Refused, not coerced. Coercing would fix that one case — `Number("-2")` is negative — and go on accepting `take: "abc"`, which binds `NaN`. #72 already chose refusal for the same two arguments on a *relation* node; this is that rule reaching the root, where it should have been first.

Two things about where it went:

- **`assertPageArgument` moved to `paginate.ts` and `plan-relations.ts` now calls it.** One function, not two with the same body. #84 *was* the two paths disagreeing; fixing it with a second copy is how they drift again. The only difference is the name reported — `take` at the root, `accounts.take` on a node — and that is a parameter.
- **The check runs inside `pagination()`,** not in each caller's argument allowlist. Three operations page — `findMany` and friends, `count`, `aggregate` — across two files, so putting it at the one place that *reads* these arguments means a fourth pager cannot be added without it. Same reasoning as invariant 1.

## A fraction is a deliberate divergence, and measuring it decided the direction

#84 assumed Prisma rejects a fractional `take`. **It does not** — it truncates toward zero. And binding one, which is what this did, has no single meaning to match:

| | `take: 1.5` |
| --- | --- |
| Prisma 6 | 1 row — truncates |
| SQLite, `limit ? = 1.5` | `SQLiteError: datatype mismatch` (`SQLITE_MISMATCH`) |
| Postgres, `limit $1 = 1.5` | 2 rows — rounds to nearest |

Read off a live Prisma client and both engines through Bun, not reasoned about. So the status quo is an opaque driver error on one dialect and a silent disagreement with Prisma *and* with the other dialect on the second — one argument, three behaviours, no line naming `take`.

Matching Prisma would mean truncating here **and** relaxing #72's relation-node rule, which refuses fractions today. Refusing keeps one rule at both levels and fails in the loud direction. `docs/orm.md` records it as a divergence rather than leaving it to be discovered.

## Tests

Seven, and every one verified **red against the unvalidated code** before being kept:

```
× a string take is refused, rather than silently paging the wrong end
× a fractional take is refused, which Prisma would have truncated
× a non-numeric skip is refused rather than bound as null
× a negative skip is refused, as it already was on a relation node
× the refusal names the operation that was asked for
× a single-row operation refuses it too, though it ignores the value
× a take that is not an integer is refused here too        (aggregate)
```

The string test also pins the **shape** of the bug — that a real `-2` flips the order where `"-2"` did not — so a future coercion cannot reintroduce it quietly. `findFirst` gets its own test because it pins `take` to 1 and never reads the caller's value: it is the one operation where the argument could have been ignored instead of refused, and refusing what was *written* rather than what survived is what keeps the rule one sentence long.

## Breaking

For anyone passing `take: "10"` from a query string today, which works by coercion. That is why #84 asked for it as its own change with a documented line rather than folded into #74.

## Verification

889 unit tests. Full template suite green on SQLite and Postgres 16, with only the pre-existing `generated.test.ts` generator-linkage probe failing (fails on the base branch too). `tsc` clean; oxlint clean apart from two pre-existing warnings in `where.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
