### PR TITLE
Nested `update`, and the pass its refusal said was missing

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -293,6 +293,8 @@ await List.create({
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
 | `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
+| `disconnect` | Clears the link. `true` on a to-one; a unique key, or a list of them, on a to-many. The column has to be nullable. |
+| `delete` | Deletes the named rows outright, not just the link. |
 
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
@@ -314,8 +316,15 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 `connectOrCreate` succeeded would together tell you a row with that key exists in someone else's
 tenant.
 
-Everything else in Prisma's nested grammar — `set`, `disconnect`, `update`, `updateMany`, `upsert`,
-`delete`, `deleteMany` — is refused, by name and with the reason. The line is **which rows an
+`disconnect` and `delete` only exist on an `update` — a `create` has nothing linked to it yet, and
+Prisma reports them as an unknown argument there too. They differ on a row that is **not** linked to
+this parent, and the difference is Prisma's: `disconnect` succeeds and changes nothing, `delete`
+raises. Both filter on the parent's key as well as yours, so neither can reach a row belonging to
+somebody else — and a row your policies hide is not reachable either, which `delete` reports as "not
+connected" rather than as denied, since that is the same answer a genuinely unlinked row gets.
+
+Everything else in Prisma's nested grammar — `set`, `update`, `updateMany`, `upsert`, `deleteMany` —
+is refused, by name and with the reason. The line is **which rows an
 operand can name, and whose columns it writes**: everything supported names its rows (a new one, or
 one you identified by unique key) and writes either a whole new row or one foreign key the ORM
 chose. `set`, `disconnect`, `delete`, `deleteMany` and `updateMany` act on rows the call did not

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -316,6 +316,12 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 `connectOrCreate` succeeded would together tell you a row with that key exists in someone else's
 tenant.
 
+> **Known gap (#98).** A child whose policy *scopes on the foreign key itself* — `scope: () => ({
+> folderId: mine })` — cannot use any relation operand that writes that key, including `connect`,
+> unless it also declares an `onUpdate`. The scope-escape guard reads the payload and cannot tell a
+> column you supplied from one the nested step put there. Pre-existing rather than new to
+> `disconnect`, and tracked separately because the decision affects `connect` too.
+
 `disconnect` and `delete` only exist on an `update` — a `create` has nothing linked to it yet, and
 Prisma reports them as an unknown argument there too. They differ on a row that is **not** linked to
 this parent, and the difference is Prisma's: `disconnect` succeeds and changes nothing, `delete`

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -295,6 +295,7 @@ await List.create({
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
 | `disconnect` | Clears the link. `true` on a to-one; a unique key, or a list of them, on a to-many. The column has to be nullable. |
 | `delete` | Deletes the named rows outright, not just the link. |
+| `update` | Writes your columns to the named row. The child's own `onUpdate` and scope rules apply to the payload. |
 
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
@@ -329,8 +330,14 @@ raises. Both filter on the parent's key as well as yours, so neither can reach a
 somebody else — and a row your policies hide is not reachable either, which `delete` reports as "not
 connected" rather than as denied, since that is the same answer a genuinely unlinked row gets.
 
-Everything else in Prisma's nested grammar — `set`, `update`, `updateMany`, `upsert`, `deleteMany` —
-is refused, by name and with the reason. The line is **which rows an
+`update` is where the two halves of the line meet: it names its row like `disconnect`, and it writes
+your columns like a top-level `update` — so the payload goes through the child's own operation and
+is judged by the child's policies. Naming a column the child scopes on is refused exactly as it
+would be at the top level. On a to-one both spellings work, `update: { … }` and
+`update: { data: { … } }`, because Prisma accepts both.
+
+Everything else in Prisma's nested grammar — `set`, `updateMany`, `upsert`, `deleteMany` — is
+refused, by name and with the reason. The line is **which rows an
 operand can name, and whose columns it writes**: everything supported names its rows (a new one, or
 one you identified by unique key) and writes either a whole new row or one foreign key the ORM
 chose. `set`, `disconnect`, `delete`, `deleteMany` and `updateMany` act on rows the call did not

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -72,7 +72,22 @@ const SUPPORTED = new Set([
   "connectOrCreate",
   "create",
   "createMany",
+  "disconnect",
+  "delete",
 ]);
+
+/**
+ * Operands that only exist on a statement with a row to act on.
+ *
+ * Prisma refuses `disconnect` and `delete` under a `create` — *"Unknown
+ * argument `disconnect`"* — and it is right to: there is nothing linked to a
+ * row that does not exist yet. Refused here rather than accepted and made a
+ * no-op, so a caller who wrote one on the wrong operation hears about it.
+ */
+const EXISTING_ROW_ONLY = new Set(["disconnect", "delete"]);
+
+/** Statements that insert a new row, so nothing is linked to it yet. */
+const CREATE_ONLY_STATEMENTS = new Set(["create", "createMany"]);
 
 /**
  * The operands still refused, and what each would take.
@@ -85,8 +100,6 @@ const SUPPORTED = new Set([
  */
 const REFUSED: Record<string, string> = {
   set: `It replaces the whole set, so it has to disconnect what is there now.`,
-  disconnect: `It clears a foreign key on rows this call did not name.`,
-  delete: `It deletes rows this call did not name.`,
   deleteMany: `It deletes rows this call did not name.`,
   // Not "it writes a row that already exists" — `connectOrCreate` does that
   // too, on the foreign side, and is supported. The difference is *whose*
@@ -223,8 +236,20 @@ function planOne(
         `data.${relation.name}.${key}`,
         schema.name,
         operation,
-        `Only 'connect', 'create' and 'createMany' are implemented.` +
+        `Only ${[...SUPPORTED].sort().join(", ")} are implemented.` +
           (why ? ` '${key}' is not: ${why}` : ""),
+      );
+    }
+
+    // `create` has no row to disconnect from, and Prisma does not offer these
+    // there either — it reports them as an unknown argument.
+    if (EXISTING_ROW_ONLY.has(key) && CREATE_ONLY_STATEMENTS.has(operation)) {
+      throw new UnsupportedQueryError(
+        `data.${relation.name}.${key}`,
+        schema.name,
+        operation,
+        `'${key}' acts on rows already linked to this one, and a '${operation}' ` +
+          `has none yet — Prisma refuses it here too. Use it on an 'update'.`,
       );
     }
   }
@@ -333,6 +358,49 @@ function planOwningSide(
    * Object only on this side. The relation holds one foreign key, so there is
    * one row to point at, and Prisma refuses an array here too.
    */
+  /**
+   * `disconnect: true` on a to-one — clear the foreign key this row holds.
+   *
+   * No step at all: the key lives on this row, so it is one more bound column
+   * set to `null`, exactly as `connect`'s direct form is one bound column set
+   * to a value. Nothing on the child is read or written, which is why there is
+   * no scoping question on this side — the row being changed is the one the
+   * statement already names.
+   *
+   * `delete` has no meaning here for the same reason it has no `createMany`:
+   * this side is a to-one, and deleting the far row through a `data` key would
+   * be deleting a row the statement is not about. Prisma does offer it; it is
+   * refused rather than guessed, because a `delete` that fires as a side effect
+   * of an unrelated update is the kind of thing to implement deliberately.
+   */
+  if (key === "disconnect") {
+    assertDisconnectable(schema, relation, fkField, operation);
+
+    if (operand !== true) {
+      throw new UnsupportedQueryError(
+        `data.${relation.name}.disconnect`,
+        schema.name,
+        operation,
+        `'${relation.name}' is a to-one, so there is one row to clear and ` +
+          `nothing to name. Prisma takes 'true' here.`,
+      );
+    }
+
+    out.contributions.push({ field: fkField, value: () => null });
+    return;
+  }
+
+  if (key === "delete") {
+    throw new UnsupportedQueryError(
+      `data.${relation.name}.delete`,
+      schema.name,
+      operation,
+      `'${relation.name}' is a to-one whose foreign key lives on this row, so ` +
+        `deleting through it would remove a row this statement is not about. ` +
+        `Delete it directly, or 'disconnect' it first.`,
+    );
+  }
+
   if (key === "connectOrCreate") {
     assertConnectOrCreateOperand(
       schema,
@@ -464,6 +532,96 @@ function planForeignSide(
   const childField = link.childField;
 
   out.keyFields.push(parentField);
+
+  /**
+   * `disconnect` and `delete` on this side both act on rows the caller named by
+   * unique key — which is what makes them expressible at all, and what puts
+   * them on the supported side of this file's line.
+   *
+   * They differ on a row that is *not* linked to this parent, and the
+   * difference is Prisma's, measured rather than chosen:
+   *
+   *     disconnect a row linked elsewhere  ->  succeeds, changes nothing
+   *     delete     a row linked elsewhere  ->  raises "are not connected"
+   *
+   * So both filter by the parent key as well as the caller's key, and only
+   * `delete` treats a miss as an error. That filter is doing two jobs at once:
+   * it reproduces Prisma's semantics, and it is what stops either operand from
+   * reaching a row belonging to a different parent.
+   *
+   * **Scoping comes from the child's own operations**, as everywhere else here:
+   * `updateMany` and `delete` go through the child's `$exec` un-pre-scoped, so
+   * a row the child's policies hide is not reachable. For `delete` that means a
+   * hidden row reports "not connected" rather than "denied" — the same answer
+   * as a row that genuinely is not linked, which is the conservative one.
+   */
+  if (key === "disconnect" || key === "delete") {
+    const deleting = key === "delete";
+    if (!deleting) assertDisconnectable(child, relation, childField, operation);
+
+    assertNamedRows(schema, relation, child, operand, key, operation);
+
+    out.after.push({
+      relation: relation.name,
+      operation: key,
+      async run(args, _context, executor, rows) {
+        const parent = rows[0];
+        if (!parent) return;
+
+        const list = listOf(at(args));
+
+        for (let index = 0; index < list.length; index++) {
+          // The caller's key *and* the link, so neither operand can reach a row
+          // attached to a different parent.
+          const where = {
+            ...(list[index] as object),
+            [childField]: parent[parentField],
+          };
+
+          if (!deleting) {
+            await executor.exec(
+              relation.model,
+              "updateMany",
+              { where, data: { [childField]: null } },
+              // NOT pre-scoped: clearing a foreign key is a write to the child,
+              // so the child's scope decides which rows are reachable.
+              false,
+            );
+            continue;
+          }
+
+          const found = (await executor.exec(
+            relation.model,
+            "findFirst",
+            { where, select: { [childField]: true } },
+            false,
+          )) as Record<string, unknown> | null;
+
+          if (!found) {
+            throw new UnsupportedQueryError(
+              `data.${relation.name}.delete`,
+              schema.name,
+              operation,
+              `the row named by ${JSON.stringify(list[index])} is not ` +
+                `connected to this ${schema.name}. Prisma raises here too, ` +
+                `rather than deleting a row belonging to somebody else.`,
+            );
+          }
+
+          await executor.exec(
+            relation.model,
+            "deleteMany",
+            { where },
+            // NOT pre-scoped, for the reason above — and `deleteMany` rather
+            // than `delete` because the `where` carries the link as well as the
+            // unique key, which `delete` refuses as a non-unique target.
+            false,
+          );
+        }
+      },
+    });
+    return;
+  }
 
   if (key === "create") {
     out.after.push({
@@ -676,6 +834,68 @@ function planForeignSide(
       }
     },
   });
+}
+
+/**
+ * The rows a `disconnect` / `delete` names, each by a unique key.
+ *
+ * Validated at plan time for the reason every operand here is: a refusal that
+ * arrives mid-transaction has to unwind a parent row that should never have
+ * been written.
+ */
+function assertNamedRows(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  operand: unknown,
+  key: string,
+  operation: string,
+): Record<string, unknown>[] {
+  const at = `data.${relation.name}.${key}`;
+  const entries = (Array.isArray(operand) ? operand : [operand]) as unknown[];
+  const out: Record<string, unknown>[] = [];
+
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new UnsupportedQueryError(
+        at,
+        schema.name,
+        operation,
+        `Expected an object naming a unique field, or an array of them.`,
+      );
+    }
+    matchUniqueKey(child, entry, `${operation}.${relation.name}.${key}`);
+    out.push(entry as Record<string, unknown>);
+  }
+
+  return out;
+}
+
+/**
+ * A `disconnect` clears a foreign key, so the column has to be nullable.
+ *
+ * Prisma refuses it on a required relation at the type level; here the schema
+ * is the only thing that knows, so the refusal says which column and why rather
+ * than letting the database report a not-null violation from inside a nested
+ * step.
+ */
+function assertDisconnectable(
+  owner: ModelSchema,
+  relation: RelationSchema,
+  fieldName: string,
+  operation: string,
+): void {
+  const field = owner.fields[fieldName];
+  if (field && field.nullable) return;
+
+  throw new UnsupportedQueryError(
+    `data.${relation.name}.disconnect`,
+    owner.name,
+    operation,
+    `'${fieldName}' is required, so there is no value to leave behind — a ` +
+      `disconnected row would have to be deleted or repointed instead. Prisma ` +
+      `does not offer 'disconnect' on a required relation either.`,
+  );
 }
 
 /**

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -419,13 +419,19 @@ function planOwningSide(
 
         const linked = parent[fkField];
         if (linked === null || linked === undefined) {
-          throw new UnsupportedQueryError(
-            `data.${relation.name}.update`,
-            schema.name,
-            operation,
-            `this ${schema.name} has no '${relation.name}' to update — ` +
-              `'${fkField}' is null. Prisma raises here too.`,
-          );
+          // The same error as the foreign side's miss, and for the same reason
+          // — this is one condition with two spellings, not two conditions.
+          // Measured rather than inferred: Prisma answers P2025 here too,
+          // *"depends on one or more records that were required but not
+          // found"*, which `failureKind` maps to `notFound`.
+          //
+          // `UnsupportedQueryError` was wrong twice over. It classifies as
+          // `other`, so the differential harness would have called it agreement
+          // with a Prisma refusal of a different kind — and it prefixes "does
+          // not support … yet", which reports a fully-implemented operation as
+          // unimplemented because a row is missing. That vocabulary has been
+          // corrected once each on #82 and #88.
+          throw new RecordNotFoundError(relation.model, "update");
         }
 
         const operandAt = at(args);

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1,4 +1,4 @@
-import { UnsupportedQueryError } from "../errors";
+import { RecordNotFoundError, UnsupportedQueryError } from "../errors";
 import type { ModelSchema, RelationSchema } from "../schema";
 import type { Binder } from "./fragment";
 import {
@@ -74,6 +74,7 @@ const SUPPORTED = new Set([
   "createMany",
   "disconnect",
   "delete",
+  "update",
 ]);
 
 /**
@@ -84,7 +85,7 @@ const SUPPORTED = new Set([
  * row that does not exist yet. Refused here rather than accepted and made a
  * no-op, so a caller who wrote one on the wrong operation hears about it.
  */
-const EXISTING_ROW_ONLY = new Set(["disconnect", "delete"]);
+const EXISTING_ROW_ONLY = new Set(["disconnect", "delete", "update"]);
 
 /** Statements that insert a new row, so nothing is linked to it yet. */
 const CREATE_ONLY_STATEMENTS = new Set(["create", "createMany"]);
@@ -101,22 +102,13 @@ const CREATE_ONLY_STATEMENTS = new Set(["create", "createMany"]);
 const REFUSED: Record<string, string> = {
   set: `It replaces the whole set, so it has to disconnect what is there now.`,
   deleteMany: `It deletes rows this call did not name.`,
-  // Not "it writes a row that already exists" — `connectOrCreate` does that
-  // too, on the foreign side, and is supported. The difference is *whose*
-  // columns: this one writes caller-supplied data, so the child's `onUpdate`
-  // and the scope-escape guard both have to run over it, where a `connect`
-  // writes one foreign key the ORM chose.
-  update:
-    `It writes caller-supplied columns to a row that already exists, so the ` +
-    `child's 'onUpdate' and the scope-escape guard have to run over the ` +
-    `payload — a pass this does not have yet.`,
   updateMany:
-    `It writes caller-supplied columns to rows this call did not name, so it ` +
-    `needs both halves: a scope on which rows match, and the child's ` +
-    `'onUpdate' over the payload.`,
+    `It writes caller-supplied columns to rows this call did not name — a ` +
+    `predicate, not a key — so there is no lookup for the child's scope to ` +
+    `narrow. 'update' names its row and is implemented.`,
   upsert:
-    `It is 'update' and 'connectOrCreate' at once, and only the second half ` +
-    `is implemented.`,
+    `It is 'update' and 'connectOrCreate' at once and needs a third thing ` +
+    `neither has: deciding which branch ran, from inside a nested step.`,
 };
 
 /** A foreign-key column on *this* model that a nested write supplies. */
@@ -401,6 +393,63 @@ function planOwningSide(
     );
   }
 
