### PR TITLE
select.ts's refusals, none of which any test reached

### DIFF
--- a/packages/gemi/orm/compile/select.test.ts
+++ b/packages/gemi/orm/compile/select.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { SqliteDialect } from "../dialect/sqlite";
+import { UnsupportedQueryError } from "../errors";
+import { account, organization, user } from "../fixtures";
+import * as registry from "../registry";
+import { compileRead } from "./read";
+import { resolveSelection } from "./select";
+import { compileWrite } from "./write";
+
+const sqlite = new SqliteDialect();
+
+/**
+ * `select.ts`'s refusals — every one of which was unreached by any test in the
+ * repo, unit or template (#114).
+ *
+ * Found by instrumenting `UnsupportedQueryError`'s constructor to record its
+ * call site and diffing that against every construction site in `orm/`: 143
+ * sites, 98 reached, 45 not. All eight of this file's were in the 45.
+ *
+ * Seven turned out reachable and correct, which is worth stating plainly —
+ * unreached is not the same as wrong. The eighth is the interesting one, and
+ * it has its own case at the bottom.
+ */
+describe("resolveSelection refuses", () => {
+  beforeEach(() => {
+    registry.clearRegistry();
+    registry.register("User", class { static $schema = user });
+    registry.register("Account", class { static $schema = account });
+    registry.register("Organization", class { static $schema = organization });
+  });
+
+  const read = (args: unknown) => {
+    try {
+      compileRead(user, "findMany", args as never, sqlite);
+      return null;
+    } catch (error) {
+      return error as UnsupportedQueryError;
+    }
+  };
+
+  const every = Object.fromEntries(
+    Object.keys(user.fields).map((name) => [name, true]),
+  );
+
+  test.each([
+    [
+      "select with omit",
+      { select: { id: true }, omit: { name: true } },
+      "select + omit",
+      /describe different column lists/,
+    ],
+    ["select is an array", { select: [1] }, "select", /Expected an object/],
+    [
+      "a selected field is not a boolean",
+      { select: { id: 1 } },
+      "select.id",
+      /Expected true or false/,
+    ],
+    ["omit is an array", { omit: [1] }, "omit", /Expected an object of fields/],
+    [
+      "omit names a relation",
+      { omit: { accounts: true } },
+      "omit.accounts",
+      /is a relation, not a column/,
+    ],
+    [
+      "an omitted field is not a boolean",
+      { omit: { name: 1 } },
+      "omit.name",
+      /Expected true or false/,
+    ],
+  ])("%s", (_label, args, argument, detail) => {
+    const error = read(args);
+
+    expect(error).toBeInstanceOf(UnsupportedQueryError);
+    expect(error!.argument).toBe(argument);
+    expect(error!.model).toBe("User");
+    expect(error!.operation).toBe("findMany");
+    expect(error!.message).toMatch(detail);
+  });
+
+  /**
+   * The eighth reachable one, kept separate because it is built from the
+   * schema rather than written out: omitting every column leaves no column
+   * list, which is not a query.
+   */
+  test("omit that names every field", () => {
+    const error = read({ omit: every });
+
+    expect(error).toBeInstanceOf(UnsupportedQueryError);
+    expect(error!.argument).toBe("omit");
+    expect(error!.message).toMatch(/omits every field on User/);
+  });
+
+  // `resolveSelection` serves reads and writes both, and the refusals are the
+  // same code — so one write case pins that the operation is reported as the
+  // caller's rather than hardcoded to a read.
+  test("a write reports its own operation", () => {
+    let error: UnsupportedQueryError | null = null;
+    try {
+      compileWrite(
+        user,
+        "update",
+        {
+          where: { id: 1 },
+          data: { name: "x" },
+          select: { id: true },
+          omit: { name: true },
+        } as never,
+        sqlite,
+      );
+    } catch (raised) {
+      error = raised as UnsupportedQueryError;
+    }
+
+    expect(error!.argument).toBe("select + omit");
+    expect(error!.operation).toBe("update");
+  });
+
+  /**
+   * **The one no caller reaches.**
+   *
+   * All four callers of `resolveSelection` check `select` + `include` before
+   * calling it, and each says it better — `plan-relations.ts` reports
+   * `'accounts: select + include'` with the relation path, which this one
+   * cannot know. So the guard is the floor under a fifth caller rather than a
+   * duplicate to delete.
+   *
+   * Called directly, because that is the honest way to reach it: going through
+   * the public API would test whichever caller pre-empted it, which is what
+   * the two cases below do deliberately.
+   */
+  describe("select with include", () => {
+    test("resolveSelection refuses it when reached directly", () => {
+      expect(() =>
+        resolveSelection(
+          user,
+          { select: { id: true }, include: { accounts: true } },
+          "findMany",
+        ),
+      ).toThrow(/only one of them on the same query/);
+    });
+
+    // ...and the two that get there first, so the pre-emption is pinned. If a
+    // caller's own check is removed, these change and the one above does not.
+    test("a read is refused by the read compiler, with no relation path", () => {
+      const error = read({ select: { id: true }, include: { accounts: true } });
+      expect(error!.argument).toBe("select + include");
+    });
+
+    test("a relation node is refused with its path", () => {
+      const error = read({
+        include: { accounts: { select: { id: true }, include: { user: true } } },
+      });
+      expect(error!.argument).toBe("accounts: select + include");
+    });
+  });
+});

