### PR TITLE
Invariant 6, asserted on the artifact that carries it

### DIFF
--- a/templates/saas-starter/app/models/generated.test.ts
+++ b/templates/saas-starter/app/models/generated.test.ts
@@ -28,6 +28,91 @@ describe("the gemi ORM generator", () => {
     }
   });
 
+  /**
+   * **Invariant 6: the generated files hold data and strings, with no import
+   * graph.**
+   *
+   * `plans/orm/README.md`: the generated schema references relations by model
+   * *name*, and the registry resolves name to class at call time, never at
+   * module load. Without that, `User.ts` imports `Post.ts` imports `User.ts`,
+   * and under ESM one of them is `undefined` during module evaluation — the
+   * classic ORM bootstrap failure, which appears the moment two models
+   * reference each other.
+   *
+   * The invariant is preserved by the *generator*, so the artifact is where it
+   * has to be asserted. It is also the kind of thing that would be broken by an
+   * obvious-looking improvement: emitting `import { PostModel } from "./Post"`
+   * beside a relation reads as more type-safe and reintroduces the cycle.
+   */
+  describe("the artifact has no import graph", () => {
+    const source = (file: string) => readFileSync(join(GENERATED, file), "utf8");
+    const importsOf = (file: string) =>
+      [...source(file).matchAll(/^\s*import\s+(type\s+)?[^;]*?from\s+"([^"]+)"/gm)].map(
+        (match) => ({ typeOnly: Boolean(match[1]), from: match[2] }),
+      );
+
+    /**
+     * The schema is the data half, and it is the one that carries relations —
+     * so it is the file a cycle would appear in first. Types only: erased at
+     * build, no runtime edge.
+     */
+    test("schema.ts imports nothing at runtime", () => {
+      const runtime = importsOf("schema.ts").filter((entry) => !entry.typeOnly);
+      expect(runtime).toEqual([]);
+    });
+
+    /** ...and it names its relation targets as strings rather than values. */
+    test("schema.ts references models by name", () => {
+      const schema = source("schema.ts");
+
+      // Emitted as JSON, so the key is quoted — matched either way so a
+      // change of emitter style does not read as a broken invariant.
+      expect(schema).toMatch(/"?model"?:\s*"User"/);
+      expect(schema).toMatch(/"?model"?:\s*"Post"/);
+      // A relation naming a *class* rather than a string would be the cycle
+      // arriving: `"model": UserModel` instead of `"model": "User"`.
+      expect(schema).not.toMatch(/"?model"?:\s*[A-Za-z_$]/);
+    });
+
+    /**
+     * No generated file may import another model's module. `models.ts` holding
+     * every class in one file is what makes that easy — and is itself part of
+     * the answer, since eleven separate files would each need the others.
+     */
+    test("no generated file imports a model module", () => {
+      for (const file of FILES) {
+        const local = importsOf(file)
+          .map((entry) => entry.from)
+          .filter((from) => from.startsWith("."));
+
+        // `./schema` and `./models` only — never a per-model module.
+        expect(local.sort(), `${file} imports ${local.join(", ")}`).toEqual(
+          local.filter((from) => from === "./schema" || from === "./models").sort(),
+        );
+      }
+    });
+
+    /**
+     * Registration is by name and happens in `index.ts`, once, for every model
+     * — so importing the generated index is the whole bootstrap.
+     */
+    test("every model class is registered by name", () => {
+      const models = source("models.ts");
+      const index = source("index.ts");
+
+      const declared = [...models.matchAll(/^export class (\w+)Model\b/gm)].map(
+        (match) => match[1],
+      );
+      expect(declared.length).toBeGreaterThan(5);
+
+      for (const name of declared) {
+        expect(index, `${name} is declared but never registered`).toContain(
+          `register("${name}", ${name}Model)`,
+        );
+      }
+    });
+  });
+
   test(
     "running prisma generate again produces a zero-line diff",
     { timeout: 120_000 },


### PR DESCRIPTION
Closes #131. Stacked on #130.

#127 and #129 covered invariants 1–4. Invariant 6 is the last structural one, and the only one whose enforcement lives in a **different package** from the rule.

> Generated schema references relations by model **name**. The registry resolves name → class at call time, never at module load. Without this, `User.ts` imports `Post.ts` imports `User.ts`, and under ESM one of them is `undefined` during module evaluation — the classic ORM bootstrap failure, and it appears the moment two models reference each other.

## It holds

| claim | state |
| --- | --- |
| `schema.ts` has no runtime import | one `import type { ModelSchema }`, erased at build |
| relations name a model by string | `"model": "Organization"` |
| no generated file imports a model module | `models.ts` → `./schema`; `index.ts` → `./models`; nothing else local |
| resolution is at call time | every `registry.has`/`registry.get` in `orm/` sits inside a function |
| template models do not import each other | `User.ts` imports `./generated` only |

## Why `generated.test.ts` could not already cover it

Its "running prisma generate again produces a zero-line diff" test catches a **hand-edit** to the artifact, because regenerating overwrites it.

It does **not** catch a violation introduced in the *generator*. That regenerates consistently — the diff stays zero, the test passes, and every model file has grown an import edge. That distinction is the whole reason these assertions are worth having, and it is visible in the verification below: each hand-edit trips both the new test and the diff test, but only the new one would survive the violation being real.

It is also the kind of invariant an obvious-looking improvement breaks. Emitting

```ts
import { PostModel } from "./Post";
relations: { posts: { model: PostModel } }
```

reads as *more* type-safe than a bare string. It is the cycle arriving.

## One more assertion

Every class `models.ts` declares is registered by `index.ts`. A generated-but-unregistered model fails later and elsewhere — from the relation planner, as `UnregisteredRelationTargetError`, which reads like a stale artifact rather than a generator that skipped one.

## A correction while writing it

My first version matched `model: "User"`. The artifact is emitted as JSON, so the key is quoted — `"model": "User"`. Now matched against both styles, so changing the emitter's formatting does not read as a broken invariant.

## Verification

| violation | caught by |
| --- | --- |
| a runtime import in `schema.ts` | "schema.ts imports nothing at runtime" |
| `"model": OrganizationModel` instead of a string | "schema.ts references models by name" |
| a declared model missing from `index.ts` | "every model class is registered by name" |

- 1182 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 599 passed on SQLite, 864 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)