### PR TITLE
Every refusal says what to do instead, because `tsc` requires it

### DIFF
--- a/packages/gemi/orm/compile/aggregate.ts
+++ b/packages/gemi/orm/compile/aggregate.ts
@@ -515,6 +515,11 @@ function assertArgs(
       );
     }
 
-    throw new UnsupportedQueryError(key, schema.name, op);
+    throw new UnsupportedQueryError(
+      key,
+      schema.name,
+      op,
+      `${op} takes ${[...AGGREGATE_ARGS].sort().join(", ")}.`,
+    );
   }
 }

--- a/packages/gemi/orm/compile/index.ts
+++ b/packages/gemi/orm/compile/index.ts
@@ -35,7 +35,14 @@ export function compile(
     return compileRead(schema, op, args, dialect, strategy);
   }
   if (isWriteOperation(op)) return compileWrite(schema, op, args, dialect);
-  throw new UnsupportedQueryError(op, schema.name, op);
+  throw new UnsupportedQueryError(
+    op,
+    schema.name,
+    op,
+    `'${op}' is not an operation this ORM compiles — the reads, the writes, ` +
+      `'aggregate' and 'groupBy' are, and a raw statement goes through ` +
+      `'DB.query' or 'DB.execute'.`,
+  );
 }
 
 export { compileRead, isReadOperation };

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -561,6 +561,9 @@ function assertNodeArgs(
       `${node.as}.${key}`,
       schema.name,
       operation,
+      `A relation node takes ${[...(many ? RELATION_ARGS : TO_ONE_ARGS)]
+        .sort()
+        .join(", ")}.`,
     );
   }
 }

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -9,7 +9,9 @@ import {
   UnsupportedQueryError,
 } from "../errors";
 import { USER_COLUMNS, account, mapped, user } from "../fixtures";
+import { compile } from "./index";
 import { compileRead } from "./read";
+import { compileWrite } from "./write";
 import { compileWhere } from "./where";
 import * as registry from "../registry";
 import type { RelationStrategy } from "./plan-relations";
@@ -670,6 +672,59 @@ describe("arguments refused by design", () => {
 });
 
 // The property the plan cache is built on, asserted directly.
