### PR TITLE
Nested `disconnect` and `delete`, which name the rows they touch

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -293,6 +293,8 @@ await List.create({
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
 | `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
+| `disconnect` | Clears the link. `true` on a to-one; a unique key, or a list of them, on a to-many. The column has to be nullable. |
+| `delete` | Deletes the named rows outright, not just the link. |
 
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
@@ -314,8 +316,15 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 `connectOrCreate` succeeded would together tell you a row with that key exists in someone else's
 tenant.
 
-Everything else in Prisma's nested grammar — `set`, `disconnect`, `update`, `updateMany`, `upsert`,
-`delete`, `deleteMany` — is refused, by name and with the reason. The line is **which rows an
+`disconnect` and `delete` only exist on an `update` — a `create` has nothing linked to it yet, and
+Prisma reports them as an unknown argument there too. They differ on a row that is **not** linked to
+this parent, and the difference is Prisma's: `disconnect` succeeds and changes nothing, `delete`
+raises. Both filter on the parent's key as well as yours, so neither can reach a row belonging to
+somebody else — and a row your policies hide is not reachable either, which `delete` reports as "not
+connected" rather than as denied, since that is the same answer a genuinely unlinked row gets.
+
+Everything else in Prisma's nested grammar — `set`, `update`, `updateMany`, `upsert`, `deleteMany` —
+is refused, by name and with the reason. The line is **which rows an
 operand can name, and whose columns it writes**: everything supported names its rows (a new one, or
 one you identified by unique key) and writes either a whole new row or one foreign key the ORM
 chose. `set`, `disconnect`, `delete`, `deleteMany` and `updateMany` act on rows the call did not

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -316,6 +316,12 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 `connectOrCreate` succeeded would together tell you a row with that key exists in someone else's
 tenant.
 
+> **Known gap (#98).** A child whose policy *scopes on the foreign key itself* — `scope: () => ({
+> folderId: mine })` — cannot use any relation operand that writes that key, including `connect`,
+> unless it also declares an `onUpdate`. The scope-escape guard reads the payload and cannot tell a
+> column you supplied from one the nested step put there. Pre-existing rather than new to
+> `disconnect`, and tracked separately because the decision affects `connect` too.
+
 `disconnect` and `delete` only exist on an `update` — a `create` has nothing linked to it yet, and
 Prisma reports them as an unknown argument there too. They differ on a row that is **not** linked to
 this parent, and the difference is Prisma's: `disconnect` succeeds and changes nothing, `delete`

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -72,7 +72,22 @@ const SUPPORTED = new Set([
   "connectOrCreate",
   "create",
   "createMany",
+  "disconnect",
+  "delete",
 ]);
+
+/**
+ * Operands that only exist on a statement with a row to act on.
+ *
+ * Prisma refuses `disconnect` and `delete` under a `create` — *"Unknown
+ * argument `disconnect`"* — and it is right to: there is nothing linked to a
+ * row that does not exist yet. Refused here rather than accepted and made a
+ * no-op, so a caller who wrote one on the wrong operation hears about it.
+ */
+const EXISTING_ROW_ONLY = new Set(["disconnect", "delete"]);
+
+/** Statements that insert a new row, so nothing is linked to it yet. */
+const CREATE_ONLY_STATEMENTS = new Set(["create", "createMany"]);
 
 /**
  * The operands still refused, and what each would take.
@@ -85,8 +100,6 @@ const SUPPORTED = new Set([
  */
 const REFUSED: Record<string, string> = {
   set: `It replaces the whole set, so it has to disconnect what is there now.`,
-  disconnect: `It clears a foreign key on rows this call did not name.`,
-  delete: `It deletes rows this call did not name.`,
   deleteMany: `It deletes rows this call did not name.`,
   // Not "it writes a row that already exists" — `connectOrCreate` does that
   // too, on the foreign side, and is supported. The difference is *whose*
@@ -223,8 +236,20 @@ function planOne(
         `data.${relation.name}.${key}`,
         schema.name,
         operation,
-        `Only 'connect', 'create' and 'createMany' are implemented.` +
+        `Only ${[...SUPPORTED].sort().join(", ")} are implemented.` +
           (why ? ` '${key}' is not: ${why}` : ""),
+      );
+    }
+
+    // `create` has no row to disconnect from, and Prisma does not offer these
+    // there either — it reports them as an unknown argument.
+    if (EXISTING_ROW_ONLY.has(key) && CREATE_ONLY_STATEMENTS.has(operation)) {
+      throw new UnsupportedQueryError(
+        `data.${relation.name}.${key}`,
+        schema.name,
+        operation,
+        `'${key}' acts on rows already linked to this one, and a '${operation}' ` +
+          `has none yet — Prisma refuses it here too. Use it on an 'update'.`,
       );
     }
   }
@@ -333,6 +358,49 @@ function planOwningSide(
    * Object only on this side. The relation holds one foreign key, so there is
    * one row to point at, and Prisma refuses an array here too.
    */
+  /**
+   * `disconnect: true` on a to-one — clear the foreign key this row holds.
+   *
+   * No step at all: the key lives on this row, so it is one more bound column
+   * set to `null`, exactly as `connect`'s direct form is one bound column set
+   * to a value. Nothing on the child is read or written, which is why there is
+   * no scoping question on this side — the row being changed is the one the
+   * statement already names.
+   *
+   * `delete` has no meaning here for the same reason it has no `createMany`:
+   * this side is a to-one, and deleting the far row through a `data` key would
+   * be deleting a row the statement is not about. Prisma does offer it; it is
+   * refused rather than guessed, because a `delete` that fires as a side effect
+   * of an unrelated update is the kind of thing to implement deliberately.
+   */
+  if (key === "disconnect") {
+    assertDisconnectable(schema, relation, fkField, operation);
+
+    if (operand !== true) {
+      throw new UnsupportedQueryError(
+        `data.${relation.name}.disconnect`,
+        schema.name,
+        operation,
+        `'${relation.name}' is a to-one, so there is one row to clear and ` +
+          `nothing to name. Prisma takes 'true' here.`,
+      );
+    }
+
+    out.contributions.push({ field: fkField, value: () => null });
+    return;
+  }
+
+  if (key === "delete") {
+    throw new UnsupportedQueryError(
+      `data.${relation.name}.delete`,
+      schema.name,
+      operation,
+      `'${relation.name}' is a to-one whose foreign key lives on this row, so ` +
+        `deleting through it would remove a row this statement is not about. ` +
+        `Delete it directly, or 'disconnect' it first.`,
+    );
+  }
+
   if (key === "connectOrCreate") {
     assertConnectOrCreateOperand(
       schema,
@@ -464,6 +532,96 @@ function planForeignSide(
   const childField = link.childField;
 
   out.keyFields.push(parentField);
+
+  /**
+   * `disconnect` and `delete` on this side both act on rows the caller named by
+   * unique key — which is what makes them expressible at all, and what puts
+   * them on the supported side of this file's line.
+   *
+   * They differ on a row that is *not* linked to this parent, and the
+   * difference is Prisma's, measured rather than chosen:
+   *
+   *     disconnect a row linked elsewhere  ->  succeeds, changes nothing
+   *     delete     a row linked elsewhere  ->  raises "are not connected"
+   *
+   * So both filter by the parent key as well as the caller's key, and only
+   * `delete` treats a miss as an error. That filter is doing two jobs at once:
+   * it reproduces Prisma's semantics, and it is what stops either operand from
+   * reaching a row belonging to a different parent.
+   *
+   * **Scoping comes from the child's own operations**, as everywhere else here:
+   * `updateMany` and `delete` go through the child's `$exec` un-pre-scoped, so
+   * a row the child's policies hide is not reachable. For `delete` that means a
+   * hidden row reports "not connected" rather than "denied" — the same answer
+   * as a row that genuinely is not linked, which is the conservative one.
+   */
+  if (key === "disconnect" || key === "delete") {
+    const deleting = key === "delete";
+    if (!deleting) assertDisconnectable(child, relation, childField, operation);
+
+    assertNamedRows(schema, relation, child, operand, key, operation);
+
+    out.after.push({
+      relation: relation.name,
+      operation: key,
+      async run(args, _context, executor, rows) {
+        const parent = rows[0];
+        if (!parent) return;
+
+        const list = listOf(at(args));
+
+        for (let index = 0; index < list.length; index++) {
+          // The caller's key *and* the link, so neither operand can reach a row
+          // attached to a different parent.
+          const where = {
+            ...(list[index] as object),
+            [childField]: parent[parentField],
+          };
+
+          if (!deleting) {
+            await executor.exec(
+              relation.model,
+              "updateMany",
+              { where, data: { [childField]: null } },
+              // NOT pre-scoped: clearing a foreign key is a write to the child,
+              // so the child's scope decides which rows are reachable.
+              false,
+            );
+            continue;
+          }
+
+          const found = (await executor.exec(
+            relation.model,
+            "findFirst",
+            { where, select: { [childField]: true } },
+            false,
+          )) as Record<string, unknown> | null;
+
+          if (!found) {
+            throw new UnsupportedQueryError(
+              `data.${relation.name}.delete`,
+              schema.name,
+              operation,
+              `the row named by ${JSON.stringify(list[index])} is not ` +
+                `connected to this ${schema.name}. Prisma raises here too, ` +
+                `rather than deleting a row belonging to somebody else.`,
+            );
+          }
+
+          await executor.exec(
+            relation.model,
+            "deleteMany",
+            { where },
+            // NOT pre-scoped, for the reason above — and `deleteMany` rather
+            // than `delete` because the `where` carries the link as well as the
+            // unique key, which `delete` refuses as a non-unique target.
+            false,
+          );
+        }
+      },
+    });
+    return;
+  }
 
   if (key === "create") {
     out.after.push({
@@ -676,6 +834,68 @@ function planForeignSide(
       }
     },
   });
+}
+
+/**
+ * The rows a `disconnect` / `delete` names, each by a unique key.
+ *
+ * Validated at plan time for the reason every operand here is: a refusal that
+ * arrives mid-transaction has to unwind a parent row that should never have
+ * been written.
+ */
+function assertNamedRows(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  operand: unknown,
+  key: string,
+  operation: string,
+): Record<string, unknown>[] {
+  const at = `data.${relation.name}.${key}`;
+  const entries = (Array.isArray(operand) ? operand : [operand]) as unknown[];
+  const out: Record<string, unknown>[] = [];
+
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new UnsupportedQueryError(
+        at,
+        schema.name,
+        operation,
+        `Expected an object naming a unique field, or an array of them.`,
+      );
+    }
+    matchUniqueKey(child, entry, `${operation}.${relation.name}.${key}`);
+    out.push(entry as Record<string, unknown>);
+  }
+
+  return out;
+}
+
+/**
+ * A `disconnect` clears a foreign key, so the column has to be nullable.
+ *
+ * Prisma refuses it on a required relation at the type level; here the schema
+ * is the only thing that knows, so the refusal says which column and why rather
+ * than letting the database report a not-null violation from inside a nested
+ * step.
+ */
+function assertDisconnectable(
+  owner: ModelSchema,
+  relation: RelationSchema,
+  fieldName: string,
+  operation: string,
+): void {
+  const field = owner.fields[fieldName];
+  if (field && field.nullable) return;
+
+  throw new UnsupportedQueryError(
+    `data.${relation.name}.disconnect`,
+    owner.name,
+    operation,
+    `'${fieldName}' is required, so there is no value to leave behind — a ` +
+      `disconnected row would have to be deleted or repointed instead. Prisma ` +
+      `does not offer 'disconnect' on a required relation either.`,
+  );
 }
 
 /**

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -174,7 +174,13 @@ export interface NestedWriteStep {
    * itself does, so this is what makes a plan legible from the outside: to a
    * test, and to whatever logs queries later.
    */
-  operation: "connect" | "connectOrCreate" | "create" | "createMany";
+  operation:
+    | "connect"
+    | "connectOrCreate"
+    | "create"
+    | "createMany"
+    | "disconnect"
+    | "delete";
   run(
     args: any,
     context: BindContext,

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -9,6 +9,7 @@ import { Application } from "gemi/foundation";
 import {
   Model,
   RecordNotFoundError,
+  ScopeEscapeError,
   clearPlanCache,
   register,
   type ModelPolicy,
@@ -479,6 +480,59 @@ describe("policies on nested writes", () => {
     ).rejects.toThrow(/is not connected/);
 
     expect(await raw.unsafe(`SELECT * FROM "Note"`)).toHaveLength(1);
+  });
+
+  /**
+   * **Pinned, not endorsed** — #98.
+   *
+   * A child scoped on its own foreign key loses every relation operand that
+   * writes that key, because `assertNoScopeEscape` reads `args.data` and cannot
+   * tell a column the caller supplied from one the nested step put there. The
+   * caller wrote `disconnect: { id }`; `folderId` is in `data` because the ORM
+   * chose it.
+   *
+   * This is **not** new to `disconnect`. `connect` has the same shape and the
+   * same failure on `feat/orm` today, which is why it is filed rather than
+   * fixed here: the decision affects an operand that already shipped.
+   *
+   * Asserted so the current behaviour is deliberate. When #98 lands this test
+   * should flip to expecting success, rather than being deleted.
+   */
+  test("a foreign-key scope refuses relation operands today", async () => {
+    class KeyScoped extends Model {
+      static $schema = noteSchema;
+      static $policies = [{ scope: () => ({ folderId: 2 }) } as ModelPolicy];
+    }
+    register("Note", KeyScoped);
+
+    try {
+      await raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+      );
+      await raw.unsafe(
+        `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+          `VALUES (20, 2, 'ours', 7)`,
+      );
+
+      const attempt = (operand: unknown) =>
+        Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { code: "ours", notes: operand },
+          }),
+        );
+
+      // Both operands, so the pin records that this is a property of the
+      // guard rather than of the one this PR added.
+      await expect(attempt({ disconnect: { id: 20 } })).rejects.toThrow(
+        ScopeEscapeError,
+      );
+      await expect(attempt({ connect: { id: 20 } })).rejects.toThrow(
+        ScopeEscapeError,
+      );
+    } finally {
+      register("Note", Note);
+    }
   });
 
   /**

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -395,6 +395,93 @@ describe("policies on nested writes", () => {
   });
 
   /**
+   * `disconnect` reaches a row by unique key, so the child's scope is the only
+   * thing standing between a caller and another tenant's row.
+   *
+   * The note below is linked to *our* folder — seeded that way deliberately —
+   * but carries the other tenant's `orgId`. So the link is right and the policy
+   * is what has to refuse: without the child's scope this clears a foreign key
+   * on a row we cannot see, and reports success.
+   */
+  test("disconnect cannot clear a row the child's policy hides", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (10, 2, 'theirs', 99)`,
+    );
+
+    await Model.asUser(OURS, () =>
+      Folder.$exec("update", {
+        where: { id: 2 },
+        // `code` is here only to satisfy "at least one field must be
+        // updated": `Folder` has no `@updatedAt`, so a relation-only update has
+        // no scalar assignment and is refused on this branch. #83 makes that
+        // compile to a select of the same returning list; until it lands, a
+        // no-op assignment keeps the test about the disconnect.
+        data: { code: "ours", notes: { disconnect: { id: 10 } } },
+      }),
+    );
+
+    const notes: any = await raw.unsafe(`SELECT "folderId" FROM "Note"`);
+    expect(notes[0].folderId).toBe(2);
+  });
+
+  /** ...and a visible one is cleared. */
+  test("disconnect clears a row the caller can see", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (11, 2, 'ours', 7)`,
+    );
+
+    await Model.asUser(OURS, () =>
+      Folder.$exec("update", {
+        where: { id: 2 },
+        // `code` is here only to satisfy "at least one field must be
+        // updated": `Folder` has no `@updatedAt`, so a relation-only update has
+        // no scalar assignment and is refused on this branch. #83 makes that
+        // compile to a select of the same returning list; until it lands, a
+        // no-op assignment keeps the test about the disconnect.
+        data: { code: "ours", notes: { disconnect: { id: 11 } } },
+      }),
+    );
+
+    const notes: any = await raw.unsafe(`SELECT "folderId" FROM "Note"`);
+    expect(notes[0].folderId).toBeNull();
+  });
+
+  /**
+   * `delete` reports a hidden row as **not connected** rather than as denied,
+   * which is the conservative answer: it is the same thing the caller would be
+   * told about a row that genuinely belongs to another parent, so the two are
+   * indistinguishable and neither confirms the row exists.
+   */
+  test("delete reports a hidden row as not connected, and leaves it", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (12, 2, 'theirs', 99)`,
+    );
+
+    await expect(
+      Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: { code: "ours", notes: { delete: { id: 12 } } },
+        }),
+      ),
+    ).rejects.toThrow(/is not connected/);
+
+    expect(await raw.unsafe(`SELECT * FROM "Note"`)).toHaveLength(1);
+  });
+
+  /**
    * A scoped model could not upsert at all: `assertScopable` refuses to put a
    * scope on one, because its where becomes an `on conflict` target and a
    * target cannot carry a predicate.

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -65,6 +65,22 @@ async function seed(prisma: PrismaClient) {
       },
     ],
   });
+
+  // Accounts for the `disconnect` / `delete` cases, **in the seed rather than
+  // in each test**. `expectSameWrite` resets to the seeded state before each
+  // client runs — that is the whole point of it — so rows written in a test
+  // body are gone by the time the comparison happens, and a case that depended
+  // on them would compare two runs against an empty table and pass whatever
+  // the code did. Two of these belong to the *second* user, which is what makes
+  // "not linked" mean something.
+  const users = await prisma.user.findMany({ orderBy: { id: "asc" } });
+  await prisma.account.createMany({
+    data: [
+      { publicId: "acc-mine-1", userId: users[0].id, organizationRole: 1 },
+      { publicId: "acc-mine-2", userId: users[0].id, organizationRole: 2 },
+      { publicId: "acc-theirs", userId: users[1].id, organizationRole: 1 },
+    ],
+  });
 }
 
 /** `[name, operation, args, tables]` — tables default to the model written. */
@@ -908,6 +924,117 @@ function suite(label: string, url?: string) {
         where: { publicId: "keep-1" },
       });
       expect(children).toHaveLength(0);
+    });
+
+    /**
+     * `disconnect` and `delete` — the operands that act on rows already linked
+     * to this one, and the pair that shows why the boundary is "which rows can
+     * be named": both take a unique key, so the child's own operations decide
+     * reachability.
+     *
+     * They differ on a row that is *not* linked, and the difference is Prisma's
+     * rather than a choice — measured before implementing:
+     *
+     *     disconnect a row linked elsewhere  ->  succeeds, changes nothing
+     *     delete     a row linked elsewhere  ->  raises "are not connected"
+     *
+     * The rows come from the seed, not from the test body: `expectSameWrite`
+     * resets to the seeded state before each client runs, so a case that set
+     * itself up would compare two runs against an empty table and pass whatever
+     * the code did.
+     */
+    test("disconnect clears the link and leaves the row", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { disconnect: { publicId: "acc-mine-1" } } },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("disconnect takes a list", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              disconnect: [
+                { publicId: "acc-mine-1" },
+                { publicId: "acc-mine-2" },
+              ],
+            },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /**
+     * A row linked to a *different* user. Prisma succeeds and changes nothing —
+     * and without the parent key in the `where`, this would clear somebody
+     * else's foreign key and still return a plausible payload.
+     */
+    test("disconnecting a row that is not linked is a no-op", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { disconnect: { publicId: "acc-theirs" } } },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("delete removes the row, not just the link", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { delete: { publicId: "acc-mine-1" } } },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /**
+     * The asymmetry, and the case that decides whether this is implemented or
+     * merely spelled: `delete` on a row belonging to a different parent
+     * **raises** where `disconnect` shrugs. Without the parent key in the
+     * `where` this deletes somebody else's row and reports success.
+     */
+    test("deleting a row that is not linked raises, as Prisma does", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { delete: { publicId: "acc-theirs" } } },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("disconnect on a to-one clears the foreign key", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { organization: { disconnect: true } },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
     });
 
     test("nested connect on the foreign side repoints the child", async () => {


### PR DESCRIPTION
#65's item three, minus the operands that do not fit the line this file draws. **Stacked on #94**, where that line is restated — hence the base, so the diff here is only the two new operands.

## Why these two and not the other three

#94's review established the boundary: every supported operand **names its rows**, so it goes through the child's own operations and the child's policies decide reachability. `set`, `deleteMany` and `updateMany` act on rows the *call* did not name — "whatever is there" has no lookup to hang a scope on — so they stay refused.

`disconnect` and `delete` both take a unique key. That is what makes them the tractable half, and it is a good sign the restated criterion is doing work rather than describing the past.

## The two differ on an unlinked row, and it is Prisma's difference

Measured before implementing:

```
disconnect a row linked elsewhere  ->  succeeds, changes nothing
delete     a row linked elsewhere  ->  raises "are not connected"
```

So both filter on the parent's key as well as the caller's, and only `delete` treats a miss as an error. That filter does two jobs at once: it reproduces the semantics, and it stops either operand from reaching a row belonging to a different parent.

Three refusals, each measured rather than assumed:

- **Under `create`** — Prisma reports them as an unknown argument, and it is right to: a row that does not exist yet has nothing linked to it.
- **`disconnect` on a required foreign key** — there is no value to leave behind. Named by column, so the message is not a not-null violation from inside a nested step.
- **`delete` through a to-one** — deleting the far row as a side effect of an unrelated update is a thing to implement deliberately, not to guess.

## Scoping

The child's own operations, as everywhere here: `updateMany`, `findFirst` and `deleteMany` all go through the child's `$exec` un-pre-scoped. A hidden row is reported by `delete` as **not connected** rather than as denied — the same answer a genuinely unlinked row gets, so the two are indistinguishable and neither confirms the row exists.

## I had the differential cases wrong first, and the way I found out is the point

They set their fixtures up in the test body. `expectSameWrite` **resets to the seeded state before each client runs** — that is the whole point of it — so the rows were gone by comparison time and every case ran against an empty `Account` table, passing whatever the code did.

I found it by removing the parent-key filter to check the cases discriminated, and watching them all still pass. The rows are in the seed now, two of them on a *different* user, and with the filter removed:

```
× disconnecting a row that is not linked is a no-op
× deleting a row that is not linked raises, as Prisma does
```

The seed carries a comment saying why, because the next case needing a fixture would otherwise be written the same wrong way.

## Tests

Six differential cases, three policy tests (including the hidden-row-reports-not-connected one), and the existing refusal table updated.

## Verification

942 unit tests. Template suite green on SQLite (507) and Postgres 16 (762), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint clean.

## One dependency worth naming

The policy tests pass a no-op scalar (`code: "ours"`) alongside the nested operand, because `Folder` has no `@updatedAt` and a relation-only `update` is refused on this base with *"At least one field must be updated"*. #83 makes that compile to a select of the same returning list; the template's `User` already has `@updatedAt`, which is why the differential cases need no such thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
