### PR TITLE
Nested `connectOrCreate`, on both sides of the key

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -245,6 +245,7 @@ await List.create({
 | `create` | Writes new related rows. One statement each. |
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
 | `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
+| `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
 
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
@@ -260,10 +261,16 @@ Three things follow from that, and all three are load-bearing:
   A `createMany` writes its rows in one statement and they are *each* scoped.
 - **A failure anywhere rolls the whole thing back**, including the parent row.
 
-Everything else in Prisma's nested grammar — `connectOrCreate`, `set`, `disconnect`, `update`,
-`updateMany`, `upsert`, `delete`, `deleteMany` — is refused, by name and with the reason. They share
-one property: each writes rows that already exist, which needs a scoping pass of its own rather than
-the child's `onCreate`. `skipDuplicates` is not implemented on `createMany` at any level.
+`connectOrCreate` is worth one more line, because a scoped-away row makes it take the *create*
+branch rather than raise: a row your policies hide reads as absent, so the call writes its own — the
+same answer you would get if it truly did not exist. That is deliberate. `connect` raising where
+`connectOrCreate` succeeded would together tell you a row with that key exists in someone else's
+tenant.
+
+Everything else in Prisma's nested grammar — `set`, `disconnect`, `update`, `updateMany`, `upsert`,
+`delete`, `deleteMany` — is refused, by name and with the reason. They share one property: each
+writes rows that already exist, which needs a scoping pass of its own rather than the child's
+`onCreate`. `skipDuplicates` is not implemented on `createMany` at any level.
 
 ### Paging a relation
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -315,9 +315,14 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 tenant.
 
 Everything else in Prisma's nested grammar — `set`, `disconnect`, `update`, `updateMany`, `upsert`,
-`delete`, `deleteMany` — is refused, by name and with the reason. They share one property: each
-writes rows that already exist, which needs a scoping pass of its own rather than the child's
-`onCreate`. `skipDuplicates` is not implemented on `createMany` at any level.
+`delete`, `deleteMany` — is refused, by name and with the reason. The line is **which rows an
+operand can name, and whose columns it writes**: everything supported names its rows (a new one, or
+one you identified by unique key) and writes either a whole new row or one foreign key the ORM
+chose. `set`, `disconnect`, `delete`, `deleteMany` and `updateMany` act on rows the call did not
+name; `update` names its row but writes your columns to it, which needs the child's `onUpdate` and
+the scope-escape guard run over the payload.
+
+`skipDuplicates` is not implemented on `createMany` at any level.
 
 ### Paging a relation
 

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -41,7 +41,12 @@ import { matchUniqueKey } from "./unique";
  * back the parent row too.
  */
 
-const SUPPORTED = new Set(["connect", "create", "createMany"]);
+const SUPPORTED = new Set([
+  "connect",
+  "connectOrCreate",
+  "create",
+  "createMany",
+]);
 
 /**
  * The operands still refused, and what each would take.
@@ -53,9 +58,6 @@ const SUPPORTED = new Set(["connect", "create", "createMany"]);
  * key, and none of it has to reason about what was there before.
  */
 const REFUSED: Record<string, string> = {
-  connectOrCreate:
-    `It is an upsert against the child, which needs the read-then-write ` +
-    `fallback 'upsert' uses when 'on conflict' cannot express the target.`,
   set: `It replaces the whole set, so it has to disconnect what is there now.`,
   disconnect: `It clears a foreign key on rows this call did not name.`,
   delete: `It deletes rows this call did not name.`,
@@ -63,7 +65,9 @@ const REFUSED: Record<string, string> = {
   update: `It writes rows that already exist, which needs its own scoping pass.`,
   updateMany:
     `It writes rows that already exist, which needs its own scoping pass.`,
-  upsert: `It is 'update' and 'connectOrCreate' at once.`,
+  upsert:
+    `It is 'update' and 'connectOrCreate' at once, and only the second half ` +
+    `is implemented.`,
 };
 
 /** A foreign-key column on *this* model that a nested write supplies. */
@@ -278,6 +282,73 @@ function planOwningSide(
     return;
   }
 
+  /**
+   * `connectOrCreate` — find the row by a unique key, and create it only if it
+   * is not there.
+   *
+   * **A hit ignores `create` entirely**, which is not what the name suggests
+   * and is worth pinning: it is `connect`-or-create, not upsert. Measured — an
+   * existing organisation kept its own name where the `create` payload named a
+   * different one.
+   *
+   * `findUnique`, not `findUniqueOrThrow`: a miss is the *other branch* here,
+   * where for a plain `connect` it is an error.
+   *
+   * Object only on this side. The relation holds one foreign key, so there is
+   * one row to point at, and Prisma refuses an array here too.
+   */
+  if (key === "connectOrCreate") {
+    assertConnectOrCreateOperand(
+      schema,
+      relation,
+      child,
+      operand,
+      operation,
+      false,
+    );
+
+    out.before.push({
+      relation: relation.name,
+      operation: "connectOrCreate",
+      async run(args, context, executor) {
+        const where = at(args)?.where;
+
+        const found = (await executor.exec(
+          relation.model,
+          "findUnique",
+          { where, select: { [referenced]: true } },
+          // NOT pre-scoped, for the reason `connect` is not: this reads another
+          // model's rows to decide what to attach, so that model's policies say
+          // which rows exist. Scoped away, a hit becomes a miss and the row is
+          // *created* — so the fallback branch is what keeps this from being a
+          // way to observe another tenant's keys.
+          false,
+        )) as Record<string, unknown> | null;
+
+        if (found) {
+          context.resolved[fkField] = found[referenced] ?? null;
+          return;
+        }
+
+        const created = (await executor.exec(
+          relation.model,
+          "create",
+          { data: at(args)?.create, select: { [referenced]: true } },
+          // NOT pre-scoped — the child's own `onCreate` scopes the new row.
+          false,
+        )) as Record<string, unknown> | null;
+
+        context.resolved[fkField] = created?.[referenced] ?? null;
+      },
+    });
+
+    out.contributions.push({
+      field: fkField,
+      value: (_args, context) => context.resolved[fkField],
+    });
+    return;
+  }
+
   // `connect`. In the common case the caller already handed us the referenced
   // value — `connect: { id: 1 }` where the relation references `id` — and no
   // query is needed at all: it is one more bound column.
@@ -467,6 +538,81 @@ function planForeignSide(
     return;
   }
 
+  /**
+   * `connectOrCreate` on this side is the pair of branches the owning side has,
+   * with `connect` spelled as an update of the child's foreign key.
+   *
+   * Both branches go through the child's own `$exec`, so both are scoped by the
+   * child's policies — and they have to be, in opposite directions: an
+   * unscopeable *update* would re-parent another tenant's row, and an unscoped
+   * *read* would let a hit reveal that a row with that key exists. Scoped, a
+   * hidden row reads as absent and the call creates its own, which is the same
+   * answer the caller would get if it truly did not exist.
+   */
+  if (key === "connectOrCreate") {
+    assertConnectOrCreateOperand(
+      schema,
+      relation,
+      child,
+      operand,
+      operation,
+      true,
+    );
+
+    out.after.push({
+      relation: relation.name,
+      operation: "connectOrCreate",
+      async run(args, _context, executor, rows) {
+        const parent = rows[0];
+        if (!parent) return;
+
+        const list = listOf(at(args));
+
+        for (let index = 0; index < list.length; index++) {
+          const item = list[index] as Record<string, unknown>;
+
+          const found = (await executor.exec(
+            relation.model,
+            "findUnique",
+            { where: item.where, select: { [childField]: true } },
+            false,
+          )) as Record<string, unknown> | null;
+
+          if (found) {
+            await executor.exec(
+              relation.model,
+              "update",
+              {
+                where: item.where,
+                data: { [childField]: parent[parentField] },
+                select: { [childField]: true },
+              },
+              false,
+            );
+            continue;
+          }
+
+          await executor.exec(
+            relation.model,
+            "create",
+            {
+              // The foreign key is ours, not the caller's — the same rule the
+              // nested `create` above follows, and Prisma leaves it out of the
+              // nested input type entirely.
+              data: {
+                ...(item.create as object),
+                [childField]: parent[parentField],
+              },
+              select: { [childField]: true },
+            },
+            false,
+          );
+        }
+      },
+    });
+    return;
+  }
+
   // `connect` on this side means "point that existing row at me", which is an
   // update of the child's foreign key — not something this row's insert can do.
   out.after.push({
@@ -494,6 +640,89 @@ function planForeignSide(
       }
     },
   });
+}
+
+/**
+ * `connectOrCreate`'s operand: `{ where, create }`, or a list of them on a
+ * to-many.
+ *
+ * Validated at plan time so a misspelled key fails when the query is compiled,
+ * rather than after the parent row has been written and the transaction has to
+ * unwind it — the same reason `createMany`'s operand is checked here.
+ *
+ * The `where` has to be a unique key, which is Prisma's rule and not merely
+ * ours: without it the lookup matches an arbitrary row and "connect or create"
+ * silently becomes "connect to whichever one came back first".
+ */
+function assertConnectOrCreateOperand(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  operand: unknown,
+  operation: string,
+  many: boolean,
+): Record<string, unknown>[] {
+  const at = `data.${relation.name}.connectOrCreate`;
+
+  if (Array.isArray(operand) && !many) {
+    throw new UnsupportedQueryError(
+      at,
+      schema.name,
+      operation,
+      `'${relation.name}' is a to-one: this row holds the foreign key, so ` +
+        `there is one row to point at and a list has no meaning. Prisma ` +
+        `refuses an array here too.`,
+    );
+  }
+
+  const entries = (Array.isArray(operand) ? operand : [operand]) as unknown[];
+
+  if (entries.length === 0) return [];
+
+  const out: Record<string, unknown>[] = [];
+
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new UnsupportedQueryError(
+        at,
+        schema.name,
+        operation,
+        `Expected an object with 'where' and 'create'.`,
+      );
+    }
+
+    const record = entry as Record<string, unknown>;
+
+    for (const required of ["where", "create"] as const) {
+      if (record[required] === undefined) {
+        throw new UnsupportedQueryError(
+          at,
+          schema.name,
+          operation,
+          `Expected a '${required}' key — 'connectOrCreate' names the row to ` +
+            `look for and the row to write if it is not there.`,
+        );
+      }
+    }
+
+    const extra = Object.keys(record).filter(
+      (key) => key !== "where" && key !== "create" && record[key] !== undefined,
+    );
+    if (extra.length > 0) {
+      throw new UnsupportedQueryError(
+        at,
+        schema.name,
+        operation,
+        `Unexpected ${extra.sort().join(", ")} — 'connectOrCreate' takes ` +
+          `'where' and 'create'.`,
+      );
+    }
+
+    matchUniqueKey(child, record.where, `${operation}.${relation.name}.connectOrCreate`);
+    out.push(record);
+  }
+
+  return out;
 }
 
 /**

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -9,7 +9,8 @@ import {
 import { matchUniqueKey } from "./unique";
 
 /**
- * Nested writes: `connect`, shallow `create`, and `createMany`.
+ * Nested writes: `connect`, `connectOrCreate`, shallow `create`, and
+ * `createMany`.
  *
  * Which direction a nested write runs in is decided by *who holds the foreign
  * key*, and the two directions are genuinely different operations:
@@ -29,12 +30,37 @@ import { matchUniqueKey } from "./unique";
  * `createMany` is the second shape and only exists on the foreign side: the same
  * rows as a nested `create`, in one statement rather than one per row.
  *
- * Everything else in Prisma's nested-write grammar — `connectOrCreate`, `set`,
- * `disconnect`, `update`, `upsert`, `delete`, `deleteMany`, `updateMany` —
- * throws `UnsupportedQueryError` naming the operation *and the reason*; see
- * `REFUSED`. They share one property, and it is the line this file draws: each
- * writes rows that **already exist**, which needs a scoping pass of its own
- * rather than the child's `onCreate`.
+ * Everything else in Prisma's nested-write grammar — `set`, `disconnect`,
+ * `update`, `upsert`, `delete`, `deleteMany`, `updateMany` — throws
+ * `UnsupportedQueryError` naming the operation *and the reason*; see `REFUSED`.
+ *
+ * **The line this file draws has two halves: which rows an operand can name,
+ * and whose columns it writes.**
+ *
+ * Every supported operand names its rows — a new one, or an existing one the
+ * caller identified by unique key — so it goes through the child's own
+ * `findUnique`, `create` or `update`, and the child's policies decide whether
+ * it is reachable at all. `set`, `disconnect`, `delete`, `deleteMany` and
+ * `updateMany` act on rows the *call* did not name, and "whatever is there" has
+ * no lookup to hang a scope on.
+ *
+ * `update` is the operand that shows the second half is needed, because it
+ * *does* name its row: `update: { where, data }`. It is refused because of what
+ * it writes — caller-supplied columns, which need the child's `onUpdate` and
+ * the scope-escape guard run over the payload. Every supported operand writes
+ * either a whole new row through the child's `create` (where `onCreate`
+ * applies) or one foreign key the ORM itself chose.
+ *
+ * This used to say the line was "each writes rows that **already exist**", and
+ * that was true until `connectOrCreate` arrived: on the foreign side a hit is
+ * an `update` of the child's foreign key, because Prisma repoints the existing
+ * row rather than duplicating it. So a supported operand does now write a row
+ * that was already there. Restated rather than deleted, because the criterion
+ * is what the next operand gets judged against — #75 built the whole `REFUSED`
+ * table on it, with a per-entry reason derived from it, and #83's `set` on an
+ * implicit many-to-many was fixed by exactly this reading: scope the delete to
+ * the rows the caller can see. A stale criterion is worse than none, because it
+ * is the one the next reader applies.
  *
  * Atomic since iteration 5: `$exec` opens a transaction for any plan carrying
  * steps, so a nested step that fails — or a child policy that denies — rolls
@@ -62,9 +88,19 @@ const REFUSED: Record<string, string> = {
   disconnect: `It clears a foreign key on rows this call did not name.`,
   delete: `It deletes rows this call did not name.`,
   deleteMany: `It deletes rows this call did not name.`,
-  update: `It writes rows that already exist, which needs its own scoping pass.`,
+  // Not "it writes a row that already exists" — `connectOrCreate` does that
+  // too, on the foreign side, and is supported. The difference is *whose*
+  // columns: this one writes caller-supplied data, so the child's `onUpdate`
+  // and the scope-escape guard both have to run over it, where a `connect`
+  // writes one foreign key the ORM chose.
+  update:
+    `It writes caller-supplied columns to a row that already exists, so the ` +
+    `child's 'onUpdate' and the scope-escape guard have to run over the ` +
+    `payload — a pass this does not have yet.`,
   updateMany:
-    `It writes rows that already exist, which needs its own scoping pass.`,
+    `It writes caller-supplied columns to rows this call did not name, so it ` +
+    `needs both halves: a scope on which rows match, and the child's ` +
+    `'onUpdate' over the payload.`,
   upsert:
     `It is 'update' and 'connectOrCreate' at once, and only the second half ` +
     `is implemented.`,

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -173,7 +173,7 @@ export interface NestedWriteStep {
    * itself does, so this is what makes a plan legible from the outside: to a
    * test, and to whatever logs queries later.
    */
