### PR TITLE
SQLite enforces foreign keys, like every other dialect

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -121,6 +121,13 @@ const user = await User.findUniqueOrThrow({
 type-checks, `user.name` does not. A key outside the operation's argument type collapses to
 `never` rather than being quietly accepted.
 
+**Foreign keys are enforced on both dialects.** SQLite leaves `pragma foreign_keys` off by
+default and so does Bun's driver, so gemi turns it on for every SQLite connection — otherwise a
+`references` in your migration would mean nothing there while meaning everything on Postgres. An
+insert naming a parent that does not exist is refused, and `onDelete: Cascade` / `SetNull` actually
+run. If you have been developing against SQLite, writes that quietly succeeded may now raise; they
+were already raising in production.
+
 Queries return **plain objects**, never class instances. That is the default and it is not a
 stepping stone: a `Pick<User, "id">` hydrated as a `User` would carry methods reading fields the
 query never fetched. See [Rows and entities](./orm-rows-and-entities.md) for the two opt-in levels

--- a/packages/gemi/database/DatabaseManager.test.ts
+++ b/packages/gemi/database/DatabaseManager.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { DatabaseManager } from "./DatabaseManager";
+
+/**
+ * `pragma foreign_keys` on a SQLite connection (#89).
+ *
+ * SQLite defaults it **off** and so does Bun's driver, which reports `0` on a
+ * fresh connection. With it off SQLite enforces nothing: an insert naming a
+ * parent that does not exist is accepted, a dangling reference survives the
+ * parent's delete, and `ON DELETE RESTRICT` does not restrict — while the
+ * migrations declare all three and Postgres enforces them always.
+ *
+ * These run against a real file rather than `:memory:`, because a foreign key
+ * needs two tables that outlive one statement, and because the file case is the
+ * one an application actually has.
+ */
+describe("sqlite foreign keys", () => {
+  const workspaces: string[] = [];
+
+  afterEach(() => {
+    for (const path of workspaces.splice(0)) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  /** The pragma's value, read off whichever connection served the statement. */
+  async function enabled(db: DatabaseManager) {
+    const rows = (await db.sql.unsafe(`pragma foreign_keys`)) as any;
+    return rows[0].foreign_keys;
+  }
+
+  function manager() {
+    const workspace = mkdtempSync(join(tmpdir(), "gemi-fk-"));
+    workspaces.push(workspace);
+    return new DatabaseManager({ url: `sqlite://${join(workspace, "t.db")}` });
+  }
+
+  async function schema(db: DatabaseManager) {
+    await db.sql.unsafe(`create table parent (id integer primary key)`);
+    await db.sql.unsafe(
+      `create table child (
+         id integer primary key,
+         pid integer references parent(id) on delete cascade
+       )`,
+    );
+    await db.sql.unsafe(`create table detachable (
+       id integer primary key,
+       pid integer references parent(id) on delete set null
+     )`);
+    await db.sql.unsafe(`insert into parent (id) values (1)`);
+  }
+
+  test("it is on", async () => {
+    const db = manager();
+    expect(await enabled(db)).toBe(1);
+    await db.close();
+  });
+
+  /**
+   * The constructor is synchronous and the pragma is a statement, so it cannot
+   * be awaited before returning. What makes that safe is that SQLite queues
+   * statements on one connection in the order they were issued — so a caller
+   * that queries immediately is already behind it.
+   *
+   * Asserted rather than assumed: this is the half that breaks first if Bun
+   * ever serves SQLite from a pool.
+   */
+  test("a query issued immediately after construction is already behind it", async () => {
+    const db = manager();
+    const [rows] = await Promise.all([
+      db.sql.unsafe(`pragma foreign_keys`) as Promise<any>,
+      db.ready,
+    ]);
+    expect(rows[0].foreign_keys).toBe(1);
+    await db.close();
+  });
+
+  /** The other half: one connection, so every statement sees the same answer. */
+  test("concurrent queries all see it", async () => {
+    const db = manager();
+    const results = await Promise.all(
+      Array.from({ length: 32 }, () => db.sql.unsafe(`pragma foreign_keys`)),
+    );
+    expect(new Set(results.map((rows: any) => rows[0].foreign_keys))).toEqual(
+      new Set([1]),
+    );
+    await db.close();
+  });
+
+  test("an insert naming a parent that does not exist is refused", async () => {
+    const db = manager();
+    await schema(db);
+
+    await expect(
+      db.sql.unsafe(`insert into child (pid) values (999)`),
+    ).rejects.toThrow(/FOREIGN KEY constraint failed/);
+
+    await db.close();
+  });
+
+  test("on delete cascade removes the children", async () => {
+    const db = manager();
+    await schema(db);
+    await db.sql.unsafe(`insert into child (pid) values (1), (1)`);
+
+    await db.sql.unsafe(`delete from parent where id = 1`);
+
+    const remaining = (await db.sql.unsafe(
+      `select count(*) as c from child`,
+    )) as any;
+    expect(remaining[0].c).toBe(0);
+    await db.close();
+  });
+
+  test("on delete set null detaches them instead", async () => {
+    const db = manager();
+    await schema(db);
+    await db.sql.unsafe(`insert into detachable (pid) values (1)`);
+
+    await db.sql.unsafe(`delete from parent where id = 1`);
+
+    const detached = (await db.sql.unsafe(`select pid from detachable`)) as any;
+    expect(detached[0].pid).toBeNull();
+    await db.close();
+  });
+
+  /**
+   * The pragma is documented as a no-op *inside* a transaction, which is why it
+   * is issued from the constructor rather than lazily on first use — a lazy
+   * version would be correct until the first use happened to be a transaction.
+   */
+  test("it holds inside a transaction, and after one", async () => {
+    const db = manager();
+    await schema(db);
+
+    await db.sql.begin(async (tx: any) => {
+      expect((await tx.unsafe(`pragma foreign_keys`))[0].foreign_keys).toBe(1);
+      await expect(
+        tx.unsafe(`insert into child (pid) values (999)`),
+      ).rejects.toThrow(/FOREIGN KEY constraint failed/);
+    });
+
+    expect(await enabled(db)).toBe(1);
+    await db.close();
+  });
+});

--- a/packages/gemi/database/DatabaseManager.ts
+++ b/packages/gemi/database/DatabaseManager.ts
@@ -17,6 +17,18 @@ export class DatabaseManager {
   public readonly dialect: Dialect;
   public readonly url: string;
 
+  /**
+   * Resolves once the connection has been configured, or rejects if it could
+   * not be. Only SQLite has anything to do; elsewhere it is already resolved.
+   *
+   * Exposed so a caller that needs the guarantee can wait for it. Nothing has
+   * to: SQLite queues statements on one connection in the order they were
+   * issued, so the pragma below is ahead of anything a caller sends after the
+   * constructor returns. That ordering is asserted in `DatabaseManager.test.ts`
+   * rather than assumed, because it is the load-bearing half.
+   */
+  public readonly ready: Promise<void>;
+
   constructor(public config: DatabaseConfig = {}) {
     const url = config.url;
     if (!url) {
@@ -31,6 +43,43 @@ export class DatabaseManager {
     this.sql = config.options
       ? new SQL(url, config.options as any)
       : new SQL(url);
+    this.ready = this.configure();
+  }
+
+  /**
+   * `pragma foreign_keys = ON`, which SQLite leaves **off** by default — and so
+   * does Bun's driver, which reports `0` on a fresh connection.
+   *
+   * Without it SQLite enforces nothing at all. Not "cascades do not fire":
+   * nothing. An insert naming a parent that does not exist is accepted, a
+   * dangling reference survives the parent's deletion, and `ON DELETE RESTRICT`
+   * does not restrict — while the migrations declare all three. Postgres
+   * enforces them always, and Prisma turns the pragma on for every SQLite
+   * connection it opens, so leaving it off meant development and production
+   * disagreed about whether the schema's constraints were real.
+   *
+   * It is also why this is more than a dialect gap. The differential harness
+   * compares gemi against Prisma on one database per dialect; with the pragma
+   * off on one side, the two were being asked to agree while running under
+   * different integrity rules, so an entire class of divergence was invisible
+   * to the instrument rather than merely untested.
+   *
+   * **Per connection, not per database**, which is what makes this a live
+   * assumption rather than a one-line fix: Bun serves SQLite from a single
+   * connection today, so setting it once holds for every later statement. If
+   * that ever becomes a pool, one statement's worth of enforcement would move
+   * to whichever connection happened to serve it. `DatabaseManager.test.ts`
+   * pins both halves — the value, and that it is the same across concurrent
+   * queries — so the day it changes is a failing test rather than a silent
+   * regression.
+   *
+   * Issued outside any transaction. SQLite documents the pragma as a no-op
+   * inside one, so a lazy "set it on first use" would be correct exactly until
+   * the first use happened to be a transaction.
+   */
+  private async configure(): Promise<void> {
+    if (this.dialect !== "sqlite") return;
+    await this.sql.unsafe("pragma foreign_keys = ON");
   }
 
   // Escape hatch matching Bun's own API, so `db.query` reads like `sql` does in

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -229,6 +229,39 @@ const CASES: Case[] = [
     update: { name: "Updated" },
     select: { email: true, name: true },
   }],
+
+  // --- foreign keys (#89) -----------------------------------------------
+  //
+  // Every one of these **succeeded on SQLite** before the pragma was turned on,
+  // writing a row that points at an organisation which does not exist, while
+  // Prisma refused it. They are in the shared matrix rather than a Postgres-only
+  // block precisely because the dialect that used to be wrong is the default
+  // one.
+  ["create naming a parent that does not exist", "create", {
+    data: { email: "orphan@example.dev", organizationId: 99999 },
+  }],
+  ["createMany naming a parent that does not exist", "createMany", {
+    data: [
+      { email: "orphan2@example.dev" },
+      { email: "orphan3@example.dev", organizationId: 99999 },
+    ],
+  }],
+  ["update repointing at a parent that does not exist", "update", {
+    where: { id: 1 }, data: { organizationId: 99999 },
+  }],
+  ["upsert inserting against a parent that does not exist", "upsert", {
+    where: { email: "orphan4@example.dev" },
+    create: { email: "orphan4@example.dev", organizationId: 99999 },
+    update: { name: "Updated" },
+  }],
+  // The nested form, where the foreign key is written by an `after` step rather
+  // than by the statement itself — a different code path to the same constraint.
+  ["nested create naming a parent that does not exist", "create", {
+    data: {
+      email: "orphan5@example.dev",
+      accounts: { create: { organizationRole: 1, organizationId: 99999 } },
+    },
+  }, ["User", "Account"]],
 ];
 
 function suite(label: string, url?: string) {


### PR DESCRIPTION
Closes #89.

## The failure

SQLite leaves `pragma foreign_keys` off by default and so does Bun's driver. Nothing in gemi turned it on, so on SQLite **nothing was enforced at all** — not "cascades did not fire":

```
pragma foreign_keys                                     ->  0
insert into child (pid) values (999)   -- no such parent   ->  ACCEPTED
delete from parent where id = 1        -- on delete cascade
select * from child                                     ->  [{pid:1}, {pid:999}]
```

An orphan inserted happily, a dangling reference survived the parent's delete, and `ON DELETE RESTRICT` did not restrict — while the migrations declare all three and Postgres enforces them always.

## Why it is worse than a dialect gap

The differential harness compares gemi against Prisma on one database per dialect, and **Prisma enables the pragma**. So the two clients were being asked to agree while running under different integrity rules: any case where gemi would violate a declared constraint passed on SQLite by not checking. A whole class of divergence was invisible to the instrument rather than merely untested — which is why this was worth doing before the `_count` work it was found by.

## The fix, and the two things it rests on

`pragma foreign_keys = ON` from the constructor. Two decisions worth naming:

- **From the constructor, not lazily.** SQLite documents the pragma as a no-op *inside* a transaction, so a "set it on first use" version would have been correct exactly until the first use happened to be a transaction.
- **Not awaited, and that needed proving.** The constructor is synchronous; the pragma is a statement. What makes it safe is that SQLite queues statements on one connection in the order they were issued, so a caller that queries immediately is already behind it. Both halves are asserted rather than assumed — the value, and that 32 concurrent queries agree on it — because they are exactly what breaks if Bun ever serves SQLite from a pool. `ready` is exposed for a caller that would rather have the guarantee than the argument.

## Tests

**Seven unit tests**, every one verified red against the unset pragma: the value, the ordering guarantee, a refused orphan insert, `ON DELETE CASCADE`, `ON DELETE SET NULL`, and a violated key inside a transaction.

**Five differential cases**, in the **shared** matrix rather than a Postgres-only block — because the dialect that used to be wrong is the default one:

```
× create naming a parent that does not exist
× createMany naming a parent that does not exist
× update repointing at a parent that does not exist
× upsert inserting against a parent that does not exist
× nested create naming a parent that does not exist
```

(shown failing against the old behaviour). Each succeeded on SQLite before this and refused on Postgres. The last writes its foreign key from an `after` step rather than from the statement itself, which is a different code path to the same constraint.

## The behaviour change

The full template suite passes with enforcement on — no fixture writes a child before its parent — so this lands without a test migration. Applications developing against SQLite may see writes start to raise that quietly succeeded. **Those were already raising in production**, which is the argument for the change rather than against it, and `docs/orm.md` says so.

## Notes for merge order

- The referential-action half is covered here at the SQL level on both actions. Its *differential* form needs children in the seed, which #90 adds — once that merges, its `delete with _count` case can widen from `["User"]` back to `["User", "Account"]`, which is the line #89's acceptance list asks for. #90 also becomes better tested by this change: with `SET NULL` actually firing, its read-before-delete path becomes load-bearing on SQLite too, not only on Postgres.
- A foreign-key violation currently lands in the harness's `other` failure kind on both sides, so the cases compare "both threw" rather than "both threw the same typed error". A `ForeignKeyConstraintError` mirroring `UniqueConstraintError` would sharpen that; out of scope here.

## Verification

910 unit tests. Full template suite green on SQLite (459) and Postgres 16 (701), with only the pre-existing `generated.test.ts` generator-linkage probe failing — it fails on the base branch too. `tsc` clean; oxlint clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
