### PR TITLE
The policy layer's malformed-input passthrough, which nothing asserted

### DIFF
--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -900,6 +900,69 @@ describe("applyNestedPolicies", () => {
     expect(out.orderBy).toBe(orderBy);
   });
 
+  /**
+   * **A malformed nested argument is left alone for the compiler to report.**
+   *
+   * The rule is stated in `scopeRelationOrderings` — "Malformed, and the
+   * compiler reports it with the message it has" — and repeated as a guard at
+   * six other places: the include walk, the `_count` walk, its `select`, the
+   * ordering walk, and two `undefined`/`false` skips.
+   *
+   * Nothing tested any of them. Every one of those guards could have its `||`
+   * turned into an `&&` with both suites still green (#137), and under that
+   * change the policy layer walks into an array where it expects a node — so
+   * the caller gets whatever that produces instead of the compiler's precise
+   * refusal. This repo has fixed that shape of failure repeatedly (#101, #107):
+   * an error that names the wrong thing sends the reader to a query they did
+   * not write.
+   *
+   * Asserted as passthrough rather than by catching an error, because the
+   * policy layer's job here is to do *nothing* — the refusal is the compiler's
+   * to make, and asserting on it here would move the contract.
+   */
+  describe("a malformed nested argument is passed through untouched", () => {
+    const scopes: ModelPolicy = { scope: () => ({ tenant: 1 }) };
+
+    const walk = (args: unknown) =>
+      applyNestedPolicies(
+        { relations: { accounts: { model: "Account", kind: "many" as const } } },
+        args as never,
+        USER,
+        false,
+        (model: string) =>
+          model === "Account"
+            ? { policies: [scopes], schema: { name: "Account", relations: {} } }
+            : undefined,
+      );
+
+    test.each([
+      ["an include node that is an array", { include: { accounts: [] } }],
+      ["an include node that is a number", { include: { accounts: 5 } }],
+      ["an include node that is a string", { include: { accounts: "yes" } }],
+      ["an orderBy node that is an array", { orderBy: { accounts: [] } }],
+      ["an orderBy node that is a number", { orderBy: { accounts: 5 } }],
+      ["a _count that is an array", { include: { _count: [] } }],
+      ["a counted relation that is an array", { include: { _count: { select: { accounts: [] } } } }],
+    ])("%s", (_label, args) => {
+      // Deep equality, not identity: the walk may copy the surrounding object
+      // on its way past. What must not change is the malformed node itself.
+      expect(walk(args)).toEqual(args);
+    });
+
+    /**
+     * `false` and `undefined` are not malformed — they are Prisma's way of
+     * saying "not this relation" — and they are skipped by a different guard
+     * that was equally untested. Same assertion, different reason, so they are
+     * named apart rather than folded into the table above.
+     */
+    test.each([
+      ["false", { include: { accounts: false } }],
+      ["undefined", { include: { accounts: undefined } }],
+    ])("an include node that is %s is skipped, not scoped", (_label, args) => {
+      expect(walk(args)).toEqual(args);
+    });
+  });
+
   test("an unregistered relation target is left for the planner to report", () => {
     const args = { include: { unknown: true } };
     const out = applyNestedPolicies(


### PR DESCRIPTION
Closes #139. Stacked on #138.

Continues #137, which left 15 `policy.ts` mutants surviving both suites.

## The contract

`scopeRelationOrderings` states it:

> Malformed, and the compiler reports it with the message it has.

The policy layer runs **before** the compiler, so when it meets a nested argument that is not the shape it expects — an array where a node belongs, a number, a string — its job is to do **nothing** and let the compiler produce the refusal. The same guard appears at seven places: the include walk, the ordering walk, the `_count` walk, its `select`, and two `undefined`/`false` skips.

None of them was tested. Every one could have its `||` turned into an `&&` with both suites green.

Under that change the policy layer walks into an array where it expects a node, and the caller gets whatever that produces instead of the compiler's refusal. That is the shape of failure #101 and #107 both fixed: an error naming a query the reader did not write.

## Measured — and most of the survivors are equivalent

Nine malformed shapes, all confirmed to pass through unchanged. Then each of the 15 survivors re-tested against the new assertions:

| | count |
| --- | --- |
| real gaps, now killed | **3** — the include walk, the ordering node, `_count.select` |
| equivalent mutants | the remaining 12 |

The equivalent ones are guards **subsumed by a later check** — the same pattern as `select.ts:28` (#115) and `provenanceOf`'s null guard (#135). `scopeCounts`'s is the clearest: inverting it lets an array through, but the loop that follows does `Object.keys([])`, finds no relation, and returns the node untouched.

Verified rather than argued — `{ _count: [] }` and `{ _count: [1, 2] }` produce byte-identical results mutated and unmutated.

**That is worth recording as a rate.** On this file most surviving mutants are not coverage gaps — the second time in three passes that the survivor list has been mostly questions rather than answers. It is the main cost of the technique and the thing to say out loud when reporting one.

## The tests

- A table over the malformed shapes each guard handles, asserted as **passthrough**. Not by catching an error: the refusal belongs to the compiler, and asserting on it here would move the contract.
- `false` and `undefined` named apart from the malformed cases — they are Prisma's way of saying "not this relation", not a mistake, and a different guard skips them.
- Deep equality rather than identity, since the walk may copy the surrounding object on its way past; what must not change is the malformed node.

## Verification

- 1212 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 599 passed on SQLite, 864 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)