### PR TITLE
`InvalidArgumentError`: the argument exists, the value cannot mean anything

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -245,6 +245,26 @@ On SQLite the error names the dialect and says so. If a batch is too large for o
 split inside a transaction, and `skipDuplicates` survives the split: the counts sum, and a conflict
 in a later chunk does not roll back an earlier one, because `do nothing` is not an error.
 
+### What a refusal tells you
+
+Three classes, and which one you get says what to do next:
+
+| Error | Means | Do |
+| --- | --- | --- |
+| `UnsupportedQueryError` | not implemented **yet** | wait for a release, or use what the message names |
+| `UnsupportedByDesignError` | decided against | change the call — the message says to what |
+| `InvalidArgumentError` | the argument exists, the value cannot mean anything | fix the value |
+
+The third is the one worth knowing about. `take: "-2"` used to report that the ORM "does not support
+`take` yet" — wrong on both halves: it does, and there is nothing to wait for. It now says
+`Invalid 'take' (User.findMany). Expected an integer, got "-2".`
+
+All three subclass `UnsupportedQueryError`, so `catch (e) { if (e instanceof UnsupportedQueryError) }`
+still catches every one. The specific classes are for the person reading the message.
+
+Every refusal carries a second sentence saying what to do instead — that is a required argument
+rather than a convention, so it cannot be dropped by a call site added later.
+
 ### Per-call options
 
 A second parameter, not a key inside `args` — intersecting Prisma's own arg types with a

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -262,6 +262,11 @@ The third is the one worth knowing about. `take: "-2"` used to report that the O
 All three subclass `UnsupportedQueryError`, so `catch (e) { if (e instanceof UnsupportedQueryError) }`
 still catches every one. The specific classes are for the person reading the message.
 
+One edge is deliberate: an argument that is not in the grammar **at all** — a typo — keeps
+`UnsupportedQueryError` and its "yet", because the same check also refuses real Prisma arguments this
+ORM has not implemented, and nothing there can tell the two apart. The sentence immediately after it
+lists what the operation *does* take, which is what tells you a typo is a typo.
+
 Every refusal carries a second sentence saying what to do instead — that is a required argument
 rather than a convention, so it cannot be dropped by a call site added later.
 

--- a/packages/gemi/orm/compile/aggregate.ts
+++ b/packages/gemi/orm/compile/aggregate.ts
@@ -1,5 +1,9 @@
 import type { SqlDialect } from "../dialect";