+  /**
+   * `update` through a to-one — this row holds the key, so the row being
+   * written is the one it points at.
+   *
+   * Prisma accepts both spellings, measured: `update: { name: "x" }` and
+   * `update: { data: { name: "x" } }`. The second is the documented one and the
+   * first is what people write; accepting only one would refuse a legal query.
+   *
+   * An `after` step rather than a `before` one, and it needs the foreign key in
+   * the statement's `RETURNING` — the far row is identified by *this* row's
+   * column, whose current value the arguments do not carry. That is why
+   * `keyFields` gains it here, where the other owning-side operands need
+   * nothing returned at all.
+   */
+  if (key === "update") {
+    out.keyFields.push(fkField);
+
+    out.after.push({
+      relation: relation.name,
+      operation: "update",
+      async run(args, _context, executor, rows) {
+        const parent = rows[0];
+        if (!parent) return;
+
+        const linked = parent[fkField];
+        if (linked === null || linked === undefined) {
+          throw new UnsupportedQueryError(
+            `data.${relation.name}.update`,
+            schema.name,
+            operation,
+            `this ${schema.name} has no '${relation.name}' to update — ` +
+              `'${fkField}' is null. Prisma raises here too.`,
+          );
+        }
+
+        const operandAt = at(args);
+        const data =
+          operandAt !== null &&
+          typeof operandAt === "object" &&
+          "data" in operandAt
+            ? (operandAt as Record<string, unknown>).data
+            : operandAt;
+
+        await executor.exec(
+          relation.model,
+          "updateMany",
+          { where: { [referenced]: linked }, data },
+          // NOT pre-scoped: the child's own policies decide whether this row is
+          // reachable and whether the payload is allowed to write what it
+          // names — its `onUpdate` and its scope-escape guard.
+          false,
+        );
+      },
+    });
+    return;
+  }
+
   if (key === "connectOrCreate") {
     assertConnectOrCreateOperand(
       schema,
@@ -555,6 +604,83 @@ function planForeignSide(
    * hidden row reports "not connected" rather than "denied" — the same answer
    * as a row that genuinely is not linked, which is the conservative one.
    */
+  /**
+   * `update: { where, data }` — the caller's columns, written to a row they
+   * named by unique key.
+   *
+   * **The pass this was refused for turns out to exist**, one layer down. The
+   * `REFUSED` entry said it "needs its own scoping pass" for `onUpdate` and the
+   * scope-escape guard; both of those live in `applyPolicies`, which the
+   * child's own `$exec` runs because this step is not pre-scoped. Verified
+   * rather than assumed:
+   *
+   *     another tenant's row  ->  { count: 0 }        the child's scope
+   *     caller names a scoped column  ->  ScopeEscapeError
+   *
+   * So the refusal was describing a gap in the wrong place. What `update`
+   * genuinely needs beyond `disconnect` is nothing: the parent-key filter that
+   * keeps it off another parent's row is the same one, and the payload is the
+   * child's business.
+   *
+   * `updateMany` stays refused because it names a *predicate* rather than a
+   * row, which is the half of the line this file draws that has not moved.
+   */
+  if (key === "update") {
+    assertNamedUpdates(schema, relation, child, operand, operation);
+
+    out.after.push({
+      relation: relation.name,
+      operation: "update",
+      async run(args, _context, executor, rows) {
+        const parent = rows[0];
+        if (!parent) return;
+
+        const list = listOf(at(args));
+
+        for (let index = 0; index < list.length; index++) {
+          const entry = list[index] as Record<string, unknown>;
+          // The caller's key *and* the link, so an `update` cannot reach a row
+          // attached to a different parent — the same filter `delete` uses,
+          // and it does the same two jobs.
+          const where = {
+            ...(entry.where as object),
+            [childField]: parent[parentField],
+          };
+
+          const found = (await executor.exec(
+            relation.model,
+            "findFirst",
+            { where, select: { [childField]: true } },
+            false,
+          )) as Record<string, unknown> | null;
+
+          if (!found) {
+            // `RecordNotFoundError`, not `UnsupportedQueryError`: nothing here
+            // is unsupported, the row simply is not there. Prisma agrees —
+            // P2025, *"depends on one or more records that were required but
+            // not found"* — and the differential harness compares the failure
+            // *kind* precisely so a refusal cannot pass as agreement with a
+            // miss. This one was `other` against Prisma's `notFound` until the
+            // harness said so.
+            throw new RecordNotFoundError(relation.model, "update");
+          }
+
+          await executor.exec(
+            relation.model,
+            "updateMany",
+            { where, data: entry.data },
+            // NOT pre-scoped, and this is the whole reason `update` is
+            // expressible: the child's own policies run over `data` — its
+            // `onUpdate` defaults, its scope-escape guard refuses a caller
+            // naming a scoped column — because they have not run yet.
+            false,
+          );
+        }
+      },
+    });
+    return;
+  }
+
   if (key === "disconnect" || key === "delete") {
     const deleting = key === "delete";
     if (!deleting) assertDisconnectable(child, relation, childField, operation);
@@ -834,6 +960,55 @@ function planForeignSide(
       }
     },
   });
+}
+
+/**
+ * `update`'s operand: `{ where, data }`, or a list of them on a to-many.
+ *
+ * `data` is *not* inspected here — it is the child's, and the child's own
+ * `$exec` validates it against the child's schema and policies. Checking it
+ * against this model would be checking the wrong shape.
+ */
+function assertNamedUpdates(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  operand: unknown,
+  operation: string,
+): Record<string, unknown>[] {
+  const at = `data.${relation.name}.update`;
+  const entries = (Array.isArray(operand) ? operand : [operand]) as unknown[];
+  const out: Record<string, unknown>[] = [];
+
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new UnsupportedQueryError(
+        at,
+        schema.name,
+        operation,
+        `Expected an object with 'where' and 'data'.`,
+      );
+    }
+
+    const record = entry as Record<string, unknown>;
+
+    for (const required of ["where", "data"] as const) {
+      if (record[required] === undefined) {
+        throw new UnsupportedQueryError(
+          at,
+          schema.name,
+          operation,
+          `Expected a '${required}' key — 'update' names the row to write and ` +
+            `the columns to write to it.`,
+        );
+      }
+    }
+
+    matchUniqueKey(child, record.where, `${operation}.${relation.name}.update`);
+    out.push(record);
+  }
+
+  return out;
 }
 
 /**

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -174,7 +174,13 @@ export interface NestedWriteStep {
    * itself does, so this is what makes a plan legible from the outside: to a
    * test, and to whatever logs queries later.
    */
