### PR TITLE
`_count` in a write's `include` is projected, not dropped

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -117,6 +117,12 @@ const user = await User.findUniqueOrThrow({
 })
 ```
 
+A write's `include` takes `_count` as a read's does — `User.create({ data, include: { _count: {
+select: { accounts: true } } } })` comes back with `_count.accounts`. It compiles to a correlated
+subquery inside the `RETURNING`, so it costs no extra statement; a `delete` carrying one reads the
+count before the row goes, for the same reason a `delete` carrying an `include` reads its children
+first.
+
 `select` and `include` narrow the **return type**, exactly as they do in Prisma — `user.email`
 type-checks, `user.name` does not. A key outside the operation's argument type collapses to
 `never` rather than being quietly accepted.

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -119,9 +119,10 @@ const user = await User.findUniqueOrThrow({
 
 A write's `include` takes `_count` as a read's does — `User.create({ data, include: { _count: {
 select: { accounts: true } } } })` comes back with `_count.accounts`. It compiles to a correlated
-subquery inside the `RETURNING`, so it costs no extra statement; a `delete` carrying one reads the
-count before the row goes, for the same reason a `delete` carrying an `include` reads its children
-first.
+subquery inside the `RETURNING`, so it costs no extra statement. Two orderings are handled so the
+number agrees with the row beside it: a `delete` carrying one reads the count *before* the row
+goes, and a write whose nested `create` writes children *after* the statement recomputes it once
+they have — otherwise `include` and `_count` would describe the same relation and disagree.
 
 `select` and `include` narrow the **return type**, exactly as they do in Prisma — `user.email`
 type-checks, `user.name` does not. A key outside the operation's argument type collapses to

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -795,6 +795,39 @@ export abstract class Model {
       // so an `include` on the same call sees what was just written.
       await runSteps(plan.after, effective, context, executor, rowsOf(result));
 
+      // ...and a `_count` on the same call has to be recomputed once they have,
+      // for the same reason `include` is attached after them rather than before.
+      //
+      // A count is a correlated subquery inside the write's own `RETURNING`, so
+      // it is evaluated at the instant the parent row is inserted — before any
+      // `after` step has written a child. That produced a single response
+      // contradicting itself:
+      //
+      //   User.create({ data: { …, accounts: { create: [a, b] } },
+      //                 include: { accounts: true, _count: { … } } })
+      //
+      //   accounts.length  2      attached after the steps
+      //   _count           0      projected before them
+      //
+      // Both keys describe the same relation on the same row. The row itself was
+      // never wrong — reading it back gives 2 — so this is the projection being
+      // frozen, which is the mirror of the `delete` case above: there the count
+      // is taken too late, here too early.
+      //
+      // **Only when there is something to be wrong about.** A write with no
+      // `after` steps keeps the projected value and costs nothing extra; one
+      // with both pays a single read. `plan.counts` is what makes that condition
+      // cheap enough to ask on every write.
+      if (plan.counts && plan.after !== undefined) {
+        await recountAfterSteps(
+          schema,
+          this as unknown as typeof Model,
+          effective,
+          rowsOf(result),
+          options,
+        );
+      }
+
       // Relations are loaded after the root rows are shaped, one query per node
       // in the include tree. Each of those queries is `$exec` on the *related
       // model's own class*, recursively — not a private helper — so a nested read
@@ -953,6 +986,48 @@ function fieldsForColumns(
     }
     return column;
   });
+}
+
+/**
+ * Re-reads the `_count` for rows whose children were written by an `after` step.
+ *
+ * One read per row rather than one for all of them, and that is not a
+ * concession: every write that can carry both a `_count` and an `after` step is
+ * a single-row operation — `create`, `update`, `upsert`. `createMany` takes no
+ * `include` at all. So the loop runs once, and writing it as a loop keeps a
+ * compound primary key expressible without an `in` list over tuples.
+ *
+ * **Pre-scoped, deliberately.** `effective` has already been through this
+ * model's policies and `applyNestedPolicies` has already scoped the `_count`
+ * node, so re-applying them would `AND` the same predicate twice — the same
+ * rows, a different plan key. This is the same reasoning `delete`'s read-first
+ * path uses, a few hundred lines up.
+ */
+async function recountAfterSteps(
+  schema: ModelSchema,
+  model: typeof Model,
+  effective: any,
+  rows: Record<string, unknown>[],
+  options: unknown,
+): Promise<void> {
+  const node = effective?.include?._count ?? effective?.select?._count;
+  if (node === undefined || rows.length === 0) return;
+
+  for (const row of rows) {
+    const where: Record<string, unknown> = {};
+    for (const field of schema.primaryKey) where[field] = row[field];
+
+    const fresh = (await (model as any).$exec(
+      "findFirst",
+      { where, select: { _count: node } },
+      markPreScoped({ strategy: (options as any)?.strategy }),
+    )) as Record<string, unknown> | null;
+
+    // `null` only if the row vanished between the write and this read, which
+    // inside the write's own transaction it cannot. Leaving the projected value
+    // alone is still the right fallback: it is stale, not invented.
+    if (fresh && fresh._count !== undefined) row._count = fresh._count;
+  }
 }
 
 function rowsOf(result: unknown): Record<string, unknown>[] {

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -818,6 +818,13 @@ export abstract class Model {
       // `after` steps keeps the projected value and costs nothing extra; one
       // with both pays a single read. `plan.counts` is what makes that condition
       // cheap enough to ask on every write.
+      //
+      // **Between `runSteps` and the `hidden` deletion, and that is
+      // load-bearing.** `select: { email, _count: … }` never asks for the
+      // primary key, so the key the recount reads the row by is on it only
+      // because the plan added it for the nested write and has not stripped it
+      // yet. Move this after the strip and the recount loses its identifier;
+      // move it before `runSteps` and there is nothing new to count.
       if (plan.counts && plan.after !== undefined) {
         await recountAfterSteps(
           schema,
@@ -1014,8 +1021,34 @@ async function recountAfterSteps(
   if (node === undefined || rows.length === 0) return;
 
   for (const row of rows) {
+    // **Every component present, or nothing.** What the plan guarantees is on
+    // the row is the *link* field — `planForeignSide` pushes `link.parentField`
+    // into `keyFields`, which is the column the relation `references`, and that
+    // is the primary key only by convention. Declare a relation
+    // `references: [publicId]`, ask for `select: { email, _count }`, and `id` is
+    // simply not there.
+    //
+    // The failure that would produce is the bad kind. `compileWhere` drops
+    // `undefined` keys, so a `where` built entirely from missing components
+    // compiles to **no predicate at all**:
+    //
+    //   findFirst({ where: { id: undefined } })  ->  select … from "User" limit ?
+    //
+    // — an arbitrary row, whose count is a plausible number rather than an
+    // error. So an incomplete key means the projected value stands, which is
+    // the same answer this already gives for a missing row: stale, not
+    // invented. Nothing here can be salvaged by guessing.
     const where: Record<string, unknown> = {};
-    for (const field of schema.primaryKey) where[field] = row[field];
+    let identified = schema.primaryKey.length > 0;
+    for (const field of schema.primaryKey) {
+      const value = row[field];
+      if (value === undefined) {
+        identified = false;
+        break;
+      }
+      where[field] = value;
+    }
+    if (!identified) continue;
 
     const fresh = (await (model as any).$exec(
       "findFirst",

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -690,7 +690,24 @@ export abstract class Model {
     //
     // Only when there is something to read. A plain `delete` still compiles to
     // one statement and opens no transaction.
-    if (op === "delete" && plan.relations !== undefined) {
+    //
+    // `plan.counts` is here for the same hazard in its quietest form, and the
+    // two dialects disagree about it. A `_count` compiles to a correlated
+    // subquery inside the `RETURNING`, and where the schema cascades:
+    //
+    //   postgres  delete … returning (select count(*) from ch …)  ->  3
+    //   sqlite    delete … returning (select count(*) from ch …)  ->  0
+    //
+    // Measured through Bun against a real `on delete cascade` on both. Postgres
+    // evaluates the subquery against the pre-statement snapshot, which is what
+    // Prisma returns; SQLite evaluates it after the cascade has run, so the
+    // count is 0 — a *number*, so nothing looks missing and no error is raised.
+    //
+    // Reading first answers it the same way it already answers the `include`
+    // case, and on both dialects rather than one. A count is not a relation
+    // plan, so `relations` stays empty for an `include: { _count: … }` on its
+    // own — hence the separate flag rather than a wider check.
+    if (op === "delete" && (plan.relations !== undefined || plan.counts)) {
       const { where } = effective;
       const projection =
         effective.select !== undefined

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -256,6 +256,33 @@ describe("skip and take", () => {
   });
 });
 
+/**
+ * The hazard `recountAfterSteps` guards against, pinned where the behaviour
+ * actually lives.
+ *
+ * Dropping `undefined` keys is right — it is how an optional filter is spelled
+ * — but it means a `where` built *entirely* from missing values is not a
+ * narrower query, it is an unfiltered one. Any caller assembling a `where` from
+ * fields it believes are on a row has to check they are there first, because
+ * the failure is an arbitrary row rather than an error.
+ */
+describe("a where whose keys are all undefined", () => {
+  test("compiles to no predicate at all, not to a miss", () => {
+    const unfiltered = text({});
+    expect(text({ where: { id: undefined } })).toBe(unfiltered);
+    expect(text({ where: {} })).toBe(unfiltered);
+    expect(text({ where: { id: undefined, email: undefined } })).toBe(
+      unfiltered,
+    );
+  });
+
+  test("one present key is still a predicate", () => {
+    expect(text({ where: { id: 1, email: undefined } })).toBe(
+      `${SELECT_USER} where "id" = ?`,
+    );
+  });
+});
+
 describe("select", () => {
   test("restricts the column list and the result keys", () => {
     const plan = compileRead(

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -782,6 +782,103 @@ describe("arguments", () => {
   });
 });
 
+/**
+ * `_count` in a write's `include` (#87).
+ *
+ * It used to be accepted and dropped — the row came back without the key and
+ * without an error — while an unknown relation name in the same `include`
+ * raised. The inconsistency is the sharper half of the complaint: the write
+ * path validated relation names and then discarded the one key that is not one.
+ */
+describe("_count on a write", () => {
+  const COUNT = { _count: { select: { accounts: true } } };
+
+  // The count correlates against the child's table, so its schema has to be
+  // resolvable — same requirement the relation planner has.
+  beforeEach(() => {
+    registry.clearRegistry();
+    registry.register("User", class { static $schema = user });
+    registry.register("Account", class { static $schema = account });
+    registry.register("Organization", class { static $schema = organization });
+  });
+
+  afterEach(() => registry.clearRegistry());
+
+  test("projects a correlated subquery into the returning list", () => {
+    const emitted = text("create", { data: { email: "a@b.c" }, include: COUNT });
+
+    expect(emitted).toContain(`select count(*)`);
+    expect(emitted).toContain(`from "Account"`);
+    // In `returning`, not as a second statement: both dialects evaluate a
+    // subquery there, so this costs no extra round trip.
+    expect(emitted.slice(emitted.indexOf(" returning "))).toContain(`count(*)`);
+  });
+
+  test("it reaches every row-returning write", () => {
+    for (const [op, args] of [
+      ["create", { data: { email: "a@b.c" } }],
+      ["update", { where: { id: 1 }, data: { name: "x" } }],
+      ["delete", { where: { id: 1 } }],
+      ["upsert", { where: { id: 1 }, create: { id: 1, email: "a@b.c" }, update: {} }],
+    ] as const) {
+      expect(text(op, { ...args, include: COUNT })).toContain(`count(*)`);
+    }
+  });
+
+  test("the filter inside a _count is bound, never inlined", () => {
+    const args = {
+      data: { email: "a@b.c" },
+      include: {
+        _count: { select: { accounts: { where: { organizationRole: 7 } } } },
+      },
+    };
+    const plan = compileWrite(user, "create", args, sqlite);
+
+    expect(plan.text).not.toContain("7");
+    expect(plan.bind(args, createBindContext())).toContain(7);
+  });
+
+  /**
+   * The flag `$exec` reads to decide that a `delete` has something to read
+   * *before* the row goes. A count is not a relation plan, so `relations` is
+   * empty for a `_count` on its own and cannot carry this.
+   *
+   * It matters because the two dialects disagree: under `on delete cascade`
+   * Postgres evaluates the subquery against the pre-statement snapshot and
+   * returns the old count, SQLite evaluates it after the cascade and returns 0.
+   * Prisma returns the old count on both.
+   */
+  test("a write carrying a _count says so, and one without does not", () => {
+    expect(
+      compileWrite(user, "delete", { where: { id: 1 }, include: COUNT }, sqlite)
+        .counts,
+    ).toBe(true);
+
+    expect(
+      compileWrite(user, "delete", { where: { id: 1 } }, sqlite).counts,
+    ).toBeUndefined();
+
+    // An `include` of a real relation is a relation plan, not a count.
+    expect(
+      compileWrite(
+        user,
+        "delete",
+        { where: { id: 1 }, include: { accounts: true } },
+        sqlite,
+      ).counts,
+    ).toBeUndefined();
+  });
+
+  test("an unknown relation inside a _count still raises", () => {
+    expect(() =>
+      text("create", {
+        data: { email: "a@b.c" },
+        include: { _count: { select: { nosuchrelation: true } } },
+      }),
+    ).toThrow(/nosuchrelation/);
+  });
+});
+
 // Invariant 2, asserted rather than argued: no value is ever inlined into the
 // SQL text. The read suite makes the same assertion; writes are the place it is
 // most tempting to break, because a column list *looks* like a good place for a

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -25,6 +25,7 @@ import {
   planNestedWrites,
 } from "./nested-writes";
 import { planRelations, strategiesOf } from "./plan-relations";
+import { type CountPlan, planRelationCounts } from "./relation-count";
 import { resolveSelection, withKeyFields } from "./select";
 import { matchUniqueKey } from "./unique";
 import { compileWhere } from "./where";
@@ -1133,6 +1134,7 @@ interface Returning {
   fields: FieldSchema[];
   hidden?: string[];
   relations: ReturnType<typeof planRelations>["plans"];
+  counts: CountPlan[];
 }
 
 /**
@@ -1158,6 +1160,7 @@ function returningClause(
       clause: sql(` returning ${keyColumn(schema, dialect)}`),
       fields: [],
       relations: [],
+      counts: [],
     };
   }
 
@@ -1167,18 +1170,26 @@ function returningClause(
     ...keyFields,
     ...(nested?.keyFields ?? []),
   ]);
+  const counts = planRelationCounts(schema, args, dialect, op);
 
   return {
     clause: concat(
       sql(" returning "),
       joinFragments(
-        fields.map((field) => sql(dialect.quoteIdent(field.column))),
+        [
+          ...fields.map((field) => sql(dialect.quoteIdent(field.column))),
+          // Last, for the same reason they go last on a read: the shaper reads
+          // scalars by position and `_count` is attached afterwards from the
+          // raw row.
+          ...counts.map((count) => count.column),
+        ],
         ", ",
       ),
     ),
     fields,
     hidden,
     relations: plans,
+    counts,
   };
 }
 
@@ -1229,12 +1240,28 @@ function plan(
     hidden: returning.hidden,
     before: nested && nested.before.length > 0 ? nested.before : undefined,
     after: nested && nested.after.length > 0 ? nested.after : undefined,
+    counts: returning.counts.length > 0 ? true : undefined,
     shape(rows) {
       // The count *is* the number of returned rows — see the note at the top of
       // this file on why it does not come from driver metadata.
       if (counting) return { count: rows.length };
 
       const shaped = shaper(rows);
+
+      // `_count` came back as extra columns the shaper knows nothing about,
+      // under aliases carrying a dot. Assembled into one object per row,
+      // because that is the shape Prisma returns — and the same assembly
+      // `compileRead` does, deliberately spelled the same way.
+      if (returning.counts.length > 0) {
+        for (let i = 0; i < shaped.length; i++) {
+          const raw = (rows[i] as Record<string, unknown>) ?? {};
+          const totals: Record<string, number> = {};
+          for (const count of returning.counts) {
+            totals[count.as] = Number(raw[count.alias] ?? 0);
+          }
+          shaped[i]._count = totals;
+        }
+      }
       // `null` when nothing matched. `$exec` turns that into
       // `RecordNotFoundError` for the operations Prisma raises on, where the
       // model's name is in scope for the message.

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -113,6 +113,17 @@ export interface QueryPlan {
    * `select` did not ask for. Dropped once the relations are attached.
    */
   hidden?: string[];
+  /**
+   * Whether this plan projects a `_count`. Undefined when it does not.
+   *
+   * A write needs this for the same reason it needs `relations`: a `delete`
+   * with either one is read *before* the row goes, so the choke point has to
+   * know there is something to read. A count is not a relation plan — it is a
+   * column in the statement, not a second query — so it cannot be discovered by
+   * looking at `relations`, and `include: { _count: … }` on its own leaves that
+   * list empty.
+   */
+  counts?: boolean;
 }
 
 /**

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -65,6 +65,21 @@ async function seed(prisma: PrismaClient) {
       },
     ],
   });
+
+  // Two accounts on Ada, so a `_count` has a number to be wrong about. Without
+  // children every count is 0 and a dropped `_count` is indistinguishable from
+  // a correct one — which is how #87 stayed invisible.
+  //
+  // Safe for the existing delete cases: `Account_userId_fkey` is
+  // `ON DELETE SET NULL`, so removing a user detaches its accounts on both
+  // sides rather than failing a constraint.
+  const [ada] = await prisma.user.findMany({ orderBy: { id: "asc" } });
+  await prisma.account.createMany({
+    data: [
+      { publicId: "a1", userId: ada.id, organizationId: acme.id },
+      { publicId: "a2", userId: ada.id, organizationId: acme.id },
+    ],
+  });
 }
 
 /** `[name, operation, args, tables]` — tables default to the model written. */
@@ -228,6 +243,58 @@ const CASES: Case[] = [
     create: { email: "unused@example.dev" },
     update: { name: "Updated" },
     select: { email: true, name: true },
+  }],
+
+  // --- _count on a write (#87) ------------------------------------------
+  //
+  // It used to be accepted and dropped: the row came back with no `_count` key
+  // and no error, while an unknown relation name in the same `include` raised.
+  // Every case below returns a number Prisma also returns, and the `update` /
+  // `upsert` / `delete` ones return a *non-zero* one, which is what separates
+  // "projected correctly" from "projected as zero".
+  ["create with _count", "create", {
+    data: { email: "c1@example.dev" },
+    include: { _count: { select: { accounts: true } } },
+  }],
+  ["update with _count", "update", {
+    where: { publicId: "p1" }, data: { name: "Counted" },
+    include: { _count: { select: { accounts: true } } },
+  }],
+  ["update with _count beside a relation", "update", {
+    where: { publicId: "p1" }, data: { name: "Counted" },
+    include: { accounts: true, _count: { select: { accounts: true } } },
+  }],
+  ["update with _count in a select", "update", {
+    where: { publicId: "p1" }, data: { name: "Counted" },
+    select: { email: true, _count: { select: { accounts: true } } },
+  }],
+  ["update with a filtered _count", "update", {
+    where: { publicId: "p1" }, data: { name: "Counted" },
+    include: {
+      _count: { select: { accounts: { where: { organizationRole: 2 } } } },
+    },
+  }],
+  ["upsert hitting, with _count", "upsert", {
+    where: { publicId: "p1" },
+    create: { email: "unused2@example.dev" },
+    update: { name: "Counted" },
+    include: { _count: { select: { accounts: true } } },
+  }],
+  // The one where the order of operations decides the answer. `Account`'s FK is
+  // `ON DELETE SET NULL`, so a count taken *after* the statement is 0 and one
+  // taken before it is 2 — which is why a `delete` carrying a `_count` is read
+  // first, the same way one carrying an `include` already was.
+  //
+  // **Discriminating on Postgres only, and the reason is its own bug.** Bun's
+  // SQLite driver leaves `pragma foreign_keys` at 0 and nothing in gemi turns it
+  // on, so no referential action ever fires there: the accounts keep pointing at
+  // the deleted user and a count taken after the delete would read 2 as well.
+  // Prisma enables the pragma, so the two disagree about the *table* — #89, and
+  // the reason this case compares `User` alone rather than asserting a
+  // difference that is really about foreign keys.
+  ["delete with _count", "delete", {
+    where: { publicId: "p1" },
+    include: { _count: { select: { accounts: true } } },
   }],
 ];
 

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -425,6 +425,57 @@ function suite(label: string, url?: string) {
       );
     });
 
+    /**
+     * A `_count` beside the `include` that produced the children.
+     *
+     * The count is a correlated subquery inside the write's own `RETURNING`, so
+     * it is evaluated before any `after` step has run — while `include` is
+     * attached after them. Unfixed, the two keys describe the same relation on
+     * the same row and disagree:
+     *
+     *     accounts.length  2
+     *     _count           { accounts: 0 }
+     *
+     * Asserting both in one comparison is the point: a test that checked only
+     * `_count` would pass against a version that also lost the children, and one
+     * that checked only `accounts` never saw the bug at all.
+     */
+    test("a _count beside a nested create counts what the steps wrote", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "counted-nested@example.dev",
+            accounts: {
+              create: [{ organizationRole: 1 }, { organizationRole: 2 }],
+            },
+          },
+          include: {
+            accounts: true,
+            _count: { select: { accounts: true } },
+          },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /** The same, through `select`, where `_count` is the only key asked for. */
+    test("a _count in a select sees the nested create too", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "counted-select@example.dev",
+            accounts: { create: { organizationRole: 1 } },
+          },
+          select: { email: true, _count: { select: { accounts: true } } },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
     test("nested connect on the foreign side repoints the child", async () => {
       await differential.reset();
       await differential.prisma.account.create({


### PR DESCRIPTION
Closes #87.

## The failure

`planRelationCounts` was called from `compile/read.ts` and nowhere else, so a `_count` in the `include` of a `create` / `update` / `delete` / `upsert` was never compiled. The statement ran, the row came back, and the key the caller asked for was absent — with no error:

```
include: { nosuchrelation: true }   ->  UnknownRelationError: 'nosuchrelation' is not a relation
                                        on model User. Known relations: organization, accounts
