### PR TITLE
Three nested operands checked their unique key after writing the parent row

### DIFF
--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1276,6 +1276,15 @@ function planForeignSide(
 
   // `connect` on this side means "point that existing row at me", which is an
   // update of the child's foreign key — not something this row's insert can do.
+  //
+  // Checked here rather than in the step below, for the reason `assertNamedRows`
+  // gives: the step runs after the parent row is written, so a key the child
+  // does not declare unwinds an insert that should never have happened. The
+  // owning side has always checked its `connect` at plan time; this side had
+  // not, which made the same operand answer differently depending on which
+  // table the foreign key is on (#110).
+  assertNamedRows(schema, relation, child, operand, key, operation);
+
   out.after.push({
     relation: relation.name,
     operation: "connect",
@@ -1284,11 +1293,6 @@ function planForeignSide(
       if (!parent) return;
 
       for (const item of listOf(at(args))) {
-        matchUniqueKey(child, item, {
-          model: schema.name,
-          operation,
-          argument: `data.${relation.name}.${key}`,
-        });
         await executor.exec(
           relation.model,
           "update",
@@ -1456,6 +1460,16 @@ function planJoinTable(
     );
   }
 
+  // `connect`, `disconnect` and `set` name existing rows by a unique key, and
+  // the step below resolves them one at a time — after the parent row exists,
+  // since a pair needs both ends. That made a key the child does not declare
+  // refuse from mid-transaction, while the *same* operand on an ordinary
+  // relation refuses from the compiler (#110). `create` names no existing row
+  // and `connectOrCreate` is checked above, so those two are not this.
+  if (key === "connect" || key === "disconnect" || key === "set") {
+    assertNamedRows(schema, relation, child, operand, key, operation);
+  }
+
   const join = link.join!;
   const parentField = link.parentField;
   const childField = link.childField;
@@ -1591,12 +1605,10 @@ function planJoinTable(
          * confirm a row the caller cannot see.
          */
         if (key === "connectOrCreate") {
+          // The `where` was validated at plan time by
+          // `assertConnectOrCreateOperand`, which the branch at the top of this
+          // function runs for both relation kinds.
           const entry = item as Record<string, unknown>;
-          matchUniqueKey(child, entry.where, {
-            model: schema.name,
-            operation,
-            argument: `data.${relation.name}.connectOrCreate.where`,
-          });
 
           const hit = (await executor.exec(
             relation.model,
@@ -1621,14 +1633,9 @@ function planJoinTable(
         }
 
         // `connect`, `disconnect` and `set` all name existing rows by a unique
-        // key. Resolved through the child's own `$exec`, so its policies decide
-        // which rows exist — otherwise a connect by any unique key reaches
-        // every tenant's.
-        matchUniqueKey(child, item, {
-          model: schema.name,
-          operation,
-          argument: `data.${relation.name}.${key}`,
-        });
+        // key — checked at plan time above. Resolved through the child's own
+        // `$exec`, so its policies decide which rows exist — otherwise a
+        // connect by any unique key reaches every tenant's.
         const found = (await executor.exec(
           relation.model,
           "findUniqueOrThrow",

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -915,6 +915,87 @@ describe("nested writes", () => {
   });
 
   /**
+   * **A key the child does not declare is refused by the compiler, on every
+   * path that names a row by one.**
+   *
+   * `assertNamedRows` states the rule: "Validated at plan time for the reason
+   * every operand here is: a refusal that arrives mid-transaction has to unwind
+   * a parent row that should never have been written."
+   *
+   * Three sites did not follow it — foreign-side `connect`, and join-table
+   * `connect`/`disconnect`/`set` — so the *same* operand was checked by the
+   * compiler on an ordinary relation and from inside a nested step through a
+   * join table, and `connect` was checked at plan time on the owning side and
+   * at run time on the foreign one. Nothing distinguished those cases; it was
+   * an omission (#110).
+   *
+   * Walked as a table rather than tested one deep, because the per-path tables
+   * are what turned "one omission" into three. Plan-time checking is sound here
+   * because the plan key carries the operand's key *names* and collapses only
+   * its values — `{ id: 1 }` and `{ id: 999 }` share a plan, `{ id: 1 }` and
+   * `{ nope: 1 }` do not.
+   */
+  describe("an undeclared unique key is refused by the compiler", () => {
+    // Not a field on `Account` or `Tag`, and not a unique key on either.
+    const BAD = { nope: 1 };
+
+    const refusal = (schema: any, data: unknown) => {
+      try {
+        compileWrite(schema, "update", { where: { id: 1 }, data } as never, sqlite);
+        return null;
+      } catch (error) {
+        return error as Error;
+      }
+    };
+
+    /**
+     * The operands that name an *existing* row by unique key, per path.
+     *
+     * `create` and `createMany` name no existing row. `updateMany` and
+     * `deleteMany` take a filter rather than a unique key, so an undeclared
+     * name there is a different question with a different answer. Those four
+     * are absent deliberately.
+     */
+    const TO_MANY: [string, unknown][] = [
+      ["connect", { connect: BAD }],
+      ["connectOrCreate", { connectOrCreate: { where: BAD, create: {} } }],
+      ["disconnect", { disconnect: BAD }],
+      ["delete", { delete: BAD }],
+      ["update", { update: { where: BAD, data: {} } }],
+      ["upsert", { upsert: { where: BAD, create: {}, update: {} } }],
+      ["set", { set: [BAD] }],
+    ];
+
+    // On a to-one the others take a boolean or carry no `where` at all.
+    const TO_ONE: [string, unknown][] = [
+      ["connect", { connect: BAD }],
+      ["connectOrCreate", { connectOrCreate: { where: BAD, create: {} } }],
+    ];
+
+    const JOIN_TABLE: [string, unknown][] = [
+      ["connect", { connect: BAD }],
+      ["connectOrCreate", { connectOrCreate: { where: BAD, create: { name: "x" } } }],
+      ["disconnect", { disconnect: BAD }],
+      ["set", { set: [BAD] }],
+    ];
+
+    test.each(TO_MANY)("%s on a to-many (the child holds the key)", (_operand, operand) => {
+      const error = refusal(user, { accounts: operand });
+      expect(error?.message).toMatch(/needs a unique field here/);
+    });
+
+    test.each(TO_ONE)("%s on a to-one (this row holds the key)", (_operand, operand) => {
+      const error = refusal(user, { organization: operand });
+      expect(error?.message).toMatch(/needs a unique field here/);
+    });
+
+    test.each(JOIN_TABLE)("%s through a join table", (_operand, operand) => {
+      const error = refusal(post, { tags: operand });
+      expect(error?.message).toMatch(/needs a unique field here/);
+    });
+  });
+
+  /**
    * **Every supported operand is answered on both sides, or refused by name.**
    *
    * `SUPPORTED` says which operands the ordinary-relation path accepts, but the
@@ -961,9 +1042,10 @@ describe("nested writes", () => {
 
       // Either it compiled, or the refusal names the operand the caller wrote.
       //
-      // The *model* is deliberately not asserted: `matchUniqueKey` reports the
-      // child whose key is missing, which is a different question from whether
-      // the operand is named, and is the same on both sides.
+      // The *model* is not asserted here — that is the subject of the fields
+      // table above, which pins it to the caller's rather than the child's.
+      // This walk is only about whether the operand names itself, which was
+      // #85's question and is a separate one.
       if (message === "") return;
       expect(message).toContain(`.${operand}`);
     });


### PR DESCRIPTION
Closes #110. Stacked on #109.

`assertNamedRows` states the rule this file follows:

> Validated at plan time for the reason every operand here is: a refusal that arrives mid-transaction has to unwind a parent row that should never have been written.

I located every `matchUniqueKey` call in `nested-writes.ts` by brace-tracking whether it sits inside an `async run()` body, rather than reading for it. Three did not follow the rule. One — join-table `connectOrCreate.where` — turned out redundant, since `assertConnectOrCreateOperand` already covers it at plan time. The other two were real.

## Measured

Compiling each operand with a key the child does not declare, and asking whether `compileWrite` refuses:

| relation kind | operand | before | after |
| --- | --- | --- | --- |
| owning (FK here) | `connect` | refused | refused |
| foreign (FK on child) | `connect` | **accepted** | refused |
| foreign | `disconnect` / `set` / `delete` / `update` / `upsert` / `connectOrCreate` | refused | refused |
| m-n (join table) | `connect` / `disconnect` / `set` | **accepted** | refused |
| m-n | `connectOrCreate` | refused | refused |

The same operand answered differently depending on which table holds the foreign key. Nothing distinguishes those cases — it was an omission, not a decision. Prisma refuses all of them client-side with a `PrismaClientValidationError`, before any statement is sent.

## What it actually cost

Multi-statement writes open an implicit transaction, so the parent row **was** rolled back. This was not data loss, and I would rather say so than overstate it. What it cost:

- A statically-invalid query did a `BEGIN` + parent `INSERT` + `ROLLBACK` before refusing. An application that puts request input into a `connect` key turned a validation error into a write transaction per request.
- `compileWrite` succeeded, so the query counted as supported and its plan was cached.
- The refusal arrived from inside a nested step rather than from the compiler — a different point in the call than every neighbouring operand's.

## The fix

`assertNamedRows` called at plan time on both paths. No new helper: the existing one already does exactly this, which is part of why the gap reads as an omission.

The two run-time checks these now shadow are removed. A check that can no longer fire reads as though it can, and this repo has had several stale guards found that way.

**Plan-time checking is sound here**, which is the assumption the existing asserts already rested on and worth pinning: the plan key carries the operand's key *names* and collapses only its values.

```
sqlite:batched:User:update:{data:{accounts:{connect:{id:number}}},where:{id:number}}
sqlite:batched:User:update:{data:{accounts:{connect:{nope:number}}},where:{id:number}}
```

`{ id: 1 }` and `{ id: 999 }` share a plan; `{ id: 1 }` and `{ nope: 1 }` do not. A check that runs once per shape cannot accept one call's key on another call's behalf.

## Tests

A table over all three paths — to-one, to-many, join table — for every operand that names an existing row by unique key. `create`/`createMany` name no existing row and `updateMany`/`deleteMany` take a filter rather than a unique key; those four are absent deliberately, and the comment says so.

Walked as a table because the per-path tables are what turned "one omission" into three.

**Verified against the unfixed source**: exactly four of the thirteen cases fail, and they are the four measured gaps. The nine that pass either way are covering the paths that were already correct, not padding.

Also corrected a comment in the neighbouring both-sides walk that #109 made false — it explained a deliberate omission by saying `matchUniqueKey` reports the child's model, which is no longer true.

## Verification

- 1065 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 592 passed on SQLite, 857 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)