### PR TITLE
`groupBy`, and the four rules that are not what the arguments suggest

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -100,7 +100,7 @@ read. It can only see modules you hand it, so it does not replace the `register`
 Fourteen operations, with Prisma's argument types verbatim:
 
 ```
-findMany   findFirst   findFirstOrThrow   findUnique   findUniqueOrThrow   count   aggregate
+findMany   findFirst   findFirstOrThrow   findUnique   findUniqueOrThrow   count   aggregate   groupBy
 create     createMany  update             updateMany   upsert              delete   deleteMany
 ```
 
@@ -171,9 +171,37 @@ await User.count({ select: { _all: true, email: true } })  // { _all: 3, email: 
 Results are typed by Prisma's own mapped types, so `_max: { position: true }` narrows to
 `{ _max: { position: number | null } }` and nothing else.
 
-**`groupBy` is not implemented.** `having` is a predicate compiler over aggregate expressions rather
-than columns, which is its own piece of work; shipping half of it typed as though it worked would be
-worse than not shipping it.
+### `groupBy`
+
+```ts
+const perOperation = await Usage.groupBy({
+  by: ["operation"],                       // or "operation" — Prisma takes both
+  where: { occurredAt: { gte: since } },
+  _sum: { credits: true },
+  _count: true,
+  having: { credits: { _sum: { gt: 0 } } },
+  orderBy: { _count: { operation: "desc" } },
+})
+// [{ operation: "render", _count: 42, _sum: { credits: 1200 } }, …]
+```
+
+The grouped columns come back flat and the aggregates nested under their kind, which is Prisma's
+shape. Four rules are worth knowing because they are not what the arguments suggest:
+
+- **`orderBy` may only name grouped columns — or an aggregate.** A group has one value for a column
+  in `by` and many for everything else, so ordering by anything else is a question with no answer.
+  SQLite answers it anyway, by picking an arbitrary row's value, so this is refused rather than
+  passed through. `orderBy: { _count: { field: "desc" } }` is the top-N-by-count query and is fine.
+- **`orderBy` is optional.** `groupBy` with none is a legal query.
+- **`having` filters groups, `where` filters rows.** `having: { role: { gt: 0 } }` needs `role` to be
+  in `by`; `having: { email: { _count: { gt: 1 } } }` does not, because a count has one value per
+  group either way. That split is Prisma's, and it is easy to read as stricter than it is.
+- **`take` / `skip` page the groups**, not the rows — unlike `aggregate`, where they page the rows
+  being aggregated.
+
+One divergence, and it is a refusal rather than a difference: `having: { role: { gt: 0, _count: { gt: 1 } } }`
+mixes a column comparison and an aggregate filter under one key. Prisma's query engine panics on that
+shape rather than answering it, so there is no behaviour to match — spell it as an `AND` of the two.
 
 ### Per-call options
 

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -555,9 +555,20 @@ function countOperation(model: string): string {
  * here: the types are Prisma's own, so narrowing stays exact and there is no
  * second definition of the shape to drift.
  *
- * `groupBy` is deliberately not beside it. `having` is a predicate compiler over
- * aggregate expressions rather than columns, and shipping half of it typed as
- * though it worked would be worse than not shipping it.
+ * `groupBy` is beside it now, and its typing is the awkward one.
+ *
+ * Prisma's `groupBy` signature is not a plain `Subset`: it carries a conditional
+ * that reports a *missing* `by` field in `orderBy` as a type error naming the
+ * field. Reproducing that machinery would mean copying a large conditional out
+ * of the generated client, where it would then be a second definition free to
+ * drift from the first — the thing every other operation here avoids.
+ *
+ * So the args type is Prisma's `${model}GroupByArgs` directly and the return is
+ * its `Get${model}GroupByPayload<T>`, which still narrows the payload exactly.
+ * The `orderBy`-must-be-in-`by` rule is enforced at runtime instead, with a
+ * message naming the field and saying why — see `compile/group-by.ts`. A
+ * compile-time error would be better; a *wrong* compile-time error, or a silent
+ * one, would be worse than a precise runtime refusal.
  */
 function aggregateOperation(model: string): string {
   return `
@@ -566,6 +577,14 @@ function aggregateOperation(model: string): string {
   ): Promise<Prisma.Get${model}AggregateType<T>> {
     return this.$exec("aggregate", args) as Promise<
       Prisma.Get${model}AggregateType<T>
+    >;
+  }
+
+  static groupBy<T extends Prisma.${model}GroupByArgs>(
+    args: Prisma.Subset<T, Prisma.${model}GroupByArgs>,
+  ): Promise<Prisma.Get${model}GroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.Get${model}GroupByPayload<T>
     >;
   }
 `;

--- a/packages/gemi/orm/compile/aggregate.ts
+++ b/packages/gemi/orm/compile/aggregate.ts
@@ -46,8 +46,8 @@ import { compileWhere } from "./where";
  */
 
 /** The aggregate functions Prisma exposes, in the order it returns them. */
-const KINDS = ["_count", "_avg", "_sum", "_min", "_max"] as const;
-type Kind = (typeof KINDS)[number];
+export const KINDS = ["_count", "_avg", "_sum", "_min", "_max"] as const;
+export type Kind = (typeof KINDS)[number];
 
 const AGGREGATE_ARGS = new Set<string>([
   "where",
@@ -73,7 +73,7 @@ const NUMERIC = new Set<ScalarType>(["Int", "Float", "BigInt", "Decimal"]);
 const UNORDERABLE = new Set<ScalarType>(["Json", "Bytes"]);
 
 /** The SQL function each kind compiles to. */
-const FUNCTION: Record<Kind, string> = {
+export const FUNCTION: Record<Kind, string> = {
   _count: "count",
   _avg: "avg",
   _sum: "sum",
@@ -81,7 +81,7 @@ const FUNCTION: Record<Kind, string> = {
   _max: "max",
 };
 
-interface Term {
+export interface Term {
   kind: Kind;
   /** Absent for `_count`'s `_all`, which is `count(*)`. */
   field?: FieldSchema;
@@ -234,9 +234,9 @@ export function compileAggregate(
 }
 
 /** The `as` a bare `_count: true` carries, which no field name can be. */
-const BARE = "";
+export const BARE = "";
 
-function aggregateTerms(
+export function aggregateTerms(
   schema: ModelSchema,
   op: string,
   args: any,
@@ -315,7 +315,7 @@ function countSelectTerms(schema: ModelSchema, op: string, select: any): Term[] 
  */
 const alias = (kind: Kind, index: number) => `${kind}_${index}`;
 
-function resolveField(
+export function resolveField(
   schema: ModelSchema,
   op: string,
   kind: Kind,
@@ -339,7 +339,7 @@ function resolveField(
   return field;
 }
 
-function assertAggregable(
+export function assertAggregable(
   schema: ModelSchema,
   op: string,
   kind: Kind,
@@ -403,7 +403,11 @@ function assertAggregable(
  *   dialect's own `decode` is exactly right. It is what turns SQLite's integer
  *   milliseconds back into a `Date`.
  */
-function coerce(term: Term, value: unknown, dialect: SqlDialect): unknown {
+export function coerce(
+  term: Term,
+  value: unknown,
+  dialect: SqlDialect,
+): unknown {
   if (term.kind === "_count") return Number(value ?? 0);
 
   // Every other aggregate is null over an empty set, and per field.

--- a/packages/gemi/orm/compile/group-by.test.ts
+++ b/packages/gemi/orm/compile/group-by.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { PostgresDialect } from "../dialect/postgres";
+import { SqliteDialect } from "../dialect/sqlite";
+import { UnknownFieldError, UnsupportedQueryError } from "../errors";
+import { account, organization, user } from "../fixtures";
+import * as registry from "../registry";
+import { compileGroupBy } from "./group-by";
+
+/**
+ * `groupBy` — the half of #64 that `aggregate` did not cover.
+ *
+ * The differential harness owns "does it match Prisma" for the shapes the
+ * template's schema can reach. What lives here is the SQL and the refusals: the
+ * `having` compiler, the `orderBy` restriction, and the argument validation,
+ * none of which a result comparison can see the reasoning of.
+ */
+
+const sqlite = new SqliteDialect();
+const postgres = new PostgresDialect();
+
+beforeEach(() => {
+  registry.clearRegistry();
+  registry.register("User", class { static $schema = user });
+  registry.register("Account", class { static $schema = account });
+  registry.register("Organization", class { static $schema = organization });
+});
+
+afterEach(() => registry.clearRegistry());
+
+const plan = (args: any, dialect = sqlite) =>
+  compileGroupBy(user, "groupBy", args, dialect);
+const text = (args: any, dialect = sqlite) => plan(args, dialect).text;
+
+describe("what it emits", () => {
+  test("the grouped column is projected and grouped by", () => {
+    expect(text({ by: ["globalRole"], _count: true })).toBe(
+      `select "globalRole" as "_by_0", count(*) as "_count_0" from "User" ` +
+        `group by "globalRole"`,
+    );
+  });
+
+  // Prisma accepts both, and the string form is what a caller reaches for with
+  // one field. Measured against a live client rather than read off the types,
+  // which look array-only.
+  test("by takes a bare string as well as an array", () => {
+    expect(text({ by: "globalRole", _count: true })).toBe(
+      text({ by: ["globalRole"], _count: true }),
+    );
+  });
+
+  test("several grouped columns keep their order", () => {
+    expect(text({ by: ["globalRole", "locale"], _count: true })).toContain(
+      `group by "globalRole", "locale"`,
+    );
+  });
+
+  test("every aggregate kind compiles to its function", () => {
+    const emitted = text({
+      by: ["globalRole"],
+      _count: { _all: true },
+      _sum: { globalRole: true },
+      _avg: { globalRole: true },
+      _min: { createdAt: true },
+      _max: { createdAt: true },
+    });
+
+    expect(emitted).toContain(`count(*)`);
+    expect(emitted).toContain(`sum("globalRole")`);
+    expect(emitted).toContain(`avg("globalRole")`);
+    expect(emitted).toContain(`min("createdAt")`);
+    expect(emitted).toContain(`max("createdAt")`);
+  });
+
+  /**
+   * Unlike `aggregate`, which wraps its rows in a subquery so the `limit` does
+   * not cap the single result row, a `limit` after `group by` already means
+   * "this many groups" — which is what Prisma means too.
+   */
+  test("take and skip page the groups, with no subquery", () => {
+    const args = { by: ["globalRole"], _count: true, take: 2, skip: 1 };
+    const emitted = text(args);
+
+    expect(emitted.match(/select /g)).toHaveLength(1);
+    expect(emitted).toContain(`group by "globalRole" limit ? offset ?`);
+    expect(plan(args).bind(args)).toEqual([2, 1]);
+  });
+
+  test("a where filters rows before grouping, and binds", () => {
+    const args = { by: ["globalRole"], _count: true, where: { locale: "fr-FR" } };
+    expect(text(args)).toContain(`where "locale" = ? group by`);
+    expect(plan(args).bind(args)).toEqual(["fr-FR"]);
+  });
+
+  test("postgres numbers the placeholders", () => {
+    const args = { by: ["globalRole"], _count: true, where: { locale: "x" }, take: 1 };
+    expect(text(args, postgres)).toContain(`where "locale" = $1`);
+    expect(text(args, postgres)).toContain(`limit $2`);
+  });
+});
+
+describe("having", () => {
+  test("an aggregate filter compiles to a function, not a column", () => {
+    const args = { by: ["globalRole"], _count: true, having: { globalRole: { _count: { gt: 1 } } } };
+    expect(text(args)).toContain(`having count("globalRole") > ?`);
+    expect(plan(args).bind(args)).toEqual([1]);
+  });
+
+  test("a plain filter on a grouped column compiles to the column", () => {
+    const args = { by: ["globalRole"], _count: true, having: { globalRole: { gt: 0 } } };
+    expect(text(args)).toContain(`having "globalRole" > ?`);
+    expect(plan(args).bind(args)).toEqual([0]);
+  });
+
+  test("a bare value is equals, the shorthand where accepts", () => {
+    const args = { by: ["globalRole"], _count: true, having: { globalRole: 2 } };
+    expect(text(args)).toContain(`having "globalRole" = ?`);
+    expect(plan(args).bind(args)).toEqual([2]);
+  });
+
+  test("AND, OR and NOT nest", () => {
+    const args = {
+      by: ["globalRole"],
+      _count: true,
+      having: {
+        OR: [{ globalRole: { equals: 0 } }, { globalRole: { _count: { gt: 1 } } }],
+      },
+    };
+    expect(text(args)).toContain(
+      `having ("globalRole" = ? or count("globalRole") > ?)`,
+    );
+    expect(plan(args).bind(args)).toEqual([0, 1]);
+  });
+
+  test("null is IS NULL rather than a bound comparison", () => {
+    const args = { by: ["name"], _count: true, having: { name: { equals: null } } };
+    expect(text(args)).toContain(`having "name" is null`);
+    expect(plan(args).bind(args)).toEqual([]);
+  });
+
+  /**
+   * Prisma: *"Every field used in `having` filters must either be an
+   * aggregation filter or be included in the selection of the query"*. SQL
+   * would reject the bare-column form too, but with a message naming neither
+   * the argument nor the model — and the *aggregate* form is legal SQL, so
+   * without this it would silently be allowed where Prisma refuses.
+   */
+  test("a plain filter on an ungrouped column is refused", () => {
+    expect(() =>
+      text({ by: ["globalRole"], _count: true, having: { locale: { equals: "x" } } }),
+    ).toThrow(/is not in 'by'/);
+  });
+
+  /**
+   * The other half of the same sentence, and the half that is easy to get
+   * wrong: an *aggregate* over an ungrouped column is accepted, because
+   * `count(locale)` has one value per group whether or not `locale` is grouped.
+   * Measured against a live Prisma client rather than inferred from the refusal
+   * above — reading that message as "the field must be in `by`" would refuse a
+   * query Prisma answers.
+   */
+  test("an aggregate filter on an ungrouped column is allowed", () => {
+    expect(
+      text({ by: ["globalRole"], _count: true, having: { locale: { _count: { gt: 1 } } } }),
+    ).toContain(`having count("locale") > ?`);
+  });
+
+  /**
+   * Prisma's query engine panics on this shape — `internal error: entered
+   * unreachable code` — so there is no behaviour to match and nothing to
+   * differentially test against. Refused by name, with the spelling that works.
+   */
+  test("mixing a plain and an aggregate filter on one key is refused", () => {
+    expect(() =>
+      text({
+        by: ["globalRole"],
+        _count: true,
+        having: { globalRole: { gt: 0, _count: { gt: 1 } } },
+      }),
+    ).toThrow(/not both/);
+  });
+
+  test("an unknown operator names itself", () => {
+    expect(() =>
+      text({ by: ["globalRole"], _count: true, having: { globalRole: { contains: 1 } } }),
+    ).toThrow(/having.globalRole.contains/);
+  });
+
+  test("no value reaches the SQL text", () => {
+    const args = {
+      by: ["globalRole"],
+      _count: true,
+      having: {
+        AND: [{ globalRole: { gt: 7 } }, { globalRole: { _count: { lte: 9 } } }],
+      },
+    };
+    expect(text(args)).not.toContain("7");
+    expect(text(args)).not.toContain("9");
+    expect(plan(args).bind(args)).toEqual([7, 9]);
+  });
+});
+
+describe("orderBy", () => {
+  test("a grouped column orders by that column", () => {
+    expect(text({ by: ["globalRole"], _count: true, orderBy: { globalRole: "desc" } })).toContain(
+      `order by "globalRole" desc`,
+    );
+  });
+
+  test("an aggregate orders by the function", () => {
+    expect(
+      text({ by: ["globalRole"], _count: true, orderBy: { _count: { globalRole: "desc" } } }),
+    ).toContain(`order by count("globalRole") desc`);
+  });
+
+  test("_count._all orders by count(*)", () => {
+    expect(
+      text({ by: ["globalRole"], _count: true, orderBy: { _count: { _all: "asc" } } }),
+    ).toContain(`order by count(*) asc`);
+  });
+
+  /**
+   * Prisma: *"Every field used for orderBy must be included in the
+   * by-arguments of the query"*. A group has one value for a grouped column and
+   * many for everything else, so ordering by an ungrouped one is a question
+   * with no answer — and SQLite answers it anyway, by picking an arbitrary
+   * row's value. A silently arbitrary order is worse than a refusal.
+   */
+  test("an ungrouped column is refused rather than silently arbitrary", () => {
+    expect(() =>
+      text({ by: ["globalRole"], _count: true, orderBy: { email: "asc" } }),
+    ).toThrow(/is not in 'by'/);
+  });
+
+  test("ordering by a subset of the grouped columns is fine", () => {
+    expect(
+      text({ by: ["globalRole", "locale"], _count: true, orderBy: { locale: "asc" } }),
+    ).toContain(`order by "locale" asc`);
+  });
+
+  /**
+   * #64 predicted Prisma would require an `orderBy` whenever `by` is given.
+   * Measured against a live client, it does not — so requiring one here would
+   * have refused a legal query.
+   */
+  test("it is optional", () => {
+    expect(text({ by: ["globalRole"], _count: true })).not.toContain("order by");
+  });
+
+  test("a direction outside the closed set is refused", () => {
+    expect(() =>
+      text({ by: ["globalRole"], _count: true, orderBy: { globalRole: "sideways" } }),
+    ).toThrow(UnsupportedQueryError);
+    expect(() =>
+      text({ by: ["globalRole"], _count: true, orderBy: { globalRole: "asc; drop table User" } }),
+    ).toThrow(UnsupportedQueryError);
+  });
+
+  test("an unknown column is an unknown field, not a group error", () => {
+    expect(() =>
+      text({ by: ["globalRole"], _count: true, orderBy: { nope: "asc" } }),
+    ).toThrow(UnknownFieldError);
+  });
+});
+
+describe("arguments", () => {
+  test("by is required", () => {
+    expect(() => text({ _count: true })).toThrow(/requires 'by'/);
+    expect(() => text(undefined)).toThrow(/requires 'by'/);
+  });
+
+  test("an empty by is refused, naming the operation that would fit", () => {
+    expect(() => text({ by: [], _count: true })).toThrow(/nothing to group/);
+  });
+
+  test("an unknown grouped field is an unknown field", () => {
+    expect(() => text({ by: ["nope"], _count: true })).toThrow(UnknownFieldError);
+  });
+
+  test("a relation cannot be grouped by", () => {
+    expect(() => text({ by: ["accounts"], _count: true })).toThrow(/is a relation/);
+  });
+
+  test("an unsupported argument names itself", () => {
+    expect(() => text({ by: ["globalRole"], include: { accounts: true } })).toThrow(
+      /include/,
+    );
+  });
+
+  /** A duplicate would return the column twice under one key. */
+  test("a repeated grouped field is grouped once", () => {
+    expect(text({ by: ["globalRole", "globalRole"], _count: true })).toBe(
+      text({ by: ["globalRole"], _count: true }),
+    );
+  });
+
+  /** Legal in Prisma: the groups themselves, with nothing aggregated. */
+  test("no aggregate at all is legal", () => {
+    expect(text({ by: ["globalRole"] })).toBe(
+      `select "globalRole" as "_by_0" from "User" group by "globalRole"`,
+    );
+  });
+});
+
+describe("shaping", () => {
+  test("grouped columns are flat and aggregates are nested", () => {
+    const compiled = plan({
+      by: ["globalRole"],
+      _count: true,
+      _sum: { globalRole: true },
+    });
+
+    expect(compiled.shape([{ _by_0: 1, _count_0: 3, _sum_1: 9 }])).toEqual([
+      { globalRole: 1, _count: 3, _sum: { globalRole: 9 } },
+    ]);
+  });
+
+  test("_count over fields is an object, like aggregate's", () => {
+    const compiled = plan({ by: ["globalRole"], _count: { _all: true, email: true } });
+    expect(compiled.shape([{ _by_0: 0, _count_0: 3, _count_1: 2 }])).toEqual([
+      { globalRole: 0, _count: { _all: 3, email: 2 } },
+    ]);
+  });
+
+  test("many groups come back as many objects", () => {
+    const compiled = plan({ by: ["globalRole"], _count: true });
+    expect(
+      compiled.shape([
+        { _by_0: 0, _count_0: 3 },
+        { _by_0: 1, _count_0: 1 },
+      ]),
+    ).toEqual([
+      { globalRole: 0, _count: 3 },
+      { globalRole: 1, _count: 1 },
+    ]);
+  });
+
+  /**
+   * The grouped column is a *value of the column*, so the dialect's own decode
+   * applies — which is what turns SQLite's integer milliseconds back into a
+   * `Date`. Grouping by a `DateTime` is unusual and getting it wrong would be
+   * silent: a number where Prisma returns a date.
+   */
+  test("a grouped column is decoded by the dialect", () => {
+    const compiled = plan({ by: ["createdAt"], _count: true });
+    const [row] = compiled.shape([{ _by_0: 1600000000000, _count_0: 1 }]) as any[];
+    expect(row.createdAt).toBeInstanceOf(Date);
+    expect(row.createdAt.toISOString()).toBe("2020-09-13T12:26:40.000Z");
+  });
+
+  test("no groups is an empty array, not null", () => {
+    expect(plan({ by: ["globalRole"], _count: true }).shape([])).toEqual([]);
+  });
+});

--- a/packages/gemi/orm/compile/group-by.ts
+++ b/packages/gemi/orm/compile/group-by.ts
@@ -1,0 +1,684 @@
+import type { SqlDialect } from "../dialect";
+import { UnknownFieldError, UnsupportedQueryError } from "../errors";
+import type { QueryPlan } from "../plan";
+import type { FieldSchema, ModelSchema } from "../schema";
+import {
+  BARE,
+  FUNCTION,
+  KINDS,
+  type Kind,
+  type Term,
+  aggregateTerms,
+  assertAggregable,
+  coerce,
+  resolveField,
+} from "./aggregate";
+import {
+  type Fragment,
+  bindValues,
+  concat,
+  joinFragments,
+  param,
+  render,
+  sql,
+} from "./fragment";
+import { pagination } from "./paginate";
+import { compileWhere } from "./where";
+
+/**
+ * `groupBy` — the second half of #64, and the half that is not just `aggregate`
+ * with a `group by` bolted on.
+ *
+ * Three things make it its own compiler rather than a flag on `compileAggregate`:
+ *
+ * - The result is **many rows with a mixed shape**: the grouped columns arrive
+ *   flat, the aggregates arrive nested under their kind, in one object.
+ * - `having` is a second predicate compiler. It filters *groups*, so its
+ *   operands are aggregate expressions as well as columns, and it has to emit
+ *   `count("x") > $1` where `compileWhere` would emit `"x" > $1`.
+ * - `orderBy` is restricted in a way no other operation's is, and it can name an
+ *   aggregate.
+ *
+ * Every rule below was read off a live Prisma 6 client rather than from its
+ * documentation, because several of them are not what the shape suggests — most
+ * of all that `orderBy` is *optional* here, where the issue that asked for this
+ * predicted it would be mandatory.
+ */
+
+const GROUP_BY_ARGS = new Set<string>([
+  "by",
+  "where",
+  "orderBy",
+  "having",
+  "take",
+  "skip",
+  ...KINDS,
+]);
+
+export function isGroupByOperation(op: string): boolean {
+  return op === "groupBy";
+}
+
+/** One grouped column, and the key it comes back under. */
+interface Grouped {
+  field: FieldSchema;
+  alias: string;
+}
+
+/**
+ * **No `ExecOptions`**, for the reason `aggregate` has none: `strategy` chooses
+ * how an include tree loads and there are no relations here, `track` records
+ * where a row came from so `save` can update it and a group is not a row.
+ */
+export function compileGroupBy(
+  schema: ModelSchema,
+  op: string,
+  args: any,
+  dialect: SqlDialect,
+): QueryPlan {
+  assertArgs(schema, op, args);
+
+  const grouped = groupedColumns(schema, op, args?.by);
+  const terms = aggregateTerms(schema, op, args);
+
+  const from = sql(` from ${dialect.quoteIdent(schema.table)}`);
+  const where = compileWhere(schema, args?.where, { dialect, operation: op }, (a) => a?.where);
+  const whereClause = where ? concat(sql(" where "), where) : sql("");
+
+  // The grouped columns first, then the aggregates. Prisma returns them the
+  // other way round in key order, which `shape` reproduces; the *select* list
+  // order is ours and the readable one is grouping first.
+  const projection = joinFragments(
+    [
+      ...grouped.map((column) =>
+        sql(
+          `${dialect.quoteIdent(column.field.column)} as ${dialect.quoteIdent(column.alias)}`,
+        ),
+      ),
+      ...terms.map((term) => sql(functionOf(term, dialect))),
+    ],
+    ", ",
+  );
+
+  const groupClause = concat(
+    sql(" group by "),
+    joinFragments(
+      grouped.map((column) => sql(dialect.quoteIdent(column.field.column))),
+      ", ",
+    ),
+  );
+
+  const having = compileHaving(schema, op, args?.having, grouped, dialect);
+  const havingClause = having ? concat(sql(" having "), having) : sql("");
+
+  const ordering = compileGroupOrdering(schema, op, args?.orderBy, grouped, dialect);
+  const orderClause = ordering ? concat(sql(" order by "), ordering) : sql("");
+
+  // `take` / `skip` page the **groups**, which is what `limit` after `group by`
+  // already means — so unlike `aggregate`, which has to wrap its rows in a
+  // subquery to keep the limit off the single result row, this needs no
+  // subquery at all.
+  //
+  // `parsed` is empty because the ordering above is already compiled: a group's
+  // `order by` may name an aggregate, which `parseOrderBy` has no way to
+  // express. Passing an empty list means `pagination` contributes only the
+  // `limit` / `offset`, and its "paginating with no orderBy sorts by the primary
+  // key" fallback cannot fire — correctly, because the primary key is not
+  // grouped and Prisma does not add one either.
+  //
+  // **This is the fourth pager, and #88 predicted it.** That PR moves `take` /
+  // `skip` validation into `pagination` itself rather than into each caller's
+  // argument allowlist, on the argument that a fourth one should not be able to
+  // arrive without it. On this branch's base it has not merged, so `groupBy`
+  // inherits the #84 behaviour — a string `take` binds its magnitude and does
+  // not flip anything. It gains the check the moment #88 lands, with no change
+  // here, which is the claim being demonstrated rather than restated.
+  const paginating = args?.take !== undefined || args?.skip !== undefined;
+  const page = paginating ? pagination(schema, args, dialect, []).clause : sql("");
+
+  const statement = concat(
+    sql("select "),
+    projection,
+    from,
+    whereClause,
+    groupClause,
+    havingClause,
+    orderClause,
+    page,
+  );
+
+  const { text, binders } = render(statement, dialect, {
+    model: schema.name,
+    operation: op,
+  });
+
+  return {
+    text,
+    bind: bindValues(binders),
+    shape(rows) {
+      return (rows as Record<string, unknown>[]).map((row) => {
+        const out: Record<string, unknown> = {};
+
+        // Aggregates first, then the grouped columns: Prisma's own key order,
+        // which matters only for a caller reading `Object.keys` but costs
+        // nothing to match.
+        for (const term of terms) {
+          if (term.kind === "_count" && term.as === BARE) {
+            out._count = coerce(term, row[term.alias], dialect);
+            continue;
+          }
+          const bucket = (out[term.kind] ??= {}) as Record<string, unknown>;
+          bucket[term.as] = coerce(term, row[term.alias], dialect);
+        }
+
+        for (const column of grouped) {
+          out[column.field.name] = dialect.needsDecode(column.field)
+            ? dialect.decode(row[column.alias], column.field)
+            : row[column.alias];
+        }
+
+        return out;
+      });
+    },
+  };
+}
+
+/** `count("x") as "_count_0"`, or `count(*)` for `_count: true` / `_all`. */
+function functionOf(term: Term, dialect: SqlDialect): string {
+  const operand = term.field ? dialect.quoteIdent(term.field.column) : "*";
+  return `${FUNCTION[term.kind]}(${operand}) as ${dialect.quoteIdent(term.alias)}`;
+}
+
+/**
+ * `by: ["role"]` and `by: "role"` are both Prisma, and the string form is the
+ * one a caller reaches for with a single field. Measured, not assumed — it is
+ * easy to read the generated types as array-only.
+ */
+function groupedColumns(schema: ModelSchema, op: string, by: unknown): Grouped[] {
+  const names = typeof by === "string" ? [by] : by;
+
+  if (!Array.isArray(names)) {
+    throw new UnsupportedQueryError(
+      "by",
+      schema.name,
+      op,
+      `Expected a field name or an array of them, got ${JSON.stringify(by)}.`,
+    );
+  }
+
+  if (names.length === 0) {
+    throw new UnsupportedQueryError(
+      "by",
+      schema.name,
+      op,
+      `At least one field is required to group by. Prisma rejects an empty ` +
+        `'by' too — without one there is nothing to group, and the answer ` +
+        `would be 'aggregate'.`,
+    );
+  }
+
+  const grouped: Grouped[] = [];
+  const seen = new Set<string>();
+
+  for (const name of names) {
+    if (typeof name !== "string") {
+      throw new UnsupportedQueryError(
+        "by",
+        schema.name,
+        op,
+        `Expected field names, got ${JSON.stringify(name)}.`,
+      );
+    }
+    // A duplicate is harmless in SQL and would return the column twice under
+    // one key, so it is dropped rather than refused.
+    if (seen.has(name)) continue;
+    seen.add(name);
+
+    if (name in schema.relations) {
+      throw new UnsupportedQueryError(
+        `by.${name}`,
+        schema.name,
+        op,
+        `'${name}' is a relation. A group is a set of rows of this model, so ` +
+          `only its own columns can name one.`,
+      );
+    }
+
+    const field = schema.fields[name];
+    if (!field) {
+      throw new UnknownFieldError(name, schema.name, Object.keys(schema.fields));
+    }
+
+    grouped.push({ field, alias: `_by_${grouped.length}` });
+  }
+
+  return grouped;
+}
+
+/**
+ * `having`, which filters **groups** rather than rows.
+ *
+ * Two operand shapes, and Prisma accepts both against the same key:
+ *
+ *     having: { role: { gt: 0 } }                 the grouped column itself
+ *     having: { role: { _count: { gt: 1 } } }     an aggregate over the group
+ *
+ * The first is only legal because `role` is in `by` — SQL would reject a bare
+ * column in `having` otherwise, and Prisma refuses it first with *"Every field
+ * used in `having` filters must either be an aggregation filter or be included
+ * in the selection of the query"*. That refusal is reproduced rather than left
+ * to the database, because the database's version of it names neither the
+ * argument nor the model.
+ *
+ * Written here rather than threaded through `compileWhere` as an option: the
+ * operand of an aggregate filter is a *function call*, not a column, and
+ * teaching the row-predicate compiler to sometimes wrap its left-hand side
+ * would put a group's rules inside the file every ordinary query uses.
+ */
+function compileHaving(
+  schema: ModelSchema,
+  op: string,
+  having: unknown,
+  grouped: Grouped[],
+  dialect: SqlDialect,
+  path: (args: any) => any = (a) => a?.having,
+): Fragment | null {
+  if (having === undefined || having === null) return null;
+  if (typeof having !== "object" || Array.isArray(having)) {
+    throw new UnsupportedQueryError(
+      "having",
+      schema.name,
+      op,
+      `Expected an object of field filters.`,
+    );
+  }
+
+  const source = having as Record<string, unknown>;
+  const parts: Fragment[] = [];
+
+  // Sorted, for the reason every walk in this compiler is: the plan cache
+  // canonicalises key order, so two argument objects differing only in it have
+  // to produce one statement.
+  for (const key of Object.keys(source).sort()) {
+    const operand = source[key];
+    if (operand === undefined) continue;
+
+    if (key === "AND" || key === "OR" || key === "NOT") {
+      const combined = combinator(schema, op, key, operand, grouped, dialect, path);
+      if (combined) parts.push(combined);
+      continue;
+    }
+
+    const aggregated = isAggregateFilter(operand);
+    const field = havingField(schema, op, key, grouped, aggregated);
+
+    if (aggregated) {
+      assertPureAggregate(schema, op, key, operand);
+      for (const kind of KINDS) {
+        const filter = (operand as Record<string, unknown>)[kind];
+        if (filter === undefined) continue;
+        assertAggregable(schema, op, kind, field);
+        parts.push(
+          comparison(
+            `${FUNCTION[kind]}(${dialect.quoteIdent(field.column)})`,
+            filter,
+            schema,
+            op,
+            `having.${key}.${kind}`,
+            (args) => path(args)?.[key]?.[kind],
+            dialect,
+          ),
+        );
+      }
+      continue;
+    }
+
+    parts.push(
+      comparison(
+        dialect.quoteIdent(field.column),
+        operand,
+        schema,
+        op,
+        `having.${key}`,
+        (args) => path(args)?.[key],
+        dialect,
+      ),
+    );
+  }
+
+  if (parts.length === 0) return null;
+  return parts.length === 1
+    ? parts[0]
+    : concat(sql("("), joinFragments(parts, " and "), sql(")"));
+}
+
+function combinator(
+  schema: ModelSchema,
+  op: string,
+  key: "AND" | "OR" | "NOT",
+  operand: unknown,
+  grouped: Grouped[],
+  dialect: SqlDialect,
+  path: (args: any) => any,
+): Fragment | null {
+  const list = Array.isArray(operand) ? operand : [operand];
+  const parts: Fragment[] = [];
+
+  for (let index = 0; index < list.length; index++) {
+    const at = Array.isArray(operand)
+      ? (args: any) => path(args)?.[key]?.[index]
+      : (args: any) => path(args)?.[key];
+    const compiled = compileHaving(schema, op, list[index], grouped, dialect, at);
+    if (compiled) parts.push(compiled);
+  }
+
+  if (parts.length === 0) {
+    // Matching `compileWhere`: an empty `AND` is vacuously true, an empty `OR`
+    // matches nothing. `NOT` of nothing is the same as `AND` of nothing.
+    return key === "OR" ? sql("false") : null;
+  }
+
+  const joined =
+    parts.length === 1
+      ? parts[0]
+      : concat(sql("("), joinFragments(parts, key === "OR" ? " or " : " and "), sql(")"));
+
+  return key === "NOT" ? concat(sql("not ("), joined, sql(")")) : joined;
+}
+
+/** `{ _count: { gt: 1 } }` rather than `{ gt: 1 }`. */
+function isAggregateFilter(operand: unknown): boolean {
+  if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
+    return false;
+  }
+  return KINDS.some((kind) => kind in (operand as Record<string, unknown>));
+}
+
+/**
+ * The field a `having` key names.
+ *
+ * **The rule is Prisma's own sentence, and it is an `or`:** *"Every field used
+ * in `having` filters must either be an aggregation filter or be included in
+ * the selection of the query"*. So which form the operand takes decides whether
+ * the field has to be grouped:
+ *
+ *     having: { role:  { gt: 0 } }             role must be in `by`
+ *     having: { email: { _count: { gt: 1 } } } any field — it is aggregated
+ *
+ * The second is legal SQL for the same reason it is legal Prisma: `count(email)`
+ * has one value per group whether or not `email` is grouped. Measured against a
+ * live client rather than inferred from the refusal of the first — reading that
+ * message as "the field must be in `by`" would have refused a query Prisma
+ * accepts, which is how this was nearly written.
+ */
+function havingField(
+  schema: ModelSchema,
+  op: string,
+  name: string,
+  grouped: Grouped[],
+  aggregated: boolean,
+): FieldSchema {
+  const field = resolveField(schema, op, "_count", name);
+  if (aggregated) return field;
+  if (grouped.some((column) => column.field.name === field.name)) return field;
+
+  throw new UnsupportedQueryError(
+    `having.${name}`,
+    schema.name,
+    op,
+    `'${name}' is not in 'by'. A 'having' filter on a plain column needs the ` +
+      `column to be grouped — a group has one value for those and many for ` +
+      `everything else. Prisma refuses this too. Add '${name}' to 'by', ` +
+      `aggregate it instead ('having: { ${name}: { _count: { … } } }'), or ` +
+      `filter the rows with 'where' rather than the groups with 'having'.`,
+  );
+}
+
+/**
+ * An operand is one form or the other, never both.
+ *
+ * `having: { role: { gt: 0, _count: { gt: 1 } } }` reads as though it should
+ * mean "the group's role is above 0 *and* it has more than one row", and there
+ * is a sensible statement for it. Prisma does not produce that statement — its
+ * query engine **panics**:
+ *
+ *     thread 'tokio-runtime-worker' panicked at
+ *       query-engine/core/src/query_graph_builder/read/aggregations/group_by.rs:136
+ *     internal error: entered unreachable code
+ *
+ * So there is nothing to match, and inventing a meaning would put gemi ahead of
+ * Prisma on a shape Prisma cannot express — which is exactly where a
+ * differential test has no oracle. Refused by name instead, with the spelling
+ * that does work.
+ */
+function assertPureAggregate(
+  schema: ModelSchema,
+  op: string,
+  name: string,
+  operand: unknown,
+): void {
+  const extra = Object.keys(operand as Record<string, unknown>).filter(
+    (key) => !(KINDS as readonly string[]).includes(key),
+  );
+  if (extra.length === 0) return;
+
+  throw new UnsupportedQueryError(
+    `having.${name}`,
+    schema.name,
+    op,
+    `A 'having' filter is either a comparison on a grouped column or a filter ` +
+      `on an aggregate of it, not both — this one mixes ` +
+      `${extra.sort().join(", ")} with an aggregate. Prisma's query engine ` +
+      `panics on this shape rather than answering it, so there is no ` +
+      `behaviour to match. Use an 'AND' of the two filters instead.`,
+  );
+}
+
+/** The comparison operators a `having` operand may use. */
+const OPERATORS: Record<string, string> = {
+  equals: "=",
+  not: "<>",
+  lt: "<",
+  lte: "<=",
+  gt: ">",
+  gte: ">=",
+};
+
+function comparison(
+  lhs: string,
+  operand: unknown,
+  schema: ModelSchema,
+  op: string,
+  argument: string,
+  locate: (args: any) => any,
+  dialect: SqlDialect,
+): Fragment {
+  // A bare value is `equals`, the same shorthand `where` accepts.
+  if (typeof operand !== "object" || operand === null || operand instanceof Date) {
+    return concat(sql(`${lhs} = `), param((args) => dialect.encodeUntyped(locate(args))));
+  }
+
+  const source = operand as Record<string, unknown>;
+  const parts: Fragment[] = [];
+
+  for (const key of Object.keys(source).sort()) {
+    const value = source[key];
+    if (value === undefined) continue;
+
+    const operator = OPERATORS[key];
+    if (!operator) {
+      throw new UnsupportedQueryError(
+        `${argument}.${key}`,
+        schema.name,
+        op,
+        `A 'having' filter takes ${Object.keys(OPERATORS).sort().join(", ")}.`,
+      );
+    }
+
+    if (value === null) {
+      parts.push(sql(`${lhs} is ${key === "not" ? "not " : ""}null`));
+      continue;
+    }
+
+    parts.push(
+      concat(
+        sql(`${lhs} ${operator} `),
+        param((args) => dialect.encodeUntyped(locate(args)?.[key])),
+      ),
+    );
+  }
+
+  if (parts.length === 0) return sql("true");
+  return parts.length === 1
+    ? parts[0]
+    : concat(sql("("), joinFragments(parts, " and "), sql(")"));
+}
+
+/**
+ * `orderBy`, under the one restriction no other operation has.
+ *
+ * *"Every field used for orderBy must be included in the by-arguments of the
+ * query"* — Prisma's own words, and the reason is that a group has one value
+ * for a grouped column and many for everything else, so ordering by an
+ * ungrouped column is a question with no answer. Reproduced rather than passed
+ * through, because SQLite answers it anyway by picking an arbitrary row's
+ * value, and a silently arbitrary order is worse than a refusal.
+ *
+ * An **aggregate** may be named — `orderBy: { _count: { role: "desc" } }` is
+ * the top-N-by-count query — and it is the one ordering term that is a function
+ * call rather than a column, which is why this does not go through
+ * `parseOrderBy`.
+ *
+ * `orderBy` is *optional* here. #64 predicted Prisma would require it whenever
+ * `by` is given; measured against a live client, `groupBy` with no `orderBy` at
+ * all is accepted, so requiring one would have refused a legal query.
+ */
+function compileGroupOrdering(
+  schema: ModelSchema,
+  op: string,
+  orderBy: unknown,
+  grouped: Grouped[],
+  dialect: SqlDialect,
+): Fragment | null {
+  if (orderBy === undefined || orderBy === null) return null;
+
+  const entries = Array.isArray(orderBy) ? orderBy : [orderBy];
+  const parts: string[] = [];
+
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null) {
+      throw new UnsupportedQueryError(
+        "orderBy",
+        schema.name,
+        op,
+        `Expected an object of fields, or an array of them.`,
+      );
+    }
+
+    for (const key of Object.keys(entry)) {
+      const value = (entry as Record<string, unknown>)[key];
+      if (value === undefined) continue;
+
+      if ((KINDS as readonly string[]).includes(key)) {
+        parts.push(...aggregateOrdering(schema, op, key as Kind, value, dialect));
+        continue;
+      }
+
+      const field = schema.fields[key];
+      if (!field) {
+        throw new UnknownFieldError(key, schema.name, Object.keys(schema.fields));
+      }
+      if (!grouped.some((column) => column.field.name === field.name)) {
+        throw new UnsupportedQueryError(
+          `orderBy.${key}`,
+          schema.name,
+          op,
+          `'${key}' is not in 'by'. Every field an 'orderBy' names has to be ` +
+            `one of the grouped columns, because a group has one value for ` +
+            `those and many for everything else. Prisma refuses this too.`,
+        );
+      }
+
+      parts.push(`${dialect.quoteIdent(field.column)} ${direction(schema, op, key, value)}`);
+    }
+  }
+
+  if (parts.length === 0) return null;
+  return sql(parts.join(", "));
+}
+
+function aggregateOrdering(
+  schema: ModelSchema,
+  op: string,
+  kind: Kind,
+  operand: unknown,
+  dialect: SqlDialect,
+): string[] {
+  if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
+    throw new UnsupportedQueryError(
+      `orderBy.${kind}`,
+      schema.name,
+      op,
+      `Expected an object of fields.`,
+    );
+  }
+
+  const parts: string[] = [];
+  const source = operand as Record<string, unknown>;
+
+  for (const key of Object.keys(source)) {
+    const value = source[key];
+    if (value === undefined) continue;
+
+    if (kind === "_count" && key === "_all") {
+      parts.push(`count(*) ${direction(schema, op, `${kind}._all`, value)}`);
+      continue;
+    }
+
+    const field = resolveField(schema, op, kind, key);
+    assertAggregable(schema, op, kind, field);
+    parts.push(
+      `${FUNCTION[kind]}(${dialect.quoteIdent(field.column)}) ` +
+        `${direction(schema, op, `${kind}.${key}`, value)}`,
+    );
+  }
+
+  return parts;
+}
+
+/** A direction is structural, never a parameter — the same rule `orderBy` has. */
+function direction(schema: ModelSchema, op: string, at: string, value: unknown): string {
+  if (value === "asc" || value === "desc") return value;
+  throw new UnsupportedQueryError(
+    `orderBy.${at}`,
+    schema.name,
+    op,
+    `Expected 'asc' or 'desc', got ${JSON.stringify(value)}.`,
+  );
+}
+
+function assertArgs(schema: ModelSchema, op: string, args: any): void {
+  if (args === undefined || args === null || typeof args !== "object") {
+    throw new UnsupportedQueryError(
+      "by",
+      schema.name,
+      op,
+      `groupBy requires 'by'.`,
+    );
+  }
+
+  for (const key of Object.keys(args).sort()) {
+    if (args[key] === undefined) continue;
+    if (GROUP_BY_ARGS.has(key)) continue;
+    throw new UnsupportedQueryError(key, schema.name, op);
+  }
+
+  if (args.by === undefined) {
+    throw new UnsupportedQueryError(
+      "by",
+      schema.name,
+      op,
+      `groupBy requires 'by'.`,
+    );
+  }
+}

--- a/packages/gemi/orm/compile/index.ts
+++ b/packages/gemi/orm/compile/index.ts
@@ -4,6 +4,7 @@ import type { Operation, QueryPlan } from "../plan";
 import type { RelationStrategy } from "./plan-relations";
 import type { ModelSchema } from "../schema";
 import { compileAggregate, isAggregateOperation } from "./aggregate";
+import { compileGroupBy, isGroupByOperation } from "./group-by";
 import { compileRead, isReadOperation } from "./read";
 import { compileWrite, isWriteOperation } from "./write";
 
@@ -30,6 +31,7 @@ export function compile(
   // Before the read check, because `aggregate` is a read whose result is
   // neither rows nor a number and so shares none of `compileRead`'s shaping.
   if (isAggregateOperation(op)) return compileAggregate(schema, op, args, dialect);
+  if (isGroupByOperation(op)) return compileGroupBy(schema, op, args, dialect);
 
   if (isReadOperation(op)) {
     return compileRead(schema, op, args, dialect, strategy);
@@ -40,6 +42,7 @@ export function compile(
 
 export { compileRead, isReadOperation };
 export { compileAggregate, isAggregateOperation } from "./aggregate";
+export { compileGroupBy, isGroupByOperation } from "./group-by";
 export { compileWrite, isWriteOperation };
 export {
   planNestedWrites,

--- a/packages/gemi/orm/plan.discrimination.test.ts
+++ b/packages/gemi/orm/plan.discrimination.test.ts
@@ -473,6 +473,69 @@ describe("plan cache discrimination", () => {
 });
 
 /**
+ * **The converse of every discrimination test above**, and nothing asserted it
+ * until a review found the class by measuring rather than by reading.
+ *
+ * Those tests check one direction: arguments that compile to *different* SQL
+ * must not share a key, because a collision silently runs the wrong statement.
+ * This checks the other: arguments that compile to the *same* SQL must not mint
+ * separate keys, because the cache is a bounded LRU — 1000 entries — and one
+ * argument recording its values verbatim fills it from a query string and
+ * evicts every other query's plan. `plan.ts` already describes that pathology
+ * for `in`-list lengths; `VALUE_KEYS`' comment names the other half, that it
+ * would put user data into a long-lived global map.
+ *
+ * Three instances of the first direction were caught by `plan.coverage`'s rule;
+ * the `having` one below was caught by nothing, because nothing looked this
+ * way.
+ */
+describe("arguments that compile to one statement share one entry", () => {
+  const SAME_STATEMENT: [string, unknown[]][] = [
+    ["where threshold", [
+      { where: { globalRole: { gt: 1 } } },
+      { where: { globalRole: { gt: 9999 } } },
+    ]],
+    ["take magnitude", [{ take: 1 }, { take: 500 }]],
+    ["skip magnitude", [{ skip: 1 }, { skip: 500 }]],
+    ["a value inside a relation filter", [
+      { where: { accounts: { some: { organizationRole: 1 } } } },
+      { where: { accounts: { some: { organizationRole: 9 } } } },
+    ]],
+    ["a value inside a nested include's where", [
+      { include: { accounts: { where: { organizationRole: 1 } } } },
+      { include: { accounts: { where: { organizationRole: 9 } } } },
+    ]],
+    // The one this test was written for. `_count` is in `LITERAL_KEYS` so a
+    // *projection* keeps its booleans — but inside a `having` the same key
+    // introduces a comparison, and its operand is a parameter like any other.
+    ["a having threshold", [
+      { by: ["globalRole"], _count: true, having: { globalRole: { _count: { gt: 1 } } } },
+      { by: ["globalRole"], _count: true, having: { globalRole: { _count: { gt: 9999 } } } },
+    ]],
+    ["a having threshold on a grouped column", [
+      { by: ["globalRole"], _count: true, having: { globalRole: { gt: 1 } } },
+      { by: ["globalRole"], _count: true, having: { globalRole: { gt: 9999 } } },
+    ]],
+  ];
+
+  test.each(SAME_STATEMENT)("%s", (_label, argsList) => {
+    clearPlanCache();
+
+    const operation = (argsList[0] as any).by ? "groupBy" : "findMany";
+    const texts = new Set(
+      argsList.map(
+        (args) => getOrCompile(user, operation as any, args, sqlite).text,
+      ),
+    );
+
+    // The premise: these really are one statement. If they are not, the test
+    // is asserting the wrong thing and should say so loudly.
+    expect(texts.size).toBe(1);
+    expect(planCacheStats()).toMatchObject({ compiles: 1, size: 1 });
+  });
+});
+
+/**
  * Acceptance criterion: not one value is inlined into the SQL text anywhere.
  *
  * The check is that no digit survives outside an identifier — identifiers are

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -12,9 +12,11 @@ import type { ModelSchema } from "./schema";
  * `Omit` is miserable.
  *
  * `aggregate` joined the list once there was a measured account of what Prisma
- * returns for one — see `compile/aggregate.ts`. `groupBy` did not follow it in
- * the same change: `having` is a second predicate compiler over aggregate
- * expressions rather than columns, which is its own piece of work.
+ * returns for one — see `compile/aggregate.ts`. `groupBy` followed in its own
+ * change, for the reason this note gave for separating them: `having` is a
+ * second predicate compiler over aggregate expressions rather than columns, and
+ * `orderBy` carries a restriction no other operation has. See
+ * `compile/group-by.ts`.
  */
 export type Operation =
   | "findUnique"
@@ -24,6 +26,7 @@ export type Operation =
   | "findMany"
   | "count"
   | "aggregate"
+  | "groupBy"
   | "create"
   | "createMany"
   | "update"
@@ -179,6 +182,12 @@ const LITERAL_KEYS = new Set([
   "_sum",
   "_min",
   "_max",
+  // `groupBy`'s grouped columns, which reach the SQL as *identifiers* — both
+  // the select list and the `group by`. `["role"]` and `["locale"]` have the
+  // same shape, `[string]`, so without this they would be one cache entry and
+  // the second caller would be grouped by the first caller's column. Silently:
+  // the result is well-formed, just grouped by something else.
+  "by",
 ]);
 
 export function canonicalShape(

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -197,6 +197,20 @@ const LITERAL_KEYS = new Set([
   "by",
 ]);
 
+/**
+ * The aggregate kinds, which mean **two different things by position**.
+ *
+ * As a *projection* — `_count: { email: true }` — their contents decide the
+ * select list, so they are in {@link LITERAL_KEYS} and recorded verbatim.
+ * Inside a `having` the same keys introduce a *comparison*, and its operand is
+ * a bound parameter like any other.
+ *
+ * Nothing else in the walk is ambiguous this way, which is why this is a set
+ * rather than a general rule: the position is what disambiguates, and only
+ * these five keys have two positions.
+ */
+const AGGREGATE_KINDS = new Set(["_count", "_avg", "_sum", "_min", "_max"]);
+
 export function canonicalShape(
   value: unknown,
   literal = false,
@@ -205,6 +219,17 @@ export function canonicalShape(
    * list's *length* stops being part of the key. See `collapsedList`.
    */
   collapseLists = false,
+  /**
+   * Set inside a `having`, where an aggregate kind is an operator rather than a
+   * projection selector.
+   *
+   * A separate flag rather than clearing `literal`, because clearing it would
+   * be wrong: `mode` lives inside `where` — already a value subtree — and
+   * *must* stay literal, since `insensitive` and `default` compile to `ilike`
+   * and `like`. So "nothing below a value key is structural" is not the rule;
+   * "an aggregate kind below a `having` is not" is.
+   */
+  inHaving = false,
 ): string {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
@@ -226,14 +251,17 @@ export function canonicalShape(
     // The exception is the `in` / `notIn` operand on a dialect that binds it as
     // one parameter, which `shapeOfMember` takes before this is reached.
     return `[${value
-      .map((item) => canonicalShape(item, literal, collapseLists))
+      .map((item) => canonicalShape(item, literal, collapseLists, inHaving))
       .join(",")}]`;
   }
 
   const entries = Object.entries(value as Record<string, unknown>)
     .filter(([, v]) => v !== undefined)
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    .map(([key, v]) => `${key}:${shapeOfMember(key, v, literal, collapseLists)}`);
+    .map(
+      ([key, v]) =>
+        `${key}:${shapeOfMember(key, v, literal, collapseLists, inHaving)}`,
+    );
   return `{${entries.join(",")}}`;
 }
 
@@ -276,6 +304,7 @@ function shapeOfMember(
   value: unknown,
   literal: boolean,
   collapseLists: boolean,
+  inHaving: boolean,
 ): string {
   // `take` is a parameter, but its *sign* is not: a negative take means "the
   // last N", which flips every ordering term and so changes the SQL text. The
@@ -293,11 +322,39 @@ function shapeOfMember(
   if (collapseLists && LIST_KEYS.has(key) && Array.isArray(value)) {
     return collapsedList(value);
   }
-  if (VALUE_KEYS.has(key)) return canonicalShape(value, false, collapseLists);
+  if (VALUE_KEYS.has(key)) {
+    return canonicalShape(value, false, collapseLists, inHaving);
+  }
+
+  /**
+   * `having` is a predicate, so its operands are parameters — and unlike every
+   * other value key it contains keys that {@link LITERAL_KEYS} would otherwise
+   * re-raise one level down.
+   *
+   * Without this, `having: { role: { _count: { gt: 5 } } }` records `gt:5`
+   * verbatim and mints one cache entry per threshold, each holding
+   * byte-identical SQL. The cap is 1000 and a threshold off a query string is
+   * ordinary, so it fills the cache and evicts every other query's plan — the
+   * same pathology `plan.ts` already describes for `in`-list lengths, and the
+   * thing `VALUE_KEYS`' own comment warns about: it would put user data into a
+   * long-lived global map.
+   *
+   * The equivalent `where` — `{ role: { gt: 5 } }` — has always been one entry,
+   * which is the behaviour this matches.
+   */
+  if (key === "having") return canonicalShape(value, false, collapseLists, true);
+
+  // In a `having`, an aggregate kind is a comparison rather than a projection,
+  // so it does not raise `literal` for its subtree.
+  if (inHaving && AGGREGATE_KINDS.has(key)) {
+    return canonicalShape(value, false, collapseLists, true);
+  }
+
   return canonicalShape(
     value,
     literal || LITERAL_KEYS.has(key),
     collapseLists,
+    inHaving,
   );
 }
 

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -300,6 +300,12 @@ const SCOPABLE = new Set<string>([
   // scope narrows it exactly as it narrows a `count` — which is the same
   // statement with one function in it.
   "aggregate",
+  // Same reasoning one step further: its `where` filters the rows *before* they
+  // are grouped, so a scope narrows which rows any group can contain. Leaving
+  // it out would not merely refuse the operation — `assertScopable` raises — so
+  // every policied model would lose `groupBy` entirely, which is how `aggregate`
+  // was found missing on #74.
+  "groupBy",
   "update",
   "updateMany",
   "delete",

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -663,6 +663,91 @@ const CASES: [string, string, unknown][] = [
   ["aggregate paginating with no orderBy", "aggregate", {
     take: 2, _count: true,
   }],
+
+  // --- groupBy (#64's second half) --------------------------------------
+  //
+  // The seed holds five users across three `globalRole` values, with one group
+  // of three — so a result that grouped by the wrong column, or aggregated over
+  // the whole table, is a different set of numbers rather than the same ones in
+  // a different order.
+  ["groupBy with a count", "groupBy", {
+    by: ["globalRole"], _count: true, orderBy: { globalRole: "asc" },
+  }],
+  // Prisma accepts the bare string, which the generated types read as
+  // array-only. Same statement, so a divergence here is a refusal, not a number.
+  ["groupBy with by as a bare string", "groupBy", {
+    by: "globalRole", _count: true, orderBy: { globalRole: "asc" },
+  }],
+  ["groupBy with no orderBy at all", "groupBy", {
+    by: ["locale"], _count: true,
+  }],
+  ["groupBy over two columns", "groupBy", {
+    by: ["globalRole", "locale"], _count: true,
+    orderBy: [{ globalRole: "asc" }, { locale: "asc" }],
+  }],
+  ["groupBy with every aggregate kind", "groupBy", {
+    by: ["globalRole"],
+    _count: true,
+    _sum: { globalRole: true },
+    _avg: { globalRole: true },
+    _min: { createdAt: true },
+    _max: { createdAt: true },
+    orderBy: { globalRole: "asc" },
+  }],
+  // `_count` per field counts non-nulls, `_all` counts rows — the seed has a
+  // user with a null name, so the two are different numbers in one group.
+  ["groupBy with a per-field count", "groupBy", {
+    by: ["globalRole"], _count: { _all: true, name: true, email: true },
+    orderBy: { globalRole: "asc" },
+  }],
+  ["groupBy with a where", "groupBy", {
+    by: ["globalRole"], where: { globalRole: { gte: 1 } }, _count: true,
+    orderBy: { globalRole: "asc" },
+  }],
+  ["groupBy matching no rows is an empty array", "groupBy", {
+    by: ["globalRole"], where: { globalRole: 99 }, _sum: { globalRole: true },
+  }],
+  ["groupBy with having on an aggregate", "groupBy", {
+    by: ["globalRole"], _count: true,
+    having: { globalRole: { _count: { gt: 1 } } },
+    orderBy: { globalRole: "asc" },
+  }],
+  ["groupBy with having on a grouped column", "groupBy", {
+    by: ["globalRole"], _count: true,
+    having: { globalRole: { gt: 0 } },
+    orderBy: { globalRole: "asc" },
+  }],
+  // The half of Prisma's rule that is easy to read backwards: an aggregate over
+  // a column that is *not* grouped is legal.
+  ["groupBy with having aggregating an ungrouped column", "groupBy", {
+    by: ["globalRole"], _count: true,
+    having: { email: { _count: { gt: 0 } } },
+    orderBy: { globalRole: "asc" },
+  }],
+  ["groupBy with having over OR", "groupBy", {
+    by: ["globalRole"], _count: true,
+    having: {
+      OR: [{ globalRole: { equals: 0 } }, { globalRole: { _count: { gt: 2 } } }],
+    },
+    orderBy: { globalRole: "asc" },
+  }],
+  ["groupBy ordered by an aggregate", "groupBy", {
+    by: ["globalRole"], _count: true,
+    orderBy: { _count: { globalRole: "desc" } },
+  }],
+  ["groupBy with take and skip over the groups", "groupBy", {
+    by: ["globalRole"], _count: true, orderBy: { globalRole: "asc" },
+    take: 2, skip: 1,
+  }],
+  // Legal in Prisma, and the shape that reads like `select distinct`.
+  ["groupBy with no aggregate at all", "groupBy", {
+    by: ["globalRole"], orderBy: { globalRole: "asc" },
+  }],
+  // Grouping by a nullable column: the null group is its own group, and it has
+  // to survive the round trip as `null` rather than being dropped.
+  ["groupBy over a nullable column", "groupBy", {
+    by: ["name"], _count: true, orderBy: { name: "asc" },
+  }],
 ];
 
 /**

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -114,6 +114,14 @@ export class AccountModel extends Model {
     >;
   }
 
+  static groupBy<T extends Prisma.AccountGroupByArgs>(
+    args: Prisma.Subset<T, Prisma.AccountGroupByArgs>,
+  ): Promise<Prisma.GetAccountGroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.GetAccountGroupByPayload<T>
+    >;
+  }
+
   static create<T extends Prisma.AccountCreateArgs>(
     args: Subset<T, Prisma.AccountCreateArgs>,
     options?: ExecOptions,
@@ -257,6 +265,14 @@ export class MagicLinkTokenModel extends Model {
   ): Promise<Prisma.GetMagicLinkTokenAggregateType<T>> {
     return this.$exec("aggregate", args) as Promise<
       Prisma.GetMagicLinkTokenAggregateType<T>
+    >;
+  }
+
+  static groupBy<T extends Prisma.MagicLinkTokenGroupByArgs>(
+    args: Prisma.Subset<T, Prisma.MagicLinkTokenGroupByArgs>,
+  ): Promise<Prisma.GetMagicLinkTokenGroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.GetMagicLinkTokenGroupByPayload<T>
     >;
   }
 
@@ -406,6 +422,14 @@ export class OrganizationModel extends Model {
     >;
   }
 
+  static groupBy<T extends Prisma.OrganizationGroupByArgs>(
+    args: Prisma.Subset<T, Prisma.OrganizationGroupByArgs>,
+  ): Promise<Prisma.GetOrganizationGroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.GetOrganizationGroupByPayload<T>
+    >;
+  }
+
   static create<T extends Prisma.OrganizationCreateArgs>(
     args: Subset<T, Prisma.OrganizationCreateArgs>,
     options?: ExecOptions,
@@ -549,6 +573,14 @@ export class OrganizationInvitationModel extends Model {
   ): Promise<Prisma.GetOrganizationInvitationAggregateType<T>> {
     return this.$exec("aggregate", args) as Promise<
       Prisma.GetOrganizationInvitationAggregateType<T>
+    >;
+  }
+
+  static groupBy<T extends Prisma.OrganizationInvitationGroupByArgs>(
+    args: Prisma.Subset<T, Prisma.OrganizationInvitationGroupByArgs>,
+  ): Promise<Prisma.GetOrganizationInvitationGroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.GetOrganizationInvitationGroupByPayload<T>
     >;
   }
 
@@ -698,6 +730,14 @@ export class PasswordResetTokenModel extends Model {
     >;
   }
 
+  static groupBy<T extends Prisma.PasswordResetTokenGroupByArgs>(
+    args: Prisma.Subset<T, Prisma.PasswordResetTokenGroupByArgs>,
+  ): Promise<Prisma.GetPasswordResetTokenGroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.GetPasswordResetTokenGroupByPayload<T>
+    >;
+  }
+
   static create<T extends Prisma.PasswordResetTokenCreateArgs>(
     args: Subset<T, Prisma.PasswordResetTokenCreateArgs>,
     options?: ExecOptions,
@@ -841,6 +881,14 @@ export class SessionModel extends Model {
   ): Promise<Prisma.GetSessionAggregateType<T>> {
     return this.$exec("aggregate", args) as Promise<
       Prisma.GetSessionAggregateType<T>
+    >;
+  }
+
+  static groupBy<T extends Prisma.SessionGroupByArgs>(
+    args: Prisma.Subset<T, Prisma.SessionGroupByArgs>,
+  ): Promise<Prisma.GetSessionGroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.GetSessionGroupByPayload<T>
     >;
   }
 
@@ -990,6 +1038,14 @@ export class SocialAccountModel extends Model {
     >;
   }
 
+  static groupBy<T extends Prisma.SocialAccountGroupByArgs>(
+    args: Prisma.Subset<T, Prisma.SocialAccountGroupByArgs>,
+  ): Promise<Prisma.GetSocialAccountGroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.GetSocialAccountGroupByPayload<T>
+    >;
+  }
+
   static create<T extends Prisma.SocialAccountCreateArgs>(
     args: Subset<T, Prisma.SocialAccountCreateArgs>,
     options?: ExecOptions,
@@ -1133,6 +1189,14 @@ export class UserModel extends Model {
   ): Promise<Prisma.GetUserAggregateType<T>> {
     return this.$exec("aggregate", args) as Promise<
       Prisma.GetUserAggregateType<T>
+    >;
+  }
+
+  static groupBy<T extends Prisma.UserGroupByArgs>(
+    args: Prisma.Subset<T, Prisma.UserGroupByArgs>,
+  ): Promise<Prisma.GetUserGroupByPayload<T>> {
+    return this.$exec("groupBy", args) as Promise<
+      Prisma.GetUserGroupByPayload<T>
     >;
   }
 

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -250,6 +250,40 @@ function suite(label: string, url?: string) {
       expect(everything._count).toBe(2);
     });
 
+    /**
+     * `groupBy`'s `where` filters the rows *before* they are grouped, so a
+     * scope narrows which rows any group can contain. Same failure mode as the
+     * aggregate above and one step worse: the operation would throw on every
+     * policied model — and `softDeletes()` carries a `scope`, so that is most
+     * of them.
+     */
+    test("scope narrows a groupBy, and the groups themselves change", async () => {
+      (ScopedUser as any).$policies = [tenantScoped];
+
+      const mine: any = await Model.asUser(ALICE, () =>
+        (ScopedUser as any).groupBy({
+          by: ["organizationId"],
+          _count: true,
+          orderBy: { organizationId: "asc" },
+        }),
+      );
+
+      // Not just a smaller count — Bob's organisation is a *group* that must
+      // not appear at all, which a scope applied after grouping would leave in.
+      expect(mine).toEqual([
+        { organizationId: ALICE.organizationId, _count: 1 },
+      ]);
+
+      const everything: any = await Model.asSystem(() =>
+        (ScopedUser as any).groupBy({
+          by: ["organizationId"],
+          _count: true,
+          orderBy: { organizationId: "asc" },
+        }),
+      );
+      expect(everything).toHaveLength(2);
+    });
+
     test("scope narrows count's per-field form too", async () => {
       (ScopedUser as any).$policies = [tenantScoped];
 


### PR DESCRIPTION
Closes #64, whose `aggregate` half shipped in #74.

## Why it is its own compiler

Not a flag on `compileAggregate`, for three reasons that all show up in the file:

- the result is many rows with a **mixed** shape — grouped columns flat, aggregates nested under their kind;
- `having` is a second predicate compiler whose operands are *function calls* rather than columns (`count("x") > $1` where `compileWhere` would emit `"x" > $1`);
- `orderBy` carries a restriction no other operation has, and may itself name an aggregate.

The term machinery is **shared, not copied** — `aggregateTerms`, `coerce`, `FUNCTION` and the kind list are now exported from `aggregate.ts`. Two copies of the `_sum`-over-`BigInt` coercion is exactly the drift #84 turned out to be.

## Every rule was measured, and four are not what the shape suggests

Three of these would have shipped wrong from reading the types or the docs:

- **`orderBy` is optional.** #64 predicted Prisma would require one whenever `by` is given. It does not — so requiring it would have refused legal queries.
- **`by` takes a bare string** as well as an array. The generated types read as array-only.
- **`having` on an ungrouped column depends on the form.** Prisma's refusal — *"must either be an aggregation filter or be included in the selection of the query"* — is an **or**. Reading it as "the field must be in `by`" refuses `having: { email: { _count: { gt: 1 } } }`, which Prisma answers, because `count(email)` has one value per group either way. I very nearly shipped that reading.
- **The `orderBy` restriction is worth reproducing rather than passing through.** SQLite will happily order by an ungrouped column, picking an arbitrary row's value. Silently arbitrary beats refused for nobody.

## One refusal with no Prisma behaviour behind it

```ts
having: { role: { gt: 0, _count: { gt: 1 } } }
```

mixes a column comparison and an aggregate filter under one key. Prisma's query engine **panics**:

```
thread 'tokio-runtime-worker' panicked at
  query-engine/core/src/query_graph_builder/read/aggregations/group_by.rs:136
internal error: entered unreachable code
```

There is a sensible statement for that shape, and inventing it would put gemi ahead of Prisma somewhere a differential test has no oracle. Refused by name, with the `AND` spelling that works.

## Plan cache and policies

**`by` joins `LITERAL_KEYS`.** The grouped columns reach the SQL as *identifiers*, and `["role"]` and `["locale"]` have the same shape — `[string]` — so without it two callers share one plan and the second is grouped by the first one's column. Well-formed, wrong, silent.

**`groupBy` joins `SCOPABLE`**, and it is load-bearing. Verified by removing it:

```
UnsupportedQueryError: gemi ORM does not support 'groupBy' yet (User.groupBy).
User has a policy with a scope, and groupBy cannot carry one: its where clause
compiles to an 'on conflict' target…
```

— the operation disappears on every policied model, pointing at `upsert`. `softDeletes()` carries a `scope`, so that is most models. This is how `aggregate` was found missing on #74.

## Tests

- **37 unit tests** over the SQL and the refusals — the `having` compiler, the `orderBy` restriction, argument validation, and that no `having` value reaches the SQL text.
- **16 differential cases** against Prisma on both dialects, including the null group, the empty result, per-field vs `_all` counts, ordering by an aggregate, and the ungrouped-aggregate `having` that the misreading would have refused.
- **A policy test asserting the *groups* change**, not only the counts: a scope applied after grouping would leave the other tenant's group in the result with a smaller number, and a test on counts alone would pass against that.

## Notes for merge order

`groupBy` is the **fourth pager**, which is the case #88 was written for: it moved `take` / `skip` validation into `pagination` itself rather than each caller's allowlist, arguing a fourth pager should not be able to arrive without it. On this base #88 has not merged, so `groupBy` inherits the #84 behaviour today and gains the check the moment it does, with no change here. The call site is the only line that differs between the two bases (`pagination` gained an `operation` parameter), and it is noted in the file.

## Verification

920 unit tests. Full template suite green on SQLite (471) and Postgres 16 (714), with only the pre-existing `generated.test.ts` generator-linkage probe failing — it fails on the base branch too. `tsc` clean on the package and on the template; oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
