### PR TITLE
Join-table `connectOrCreate`, and a rule I invented that Prisma contradicts

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -422,12 +422,11 @@ as `connect` does, and it silently ignores a named row that does not exist.
 rows only. Their operands are shaped differently and it is easy to get backwards: `updateMany` wraps
 its filter in `where` and carries a `data` beside it, while `deleteMany` *is* the filter.
 
-**An implicit many-to-many accepts a narrower set**, and the split is by what an operand is *about*:
-`connect`, `create`, `disconnect` and `set` act on the **link** and work on both. `connectOrCreate`,
-`createMany`, `delete`, `update`, `updateMany` and `deleteMany` act on the far **row**, and a join
-table has two foreign keys and no row of its own — so each is refused there with which of those it
-is. `delete` is the clearest: through a join table it would mean deleting the far row rather than
-the link, which is what `disconnect` already does.
+**An implicit many-to-many accepts a narrower set** — `connect`, `connectOrCreate`, `create`,
+`disconnect` and `set`. The four that are missing (`update`, `updateMany`, `delete`, `deleteMany`)
+reach the far row *through* the pairs, which that path does not do yet; Prisma implements all four,
+so these are gaps rather than decisions and the refusals say so. `createMany` is the exception:
+Prisma does not offer it through a join table either.
 
 Only `upsert` in Prisma's nested grammar is refused, by name and with the reason. The line is **which rows an
 operand can name, and whose columns it writes**: everything supported names its rows (a new one, or

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1152,29 +1152,44 @@ function planForeignSide(
  * What an implicit many-to-many accepts, and how it differs from
  * {@link SUPPORTED} — which is the ordinary-relation set.
  *
- * **The two are reconciled deliberately.** `planOne` checks `link.join` first
- * and returns, so this path never consults `SUPPORTED` at all: the sets can
+ * **The two must be reconciled deliberately.** `planOne` checks `link.join`
+ * first and returns, so this path never consults `SUPPORTED` at all: the sets
  * drift without anything failing to compile and without a test noticing, and
  * they did — #83 landed this one while four branches were adding to the other,
  * none of which could see it from inside itself.
  *
- * The asymmetries that remain are decisions rather than omissions, and are
- * named in {@link JOIN_TABLE_REFUSED} beside the reasons. In short: the
- * operands that are *about the link* work here, and the ones that are about the
- * far **row** do not, because a join table has two foreign keys and no row of
- * its own to act on.
+ * **The gaps are unimplemented, not by design, and that is measured rather than
+ * reasoned.** An earlier version of this comment claimed the split was "the
+ * link versus the far row" — operands about the pair work here, operands about
+ * the far row do not. It is a tidy rule and it is wrong. Prisma offers five of
+ * the six through an implicit m-n:
  *
- *     connect  create  disconnect  set        both paths
- *     connectOrCreate  createMany  delete  update  updateMany  deleteMany
- *                                                  ordinary relations only
+ *     update           OK   the far row is updated
+ *     delete           OK   the far row is deleted, not just the pair
+ *     deleteMany       OK
+ *     updateMany       OK
+ *     connectOrCreate  OK
+ *     createMany       Unknown argument — Prisma refuses it here too
+ *
+ * So `delete` through a join table really does mean deleting the far row, which
+ * is the opposite of what that rule predicted. Only `createMany` is a genuine
+ * refusal, and it is Prisma's rather than ours.
+ *
+ * `connectOrCreate` is implemented here because #83 already had both of its
+ * halves — `connect` inserts a pair for an existing row, `create` writes the
+ * row and its pair — so it is those two selected by a lookup. The remaining
+ * four reach the far row *through* the pairs, which is a second hop this path
+ * does not have yet; {@link JOIN_TABLE_REFUSED} says so in those terms rather
+ * than inventing a principle.
  *
  * `set` is the one operand with **two implementations** — this file's
  * join-table version from #83 and the ordinary-relation one — and they agree
- * because both were reasoned to "replace the set I can see" independently,
- * not because they share anything. Worth knowing when either is changed.
+ * because both were reasoned to "replace the set I can see" independently, not
+ * because they share anything. Worth knowing when either is changed.
  */
 const JOIN_TABLE_SUPPORTED = new Set([
   "connect",
+  "connectOrCreate",
   "disconnect",
   "set",
   "create",
@@ -1189,27 +1204,26 @@ const JOIN_TABLE_SUPPORTED = new Set([
  * wearing the same name.
  */
 const JOIN_TABLE_REFUSED: Record<string, string> = {
-  delete:
-    `Through a join table, 'delete' would mean deleting the far row rather ` +
-    `than the link — which is what 'disconnect' does here, and is the same ` +
-    `distinction those two draw on an ordinary relation. Delete the row ` +
-    `directly, or 'disconnect' it.`,
-  update:
-    `A join table holds two foreign keys and no columns of its own, so there ` +
-    `is nothing here to update. Write the far row through its own model.`,
-  updateMany:
-    `As 'update': the pairs have no columns to write. Filter the far model ` +
-    `directly.`,
-  deleteMany:
-    `As 'delete': this would remove far rows rather than links, and by a ` +
-    `predicate rather than a key. Use 'set' to replace the links.`,
-  connectOrCreate:
-    `It needs the far row's unique key to decide the branch, then a pair ` +
-    `written for either outcome — two statements whose failure modes differ, ` +
-    `which is why 'connect' and 'create' are offered separately here.`,
+  // Prisma's own refusal, not this ORM's — the one entry here that is a
+  // decision rather than a gap, and it is not gemi's decision.
   createMany:
-    `Each row needs a pair written for it as well, so it is not the single ` +
-    `statement 'createMany' exists to be. Use 'create'.`,
+    `Prisma does not offer 'createMany' through an implicit many-to-many ` +
+    `either — it reports it as an unknown argument. Use 'create', which writes ` +
+    `the row and its pair.`,
+  // The four that reach the far row through the pairs. Prisma implements all
+  // of them; this path does not have the second hop yet.
+  update:
+    `Reaching the far row means reading the pairs first, which this path does ` +
+    `not do yet. Update the related model directly, filtered by its own key.`,
+  updateMany:
+    `As 'update': it needs the pairs read before the far rows can be matched.`,
+  delete:
+    `It deletes the far row rather than the pair — Prisma does this through a ` +
+    `join table too — and reaching it means reading the pairs first, which ` +
+    `this path does not do yet. Use 'disconnect' to remove the link, or delete ` +
+    `the row through its own model.`,
+  deleteMany:
+    `As 'delete': the far rows have to be found through the pairs first.`,
 };
 
 /**
@@ -1250,6 +1264,17 @@ function planJoinTable(
   out: NestedWritePlanning,
   dialect: SqlDialect,
 ): void {
+  if (key === "connectOrCreate") {
+    assertConnectOrCreateOperand(
+      schema,
+      relation,
+      child,
+      operand,
+      operation,
+      relation.kind === "many",
+    );
+  }
+
   if (!JOIN_TABLE_SUPPORTED.has(key)) {
     const why = JOIN_TABLE_REFUSED[key];
     if (why) {
@@ -1391,6 +1416,48 @@ function planJoinTable(
             false,
           )) as Record<string, unknown> | null;
           if (created) childKeys.push(created[childField]);
+          continue;
+        }
+
+        /**
+         * `connectOrCreate` is the two branches above selected by a lookup, so
+         * it needed no new machinery here — which is why it is the one of the
+         * five missing operands this change adds.
+         *
+         * `findUnique`, not the `findUniqueOrThrow` the `connect` path below
+         * uses: a miss is the *other branch* here rather than an error. And a
+         * scoped-away hit therefore takes the create branch, which is the same
+         * answer the ordinary-relation `connectOrCreate` gives and closes the
+         * same probe — `connect` raising where this succeeds would together
+         * confirm a row the caller cannot see.
+         */
+        if (key === "connectOrCreate") {
+          const entry = item as Record<string, unknown>;
+          matchUniqueKey(
+            child,
+            entry.where,
+            `${operation}.${relation.name}.connectOrCreate`,
+          );
+
+          const hit = (await executor.exec(
+            relation.model,
+            "findUnique",
+            { where: entry.where, select: { [childField]: true } },
+            false,
+          )) as Record<string, unknown> | null;
+
+          if (hit) {
+            childKeys.push(hit[childField]);
+            continue;
+          }
+
+          const made = (await executor.exec(
+            relation.model,
+            "create",
+            { data: entry.create, select: { [childField]: true } },
+            false,
+          )) as Record<string, unknown> | null;
+          if (made) childKeys.push(made[childField]);
           continue;
         }
 

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -747,10 +747,21 @@ function planForeignSide(
         const operandAt = at(args) as Record<string, unknown>;
         const filter = updating ? operandAt?.where : operandAt;
 
-        const where = {
-          ...(filter as object),
-          [childField]: parent[parentField],
-        };
+        // **`AND`, not a spread.** A spread lets the parent key *overwrite* a
+        // caller filter naming the same column: `deleteMany: { userId: 9 }` on
+        // this parent's relation became `{ userId: <this parent> }`, so a query
+        // asking for children belonging to somebody else deleted every one of
+        // this parent's instead. Silent, and in the deleting direction.
+        //
+        // Prisma conjoins — measured, because the whole question is what it
+        // does rather than what is tidy:
+        //
+        //   deleteMany { userId: <other> }  ->  nothing deleted
+        //
+        // Conjoining also keeps the parent restriction *unforgeable* while
+        // letting the caller's predicate narrow, which is exactly what
+        // `withScope` does for a policy fragment and for the same reason.
+        const where = conjoin(filter, { [childField]: parent[parentField] });
 
         await executor.exec(
           relation.model,
@@ -827,11 +838,12 @@ function planForeignSide(
           const entry = list[index] as Record<string, unknown>;
           // The caller's key *and* the link, so an `update` cannot reach a row
           // attached to a different parent — the same filter `delete` uses,
-          // and it does the same two jobs.
-          const where = {
-            ...(entry.where as object),
+          // and it does the same two jobs. `AND` rather than a spread for the
+          // reason `updateMany` documents: a key naming the foreign column
+          // itself would otherwise be overwritten rather than honoured.
+          const where = conjoin(entry.where, {
             [childField]: parent[parentField],
-          };
+          });
 
           const found = (await executor.exec(
             relation.model,
@@ -884,11 +896,11 @@ function planForeignSide(
 
         for (let index = 0; index < list.length; index++) {
           // The caller's key *and* the link, so neither operand can reach a row
-          // attached to a different parent.
-          const where = {
-            ...(list[index] as object),
+          // attached to a different parent. `AND` rather than a spread — see
+          // `updateMany`.
+          const where = conjoin(list[index], {
             [childField]: parent[parentField],
-          };
+          });
 
           if (!deleting) {
             await executor.exec(
@@ -1520,6 +1532,35 @@ async function runPairStatement(
   values: unknown[],
 ): Promise<void> {
   await executor.query(text, values);
+}
+
+/**
+ * The caller's filter and the parent restriction, as a conjunction.
+ *
+ * Never a spread. A spread merges by *key*, so a caller naming the foreign key
+ * column silently replaces the restriction that keeps the operand on this
+ * parent's rows — and the failure is a wider write, not an error. `AND` cannot
+ * be overwritten by any key the caller chooses, and it still lets their
+ * predicate narrow, which is the property `withScope` relies on for policy
+ * fragments.
+ *
+ * An empty or absent filter contributes nothing, so the common case is the
+ * restriction alone rather than `AND` of one thing.
+ */
+function conjoin(
+  filter: unknown,
+  restriction: Record<string, unknown>,
+): Record<string, unknown> {
+  if (
+    filter === undefined ||
+    filter === null ||
+    typeof filter !== "object" ||
+    Array.isArray(filter) ||
+    Object.keys(filter as object).length === 0
+  ) {
+    return restriction;
+  }
+  return { AND: [filter as object, restriction] };
 }
 
 /**

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -863,9 +863,8 @@ describe("nested writes", () => {
    * four other branches were in flight at once.
    */
   describe("ordinary relations and implicit many-to-many", () => {
-    const BOTH = ["connect", "create", "disconnect", "set"];
+    const BOTH = ["connect", "connectOrCreate", "create", "disconnect", "set"];
     const ORDINARY_ONLY = [
-      "connectOrCreate",
       "createMany",
       "delete",
       "update",
@@ -874,9 +873,11 @@ describe("nested writes", () => {
     ];
 
     /**
-     * The operands that are about the *link* work on both. The ones about the
-     * far **row** do not, because a join table has two foreign keys and no row
-     * of its own to act on — and each says which of those it is.
+     * The remaining gaps, each with a reason that says whether it is Prisma's
+     * refusal or this path's missing second hop — measured, not reasoned. An
+     * earlier version of this test asserted a "link versus far row" split that
+     * Prisma contradicts: it implements `delete` through a join table, and it
+     * deletes the far row.
      */
     test.each(ORDINARY_ONLY)("%s is refused through a join table, with a reason", (operand) => {
       expect(() =>
@@ -889,7 +890,7 @@ describe("nested writes", () => {
       ).toThrow(/means something different through a join table/);
     });
 
-    test("the shared operands are not refused there", () => {
+    test("the operands both paths implement are not refused there", () => {
       for (const operand of BOTH) {
         expect(() =>
           compileWrite(

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -1622,6 +1622,43 @@ function suite(label: string, url?: string) {
       );
     });
 
+    /**
+     * The case the parent restriction has to survive: a caller filter that
+     * names the **foreign key column itself**, pointing at a different parent.
+     *
+     * Merging by key let the restriction overwrite it, so "this parent's
+     * children belonging to user 2" — which is nothing — became "all of this
+     * parent's children". Prisma conjoins and deletes nothing; measured before
+     * fixing, because the question is what it does rather than what is tidy.
+     */
+    test("deleteMany with a filter on the foreign key deletes nothing", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { accounts: { deleteMany: { userId: 2 } } },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("updateMany with a filter on the foreign key writes nothing", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              updateMany: { where: { userId: 2 }, data: { organizationRole: 7 } },
+            },
+          },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
     test("nested connect on the foreign side repoints the child", async () => {
       await differential.reset();
       await differential.prisma.account.create({


### PR DESCRIPTION
Follows the merge-order note on #104, and corrects the reconciliation I pushed for it one commit earlier. **Stacked on #105.**

## The rule was wrong, and I did not check it

#105 reconciled the two operand sets and explained the split as *"the link versus the far row"* — operands about the pair work through a join table, operands about the far row do not. Tidy, and false. Measured against Prisma on the template's own models:

```
update           OK   the far row is updated
delete           OK   the far row is deleted, not just the pair
deleteMany       OK
updateMany       OK
connectOrCreate  OK
createMany       Unknown argument — Prisma refuses it here too
```

`delete` through a join table **does** mean deleting the far row, which is the opposite of what the rule predicted. Five of the six gaps are *unimplemented* rather than principled; only `createMany` is a genuine refusal, and it is Prisma's rather than this ORM's.

That is the fifth `REFUSED`-style reason in this series to turn out stale — and the first I wrote myself, one commit after documenting the pattern. The lesson the other four taught is that a refusal naming **machinery** is checkable and one naming a **principle** is not. "The link versus the far row" is a principle, and it survived exactly as long as it took to run it.

## What this adds

`connectOrCreate`, because #83 already had both of its halves — `connect` inserts a pair for an existing row, `create` writes the row and its pair — so it is those two selected by a lookup and needed no new machinery. `findUnique` rather than `findUniqueOrThrow`, so a scoped-away hit takes the create branch: the same answer the ordinary-relation operand gives, closing the same probe.

The other four now say what they are: the far row is reachable only by reading the pairs first, which that path does not do yet. Each names the missing hop rather than a principle, so the next person can check it the way I should have.

## Verification

1024 unit tests. Template suite green on SQLite (586) and Postgres 16 (851), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint clean.

## One thing I could not settle, flagged rather than claimed

The m-n differential cases from #83 call a `seedTags()` helper **inside the test body**, and `expectSameWrite` resets to the seeded state before each client runs — which is the pattern that made four of my own cases vacuous on #96. Removing `seedTags` leaves four of the eight still failing, so at least half genuinely depend on it; I could not determine within a reasonable probe whether the other four are comparing against an empty `Tag` table.

Worth someone checking with fresh eyes — the decisive test is whether the tags exist at comparison time, not whether the case passes. I am recording it as a question rather than a finding because I have not proven it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
