### PR TITLE
`track`'s relationKeys parameter never changed the outcome

### DIFF
--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -304,7 +304,7 @@ export abstract class Model {
     Object.assign(instance, row);
     // Tracked on the instance, not the argument — `save()` on the instance has
     // to diff against the values it was constructed from.
-    track(instance, schema, []);
+    track(instance, schema);
 
     return instance;
   }
@@ -905,8 +905,7 @@ export abstract class Model {
       // override gets provenance for free — which is the same argument that put
       // everything else in `$exec`.
       if (options?.track === true) {
-        const relationKeys = (plan.relations ?? []).map((relation) => relation.as);
-        for (const row of rowsOf(result)) track(row, schema, relationKeys);
+        for (const row of rowsOf(result)) track(row, schema);
       }
 
       return result;

--- a/packages/gemi/orm/provenance.test.ts
+++ b/packages/gemi/orm/provenance.test.ts
@@ -22,14 +22,14 @@ describe("what gets snapshotted", () => {
   test("only the fields actually present on the row", () => {
     // A partial select: the row has two of the model's fields.
     const row = { id: 1, email: "a@b.c" };
-    track(row, user, []);
+    track(row, user);
 
     expect(provenanceOf(row)?.snapshot).toEqual({ id: 1, email: "a@b.c" });
   });
 
   test("the primary key is captured separately, at fetch time", () => {
     const row = { id: 7, email: "a@b.c" };
-    track(row, user, []);
+    track(row, user);
 
     // Captured rather than read at save time, so mutating `id` cannot move the
     // row a save targets — it would otherwise update a different record.
@@ -37,24 +37,52 @@ describe("what gets snapshotted", () => {
     expect(provenanceOf(row)?.key).toEqual({ id: 7 });
   });
 
-  test("relation keys are excluded", () => {
-    const row = { id: 1, email: "a@b.c", accounts: [] as unknown[] };
-    track(row, user, ["accounts"]);
+  /**
+   * An attached relation never enters the snapshot, because it is not one of
+   * the schema's fields — which is the *only* thing that excludes it.
+   *
+   * This test used to pass `["accounts"]` as a `relationKeys` argument and read
+   * as though that was what excluded it. It was not: the argument never changed
+   * the outcome, and the test passed identically with `[]`. The parameter is
+   * gone; the cases below are what the exclusion actually rests on, so they
+   * cover every shape a relation read attaches rather than one.
+   */
+  test.each([
+    ["a to-many array", { accounts: [] as unknown[] }],
+    ["a to-one object", { organization: { id: 3 } }],
+    ["a relation count", { _count: { accounts: 1 } }],
+    ["all three at once", { accounts: [{ id: 9 }], organization: { id: 3 }, _count: { accounts: 1 } }],
+  ])("%s is excluded from the snapshot", (_label, attached) => {
+    const row = { id: 1, email: "a@b.c", ...attached };
+    track(row, user);
 
-    // An attached child array in the snapshot would make every save look dirty,
-    // since the relation loader replaces it.
     expect(provenanceOf(row)?.snapshot).toEqual({ id: 1, email: "a@b.c" });
+  });
+
+  /**
+   * ...and the mechanism, stated directly: no relation can be a field, so the
+   * field check is sufficient on its own. Prisma enforces this — a model cannot
+   * declare a scalar and a relation under one name — and it is the assumption
+   * the removal rests on.
+   */
+  test("no relation name is also a field name", () => {
+    for (const schema of [user, organization]) {
+      const overlap = Object.keys(schema.relations ?? {}).filter(
+        (name) => name in schema.fields,
+      );
+      expect(overlap, `${schema.name} declares both`).toEqual([]);
+    }
   });
 
   test("keys that are not fields are ignored", () => {
     const row = { id: 1, notAField: true };
-    track(row, user, []);
+    track(row, user);
     expect(provenanceOf(row)?.snapshot).toEqual({ id: 1 });
   });
 
   test("the model name is recorded", () => {
     const row = { id: 1 };
-    track(row, organization, []);
+    track(row, organization);
     expect(provenanceOf(row)?.model).toBe("Organization");
   });
 });
@@ -62,13 +90,13 @@ describe("what gets snapshotted", () => {
 describe("what counts as changed", () => {
   test("an untouched row has no changes", () => {
     const row = { id: 1, email: "a@b.c", name: "A" };
-    track(row, user, []);
+    track(row, user);
     expect(changedFields(row, user)).toEqual({});
   });
 
   test("only the mutated field", () => {
     const row: any = { id: 1, email: "a@b.c", name: "A" };
-    track(row, user, []);
+    track(row, user);
     row.name = "B";
 
     expect(changedFields(row, user)).toEqual({ name: "B" });
@@ -76,7 +104,7 @@ describe("what counts as changed", () => {
 
   test("setting a field back to its fetched value is not a change", () => {
     const row: any = { id: 1, name: "A" };
-    track(row, user, []);
+    track(row, user);
     row.name = "B";
     row.name = "A";
 
@@ -85,7 +113,7 @@ describe("what counts as changed", () => {
 
   test("null and undefined are distinguished from a value", () => {
     const row: any = { id: 1, name: "A", deletedAt: null };
-    track(row, user, []);
+    track(row, user);
     row.name = null;
 
     expect(changedFields(row, user)).toEqual({ name: null });
@@ -99,7 +127,7 @@ describe("what counts as changed", () => {
    */
   test("a Date is compared by instant, not by reference", () => {
     const row: any = { id: 1, createdAt: new Date("2024-01-01T00:00:00Z") };
-    track(row, user, []);
+    track(row, user);
 
     row.createdAt = new Date("2024-01-01T00:00:00Z");
     expect(changedFields(row, user)).toEqual({});
@@ -119,7 +147,7 @@ describe("what counts as changed", () => {
    */
   test("assigning to a field the row never fetched is refused", () => {
     const row: any = { id: 1, email: "a@b.c" };
-    track(row, user, []);
+    track(row, user);
     row.password = "hunter2";
 
     expect(() => changedFields(row, user)).toThrow(/was not fetched/);
@@ -130,7 +158,7 @@ describe("what counts as changed", () => {
     // The legal half of the same situation: a partial row that only touches what
     // it read. `password` is simply absent, so there is nothing to refuse.
     const row: any = { id: 1, email: "a@b.c" };
-    track(row, user, []);
+    track(row, user);
     row.email = "changed@b.c";
 
     expect(changedFields(row, user)).toEqual({ email: "changed@b.c" });
@@ -152,7 +180,7 @@ describe("identity semantics", () => {
    */
   test("a spread copy carries no provenance", () => {
     const row = { id: 1, email: "a@b.c" };
-    track(row, user, []);
+    track(row, user);
 
     expect(isTracked(row)).toBe(true);
     expect(isTracked({ ...row })).toBe(false);
@@ -160,7 +188,7 @@ describe("identity semantics", () => {
 
   test("a JSON round trip carries no provenance", () => {
     const row = { id: 1, email: "a@b.c" };
-    track(row, user, []);
+    track(row, user);
     expect(isTracked(JSON.parse(JSON.stringify(row)))).toBe(false);
   });
 
@@ -174,8 +202,8 @@ describe("identity semantics", () => {
   test("two rows tracked separately do not share a snapshot", () => {
     const a: any = { id: 1, name: "A" };
     const b: any = { id: 2, name: "B" };
-    track(a, user, []);
-    track(b, user, []);
+    track(a, user);
+    track(b, user);
 
     a.name = "changed";
     expect(changedFields(a, user)).toEqual({ name: "changed" });
@@ -186,7 +214,7 @@ describe("identity semantics", () => {
 describe("resnapshot", () => {
   test("a second save of the same row is a no-op", () => {
     const row: any = { id: 1, name: "A" };
-    track(row, user, []);
+    track(row, user);
     row.name = "B";
 
     const changed = changedFields(row, user);
@@ -198,7 +226,7 @@ describe("resnapshot", () => {
 
   test("only the written fields are resnapshotted", () => {
     const row: any = { id: 1, name: "A", locale: "en-US" };
-    track(row, user, []);
+    track(row, user);
     row.name = "B";
     row.locale = "en-GB";
 

--- a/packages/gemi/orm/provenance.ts
+++ b/packages/gemi/orm/provenance.ts
@@ -53,20 +53,25 @@ const provenance = new WeakMap<object, Provenance>();
  * means structural comparison per row per field, which is exactly the per-row
  * cost this feature is trying to keep off the default path.
  */
-export function track(
-  row: object,
-  schema: ModelSchema,
-  relationKeys: readonly string[],
-): void {
+export function track(row: object, schema: ModelSchema): void {
   const snapshot: Record<string, unknown> = {};
   const key: Record<string, unknown> = {};
   const source = row as Record<string, unknown>;
-  const skip = new Set(relationKeys);
 
   for (const name of Object.keys(source)) {
-    // Relations are not this row's columns to write, and an attached child array
-    // in a snapshot would make every `save` look dirty.
-    if (skip.has(name)) continue;
+    // The schema's own columns and nothing else. That covers the two things a
+    // shaped row carries besides them — an attached relation, and a `_count` —
+    // because neither is a field, and Prisma will not let a relation share a
+    // name with one.
+    //
+    // This used to take a `relationKeys` list and skip those first. It never
+    // changed the outcome: every name it excluded was excluded again on the
+    // next line. What it did do was make the two call sites look like they
+    // disagreed — `wrap` passed `[]`, `$exec` passed the plan's relations — and
+    // give the reason for the exclusion to a line that was not performing it.
+    // An attached child array in a snapshot would make every `save` look dirty,
+    // since the relation loader replaces it; this is the line that prevents
+    // that.
     if (!(name in schema.fields)) continue;
     snapshot[name] = source[name];
   }


### PR DESCRIPTION
Closes #133. Stacked on #132.

Invariant 5 was the last of the six I had not looked at. **It holds** — provenance is off by default (`options?.track === true`, strict equality) and `ActiveRecordModel` is the per-model half, since it hydrates through `Model.wrap`, which tracks. Looking at it turned up something adjacent.

## The parameter does nothing

```ts
const skip = new Set(relationKeys);
for (const name of Object.keys(source)) {
  // Relations are not this row's columns to write, and an attached child array
  // in a snapshot would make every `save` look dirty.
  if (skip.has(name)) continue;
  if (!(name in schema.fields)) continue;
  snapshot[name] = source[name];
}
```

**Every name `skip` excludes is excluded again on the next line.** A relation is never a field — Prisma will not let a model declare a scalar and a relation under one name — so the second check subsumes the first entirely.

Measured: a row carrying `accounts`, `organization` and `_count` snapshots byte-identically with the relation keys passed and with `[]`.

## What it cost

Legibility, twice.

**The two call sites looked like they disagreed.** `Model.wrap` passed `[]`; `$exec` passed `plan.relations.map(r => r.as)`. A reader comparing them would reasonably conclude an instance from `wrap` is snapshotted differently from one from a query — and specifically that `wrap` had forgotten something. Neither is true.

**The reason sat on the wrong line.** The comment explaining why relations must stay out of a snapshot was attached to the `skip` check rather than to the field check that actually enforces it.

## The test was vacuous

```ts
test("relation keys are excluded", () => {
  const row = { id: 1, email: "a@b.c", accounts: [] as unknown[] };
  track(row, user, ["accounts"]);
  expect(provenanceOf(row)?.snapshot).toEqual({ id: 1, email: "a@b.c" });
});
```

Changing `["accounts"]` to `[]` — **it still passes.** The test named after the parameter never exercised it; the one immediately below covers the real mechanism.

Fourth vacuous test found in this series, after #96, #106 and #123.

## The change

- Parameter removed; the reason moved onto the field check that performs the exclusion.
- The test replaced by one over **every shape a relation read attaches** — a to-many array, a to-one object, a `_count`, and all three at once — rather than the single array it used.
- A test stating the assumption the removal rests on: no relation name is also a field name.

`track` is exported from `orm/index.ts`, so this changes a public signature. Worth stating plainly, though the argument it drops was inert.

## Verification

Deleting the field check fails **all four** new cases. The old test would have kept passing, on the strength of an argument that did nothing.

- 1186 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 599 passed on SQLite, 864 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)