### PR TITLE
`divide`, the one arithmetic operator the differential never compared

### DIFF
--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -198,6 +198,24 @@ const CASES: Case[] = [
   ["update with multiply", "update", {
     where: { id: 3 }, data: { globalRole: { multiply: 3 } },
   }],
+  // `divide` was the one arithmetic operator the differential never compared,
+  // sitting in the table beside three that it did. It is also the one with an
+  // edge that behaves differently per dialect, hence the two cases below it.
+  ["update with divide", "update", {
+    where: { id: 1 }, data: { globalRole: { divide: 2 } },
+  }],
+  // An Int divided into a non-integer: whether the result truncates, rounds or
+  // becomes a float is a database question, and both clients have to answer it
+  // the same way.
+  ["update with divide leaving a remainder", "update", {
+    where: { id: 2 }, data: { globalRole: { divide: 3 } },
+  }],
+  // Division by zero: Postgres raises, SQLite yields null — and `globalRole` is
+  // not nullable, so the two dialects fail differently. Both clients still have
+  // to fail the *same* way as each other on whichever dialect is running.
+  ["update with divide by zero", "update", {
+    where: { id: 1 }, data: { globalRole: { divide: 0 } },
+  }],
   ["update matching nothing", "update", {
     where: { id: 99999 }, data: { name: "x" },
   }],


### PR DESCRIPTION
Closes #121. Stacked on #120.

#101 and #105 both survived because no differential case covered them, and both said so in as many words. Rather than keep noticing that after the fact, I measured what the harness actually compares — instrumenting `expectSame` and `expectSameWrite` to record model, operation and argument keys, then running both dialects.

## What the differential reaches

**98 distinct (model, operation, argument-key-set) combinations, across 15 operations and 7 models.**

| operation | distinct arg-key sets |
| --- | --- |
| `findMany` | 23 |
| `aggregate` | 15 |
| `groupBy` / `count` | 8 each |
| `findFirst` | 6 |
| `upsert` / `update` / `findUnique` / `delete` / `create` | 3 each |
| `updateMany` / `findUniqueOrThrow` / `createMany` | 2 each |
| `findFirstOrThrow` / `deleteMany` | 1 each |

Walking every key at every depth rather than only the top level:

- **all 12 `where` operators** — `contains`, `endsWith`, `equals`, `gt`, `gte`, `in`, `lt`, `lte`, `mode`, `not`, `notIn`, `startsWith`;
- all five relation filters (`some`, `every`, `none`, `is`, `isNot`), all three logical operators;
- every top-level read and write argument the ORM implements.

`cursor` and `distinct` never appear. **That is correct, not a gap** — both are in `PERMANENTLY_REFUSED` with measured justifications, so there is nothing to compare: gemi refuses where Prisma accepts, by decision. I checked rather than assuming they were an oversight.

## The gap

`ARITHMETIC` declares four operators. The differential table had cases for `increment`, `decrement` and `multiply` on consecutive lines — and none for `divide`.

It is also the one of the four whose edges are dialect-dependent:

- **division by zero** — Postgres raises `division_by_zero`, SQLite yields `null`, and `globalRole` is not nullable, so the two dialects fail in different ways;
- **a remainder** — whether an `Int` divided into a non-integer truncates, rounds, or becomes a float is the database's answer, not the ORM's.

## Measured

Three cases: plain, with a remainder, and by zero.

**They pass on both dialects.** gemi and Prisma agree throughout, including the by-zero case, on SQLite and Postgres 16 alike. No defect — worth saying plainly rather than implying a find.

What changes is that the last uncovered arithmetic operator is covered, and that the differential's reach is a measured fact rather than an assumption. The measurement is the artifact here; the gap it turned up was small, which is itself the useful result.

## Verification

- Template suite: 595 passed on SQLite, 860 on Postgres 16 (up 3 on each — the new cases).
- `tsc --noEmit` and `oxlint` unchanged and clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)