+/**
+ * #61's second half: **every refusal says what to do instead.**
+ *
+ * The first half — separating "not yet" from "out of scope" — landed in #78 as
+ * `UnsupportedByDesignError`. This is the other one: `detail` was optional, and
+ * the call sites that omitted it were the highest-traffic ones, on the path a
+ * typo takes. They said only *that* something was refused, to the reader least
+ * likely to know why.
+ *
+ * `detail` is required now, so `tsc` enforces it rather than a convention —
+ * and the enforcement found three more sites than a search for the pattern
+ * did, which is the argument for the type over the grep.
+ *
+ * The assertion is deliberately not "the message contains X": it is that a
+ * refusal is more than its first sentence. A call site added later with an
+ * empty string would satisfy the compiler and fail here.
+ */
+describe("every refusal says what to do instead", () => {
+  const REFUSALS: [string, () => unknown][] = [
+    ["an argument the read does not take", () => text({ nope: 1 })],
+    ["an argument the write does not take", () =>
+      compileWrite(user, "create", { data: { email: "a@b.c" }, nope: 1 } as any, sqlite)],
+    ["an operator that is not one", () => text({ where: { email: { weird: 1 } } })],
+    ["a mode that is neither", () =>
+      text({ where: { email: { contains: "x", mode: "loud" } } })],
+    ["an operation that is not one", () => compile(user, "frobnicate" as any, {}, sqlite)],
+  ];
+
+  test.each(REFUSALS)("%s", (_label, run) => {
+    let message = "";
+    try {
+      run();
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).not.toBe("");
+
+    // The prefix is `does not support 'x' yet (Model.op).` — a refusal that
+    // stops there is the thing #61 is about, so the detail has to follow it.
+    const detail = message.slice(message.indexOf(").") + 2).trim();
+    expect(detail.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * The two errors that already met this standard, and set it: both enumerate
+   * the valid names rather than only rejecting the invalid one.
+   */
+  test("an unknown field still lists the fields", () => {
+    expect(() => text({ where: { nope: 1 } })).toThrow(/Known fields:/);
+  });
+});
+
 describe("compile is a function of shape, not values", () => {
   test("the same shape with different values is byte identical", () => {
     const a = compileRead(user, "findMany", { where: { email: "a" } }, sqlite);

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -356,6 +356,11 @@ function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
       throw new UnsupportedByDesignError(key, schema.name, op, permanent);
     }
 
-    throw new UnsupportedQueryError(key, schema.name, op);
+    throw new UnsupportedQueryError(
+      key,
+      schema.name,
+      op,
+      `${op} takes ${[...allowed].sort().join(", ")}.`,
+    );
   }
 }

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -514,6 +514,7 @@ function compileFieldFilter(
         `mode: ${JSON.stringify(filter.mode)}`,
         schema.name,
         context.operation,
+        `Prisma takes 'default' or 'insensitive'.`,
       );
     }
     if (!dialect.supportsInsensitiveMode) {
@@ -538,6 +539,7 @@ function compileFieldFilter(
         `where.${field.name}.${key}`,
         schema.name,
         context.operation,
+        `A scalar filter takes ${[...OPERATORS].sort().join(", ")}.`,
       );
     }
 

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -124,7 +124,13 @@ export function compileWrite(
     case "upsert":
       return compileUpsert(schema, op, args, dialect);
     default:
-      throw new UnsupportedQueryError(op, schema.name, op);
+      throw new UnsupportedQueryError(
+        op,
+        schema.name,
+        op,
+        `'${op}' is not a write operation. The writes are ` +
+          `${Object.keys(WRITE_ARGS).sort().join(", ")}.`,
+      );
   }
 }
 
@@ -1346,7 +1352,12 @@ function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
   for (const key of Object.keys(args).sort()) {
     if (args[key] === undefined) continue;
     if (!allowed.has(key)) {
-      throw new UnsupportedQueryError(key, schema.name, op);
+      throw new UnsupportedQueryError(
+        key,
+        schema.name,
+        op,
+        `${op} takes ${[...allowed].sort().join(", ")}.`,
+      );
     }
   }
 

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -11,11 +11,32 @@ export class UnsupportedQueryError extends Error {
     public readonly argument: string,
     public readonly model: string,
     public readonly operation: string,
-    detail?: string,
+    /**
+     * What cannot work, and what to do instead.
+     *
+     * **Required**, which is the second half of #61 — the first being the
+     * `UnsupportedByDesignError` split beside this. It was optional, and the
+     * refusals that omitted it were the highest-traffic ones: an argument the
+     * operation does not accept, on the path a typo takes. Those said only
+     * *that* something was refused, to the reader least likely to know why.
+     *
+     * Required rather than conventionally-supplied for the reason five other
+     * parameters here are — `render`'s `origin`, `changedFields`' `schema`,
+     * `RelationExecutor.exec`'s `preScoped`, `resolveLink`'s `operation`,
+     * `assertPageArgument`'s reported name: where omitting an argument produces
+     * a *worse* result rather than an error, `tsc` is the only thing that keeps
+     * a convention. Ninety-five of a hundred call sites already passed one; the
+     * five that did not are exactly the ones nobody revisited.
+     *
+     * `UnknownFieldError` and `UnknownRelationError` set the standard this
+     * meets: both enumerate the valid names rather than only rejecting the
+     * invalid one.
+     */
+    detail: string,
   ) {
     super(
-      `gemi ORM does not support '${argument}' yet (${model}.${operation}).` +
-        (detail ? ` ${detail}` : ""),
+      `gemi ORM does not support '${argument}' yet (${model}.${operation}). ` +
+        detail,
     );
     this.name = "UnsupportedQueryError";
   }
@@ -43,7 +64,7 @@ export class UnsupportedByDesignError extends UnsupportedQueryError {
     /** What to use instead. Required — see #61: a refusal owes the caller a next step. */
     reason: string,
   ) {
-    super(argument, model, operation);
+    super(argument, model, operation, reason);
     this.name = "UnsupportedByDesignError";
     this.message =
       `gemi ORM does not implement '${argument}' (${model}.${operation}), ` +


### PR DESCRIPTION
Closes the second half of **#61**. The first half — separating "not yet" from "out of scope" — landed in #78 as `UnsupportedByDesignError`.

## The gap

`UnsupportedQueryError`'s `detail` was optional, and the call sites that omitted it were the highest-traffic ones: *an argument this operation does not accept*, which is the path a typo takes. They told the reader least likely to know why only **that** something was refused.

## Required, not conventional

For the reason five other parameters here are — `render`'s `origin`, `changedFields`' `schema`, `RelationExecutor.exec`'s `preScoped`, `resolveLink`'s `operation`, `assertPageArgument`'s reported name. Where omitting an argument produces a *worse result* rather than an error, `tsc` is the only thing that keeps a convention.

**And it found three sites a search did not.** I counted first with a script — 108 call sites, five without a detail — and the compiler answered **eight**. The three it added were `mode`, an unknown scalar operator, and a relation-node argument: all reachable from a typo, none matched by a crude arg-count. That gap is the argument for the type over the grep, and it is why this is a signature change rather than six edits.

## The details enumerate what *is* accepted

Which is the standard `UnknownFieldError` and `UnknownRelationError` already set — they list the valid names rather than only rejecting the invalid one:

```
'nope' yet (User.findMany). findMany takes include, omit, orderBy, select, skip, take, where.
'nope' yet (User.create). create takes data, include, omit, select.
'where.email.weird' yet (User.findMany). A scalar filter takes contains, endsWith, equals,
    gt, gte, in, lt, lte, mode, not, notIn, startsWith.
'mode: "loud"' yet (User.findMany). Prisma takes 'default' or 'insensitive'.
```

## The test pins the property, not the wording

A refusal has to be **more than its first sentence** — deliberately not "the message contains X". A call site added later with an empty string would satisfy the compiler and still fail here, which is exactly the hole a required parameter alone leaves. Verified by emptying one and watching it fail.

## One process note

`#61` was **unlabelled**, which is why it never appeared in any pass over the `orm` issues — and why four separate PRs rediscovered pieces of it. #82 removed the word from the dialect message, #88 recorded it as a category error and deferred, #100 and #101 each fixed their own call site. Each was right locally; none found the issue that owns the problem. It is labelled now.

The remaining piece of #61 is the *wording* of the prefix itself — "does not support 'x' **yet**" is still wrong for a refusal that is neither a gap nor a by-design feature decision (invalid input, an internal key, a missing row). That is a smaller question than the split #78 made and is best decided against the current messages rather than the ones the issue was written from, several of which have since shipped.

## Verification

959 unit tests. Template suite green on SQLite (509) and Postgres 16 (770), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
