### PR TITLE
A to-one whose foreign key is on the child was planned as a list

### DIFF
--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -704,6 +704,54 @@ function planForeignSide(
   out.keyFields.push(parentField);
 
   /**
+   * **A to-one whose key is on the child**, which this function otherwise plans
+   * as though the child were a list.
+   *
+   * It had exactly one `kind` check — `createMany`'s, further down — because no
+   * fixture had the shape, so nothing ever reached this side with `kind: "one"`
+   * (#116). Everything else took the to-many spelling: `updateMany` and
+   * `deleteMany` *compiled*, and `update` / `delete` / `upsert` were refused
+   * for looking wrong rather than for being unimplemented here.
+   *
+   * Measured against the generated client rather than reasoned about. Prisma's
+   * to-one nested input is
+   *
+   *     { create, connectOrCreate, upsert, disconnect, delete, connect, update }
+   *
+   * with no `createMany`, `set`, `updateMany` or `deleteMany` key at all — so
+   * the first group below is refused for the same reason `planOwningSide`
+   * refuses it, and says so in the same words. The second group exists on that
+   * input but not here yet, and the refusal now says *that* instead of
+   * complaining about the operand's shape.
+   */
+  if (relation.kind !== "many") {
+    if (key === "set" || key === "updateMany" || key === "deleteMany") {
+      throw new UnsupportedQueryError(
+        `data.${relation.name}.${key}`,
+        schema.name,
+        operation,
+        `'${relation.name}' is a to-one: there is a single ${child.name} row, ` +
+          `so there is no set of rows for '${key}' to act on. Prisma does not ` +
+          `offer it on a to-one either. Use 'connect', 'disconnect' or ` +
+          `'update'.`,
+      );
+    }
+
+    if (key === "update" || key === "delete" || key === "upsert") {
+      throw new UnsupportedQueryError(
+        `data.${relation.name}.${key}`,
+        schema.name,
+        operation,
+        `'${relation.name}' is a to-one whose foreign key lives on ` +
+          `${child.name}, and '${key}' is not implemented for that shape yet. ` +
+          `On a to-one Prisma takes the data directly rather than the ` +
+          `{ where, data } form this side expects. Reach the row through the ` +
+          `${child.name} model directly, or use 'connect' and 'disconnect'.`,
+      );
+    }
+  }
+
+  /**
    * `disconnect` and `delete` on this side both act on rows the caller named by
    * unique key — which is what makes them expressible at all, and what puts
    * them on the supported side of this file's line.

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -9,7 +9,17 @@ import {
   UnknownFieldError,
   UnsupportedQueryError,
 } from "../errors";
-import { account, bare, organization, post, reading, tag, user } from "../fixtures";
+import {
+  account,
+  bare,
+  organization,
+  post,
+  profile,
+  reading,
+  tag,
+  user,
+  userWithProfile,
+} from "../fixtures";
 import * as registry from "../registry";
 import { compileWrite } from "./write";
 
@@ -911,6 +921,96 @@ describe("nested writes", () => {
         expect(refusal.operation).toBe("delete");
         expect(refusal.argument).toBe("where");
       }
+    });
+  });
+
+  /**
+   * **Both sides of a to-one answer the same way**, which they did not.
+   *
+   * `planForeignSide` had exactly one `relation.kind` check — `createMany`'s —
+   * because no fixture had a to-one whose foreign key is on the child, so
+   * nothing ever reached it with `kind: "one"` (#116). Everything else planned
+   * the child as a list: `updateMany` and `deleteMany` **compiled**, and
+   * `update` / `delete` / `upsert` were refused for not looking like the
+   * to-many spelling rather than for being unimplemented on this shape.
+   *
+   * Prisma's to-one nested input, read off the generated client:
+   *
+   *     { create, connectOrCreate, upsert, disconnect, delete, connect, update }
+   *
+   * — no `createMany`, `set`, `updateMany` or `deleteMany` key at all.
+   *
+   * Walked as a table over both sides, because the two disagreeing *is* the
+   * defect and a one-sided test cannot see it.
+   */
+  describe("a to-one answers the same on both sides", () => {
+    beforeEach(() => {
+      registry.register("Profile", class { static $schema = profile });
+      registry.register("User", class { static $schema = userWithProfile });
+    });
+
+    const refuse = (relation: string, operand: Record<string, unknown>) => {
+      try {
+        compileWrite(
+          userWithProfile,
+          "update",
+          { where: { id: 1 }, data: { [relation]: operand } } as never,
+          sqlite,
+        );
+        return null;
+      } catch (error) {
+        return error as UnsupportedQueryError;
+      }
+    };
+
+    /**
+     * The four keys Prisma's to-one input does not have. Refused by name on
+     * both sides, with the same reason — `createMany` already was, the other
+     * three were the gap.
+     */
+    test.each([
+      ["set", { set: [{ id: 1 }] }],
+      ["updateMany", { updateMany: { where: {}, data: {} } }],
+      ["deleteMany", { deleteMany: {} }],
+      ["createMany", { createMany: { data: [{}] } }],
+    ])("%s is refused on both sides", (operand, value) => {
+      // `organization` — this row holds the key. `profile` — the child does.
+      for (const relation of ["organization", "profile"]) {
+        const error = refuse(relation, value);
+        expect(error, `${relation}.${operand} compiled`).not.toBeNull();
+        expect(error!.argument).toBe(`data.${relation}.${operand}`);
+        expect(error!.model).toBe("User");
+        expect(error!.message).toMatch(/is a to-one/);
+      }
+    });
+
+    /**
+     * The three that *are* on Prisma's to-one input. Not implemented on the
+     * foreign side — the point is that the refusal now says so, instead of
+     * blaming the operand's shape.
+     */
+    test.each([
+      ["update", { update: { bio: "y" } }],
+      ["delete", { delete: true }],
+      ["upsert", { upsert: { create: {}, update: {} } }],
+    ])("%s on the foreign side names the shape, not the spelling", (operand, value) => {
+      const error = refuse("profile", value);
+
+      expect(error).not.toBeNull();
+      expect(error!.argument).toBe(`data.profile.${operand}`);
+      expect(error!.message).toMatch(/foreign key lives on Profile/);
+      // The old refusals complained about the operand's spelling instead.
+      expect(error!.message).not.toMatch(/Expected an object/);
+    });
+
+    // The operands that work on this shape, so the refusals above are not
+    // simply "everything fails".
+    test.each([
+      ["create", { create: { bio: "x" } }],
+      ["connect", { connect: { userId: 1 } }],
+      ["connectOrCreate", { connectOrCreate: { where: { userId: 1 }, create: { bio: "x" } } }],
+    ])("%s still compiles on the foreign side", (_operand, value) => {
+      expect(refuse("profile", value)).toBeNull();
     });
   });
 

--- a/packages/gemi/orm/fixtures.ts
+++ b/packages/gemi/orm/fixtures.ts
@@ -766,6 +766,90 @@ export const bare: ModelSchema = {
   relations: {},
 };
 
+/**
+ * A one-to-one whose foreign key lives on the **child**, which nothing else
+ * here has:
+ *
+ *     model User    { profile Profile? }
+ *     model Profile { userId Int @unique
+ *                     user   User @relation(fields: [userId], references: [id]) }
+ *
+ * Every other to-one in these fixtures holds its own key, so `planForeignSide`
+ * was only ever reached with `kind: "many"` — and it has exactly one `kind`
+ * check, which is why every other operand treated the child as a list (#116).
+ *
+ * `userWithProfile` rather than adding the relation to `user`: the emitted
+ * column list is asserted verbatim in several tests, and a relation adds no
+ * column but the fixture is compared as a whole in others.
+ */
+export const profile: ModelSchema = {
+  name: "Profile",
+  table: "Profile",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    bio: {
+      name: "bio",
+      column: "bio",
+      type: "String",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    // Required and unique — that pairing is what makes the relation a to-one
+    // rather than a to-many, and `@unique` is what Prisma requires for it.
+    userId: {
+      name: "userId",
+      column: "userId",
+      type: "Int",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [["userId"]],
+  relations: {
+    user: {
+      name: "user",
+      model: "User",
+      kind: "one",
+      relationName: "ProfileToUser",
+      from: ["userId"],
+      to: ["id"],
+      nullable: false,
+    },
+  },
+};
+
+/**
+ * `user`, plus the far side of {@link profile} — `kind: "one"` with empty
+ * `from`/`to`, which is how the foreign side of any relation is spelled: the
+ * link is resolved through the child's opposing relation, not stated here.
+ */
+export const userWithProfile: ModelSchema = {
+  ...user,
+  relations: {
+    ...user.relations,
+    profile: {
+      name: "profile",
+      model: "Profile",
+      kind: "one",
+      relationName: "ProfileToUser",
+      from: [],
+      to: [],
+      nullable: true,
+    },
+  },
+};
+
 /** The full explicit column list `findMany` emits for `user`, unparameterised. */
 export const USER_COLUMNS =
   '"id", "publicId", "name", "email", "emailVerifiedAt", "verificationToken", ' +


### PR DESCRIPTION
Closes #116. Stacked on #115.

#114 found `nested-writes.ts:1156` unreached — a `relation.kind` guard whose comment claims it is reachable. It is, and chasing why nothing reached it turned up something larger.

`planForeignSide` contains **exactly one** `relation.kind` check: that one. The shape that reaches it is Prisma's one-to-one with the key on the child —

```prisma
model User    { profile Profile? }
model Profile { userId Int @unique   user User @relation(fields: [userId], references: [id]) }
```

— and **no fixture in the repo has it**, nor does any generated template model. So this side was only ever reached with `kind: "many"`, and being the only `kind` check, every other operand planned the child as a list.

## Measured

Built the shape and compiled every operand on both sides of a to-one:

| operand | owning (key here) | foreign (key on child) |
| --- | --- | --- |
| `create` / `connect` / `connectOrCreate` | compiles | compiles |
| `update` | compiles (bare data) | **refused** — "Expected an object with 'where' and 'data'" |
| `delete` | refused by name | **refused** — "Expected an object naming a unique field" |
| `upsert` | refused by name | **refused** — wants `{ where, create, update }` |
| `set` | refused by name | refused, but via `assertDisconnectable` |
| `createMany` | refused by name | refused by name — the one `kind` check |
| `updateMany` | refused by name | **compiles** |
| `deleteMany` | refused by name | **compiles** |

## What Prisma accepts

Read off the generated client (`@prisma/client` 6.19.2), not reasoned about:

```ts
export type UserUpdateOneWithoutAccountsNestedInput = {
  create?; connectOrCreate?; upsert?; disconnect?; delete?; connect?; update?
}
```

**No `createMany`, `set`, `updateMany` or `deleteMany` key at all** — the to-many input has all eleven. So the table splits in two:

**Accepts what Prisma rejects.** `updateMany` and `deleteMany` compiled. This is the half that can act rather than merely annoy, and it is the half `planOwningSide` already refuses by name — #107 did that work for one side and it was never done for the other. Now refused in the same words.

**Refuses what Prisma has, for the wrong reason.** `update`, `delete` and `upsert` were refused for not matching the to-many spelling, when the real answer is that the shape is unimplemented here. The refusal now names the shape. `set` is the same story with a subtler cause: it *did* refuse, but through `assertDisconnectable` — `'Profile.userId' is required` — which is true and beside the point. The walk asserts the reason rather than that something threw, so it catches that.

## The fixture

Its absence is the root cause, so it is added: `profile`, plus `userWithProfile` carrying the far side (`kind: "one"` with empty `from`/`to`, resolved through the child's opposing relation). Kept as a separate export rather than folded into `user`, because several tests assert `user`'s emitted column list verbatim.

## Tests

A table over **both sides**, because the two disagreeing is the defect and a one-sided test cannot see it — the same shape as #113's walk.

**Verified against the unfixed source: six of the ten cases fail**, and they are the six measured gaps. The four that pass are `createMany` (already refused) and the three operands that genuinely work, so the table is covering rather than padding.

## Reads are fine

Checked, and worth recording since the fixture now makes it testable: `include` plans on both batched and lateral, the relation plan carries `kind: "one"` so the shaper returns an object rather than an array, `where: { profile: { is / isNot } }` and `orderBy` compile, and `_count` on it is refused by name. The gap was writes only.

## Verification

- 1098 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 592 passed on SQLite, 857 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)