--- a/packages/gemi/orm/compile/select.ts
+++ b/packages/gemi/orm/compile/select.ts
@@ -24,6 +24,17 @@ export function resolveSelection(
   const omit = args?.omit;
 
   // Prisma rejects using both, because the result shape would be ambiguous.
+  //
+  // **No current caller reaches this**, and that is deliberate rather than
+  // dead. All four check it first and say it better: `plan-relations.ts:506`
+  // reports `'accounts: select + include'` with the relation path, which this
+  // one has no way to know. So this is the floor under a fifth caller, not a
+  // duplicate to delete — the distinction #114 exists to record, and the
+  // reason the test for it calls `resolveSelection` directly.
+  //
+  //   read.ts:206          pre-empted by read.ts:341
+  //   write.ts:1277        pre-empted by write.ts:1411
+  //   plan-relations.ts:660 and lateral.ts:291   by plan-relations.ts:506
   if (select !== undefined && args?.include !== undefined) {
     throw new UnsupportedQueryError(
       "select + include",


### PR DESCRIPTION
Part of #114. Stacked on #113.

## Why this file

#108, #110 and #112 were all in code no test reached — #112's `assertDisconnectable`, `softDelete` and `resolveStrategy` had **no test at all** between them, on any call site. Three for three is a pattern worth measuring rather than continuing to find one function at a time.

`@vitest/coverage-v8` is not installed, and line coverage answers a slightly different question anyway. So I temporarily instrumented `UnsupportedQueryError`'s constructor to record the first `orm/` stack frame that is not `errors.ts`, ran both suites, and diffed against every construction site in `orm/` found by parsing rather than by grepping messages.

**143 sites. 98 reached. 45 never constructed.** All eight of `select.ts`'s were in the 45 — the only file where *every* refusal was unreached, which is why this starts there. Full per-file breakdown in #114.

## Seven were reachable and correct

| line | refusal | reachable |
| --- | --- | --- |
| 28 | `select` + `include` | **no** |
| 41 | `select` + `omit` | yes |
| 59 | `select` is not an object | yes |
| 107 | `select.x` is not a boolean | yes |
| 161 | `omit` is not an object | yes |
| 179 | `omit` names a relation | yes |
| 193 | `omit.x` is not a boolean | yes |
| 213 | `omit` omits every field | yes |

Unreached is not the same as wrong, and I would rather report that than imply otherwise. No defect here. They are tested now because the three above are the argument for it — each asserts the structured fields, not just that something threw.

## The eighth cannot fire

`resolveSelection` has four callers and **every one checks `select` + `include` first**:

| caller | pre-empted by |
| --- | --- |
| `read.ts:206` | `read.ts:341` |
| `write.ts:1277` | `write.ts:1411` |
| `plan-relations.ts:660` | `plan-relations.ts:506` |
| `lateral.ts:291` | `plan-relations.ts:506` |

**This is not a stale guard to delete**, and I want to be careful about that, because #111 deleted two shadowed checks and the reasoning does not carry over. There the shadowed check was in the same path with identical output. Here the callers say it *better* — `plan-relations.ts` reports `'accounts: select + include'` with the relation path, which the generic one has no way to know — and this one is the floor under a fifth caller.

What it lacked was anything recording the difference between defensive and dead. So:

- the comment names which caller pre-empts each path, so the next reader does not re-derive it;
- the test calls `resolveSelection` **directly**, which is the honest way to reach it — going through the public API would test whichever caller got there first;
- two more cases pin the pre-emption itself, including the relation-path spelling. If a caller's own check is removed, those change and the direct one does not.

## Verification

Re-measured with the instrumentation after: all eight reached. The unit-suite unreached total drops **49 → 41**, which is 45 → 37 counting the template suite.

- 1088 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 592 passed on SQLite, 857 on Postgres 16.

The instrumentation was reverted; it is a recipe, not committed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)