### PR TITLE
Three refusals reported a model that was not the caller's

### DIFF
--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -590,7 +590,10 @@ export abstract class Model {
     // `defaultStrategy`, and either way it reaches the plan key — two strategies
     // emit different SQL for the same arguments, so sharing a plan between them
     // would run one request's statement for the other's.
-    const strategy = resolveStrategy(options?.strategy, dialect);
+    const strategy = resolveStrategy(options?.strategy, dialect, {
+      model: schema.name,
+      operation: op,
+    });
 
     // `createMany` past the driver's parameter ceiling, which used to raise.
     //

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -8,7 +8,7 @@ import {
   relatedSchema,
   resolveLink,
 } from "./plan-relations";
-import { matchUniqueKey } from "./unique";
+import { matchUniqueKey, type RefusalOrigin } from "./unique";
 
 /**
  * Nested writes: `connect`, `connectOrCreate`, shallow `create`, and
@@ -417,7 +417,11 @@ function planOwningSide(
    * of an unrelated update is the kind of thing to implement deliberately.
    */
   if (key === "disconnect") {
-    assertDisconnectable(schema, relation, fkField, operation);
+    assertDisconnectable(schema, relation, fkField, {
+      model: schema.name,
+      operation,
+      argument: `data.${relation.name}.disconnect`,
+    });
 
     if (operand !== true) {
       throw new UnsupportedQueryError(
@@ -922,7 +926,11 @@ function planForeignSide(
 
   if (key === "set") {
     assertNamedRows(schema, relation, child, operand, "set", operation);
-    assertDisconnectable(child, relation, childField, operation);
+    assertDisconnectable(child, relation, childField, {
+      model: schema.name,
+      operation,
+      argument: `data.${relation.name}.set`,
+    });
 
     out.after.push({
       relation: relation.name,
@@ -1024,7 +1032,13 @@ function planForeignSide(
 
   if (key === "disconnect" || key === "delete") {
     const deleting = key === "delete";
-    if (!deleting) assertDisconnectable(child, relation, childField, operation);
+    if (!deleting) {
+      assertDisconnectable(child, relation, childField, {
+        model: schema.name,
+        operation,
+        argument: `data.${relation.name}.disconnect`,
+      });
+    }
 
     assertNamedRows(schema, relation, child, operand, key, operation);
 
@@ -1918,23 +1932,32 @@ function assertNamedRows(
  * is the only thing that knows, so the refusal says which column and why rather
  * than letting the database report a not-null violation from inside a nested
  * step.
+ *
+ * `owner` and `caller` are separate parameters because they are separate
+ * questions, and one parameter answering both is what went wrong. The column
+ * lives on whichever side holds the foreign key — the caller's row on a to-one,
+ * the child's on a to-many — and that is what the *message* has to name. The
+ * *structured* model is always the caller's. Passing `owner` for both meant a
+ * `User.update` reported `model = "Account"` on the foreign side while the
+ * owning side reported `User`, from the same function (#112).
  */
 function assertDisconnectable(
   owner: ModelSchema,
   relation: RelationSchema,
   fieldName: string,
-  operation: string,
+  caller: RefusalOrigin,
 ): void {
   const field = owner.fields[fieldName];
   if (field && field.nullable) return;
 
   throw new UnsupportedQueryError(
-    `data.${relation.name}.disconnect`,
-    owner.name,
-    operation,
-    `'${fieldName}' is required, so there is no value to leave behind — a ` +
-      `disconnected row would have to be deleted or repointed instead. Prisma ` +
-      `does not offer 'disconnect' on a required relation either.`,
+    caller.argument,
+    caller.model,
+    caller.operation,
+    `'${owner.name}.${fieldName}' is required, so there is no value to leave ` +
+      `behind — a disconnected row would have to be deleted or repointed ` +
+      `instead. Prisma does not offer 'disconnect' on a required relation ` +
+      `either.`,
   );
 }
 

--- a/packages/gemi/orm/compile/strategy.test.ts
+++ b/packages/gemi/orm/compile/strategy.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+
+import { PostgresDialect } from "../dialect/postgres";
+import { SqliteDialect } from "../dialect/sqlite";
+import { UnsupportedQueryError } from "../errors";
+import { lateralStrategy } from "./lateral";
+import { batchedStrategy } from "./plan-relations";
+import { defaultStrategy, resolveStrategy } from "./strategy";
+
+const sqlite = new SqliteDialect();
+const postgres = new PostgresDialect();
+
+const origin = { model: "User", operation: "findMany" };
+
+/**
+ * `resolveStrategy` had no test, and its refusal reported `"Model"` as the
+ * model and `"$exec"` as the operation — a base class, and something that is
+ * not one of the thirteen operations (#112). Its one caller has both in scope.
+ */
+describe("resolveStrategy", () => {
+  test("the default is per dialect: lateral on postgres, batched on sqlite", () => {
+    expect(defaultStrategy(postgres)).toBe(lateralStrategy);
+    expect(defaultStrategy(sqlite)).toBe(batchedStrategy);
+    expect(resolveStrategy(undefined, postgres, origin)).toBe(lateralStrategy);
+    expect(resolveStrategy(undefined, sqlite, origin)).toBe(batchedStrategy);
+  });
+
+  test.each([
+    ["batched", batchedStrategy],
+    ["lateral", lateralStrategy],
+  ])("%s is honoured over the dialect's default", (named, expected) => {
+    // Named on sqlite, whose default is `batched`, so `lateral` proves the name
+    // is what decided rather than the dialect.
+    expect(resolveStrategy(named, sqlite, origin)).toBe(expected);
+  });
+
+  /**
+   * A typo raises rather than falling back — the reason `resolveStrategy`
+   * gives is that a silent fallback would be a performance mystery with no
+   * error attached.
+   */
+  test("an unknown name names the caller's query", () => {
+    let error: UnsupportedQueryError | null = null;
+    try {
+      resolveStrategy("latteral", postgres, origin);
+    } catch (raised) {
+      error = raised as UnsupportedQueryError;
+    }
+
+    expect(error).toBeInstanceOf(UnsupportedQueryError);
+    expect(error!.model).toBe("User");
+    expect(error!.operation).toBe("findMany");
+    // The value is quoted in the argument, so the message shows the typo back.
+    expect(error!.argument).toBe(`strategy: "latteral"`);
+  });
+});

--- a/packages/gemi/orm/compile/strategy.ts
+++ b/packages/gemi/orm/compile/strategy.ts
@@ -56,6 +56,11 @@ export function defaultStrategy(dialect: SqlDialect): RelationStrategy {
 export function resolveStrategy(
   named: string | undefined,
   dialect: SqlDialect,
+  // Required, so the caller cannot fall back to a placeholder without saying
+  // so. This used to report `"Model"` and `"$exec"` — a base class and
+  // something that is not one of the thirteen operations — while `$exec`, its
+  // only caller, had both in scope (#112).
+  origin: { model: string; operation: string },
 ): RelationStrategy {
   if (named === undefined) return defaultStrategy(dialect);
   if (named === "batched") return batchedStrategy;
@@ -63,8 +68,8 @@ export function resolveStrategy(
 
   throw new UnsupportedQueryError(
     `strategy: ${JSON.stringify(named)}`,
-    "Model",
-    "$exec",
+    origin.model,
+    origin.operation,
     `Unknown relation strategy. Expected "batched" or "lateral".`,
   );
 }

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -915,6 +915,102 @@ describe("nested writes", () => {
   });
 
   /**
+   * **`disconnect` on a required relation reports the caller's model, and says
+   * whose column is required.**
+   *
+   * `assertDisconnectable` has three call sites and they disagreed about what
+   * its first parameter meant. The owning side passed the caller's schema; the
+   * two foreign-side sites passed the *child*, whose name then landed in the
+   * structured `model` field. So `User.update` refused with `model = "Account"`
+   * from one branch and `model = "User"` from another, out of one function
+   * (#112).
+   *
+   * **It had no test at all** — nothing in the repo matched its message, which
+   * is how two of three sites stayed wrong. The fixtures could not reach it
+   * either: none has a required foreign key on a to-many child, so the clones
+   * below make one. That absence is the whole reason this needs saying.
+   *
+   * The two things the function needs are now separate parameters, because they
+   * are separate questions: the column's owner (for the message) and the caller
+   * (for the fields).
+   */
+  describe("disconnect on a required relation", () => {
+    // `Account.userId` required — the child holds the key, so the foreign-side
+    // branches are reachable.
+    const strictAccount = {
+      ...account,
+      fields: {
+        ...account.fields,
+        userId: { ...account.fields.userId, nullable: false },
+      },
+    } as typeof account;
+
+    // `User.organizationId` required — this row holds the key, for the owning
+    // side.
+    const strictUser = {
+      ...user,
+      fields: {
+        ...user.fields,
+        organizationId: { ...user.fields.organizationId, nullable: false },
+      },
+    } as typeof user;
+
+    const refuse = (schema: typeof user, data: unknown) => {
+      try {
+        compileWrite(schema, "update", { where: { id: 1 }, data } as never, sqlite);
+        return null;
+      } catch (error) {
+        return error as UnsupportedQueryError;
+      }
+    };
+
+    describe("the child holds the key", () => {
+      beforeEach(() => {
+        registry.clearRegistry();
+        registry.register("User", class { static $schema = user });
+        registry.register("Account", class { static $schema = strictAccount });
+        registry.register("Organization", class { static $schema = organization });
+      });
+
+      test.each([
+        ["disconnect", { accounts: { disconnect: { id: 1 } } }],
+        ["set", { accounts: { set: [{ id: 1 }] } }],
+      ])("%s reports User, and names Account's column", (operand, data) => {
+        const error = refuse(user, data);
+        expect(error).not.toBeNull();
+
+        // The caller's query — this was `Account` before.
+        expect(error!.model).toBe("User");
+        expect(error!.operation).toBe("update");
+        expect(error!.argument).toBe(`data.accounts.${operand}`);
+
+        // ...and the column is qualified, since it is not on the model above.
+        expect(error!.message).toContain("'Account.userId' is required");
+      });
+    });
+
+    describe("this row holds the key", () => {
+      beforeEach(() => {
+        registry.clearRegistry();
+        registry.register("User", class { static $schema = strictUser });
+        registry.register("Account", class { static $schema = account });
+        registry.register("Organization", class { static $schema = organization });
+      });
+
+      // The site that was already right. Kept so the two cannot drift apart
+      // again without a test noticing — the divergence was the defect.
+      test("disconnect reports User, and names User's own column", () => {
+        const error = refuse(strictUser, { organization: { disconnect: true } });
+        expect(error).not.toBeNull();
+        expect(error!.model).toBe("User");
+        expect(error!.operation).toBe("update");
+        expect(error!.argument).toBe("data.organization.disconnect");
+        expect(error!.message).toContain("'User.organizationId' is required");
+      });
+    });
+  });
+
+  /**
    * **A key the child does not declare is refused by the compiler, on every
    * path that names a row by one.**
    *

--- a/packages/gemi/orm/soft-deletes.test.ts
+++ b/packages/gemi/orm/soft-deletes.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+
+import { UnsupportedQueryError } from "./errors";
+import { user } from "./fixtures";
+import { softDelete, softDeleteMany } from "./soft-deletes";
+
+/**
+ * The refusal `softDelete` raises when the caller passes a `data`.
+ *
+ * It reported the literal string `"soft delete"` as the model.
+ * `UnsupportedQueryError` documents `model` as inspectable, and that is not a
+ * model name — nothing can ever match it (#112). The real one was in hand: the
+ * wrapped model carries `$schema`, which the structural parameter type was
+ * hiding rather than the value being absent.
+ *
+ * `softDelete` had no test at all, which is how it stayed that way.
+ */
+describe("softDelete refuses a data argument", () => {
+  // Stands in for a generated model: the write to delegate to, and `$schema`.
+  const model = {
+    calls: [] as unknown[],
+    $schema: user,
+    update(args: unknown) {
+      this.calls.push(args);
+      return Promise.resolve({ id: 1 });
+    },
+    updateMany(args: unknown) {
+      this.calls.push(args);
+      return Promise.resolve({ count: 1 });
+    },
+  };
+
+  const caught = async (run: () => Promise<unknown>) => {
+    try {
+      await run();
+      return null;
+    } catch (error) {
+      return error as UnsupportedQueryError;
+    }
+  };
+
+  test.each([
+    ["delete", () => softDelete(model)({ where: { id: 1 }, data: { name: "x" } })],
+    [
+      "deleteMany",
+      () => softDeleteMany(model)({ where: { id: 1 }, data: { name: "x" } }),
+    ],
+  ])("%s names the model it was built for", async (operation, run) => {
+    const error = await caught(run);
+
+    expect(error).toBeInstanceOf(UnsupportedQueryError);
+    expect(error!.model).toBe("User");
+    expect(error!.operation).toBe(operation);
+    expect(error!.argument).toBe("data");
+  });
+
+  // The other half: it refuses instead of writing, rather than doing both.
+  test("nothing is delegated when it refuses", async () => {
+    model.calls.length = 0;
+    await caught(() => softDelete(model)({ where: { id: 1 }, data: {} }));
+    expect(model.calls).toEqual([]);
+  });
+
+  test("without a data it delegates, stamping the timestamp", async () => {
+    model.calls.length = 0;
+    await softDelete(model)({ where: { id: 1 } });
+
+    expect(model.calls).toHaveLength(1);
+    const args = model.calls[0] as { where: unknown; data: { deletedAt: Date } };
+    expect(args.where).toEqual({ id: 1 });
+    expect(args.data.deletedAt).toBeInstanceOf(Date);
+  });
+
+  test("the field is configurable, and the refusal is not", async () => {
+    model.calls.length = 0;
+    await softDelete(model, { field: "archivedAt" })({ where: { id: 1 } });
+
+    const args = model.calls[0] as { data: Record<string, unknown> };
+    expect(args.data.archivedAt).toBeInstanceOf(Date);
+
+    const error = await caught(() =>
+      softDelete(model, { field: "archivedAt" })({ data: {} }),
+    );
+    expect(error!.model).toBe("User");
+  });
+});

--- a/packages/gemi/orm/soft-deletes.ts
+++ b/packages/gemi/orm/soft-deletes.ts
@@ -86,6 +86,18 @@ export function softDeletes<M = any>(
 }
 
 /**
+ * What `softDelete` needs from the model it wraps: the write to delegate to,
+ * and the schema to name in a refusal.
+ *
+ * Structural rather than `typeof Model`, so a caller can pass anything that
+ * behaves like one — which is why `$schema` is optional here even though every
+ * generated model has it.
+ */
+type SoftDeletable<T, Op extends string> = {
+  [K in Op]: (args: any) => Promise<T>;
+} & { $schema?: { name: string } };
+
+/**
  * The write half: rewrites a `delete` into an `update` that sets the timestamp.
  *
  * Kept separate from `softDeletes()` and applied at the call site rather than
@@ -108,13 +120,13 @@ export function softDeletes<M = any>(
  * a hard delete of a missing row would.
  */
 export function softDelete<T, M = any>(
-  model: { update(args: any): Promise<T> },
+  model: SoftDeletable<T, "update">,
   options: SoftDeleteOptions<M> = {},
 ): (args: any) => Promise<T> {
   const field = options.field ?? "deletedAt";
 
   return (args: any) => {
-    assertNoData(args, "delete");
+    assertNoData(model, args, "delete");
     return model.update({
       ...args,
       data: { [field]: new Date() },
@@ -123,13 +135,13 @@ export function softDelete<T, M = any>(
 }
 
 export function softDeleteMany<T, M = any>(
-  model: { updateMany(args: any): Promise<T> },
+  model: SoftDeletable<T, "updateMany">,
   options: SoftDeleteOptions<M> = {},
 ): (args: any) => Promise<T> {
   const field = options.field ?? "deletedAt";
 
   return (args: any = {}) => {
-    assertNoData(args, "deleteMany");
+    assertNoData(model, args, "deleteMany");
     return model.updateMany({
       ...args,
       data: { [field]: new Date() },
@@ -142,12 +154,21 @@ export function softDeleteMany<T, M = any>(
  * are calling something else — most likely they wrote `update` and meant it.
  * Refused rather than silently overwritten by the timestamp.
  */
-function assertNoData(args: any, operation: string): void {
+function assertNoData(
+  model: { $schema?: { name: string } },
+  args: any,
+  operation: string,
+): void {
   if (args?.data === undefined) return;
 
   throw new UnsupportedQueryError(
     "data",
-    "soft delete",
+    // The real model, not the literal `"soft delete"` this used to pass.
+    // `UnsupportedQueryError` documents `model` as inspectable, and a string
+    // that is not a model name can never be what an application matches on
+    // (#112). `$schema` is optional only because the parameter is structural —
+    // every generated model carries it.
+    model.$schema?.name ?? "unknown",
     operation,
     `${operation} takes no 'data' — the soft-delete rewrite supplies it. ` +
       `Call update directly if you meant to change other fields at the same ` +


### PR DESCRIPTION
Closes #112. Stacked on #111.

#108 fixed this for `matchUniqueKey`, and only there. I swept all **143** `UnsupportedQueryError` / `InvalidArgumentError` construction sites in `orm/` and checked what lands in the `model` slot. Three more were wrong.

## 1. `assertDisconnectable` reported the child on the foreign side

Three call sites, disagreeing about what the first parameter meant:

| line | passed | correct? |
| --- | --- | --- |
| 420 | `schema` — the caller's | yes |
| 925 | `child` | **no** |
| 1027 | `child` | **no** |

Measured, with a required `Account.userId`:

```
User.update({ data: { accounts: { disconnect: { id: 1 } } } })
  → model=Account operation=update argument=data.accounts.disconnect
```

`operation` and `argument` were right; only `model` was wrong, and only on the foreign side — so one function answered two different ways depending on which branch you reached.

The parameter is named `owner`, and that is the honest name for what the *message* needs: it says which column is required, and the column lives on whichever side holds the foreign key. That is a genuinely different question from whose query this is, and one parameter cannot answer both — the same shape as #108. Now two do: `owner` for the message, a required `RefusalOrigin` for the fields.

The message now qualifies the column — `'Account.userId' is required` rather than `'userId'` — because on the foreign side it is not a column of the model the caller named.

## 2. `soft-deletes.ts` passed the literal `"soft delete"` as the model

Not a model name, and never can be. The real one was in hand: `softDelete(model)` receives the model class and every generated model carries `static $schema = schema.User`. The `{ update(args): Promise<T> }` structural parameter type was hiding it rather than the value being absent — so the fix is to widen the type, not to plumb a new argument.

## 3. `resolveStrategy` passed `"Model"` and `"$exec"`

A base class, and something that is not one of the thirteen operations. Its one caller (`Model.ts:593`) has both in scope. Made **required**, so the next caller cannot quietly reintroduce a placeholder — the same `tsc`-enforces-the-convention pattern as #102.

## Deliberately unchanged

- `sql.ts` passes `"DB"`. `DB.sql` is the raw-SQL surface and there genuinely is no model. A placeholder is the right answer when nothing else exists, and this is that case.
- `policy.ts:719` and `:745` put the *operation* in the `argument` slot, which reads as "the whole query rather than one argument". Their model and operation are already the caller's.

## Coverage

**Two of the three had no test at all**, which is how they stayed wrong:

- `assertDisconnectable` matched nothing in the repo, on any of its three sites. The fixtures could not reach it either — none has a required foreign key on a to-many child, which is exactly the configuration the two broken sites serve. The test clones one.
- `softDelete` / `softDeleteMany` were untested entirely. The new file covers the refusal *and* the delegation, since a refusal test alone would pass against a version that refuses everything.
- `resolveStrategy` was untested. The new file covers the dialect defaults and the override as well as the refusal.

**Verified against the unfixed source**: every model assertion fails. One nuance worth stating — the owning-side `disconnect` case fails on the *qualified column name*, not the model, which was already correct there. It is kept because the divergence between the two branches was the defect, and a test on only the broken side would let them drift apart again.

## Verification

- 1077 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 592 passed on SQLite, 857 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)