### PR TITLE
A composite `include` is one plan on Postgres, through `unnest`

### DIFF
--- a/packages/gemi/orm/compile/composite-relations.test.ts
+++ b/packages/gemi/orm/compile/composite-relations.test.ts
@@ -279,6 +279,56 @@ describe("plan discrimination", () => {
   });
 });
 
+/**
+ * `$compositeIn` is internal, and that is enforced rather than claimed.
+ *
+ * The branch that compiles it sits **above** the field lookup in
+ * `compileWhere`, so a caller writing the key by hand used to be honoured. Not
+ * an injection — the fields are resolved against the schema, the columns go
+ * through `quoteIdent`, the values are bound — but an undocumented input
+ * surface with none of the operand validation its neighbours have, and one
+ * shape that compiled clean and deferred its failure to bind time.
+ *
+ * The operand now has to carry a module-private `Symbol` the planner attaches,
+ * which an application cannot reach. Same mechanism as `markPreScoped` and
+ * `markOrmAuthored`, for the same reason: a claim about who may do something is
+ * worth only as much as the thing that enforces it.
+ */
+describe("the composite-in key is the planner's alone", () => {
+  const attempt = (operand: unknown) => () =>
+    compileRead(ledgerEntry, "findMany", { where: { $compositeIn: operand } }, postgres);
+
+  test("a hand-written one is refused, however well formed", () => {
+    expect(
+      attempt({ fields: ["tenantId", "ledgerCode"], values: [[1, "a"]] }),
+    ).toThrow(UnsupportedQueryError);
+    expect(
+      attempt({ fields: ["tenantId", "ledgerCode"], values: [[1, "a"]] }),
+    ).toThrow(/not part of the query grammar/);
+  });
+
+  /**
+   * The three shapes that used to escape validation: two raw `TypeError`s from
+   * a destructure and a `.map`, and one that compiled with no `values` at all.
+   * Every one is now an `UnsupportedQueryError` naming the key.
+   */
+  test.each([
+    ["null", null],
+    ["fields not an array", { fields: "tenantId", values: [[1]] }],
+    ["no values at all", { fields: ["tenantId"] }],
+    ["a tuple of the wrong width", { fields: ["tenantId", "ledgerCode"], values: [[1]] }],
+  ])("a malformed one is refused with a path: %s", (_label, operand) => {
+    expect(attempt(operand)).toThrow(UnsupportedQueryError);
+    expect(attempt(operand)).not.toThrow(TypeError);
+  });
+
+  /** ...and the planner's own still compiles, on the dialect that binds it. */
+  test("the planner's own is accepted", () => {
+    const plan = compileRead(ledgerEntry, "findMany", { include: { ledger: true } }, postgres);
+    expect(plan.relations).toHaveLength(1);
+  });
+});
+
 describe("a nested write still refuses, and says why", () => {
   const run = () =>
     compileWrite(

--- a/packages/gemi/orm/compile/composite-relations.test.ts
+++ b/packages/gemi/orm/compile/composite-relations.test.ts
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { PostgresDialect } from "../dialect/postgres";
 import { SqliteDialect } from "../dialect/sqlite";
-import { UnsupportedQueryError } from "../errors";
+import { UnknownFieldError, UnsupportedQueryError } from "../errors";
 import { ledger, ledgerEntry } from "../fixtures";
 import * as registry from "../registry";
 import { lateralStrategy } from "./lateral";
 import { compileRead } from "./read";
 import { compileWrite } from "./write";
+import { plannerCompositeIn } from "./where";
 
 /**
  * Multi-field relations — `@relation(fields: [a, b], references: [c, d])`.
@@ -298,13 +299,17 @@ describe("the composite-in key is the planner's alone", () => {
   const attempt = (operand: unknown) => () =>
     compileRead(ledgerEntry, "findMany", { where: { $compositeIn: operand } }, postgres);
 
-  test("a hand-written one is refused, however well formed", () => {
-    expect(
-      attempt({ fields: ["tenantId", "ledgerCode"], values: [[1, "a"]] }),
-    ).toThrow(UnsupportedQueryError);
-    expect(
-      attempt({ fields: ["tenantId", "ledgerCode"], values: [[1, "a"]] }),
-    ).toThrow(/not part of the query grammar/);
+  /**
+   * The **unknown-key treatment**, which is what the original comment promised.
+   * `UnsupportedQueryError` would say "does not support '$compositeIn' *yet*",
+   * a promise about a key that is deliberately not in the grammar — the word
+   * #82 and #88 have each already corrected once.
+   */
+  test("a hand-written one is not a field on the model", () => {
+    const operand = { fields: ["tenantId", "ledgerCode"], values: [[1, "a"]] };
+    expect(attempt(operand)).toThrow(UnknownFieldError);
+    expect(attempt(operand)).toThrow(/is not a field on model LedgerEntry/);
+    expect(attempt(operand)).not.toThrow(/yet/);
   });
 
   /**
@@ -317,9 +322,24 @@ describe("the composite-in key is the planner's alone", () => {
     ["fields not an array", { fields: "tenantId", values: [[1]] }],
     ["no values at all", { fields: ["tenantId"] }],
     ["a tuple of the wrong width", { fields: ["tenantId", "ledgerCode"], values: [[1]] }],
-  ])("a malformed one is refused with a path: %s", (_label, operand) => {
-    expect(attempt(operand)).toThrow(UnsupportedQueryError);
+  ])("a malformed one is refused rather than crashing: %s", (_label, operand) => {
+    // Every one of these used to be a raw `TypeError` from a destructure or a
+    // `.map`, or — for "no values at all" — a clean compile whose failure
+    // arrived at bind time.
+    expect(attempt(operand)).toThrow(UnknownFieldError);
     expect(attempt(operand)).not.toThrow(TypeError);
+  });
+
+  /**
+   * The planner's *own* malformed operand is a different audience: an internal
+   * invariant that does not hold is genuinely something the ORM does not
+   * support, and there "yet" is the honest word.
+   */
+  test("a malformed operand from the planner names the invariant", () => {
+    const planners = plannerCompositeIn(["tenantId"], [[1, "extra"]]);
+    expect(() =>
+      compileRead(ledgerEntry, "findMany", { where: { $compositeIn: planners } }, postgres),
+    ).toThrow(/the planner built/);
   });
 
   /** ...and the planner's own still compiles, on the dialect that binds it. */

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -10,7 +10,12 @@ import {
 import { assertPageArgument } from "./paginate";
 import { COUNT_KEY } from "../relation-filters";
 import * as registry from "../registry";
-import type { FieldSchema, ModelSchema, RelationSchema } from "../schema";
+import type {
+  FieldSchema,
+  ModelSchema,
+  RelationSchema,
+  ScalarType,
+} from "../schema";
 import {
   type BindContext,
   type Fragment,
@@ -20,6 +25,7 @@ import {
   sql,
 } from "./fragment";
 import { resolveSelection } from "./select";
+import { COMPOSITE_IN } from "./where";
 
 /**
  * The relation planner: an include tree plus a root model in, a *strategy* out.
@@ -1093,7 +1099,13 @@ async function loadDirect(
   if (keys.length === 0) return;
 
   const node = request.locate(context.args);
-  const query = childQuery(node, link.childFields, keys);
+  const query = childQuery(
+    node,
+    link.childFields,
+    keys,
+    request.child,
+    request.dialect,
+  );
 
   const rows = (await context.executor.exec(
     request.relation.model,
@@ -1187,7 +1199,13 @@ async function loadThroughJoinTable(
   if (childKeys.length === 0) return;
 
   const node = request.locate(context.args);
-  const query = childQuery(node, link.childFields, childKeys);
+  const query = childQuery(
+    node,
+    link.childFields,
+    childKeys,
+    request.child,
+    request.dialect,
+  );
 
   const rows = (await context.executor.exec(
     request.relation.model,
@@ -1275,6 +1293,8 @@ function childQuery(
   node: unknown,
   childFields: string[],
   keys: unknown[][],
+  childSchema: ModelSchema,
+  dialect: SqlDialect,
 ): { args: Record<string, unknown>; hidden: boolean } {
   const relationArgs = (
     node === true || node === null || typeof node !== "object" ? {} : node
@@ -1310,23 +1330,16 @@ function childQuery(
    *        sqlite    composite: 4 keys    single: 4 keys
    *        postgres  composite: 4 keys    single: 1 key
    *
-   *    SQLite churns either way and always has. The Postgres asymmetry is new,
-   *    and it is the churn `collapsedList` was written to prevent arriving
-   *    through the door it does not cover. A form where the parent keys ride in
-   *    one parameter — `(a, b) in (select * from unnest($1::int[], $2::text[]))`
-   *    — would fix it there and is filed rather than guessed at here, because
-   *    it needs the column types and its own coverage on both dialects. #97.
+    *    **Closed on Postgres by #97**, which is why `compositeFilter` below asks
+   *    the dialect rather than always building the `OR`: `unnest` binds one
+   *    array per *column*, so the text is fixed and every parent count is one
+   *    entry. SQLite has no such form and keeps the `OR`, churning as it always
+   *    has — `plan.ts` records that a coarser key cannot fix that side.
    */
   const filter =
     childFields.length === 1
       ? { [childFields[0]]: { in: keys.map((key) => key[0]) } }
-      : {
-          OR: keys.map((key) =>
-            Object.fromEntries(
-              childFields.map((field, index) => [field, key[index]]),
-            ),
-          ),
-        };
+      : compositeFilter(childSchema, childFields, keys, dialect);
   const args: Record<string, unknown> = {
     where:
       relationArgs.where === undefined
@@ -1354,6 +1367,45 @@ function childQuery(
     (args.select as Record<string, unknown>)[field] = true;
   }
   return { args, hidden: true };
+}
+
+/**
+ * The filter for a composite join key: a tuple `in` where the dialect can bind
+ * one, and an `OR` of `AND`s where it cannot.
+ *
+ * **The `OR` is the portable form and stays the fallback**, for the reasons it
+ * was chosen originally: it is one shape both dialects compile, through the
+ * `where` compiler every other filter goes through, so it inherits the
+ * parameter accounting and the injection rules. What it does not inherit is a
+ * fixed SQL text — its length grows with the parent count, so the plan cache
+ * mints an entry per page size (#97).
+ *
+ * `unnest` fixes that on Postgres by binding one array per *column* instead of
+ * one placeholder per parent, so the text is constant. The dialect is asked
+ * whether it can spell every column's type rather than told: an unmappable
+ * type keeps the `OR`, because a cast that does not round-trip exactly is
+ * silently wrong rows rather than an error.
+ */
+function compositeFilter(
+  child: ModelSchema,
+  childFields: string[],
+  keys: unknown[][],
+  dialect: SqlDialect,
+): Record<string, unknown> {
+  const types = childFields.map((name) => child.fields[name]?.type);
+
+  if (
+    types.every((type) => type !== undefined) &&
+    dialect.canBindCompositeIn(types as ScalarType[])
+  ) {
+    return { [COMPOSITE_IN]: { fields: childFields, values: keys } };
+  }
+
+  return {
+    OR: keys.map((key) =>
+      Object.fromEntries(childFields.map((field, index) => [field, key[index]])),
+    ),
+  };
 }
 
 /**

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -25,7 +25,7 @@ import {
   sql,
 } from "./fragment";
 import { resolveSelection } from "./select";
-import { COMPOSITE_IN } from "./where";
+import { COMPOSITE_IN, plannerCompositeIn } from "./where";
 
 /**
  * The relation planner: an include tree plus a root model in, a *strategy* out.
@@ -1398,7 +1398,7 @@ function compositeFilter(
     types.every((type) => type !== undefined) &&
     dialect.canBindCompositeIn(types as ScalarType[])
   ) {
-    return { [COMPOSITE_IN]: { fields: childFields, values: keys } };
+    return { [COMPOSITE_IN]: plannerCompositeIn(childFields, keys) };
   }
 
   return {

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -586,6 +586,39 @@ function assertCompositeInOperand(
   operand: unknown,
   context: WhereContext,
 ): string[] {
+  /**
+   * A caller's key gets the **unknown-key treatment**, which is what the
+   * original comment promised and what every other key it is not a field for
+   * already gets. `UnsupportedQueryError` would render "does not support
+   * '$compositeIn' *yet*" — a promise about a key that is deliberately not in
+   * the grammar and never will be. That word has now been corrected once each
+   * on #82 and #88; this is the third time it has been raised, which is enough
+   * to stop treating it as a wording nit and use the error that is simply
+   * accurate: `$compositeIn` is not a field on this model.
+   */
+  const notAField = (): never => {
+    throw new UnknownFieldError(
+      COMPOSITE_IN,
+      schema.name,
+      Object.keys(schema.fields),
+    );
+  };
+
+  if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
+    return notAField();
+  }
+
+  if ((operand as Record<symbol, unknown>)[PLANNER] !== true) {
+    return notAField();
+  }
+
+  /**
+   * Below here the operand *is* the planner's, so a bad shape is this ORM's bug
+   * rather than a caller's — and `UnsupportedQueryError` is the right class for
+   * it: an internal invariant that does not hold is genuinely something the
+   * ORM does not support, and "yet" is the honest word for a state it should
+   * not be in.
+   */
   const refuse = (detail: string): never => {
     throw new UnsupportedQueryError(
       COMPOSITE_IN,
@@ -594,21 +627,6 @@ function assertCompositeInOperand(
       detail,
     );
   };
-
-  if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
-    return refuse(
-      `'${COMPOSITE_IN}' is not part of the query grammar — it is how the ` +
-        `relation planner matches a composite key, and nothing else builds one.`,
-    );
-  }
-
-  if ((operand as Record<symbol, unknown>)[PLANNER] !== true) {
-    return refuse(
-      `'${COMPOSITE_IN}' is not part of the query grammar — it is how the ` +
-        `relation planner matches a composite key. To filter on several ` +
-        `columns, write them as ordinary keys, or as an 'OR' of them.`,
-    );
-  }
 
   const { fields, values } = operand as CompositeInOperand;
 

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -88,6 +88,11 @@ export function compileWhere(
       continue;
     }
 
+    if (key === COMPOSITE_IN) {
+      predicates.push(compileCompositeIn(schema, value, context, at));
+      continue;
+    }
+
     if (key === "NOT") {
       const negated = compileGroup(schema, value, context, at, "AND");
       // `NOT` of nothing is vacuously true, so it contributes no predicate.
@@ -485,6 +490,64 @@ const COMPARISONS: Record<string, string> = {
   gt: ">",
   gte: ">=",
 };
+
+/**
+ * The internal key a batched relation loader uses to match a **tuple** of
+ * columns against a list of tuples — the composite-relation counterpart of
+ * `in`, and the reason #97 exists.
+ *
+ * **`$`-prefixed because a Prisma field cannot be.** Field names match
+ * `[A-Za-z][A-Za-z0-9_]*`, so this cannot collide with a column, which a
+ * `__`-prefixed name could not promise. It is not part of the public argument
+ * grammar: nothing outside `plan-relations.ts` builds one, and a caller writing
+ * it by hand gets the same treatment as any unknown key everywhere else,
+ * because the schema has no such field.
+ */
+export const COMPOSITE_IN = "$compositeIn";
+
+/** `{ fields: ["a", "b"], values: [[1, "x"], [2, "y"]] }`. */
+interface CompositeInOperand {
+  fields: string[];
+  values: unknown[][];
+}
+
+/**
+ * `(a, b) in (…)`, in whichever form the dialect can bind.
+ *
+ * Only ever reached on a dialect whose `canBindCompositeIn` said yes for these
+ * column types — `plan-relations.ts` asks before it emits this key, and keeps
+ * the portable `OR` of `AND`s otherwise. So there is no fallback here: arriving
+ * with a dialect that cannot express it is a bug in that decision, not a shape
+ * to degrade.
+ */
+function compileCompositeIn(
+  schema: ModelSchema,
+  operand: unknown,
+  context: WhereContext,
+  locate: (args: any) => any,
+): Fragment {
+  const { dialect } = context;
+  const { fields } = operand as CompositeInOperand;
+
+  const resolved = fields.map((name) => {
+    const field = schema.fields[name];
+    if (!field) {
+      throw new UnknownFieldError(name, schema.name, Object.keys(schema.fields));
+    }
+    return field;
+  });
+
+  const columns = resolved.map(
+    (field) =>
+      `${context.qualifier ?? ""}${dialect.quoteIdent(field.column)}`,
+  );
+
+  return dialect.compositeIn(
+    columns,
+    resolved.map((field) => field.type),
+    (args) => (locate(args) as CompositeInOperand).values,
+  );
+}
 
 function compileFieldFilter(
   schema: ModelSchema,

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -498,17 +498,39 @@ const COMPARISONS: Record<string, string> = {
  *
  * **`$`-prefixed because a Prisma field cannot be.** Field names match
  * `[A-Za-z][A-Za-z0-9_]*`, so this cannot collide with a column, which a
- * `__`-prefixed name could not promise. It is not part of the public argument
- * grammar: nothing outside `plan-relations.ts` builds one, and a caller writing
- * it by hand gets the same treatment as any unknown key everywhere else,
- * because the schema has no such field.
+ * `__`-prefixed name could not promise.
+ *
+ * It is not part of the public argument grammar, and that is **enforced rather
+ * than asserted**. This branch sits above the field lookup, so a caller writing
+ * the key by hand used to be honoured — not an injection, since the fields are
+ * resolved against the schema and the values are bound, but an undocumented
+ * input surface with none of the operand validation its neighbours have. The
+ * operand now has to carry {@link PLANNER}, a module-private `Symbol` an
+ * application cannot reach, exactly as `markPreScoped` and `markOrmAuthored`
+ * gate their own claims.
  */
 export const COMPOSITE_IN = "$compositeIn";
+
+/**
+ * Marks a composite-`in` operand as the planner's own.
+ *
+ * A `Symbol`, so it is invisible to `Object.entries` — which means it does not
+ * reach the plan key, where it would be noise, and cannot be written in JSON by
+ * a caller who has seen the key name in a stack trace.
+ */
+const PLANNER = Symbol("gemi.orm.compositeInFromPlanner");
 
 /** `{ fields: ["a", "b"], values: [[1, "x"], [2, "y"]] }`. */
 interface CompositeInOperand {
   fields: string[];
   values: unknown[][];
+}
+
+export function plannerCompositeIn(
+  fields: string[],
+  values: unknown[][],
+): Record<string, unknown> {
+  return { [PLANNER]: true, fields, values };
 }
 
 /**
@@ -527,7 +549,7 @@ function compileCompositeIn(
   locate: (args: any) => any,
 ): Fragment {
   const { dialect } = context;
-  const { fields } = operand as CompositeInOperand;
+  const fields = assertCompositeInOperand(schema, operand, context);
 
   const resolved = fields.map((name) => {
     const field = schema.fields[name];
@@ -547,6 +569,69 @@ function compileCompositeIn(
     resolved.map((field) => field.type),
     (args) => (locate(args) as CompositeInOperand).values,
   );
+}
+
+/**
+ * The operand's shape, checked at **plan** time.
+ *
+ * Every other operand in this file is validated here rather than left to fail
+ * at bind time — `assertCreateManyOperand`'s note says why: a refusal that
+ * arrives later has to unwind work that should never have started. This one
+ * was the exception, and it showed: `{ $compositeIn: null }` raised a raw
+ * `TypeError` from a destructure, and `{ fields: ["id"] }` with no `values` at
+ * all compiled clean and deferred its failure to bind time.
+ */
+function assertCompositeInOperand(
+  schema: ModelSchema,
+  operand: unknown,
+  context: WhereContext,
+): string[] {
+  const refuse = (detail: string): never => {
+    throw new UnsupportedQueryError(
+      COMPOSITE_IN,
+      schema.name,
+      context.operation,
+      detail,
+    );
+  };
+
+  if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
+    return refuse(
+      `'${COMPOSITE_IN}' is not part of the query grammar — it is how the ` +
+        `relation planner matches a composite key, and nothing else builds one.`,
+    );
+  }
+
+  if ((operand as Record<symbol, unknown>)[PLANNER] !== true) {
+    return refuse(
+      `'${COMPOSITE_IN}' is not part of the query grammar — it is how the ` +
+        `relation planner matches a composite key. To filter on several ` +
+        `columns, write them as ordinary keys, or as an 'OR' of them.`,
+    );
+  }
+
+  const { fields, values } = operand as CompositeInOperand;
+
+  // Below here the operand *is* the planner's, so these are its bugs rather
+  // than a caller's — worth catching at compile time for the same reason, and
+  // worth a different sentence because the audience is different.
+  if (!Array.isArray(fields) || fields.length === 0) {
+    return refuse(`the planner built a '${COMPOSITE_IN}' with no fields.`);
+  }
+  if (!fields.every((name) => typeof name === "string")) {
+    return refuse(`the planner built a '${COMPOSITE_IN}' with a non-string field.`);
+  }
+  if (!Array.isArray(values)) {
+    return refuse(`the planner built a '${COMPOSITE_IN}' with no values.`);
+  }
+  if (!values.every((tuple) => Array.isArray(tuple) && tuple.length === fields.length)) {
+    return refuse(
+      `the planner built a '${COMPOSITE_IN}' whose tuples do not all have ` +
+        `${fields.length} value(s).`,
+    );
+  }
+
+  return fields;
 }
 
 function compileFieldFilter(

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -1,6 +1,6 @@
 import type { Dialect } from "../../database/dialect";
 import type { Binder, Fragment } from "../compile/fragment";
-import type { FieldSchema } from "../schema";
+import type { FieldSchema, ScalarType } from "../schema";
 import { PostgresDialect } from "./postgres";
 import { SqliteDialect } from "./sqlite";
 
@@ -151,6 +151,37 @@ export interface SqlDialect {
 
   /** `<lhs> like <pattern>`, case-insensitively when the dialect can. */
   like(lhs: string, insensitive: boolean, pattern: Binder): Fragment;
+
+  /**
+   * Whether this dialect can match a **tuple** of columns against a list of
+   * tuples in a statement whose text does not grow with the list.
+   *
+   * The single-column case is `inList`, and on Postgres `= any($1)` already
+   * gives one SQL text for every length — which is what lets `collapsedList`
+   * keep a batched relation query to one plan entry however many parents it
+   * has. A relation joining on *more than one* field cannot use it, so the
+   * loader falls back to an `OR` of `AND`s whose text does grow, and the plan
+   * cache churns with the parent count (#97).
+   *
+   * `unnest` closes that on Postgres — one array parameter per *column*, so the
+   * text is fixed — but it needs each column's SQL type for the cast, and the
+   * types are asked about here rather than assumed: a dialect that cannot spell
+   * one of them says so and the caller keeps the portable `OR`.
+   */
+  canBindCompositeIn(types: readonly ScalarType[]): boolean;
+
+  /**
+   * `(a, b) in (select * from unnest($1::t[], $2::u[]))`.
+   *
+   * `values` yields one tuple per parent at bind time; the dialect decides how
+   * they are transposed into per-column arrays. Only called when
+   * {@link canBindCompositeIn} returned true for these types.
+   */
+  compositeIn(
+    columns: readonly string[],
+    types: readonly ScalarType[],
+    values: Binder,
+  ): Fragment;
 
   /**
    * `limit`/`offset`. Both are values and therefore parameters — this is the

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -7,7 +7,7 @@ import {
   sql,
 } from "../compile/fragment";
 import { DecodeError } from "../errors";
-import type { FieldSchema } from "../schema";
+import type { FieldSchema, ScalarType } from "../schema";
 import type { ConstraintViolation, SqlDialect } from "./index";
 
 // Postgres has real `timestamptz`, `boolean`, `numeric` and `jsonb` types, so
@@ -74,6 +74,77 @@ export class PostgresDialect implements SqlDialect {
       sql(`${lhs} ${operator} (`),
       param((args, context) => arrayLiteral(values(args, context) as unknown[])),
       sql(")"),
+    );
+  }
+
+  /**
+   * The SQL type each Prisma scalar takes inside an `unnest` cast.
+   *
+   * **Deliberately not the whole table.** Only the types a composite join key
+   * realistically uses are here, and anything else falls back to the portable
+   * `OR` rather than being guessed at — the cast has to round-trip the value
+   * exactly, and a wrong one is silently wrong rows rather than an error.
+   *
+   * `DateTime` is the instructive absence: Prisma maps it to `timestamp(3)`,
+   * and this driver's own note records that a zoneless timestamp decodes
+   * differently depending on which protocol the statement used. Putting that
+   * through a text array literal adds a second representation question to one
+   * that is already open, for a key type nobody joins on.
+   */
+  private static readonly COMPOSITE_IN_TYPES: Partial<
+    Record<ScalarType, string>
+  > = {
+    Int: "int",
+    BigInt: "bigint",
+    String: "text",
+    Boolean: "boolean",
+  };
+
+  canBindCompositeIn(types: readonly ScalarType[]): boolean {
+    return (
+      types.length > 0 &&
+      types.every((type) => PostgresDialect.COMPOSITE_IN_TYPES[type])
+    );
+  }
+
+  /**
+   * `(a, b) in (select * from unnest($1::int[], $2::text[]))`.
+   *
+   * **One parameter per column, not per parent**, which is the whole point:
+   * the text is fixed however many tuples arrive, so a batched composite
+   * `include` is one plan entry rather than one per parent count (#97). The
+   * `OR` it replaces costs a placeholder per field *per parent* and a plan key
+   * per length.
+   *
+   * The tuples arrive row-wise — one array per parent — and are transposed
+   * here, because that is the shape the loader has and the shape `unnest`
+   * needs. Serialized as Postgres array literals for the reason `inList`
+   * already documents: this driver rejects a JS array bound against an array
+   * parameter, and the literal is still one bound value that never touches the
+   * SQL text.
+   */
+  compositeIn(
+    columns: readonly string[],
+    types: readonly ScalarType[],
+    values: Binder,
+  ): Fragment {
+    const arrays = columns.map((_column, index) =>
+      concat(
+        param((args, context) =>
+          arrayLiteral(
+            (values(args, context) as unknown[][]).map((tuple) => tuple[index]),
+          ),
+        ),
+        sql(`::${PostgresDialect.COMPOSITE_IN_TYPES[types[index]]}[]`),
+      ),
+    );
+
+    return concat(
+      sql(`(${columns.join(", ")}) in (select * from unnest(`),
+      ...arrays.flatMap((array, index) =>
+        index === 0 ? [array] : [sql(", "), array],
+      ),
+      sql("))"),
     );
   }
 

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -117,6 +117,28 @@ export class SqliteDialect implements SqlDialect {
     );
   }
 
+  /**
+   * Never. SQLite has no `unnest`, and its row-value `in` still needs one
+   * `(?, ?)` group per tuple — so the text grows with the list either way and
+   * there is nothing to gain over the `OR` the loader already builds.
+   *
+   * That is consistent with the single-column case: `plan.ts` records that "a
+   * coarser key cannot fix the SQLite side", because every distinct length is
+   * genuinely a different statement here.
+   */
+  canBindCompositeIn(): boolean {
+    return false;
+  }
+
+  compositeIn(): Fragment {
+    // Unreachable: the caller asks `canBindCompositeIn` first and keeps the
+    // portable `OR` when it says no. Throwing rather than emitting something
+    // plausible keeps the two from disagreeing silently.
+    throw new Error(
+      "SQLite cannot bind a composite `in`; `canBindCompositeIn` is the guard.",
+    );
+  }
+
   like(lhs: string, _insensitive: boolean, pattern: Binder): Fragment {
     // `_insensitive` is unreachable — the compiler checks
     // `supportsInsensitiveMode` and raises a contextful error first.

--- a/packages/gemi/orm/plan.discrimination.test.ts
+++ b/packages/gemi/orm/plan.discrimination.test.ts
@@ -456,53 +456,58 @@ describe("plan cache discrimination", () => {
   });
 
   /**
-   * The gap `collapsedList` does not cover, pinned so it changes deliberately.
+   * The gap `collapsedList` did not cover, now closed on Postgres (#97).
    *
-   * A composite relation cannot be filtered with a single `in`, so the batched
-   * loader builds an `OR` of `AND`s — whose text varies with its branch count,
-   * so it cannot be collapsed the way `= any($1)` can. The result is that
-   * Postgres, otherwise immune to parent-count churn, is not immune for a
-   * composite relation.
+   * This test was added by #95 asserting the *churn* — a composite `include`
+   * minting one plan per parent count on both dialects — and written to flip
+   * rather than be deleted when the fix landed. This is the flip.
    *
-   * Asserted rather than left as a comment because the *asymmetry* is the
-   * surprising part: same include, same query shape, different relation arity.
-   * If a future change makes the composite path collapse too, this is what
-   * should say so.
+   * A composite key now binds one array per **column** through `unnest`, so the
+   * SQL text is fixed however many parents arrive and every length is one
+   * entry. SQLite keeps the `OR`, whose text genuinely does grow, and churns as
+   * it always has — `plan.ts` records that a coarser key cannot fix that side.
    */
-  test("a composite parent filter churns on both dialects, unlike a single-field one", () => {
+  test("a composite parent filter is one plan on postgres, many on sqlite", () => {
     const counts = [2, 3, 10, 50];
-
     const composite = (dialect: SqliteDialect | PostgresDialect) =>
       new Set(
         counts.map((n) =>
-          planKey(dialect, "Ledger", "findMany", {
+          planKey(dialect, "LedgerEntry", "findMany", {
             where: {
-              OR: Array.from({ length: n }, (_, i) => ({
-                tenantId: 1,
-                code: `c${i}`,
-              })),
+              $compositeIn: {
+                fields: ["tenantId", "ledgerCode"],
+                values: Array.from({ length: n }, (_, i) => [1, `c${i}`]),
+              },
             },
           }),
         ),
       ).size;
 
-    const single = (dialect: SqliteDialect | PostgresDialect) =>
-      new Set(
-        counts.map((n) =>
-          planKey(dialect, "User", "findMany", {
-            where: { id: { in: Array.from({ length: n }, (_, i) => i) } },
+    expect(composite(postgres)).toBe(1);
+    expect(composite(sqlite)).toBe(counts.length);
+  });
+
+  /**
+   * The half the collapse must **not** take with it: the joined columns are
+   * *identifiers* in the emitted SQL, so two relations joining on different
+   * ones — or on the same ones in a different order, which pairs the sides
+   * differently — must not share an entry.
+   */
+  test("the joined columns still discriminate, on both dialects", () => {
+    for (const dialect of [sqlite, postgres]) {
+      const keys = new Set(
+        [
+          ["tenantId", "ledgerCode"],
+          ["ledgerCode", "tenantId"],
+          ["tenantId", "id"],
+        ].map((fields) =>
+          planKey(dialect, "LedgerEntry", "findMany", {
+            where: { $compositeIn: { fields, values: [[1, "a"]] } },
           }),
         ),
-      ).size;
-
-    // SQLite expands an `in` to one placeholder per element, so it churns
-    // either way and always has.
-    expect(single(sqlite)).toBe(counts.length);
-    expect(composite(sqlite)).toBe(counts.length);
-
-    // Postgres collapses an `in` to one key — and cannot collapse the `OR`.
-    expect(single(postgres)).toBe(1);
-    expect(composite(postgres)).toBe(counts.length);
+      );
+      expect(keys.size).toBe(3);
+    }
   });
 
   // Postgres is the exception that proves the point: there, every in-length

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -232,6 +232,14 @@ export function canonicalShape(
 const LIST_KEYS = new Set(["in", "notIn"]);
 
 /**
+ * The internal composite-`in` key — see `compile/where.ts`, which owns it.
+ *
+ * Spelled here rather than imported to keep `plan.ts` free of a dependency on
+ * the compiler, the way it already is for every other key it recognises.
+ */
+const COMPOSITE_IN = "$compositeIn";
+
+/**
  * `in: [1, 2]` and `in: [1, 2, 3]` on Postgres are the same SQL text — the
  * whole array binds to `= any($1)` — so they must be the same cache entry.
  *
@@ -257,11 +265,11 @@ const LIST_KEYS = new Set(["in", "notIn"]);
  *     sqlite    composite: 4 keys    single: 4 keys
  *     postgres  composite: 4 keys    single: 1 key
  *
- * So the churn this function prevents for a single-field relation still happens
- * for a composite one on Postgres. SQLite was always in that position. Fixing
- * it needs a form where the parent keys ride in one parameter — Postgres can,
- * with `unnest` over one array per column — which is a dialect method rather
- * than a key change, and is filed as #97 rather than sketched here.
+ * That gap is closed on Postgres by #97: a composite key binds one array per
+ * *column* through `unnest`, so its text is fixed too, and `shapeOfMember`
+ * collapses its tuple list on the same condition this function uses. SQLite has
+ * no such form, keeps the `OR`, and churns as it always has — which is the same
+ * sentence as above, and for the same reason.
  */
 function collapsedList(value: unknown[]): string {
   return value.length === 0 ? "[]" : "[*]";
@@ -302,6 +310,33 @@ function shapeOfMember(
   if (collapseLists && LIST_KEYS.has(key) && Array.isArray(value)) {
     return collapsedList(value);
   }
+  /**
+   * A composite `in`'s tuple list collapses on exactly the dialects where its
+   * SQL text does not grow with it — the same condition, and the same reason,
+   * as `collapsedList` for a single-column `in`.
+   *
+   * On Postgres the tuples become one array parameter per *column*, so every
+   * parent count is one statement and must be one entry: without this a batched
+   * composite `include` mints a plan per page size, which is #97 and the whole
+   * point of the `unnest` form. On SQLite the key is never emitted — the loader
+   * keeps the `OR`, whose text does grow — so the collapse cannot be reached
+   * there to be wrong.
+   *
+   * The `fields` stay verbatim: they are *identifiers* in the emitted SQL, so
+   * two relations joining on different columns must not share an entry. Only
+   * the tuple list is collapsed.
+   */
+  if (key === COMPOSITE_IN) {
+    const operand = value as { fields: unknown; values: unknown[] };
+    return canonicalShape(
+      collapseLists
+        ? { fields: operand.fields, values: collapsedList(operand.values) }
+        : value,
+      true,
+      collapseLists,
+    );
+  }
+
   if (VALUE_KEYS.has(key)) return canonicalShape(value, false, collapseLists);
   return canonicalShape(
     value,


### PR DESCRIPTION
Closes #97. **Stacked on #95**, which added composite relations and measured the churn this removes — hence the base, so the diff here is only the fix.

## The gap

`collapsedList` keeps a batched relation query to one plan entry however many parents it has, because on Postgres `= any($1)` gives one SQL text for every length. A relation joining on more than one field cannot use it, so the loader built an `OR` of `AND`s whose text grows — and the plan key grew with it:

```
before   sqlite   composite: 4 keys    single: 4 keys
         postgres composite: 4 keys    single: 1 key
after    postgres composite: 1 key
```

`(a, b) in (select * from unnest($1::int[], $2::text[]))` binds **one array per column** rather than one placeholder per parent, so the text is fixed. SQLite has no such form, keeps the `OR`, and churns as it always has — `plan.ts` already records that a coarser key cannot fix that side, and the internal key is never emitted there to be collapsed wrongly.

## Behind the seam the review pointed at

Your note on #95 was that `SqlDialect.inList` already exists *because the two databases disagree about structure rather than spelling* — and this is the same disagreement one arity up. So `canBindCompositeIn` / `compositeIn` sit beside it rather than becoming a branch in the compiler.

## Three decisions

- **The dialect is asked, not told.** `canBindCompositeIn` takes the column types; Postgres answers for `Int`, `BigInt`, `String` and `Boolean` only, and anything else keeps the `OR`. A cast that does not round-trip exactly is *silently wrong rows*, not an error, so the map is deliberately short. `DateTime` is the instructive absence: this driver's own note records that a zoneless timestamp already decodes differently depending on which protocol the statement used, and a text array literal would add a second representation question to one that is already open — for a key type nobody joins on.
- **`$compositeIn`, because a Prisma field name cannot start with `$`.** A `__` prefix could collide with a column; this cannot. It is internal — only `plan-relations.ts` builds one — and a caller writing it by hand meets the same unknown-key treatment as anywhere else, since no schema has that field.
- **The collapse takes the tuple list and not the fields.** The joined columns are *identifiers* in the emitted SQL, so two relations joining on different ones — or on the same ones in a different **order**, which pairs the sides differently — must stay different entries.

## Tests

The churn test #95 added was written to flip rather than be deleted, and this is the flip: it asserts one plan on Postgres and many on SQLite. A companion pins the half the collapse must not take with it — three distinct field lists produce three keys, on both dialects.

All ten composite differential cases pass on Postgres with `unnest` actually in use, and SQLite still emits the `OR`. I checked both by reading the child query the loader builds rather than inferring it from green tests:

```
postgres  child where: {"$compositeIn":{"fields":["tenantId","code"],"values":[[1,"a"]]}}
sqlite    child where: {"OR":[{"tenantId":1,"code":"a"}]}
```

## Verification

933 unit tests. Template suite green on SQLite (501) and Postgres 16 (752), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