-  operation: "connect" | "create" | "createMany";
+  operation: "connect" | "connectOrCreate" | "create" | "createMany";
   run(
     args: any,
     context: BindContext,

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -737,7 +737,6 @@ describe("nested writes", () => {
   });
 
   test.each([
-    "connectOrCreate",
     "set",
     "disconnect",
     "update",
@@ -760,13 +759,132 @@ describe("nested writes", () => {
    */
   test("a refusal explains what the operand would take", () => {
     expect(() =>
-      text("create", {
-        data: { email: "a@b.c", organization: { connectOrCreate: {} } },
-      }),
-    ).toThrow(/upsert against the child/);
+      text("create", { data: { email: "a@b.c", organization: { set: {} } } }),
+    ).toThrow(/replaces the whole set/);
     expect(() =>
       text("create", { data: { email: "a@b.c", accounts: { deleteMany: {} } } }),
     ).toThrow(/deletes rows this call did not name/);
+  });
+
+  /**
+   * `connectOrCreate` — find by a unique key, create only if it is not there.
+   *
+   * **A hit ignores `create` entirely**, which the name does not suggest: it is
+   * connect-*or*-create, not upsert. Measured against Prisma — an existing row
+   * kept its own values where the `create` payload named different ones — and
+   * the differential cases pin it.
+   */
+  describe("connectOrCreate", () => {
+    const entry = {
+      where: { publicId: "o1" },
+      create: { publicId: "o1", name: "Made" },
+    };
+
+    test("the owning side resolves before the parent insert", () => {
+      const plan = compileWrite(
+        user,
+        "create",
+        { data: { email: "a@b.c", organization: { connectOrCreate: entry } } },
+        sqlite,
+      );
+
+      expect(plan.before).toHaveLength(1);
+      expect(plan.before?.[0].operation).toBe("connectOrCreate");
+      // The foreign key is on this row, so it is a bound column rather than a
+      // second statement afterwards.
+      expect(plan.after).toBeUndefined();
+    });
+
+    test("the foreign side resolves after it, and returns the key", () => {
+      const plan = compileWrite(
+        user,
+        "create",
+        {
+          data: {
+            email: "a@b.c",
+            accounts: {
+              connectOrCreate: {
+                where: { publicId: "acc1" },
+                create: { organizationRole: 1 },
+              },
+            },
+          },
+        },
+        sqlite,
+      );
+
+      expect(plan.after).toHaveLength(1);
+      expect(plan.after?.[0].operation).toBe("connectOrCreate");
+      expect(plan.text).toContain(`"id"`);
+    });
+
+    test("a to-one refuses a list, as Prisma does", () => {
+      expect(() =>
+        text("create", {
+          data: { email: "a@b.c", organization: { connectOrCreate: [entry] } },
+        }),
+      ).toThrow(/a list has no meaning/);
+    });
+
+    test("a to-many takes one or a list", () => {
+      for (const operand of [entry, [entry, entry]]) {
+        expect(() =>
+          text("create", {
+            data: {
+              email: "a@b.c",
+              accounts: {
+                connectOrCreate: Array.isArray(operand)
+                  ? operand.map(() => ({
+                      where: { publicId: "acc1" },
+                      create: { organizationRole: 1 },
+                    }))
+                  : { where: { publicId: "acc1" }, create: { organizationRole: 1 } },
+              },
+            },
+          }),
+        ).not.toThrow();
+      }
+    });
+
+    test.each(["where", "create"])("a missing '%s' is refused by name", (key) => {
+      const partial: Record<string, unknown> = { ...entry };
+      delete partial[key];
+
+      expect(() =>
+        text("create", {
+          data: { email: "a@b.c", organization: { connectOrCreate: partial } },
+        }),
+      ).toThrow(new RegExp(`Expected a '${key}' key`));
+    });
+
+    test("an unexpected key is refused rather than ignored", () => {
+      expect(() =>
+        text("create", {
+          data: {
+            email: "a@b.c",
+            organization: { connectOrCreate: { ...entry, update: {} } },
+          },
+        }),
+      ).toThrow(/Unexpected update/);
+    });
+
+    /**
+     * Prisma's rule, and not merely ours: without a unique `where` the lookup
+     * matches an arbitrary row and "connect or create" quietly becomes
+     * "connect to whichever came back first".
+     */
+    test("a non-unique where is refused at compile time", () => {
+      expect(() =>
+        text("create", {
+          data: {
+            email: "a@b.c",
+            organization: {
+              connectOrCreate: { where: { name: "Acme" }, create: { name: "Acme" } },
+            },
+          },
+        }),
+      ).toThrow();
+    });
   });
 
   /**

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -330,6 +330,71 @@ describe("policies on nested writes", () => {
   });
 
   /**
+   * `connectOrCreate` against a row this caller cannot see.
+   *
+   * The interesting part is that it must not raise. A scoped-away hit reads as
+   * a **miss**, so the call takes the create branch and writes its own row —
+   * which is the same answer the caller would get if the row genuinely did not
+   * exist, and is what stops `connectOrCreate` from being a way to *probe* for
+   * another tenant's keys: `connect` raising and `connectOrCreate` succeeding
+   * would together tell you the row is there.
+   *
+   * The created row then carries our own tenant, because the child's `onCreate`
+   * scopes it.
+   */
+  test("connectOrCreate cannot see another tenant's row, and creates instead", async () => {
+    await Model.asUser(OURS, () =>
+      Note.$exec("create", {
+        data: {
+          label: "n",
+          folder: {
+            connectOrCreate: {
+              where: { code: "theirs" },
+              create: { code: "theirs-mine" },
+            },
+          },
+        },
+      }),
+    );
+
+    const folders: any = await raw.unsafe(
+      `SELECT "code", "orgId" FROM "Folder" ORDER BY "id"`,
+    );
+
+    // The other tenant's row is untouched, and ours was created beside it.
+    expect(folders).toHaveLength(2);
+    expect(folders[1].code).toBe("theirs-mine");
+    expect(folders[1].orgId).toBe(7);
+  });
+
+  /** ...and a visible row is connected, not duplicated. */
+  test("connectOrCreate connects a row this caller can see", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+
+    await Model.asUser(OURS, () =>
+      Note.$exec("create", {
+        data: {
+          label: "n",
+          folder: {
+            connectOrCreate: {
+              where: { code: "ours" },
+              create: { code: "ours" },
+            },
+          },
+        },
+      }),
+    );
+
+    const folders: any = await raw.unsafe(`SELECT * FROM "Folder"`);
+    expect(folders).toHaveLength(2);
+
+    const notes: any = await raw.unsafe(`SELECT * FROM "Note"`);
+    expect(notes[0].folderId).toBe(2);
+  });
+
+  /**
    * A scoped model could not upsert at all: `assertScopable` refuses to put a
    * scope on one, because its where becomes an `on conflict` target and a
    * target cannot carry a predicate.

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -418,6 +418,135 @@ function suite(label: string, url?: string) {
 
     // Verified against Prisma: an empty list writes nothing and does not error,
     // and the parent still comes back with `accounts: []`.
+    /**
+     * `connectOrCreate` — and the case that decides whether it is implemented
+     * or merely spelled: **a hit must ignore `create` entirely.** The seeded
+     * organisation is named "Acme"; the payload below names something else, and
+     * the row has to come back unchanged. An implementation that upserted would
+     * pass a test that only checked "one organisation exists".
+     */
+    test("connectOrCreate on the owning side connects, leaving the row alone", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "coc1@example.dev",
+            organization: {
+              connectOrCreate: {
+                where: { publicId: "o1" },
+                create: { publicId: "o1", name: "SHOULD-NOT-APPEAR" },
+              },
+            },
+          },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    test("connectOrCreate on the owning side creates when it misses", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "coc2@example.dev",
+            organization: {
+              connectOrCreate: {
+                where: { publicId: "brand-new" },
+                create: { publicId: "brand-new", name: "Made" },
+              },
+            },
+          },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    /**
+     * On this side a hit **repoints** the existing child at the new parent,
+     * which is what `connect` means here — so the assertion is on the `Account`
+     * table, not only on what came back.
+     */
+    test("connectOrCreate on the foreign side repoints an existing child", async () => {
+      await differential.reset();
+      await differential.prisma.account.create({
+        data: { publicId: "loose-coc", organizationRole: 1 },
+      });
+
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "coc3@example.dev",
+            accounts: {
+              connectOrCreate: {
+                where: { publicId: "loose-coc" },
+                create: { publicId: "loose-coc", organizationRole: 9 },
+              },
+            },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("connectOrCreate on the foreign side creates when it misses", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "coc4@example.dev",
+            accounts: {
+              connectOrCreate: {
+                where: { publicId: "no-such-account" },
+                create: { publicId: "no-such-account", organizationRole: 2 },
+              },
+            },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /** A list where one entry hits and the other does not — both branches, one call. */
+    test("connectOrCreate takes a list, hitting and missing in one call", async () => {
+      await differential.reset();
+      await differential.prisma.account.create({
+        data: { publicId: "mixed-hit", organizationRole: 1 },
+      });
+
+      await differential.expectSameWrite(
+        "User",
+        "create",
+        {
+          data: {
+            email: "coc5@example.dev",
+            accounts: {
+              connectOrCreate: [
+                {
+                  where: { publicId: "mixed-hit" },
+                  create: { publicId: "mixed-hit", organizationRole: 9 },
+                },
+                {
+                  where: { publicId: "mixed-miss" },
+                  create: { publicId: "mixed-miss", organizationRole: 3 },
+                },
+              ],
+            },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
     test("nested createMany with no rows writes the parent alone", async () => {
       await differential.expectSameWrite(
         "User",


### PR DESCRIPTION
The second item on #65's own suggested order, after `createMany`. **Stacked on #75**, which is where `createMany` lives — hence the base, so the diff here is only the new operand.

## The thing the name gets wrong

**A hit ignores `create` entirely.** It is connect-*or*-create, not upsert. Measured against Prisma rather than assumed: an existing organisation kept its own name where the `create` payload named a different one, and an existing account kept its own role.

The differential case is written so an implementation that upserted would fail it — the create payload is named `SHOULD-NOT-APPEAR`. A test that only checked "one organisation exists afterwards" would pass against the wrong implementation.

## Both directions, because they are different work

- **This row holds the foreign key** → a `before` step that resolves to one more bound column.
- **The child holds it** → a hit is an `update` of the child's key (Prisma *repoints* the existing row rather than duplicating it — verified), a miss is a `create` with the key stamped on.

`findUnique`, not `findUniqueOrThrow`: a miss is the *other branch* here, where for a plain `connect` it is an error.

## The scoped-away case is the interesting one, and it must not raise

Both branches go through the child's own `$exec`, so both are scoped — and they have to be, in **opposite directions**:

- an unscoped *update* would re-parent another tenant's row;
- an unscoped *read* would let a hit reveal that a row with that key exists.

Scoped, a hidden row reads as absent and the call creates its own — the same answer the caller would get if it genuinely did not exist. That symmetry is the point: `connect` raising while `connectOrCreate` succeeded would together confirm the row is there, which is a probe.

Verified by pre-scoping the lookup and watching the test fail — with the child's policy skipped it connects to the other tenant's folder, leaving one row where there should be two:

```
× connectOrCreate cannot see another tenant's row, and creates instead
  expected [ { code: 'theirs', orgId: 99 }, …(4) ] to have a length of 2 but got 1
```

## Validated at plan time

`where` and `create` both required, no other keys, `where` unique, and a list refused on a to-one — Prisma refuses all four the same way. Checked when the query compiles rather than after the parent row is written and the transaction has to unwind it, which is the same reason `createMany`'s operand is checked there.

## Tests

- **5 differential cases** — hit and miss on each side, plus a list that does both in one call. The foreign-side ones compare the `Account` table, not only the returned payload, because a hit is a write to a row the call did not create.
- **9 unit tests** over the plan shape (which side gets a `before` vs an `after` step) and the four refusals.
- **2 policy tests**, one of them verified red against a pre-scoped lookup.

## Verification

899 unit tests. Full template suite green on SQLite (473) and Postgres 16 (715), with only the pre-existing `generated.test.ts` generator-linkage probe failing — it fails on the base branch too. `tsc` clean; oxlint clean.

## What is left on #65

`set` / `disconnect` / `delete` / `deleteMany` on ordinary to-many relations — item 3, and cheap now that both sides' child-statement sequencing exists — then the nested `update` / `updateMany` / `upsert` family, which #65 itself flags as the place to stop and decide whether the whole tree is in scope. (#83 covers those operands for *implicit many-to-many* only, where there is a join table rather than a foreign key.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
