### PR TITLE
The orderBy list branch, and a correction to #135's method

### DIFF
--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -820,6 +820,86 @@ describe("applyNestedPolicies", () => {
     expect(out.orderBy.accounts).toEqual({ _count: "asc", where: seen });
   });
 
+  /**
+   * The **array** form of `orderBy`, which Prisma accepts and nothing covered.
+   *
+   * `scopeRelationOrderings` takes a list through its own branch, and neither
+   * suite entered it: mutating that branch's `changed` comparison left both
+   * green (#135).
+   *
+   * I expected the flag to be load-bearing and it is not — measured, because
+   * the first version of this comment claimed a scope could be dropped. Under
+   * the inversion the entries still come back scoped; what changes is only
+   * whether the array is rebuilt. So the flag is an allocation choice, and the
+   * two tests below split accordingly: this one pins that every entry is
+   * scoped, and the next pins the flag itself.
+   *
+   * Two entries, so the branch is exercised as a list rather than a
+   * single-element special case, and one of them a plain column so an untouched
+   * entry is asserted to come through intact.
+   */
+  test("every entry of an orderBy list is scoped, not just the object form", () => {
+    const reportsOperation: ModelPolicy = {
+      scope: (context) => ({ seenOperation: context.operation }),
+    };
+
+    const out = applyNestedPolicies(
+      {
+        relations: {
+          accounts: { model: "Account", kind: "many" as const },
+          posts: { model: "Post", kind: "many" as const },
+        },
+      },
+      {
+        orderBy: [
+          { name: "asc" },
+          { accounts: { _count: "asc" } },
+          { posts: { _count: "desc" } },
+        ],
+      },
+      USER,
+      false,
+      (model: string) =>
+        model === "Account" || model === "Post"
+          ? {
+              policies: [reportsOperation],
+              schema: { name: model, relations: {} },
+            }
+          : undefined,
+    );
+
+    const seen = { seenOperation: "findMany" };
+    expect(out.orderBy).toEqual([
+      // A plain column is not a relation and is returned untouched.
+      { name: "asc" },
+      { accounts: { _count: "asc", where: seen } },
+      { posts: { _count: "desc", where: seen } },
+    ]);
+  });
+
+  /**
+   * ...and a list whose entries name no policied relation is returned **as it
+   * was**, rather than as an equal copy.
+   *
+   * This is the assertion that kills the mutant. The `changed` flag exists so
+   * that an array nothing rewrote is not rebuilt per query, and identity is the
+   * only thing that can see that — `toEqual` passes either way, which is
+   * exactly why the branch went uncovered.
+   */
+  test("an orderBy list with nothing to scope is not rebuilt", () => {
+    const orderBy = [{ name: "asc" }, { email: "desc" }];
+
+    const out = applyNestedPolicies(
+      { relations: { accounts: { model: "Account", kind: "many" as const } } },
+      { orderBy },
+      USER,
+      false,
+      () => undefined,
+    );
+
+    expect(out.orderBy).toBe(orderBy);
+  });
+
   test("an unregistered relation target is left for the planner to report", () => {
     const args = { include: { unknown: true } };
     const out = applyNestedPolicies(


### PR DESCRIPTION
Closes #137. Stacked on #136.

Continues #135, which left `policy.ts`'s survivors untriaged — and **corrects its method**.

## The method was wrong, and the number with it

#135's harness ran only `vitest run orm`. Policy behaviour is largely asserted in the **template's** suite, so a mutant surviving the unit run was not yet evidence of anything, and I reported it as though it were.

Re-checked all 20 `policy.ts` survivors against both suites:

| | count |
| --- | --- |
| survive both suites | **16** |
| killed by the template suite alone | **4** |

The clearest of the four is `isPreScoped`'s `[PRE_SCOPED] === true`. Inverting it makes every ordinary query read as pre-scoped and skip its policies — unit suite green, template suite **15 failures**.

A survivor list is exactly the kind of artifact that gets mistaken for a defect list, so the correction is on #135 as well as here.

## The one worth acting on

`scopeRelationOrderings` takes an **array** `orderBy` through its own branch, and neither suite entered it. Prisma accepts `orderBy: [{ a: "asc" }, { b: "desc" }]`; `policy.test.ts` covered only the object form.

## A claim I withdrew while writing it

My first reading was that inverting that branch's `if (scoped !== entry) changed = true` would discard the scope and return the unscoped ordering — an information leak, since ordering by an unscoped relation count ranks rows by a number computed over rows the caller cannot see.

**Measured, and that is not what happens.** Under the inversion the entries still come back scoped; the only difference is whether the array is rebuilt. The flag is an allocation choice, not a correctness guard.

I went looking for the leak, instrumented the branch to confirm it was even entered, and found the returned value identical either way. The comment in the test now says that, rather than the more dramatic version I first wrote.

The mutant is still worth killing — an uncovered branch is an uncovered branch — but by the assertion that can actually see it. `toEqual` passes either way; only **identity** distinguishes "returned as it was" from "rebuilt equal", which is precisely why the branch stayed uncovered.

## The tests

- every entry of a list is scoped, with a plain column passing through untouched and two entries so the branch is not exercised as a single-element special case;
- the `changed` flag pinned by identity — this is the one that kills the mutant.

The other 15 survivors are left open, with the corrected method recorded so the next pass re-checks against both suites first.

- 1203 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 599 passed on SQLite, 864 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)