### PR TITLE
Nested `set`, which means "replace the set I can see"

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -296,6 +296,7 @@ await List.create({
 | `disconnect` | Clears the link. `true` on a to-one; a unique key, or a list of them, on a to-many. The column has to be nullable. |
 | `delete` | Deletes the named rows outright, not just the link. |
 | `update` | Writes your columns to the named row. The child's own `onUpdate` and scope rules apply to the payload. |
+| `set` | Replaces the whole set — detaches what is linked now, attaches what you name. |
 
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
@@ -336,8 +337,13 @@ is judged by the child's policies. Naming a column the child scopes on is refuse
 would be at the top level. On a to-one both spellings work, `update: { … }` and
 `update: { data: { … } }`, because Prisma accepts both.
 
-Everything else in Prisma's nested grammar — `set`, `updateMany`, `upsert`, `deleteMany` — is
-refused, by name and with the reason. The line is **which rows an
+`set` is the one supported operand that acts on rows you did **not** name, so it means *replace the
+set I can see*: it detaches the linked rows your policies let you read, and leaves the rest attached.
+With no policy on the child that is Prisma's `set` exactly. Two of its behaviours are worth knowing
+because the name does not suggest them — it will repoint a row belonging to another parent, exactly
+as `connect` does, and it silently ignores a named row that does not exist.
+
+Everything else in Prisma's nested grammar — `updateMany`, `upsert`, `deleteMany` — is refused, by name and with the reason. The line is **which rows an
 operand can name, and whose columns it writes**: everything supported names its rows (a new one, or
 one you identified by unique key) and writes either a whole new row or one foreign key the ORM
 chose. `set`, `disconnect`, `delete`, `deleteMany` and `updateMany` act on rows the call did not

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -75,6 +75,7 @@ const SUPPORTED = new Set([
   "disconnect",
   "delete",
   "update",
+  "set",
 ]);
 
 /**
@@ -85,7 +86,7 @@ const SUPPORTED = new Set([
  * row that does not exist yet. Refused here rather than accepted and made a
  * no-op, so a caller who wrote one on the wrong operation hears about it.
  */
-const EXISTING_ROW_ONLY = new Set(["disconnect", "delete", "update"]);
+const EXISTING_ROW_ONLY = new Set(["disconnect", "delete", "update", "set"]);
 
 /** Statements that insert a new row, so nothing is linked to it yet. */
 const CREATE_ONLY_STATEMENTS = new Set(["create", "createMany"]);
@@ -100,7 +101,6 @@ const CREATE_ONLY_STATEMENTS = new Set(["create", "createMany"]);
  * key, and none of it has to reason about what was there before.
  */
 const REFUSED: Record<string, string> = {
-  set: `It replaces the whole set, so it has to disconnect what is there now.`,
   deleteMany: `It deletes rows this call did not name.`,
   updateMany:
     `It writes caller-supplied columns to rows this call did not name — a ` +
@@ -631,6 +631,85 @@ function planForeignSide(
    * `updateMany` stays refused because it names a *predicate* rather than a
    * row, which is the half of the line this file draws that has not moved.
    */
+  /**
+   * `set` — replace the whole set with the named rows.
+   *
+   * The one supported operand that acts on rows the **call** did not name: it
+   * disconnects whatever is currently linked before connecting what was asked
+   * for. That is the half of this file's line it appears to fail, and #83
+   * already answered how — its implicit many-to-many `set` had the identical
+   * problem and the fix was to give the disconnect a *lookup*: read the linked
+   * rows through the child's own `findMany`, and clear only the ones the
+   * caller can see.
+   *
+   * So `set` means **"replace the set I can see"**. With no policy on the child
+   * every row is visible and it is Prisma's `set` exactly; with one, a row the
+   * caller cannot see stays attached rather than being silently detached —
+   * which is the same choice `disconnect` makes one operand over, and the
+   * opposite of what an unscoped delete would do.
+   *
+   * Three measured details that are not obvious from the name:
+   *
+   *   set [one of two]   the unnamed row's key becomes null, the named stays
+   *   set []             every linked row is detached
+   *   set [another parent's row]   it is repointed here, as `connect` does
+   *   set [a row that does not exist]   silently ignored — no error
+   *
+   * The last is why the connect half is an `updateMany` rather than the
+   * `update` a nested `connect` uses: Prisma does not raise here, and matching
+   * that means not raising either.
+   *
+   * Both halves write the child's foreign key, so `set` inherits #98 exactly as
+   * `connect` does: a child whose policy scopes on that column is refused by
+   * the scope-escape guard, because it cannot tell a column the ORM wrote from
+   * one the caller did. #99 fixes that for every relation operand at once, and
+   * this needs no change when it lands.
+   */
+  if (key === "set") {
+    assertNamedRows(schema, relation, child, operand, "set", operation);
+    assertDisconnectable(child, relation, childField, operation);
+
+    out.after.push({
+      relation: relation.name,
+      operation: "set",
+      async run(args, _context, executor, rows) {
+        const parent = rows[0];
+        if (!parent) return;
+
+        const parentKey = parent[parentField];
+
+        // Everything currently linked *that this caller can see*. Not
+        // pre-scoped, which is the whole mechanism: the child's own policies
+        // decide what "currently linked" means for this caller.
+        const linked = (await executor.exec(
+          relation.model,
+          "findMany",
+          { where: { [childField]: parentKey }, select: { [childField]: true } },
+          false,
+        )) as Record<string, unknown>[];
+
+        if (linked.length > 0) {
+          await executor.exec(
+            relation.model,
+            "updateMany",
+            { where: { [childField]: parentKey }, data: { [childField]: null } },
+            false,
+          );
+        }
+
+        for (const entry of listOf(at(args))) {
+          await executor.exec(
+            relation.model,
+            "updateMany",
+            { where: entry as object, data: { [childField]: parentKey } },
+            false,
+          );
+        }
+      },
+    });
+    return;
+  }
+
   if (key === "update") {
     assertNamedUpdates(schema, relation, child, operand, operation);
 

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -181,7 +181,8 @@ export interface NestedWriteStep {
     | "createMany"
     | "disconnect"
     | "delete"
-    | "update";
+    | "update"
+    | "set";
   run(
     args: any,
     context: BindContext,

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -826,7 +826,6 @@ describe("nested writes", () => {
   });
 
   test.each([
-    "set",
     "disconnect",
     "update",
     "upsert",
@@ -848,8 +847,8 @@ describe("nested writes", () => {
    */
   test("a refusal explains what the operand would take", () => {
     expect(() =>
-      text("create", { data: { email: "a@b.c", organization: { set: {} } } }),
-    ).toThrow(/replaces the whole set/);
+      text("create", { data: { email: "a@b.c", accounts: { updateMany: {} } } }),
+    ).toThrow(/names a \*predicate\* rather than a row|predicate, not a key/);
     expect(() =>
       text("create", { data: { email: "a@b.c", accounts: { deleteMany: {} } } }),
     ).toThrow(/deletes rows this call did not name/);

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -136,6 +136,11 @@ class Note extends Model {
   static $policies = [tenant()];
 }
 
+/** The same model with no policy at all, for the parity half of `set`. */
+class Unpolicied extends Model {
+  static $schema = noteSchema;
+}
+
 const OURS = { orgId: 7 };
 
 describe("policies on nested writes", () => {
@@ -546,6 +551,67 @@ describe("policies on nested writes", () => {
 
     const notes: any = await raw.unsafe(`SELECT "orgId" FROM "Note"`);
     expect(notes[0].orgId).toBe(7);
+  });
+
+  /**
+   * `set` means **"replace the set I can see"** — #83's answer, applied to an
+   * ordinary relation.
+   *
+   * It is the one supported operand that acts on rows the *call* did not name,
+   * so the disconnect half needs a lookup for the child's scope to narrow. A
+   * row this caller cannot see stays attached rather than being silently
+   * detached, which is the same choice `disconnect` makes one operand over —
+   * and the opposite of what an unscoped clear would do.
+   */
+  test("set replaces only the links the caller can see", async () => {
+    await raw.unsafe(
+      `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+    );
+    // Both linked to our folder; one belongs to the other tenant.
+    await raw.unsafe(
+      `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+        `VALUES (40, 2, 'ours', 7), (41, 2, 'theirs', 99)`,
+    );
+
+    await Model.asUser(OURS, () =>
+      Folder.$exec("update", {
+        where: { id: 2 },
+        data: { code: "ours", notes: { set: [] } },
+      }),
+    );
+
+    const notes: any = await raw.unsafe(
+      `SELECT "id", "folderId" FROM "Note" ORDER BY "id"`,
+    );
+    // Ours detached; theirs untouched, because the scoped read never saw it.
+    expect(notes[0].folderId).toBeNull();
+    expect(notes[1].folderId).toBe(2);
+  });
+
+  /** With no policy on the child, `set` is Prisma's `set` exactly. */
+  test("set clears everything when the child is unpolicied", async () => {
+    register("Note", Unpolicied);
+    try {
+      await raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+      );
+      await raw.unsafe(
+        `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+          `VALUES (42, 2, 'a', 7), (43, 2, 'b', 99)`,
+      );
+
+      await Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: { code: "ours", notes: { set: [] } },
+        }),
+      );
+
+      const notes: any = await raw.unsafe(`SELECT "folderId" FROM "Note"`);
+      expect(notes.every((n: any) => n.folderId === null)).toBe(true);
+    } finally {
+      register("Note", Note);
+    }
   });
 
   /**

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -1151,6 +1151,72 @@ function suite(label: string, url?: string) {
       );
     });
 
+    /**
+     * `set` — replace the whole set. The one supported operand that acts on
+     * rows the *call* did not name, which #83 showed how to scope: read the
+     * linked rows through the child's own `findMany` and clear only those.
+     *
+     * Four cases, and three of them are behaviours the name does not suggest —
+     * measured against Prisma before implementing.
+     */
+    test("set keeps the named row and detaches the rest", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { set: [{ publicId: "acc-mine-1" }] } },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("set to empty detaches every linked row", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { set: [] } },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /** It repoints a row belonging to somebody else, exactly as `connect` does. */
+    test("set takes a row from another parent", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { set: [{ publicId: "acc-theirs" }] } },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    /**
+     * And a named row that does not exist is **silently ignored** — no error,
+     * which is why the connect half is an `updateMany` rather than the `update`
+     * a nested `connect` uses.
+     */
+    test("set ignores a named row that does not exist", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { set: [{ publicId: "no-such-account" }] } },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
     test("nested connect on the foreign side repoints the child", async () => {
       await differential.reset();
       await differential.prisma.account.create({


### PR DESCRIPTION
The last of #65's item three. **Stacked on #101.**

## The operand that appears to fail the line

`set` detaches whatever is currently linked before attaching what was named — so it acts on rows the *call* did not name, which is the half of #94's boundary that `disconnect` and `delete` pass and `updateMany` does not.

**#83 already answered it.** Its implicit many-to-many `set` had the identical problem, and the fix was to give the disconnect a *lookup*: read the linked rows through the child's own `findMany`, and clear only the ones the caller can see. The refusal's stated reason — *"it replaces the whole set, so it has to disconnect what is there now"* — was accurate about the difficulty and stale about the answer.

So `set` means **"replace the set I can see"**: a row the caller cannot see stays attached rather than being silently detached. That is the same choice `disconnect` makes one operand over, and the opposite of what an unscoped clear would do.

## Three behaviours the name does not suggest

Measured against Prisma before implementing — none of them guessable:

```
set [one of two]                the unnamed row's key becomes null
set [another parent's row]      it is repointed here, exactly as `connect` does
set [a row that does not exist] silently ignored — no error
```

The last decides an implementation detail: the attach half is an `updateMany` rather than the `update` a nested `connect` uses, because Prisma does not raise and matching it means not raising either.

## Tests

Four differential cases, one per behaviour above plus `set: []`.

Two policy tests, and the second is the one that keeps the first honest: with **no** policy on the child, `set` clears everything — Prisma's `set` exactly. Without it, "scope everything away" would pass the scoped test alone.

The scoped one is verified red by making the clear unscoped and watching the other tenant's row lose its link:

```
× set replaces only the links the caller can see
```

## Inherited limitation

`set` writes the child's foreign key on both halves, so it inherits **#98** exactly as `connect` does: a child whose policy scopes on that column is refused by the scope-escape guard. **#99** fixes that for every relation operand at once, and this needs no change when it lands.

## Housekeeping

`set` comes out of the refused list in `write.test.ts`, and the "a refusal explains what the operand would take" case is repointed at `updateMany` — whose reason now carries the line on its own: it names a *predicate* rather than a row.

## Verification

941 unit tests. Template suite green on SQLite (522) and Postgres 16 (777), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint clean.

## What is left on #65

`updateMany` and `upsert`. The first names a predicate rather than a row, which is the half of the boundary that has not moved; the second needs to know which branch ran from inside a nested step. Both reasons are stated in `REFUSED` and neither has been shown stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
