### PR TITLE
The scope-escape guard judges the caller's columns, not the ORM's

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -305,6 +305,10 @@ Three things follow from that, and all three are load-bearing:
 - **The child's policies apply.** Each nested row goes through the related model's own `$exec`, so
   its `onCreate` stamps the tenant column and its `scope` decides which rows a `connect` can reach.
   A `createMany` writes its rows in one statement and they are *each* scoped.
+  A relation operand writes one column — the relation's own key — and the
+  scope-escape guard knows the ORM wrote it, so a child scoped on its foreign
+  key can still be connected. A column *you* name in `data` is judged exactly as
+  before.
 - **A failure anywhere rolls the whole thing back**, including the parent row.
 
 Everything else in Prisma's nested grammar — `connectOrCreate`, `set`, `disconnect`, `update`,

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -40,7 +40,9 @@ import {
   applyRedaction,
   currentUser,
   isPreScoped,
+  markOrmAuthored,
   markPreScoped,
+  ormAuthoredFields,
   policiesFor,
   policyContext,
   type PolicyEntry,
@@ -582,7 +584,12 @@ export abstract class Model {
       // the same predicate twice; re-running `redact` on an already-redacted row
       // is a no-op.
       if (!preScoped) {
-        effective = applyPolicies(policies, policy, args);
+        effective = applyPolicies(
+          policies,
+          policy,
+          args,
+          ormAuthoredFields(options),
+        );
       }
     }
 
@@ -643,16 +650,20 @@ export abstract class Model {
       // grandchild folded anyway and the statement count was one lower than the
       // caller asked for. Found by the query-count test, which is the only thing
       // that could have found it: the results were identical either way.
-      exec: (model, operation, relationArgs, preScoped) =>
-        registry
+      exec: (model, operation, relationArgs, preScoped, ormAuthored) => {
+        const base = preScoped
+          ? markPreScoped({ strategy: options?.strategy })
+          : { strategy: options?.strategy };
+        return registry
           .get<typeof Model>(model)
           .$exec(
             operation as Operation,
             relationArgs,
-            (preScoped
-              ? markPreScoped({ strategy: options?.strategy })
-              : { strategy: options?.strategy }) as never,
-          ),
+            (ormAuthored && ormAuthored.length > 0
+              ? markOrmAuthored(base, ormAuthored)
+              : base) as never,
+          );
+      },
       // The one query with no model behind it — the implicit m-n join table —
       // resolves its connection here rather than reaching for the pool, so it
       // joins the transaction like everything else.

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -490,6 +490,10 @@ function planForeignSide(
           // to the child, and the child's scope decides which rows are reachable
           // — otherwise `connect` re-parents another tenant's row.
           false,
+          // ...and the column being written is *ours*, not the caller's. Without
+          // this, a child whose policy scopes on its foreign key is refused for
+          // a write it never made — see #98 and `ormAuthoredFields`.
+          [childField],
         );
       }
     },

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -113,6 +113,17 @@ export interface RelationExecutor {
     op: string,
     args: unknown,
     preScoped: boolean,
+    /**
+     * Columns of `args.data` this step wrote itself — a relation operand's own
+     * foreign key, whose value is the parent this statement is about.
+     *
+     * Only the scope-escape guard reads it, so that a child scoped on its
+     * foreign key is not refused for a write the caller did not make (#98).
+     * Optional, and omitting it makes the guard *stricter*: an omission is a
+     * refused query rather than a silent escape, which is why this one may be
+     * optional where `preScoped` may not.
+     */
+    ormAuthored?: readonly string[],
   ): Promise<unknown>;
   /**
    * A statement with no model behind it. Exactly one query in the ORM is like

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -453,6 +453,11 @@ export function applyPolicies(
   policies: readonly ModelPolicy[],
   context: PolicyContext,
   args: any,
+  /**
+   * Columns of `args.data` the ORM wrote rather than the caller — see
+   * {@link ormAuthoredFields}. Only the scope-escape guard reads it.
+   */
+  ormAuthored: readonly string[] = [],
 ): any {
   if (policies.length === 0) return args;
 
@@ -534,7 +539,7 @@ export function applyPolicies(
   // whoever put it there — which is the only version of the question worth
   // asking.
   if (unguarded !== undefined) {
-    assertNoScopeEscape(unguarded, context, out);
+    assertNoScopeEscape(unguarded, context, out, ormAuthored);
   }
 
   return out;
@@ -652,11 +657,29 @@ function assertNoScopeEscape(
   unguarded: readonly string[],
   context: PolicyContext,
   args: any,
+  /**
+   * Columns the ORM itself wrote — a relation operand's own foreign key.
+   *
+   * The guard exists to stop a **caller** moving a row out of the scope that
+   * selected it by naming a scoped column in `data`. A relation key is not
+   * that: its value is the ORM's, the parent was reached through the parent
+   * model's own scoping, and a child row this caller cannot see was already
+   * refused before this runs. What is left is the operand doing what it means.
+   *
+   * Empty by default, and that direction matters: forgetting to pass it makes
+   * the guard *stricter*, not looser, so an omission is a refused query rather
+   * than a silent escape. That is the opposite of #79's defaulted `operation`,
+   * where the default was the wrong answer — which is why this one is allowed
+   * to have a default at all.
+   */
+  ormAuthored: readonly string[] = [],
 ): void {
   const data = args?.data;
   if (typeof data !== "object" || data === null) return;
 
-  const escaping = unguarded.filter((field) => field in data);
+  const escaping = unguarded.filter(
+    (field) => field in data && !ormAuthored.includes(field),
+  );
   if (escaping.length === 0) return;
 
   throw new ScopeEscapeError(context.model, context.operation, [
@@ -891,6 +914,44 @@ export function isPreScoped(options: unknown): boolean {
     (options as Record<symbol, unknown>)[PRE_SCOPED] === true
   );
 }
+
+/**
+ * Columns in this call's `data` that the **ORM** put there, not the caller.
+ *
+ * A nested relation operand writes exactly one column: the relation's own
+ * foreign key, with a value this statement chose — the parent it is about, or
+ * `null` for a `disconnect`. `assertNoScopeEscape` reads `args.data` and cannot
+ * tell that apart from a caller naming the same column, so a child whose policy
+ * scopes on its foreign key lost every relation operand that writes it (#98):
+ *
+ *     connect     ScopeEscapeError: Note.update writes 'folderId', which
+ *                 Note's policy also scopes on…
+ *     disconnect  ScopeEscapeError: Note.updateMany writes 'folderId', …
+ *
+ * The caller wrote `connect: { id: 1 }`. The error described a write they had
+ * not made and sent them to their own `data`, where there was nothing to find.
+ *
+ * **A module-private `Symbol`, for the same reason `PRE_SCOPED` is one**: it is
+ * not exported from `orm/index.ts`, so an application cannot forge it and it
+ * cannot become a way to write a scoped column past the guard. An
+ * `ExecOptions` field would have been exactly that door.
+ */
+const ORM_AUTHORED = Symbol("gemi.orm.columnsWrittenByTheOrm");
+
+export function markOrmAuthored(
+  options: object | undefined,
+  fields: readonly string[],
+): object {
+  return { ...options, [ORM_AUTHORED]: fields };
+}
+
+export function ormAuthoredFields(options: unknown): readonly string[] {
+  if (typeof options !== "object" || options === null) return EMPTY_FIELDS;
+  const fields = (options as Record<symbol, unknown>)[ORM_AUTHORED];
+  return Array.isArray(fields) ? (fields as string[]) : EMPTY_FIELDS;
+}
+
+const EMPTY_FIELDS: readonly string[] = [];
 
 /** Resolves a model name to its policies, so this file need not import the registry. */
 export type PolicyLookup = (model: string) => {

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -9,6 +9,7 @@ import { Application } from "gemi/foundation";
 import {
   Model,
   RecordNotFoundError,
+  ScopeEscapeError,
   clearPlanCache,
   register,
   type ModelPolicy,
@@ -327,6 +328,82 @@ describe("policies on nested writes", () => {
     const notes: any = await raw.unsafe(`SELECT * FROM "Note"`);
     expect(notes[0].folderId).toBe(2);
     expect(notes[0].orgId).toBe(7);
+  });
+
+  /**
+   * A child whose policy scopes on its **own foreign key** — `{ folderId: … }`,
+   * a plausible "my notes" scope — and which declares no `onUpdate` (#98).
+   *
+   * `connect` writes exactly that column, so `assertNoScopeEscape` used to
+   * refuse it: the guard reads `args.data` and could not tell a column the
+   * caller supplied from one the nested step put there. The caller wrote
+   * `connect: { id }`; `folderId` was in `data` because the ORM chose it.
+   *
+   * The row is still only reachable through the child's own scope — that is a
+   * different mechanism and it is untouched, which the second test pins.
+   */
+  test("a foreign-key scope no longer refuses a nested connect", async () => {
+    class KeyScoped extends Model {
+      static $schema = noteSchema;
+      static $policies = [{ scope: () => ({ folderId: 2 }) } as ModelPolicy];
+    }
+    register("Note", KeyScoped);
+
+    try {
+      await raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+      );
+      await raw.unsafe(
+        `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+          `VALUES (20, 2, 'ours', 7)`,
+      );
+
+      await Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: { code: "ours", notes: { connect: { id: 20 } } },
+        }),
+      );
+
+      const notes: any = await raw.unsafe(`SELECT "folderId" FROM "Note"`);
+      expect(notes[0].folderId).toBe(2);
+    } finally {
+      register("Note", Note);
+    }
+  });
+
+  /**
+   * The half that must not move: a **caller** naming the scoped column in
+   * `data` is still refused. The marker lists the columns the ORM wrote, so
+   * anything else in the payload is judged exactly as before.
+   */
+  test("a caller naming the scoped column is still refused", async () => {
+    class KeyScoped extends Model {
+      static $schema = noteSchema;
+      static $policies = [{ scope: () => ({ folderId: 2 }) } as ModelPolicy];
+    }
+    register("Note", KeyScoped);
+
+    try {
+      await raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+      );
+      await raw.unsafe(
+        `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+          `VALUES (21, 2, 'ours', 7)`,
+      );
+
+      await expect(
+        Model.asUser(OURS, () =>
+          KeyScoped.$exec("update", {
+            where: { id: 21 },
+            data: { folderId: 9 },
+          }),
+        ),
+      ).rejects.toThrow(ScopeEscapeError);
+    } finally {
+      register("Note", Note);
+    }
   });
 
   /**


### PR DESCRIPTION
Closes #98. Found in review of #96, but **not caused by it** — `connect` has had this since it merged, which is why the fix belongs here on `feat/orm` rather than inside a PR adding more operands.

## The failure

A child whose policy scopes on its **own foreign key** — `{ folderId: mine }`, a plausible "my notes" scope — and which declares no `onUpdate`:

```
connect     ScopeEscapeError: Note.update writes 'folderId', which Note's policy also scopes on…
disconnect  ScopeEscapeError: Note.updateMany writes 'folderId', …          (#96)
```

The caller wrote `connect: { id: 1 }`. `folderId` is in `data` because **the nested step put it there** — its value is the parent this statement is about. `assertNoScopeEscape` reads `args.data` and cannot tell that from a caller naming the same column, so the error describes a write the caller never made and sends them to their own payload, where there is nothing to find. Same shape as #85's `Account.create` message: a refusal that misnames its own origin.

## Which reading, and why

Of the two the review offered, this takes "the guard should not fire". Its stated purpose is to stop a **caller** moving a row out of the scope that selected it by naming a scoped column in `data`. A relation key is not that:

- the value is the ORM's, not the caller's;
- the parent was reached through the parent model's own scoping;
- a child row the caller cannot see is **already refused** by the child's scope before this runs — a different mechanism, untouched here, and pinned by the existing tests.

What is left is the operand doing exactly what it means.

## The mechanism follows `markPreScoped` exactly

A module-private `Symbol`, **not exported from `orm/index.ts`**, so an application cannot forge it. An `ExecOptions` field would have been a public door for writing a scoped column past the guard — the thing iteration 6 spent three review rounds closing.

The new parameter is optional, and the direction is the point: **omitting it makes the guard stricter**, so a call site that forgets is a refused query rather than a silent escape. That is the opposite of #79's defaulted `operation`, where the default was the wrong answer — and it is why this one is allowed a default at all. The comment says so, because "some defaults are fine" is exactly the reasoning that erodes.

## Tests

Two, both directions, and the first verified red by removing the marker:

- a foreign-key-scoped child **can** now be connected, and the row lands on the right parent;
- a caller naming that same column in `data` is **still refused**.

The second is the one that matters: the marker lists the columns the ORM wrote, so anything else in the payload is judged exactly as before.

## Merge-order note

#96 pins the current refusal across `connect` *and* `disconnect`, deliberately, so that the behaviour was deliberate rather than accidental. Whichever lands second, that pin flips to expecting success — it was written to flip rather than to be deleted.

## Verification

935 unit tests. Template suite green on SQLite (493) and Postgres 16 (748), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