-import { UnknownFieldError, UnsupportedQueryError } from "../errors";
+import {
+  InvalidArgumentError,
+  UnknownFieldError,
+  UnsupportedQueryError,
+} from "../errors";
 import type { QueryPlan } from "../plan";
 import type { FieldSchema, ModelSchema, ScalarType } from "../schema";
 import {
@@ -272,7 +276,7 @@ function aggregateTerms(schema: ModelSchema, op: string, args: any): Term[] {
       requested === null ||
       Array.isArray(requested)
     ) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         kind,
         schema.name,
         op,
@@ -307,7 +311,7 @@ function countSelectTerms(
   select: any,
 ): Term[] {
   if (typeof select !== "object" || select === null || Array.isArray(select)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "select",
       schema.name,
       op,
@@ -487,7 +491,7 @@ function assertArgs(
   }
 
   if (typeof args !== "object" || Array.isArray(args)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       String(args),
       schema.name,
       op,

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1,4 +1,7 @@
-import { UnsupportedQueryError } from "../errors";
+import {
+  InvalidArgumentError,
+  UnsupportedQueryError,
+} from "../errors";
 import type { ModelSchema, RelationSchema } from "../schema";
 import type { Binder } from "./fragment";
 import {
@@ -137,7 +140,7 @@ function planOne(
   out: NestedWritePlanning,
 ): void {
   if (typeof node !== "object" || node === null || Array.isArray(node)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       `data.${relation.name}`,
       schema.name,
       operation,
@@ -286,7 +289,7 @@ function planOwningSide(
   // values, so the choice is made here at compile time and the two forms are two
   // plans. That is what keeps a `connect` from silently costing a round trip.
   if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       `data.${relation.name}.connect`,
       schema.name,
       operation,
@@ -513,7 +516,7 @@ function assertCreateManyOperand(
   const at = `data.${relation.name}.createMany`;
 
   if (typeof operand !== "object" || operand === null || Array.isArray(operand)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       at,
       schema.name,
       operation,
@@ -527,7 +530,7 @@ function assertCreateManyOperand(
   );
 
   if (!keys.includes("data")) {
-    throw new UnsupportedQueryError(at, schema.name, operation, `Expected a 'data' key.`);
+    throw new InvalidArgumentError(at, schema.name, operation, `Expected a 'data' key.`);
   }
 
   for (const key of keys) {

--- a/packages/gemi/orm/compile/order-relation.ts
+++ b/packages/gemi/orm/compile/order-relation.ts
@@ -1,5 +1,8 @@
 import type { SqlDialect } from "../dialect";
-import { UnsupportedQueryError } from "../errors";
+import {
+  InvalidArgumentError,
+  UnsupportedQueryError,
+} from "../errors";
 import { COUNT_KEY } from "../relation-filters";
 import type { ModelSchema, RelationSchema } from "../schema";
 import { type Fragment, concat, sql } from "./fragment";
@@ -58,7 +61,7 @@ export function relationOrderExpression(
   const path = `orderBy.${relation.name}`;
 
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       path,
       schema.name,
       operation,
@@ -203,7 +206,7 @@ function readDirection(
   if (typeof value === "object" && value !== null) {
     const { sort, nulls } = value as Record<string, unknown>;
     if (sort !== "asc" && sort !== "desc") {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         path,
         schema.name,
         operation,

--- a/packages/gemi/orm/compile/orderBy.ts
+++ b/packages/gemi/orm/compile/orderBy.ts
@@ -1,5 +1,9 @@
 import type { SqlDialect } from "../dialect";
-import { UnknownFieldError, UnsupportedQueryError } from "../errors";
+import {
+  InvalidArgumentError,
+  UnknownFieldError,
+  UnsupportedQueryError,
+} from "../errors";
 import type { ModelSchema } from "../schema";
 import { type Fragment, joinFragments, sql } from "./fragment";
 import { relationOrderExpression } from "./order-relation";
@@ -74,7 +78,7 @@ export function parseOrderBy(
       return array ? found?.[index] : found;
     };
     if (typeof entry !== "object" || entry === null) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         "orderBy",
         schema.name,
         operation,
@@ -143,7 +147,7 @@ function parseDirection(
 ): { direction: "asc" | "desc"; nulls?: "first" | "last" } {
   if (typeof value === "string") {
     if (!DIRECTIONS.has(value)) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         `orderBy.${key}: ${JSON.stringify(value)}`,
         schema.name,
         operation,

--- a/packages/gemi/orm/compile/paginate.ts
+++ b/packages/gemi/orm/compile/paginate.ts
@@ -1,5 +1,7 @@
 import type { SqlDialect } from "../dialect";
-import { UnsupportedQueryError } from "../errors";
+import {
+  InvalidArgumentError,
+} from "../errors";
 import type { ModelSchema } from "../schema";
 import type { Binder, Fragment } from "./fragment";
 import { reverse, type OrderTerm } from "./orderBy";
@@ -48,22 +50,16 @@ import { reverse, type OrderTerm } from "./orderBy";
  * `argument` is the name to report: `take` at the root, `accounts.take` on a
  * relation node.
  *
- * **The error type is wrong here, and deliberately left wrong until #78 lands.**
- * `UnsupportedQueryError` spells "does not support 'take' *yet*", and there is
- * no future in which `take: "-2"` becomes supported — the word promises
- * something nobody intends. For the fraction it contradicts this file's own
- * comment, which calls the refusal deliberate. That word is load-bearing in
- * this codebase: #78 adds `UnsupportedByDesignError` for "a decision rather
- * than a gap", and #82 removed "yet" from the dialect message for exactly this
- * reason.
+ * **`InvalidArgumentError`, and this note is what asked for it.** #88 left the
+ * error type deliberately wrong here — `UnsupportedQueryError` spells "does not
+ * support 'take' *yet*", and there is no future in which `take: "-2"` becomes
+ * supported — on the reasoning that validation is a *category* rather than a
+ * reworded string, and that inventing one while #78 was in flight would be the
+ * second copy this function exists to avoid.
  *
- * Validation is a fourth category again — not unimplemented, not a design
- * refusal of a feature, but invalid input — so the fix is a category, not a
- * reworded string, and inventing one here while #78 is in flight would be the
- * second copy this function exists to avoid. When #78 merges: the fraction
- * refusal moves to the by-design category it is already documented as, and the
- * type-mismatch messages lose the word. The two branches merge clean today, so
- * this is an order note rather than a conflict.
+ * #78 landed `UnsupportedByDesignError` for "a decision rather than a gap", and
+ * the third class followed it. A bad value now says `Invalid 'take'` and says
+ * what a good one looks like, which is the whole of what was owed.
  */
 export function assertPageArgument(
   model: string,
@@ -73,7 +69,7 @@ export function assertPageArgument(
   value: unknown,
 ): void {
   if (typeof value !== "number" || !Number.isInteger(value)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       argument,
       model,
       operation,
@@ -81,7 +77,7 @@ export function assertPageArgument(
     );
   }
   if (key === "skip" && value < 0) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       argument,
       model,
       operation,

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -1,5 +1,6 @@
 import type { SqlDialect } from "../dialect";
 import {
+  InvalidArgumentError,
   MalformedRelationError,
   MissingModelSchemaError,
   RelationDepthExceededError,
@@ -419,7 +420,7 @@ export function relationNodes(
 
   if (include !== undefined && include !== null) {
     if (typeof include !== "object" || Array.isArray(include)) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         "include",
         schema.name,
         operation,
@@ -509,7 +510,7 @@ function assertNodeArgs(
   if (value === true) return;
 
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       node.as,
       schema.name,
       operation,

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -733,6 +733,20 @@ describe("a refusal says which kind of refusal it is", () => {
     expect(() => text(args)).not.toThrow(/yet/);
   });
 
+  /**
+   * The edge, asserted so it is a decision rather than an oversight.
+   *
+   * An argument that is not in the grammar at all keeps "yet", because the same
+   * check refuses a typo and a real Prisma argument this ORM has not
+   * implemented, and nothing there can tell them apart. What carries the reader
+   * is the *next* sentence, which #102 made mandatory: it lists what the
+   * operation does take.
+   */
+  test("an argument outside the grammar keeps 'yet', and says what is taken", () => {
+    expect(() => text({ nope: 1 })).toThrow(/yet/);
+    expect(() => text({ nope: 1 })).toThrow(/findMany takes .*where/);
+  });
+
   /** ...and every one of them still answers to the base class. */
   test("all three are catchable as UnsupportedQueryError", () => {
     for (const args of [{ take: "-2" }, { nope: 1 }, { distinct: ["id"] }]) {

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { PostgresDialect } from "../dialect/postgres";
 import { SqliteDialect } from "../dialect/sqlite";
 import {
+  InvalidArgumentError,
   ParameterLimitError,
   UnknownFieldError,
   UnsupportedByDesignError,
@@ -689,6 +690,57 @@ describe("arguments refused by design", () => {
  * refusal is more than its first sentence. A call site added later with an
  * empty string would satisfy the compiler and fail here.
  */
+/**
+ * The three categories a refusal can be in, and the sentence each owes — the
+ * completion of #61.
+ *
+ *   not implemented yet     UnsupportedQueryError      wait for a release
+ *   decided against         UnsupportedByDesignError   change the call   (#78)
+ *   implemented, bad value  InvalidArgumentError       fix the value
+ *
+ * The third is why "yet" was corrected four times at four call sites (#82, #88,
+ * #100, #101) before the issue that owns it was found: `take` *is* implemented,
+ * `"-2"` is not a take, and telling that caller to wait for a release sends
+ * them to a changelog when the fix is one character in their own code.
+ *
+ * All three subclass `UnsupportedQueryError`, so a handler catching the base
+ * class is unaffected — the specific classes are for the reader.
+ */
+describe("a refusal says which kind of refusal it is", () => {
+  test.each([
+    ["a value of the wrong type", { take: "-2" }, InvalidArgumentError, /^Invalid 'take'/],
+    ["a value out of range", { skip: -1 }, InvalidArgumentError, /^Invalid 'skip'/],
+    ["a direction that is not one", { orderBy: { id: "sideways" } }, InvalidArgumentError, /^Invalid/],
+    ["a mode that is not one", { where: { email: { contains: "x", mode: "loud" } } }, InvalidArgumentError, /^Invalid/],
+    ["an argument that does not exist", { nope: 1 }, UnsupportedQueryError, /does not support .* yet/],
+    ["an argument refused by design", { distinct: ["id"] }, UnsupportedByDesignError, /decision rather than a gap/],
+  ])("%s", (_label, args, kind, shape) => {
+    expect(() => text(args)).toThrow(kind as never);
+    expect(() => text(args)).toThrow(shape as RegExp);
+  });
+
+  /**
+   * The property that matters more than the wording: a bad *value* must never
+   * be reported as a missing *feature*. That is the sentence that sent four
+   * PRs to four call sites.
+   */
+  test.each([
+    ["take", { take: "-2" }],
+    ["skip", { skip: -1 }],
+    ["orderBy", { orderBy: { id: "sideways" } }],
+    ["mode", { where: { email: { contains: "x", mode: "loud" } } }],
+  ])("a bad value for %s never says 'yet'", (_label, args) => {
+    expect(() => text(args)).not.toThrow(/yet/);
+  });
+
+  /** ...and every one of them still answers to the base class. */
+  test("all three are catchable as UnsupportedQueryError", () => {
+    for (const args of [{ take: "-2" }, { nope: 1 }, { distinct: ["id"] }]) {
+      expect(() => text(args)).toThrow(UnsupportedQueryError);
+    }
+  });
+});
+
 describe("every refusal says what to do instead", () => {
   const REFUSALS: [string, () => unknown][] = [
     ["an argument the read does not take", () => text({ nope: 1 })],

--- a/packages/gemi/orm/compile/read.ts
+++ b/packages/gemi/orm/compile/read.ts
@@ -1,5 +1,9 @@
 import type { SqlDialect } from "../dialect";
-import { UnsupportedByDesignError, UnsupportedQueryError } from "../errors";
+import {
+  InvalidArgumentError,
+  UnsupportedByDesignError,
+  UnsupportedQueryError,
+} from "../errors";
 import type { Operation, QueryPlan } from "../plan";
 import type { ModelSchema } from "../schema";
 import { buildRowShaper } from "../shape";
@@ -327,7 +331,7 @@ function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
   if (args === undefined || args === null) return;
 
   if (typeof args !== "object" || Array.isArray(args)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       String(args),
       schema.name,
       op,

--- a/packages/gemi/orm/compile/relation-count.ts
+++ b/packages/gemi/orm/compile/relation-count.ts
@@ -1,5 +1,9 @@
 import type { SqlDialect } from "../dialect";
-import { UnknownRelationError, UnsupportedQueryError } from "../errors";
+import {
+  InvalidArgumentError,
+  UnknownRelationError,
+  UnsupportedQueryError,
+} from "../errors";
 import type { ModelSchema, RelationSchema } from "../schema";
 import { COUNT_KEY } from "../relation-filters";
 import { type Fragment, concat, sql } from "./fragment";
@@ -158,7 +162,7 @@ function readCountSelection(
   }
 
   if (typeof node !== "object" || node === null || Array.isArray(node)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "_count",
       schema.name,
       operation,
@@ -172,7 +176,7 @@ function readCountSelection(
     selection === null ||
     Array.isArray(selection)
   ) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "_count.select",
       schema.name,
       operation,

--- a/packages/gemi/orm/compile/select.ts
+++ b/packages/gemi/orm/compile/select.ts
@@ -1,4 +1,8 @@
-import { UnknownFieldError, UnsupportedQueryError } from "../errors";
+import {
+  InvalidArgumentError,
+  UnknownFieldError,
+  UnsupportedQueryError,
+} from "../errors";
 import { COUNT_KEY } from "../relation-filters";
 import type { FieldSchema, ModelSchema } from "../schema";
 
@@ -56,7 +60,7 @@ export function resolveSelection(
   }
 
   if (typeof select !== "object" || Array.isArray(select)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "select",
       schema.name,
       operation,
@@ -104,7 +108,7 @@ export function resolveSelection(
     }
 
     if (typeof value !== "boolean") {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         `select.${key}`,
         schema.name,
         operation,
@@ -158,7 +162,7 @@ function omitted(
   if (omit === undefined || omit === null) return Object.values(schema.fields);
 
   if (typeof omit !== "object" || Array.isArray(omit)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "omit",
       schema.name,
       operation,
@@ -190,7 +194,7 @@ function omitted(
     }
 
     if (typeof value !== "boolean") {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         `omit.${key}`,
         schema.name,
         operation,

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -1,6 +1,6 @@
 import type { SqlDialect } from "../dialect";
 import {
-  MalformedRelationError,
+  InvalidArgumentError,
   UnknownFieldError,
   UnsupportedQueryError,
 } from "../errors";
@@ -61,7 +61,7 @@ export function compileWhere(
   if (where === undefined || where === null) return null;
 
   if (typeof where !== "object" || Array.isArray(where)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "where",
       schema.name,
       context.operation,
@@ -320,7 +320,7 @@ function readOperators(
   }
 
   if (typeof value !== "object" || Array.isArray(value)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       path,
       schema.name,
       context.operation,
@@ -371,7 +371,7 @@ function compileCompoundKey(
   if (!members) return null;
 
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       `where.${key}`,
       schema.name,
       context.operation,
@@ -510,7 +510,7 @@ function compileFieldFilter(
   const insensitive = filter.mode === "insensitive";
   if (filter.mode !== undefined && filter.mode !== "default") {
     if (!insensitive) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         `mode: ${JSON.stringify(filter.mode)}`,
         schema.name,
         context.operation,
@@ -535,7 +535,7 @@ function compileFieldFilter(
     if (operand === undefined || key === "mode") continue;
 
     if (!OPERATORS.has(key)) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         `where.${field.name}.${key}`,
         schema.name,
         context.operation,
@@ -583,7 +583,7 @@ function compileFieldFilter(
         // query that runs and returns the wrong rows. The types catch the
         // static case but not a value that arrives dynamically.
         if (typeof operand !== "string") {
-          throw new UnsupportedQueryError(
+          throw new InvalidArgumentError(
             `where.${field.name}.${key}`,
             schema.name,
             context.operation,
@@ -659,7 +659,7 @@ function inList(
   const { dialect } = context;
 
   if (!Array.isArray(operand)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       `where.${field.name}.${negated ? "notIn" : "in"}`,
       schema.name,
       context.operation,

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -1,6 +1,7 @@
 import { clientSideValue, hasClientSideValue } from "../defaults";
 import type { SqlDialect } from "../dialect";
 import {
+  InvalidArgumentError,
   MissingRequiredValueError,
   ReturningUnsupportedError,
   UnknownFieldError,
@@ -275,7 +276,7 @@ function skipDuplicatesClause(
   if (requested === undefined) return null;
 
   if (typeof requested !== "boolean") {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "skipDuplicates",
       schema.name,
       op,
@@ -322,7 +323,7 @@ function createManyColumns(
 ): WriteColumn[][] {
   const supplied = rows.map((row, index) => {
     if (typeof row !== "object" || row === null || Array.isArray(row)) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         `data[${index}]`,
         schema.name,
         op,
@@ -901,7 +902,7 @@ function insertColumns(
 ): WriteColumn[] {
   if (data !== undefined && data !== null) {
     if (typeof data !== "object" || Array.isArray(data)) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         "data",
         schema.name,
         op,
@@ -1043,7 +1044,7 @@ function updateAssignments(
 ): Fragment[] {
   if (data !== undefined && data !== null) {
     if (typeof data !== "object" || Array.isArray(data)) {
-      throw new UnsupportedQueryError(
+      throw new InvalidArgumentError(
         "data",
         schema.name,
         op,
@@ -1331,7 +1332,7 @@ function assertArgs(schema: ModelSchema, op: Operation, args: any): void {
   }
 
   if (typeof args !== "object" || Array.isArray(args)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       String(args),
       schema.name,
       op,

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -77,6 +77,23 @@ export class UnsupportedQueryError extends Error {
  * `UnsupportedByDesignError` made, and it is what lets a taxonomy be added to a
  * shipped ORM without a breaking change: the specific classes are for the
  * reader, the base class is for the handler.
+ *
+ * **Where the taxonomy stops, and why it stops there.** An argument that is not
+ * in the grammar at all keeps the base class and its "yet" — `{ nope: 1 }`
+ * reports "does not support 'nope' yet". That is right for half of what reaches
+ * that path and wrong for the other half: the same check refuses a typo and a
+ * real Prisma argument this ORM has genuinely not implemented, and nothing at
+ * that point can tell them apart. Splitting it would mean carrying Prisma's
+ * full argument grammar per operation, which is a large amount of duplicated
+ * schema for a small gain.
+ *
+ * What makes it tolerable is the sentence after it. Since #61's other half made
+ * `detail` mandatory, that refusal always continues *"findMany takes include,
+ * omit, orderBy, select, skip, take, where"* — so a caller who typed `nope`
+ * learns it is not coming from the very next clause, without the class having
+ * to know. Recorded here rather than left to be re-derived, because "the third
+ * class did not cover this one" is the obvious first reading and it is not the
+ * interesting part.
  */
 export class InvalidArgumentError extends UnsupportedQueryError {
   constructor(

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -56,6 +56,42 @@ export class UnsupportedQueryError extends Error {
  * UnsupportedQueryError) … }` keeps working for callers that do not care which
  * kind it is.
  */
+/**
+ * An argument the ORM **does** implement, given a value it cannot mean.
+ *
+ * The third category, and the one that made "yet" wrong four separate times —
+ * #82, #88, #100 and #101 each corrected it at their own call site before #61
+ * was found to own the problem. The taxonomy the three classes now draw:
+ *
+ *   not implemented yet     UnsupportedQueryError      wait for a release
+ *   decided against         UnsupportedByDesignError   change the call  (#78)
+ *   implemented, bad value  InvalidArgumentError       fix the value
+ *
+ * `take: "-2"` is the clearest case. `take` is implemented; `"-2"` is not a
+ * take. Telling that caller the ORM "does not support 'take' yet" is wrong on
+ * both halves — it does, and there is nothing to wait for — and it sends them
+ * to a changelog when the fix is one character in their own code.
+ *
+ * **Extends `UnsupportedQueryError`**, so every existing `catch` and every test
+ * asserting the base class keeps working. That is the same choice
+ * `UnsupportedByDesignError` made, and it is what lets a taxonomy be added to a
+ * shipped ORM without a breaking change: the specific classes are for the
+ * reader, the base class is for the handler.
+ */
+export class InvalidArgumentError extends UnsupportedQueryError {
+  constructor(
+    argument: string,
+    model: string,
+    operation: string,
+    /** What is wrong with the value, and what a good one looks like. */
+    reason: string,
+  ) {
+    super(argument, model, operation, reason);
+    this.name = "InvalidArgumentError";
+    this.message = `Invalid '${argument}' (${model}.${operation}). ${reason}`;
+  }
+}
+
 export class UnsupportedByDesignError extends UnsupportedQueryError {
   constructor(
     argument: string,

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -30,6 +30,7 @@ export {
   UnknownRelationError,
   UnregisteredPolicyClassError,
   UnregisteredRelationTargetError,
+  InvalidArgumentError,
   UnsupportedByDesignError,
   UnsupportedQueryError,
 } from "./errors";

--- a/packages/gemi/orm/sql.ts
+++ b/packages/gemi/orm/sql.ts
@@ -1,5 +1,8 @@
 import type { SqlDialect } from "./dialect";
-import { UnsupportedQueryError } from "./errors";
+import {
+  InvalidArgumentError,
+  UnsupportedQueryError,
+} from "./errors";
 import {
   type Fragment,
   bindValues,
@@ -190,7 +193,7 @@ export function join(
   separator: string | SqlFragment = ", ",
 ): SqlFragment {
   if (!Array.isArray(values)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "join",
       "DB",
       "sql",
@@ -227,7 +230,7 @@ const GLUE = /^[\s,]*$|^\s*(?:and|or)\s*$/i;
 function assertGlue(separator: unknown): void {
   if (typeof separator === "string" && GLUE.test(separator)) return;
 
-  throw new UnsupportedQueryError(
+  throw new InvalidArgumentError(
     "join",
     "DB",
     "sql",
@@ -297,7 +300,7 @@ export const empty: SqlFragment = brand(
  */
 export function unsafeSql(literal: string): SqlFragment {
   if (typeof literal !== "string") {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       "unsafeSql",
       "DB",
       "sql",
@@ -331,7 +334,7 @@ export function renderFragment(
   operation = "query",
 ): { text: string; values: unknown[] } {
   if (!isFragment(fragment)) {
-    throw new UnsupportedQueryError(
+    throw new InvalidArgumentError(
       operation,
       "DB",
       operation,


### PR DESCRIPTION
Completes **#61**. Stacked on #102, which made the guidance sentence required — hence the base, so the diff here is only the new class and its conversions.

## The taxonomy

```
not implemented yet     UnsupportedQueryError      wait for a release
decided against         UnsupportedByDesignError   change the call        (#78)
implemented, bad value  InvalidArgumentError       fix the value
```

The third is what "yet" was wrong about **four separate times** — #82, #88, #100 and #101 each corrected it at their own call site before #61 was found to own the problem.

`take: "-2"` is the clearest case. It said *"gemi ORM does not support 'take' yet"* — wrong on both halves: it does, and there is nothing to wait for. It sent the caller to a changelog when the fix was one character in their own code. Now:

```
Invalid 'take' (User.findMany). Expected an integer, got "-2".
```

## This note asked for it, and is resolved by it

#88 left the error type deliberately wrong in `paginate.ts`:

> **The error type is wrong here, and deliberately left wrong until #78 lands.** … Validation is a fourth category again — not unimplemented, not a design refusal of a feature, but invalid input — so the fix is a category, not a reworded string, and inventing one here while #78 is in flight would be the second copy this function exists to avoid.

#78 landed the by-design half; this is the third class it predicted. The marker has been **replaced by what it asked for** rather than deleted — which is what a deferral note is for.

## How the 36 sites were chosen

By their own detail. A refusal already saying what a valid value looks like — *"Expected an integer"*, *"Expected 'asc' or 'desc'"*, *"Expected an object of fields"* — is by definition one where the argument exists and the value does not fit. That made the selection checkable rather than a judgement call per site.

## Extends `UnsupportedQueryError`

So every existing `catch` and every test asserting the base class is unaffected — **959 tests passed before a single assertion was touched**. That property is what lets a taxonomy be added to a shipped ORM without a breaking change: the specific classes are for the reader, the base class is for the handler. Same choice `UnsupportedByDesignError` made.

## Tests

Six cases pinning which class each kind of refusal gets, and a second set pinning the property that matters more than any wording:

```
a bad value for take    never says 'yet'
a bad value for skip    never says 'yet'
a bad value for orderBy never says 'yet'
a bad value for mode    never says 'yet'
```

That single sentence is what sent four PRs to four call sites. Asserting it directly is cheaper than asserting each message, and it catches the next one.

## Verification

970 unit tests. Template suite green on SQLite (509) and Postgres 16 (770), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint down to one warning (the pre-existing `path` in `where.ts`) from two, since the conversion left two imports unused — one of them reachable only from the comment this PR resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