-  operation: "connect" | "connectOrCreate" | "create" | "createMany";
+  operation:
+    | "connect"
+    | "connectOrCreate"
+    | "create"
+    | "createMany"
+    | "disconnect"
+    | "delete";
   run(
     args: any,
     context: BindContext,

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -180,7 +180,8 @@ export interface NestedWriteStep {
     | "create"
     | "createMany"
     | "disconnect"
-    | "delete";
+    | "delete"
+    | "update";
   run(
     args: any,
     context: BindContext,

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -483,6 +483,72 @@ describe("policies on nested writes", () => {
   });
 
   /**
+   * The claim `update` is implemented on: **the child's own `$exec` already
+   * carries the pass the refusal said was missing.**
+   *
+   * `REFUSED` used to say a nested `update` "needs its own scoping pass" for
+   * `onUpdate` and the scope-escape guard. Both live in `applyPolicies`, which
+   * runs because the step is not pre-scoped — so the pass was never missing,
+   * it was one layer down. These two assert that, from the outside.
+   */
+  test("a nested update is scoped by the child, not by the caller", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    // Linked to our folder, but owned by the other tenant.
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (30, 2, 'theirs', 99)`,
+    );
+
+    await expect(
+      Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: {
+            code: "ours",
+            notes: { update: { where: { id: 30 }, data: { label: "hacked" } } },
+          },
+        }),
+      ),
+    ).rejects.toThrow(RecordNotFoundError);
+
+    const notes: any = await raw.unsafe(`SELECT "label" FROM "Note"`);
+    expect(notes[0].label).toBe("theirs");
+  });
+
+  /**
+   * ...and the payload is judged by the child too: naming a column the child's
+   * policy scopes on is refused, exactly as it would be at the top level. The
+   * caller wrote this one, so #98's provenance exemption does not apply — which
+   * is the distinction that makes both tests worth having.
+   */
+  test("a nested update cannot write the child's scoped column", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (31, 2, 'ours', 7)`,
+    );
+
+    await expect(
+      Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: {
+            code: "ours",
+            notes: { update: { where: { id: 31 }, data: { orgId: 99 } } },
+          },
+        }),
+      ),
+    ).rejects.toThrow(ScopeEscapeError);
+
+    const notes: any = await raw.unsafe(`SELECT "orgId" FROM "Note"`);
+    expect(notes[0].orgId).toBe(7);
+  });
+
+  /**
    * **Pinned, not endorsed** — #98.
    *
    * A child scoped on its own foreign key loses every relation operand that

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -9,6 +9,7 @@ import { Application } from "gemi/foundation";
 import {
   Model,
   RecordNotFoundError,
+  ScopeEscapeError,
   clearPlanCache,
   register,
   type ModelPolicy,
@@ -479,6 +480,59 @@ describe("policies on nested writes", () => {
     ).rejects.toThrow(/is not connected/);
 
     expect(await raw.unsafe(`SELECT * FROM "Note"`)).toHaveLength(1);
+  });
+
+  /**
+   * **Pinned, not endorsed** — #98.
+   *
+   * A child scoped on its own foreign key loses every relation operand that
+   * writes that key, because `assertNoScopeEscape` reads `args.data` and cannot
+   * tell a column the caller supplied from one the nested step put there. The
+   * caller wrote `disconnect: { id }`; `folderId` is in `data` because the ORM
+   * chose it.
+   *
+   * This is **not** new to `disconnect`. `connect` has the same shape and the
+   * same failure on `feat/orm` today, which is why it is filed rather than
+   * fixed here: the decision affects an operand that already shipped.
+   *
+   * Asserted so the current behaviour is deliberate. When #98 lands this test
+   * should flip to expecting success, rather than being deleted.
+   */
+  test("a foreign-key scope refuses relation operands today", async () => {
+    class KeyScoped extends Model {
+      static $schema = noteSchema;
+      static $policies = [{ scope: () => ({ folderId: 2 }) } as ModelPolicy];
+    }
+    register("Note", KeyScoped);
+
+    try {
+      await raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+      );
+      await raw.unsafe(
+        `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+          `VALUES (20, 2, 'ours', 7)`,
+      );
+
+      const attempt = (operand: unknown) =>
+        Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { code: "ours", notes: operand },
+          }),
+        );
+
+      // Both operands, so the pin records that this is a property of the
+      // guard rather than of the one this PR added.
+      await expect(attempt({ disconnect: { id: 20 } })).rejects.toThrow(
+        ScopeEscapeError,
+      );
+      await expect(attempt({ connect: { id: 20 } })).rejects.toThrow(
+        ScopeEscapeError,
+      );
+    } finally {
+      register("Note", Note);
+    }
   });
 
   /**

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -395,6 +395,93 @@ describe("policies on nested writes", () => {
   });
 
   /**
+   * `disconnect` reaches a row by unique key, so the child's scope is the only
+   * thing standing between a caller and another tenant's row.
+   *
+   * The note below is linked to *our* folder — seeded that way deliberately —
+   * but carries the other tenant's `orgId`. So the link is right and the policy
+   * is what has to refuse: without the child's scope this clears a foreign key
+   * on a row we cannot see, and reports success.
+   */
+  test("disconnect cannot clear a row the child's policy hides", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (10, 2, 'theirs', 99)`,
+    );
+
+    await Model.asUser(OURS, () =>
+      Folder.$exec("update", {
+        where: { id: 2 },
+        // `code` is here only to satisfy "at least one field must be
+        // updated": `Folder` has no `@updatedAt`, so a relation-only update has
+        // no scalar assignment and is refused on this branch. #83 makes that
+        // compile to a select of the same returning list; until it lands, a
+        // no-op assignment keeps the test about the disconnect.
+        data: { code: "ours", notes: { disconnect: { id: 10 } } },
+      }),
+    );
+
+    const notes: any = await raw.unsafe(`SELECT "folderId" FROM "Note"`);
+    expect(notes[0].folderId).toBe(2);
+  });
+
+  /** ...and a visible one is cleared. */
+  test("disconnect clears a row the caller can see", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (11, 2, 'ours', 7)`,
+    );
+
+    await Model.asUser(OURS, () =>
+      Folder.$exec("update", {
+        where: { id: 2 },
+        // `code` is here only to satisfy "at least one field must be
+        // updated": `Folder` has no `@updatedAt`, so a relation-only update has
+        // no scalar assignment and is refused on this branch. #83 makes that
+        // compile to a select of the same returning list; until it lands, a
+        // no-op assignment keeps the test about the disconnect.
+        data: { code: "ours", notes: { disconnect: { id: 11 } } },
+      }),
+    );
+
+    const notes: any = await raw.unsafe(`SELECT "folderId" FROM "Note"`);
+    expect(notes[0].folderId).toBeNull();
+  });
+
+  /**
+   * `delete` reports a hidden row as **not connected** rather than as denied,
+   * which is the conservative answer: it is the same thing the caller would be
+   * told about a row that genuinely belongs to another parent, so the two are
+   * indistinguishable and neither confirms the row exists.
+   */
+  test("delete reports a hidden row as not connected, and leaves it", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (12, 2, 'theirs', 99)`,
+    );
+
+    await expect(
+      Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: { code: "ours", notes: { delete: { id: 12 } } },
+        }),
+      ),
+    ).rejects.toThrow(/is not connected/);
+
+    expect(await raw.unsafe(`SELECT * FROM "Note"`)).toHaveLength(1);
+  });
+
+  /**
    * A scoped model could not upsert at all: `assertScopable` refuses to put a
    * scope on one, because its where becomes an `on conflict` target and a
    * target cannot carry a predicate.

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -65,6 +65,22 @@ async function seed(prisma: PrismaClient) {
       },
     ],
   });
+
+  // Accounts for the `disconnect` / `delete` cases, **in the seed rather than
+  // in each test**. `expectSameWrite` resets to the seeded state before each
+  // client runs — that is the whole point of it — so rows written in a test
+  // body are gone by the time the comparison happens, and a case that depended
+  // on them would compare two runs against an empty table and pass whatever
+  // the code did. Two of these belong to the *second* user, which is what makes
+  // "not linked" mean something.
+  const users = await prisma.user.findMany({ orderBy: { id: "asc" } });
+  await prisma.account.createMany({
+    data: [
+      { publicId: "acc-mine-1", userId: users[0].id, organizationRole: 1 },
+      { publicId: "acc-mine-2", userId: users[0].id, organizationRole: 2 },
+      { publicId: "acc-theirs", userId: users[1].id, organizationRole: 1 },
+    ],
+  });
 }
 
 /** `[name, operation, args, tables]` — tables default to the model written. */
