### PR TITLE
Composite relations: every read surface joins on all of the fields

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -293,6 +293,19 @@ await List.create({
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
 | `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
 
+**A relation may join on more than one field.** `@relation(fields: [tenantId, orderId], references:
+[tenantId, id])` is the tenant-scoped composite-key style, and every read surface handles it: an
+`include` under either strategy, a relation filter, a `_count`, and an `orderBy` through the
+relation. The correlation becomes one equality per field; the batched strategy filters its children
+with an `OR` of `AND`s rather than a tuple `in`, because that is one shape both dialects already
+compile.
+
+Two consequences worth knowing. A composite join uses one placeholder *per field per parent*, so
+SQLite's parameter ceiling arrives proportionally sooner on a wide `include` — `ParameterLimitError`
+still names it rather than letting the driver fail. And a **nested write** through a composite
+relation is refused: it would have to contribute that many foreign-key columns to the insert, which
+is not implemented. Write the child separately with its keys set.
+
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
 child holds it, nothing can be written until this row exists, so those run after — which is why the

--- a/packages/gemi/orm/compile/composite-relations.test.ts
+++ b/packages/gemi/orm/compile/composite-relations.test.ts
@@ -12,23 +12,23 @@ import { compileWrite } from "./write";
 /**
  * Multi-field relations — `@relation(fields: [a, b], references: [c, d])`.
  *
- * Not implemented (#67), and the point of this file is the *shape* of the
- * refusal rather than the feature:
+ * **This file has inverted, exactly as it said it would.** It used to assert
+ * that seven surfaces refuse a composite relation, on the reasoning that a
+ * one-field assumption reached by any path would join on the first field and
+ * silently return the wrong rows. #67 implements six of the seven, so those six
+ * now assert the SQL — *every* joined field appears in the correlation, which is
+ * the same property from the other side.
  *
- * 1. **Every surface refuses.** A one-field assumption reached by any path
- *    would join on the first field and silently return the wrong rows — the
- *    worst failure available here, because the query succeeds. Seven surfaces
- *    correlate over a relation, and each has its own compiler; they are safe
- *    only because all seven resolve their link through one function. That is a
- *    property to hold, not a coincidence to rediscover.
+ * The seventh is a nested write, and it still refuses: reading across a
+ * composite relation is a wider correlation, writing through one would have to
+ * contribute that many foreign-key columns to an insert. The refusal is now a
+ * `singleFieldLink` call rather than a shared resolver, so the narrowing is a
+ * function nobody can reach past — there is no single-field property on `Link`
+ * to index into.
  *
- * 2. **Each names the operation it came from.** They all used to report
- *    `(Model.include)` — a composite relation named in a `where`, in an
- *    `orderBy`, or in a nested `connect` on a `create` sent the reader to an
- *    `include` they had not written.
- *
- * When the feature lands this file inverts: the refusals become assertions
- * about emitted SQL, and the list of surfaces is already here.
+ * What has *not* changed is the reason the list is exhaustive: all seven still
+ * resolve their link through one function, so a new surface inherits composite
+ * support rather than having to grow it.
  */
 
 const sqlite = new SqliteDialect();
@@ -42,19 +42,22 @@ beforeEach(() => {
 
 afterEach(() => registry.clearRegistry());
 
-/** `[surface, run, model, operation]` — the seven paths that correlate. */
-const SURFACES: [string, () => unknown, string, string][] = [
+/**
+ * `[surface, run, fragments]` — the read paths that correlate, and the SQL each
+ * has to contain. Every one names *both* joined fields.
+ */
+const READ_SURFACES: [string, () => unknown, string[]][] = [
   [
-    "include, to-many",
+    "include, to-many (batched)",
     () => compileRead(ledger, "findMany", { include: { entries: true } }, sqlite),
-    "Ledger",
-    "findMany",
+    // The batched strategy adds nothing to the root statement; it selects both
+    // key fields so the second query can be filtered and stitched.
+    [`"tenantId"`, `"code"`],
   ],
   [
-    "include, to-one",
+    "include, to-one (batched)",
     () => compileRead(ledgerEntry, "findMany", { include: { ledger: true } }, sqlite),
-    "LedgerEntry",
-    "findMany",
+    [`"tenantId"`, `"ledgerCode"`],
   ],
   [
     "include under the lateral strategy",
@@ -66,8 +69,10 @@ const SURFACES: [string, () => unknown, string, string][] = [
         postgres,
         lateralStrategy,
       ),
-    "Ledger",
-    "findMany",
+    [
+      `"tenantId" = "Ledger"."tenantId"`,
+      `"ledgerCode" = "Ledger"."code"`,
+    ],
   ],
   [
     "a relation filter",
@@ -78,8 +83,10 @@ const SURFACES: [string, () => unknown, string, string][] = [
         { where: { entries: { some: { amount: 1 } } } },
         sqlite,
       ),
-    "Ledger",
-    "findMany",
+    [
+      `"_r0"."tenantId" = "Ledger"."tenantId"`,
+      `"_r0"."ledgerCode" = "Ledger"."code"`,
+    ],
   ],
   [
     "_count",
@@ -90,8 +97,10 @@ const SURFACES: [string, () => unknown, string, string][] = [
         { include: { _count: { select: { entries: true } } } },
         sqlite,
       ),
-    "Ledger",
-    "findMany",
+    [
+      `"_c0"."tenantId" = "Ledger"."tenantId"`,
+      `"_c0"."ledgerCode" = "Ledger"."code"`,
+    ],
   ],
   [
     "an orderBy through a relation",
@@ -102,84 +111,198 @@ const SURFACES: [string, () => unknown, string, string][] = [
         { orderBy: { ledger: { title: "asc" } } },
         sqlite,
       ),
-    "LedgerEntry",
-    "findMany",
-  ],
-  [
-    "a nested write",
-    () =>
-      compileWrite(
-        ledger,
-        "create",
-        {
-          data: {
-            tenantId: 1,
-            code: "a",
-            title: "t",
-            entries: { create: { amount: 1 } },
-          },
-        },
-        sqlite,
-      ),
-    "Ledger",
-    "create",
+    [
+      `"tenantId" = "LedgerEntry"."tenantId"`,
+      `"code" = "LedgerEntry"."ledgerCode"`,
+    ],
   ],
 ];
 
-describe("a multi-field relation is refused, everywhere", () => {
-  test.each(SURFACES)("%s", (_label, run) => {
-    expect(run).toThrow(UnsupportedQueryError);
-    expect(run).toThrow(/joins on 2 fields/);
+describe("every read surface joins on all of the fields", () => {
+  /**
+   * `LedgerEntry` points at `Ledger` on `(tenantId, ledgerCode)`, so a
+   * correlation that named only the first would match every ledger in the
+   * tenant — the failure this file was written to prevent, and the one that
+   * *succeeds* rather than raising.
+   */
+  test.each(READ_SURFACES)("%s", (_label, run, expected) => {
+    const text = (run() as { text: string }).text;
+    for (const fragment of expected) expect(text).toContain(fragment);
+  });
+
+  /** The pairing is positional, so both halves have to line up. */
+  test("the correlation pairs the fields in order, not by name", () => {
+    const { text } = compileRead(
+      ledger,
+      "findMany",
+      { include: { _count: { select: { entries: true } } } },
+      sqlite,
+    );
+
+    // `tenantId` matches `tenantId` and `code` matches `ledgerCode` — a
+    // by-name pairing would fail to find the second and a positional one that
+    // slipped would compare the wrong pair.
+    expect(text).toContain(`"_c0"."tenantId" = "Ledger"."tenantId"`);
+    expect(text).toContain(`"_c0"."ledgerCode" = "Ledger"."code"`);
   });
 
   /**
-   * The half that was wrong: a refusal has to name where it came from, or it
-   * sends the reader to a query they did not write. `#61`'s rule.
+   * The batched strategy pages its children with an `in` over the parents'
+   * keys, which a composite relation cannot express as one list. It becomes an
+   * `OR` of `AND`s in *argument* space — one shape both dialects already
+   * compile — rather than a tuple `in`, which only Postgres has.
    */
-  test.each(SURFACES)("%s names its own operation", (_label, run, model, operation) => {
-    expect(run).toThrow(`(${model}.${operation})`);
-  });
+  test("the batched strategy filters children by an OR of ANDs", async () => {
+    const plan = compileRead(ledger, "findMany", { include: { entries: true } }, sqlite);
+    const relation = plan.relations![0];
 
-  /** And says what to do instead, rather than only what it will not do. */
-  test("the message offers a way through", () => {
-    const run = () =>
-      compileRead(ledger, "findMany", { include: { entries: true } }, sqlite);
+    expect(relation.parentFields).toEqual(["tenantId", "code"]);
 
-    expect(run).toThrow(/composite key comparison/);
-    expect(run).toThrow(/DB\.query/);
+    const seen: any[] = [];
+    await relation.load(
+      [
+        { tenantId: 1, code: "a" },
+        { tenantId: 2, code: "b" },
+      ] as any,
+      {},
+      {
+        exec: async (_model: string, _op: string, args: any) => {
+          seen.push(args);
+          return [];
+        },
+      } as any,
+    );
+
+    expect(seen[0].where).toEqual({
+      OR: [
+        { tenantId: 1, ledgerCode: "a" },
+        { tenantId: 2, ledgerCode: "b" },
+      ],
+    });
   });
 
   /**
-   * Both sides, because the two are resolved differently: the owning side reads
-   * `from` / `to` off its own relation, and the other side has to find its
-   * counterpart through `relationName` first.
+   * The stitch key is a tuple, so two parents differing only in *where* the
+   * boundary falls must not collide. Concatenation would put `("ab", "c")` and
+   * `("a", "bc")` in the same bucket and attach each parent's children to the
+   * other — silently, since both queries succeed.
    */
-  test("it is refused from the referenced side as well as the owning one", () => {
-    expect(() =>
-      compileRead(ledger, "findMany", { include: { entries: true } }, sqlite),
-    ).toThrow(/to: tenantId, code/);
+  test("the stitch key cannot collide across the field boundary", async () => {
+    const plan = compileRead(ledgerEntry, "findMany", { include: { ledger: true } }, sqlite);
+    const relation = plan.relations![0];
 
-    expect(() =>
-      compileRead(ledgerEntry, "findMany", { include: { ledger: true } }, sqlite),
-    ).toThrow(/from: tenantId, ledgerCode/);
+    // `ledger: null` is what the shaper writes before relations are attached;
+    // a to-one only fills a slot that is already there.
+    const parents: any[] = [
+      { id: 1, tenantId: 1, ledgerCode: "b", ledger: null },
+      { id: 2, tenantId: 1, ledgerCode: "bc", ledger: null },
+      { id: 3, tenantId: 1, ledgerCode: "b", ledger: null },
+    ];
+
+    await relation.load(parents, {}, {
+      exec: async () => [
+        { tenantId: 1, code: "b", title: "b" },
+        { tenantId: 1, code: "bc", title: "bc" },
+      ],
+    } as any);
+
+    // Concatenating the fields would make `(1, "b")` and `(1, "bc")` adjacent
+    // strings and, with a third parent, indistinguishable — each parent has to
+    // get its own ledger.
+    expect(parents[0].ledger).toMatchObject({ title: "b" });
+    expect(parents[1].ledger).toMatchObject({ title: "bc" });
+    expect(parents[2].ledger).toMatchObject({ title: "b" });
   });
+});
 
-  /**
-   * A single-field relation on the same models still compiles — otherwise this
-   * suite would pass for a compiler that refused every relation.
-   */
-  test("a single-field relation is unaffected", () => {
-    registry.register("Ledger", class { static $schema = ledger });
-    const single = {
+/**
+ * #67's third acceptance item: two composite relations differing only in field
+ * *order* have to be two plans.
+ *
+ * The order is what pairs the sides, so `(tenantId, code)` and `(code,
+ * tenantId)` are different joins that compile to different SQL — and the
+ * argument shapes are identical, which is exactly the collision the plan cache
+ * is built to avoid. The field names come from the schema rather than the
+ * arguments, so this is really a check that the *schema* reaches the key.
+ */
+describe("plan discrimination", () => {
+  test("field order changes the emitted correlation", () => {
+    const flipped: any = {
       ...ledgerEntry,
       relations: {
-        ledger: { ...ledgerEntry.relations.ledger, from: ["ledgerCode"], to: ["code"] },
+        ...ledgerEntry.relations,
+        ledger: {
+          ...ledgerEntry.relations.ledger,
+          from: ["ledgerCode", "tenantId"],
+          to: ["code", "tenantId"],
+        },
       },
     };
-    registry.register("LedgerEntry", class { static $schema = single });
+
+    const straight = compileRead(
+      ledgerEntry,
+      "findMany",
+      { orderBy: { ledger: { title: "asc" } } },
+      sqlite,
+    ).text;
+    const reversed = compileRead(
+      flipped,
+      "findMany",
+      { orderBy: { ledger: { title: "asc" } } },
+      sqlite,
+    ).text;
+
+    // Same pairs, written the other way round — and if the two sides were
+    // paired by *name* rather than by position these would be identical.
+    expect(straight).not.toBe(reversed);
+    expect(reversed).toContain(`"code" = "LedgerEntry"."ledgerCode"`);
+    expect(reversed).toContain(`"tenantId" = "LedgerEntry"."tenantId"`);
+  });
+
+  /**
+   * A mismatched pair is the artifact disagreeing with the schema, not a query
+   * the caller can fix — so it is a `MalformedRelationError` rather than an
+   * unsupported query, and it names both sides.
+   */
+  test("sides of different lengths are a malformed relation", () => {
+    const lopsided: any = {
+      ...ledgerEntry,
+      relations: {
+        ...ledgerEntry.relations,
+        ledger: { ...ledgerEntry.relations.ledger, to: ["code"] },
+      },
+    };
 
     expect(() =>
-      compileRead(single, "findMany", { include: { ledger: true } }, sqlite),
-    ).not.toThrow();
+      compileRead(lopsided, "findMany", { include: { ledger: true } }, sqlite),
+    ).toThrow(/joins 2 field\(s\) to 1/);
+  });
+});
+
+describe("a nested write still refuses, and says why", () => {
+  const run = () =>
+    compileWrite(
+      ledger,
+      "create",
+      {
+        data: {
+          tenantId: 1,
+          code: "a",
+          title: "t",
+          entries: { create: { amount: 1 } },
+        },
+      },
+      sqlite,
+    );
+
+  test("it names the field count and the reason", () => {
+    expect(run).toThrow(UnsupportedQueryError);
+    expect(run).toThrow(/joins on 2 fields/);
+    expect(run).toThrow(/Reading across a composite relation works/);
+  });
+
+  /** #61's rule: a refusal that misnames its origin sends the reader astray. */
+  test("it names its own operation", () => {
+    expect(run).toThrow("(Ledger.create)");
   });
 });

--- a/packages/gemi/orm/compile/correlate.ts
+++ b/packages/gemi/orm/compile/correlate.ts
@@ -68,17 +68,44 @@ export function correlate(
 
   const quoted = dialect.quoteIdent(alias);
   const qualifier = `${quoted}.`;
-  const childKey = `${qualifier}${dialect.quoteIdent(column(child, relation, link.childField))}`;
-  const parentKey = `${parentQualifier}${dialect.quoteIdent(column(parent, relation, link.parentField))}`;
+
+  /**
+   * One equality per joined field, `and`ed.
+   *
+   * This is the whole of the composite-relation change for three of the four
+   * correlated surfaces — a relation filter, a `_count` and an `orderBy` all
+   * build their subquery here — which is the payoff for hoisting the
+   * correlation into one function rather than leaving three copies of it.
+   */
+  const correlation = link.parentFields
+    .map((parentField, index) => {
+      const childKey = `${qualifier}${dialect.quoteIdent(
+        column(child, relation, link.childFields[index]),
+      )}`;
+      const parentKey = `${parentQualifier}${dialect.quoteIdent(
+        column(parent, relation, parentField),
+      )}`;
+      return `${childKey} = ${parentKey}`;
+    })
+    .join(" and ");
 
   if (!link.join) {
     return {
       child,
       source: `${dialect.quoteIdent(child.table)} as ${quoted}`,
-      correlation: `${childKey} = ${parentKey}`,
+      correlation,
       qualifier,
     };
   }
+
+  // A join table always has exactly two columns, so the m-n branch below stays
+  // single-field by construction rather than by assumption.
+  const childKey = `${qualifier}${dialect.quoteIdent(
+    column(child, relation, link.childFields[0]),
+  )}`;
+  const parentKey = `${parentQualifier}${dialect.quoteIdent(
+    column(parent, relation, link.parentFields[0]),
+  )}`;
 
   // The join table gets the child's alias with a `j`, so two nested m-n filters
   // cannot collide any more than their children can.

--- a/packages/gemi/orm/compile/lateral.ts
+++ b/packages/gemi/orm/compile/lateral.ts
@@ -122,7 +122,7 @@ export const lateralStrategy: RelationStrategy = {
       as: request.as,
       model: request.relation.model,
       kind: request.relation.kind,
-      parentField: link.parentField,
+      parentFields: link.parentFields,
       strategy: "lateral",
       root: {
         column: concat(
@@ -334,13 +334,19 @@ function foldNode(input: FoldInput): Fold {
   );
 
   // The correlation: the child's foreign key against the *parent's* column.
-  // This is the whole of "lateral" — the subquery references the outer row.
+  // This is the whole of "lateral" — the subquery references the outer row —
+  // and one equality per joined field is the whole of composite support here.
   const correlation = sql(
-    `${childQualifier}${dialect.quoteIdent(
-      fieldOf(child, input.link.childField).column,
-    )} = ${dialect.quoteIdent(input.parent.table)}.${dialect.quoteIdent(
-      fieldOf(input.parent, input.link.parentField).column,
-    )}`,
+    input.link.parentFields
+      .map(
+        (parentField, index) =>
+          `${childQualifier}${dialect.quoteIdent(
+            fieldOf(child, input.link.childFields[index]).column,
+          )} = ${dialect.quoteIdent(input.parent.table)}.${dialect.quoteIdent(
+            fieldOf(input.parent, parentField).column,
+          )}`,
+      )
+      .join(" and "),
   );
 
   const filter = compileWhere(

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -5,6 +5,7 @@ import {
   type NestedWriteStep,
   relatedSchema,
   resolveLink,
+  singleFieldLink,
 } from "./plan-relations";
 import { matchUniqueKey } from "./unique";
 
@@ -192,7 +193,19 @@ function planOne(
   if (keys.length === 0) return;
 
   const child = relatedSchema(schema, relation);
-  const link = resolveLink(schema, child, relation, operation);
+
+  // **Narrowed to one field, deliberately.** Reading across a composite
+  // relation works (#67); writing through one would have to contribute that
+  // many foreign-key columns to this insert, which is a different piece of
+  // work — so it is refused here by name rather than silently writing the
+  // first field. The narrowing is a function call rather than an index, so
+  // there is no single-field property on `Link` to reach for by accident.
+  const link = singleFieldLink(
+    resolveLink(schema, child, relation, operation),
+    schema,
+    relation,
+    operation,
+  );
 
   // `from` is non-empty exactly on the side that holds the foreign key.
   const owning = relation.from.length > 0;

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -201,10 +201,13 @@ export interface RelationPlan {
   model: string;
   kind: "one" | "many";
   /**
-   * The parent *field* whose value keys the stitch. The root query must select
-   * it even when the caller's `select` did not ask for it.
+   * The parent *fields* whose values key the stitch. The root query must select
+   * every one of them even when the caller's `select` did not ask for it.
+   *
+   * A list because a relation may join on more than one field; for the ordinary
+   * single-field case it holds one.
    */
-  parentField: string;
+  parentFields: string[];
   /** Which strategy produced this plan. Reported by tests and, later, metrics. */
   strategy: string;
   /** Fetches the children for these parents and attaches them in place. */
@@ -337,7 +340,7 @@ export function planRelations(
     });
 
     plans.push(plan);
-    keyFields.add(plan.parentField);
+    for (const field of plan.parentFields) keyFields.add(field);
   }
 
   return { plans, keyFields: [...keyFields] };
@@ -669,12 +672,60 @@ function validateSubtree(
 // --- topology --------------------------------------------------------------
 
 export interface Link {
-  /** Field on the parent whose value the child is matched against. */
-  parentField: string;
-  /** Field on the child holding the matching value. */
-  childField: string;
+  /**
+   * Fields on the parent whose values the child is matched against, paired
+   * positionally with {@link childFields}.
+   *
+   * **A list, because a relation may join on more than one field.**
+   * `@relation(fields: [tenantId, orderId], references: [tenantId, id])` is a
+   * deliberate schema style — every table carries the tenant — and it used to
+   * be refused on every surface. The pairing is positional and Prisma
+   * guarantees the two sides are the same length, which `resolveLink` checks
+   * rather than assumes.
+   *
+   * Singular access is a *narrowing* and has to be justified: nested writes
+   * still take one field at a time, so they go through {@link singleFieldLink},
+   * which refuses a composite relation by name. That is a type-level guard
+   * rather than a convention — there is no `parentField` to reach for.
+   */
+  parentFields: string[];
+  /** Fields on the child holding the matching values. */
+  childFields: string[];
   /** Set for Prisma's implicit many-to-many, which joins through a table. */
   join?: { table: string; parentColumn: string; childColumn: string };
+}
+
+/**
+ * The one-field view of a link, for the callers that genuinely cannot take more.
+ *
+ * A nested write contributes a *column* to an insert, so a composite relation
+ * would be several — a different piece of work from reading across one, and
+ * refused here rather than silently writing the first field. #67's acceptance
+ * list is the read surfaces; this keeps the write side honest about the gap.
+ */
+export function singleFieldLink(
+  link: Link,
+  parent: ModelSchema,
+  relation: RelationSchema,
+  operation: string,
+): { parentField: string; childField: string; join?: Link["join"] } {
+  if (link.parentFields.length !== 1) {
+    throw new UnsupportedQueryError(
+      relation.name,
+      parent.name,
+      operation,
+      `${relation.name} joins on ${link.parentFields.length} fields ` +
+        `(${link.parentFields.join(", ")}). Reading across a composite ` +
+        `relation works; writing through one would have to contribute that ` +
+        `many foreign-key columns to this insert, which is not implemented. ` +
+        `Write the child separately with its keys set.`,
+    );
+  }
+  return {
+    parentField: link.parentFields[0],
+    childField: link.childFields[0],
+    join: link.join,
+  };
 }
 
 /**
@@ -713,10 +764,7 @@ export function resolveLink(
   if (relation.joinTable) return joinTableLink(parent, child, relation);
 
   if (relation.from.length > 0) {
-    return {
-      parentField: single(parent, relation, relation.from, "from", operation),
-      childField: single(parent, relation, relation.to, "to", operation),
-    };
+    return paired(parent, relation, relation.from, relation.to, operation);
   }
 
   const other = otherSide(parent, child, relation);
@@ -729,10 +777,46 @@ export function resolveLink(
     );
   }
 
-  return {
-    parentField: single(parent, relation, other.to, "to", operation),
-    childField: single(parent, relation, other.from, "from", operation),
-  };
+  // Read from the far side, so `to` is what *this* model holds.
+  return paired(parent, relation, other.to, other.from, operation);
+}
+
+/**
+ * The two sides of a join, checked to line up.
+ *
+ * Prisma guarantees `fields` and `references` are the same length — it refuses
+ * the schema otherwise — so a mismatch here means the generated artifact and
+ * the schema disagree, which is a `MalformedRelationError` rather than an
+ * unsupported query. Checked rather than assumed because the pairing is
+ * positional: a silent length mismatch would join on whichever fields happened
+ * to line up.
+ */
+function paired(
+  parent: ModelSchema,
+  relation: RelationSchema,
+  parentFields: string[],
+  childFields: string[],
+  operation: string,
+): Link {
+  if (parentFields.length === 0) {
+    throw new UnsupportedQueryError(
+      relation.name,
+      parent.name,
+      operation,
+      `${relation.name} names no join fields.`,
+    );
+  }
+
+  if (parentFields.length !== childFields.length) {
+    throw new MalformedRelationError(
+      parent.name,
+      relation.name,
+      `it joins ${parentFields.length} field(s) to ${childFields.length}: ` +
+        `${parentFields.join(", ")} against ${childFields.join(", ")}.`,
+    );
+  }
+
+  return { parentFields, childFields };
 }
 
 /** The far end of the relation, found by the name both sides share. */
@@ -780,28 +864,6 @@ function otherSide(
  * `create`. A refusal that misnames where it came from sends the reader to a
  * query they did not write — see #61.
  */
-function single(
-  parent: ModelSchema,
-  relation: RelationSchema,
-  fields: string[],
-  side: string,
-  operation: string,
-): string {
-  if (fields.length !== 1) {
-    throw new UnsupportedQueryError(
-      relation.name,
-      parent.name,
-      operation,
-      `${relation.name} joins on ${fields.length} fields (${side}: ` +
-        `${fields.join(", ") || "none"}). A multi-field relation needs a ` +
-        `composite key comparison on both sides — a tuple 'in' for the ` +
-        `batched strategy, a conjunction for the lateral one — which is not ` +
-        `implemented. Query the two models separately and join them in ` +
-        `process, or write the join with 'sql' and 'DB.query'.`,
-    );
-  }
-  return fields[0];
-}
 
 /**
  * Prisma's implicit many-to-many has no join *model*: it is a bare
@@ -834,8 +896,8 @@ function joinTableLink(
     }
 
     return {
-      parentField: primaryKey(parent, relation),
-      childField: primaryKey(child, relation),
+      parentFields: [primaryKey(parent, relation)],
+      childFields: [primaryKey(child, relation)],
       join: {
         table,
         parentColumn: owner,
@@ -856,8 +918,8 @@ function joinTableLink(
   const parentColumn = parent.name === a ? "A" : "B";
 
   return {
-    parentField: primaryKey(parent, relation),
-    childField: primaryKey(child, relation),
+    parentFields: [primaryKey(parent, relation)],
+    childFields: [primaryKey(child, relation)],
     join: {
       table,
       parentColumn,
@@ -954,19 +1016,37 @@ export const batchedStrategy: RelationStrategy = {
     );
 
     // Resolved at plan time so a stale artifact fails when the query is
-    // compiled rather than after the root query has already run.
+    // compiled rather than after the root query has already run. Every joined
+    // field is checked, not only the first — a composite relation whose second
+    // field is unkeyable would otherwise fail mid-stitch.
+    for (const name of link.parentFields) {
+      assertKeyable(
+        request.parent,
+        request.relation,
+        field(request.parent, request.relation, name),
+      );
+    }
+    for (const name of link.childFields) {
+      assertKeyable(
+        request.child,
+        request.relation,
+        field(request.child, request.relation, name),
+      );
+    }
+
+    // The join-table hops below encode and decode through the *first* field,
+    // which is exact: `_PostToTag` has two columns and `resolveLink` gives a
+    // one-element list for it.
     const parentKeyField = field(
       request.parent,
       request.relation,
-      link.parentField,
+      link.parentFields[0],
     );
     const childKeyField = field(
       request.child,
       request.relation,
-      link.childField,
+      link.childFields[0],
     );
-    assertKeyable(request.parent, request.relation, parentKeyField);
-    assertKeyable(request.child, request.relation, childKeyField);
 
     const many = request.relation.kind === "many";
 
@@ -974,7 +1054,7 @@ export const batchedStrategy: RelationStrategy = {
       as: request.as,
       model: request.relation.model,
       kind: request.relation.kind,
-      parentField: link.parentField,
+      parentFields: link.parentFields,
       strategy: BATCHED,
       load(parents, args, executor) {
         const context = {
@@ -1007,13 +1087,13 @@ async function loadDirect(
   link: Link,
   context: LoadContext,
 ): Promise<void> {
-  const { keys, byKey } = index(context.parents, link.parentField);
+  const { keys, byKey } = index(context.parents, link.parentFields);
   // Every parent's key is null: nothing can match, and the defaults the shaper
   // already wrote (`null` / `[]`) are the answer.
   if (keys.length === 0) return;
 
   const node = request.locate(context.args);
-  const query = childQuery(node, link.childField, keys);
+  const query = childQuery(node, link.childFields, keys);
 
   const rows = (await context.executor.exec(
     request.relation.model,
@@ -1025,13 +1105,17 @@ async function loadDirect(
   )) as Row[];
 
   for (const row of rows) {
-    const bucket = byKey.get(keyOf(row[link.childField]));
+    const bucket = byKey.get(
+      compositeKey(link.childFields.map((field) => row[field])),
+    );
     if (!bucket) continue;
     for (const parent of bucket) attach(parent, request.as, row, context.many);
   }
 
   if (query.hidden) {
-    for (const row of rows) delete row[link.childField];
+    for (const row of rows) {
+      for (const field of link.childFields) delete row[field];
+    }
   }
 }
 
@@ -1057,7 +1141,10 @@ async function loadThroughJoinTable(
   link: Link,
   context: LoadContext,
 ): Promise<void> {
-  const { keys, byKey } = index(context.parents, link.parentField);
+  // A join table has exactly two columns, so this hop is single-field by
+  // construction — `resolveLink` returns one-element lists for it, and the
+  // `[0]` below is that fact rather than an assumption about relations.
+  const { keys, byKey } = index(context.parents, link.parentFields);
   if (keys.length === 0) return;
 
   const { dialect } = request;
@@ -1066,19 +1153,19 @@ async function loadThroughJoinTable(
   const pairs = (await readPairs(
     dialect,
     join,
-    keys.map((key) => dialect.encode(key, context.parentKeyField)),
+    keys.map((key) => dialect.encode(key[0], context.parentKeyField)),
     context.executor,
   )) as Row[];
 
   // Parents keyed by the *child* id they link to, so the second hop can stitch
   // in one pass over its rows. Built once, not searched per row.
-  const owners = new Map<unknown, Row[]>();
-  const childKeys: unknown[] = [];
+  const owners = new Map<string, Row[]>();
+  const childKeys: unknown[][] = [];
 
   for (const pair of pairs) {
-    const parentKey = keyOf(
+    const parentKey = compositeKey([
       dialect.decode(pair[join.parentColumn], context.parentKeyField),
-    );
+    ]);
     const linked = byKey.get(parentKey);
     if (!linked) continue;
 
@@ -1086,13 +1173,13 @@ async function loadThroughJoinTable(
       pair[join.childColumn],
       context.childKeyField,
     );
-    const childKey = keyOf(childValue);
+    const childKey = compositeKey([childValue]);
 
     let bucket = owners.get(childKey);
     if (bucket === undefined) {
       bucket = [];
       owners.set(childKey, bucket);
-      childKeys.push(childValue);
+      childKeys.push([childValue]);
     }
     for (const parent of linked) bucket.push(parent);
   }
@@ -1100,7 +1187,7 @@ async function loadThroughJoinTable(
   if (childKeys.length === 0) return;
 
   const node = request.locate(context.args);
-  const query = childQuery(node, link.childField, childKeys);
+  const query = childQuery(node, link.childFields, childKeys);
 
   const rows = (await context.executor.exec(
     request.relation.model,
@@ -1114,13 +1201,13 @@ async function loadThroughJoinTable(
   // Iterated in the child query's order rather than the pairs' order, so a
   // relation-level `orderBy` still describes what each parent receives.
   for (const row of rows) {
-    const bucket = owners.get(keyOf(row[link.childField]));
+    const bucket = owners.get(compositeKey([row[link.childFields[0]]]));
     if (!bucket) continue;
     for (const parent of bucket) attach(parent, request.as, row, context.many);
   }
 
   if (query.hidden) {
-    for (const row of rows) delete row[link.childField];
+    for (const row of rows) delete row[link.childFields[0]];
   }
 }
 
@@ -1186,14 +1273,39 @@ async function readPairs(
  */
 function childQuery(
   node: unknown,
-  childField: string,
-  keys: unknown[],
+  childFields: string[],
+  keys: unknown[][],
 ): { args: Record<string, unknown>; hidden: boolean } {
   const relationArgs = (
     node === true || node === null || typeof node !== "object" ? {} : node
   ) as Record<string, unknown>;
 
-  const filter = { [childField]: { in: keys } };
+  /**
+   * One field is an `in`; several are an `OR` of `AND`s.
+   *
+   * **Written in argument space rather than as a tuple `in`**, which is the
+   * decision worth recording. Postgres has `(a, b) in ((…),(…))` and SQLite
+   * does not, so emitting it would mean a new dialect method and two spellings
+   * of the same predicate. `OR: [{ a: 1, b: 2 }, …]` is one shape both dialects
+   * already compile, through the `where` compiler that every other filter goes
+   * through — so it inherits the parameter accounting, the plan key and the
+   * injection rules instead of needing its own.
+   *
+   * It costs one placeholder per field per parent, where a tuple `in` would
+   * cost the same. `ParameterLimitError` therefore fires proportionally sooner
+   * on a composite relation, which is the honest behaviour: the ceiling is on
+   * placeholders and a composite key uses more of them.
+   */
+  const filter =
+    childFields.length === 1
+      ? { [childFields[0]]: { in: keys.map((key) => key[0]) } }
+      : {
+          OR: keys.map((key) =>
+            Object.fromEntries(
+              childFields.map((field, index) => [field, key[index]]),
+            ),
+          ),
+        };
   const args: Record<string, unknown> = {
     where:
       relationArgs.where === undefined
@@ -1207,15 +1319,33 @@ function childQuery(
   const select = relationArgs.select as Record<string, unknown> | undefined;
   if (select === undefined) return { args, hidden: false };
 
-  if (select[childField] === true) {
+  const missing = childFields.filter((field) => select[field] !== true);
+  if (missing.length === 0) {
     args.select = select;
     return { args, hidden: false };
   }
 
-  // The stitch key has to come back even when the caller did not ask for it.
-  // `attachRelations`' counterpart on the parent side deletes it again.
-  args.select = { ...select, [childField]: true };
+  // The stitch key has to come back even when the caller did not ask for it —
+  // every field of it. `attachRelations`' counterpart on the parent side
+  // deletes them again.
+  args.select = { ...select };
+  for (const field of missing) {
+    (args.select as Record<string, unknown>)[field] = true;
+  }
   return { args, hidden: true };
+}
+
+/**
+ * A map key for a tuple of values that cannot collide with a different tuple.
+ *
+ * `JSON.stringify` of the *normalised* values, not concatenation: `"a" + "b"`
+ * and `"ab" + ""` are the same string, and these are user data. Normalising
+ * first is what makes a `Date` and a `Bytes` key work at all, since neither
+ * compares by identity — `keyOf` already had to solve that for the single-field
+ * case, so this reuses it rather than restating it.
+ */
+function compositeKey(values: unknown[]): string {
+  return JSON.stringify(values.map(keyOf));
 }
 
 /**
@@ -1249,25 +1379,27 @@ function attach(parent: Row, as: string, row: Row, many: boolean): void {
  */
 function index(
   parents: Row[],
-  on: string,
-): { keys: unknown[]; byKey: Map<unknown, Row[]> } {
-  const byKey = new Map<unknown, Row[]>();
-  const keys: unknown[] = [];
+  on: string[],
+): { keys: unknown[][]; byKey: Map<string, Row[]> } {
+  const byKey = new Map<string, Row[]>();
+  const keys: unknown[][] = [];
 
   for (const parent of parents) {
-    const value = parent[on];
-    // A null foreign key matches nothing — `in` would not match it either —
-    // and the shaper has already written the `null` the caller sees.
-    if (value === null || value === undefined) continue;
+    const values = on.map((field) => parent[field]);
+    // A null anywhere in the key matches nothing — `in` would not match it
+    // either — and the shaper has already written the `null` the caller sees.
+    // For a composite key one null is enough: SQL equality on the other fields
+    // cannot rescue it.
+    if (values.some((value) => value === null || value === undefined)) continue;
 
-    const key = keyOf(value);
+    const key = compositeKey(values);
     let bucket = byKey.get(key);
     if (bucket === undefined) {
       bucket = [];
       byKey.set(key, bucket);
-      // The raw value, not the map key: this is what gets bound into the `in`
+      // The raw values, not the map key: these are what get bound into the `in`
       // list, and the dialect's encoder expects the value Prisma would hold.
-      keys.push(value);
+      keys.push(values);
     }
     bucket.push(parent);
   }

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -1283,18 +1283,39 @@ function childQuery(
   /**
    * One field is an `in`; several are an `OR` of `AND`s.
    *
-   * **Written in argument space rather than as a tuple `in`**, which is the
-   * decision worth recording. Postgres has `(a, b) in ((…),(…))` and SQLite
-   * does not, so emitting it would mean a new dialect method and two spellings
-   * of the same predicate. `OR: [{ a: 1, b: 2 }, …]` is one shape both dialects
-   * already compile, through the `where` compiler that every other filter goes
-   * through — so it inherits the parameter accounting, the plan key and the
-   * injection rules instead of needing its own.
+   * **Written in argument space rather than as a tuple `in`, and the trade is
+   * portability and reuse against plan quality — not the absence of a seam.**
+   * `SqlDialect.inList` is already a dialect method that exists because the two
+   * databases disagree about structure rather than spelling, so a tuple form
+   * would sit exactly where the architecture expects it. The reason to prefer
+   * `OR` anyway is that it is one shape both dialects already compile, through
+   * the `where` compiler every other filter goes through — so it inherits the
+   * parameter accounting, the plan key and the injection rules instead of
+   * needing its own. An N-branch `OR` and a tuple `IN` are not equivalent to a
+   * query planner on a large parent set, and that is the cost being paid.
    *
-   * It costs one placeholder per field per parent, where a tuple `in` would
-   * cost the same. `ParameterLimitError` therefore fires proportionally sooner
-   * on a composite relation, which is the honest behaviour: the ceiling is on
-   * placeholders and a composite key uses more of them.
+   * Two consequences, and the second is the one that is easy to miss:
+   *
+   * 1. It costs one placeholder per field per parent, so `ParameterLimitError`
+   *    fires proportionally sooner on a composite relation. The ceiling is on
+   *    placeholders and a composite key uses more of them.
+   *
+   * 2. **It does not reach `collapsedList`, so the plan key varies with the
+   *    parent count on Postgres too.** That collapse covers `in` / `notIn`,
+   *    where `= any($1)` makes every length one SQL text; an `OR`'s text
+   *    genuinely varies, so a shared key would hand a plan the wrong number of
+   *    placeholders — the trap `collapsedList` already describes for SQLite.
+   *    Measured over parent counts 2, 3, 10, 50:
+   *
+   *        sqlite    composite: 4 keys    single: 4 keys
+   *        postgres  composite: 4 keys    single: 1 key
+   *
+   *    SQLite churns either way and always has. The Postgres asymmetry is new,
+   *    and it is the churn `collapsedList` was written to prevent arriving
+   *    through the door it does not cover. A form where the parent keys ride in
+   *    one parameter — `(a, b) in (select * from unnest($1::int[], $2::text[]))`
+   *    — would fix it there and is filed rather than guessed at here, because
+   *    it needs the column types and its own coverage on both dialects. #97.
    */
   const filter =
     childFields.length === 1

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -866,7 +866,7 @@ describe("root contributions in compileRead", () => {
         return {
           as: request.as,
           kind: request.relation.kind,
-          parentField: "id",
+          parentFields: ["id"],
           strategy: "folded",
           root: {
             column: sql(`"folded"."data" as ${request.dialect.quoteIdent(request.as)}`),

--- a/packages/gemi/orm/compile/relations.test.ts
+++ b/packages/gemi/orm/compile/relations.test.ts
@@ -162,7 +162,7 @@ describe("planning", () => {
     expect(plan.relations![0]).toMatchObject({
       as: "accounts",
       kind: "many",
-      parentField: "id",
+      parentFields: ["id"],
       strategy: "batched",
     });
   });
@@ -172,11 +172,11 @@ describe("planning", () => {
     expect(compile({ include: { organization: true } }).relations![0]).toMatchObject({
       as: "organization",
       kind: "one",
-      parentField: "organizationId",
+      parentFields: ["organizationId"],
     });
-    expect(compile({ include: { accounts: true } }).relations![0].parentField).toBe(
-      "id",
-    );
+    expect(
+      compile({ include: { accounts: true } }).relations![0].parentFields,
+    ).toEqual(["id"]);
   });
 
   test("a select that omits the join key still fetches it, hidden", () => {
@@ -602,7 +602,7 @@ describe("implicit many-to-many", () => {
       as: "tags",
       kind: "many",
       // Both sides join on their own primary key; the join table holds the pair.
-      parentField: "id",
+      parentFields: ["id"],
     });
     expect(plan.text).toBe('select "id", "title" from "Post"');
   });
@@ -702,7 +702,7 @@ describe("root contributions", () => {
       plan: {
         as: "accounts",
         kind: "many" as const,
-        parentField: "id",
+        parentFields: ["id"],
         strategy: "test",
         root,
         load: async () => {

--- a/packages/gemi/orm/plan.discrimination.test.ts
+++ b/packages/gemi/orm/plan.discrimination.test.ts
@@ -455,6 +455,56 @@ describe("plan cache discrimination", () => {
     );
   });
 
+  /**
+   * The gap `collapsedList` does not cover, pinned so it changes deliberately.
+   *
+   * A composite relation cannot be filtered with a single `in`, so the batched
+   * loader builds an `OR` of `AND`s — whose text varies with its branch count,
+   * so it cannot be collapsed the way `= any($1)` can. The result is that
+   * Postgres, otherwise immune to parent-count churn, is not immune for a
+   * composite relation.
+   *
+   * Asserted rather than left as a comment because the *asymmetry* is the
+   * surprising part: same include, same query shape, different relation arity.
+   * If a future change makes the composite path collapse too, this is what
+   * should say so.
+   */
+  test("a composite parent filter churns on both dialects, unlike a single-field one", () => {
+    const counts = [2, 3, 10, 50];
+
+    const composite = (dialect: SqliteDialect | PostgresDialect) =>
+      new Set(
+        counts.map((n) =>
+          planKey(dialect, "Ledger", "findMany", {
+            where: {
+              OR: Array.from({ length: n }, (_, i) => ({
+                tenantId: 1,
+                code: `c${i}`,
+              })),
+            },
+          }),
+        ),
+      ).size;
+
+    const single = (dialect: SqliteDialect | PostgresDialect) =>
+      new Set(
+        counts.map((n) =>
+          planKey(dialect, "User", "findMany", {
+            where: { id: { in: Array.from({ length: n }, (_, i) => i) } },
+          }),
+        ),
+      ).size;
+
+    // SQLite expands an `in` to one placeholder per element, so it churns
+    // either way and always has.
+    expect(single(sqlite)).toBe(counts.length);
+    expect(composite(sqlite)).toBe(counts.length);
+
+    // Postgres collapses an `in` to one key — and cannot collapse the `OR`.
+    expect(single(postgres)).toBe(1);
+    expect(composite(postgres)).toBe(counts.length);
+  });
+
   // Postgres is the exception that proves the point: there, every in-length
   // shares one SQL text on purpose — so it shares one cache entry too, and the
   // extra entries are the cost of SQLite's expansion rather than a fact about

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -244,6 +244,24 @@ const LIST_KEYS = new Set(["in", "notIn"]);
  *
  * An empty list keeps its own key: `in: []` compiles to a constant-false
  * predicate rather than to `= any($1)`, which is a different text.
+ *
+ * **It covers `in` / `notIn` and nothing else, which leaves one gap worth
+ * naming here rather than only where it happens.** A relation joining on more
+ * than one field cannot be filtered with a single `in`, so the batched loader
+ * builds an `OR` of `AND`s instead (see `childQuery`) — and an `OR`'s text
+ * genuinely varies with its branch count, so it cannot be collapsed the way a
+ * Postgres `= any($1)` can: a shared key would hand a plan the wrong number of
+ * placeholders, which is the trap described above for SQLite. Measured over
+ * parent counts 2, 3, 10, 50:
+ *
+ *     sqlite    composite: 4 keys    single: 4 keys
+ *     postgres  composite: 4 keys    single: 1 key
+ *
+ * So the churn this function prevents for a single-field relation still happens
+ * for a composite one on Postgres. SQLite was always in that position. Fixing
+ * it needs a form where the parent keys ride in one parameter — Postgres can,
+ * with `unnest` over one array per column — which is a dialect method rather
+ * than a key change, and is filed as #97 rather than sketched here.
  */
 function collapsedList(value: unknown[]): string {
   return value.length === 0 ? "[]" : "[*]";

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -9,6 +9,8 @@ import {
 } from "./differential";
 import {
   AccountModel,
+  LedgerEntryModel,
+  LedgerModel,
   OrganizationModel,
   SocialAccountModel,
   UserModel,
@@ -20,6 +22,27 @@ import {
 const EPOCH = 1600000000000;
 
 async function seed(prisma: PrismaClient) {
+  // A relation joining on two fields (#67), in the tenant-scoped shape: the
+  // *same* ledger code appears in two tenants, so a join that used only the
+  // first field — or only the second — returns the wrong entries rather than
+  // failing. Two ledgers in tenant 1 whose codes differ only in length also
+  // pin the stitch key against concatenation: `(1, "a")` and `(1, "ab")`.
+  await prisma.ledger.createMany({
+    data: [
+      { tenantId: 1, code: "a", title: "one-a" },
+      { tenantId: 1, code: "ab", title: "one-ab" },
+      { tenantId: 2, code: "a", title: "two-a" },
+    ],
+  });
+  await prisma.ledgerEntry.createMany({
+    data: [
+      { tenantId: 1, ledgerCode: "a", amount: 10, memo: "first" },
+      { tenantId: 1, ledgerCode: "a", amount: 20, memo: null },
+      { tenantId: 1, ledgerCode: "ab", amount: 30, memo: "ab only" },
+      { tenantId: 2, ledgerCode: "a", amount: 40, memo: "other tenant" },
+    ],
+  });
+
   // Two organizations so a to-one include has something to discriminate, and
   // so `organization.users` is a to-many with more than one member.
   await prisma.organization.createMany({
@@ -853,6 +876,8 @@ function suite(label: string, url?: string) {
           SocialAccount: SocialAccountModel as never,
           Account: AccountModel as never,
           Organization: OrganizationModel as never,
+          Ledger: LedgerModel as never,
+          LedgerEntry: LedgerEntryModel as never,
         },
         seed,
         url,
@@ -861,6 +886,62 @@ function suite(label: string, url?: string) {
 
     afterAll(async () => {
       await differential?.dispose();
+    });
+
+    /**
+     * A relation joining on **two** fields (#67).
+     *
+     * The seed is arranged so a partial join is *wrong* rather than empty: the
+     * code `"a"` exists in both tenants, so joining on the code alone pulls in
+     * the other tenant's entries, and joining on the tenant alone pulls in
+     * `"ab"`'s. Either mistake returns rows, which is why these compare against
+     * Prisma rather than asserting a count.
+     */
+    describe("composite relations", () => {
+      const COMPOSITE: [string, string, string, unknown][] = [
+        ["to-many include", "Ledger", "findMany", {
+          orderBy: [{ tenantId: "asc" }, { code: "asc" }],
+          include: { entries: { orderBy: { id: "asc" } } },
+        }],
+        ["to-one include", "LedgerEntry", "findMany", {
+          orderBy: { id: "asc" }, include: { ledger: true },
+        }],
+        ["to-many include with a select on the child", "Ledger", "findMany", {
+          orderBy: [{ tenantId: "asc" }, { code: "asc" }],
+          include: { entries: { select: { amount: true }, orderBy: { amount: "asc" } } },
+        }],
+        // The stitch key has to come back even when the select omits it, and
+        // then be removed again — for *both* fields.
+        ["to-one select that omits both key fields", "LedgerEntry", "findMany", {
+          orderBy: { id: "asc" }, select: { amount: true, ledger: true },
+        }],
+        ["relation filter through a composite join", "Ledger", "findMany", {
+          where: { entries: { some: { amount: { gte: 30 } } } },
+          orderBy: [{ tenantId: "asc" }, { code: "asc" }],
+        }],
+        ["relation filter, none", "Ledger", "findMany", {
+          where: { entries: { none: { amount: { gte: 30 } } } },
+          orderBy: [{ tenantId: "asc" }, { code: "asc" }],
+        }],
+        ["_count through a composite join", "Ledger", "findMany", {
+          orderBy: [{ tenantId: "asc" }, { code: "asc" }],
+          include: { _count: { select: { entries: true } } },
+        }],
+        ["orderBy through a composite join", "LedgerEntry", "findMany", {
+          orderBy: [{ ledger: { title: "desc" } }, { id: "asc" }],
+        }],
+        ["a where on the far side of a to-one", "LedgerEntry", "findMany", {
+          where: { ledger: { title: "one-a" } }, orderBy: { id: "asc" },
+        }],
+        ["nested include, two levels through the composite", "Ledger", "findMany", {
+          orderBy: [{ tenantId: "asc" }, { code: "asc" }],
+          include: { entries: { orderBy: { id: "asc" }, include: { ledger: true } } },
+        }],
+      ];
+
+      test.each(COMPOSITE)("%s", async (_name, model, operation, args) => {
+        await differential.expectSame(model, operation, args);
+      });
     });
 
     test.each(CASES)("%s", async (_name, operation, args) => {

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -198,6 +198,13 @@ export async function createDifferential(options: {
     "User",
     "OrganizationInvitation",
     "Organization",
+    // The composite-relation pair (#67). Adding a model to the schema without
+    // adding it here is a *silent* omission on SQLite, where every run gets a
+    // fresh temp database, and a loud one on Postgres, where the second run's
+    // seed collides with the first's rows — which is exactly how this was
+    // found, and the second time in this suite's history.
+    "LedgerEntry",
+    "Ledger",
   ];
 
   /**

--- a/templates/saas-starter/app/models/generated/index.ts
+++ b/templates/saas-starter/app/models/generated/index.ts
@@ -8,6 +8,8 @@ import { assertSchemaArtifactVersion, register } from "gemi/orm";
 import { ARTIFACT_VERSION } from "./schema";
 import {
   AccountModel,
+  LedgerModel,
+  LedgerEntryModel,
   MagicLinkTokenModel,
   OrganizationModel,
   OrganizationInvitationModel,
@@ -23,6 +25,8 @@ assertSchemaArtifactVersion(ARTIFACT_VERSION);
 // lets two models reference each other without the generated files forming an
 // import cycle.
 register("Account", AccountModel);
+register("Ledger", LedgerModel);
+register("LedgerEntry", LedgerEntryModel);
 register("MagicLinkToken", MagicLinkTokenModel);
 register("Organization", OrganizationModel);
 register("OrganizationInvitation", OrganizationInvitationModel);

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -177,6 +177,298 @@ export class AccountModel extends Model {
 // accepted: `Model`'s constructor is `protected`, so the only way to get an
 // instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
 // oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
+export interface LedgerModel extends Prisma.LedgerGetPayload<{}> {}
+
+export type LedgerPolicy = ModelPolicy<
+  Prisma.LedgerWhereInput,
+  Prisma.LedgerCreateInput,
+  Prisma.LedgerGetPayload<{}>
+>;
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class LedgerScopedPolicy extends ScopedPolicy<
+  Prisma.LedgerWhereInput,
+  Prisma.LedgerCreateInput,
+  Prisma.LedgerGetPayload<{}>
+> {}
+
+export class LedgerModel extends Model {
+  static $schema = schema.Ledger;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.LedgerWhereInput,
+    Prisma.LedgerCreateInput,
+    Prisma.LedgerGetPayload<{}>
+  >[];
+
+  static findMany<T extends Prisma.LedgerFindManyArgs>(
+    args?: Subset<T, Prisma.LedgerFindManyArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T>[]> {
+    return this.$exec("findMany", args, options) as Promise<Prisma.LedgerGetPayload<T>[]>;
+  }
+
+  static findFirst<T extends Prisma.LedgerFindFirstArgs>(
+    args?: Subset<T, Prisma.LedgerFindFirstArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T> | null> {
+    return this.$exec("findFirst", args, options) as Promise<Prisma.LedgerGetPayload<T> | null>;
+  }
+
+  static findFirstOrThrow<T extends Prisma.LedgerFindFirstOrThrowArgs>(
+    args?: Subset<T, Prisma.LedgerFindFirstOrThrowArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T>> {
+    return this.$exec("findFirstOrThrow", args, options) as Promise<Prisma.LedgerGetPayload<T>>;
+  }
+
+  static findUnique<T extends Prisma.LedgerFindUniqueArgs>(
+    args: Subset<T, Prisma.LedgerFindUniqueArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T> | null> {
+    return this.$exec("findUnique", args, options) as Promise<Prisma.LedgerGetPayload<T> | null>;
+  }
+
+  static findUniqueOrThrow<T extends Prisma.LedgerFindUniqueOrThrowArgs>(
+    args: Subset<T, Prisma.LedgerFindUniqueOrThrowArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T>> {
+    return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.LedgerGetPayload<T>>;
+  }
+
+  static count(args?: Omit<Prisma.LedgerCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.LedgerCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.LedgerCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.LedgerCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.LedgerAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.LedgerAggregateArgs>,
+  ): Promise<Prisma.GetLedgerAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetLedgerAggregateType<T>
+    >;
+  }
+
+  static create<T extends Prisma.LedgerCreateArgs>(
+    args: Subset<T, Prisma.LedgerCreateArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T>> {
+    return this.$exec("create", args, options) as Promise<Prisma.LedgerGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.LedgerUpdateArgs>(
+    args: Subset<T, Prisma.LedgerUpdateArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T>> {
+    return this.$exec("update", args, options) as Promise<Prisma.LedgerGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.LedgerDeleteArgs>(
+    args: Subset<T, Prisma.LedgerDeleteArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T>> {
+    return this.$exec("delete", args, options) as Promise<Prisma.LedgerGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.LedgerUpsertArgs>(
+    args: Subset<T, Prisma.LedgerUpsertArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerGetPayload<T>> {
+    return this.$exec("upsert", args, options) as Promise<Prisma.LedgerGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.LedgerCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.LedgerUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.LedgerDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
+
+  static wrap<C extends { prototype: unknown }, R extends Prisma.LedgerGetPayload<{}>>(
+    this: C,
+    row: R,
+  ): C["prototype"] & R {
+    return (Model.wrap as (row: object) => any).call(this, row);
+  }
+}
+
+// Merges the row's columns into the instance type, so a method on a subclass can
+// read `this.email`. No runtime output.
+//
+// oxlint flags class/interface merging because TypeScript does not check the
+// merged properties are initialised — a directly constructed instance would type
+// as carrying every column while holding none. That hazard is closed rather than
+// accepted: `Model`'s constructor is `protected`, so the only way to get an
+// instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
+export interface LedgerEntryModel extends Prisma.LedgerEntryGetPayload<{}> {}
+
+export type LedgerEntryPolicy = ModelPolicy<
+  Prisma.LedgerEntryWhereInput,
+  Prisma.LedgerEntryCreateInput,
+  Prisma.LedgerEntryGetPayload<{}>
+>;
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class LedgerEntryScopedPolicy extends ScopedPolicy<
+  Prisma.LedgerEntryWhereInput,
+  Prisma.LedgerEntryCreateInput,
+  Prisma.LedgerEntryGetPayload<{}>
+> {}
+
+export class LedgerEntryModel extends Model {
+  static $schema = schema.LedgerEntry;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    Prisma.LedgerEntryWhereInput,
+    Prisma.LedgerEntryCreateInput,
+    Prisma.LedgerEntryGetPayload<{}>
+  >[];
+
+  static findMany<T extends Prisma.LedgerEntryFindManyArgs>(
+    args?: Subset<T, Prisma.LedgerEntryFindManyArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T>[]> {
+    return this.$exec("findMany", args, options) as Promise<Prisma.LedgerEntryGetPayload<T>[]>;
+  }
+
+  static findFirst<T extends Prisma.LedgerEntryFindFirstArgs>(
+    args?: Subset<T, Prisma.LedgerEntryFindFirstArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T> | null> {
+    return this.$exec("findFirst", args, options) as Promise<Prisma.LedgerEntryGetPayload<T> | null>;
+  }
+
+  static findFirstOrThrow<T extends Prisma.LedgerEntryFindFirstOrThrowArgs>(
+    args?: Subset<T, Prisma.LedgerEntryFindFirstOrThrowArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T>> {
+    return this.$exec("findFirstOrThrow", args, options) as Promise<Prisma.LedgerEntryGetPayload<T>>;
+  }
+
+  static findUnique<T extends Prisma.LedgerEntryFindUniqueArgs>(
+    args: Subset<T, Prisma.LedgerEntryFindUniqueArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T> | null> {
+    return this.$exec("findUnique", args, options) as Promise<Prisma.LedgerEntryGetPayload<T> | null>;
+  }
+
+  static findUniqueOrThrow<T extends Prisma.LedgerEntryFindUniqueOrThrowArgs>(
+    args: Subset<T, Prisma.LedgerEntryFindUniqueOrThrowArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T>> {
+    return this.$exec("findUniqueOrThrow", args, options) as Promise<Prisma.LedgerEntryGetPayload<T>>;
+  }
+
+  static count(args?: Omit<Prisma.LedgerEntryCountArgs, "select">): Promise<number>;
+  static count<T extends Prisma.LedgerEntryCountArgs>(
+    args: Prisma.SelectSubset<T, Prisma.LedgerEntryCountArgs> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<Prisma.GetScalarType<T["select"], Prisma.LedgerEntryCountAggregateOutputType>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends Prisma.LedgerEntryAggregateArgs>(
+    args: Prisma.Subset<T, Prisma.LedgerEntryAggregateArgs>,
+  ): Promise<Prisma.GetLedgerEntryAggregateType<T>> {
+    return this.$exec("aggregate", args) as Promise<
+      Prisma.GetLedgerEntryAggregateType<T>
+    >;
+  }
+
+  static create<T extends Prisma.LedgerEntryCreateArgs>(
+    args: Subset<T, Prisma.LedgerEntryCreateArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T>> {
+    return this.$exec("create", args, options) as Promise<Prisma.LedgerEntryGetPayload<T>>;
+  }
+
+  static update<T extends Prisma.LedgerEntryUpdateArgs>(
+    args: Subset<T, Prisma.LedgerEntryUpdateArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T>> {
+    return this.$exec("update", args, options) as Promise<Prisma.LedgerEntryGetPayload<T>>;
+  }
+
+  static delete<T extends Prisma.LedgerEntryDeleteArgs>(
+    args: Subset<T, Prisma.LedgerEntryDeleteArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T>> {
+    return this.$exec("delete", args, options) as Promise<Prisma.LedgerEntryGetPayload<T>>;
+  }
+
+  static upsert<T extends Prisma.LedgerEntryUpsertArgs>(
+    args: Subset<T, Prisma.LedgerEntryUpsertArgs>,
+    options?: ExecOptions,
+  ): Promise<Prisma.LedgerEntryGetPayload<T>> {
+    return this.$exec("upsert", args, options) as Promise<Prisma.LedgerEntryGetPayload<T>>;
+  }
+
+  static createMany(
+    args?: Prisma.LedgerEntryCreateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: Prisma.LedgerEntryUpdateManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: Prisma.LedgerEntryDeleteManyArgs,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
+
+  static wrap<C extends { prototype: unknown }, R extends Prisma.LedgerEntryGetPayload<{}>>(
+    this: C,
+    row: R,
+  ): C["prototype"] & R {
+    return (Model.wrap as (row: object) => any).call(this, row);
+  }
+}
+
+// Merges the row's columns into the instance type, so a method on a subclass can
+// read `this.email`. No runtime output.
+//
+// oxlint flags class/interface merging because TypeScript does not check the
+// merged properties are initialised — a directly constructed instance would type
+// as carrying every column while holding none. That hazard is closed rather than
+// accepted: `Model`'s constructor is `protected`, so the only way to get an
+// instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 export interface MagicLinkTokenModel extends Prisma.MagicLinkTokenGetPayload<{}> {}
 
 export type MagicLinkTokenPolicy = ModelPolicy<

--- a/templates/saas-starter/app/models/generated/schema.ts
+++ b/templates/saas-starter/app/models/generated/schema.ts
@@ -146,6 +146,124 @@ export const Account: ModelSchema = {
   }
 };
 
+export const Ledger: ModelSchema = {
+  "name": "Ledger",
+  "table": "Ledger",
+  "fields": {
+    "tenantId": {
+      "name": "tenantId",
+      "column": "tenantId",
+      "type": "Int",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "code": {
+      "name": "code",
+      "column": "code",
+      "type": "String",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "title": {
+      "name": "title",
+      "column": "title",
+      "type": "String",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    }
+  },
+  "primaryKey": [
+    "tenantId",
+    "code"
+  ],
+  "uniques": [],
+  "relations": {
+    "entries": {
+      "name": "entries",
+      "model": "LedgerEntry",
+      "kind": "many",
+      "relationName": "LedgerToLedgerEntry",
+      "from": [],
+      "to": [],
+      "nullable": false
+    }
+  }
+};
+
+export const LedgerEntry: ModelSchema = {
+  "name": "LedgerEntry",
+  "table": "LedgerEntry",
+  "fields": {
+    "id": {
+      "name": "id",
+      "column": "id",
+      "type": "Int",
+      "nullable": false,
+      "isId": true,
+      "isUpdatedAt": false,
+      "default": {
+        "kind": "autoincrement"
+      }
+    },
+    "tenantId": {
+      "name": "tenantId",
+      "column": "tenantId",
+      "type": "Int",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "ledgerCode": {
+      "name": "ledgerCode",
+      "column": "ledgerCode",
+      "type": "String",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "amount": {
+      "name": "amount",
+      "column": "amount",
+      "type": "Int",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "memo": {
+      "name": "memo",
+      "column": "memo",
+      "type": "String",
+      "nullable": true,
+      "isId": false,
+      "isUpdatedAt": false
+    }
+  },
+  "primaryKey": [
+    "id"
+  ],
+  "uniques": [],
+  "relations": {
+    "ledger": {
+      "name": "ledger",
+      "model": "Ledger",
+      "kind": "one",
+      "relationName": "LedgerToLedgerEntry",
+      "from": [
+        "tenantId",
+        "ledgerCode"
+      ],
+      "to": [
+        "tenantId",
+        "code"
+      ],
+      "nullable": false
+    }
+  }
+};
+
 export const MagicLinkToken: ModelSchema = {
   "name": "MagicLinkToken",
   "table": "MagicLinkToken",

--- a/templates/saas-starter/prisma/migrations/20260729000000_composite_relation/migration.sql
+++ b/templates/saas-starter/prisma/migrations/20260729000000_composite_relation/migration.sql
@@ -1,0 +1,24 @@
+-- A relation joining on two fields, for #67.
+--
+-- Hand-written to match what `prisma migrate` emits for SQLite: the composite
+-- primary key becomes a table-level PRIMARY KEY, and the foreign key names both
+-- columns in order.
+CREATE TABLE "Ledger" (
+    "tenantId" INTEGER NOT NULL,
+    "code" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+
+    PRIMARY KEY ("tenantId", "code")
+);
+
+CREATE TABLE "LedgerEntry" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "tenantId" INTEGER NOT NULL,
+    "ledgerCode" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "memo" TEXT,
+
+    CONSTRAINT "LedgerEntry_tenantId_ledgerCode_fkey" FOREIGN KEY ("tenantId", "ledgerCode") REFERENCES "Ledger" ("tenantId", "code") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "LedgerEntry_tenantId_ledgerCode_idx" ON "LedgerEntry"("tenantId", "ledgerCode");

--- a/templates/saas-starter/prisma/schema.prisma
+++ b/templates/saas-starter/prisma/schema.prisma
@@ -174,3 +174,32 @@ model MagicLinkToken {
   @@unique([token, email])
   @@unique([pin, email])
 }
+
+/// A relation that joins on **two** fields (#67).
+///
+/// The shape is the tenant-scoped composite key: every table carries `tenantId`
+/// and every relation joins on `(tenantId, …)`. It is a deliberate schema style
+/// rather than an exotic one, and an application using it could not `include`
+/// at all until composite joins existed — so the differential harness needs a
+/// model with one to compare against Prisma.
+model Ledger {
+  tenantId Int
+  code     String
+  title    String
+
+  entries LedgerEntry[]
+
+  @@id([tenantId, code])
+}
+
+model LedgerEntry {
+  id         Int    @id @default(autoincrement())
+  tenantId   Int
+  ledgerCode String
+  amount     Int
+  memo       String?
+
+  ledger Ledger @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])
+
+  @@index([tenantId, ledgerCode])
+}


### PR DESCRIPTION
Closes #67, whose groundwork — the refusal that reached every surface — was #79.

`@relation(fields: [tenantId, orderId], references: [tenantId, id])` is the tenant-scoped composite-key style, and an application using it could not `include` at all. `Link` now carries `parentFields` / `childFields` rather than one of each, and the six read surfaces widen with it.

## The refusal's structure is what made this small

#79 established that all seven surfaces resolve their link through **one function**, precisely so a one-field assumption could not be reached by any path. That property inverted cleanly: `correlate()` gaining a conjunction fixes three surfaces at once — a relation filter, a `_count` and an `orderBy` — because hoisting the correlation into one function is what #58 did.

`composite-relations.test.ts` predicted this in its own header — *"when the feature lands this file inverts: the refusals become assertions about emitted SQL, and the list of surfaces is already here"* — and it has, with the surface list reused rather than rewritten.

## Three decisions worth naming

- **An `OR` of `AND`s, not a tuple `in`.** Postgres has `(a, b) in ((…),(…))`; SQLite does not, so a tuple would mean a new dialect method and two spellings of one predicate. `OR: [{ a: 1, b: 2 }, …]` is a shape both dialects already compile, through the `where` compiler every other filter goes through — so it inherits the parameter accounting, the plan key and the injection rules instead of needing its own. It costs the same placeholders either way, so `ParameterLimitError` fires proportionally sooner on a composite relation. That is the honest behaviour: the ceiling is on placeholders and a composite key uses more of them.
- **The stitch key is `JSON.stringify` of the normalised values.** Not concatenation — `("ab", "c")` and `("a", "bc")` are the same string, and these are user data, so parents would collect each other's children *silently*, since both queries succeed. `keyOf` already solved `Date` and `Bytes` for the single-field case, so this reuses it rather than restating it. The seed carries `(1, "a")` and `(1, "ab")` for exactly this, and there is a unit test with three parents across that boundary.
- **Nested writes still refuse**, through a `singleFieldLink` call rather than a shared resolver. Reading across a composite relation is a wider correlation; writing through one would contribute that many foreign-key columns to an insert, which is different work. The narrowing is a function nobody can reach past — there is no single-field property on `Link` to index into — which is #79's own argument applied one level down.

## Tests

**Ten differential cases** against Prisma on both dialects (batched on SQLite, lateral on Postgres), over a schema whose seed makes a *partial* join wrong rather than empty: the code `"a"` exists in two tenants, so joining on the code alone pulls in the other tenant's entries, and joining on the tenant alone pulls in `"ab"`'s. Either mistake returns rows, which is why these compare against Prisma rather than asserting counts. They cover to-many and to-one, a child `select` that omits both key fields, `some` / `none`, `_count`, `orderBy` through the relation, a `where` on the far side, and two levels of nesting.

**Plan-cache discrimination**, as #67 asks: two relations differing only in field *order* compile differently — which also catches a by-name pairing, since the sides pair positionally. Plus a length mismatch reported as a `MalformedRelationError` naming both sides, because that is the artifact disagreeing with the schema rather than a query anyone can fix.

## One thing found on the way

The differential harness's truncation list did not know about the new models. That is **silent on SQLite**, where every run gets a fresh temp database, and **loud on Postgres**, where the second run's seed collides with the first's rows — which is how I found it. Second time that has bitten this suite (the first was `Post` / `Tag` on #83), so the list now carries a comment saying so.

## Verification

931 unit tests. Template suite green on SQLite (501) and Postgres 16 (752), **identical across two consecutive Postgres runs** against one database, which is the check the isolation bug demands. `tsc` clean; oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