include: { _count: { … } }          ->  accepted, dropped, no error
```

The write path validated relation names in an `include` and then discarded the one key that is not one.

## Projected, not refused

Both options were on the ticket. Projecting, because both dialects evaluate a correlated subquery inside `RETURNING` — measured through Bun against SQLite and Postgres 16 — so the same plan `compileRead` builds goes straight into the returning list and costs **no second round trip**. The shaper assembles `_count` from the raw row exactly as the read path does, deliberately spelled the same way rather than abstracted.

## `delete` is where the dialects disagree

This is the part that needed more than plumbing. Under `on delete cascade`:

| | `delete … returning (select count(*) from ch …)` |
| --- | --- |
| Postgres | **3** — pre-statement snapshot, which is what Prisma returns |
| SQLite | **0** — evaluated after the cascade |

So on SQLite the count would come back as a *number*, just the wrong one, with nothing missing and nothing raised.

`$exec` already reads a `delete`'s relations **before** the row goes, inside a transaction — that is the documented fix for the same hazard on `include`. A `_count` now sets a flag that puts the delete on that same path, so the answer is right on both dialects rather than one. It has to be a flag rather than a wider check on `relations`: a count is not a relation plan, so `relations` stays empty for an `include: { _count: … }` on its own.

## Tests

**Seven differential cases** against Prisma, covering `create`, `update` (with `include`, beside a relation, in a `select`, and with a filtered count), `upsert` and `delete`. The `update` / `upsert` / `delete` ones return a **non-zero** count, which is what separates "projected correctly" from "projected as zero" — the seed grows two accounts on Ada so there is a number to be wrong about. Safe for the existing delete cases: `Account_userId_fkey` is `ON DELETE SET NULL`, so removing a user detaches its accounts on both sides rather than failing a constraint.

**Nine unit tests**, including the one that keeps this from being cosmetic: the `where` inside a `_count` is bound, never inlined.

## Finding out why the `delete` case only discriminates on Postgres turned up something worse

Bun's SQLite driver leaves the pragma at SQLite's default and nothing in gemi turns it on:

```
bun sqlite default foreign_keys -> [{"foreign_keys":0}]
```

So on SQLite **no referential action fires at all**: a deleted user's accounts keep pointing at it, `ON DELETE RESTRICT` does not restrict, and `ON DELETE CASCADE` silently does nothing. Prisma enables the pragma. Measured through the harness — one statement each, one database:

```
                    Account.userId after deleting the user
prisma (fk on)      null, null
gemi   (fk off)     1, 1
```

Filed as **#89**. It is why the `delete with _count` case compares `User` alone rather than `["User", "Account"]` — it could not distinguish a `_count` bug from a foreign-key one, and asserting the wrong thing loudly is worse than asserting less.

It went unnoticed because the harness compares the *written* model's table by default, and no case had ever read a child table back after a parent write.

## Verification

887 unit tests. Full template suite green on SQLite (461 passed) and Postgres 16 (703 passed), with only the pre-existing `generated.test.ts` generator-linkage probe failing — it fails on the base branch too. `tsc` clean; oxlint clean apart from two pre-existing warnings in `where.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