@@ -908,6 +924,117 @@ function suite(label: string, url?: string) {
         where: { publicId: "keep-1" },
       });
       expect(children).toHaveLength(0);
+    });
+
+    /**
+     * `disconnect` and `delete` — the operands that act on rows already linked
+     * to this one, and the pair that shows why the boundary is "which rows can
+     * be named": both take a unique key, so the child's own operations decide
+     * reachability.
+     *
+     * They differ on a row that is *not* linked, and the difference is Prisma's
+     * rather than a choice — measured before implementing:
+     *
+     *     disconnect a row linked elsewhere  ->  succeeds, changes nothing
+     *     delete     a row linked elsewhere  ->  raises "are not connected"
+     *
+     * The rows come from the seed, not from the test body: `expectSameWrite`
+     * resets to the seeded state before each client runs, so a case that set
+     * itself up would compare two runs against an empty table and pass whatever
+     * the code did.
+     */
+    test("disconnect clears the link and leaves the row", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { disconnect: { publicId: "acc-mine-1" } } },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("disconnect takes a list", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              disconnect: [
+                { publicId: "acc-mine-1" },
+                { publicId: "acc-mine-2" },
+              ],
+            },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /**
+     * A row linked to a *different* user. Prisma succeeds and changes nothing —
+     * and without the parent key in the `where`, this would clear somebody
+     * else's foreign key and still return a plausible payload.
+     */
+    test("disconnecting a row that is not linked is a no-op", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { disconnect: { publicId: "acc-theirs" } } },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("delete removes the row, not just the link", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { delete: { publicId: "acc-mine-1" } } },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /**
+     * The asymmetry, and the case that decides whether this is implemented or
+     * merely spelled: `delete` on a row belonging to a different parent
+     * **raises** where `disconnect` shrugs. Without the parent key in the
+     * `where` this deletes somebody else's row and reports success.
+     */
+    test("deleting a row that is not linked raises, as Prisma does", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { delete: { publicId: "acc-theirs" } } },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("disconnect on a to-one clears the foreign key", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { organization: { disconnect: true } },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
     });
 
     test("nested connect on the foreign side repoints the child", async () => {

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -1129,6 +1129,28 @@ function suite(label: string, url?: string) {
       );
     });
 
