### PR TITLE
Nested `upsert`, and `REFUSED` is empty

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -372,6 +372,7 @@ await List.create({
 | `set` | Replaces the whole set — detaches what is linked now, attaches what you name. |
 | `updateMany` | Writes your columns to this parent's rows matching a filter. |
 | `deleteMany` | Deletes this parent's rows matching a filter — the filter goes directly under the key, not inside a `where`. |
+| `upsert` | Finds the row **among this parent's**, updates it, or creates it. |
 
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
@@ -428,12 +429,21 @@ reach the far row *through* the pairs, which that path does not do yet; Prisma i
 so these are gaps rather than decisions and the refusals say so. `createMany` is the exception:
 Prisma does not offer it through a join table either.
 
-Only `upsert` in Prisma's nested grammar is refused, by name and with the reason. The line is **which rows an
-operand can name, and whose columns it writes**: everything supported names its rows (a new one, or
-one you identified by unique key) and writes either a whole new row or one foreign key the ORM
-chose. `set`, `disconnect`, `delete`, `deleteMany` and `updateMany` act on rows the call did not
-name; `update` names its row but writes your columns to it, which needs the child's `onUpdate` and
-the scope-escape guard run over the payload.
+`upsert` looks for its row **among this parent's** rather than globally, which is Prisma's own
+semantics and is the detail that decides what it does: naming a row that exists but belongs
+elsewhere takes the *create* branch and collides on the unique key, rather than updating somebody
+else's row.
+
+Every operand in Prisma's nested grammar is now implemented for an ordinary relation. Ones that act
+on rows already linked to this one — `disconnect`, `delete`, `update`, `updateMany`, `deleteMany`,
+`set`, `upsert` — are available on an `update` and refused on a `create`, which has nothing linked
+to it yet; Prisma reports them as unknown arguments there too.
+
+Two rules hold across all of them. The **foreign key is the ORM's to set**, so a nested row naming
+it is describing a different parent than the call is, and it is overwritten. And the **parent
+restriction is conjoined, never merged** — a filter naming the foreign key column is narrowed by the
+restriction rather than replacing it, so `deleteMany: { userId: <someone else> }` deletes nothing
+rather than everything.
 
 `skipDuplicates` is not implemented on `createMany` at any level.
 

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -507,6 +507,58 @@ function planOwningSide(
     return;
   }
 
+  /**
+   * `upsert` through a to-one, refused **by name**.
+   *
+   * The far row is identified by *this* row's foreign key, so an absent one
+   * means creating the far row and then writing back to a parent that has
+   * already been inserted — a shape no other operand here needs, and the
+   * reason this side is not implemented.
+   *
+   * Named rather than left to fall through, which is what it did: with no
+   * branch of its own it reached the `connect` handling below and reported
+   * `'where' yet (Organization.update.organization.connect)` — a different
+   * operand, a different model, and a claim that `{ id: 1 }` is not a unique
+   * field when it is. The real failure was that a `{ where, create, update }`
+   * operand was being read as a connect key.
+   *
+   * That is the shape #85 was filed for and #101 fixed on its own path: a
+   * refusal that misnames its origin sends the reader to a query they did not
+   * write.
+   */
+  /**
+   * The list operands, refused by name on a to-one.
+   *
+   * `set`, `updateMany` and `deleteMany` describe *many* rows, and this side
+   * has one by construction — Prisma does not offer them here either. They were
+   * in `SUPPORTED` with no branch on this side, so they fell through to the
+   * `connect` handling below and reported `connect` back to a caller who wrote
+   * something else. Same fall-through as `upsert`'s, found by the same test.
+   */
+  if (key === "set" || key === "updateMany" || key === "deleteMany") {
+    throw new UnsupportedQueryError(
+      `data.${relation.name}.${key}`,
+      schema.name,
+      operation,
+      `'${relation.name}' is a to-one: this row holds a single foreign key, so ` +
+        `there is no set of rows for '${key}' to act on. Prisma does not ` +
+        `accept it here either. Use 'connect', 'disconnect' or 'update'.`,
+    );
+  }
+
+  if (key === "upsert") {
+    throw new UnsupportedQueryError(
+      `data.${relation.name}.upsert`,
+      schema.name,
+      operation,
+      `'${relation.name}' is a to-one, and this row holds its foreign key — ` +
+        `so an absent far row would have to be created and then written back ` +
+        `to a ${schema.name} that has already been inserted. That is not ` +
+        `implemented. Upsert the ${relation.model} directly, then 'connect' ` +
+        `it.`,
+    );
+  }
+
   if (key === "connectOrCreate") {
     assertConnectOrCreateOperand(
       schema,

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -80,6 +80,7 @@ const SUPPORTED = new Set([
   "set",
   "updateMany",
   "deleteMany",
+  "upsert",
 ]);
 
 /**
@@ -97,6 +98,7 @@ const EXISTING_ROW_ONLY = new Set([
   "set",
   "updateMany",
   "deleteMany",
+  "upsert",
 ]);
 
 /** Statements that insert a new row, so nothing is linked to it yet. */
@@ -111,11 +113,21 @@ const CREATE_ONLY_STATEMENTS = new Set(["create", "createMany"]);
  * exist*, which is the line: everything supported writes new rows or repoints a
  * key, and none of it has to reason about what was there before.
  */
-const REFUSED: Record<string, string> = {
-  upsert:
-    `It is 'update' and 'connectOrCreate' at once and needs a third thing ` +
-    `neither has: deciding which branch ran, from inside a nested step.`,
-};
+/**
+ * Nothing, now — and that is the point of leaving the table here.
+ *
+ * Every entry it once held described machinery that turned out to exist one
+ * layer down: five of them said a pass was missing that the child's own
+ * `$exec` already runs, and the sixth — `upsert`'s — said the branch could not
+ * be decided from inside a nested step, when `connectOrCreate` had been
+ * deciding one the same way since #94.
+ *
+ * Kept rather than deleted because the next operand added here should have to
+ * write its reason down, and because a reason naming *machinery* is checkable
+ * where one naming a *principle* is not. That distinction is the only thing
+ * that made six stale entries findable.
+ */
+const REFUSED: Record<string, string> = {};
 
 /** A foreign-key column on *this* model that a nested write supplies. */
 export interface ForeignKeyContribution {
@@ -733,6 +745,81 @@ function planForeignSide(
    * needs to know which branch ran from inside a nested step, which neither
    * half of it provides.
    */
+  /**
+   * `upsert` — find by a unique key **within this parent's rows**, update it or
+   * create it.
+   *
+   * Its refusal said it *"needs a third thing neither half has: deciding which
+   * branch ran, from inside a nested step"*. It does not: the lookup decides
+   * the branch, exactly as `connectOrCreate` has decided one since #94. That is
+   * the sixth `REFUSED` reason in this series to describe machinery that was
+   * already there.
+   *
+   * **Scoped to this parent, which is Prisma's own semantics and not an
+   * embellishment** — measured, because it is the detail that decides what the
+   * operand means:
+   *
+   *   upsert a row belonging to another parent
+   *     ->  Unique constraint failed on the fields: (`publicId`)
+   *
+   * Prisma looks only among *this* parent's children, does not find it, takes
+   * the create branch, and collides. So the conjunction that keeps every other
+   * filter operand on this parent is what produces the right branch here, not
+   * merely what keeps it safe.
+   */
+  if (key === "upsert") {
+    assertUpsertOperand(schema, relation, child, operand, operation);
+
+    out.after.push({
+      relation: relation.name,
+      operation: "upsert",
+      async run(args, _context, executor, rows) {
+        const parent = rows[0];
+        if (!parent) return;
+
+        for (const entry of listOf(at(args)) as Record<string, unknown>[]) {
+          const where = conjoin(entry.where, {
+            [childField]: parent[parentField],
+          });
+
+          const hit = (await executor.exec(
+            relation.model,
+            "findFirst",
+            { where, select: { [childField]: true } },
+            false,
+          )) as Record<string, unknown> | null;
+
+          if (hit) {
+            await executor.exec(
+              relation.model,
+              "updateMany",
+              { where, data: entry.update },
+              // NOT pre-scoped: the child's `onUpdate` and scope-escape guard
+              // judge the payload, as they do for a nested `update`.
+              false,
+            );
+            continue;
+          }
+
+          await executor.exec(
+            relation.model,
+            "create",
+            {
+              // The foreign key is ours, as it is for every create here.
+              data: {
+                ...(entry.create as object),
+                [childField]: parent[parentField],
+              },
+              select: { [childField]: true },
+            },
+            false,
+          );
+        }
+      },
+    });
+    return;
+  }
+
   if (key === "updateMany" || key === "deleteMany") {
     const updating = key === "updateMany";
     assertManyOperand(schema, relation, operand, key, operation);
@@ -1532,6 +1619,50 @@ async function runPairStatement(
   values: unknown[],
 ): Promise<void> {
   await executor.query(text, values);
+}
+
+/**
+ * `upsert`'s operand: `{ where, create, update }`, or a list of them.
+ *
+ * All three are required — the lookup, and one payload per branch. Checked at
+ * plan time like every other operand here, so a missing key fails when the
+ * query compiles rather than after the parent row is written.
+ */
+function assertUpsertOperand(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  operand: unknown,
+  operation: string,
+): void {
+  const at = `data.${relation.name}.upsert`;
+  const entries = (Array.isArray(operand) ? operand : [operand]) as unknown[];
+
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new UnsupportedQueryError(
+        at,
+        schema.name,
+        operation,
+        `Expected an object with 'where', 'create' and 'update'.`,
+      );
+    }
+
+    const record = entry as Record<string, unknown>;
+    for (const required of ["where", "create", "update"] as const) {
+      if (record[required] === undefined) {
+        throw new UnsupportedQueryError(
+          at,
+          schema.name,
+          operation,
+          `Expected a '${required}' key — 'upsert' names the row to look for, ` +
+            `what to write if it is there, and what to write if it is not.`,
+        );
+      }
+    }
+
+    matchUniqueKey(child, record.where, `${operation}.${relation.name}.upsert`);
+  }
 }
 
 /**

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -185,7 +185,8 @@ export interface NestedWriteStep {
     | "update"
     | "set"
     | "updateMany"
-    | "deleteMany";
+    | "deleteMany"
+    | "upsert";
   run(
     args: any,
     context: BindContext,

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -840,17 +840,17 @@ describe("nested writes", () => {
   );
 
   /**
-   * The refusals now say *why*, which is the difference between "wait" and
-   * "rewrite this call site". Every one of them writes rows that already exist,
-   * which is the line: what is supported writes new rows or repoints a key.
+   * `REFUSED` is empty now: every entry it held described machinery that
+   * turned out to exist one layer down. What still refuses on a `create` is the
+   * *statement*, not the operand — a row that does not exist yet has nothing
+   * linked to it, and Prisma reports these as unknown arguments there too.
    */
-  test("a refusal explains what the operand would take", () => {
-    expect(() =>
-      text("create", { data: { email: "a@b.c", organization: { upsert: {} } } }),
-    ).toThrow(/deciding which branch ran/);
-    expect(() =>
-      text("create", { data: { email: "a@b.c", accounts: { deleteMany: {} } } }),
-    ).toThrow(/has none yet/);
+  test("an operand that needs an existing row says so on a create", () => {
+    for (const operand of ["upsert", "deleteMany", "disconnect", "update"]) {
+      expect(() =>
+        text("create", { data: { email: "a@b.c", accounts: { [operand]: {} } } }),
+      ).toThrow(/has none yet/);
+    }
   });
 
   /**

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -854,6 +854,76 @@ describe("nested writes", () => {
   });
 
   /**
+   * **Every supported operand is answered on both sides, or refused by name.**
+   *
+   * `SUPPORTED` says which operands the ordinary-relation path accepts, but the
+   * two sides are separate dispatches — `planOwningSide` when this row holds
+   * the key, `planForeignSide` when the child does. An operand can be in the
+   * set and unimplemented on one of them, and then it falls through to whatever
+   * handler comes last: `upsert` reached the `connect` path and reported
+   * `'where' yet (Organization.update.organization.connect)` — a different
+   * operand, a different model, and a claim that `{ id: 1 }` is not a unique
+   * key when it is.
+   *
+   * That is a gap `REFUSED` cannot cover, because the operand is not refused —
+   * it is supported, on one side. This walks the set and asserts that whatever
+   * comes back names the operand the caller actually wrote, which is the
+   * property #85 was filed about.
+   */
+  describe("every supported operand answers for itself on both sides", () => {
+    const OPERANDS = [
+      "connect",
+      "connectOrCreate",
+      "create",
+      "createMany",
+      "disconnect",
+      "delete",
+      "update",
+      "updateMany",
+      "deleteMany",
+      "set",
+      "upsert",
+    ];
+
+    // `organization` is the to-one — this row holds the key. `accounts` is the
+    // to-many — the child does.
+    test.each(OPERANDS)("%s on a to-one names itself", (operand) => {
+      let message = "";
+      try {
+        text("update", {
+          where: { id: 1 },
+          data: { organization: { [operand]: {} } },
+        });
+      } catch (error) {
+        message = (error as Error).message;
+      }
+
+      // Either it compiled, or the refusal names the operand the caller wrote.
+      //
+      // The *model* is deliberately not asserted: `matchUniqueKey` reports the
+      // child whose key is missing, which is a different question from whether
+      // the operand is named, and is the same on both sides.
+      if (message === "") return;
+      expect(message).toContain(`.${operand}`);
+    });
+
+    test.each(OPERANDS)("%s on a to-many names itself", (operand) => {
+      let message = "";
+      try {
+        text("update", {
+          where: { id: 1 },
+          data: { accounts: { [operand]: {} } },
+        });
+      } catch (error) {
+        message = (error as Error).message;
+      }
+
+      if (message === "") return;
+      expect(message).toContain(`.${operand}`);
+    });
+  });
+
+  /**
    * The two operand sets, reconciled — and asserted, because nothing else can
    * see the divergence.
    *

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -1659,6 +1659,75 @@ function suite(label: string, url?: string) {
       );
     });
 
+    /**
+     * `upsert` — the lookup decides the branch, and it looks only among **this
+     * parent's** rows. The third case is the one that shows the difference:
+     * `acc-theirs` exists globally but not here, so Prisma takes the *create*
+     * branch and collides on the unique key rather than updating somebody
+     * else's row.
+     */
+    test("upsert updates the row when it is this parent's", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              upsert: {
+                where: { publicId: "acc-mine-1" },
+                create: { publicId: "acc-mine-1", organizationRole: 5 },
+                update: { organizationRole: 9 },
+              },
+            },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("upsert creates when there is no such row", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              upsert: {
+                where: { publicId: "brand-new" },
+                create: { publicId: "brand-new", organizationRole: 3 },
+                update: { organizationRole: 9 },
+              },
+            },
+          },
+          include: { accounts: true },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
+    test("upsert on another parent's row collides rather than updating it", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            accounts: {
+              upsert: {
+                where: { publicId: "acc-theirs" },
+                create: { publicId: "acc-theirs", organizationRole: 4 },
+                update: { organizationRole: 7 },
+              },
+            },
+          },
+        },
+        { tables: ["User", "Account"] },
+      );
+    });
+
     test("nested connect on the foreign side repoints the child", async () => {
       await differential.reset();
       await differential.prisma.account.create({

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -88,6 +88,23 @@ async function seed(prisma: PrismaClient) {
   // Safe for the delete cases either way: `Account_userId_fkey` is
   // `ON DELETE SET NULL`, so removing a user detaches its accounts on both
   // sides rather than failing a constraint.
+  // The implicit many-to-many fixtures, **in the seed for the same reason as
+  // the accounts above** — and this one was found the hard way. They used to be
+  // written by a `seedTags()` helper called from each test body, which
+  // `expectSameWrite`'s own reset then wiped: every m-n case was comparing two
+  // runs against an empty `Tag` table, agreeing that both clients failed, and
+  // passing whatever the code did.
+  //
+  // One post already linked to two of the three tags, so `disconnect`, `set`
+  // and a repeated `connect` all have something to act on and something to
+  // leave alone.
+  await prisma.tag.createMany({
+    data: [{ label: "red" }, { label: "blue" }, { label: "green" }],
+  });
+  await prisma.post.create({
+    data: { title: "existing", tags: { connect: [{ label: "red" }, { label: "blue" }] } },
+  });
+
   const users = await prisma.user.findMany({ orderBy: { id: "asc" } });
   await prisma.account.createMany({
     data: [
@@ -402,15 +419,7 @@ function suite(label: string, url?: string) {
      * Comparing the table contents afterwards is what catches that.
      */
     describe("an implicit many-to-many", () => {
-      const seedTags = async () => {
-        await differential.reset();
-        await differential.prisma.tag.createMany({
-          data: [{ label: "red" }, { label: "blue" }, { label: "green" }],
-        });
-      };
-
       test("connect attaches existing rows", async () => {
-        await seedTags();
         await differential.expectSameWrite(
           "Post",
           "create",
@@ -426,7 +435,6 @@ function suite(label: string, url?: string) {
       });
 
       test("create writes the child and the pair", async () => {
-        await seedTags();
         await differential.expectSameWrite(
           "Post",
           "create",
@@ -439,7 +447,6 @@ function suite(label: string, url?: string) {
       });
 
       test("connect and create together", async () => {
-        await seedTags();
         await differential.expectSameWrite(
           "Post",
           "create",
@@ -455,14 +462,6 @@ function suite(label: string, url?: string) {
       });
 
       test("disconnect removes one pair and leaves the row", async () => {
-        await seedTags();
-        await differential.prisma.post.create({
-          data: {
-            title: "existing",
-            tags: { connect: [{ label: "red" }, { label: "blue" }] },
-          },
-        });
-
         await differential.expectSameWrite(
           "Post",
           "update",
@@ -477,11 +476,6 @@ function suite(label: string, url?: string) {
 
       /** Two statements — delete then insert — inside the step's transaction. */
       test("set replaces the whole set", async () => {
-        await seedTags();
-        await differential.prisma.post.create({
-          data: { title: "existing", tags: { connect: [{ label: "red" }] } },
-        });
-
         await differential.expectSameWrite(
           "Post",
           "update",
@@ -495,11 +489,6 @@ function suite(label: string, url?: string) {
       });
 
       test("set to nothing clears them", async () => {
-        await seedTags();
-        await differential.prisma.post.create({
-          data: { title: "existing", tags: { connect: [{ label: "red" }] } },
-        });
-
         await differential.expectSameWrite(
           "Post",
           "update",
@@ -518,11 +507,6 @@ function suite(label: string, url?: string) {
        * unique violation — neither Prisma's behaviour nor a useful one.
        */
       test("connecting the same pair twice is a no-op", async () => {
-        await seedTags();
-        await differential.prisma.post.create({
-          data: { title: "existing", tags: { connect: [{ label: "red" }] } },
-        });
-
         await differential.expectSameWrite(
           "Post",
           "update",
@@ -535,17 +519,17 @@ function suite(label: string, url?: string) {
         );
       });
 
-      /** The far direction: the same relation written from `Tag`. */
+      /**
+       * The far direction: the same relation written from `Tag`. `green` is
+       * the seeded tag with no posts, so the connect has something to change.
+       */
       test("the relation writes from the other side too", async () => {
-        await seedTags();
-        await differential.prisma.post.create({ data: { title: "a" } });
-
         await differential.expectSameWrite(
           "Tag",
           "update",
           {
-            where: { label: "red" },
-            data: { posts: { connect: [{ id: 1 }] } },
+            where: { label: "green" },
+            data: { posts: { connect: [{ title: "existing" }] } },
             include: { posts: true },
           },
           { tables: ["Post", "Tag"] },


### PR DESCRIPTION
Completes **#65**. Stacked on #106.

## The sixth stale reason

`upsert`'s entry said it *"needs a third thing neither half has: deciding which branch ran, from inside a nested step."* It does not — the lookup decides the branch, exactly as `connectOrCreate` has decided one since #94.

That is the sixth `REFUSED` entry in this series to describe machinery that was already there. The pattern across all six: a reason naming **machinery** is checkable, and one naming a **principle** is not. Five named a missing pass that the child's own `$exec` already ran; this one named a missing decision that a `findFirst` already makes. The one I wrote myself on #105 named a principle and was wrong within a commit.

## Scoped to this parent, which is what the operand means

Measured, because it decides the behaviour rather than merely constraining it:

```
upsert a row belonging to another parent
  ->  Unique constraint failed on the fields: (`publicId`)
```

Prisma looks only among **this** parent's children, does not find it, takes the *create* branch, and collides. So the conjunction #106 added is what produces the right branch here — the same mechanism answering a second question, not a safety net bolted on.

## `REFUSED` is empty, and stays

Kept rather than deleted: the next operand added here should have to write its reason down, and the table is where six wrong ones were findable.

## Tests

Three differential cases — the hit, the miss, and the collision. The third is the one that separates "scoped to this parent" from "found globally"; without it an implementation that looked up the row globally and updated it would pass the first two.

## Not implemented

The **to-one** form. Its far row is identified by *this* row's foreign key, so an absent one means creating the far row and then writing back to a parent that has already been inserted — a shape none of the other operands need. Recorded as what it is rather than left to be rediscovered.

## Verification

1024 unit tests. Template suite green on SQLite (591) and Postgres 16 (856), with only the pre-existing `generated.test.ts` linkage probe failing. `tsc` clean; oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