+    /**
+     * The owning-side miss — the case that was missing, and the reason its
+     * twin's fix did not carry over.
+     *
+     * The third seeded user has no organisation, so the foreign key is null and
+     * there is nothing to update. Prisma answers P2025 (`notFound`); the
+     * harness compares the failure *kind*, so an `UnsupportedQueryError` here
+     * reads as `other` and disagrees. The connected to-one cases above never
+     * touch this branch.
+     */
+    test("updating a to-one that is not there raises, as Prisma does", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { publicId: "p3" },
+          data: { organization: { update: { name: "Nowhere" } } },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
     test("nested connect on the foreign side repoints the child", async () => {
       await differential.reset();
       await differential.prisma.account.create({

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -1037,6 +1037,98 @@ function suite(label: string, url?: string) {
       );
     });
 
+    /**
+     * `update` — caller columns, written to a row they named by unique key.
+     *
+     * The seeded accounts make the "not linked" case mean something: two
+     * belong to user 1 and one to user 2, so an `update` naming the third has
+     * to raise rather than reach across.
+     */
+    test("update writes the named child", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              update: {
+                where: { publicId: "acc-mine-1" },
+                data: { organizationRole: 9 },
+              },
+            },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("update takes a list", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              update: [
+                { where: { publicId: "acc-mine-1" }, data: { organizationRole: 8 } },
+                { where: { publicId: "acc-mine-2" }, data: { organizationRole: 7 } },
+              ],
+            },
+          },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("updating a row that is not linked raises, as Prisma does", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              update: {
+                where: { publicId: "acc-theirs" },
+                data: { organizationRole: 9 },
+              },
+            },
+          },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /** Prisma accepts both spellings on a to-one; so does this. */
+    test("update through a to-one, bare data", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { organization: { update: { name: "Renamed" } } },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    test("update through a to-one, wrapped in data", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { organization: { update: { data: { name: "Wrapped" } } } },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
     test("nested connect on the foreign side repoints the child", async () => {
       await differential.reset();
       await differential.prisma.account.create({


### PR DESCRIPTION
#65's item four, minus the two operands that still do not fit the line. **Stacked on #96.**

## The refusal was describing a gap in the wrong place

`REFUSED` said a nested `update` *"writes caller-supplied columns to a row that already exists, so the child's `onUpdate` and the scope-escape guard have to run over the payload — a pass this does not have yet."*

**The pass exists. It is one layer down.** Both live in `applyPolicies`, which the child's own `$exec` runs because a nested write step is not pre-scoped — the same property that stops `connect` reaching another tenant's row. Checked rather than argued, straight through the child's `updateMany`:

```
another tenant's row          ->  { count: 0 }
caller names a scoped column  ->  ScopeEscapeError
```

So what `update` needs beyond `disconnect` turns out to be **nothing**: the parent-key filter that keeps it off another parent's row is the same one, and the payload is the child's business — which is what routing it through the child's own operation means.

That is the second time this session that a `REFUSED` reason turned out to be stale rather than a real constraint, which is an argument for the entries naming *machinery* rather than *features* — this one named machinery, and that is exactly why it was checkable.

## What stays refused, and now for accurate reasons

- **`updateMany`** names a *predicate* rather than a row, so there is no lookup for the child's scope to narrow. That is the half of #94's line that has not moved.
- **`upsert`** needs a third thing neither half has: deciding which branch ran, from inside a nested step. Its old reason — "only the second half is implemented" — is no longer true now that both halves are.

## Both directions

The to-one form needed the foreign key in the statement's `RETURNING`, because the far row is identified by *this* row's column and the arguments do not carry its current value. It is the only owning-side operand that needs anything returned.

Prisma accepts both spellings there — `update: { … }` and `update: { data: { … } }` — measured, and accepting only the documented one would refuse a legal query.

## The harness caught the error type

A row that is not connected raises `RecordNotFoundError`, not `UnsupportedQueryError`. The differential harness compares the failure **kind** precisely so a refusal cannot pass as agreement with a miss, and this one was `other` against Prisma's `notFound` until it failed:

```
prisma threw but gemi threw — gemi ORM does not support 'data.accounts.update' yet…
expected { kind: 'other' } to deeply equal { kind: 'notFound' }
```

Nothing about that query is unsupported; the row is simply not there.

## Tests

Five differential cases — the named row, a list, the not-linked raise, and both to-one spellings — plus two policy tests asserting the claim this PR rests on: a nested update is scoped by the child, and its payload is judged by the child.

## Verification

942 unit tests. Template suite green on SQLite (515) and Postgres 16 (770), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
