### PR TITLE
The two shapers were asserted to succeed alike, never to fail alike

### DIFF
--- a/packages/gemi/orm/shape.test.ts
+++ b/packages/gemi/orm/shape.test.ts
@@ -4,11 +4,13 @@ import { afterEach, describe, expect, test } from "vitest";
 import { PostgresDialect } from "./dialect/postgres";
 import { SqliteDialect } from "./dialect/sqlite";
 import { mapped, reading, user } from "./fixtures";
+import type { FieldSchema } from "./schema";
 import {
   buildInterpretedShaper,
   buildRowShaper,
   setShaperCompilation,
   shaperCompilationAvailable,
+  type RowShaper,
   type ShapedRelation,
 } from "./shape";
 
@@ -159,6 +161,22 @@ describe("compiled and interpreted shapers agree", () => {
         },
       ],
     ],
+    // ...and the same shape on sqlite, where `Bytes` has no decode branch at
+    // all and falls through. The table covered it on postgres only, so a
+    // divergence confined to the passthrough side would not have shown.
+    [
+      "reading with bytes, sqlite",
+      reading,
+      sqlite,
+      [
+        {
+          id: 1,
+          at: 1_717_200_000_000,
+          digest: new Uint8Array([1, 2, 3]),
+          value: 1.5,
+        },
+      ],
+    ],
     ["a row missing every optional column", user, sqlite, [{ id: 1 }]],
     ["no rows at all", user, sqlite, []],
   ];
@@ -174,6 +192,55 @@ describe("compiled and interpreted shapers agree", () => {
     expect(JSON.stringify(compiled(rows), stable)).toBe(
       JSON.stringify(interpreted(rows), stable),
     );
+  });
+
+  /**
+   * **The two shapers have to fail alike, not only succeed alike.**
+   *
+   * The table above compares output, which says nothing about a row the
+   * decoders refuse. `DecodeError` is raised from inside `dialect.decode`, and
+   * the compiled shaper *inlines* what the interpreted one calls — so a
+   * divergence here would be one path throwing while the other returned
+   * something plausible, on exactly the malformed input that made it matter.
+   *
+   * That is the same lesson the differential harness already carries: it
+   * compares failure *kind* rather than only values, because two clients that
+   * agree when things work and disagree when they do not have not been shown
+   * to agree.
+   *
+   * All three decoders that can refuse are covered on both dialects — `BigInt`
+   * (`BigInt(3.5)` throws a RangeError), `Json` (unparseable), and `DateTime`.
+   */
+  describe("both shapers fail alike", () => {
+    const outcome = (shaper: RowShaper, rows: unknown[]) => {
+      try {
+        return {
+          threw: false,
+          value: JSON.stringify(shaper(rows), (_key, value) =>
+            typeof value === "bigint" ? `${value}n` : value,
+          ),
+        };
+      } catch (error) {
+        return { threw: true, value: (error as Error).constructor.name };
+      }
+    };
+
+    test.each([
+      ["a BigInt that is not an integer", "sqlite", sqlite, { size: 3.5 }],
+      ["a BigInt that is not an integer", "postgres", postgres, { size: 3.5 }],
+      ["a Json that will not parse", "sqlite", sqlite, { payload: "{not json" }],
+      ["a Json that will not parse", "postgres", postgres, { payload: "{not json" }],
+      ["a DateTime that is not one", "sqlite", sqlite, { occurred_at: "not a date" }],
+      ["a DateTime that is not one", "postgres", postgres, { occurred_at: "not a date" }],
+    ])("%s, %s", (_label, _dialectName, dialect, bad) => {
+      const fields = Object.values(mapped.fields) as FieldSchema[];
+      const rows = [{ id: 1, ...bad }];
+
+      const compiled = outcome(buildRowShaper(fields, dialect), rows);
+      const interpreted = outcome(buildInterpretedShaper(fields, dialect), rows);
+
+      expect(compiled).toEqual(interpreted);
+    });
   });
 
   const relations: ShapedRelation[] = [


### PR DESCRIPTION
Closes #141. Stacked on #140.

`shape.ts` keeps two implementations of one thing, and says what protects them:

> Exported because the two implementations must produce *identical* output, and a test can only assert that if it can obtain both. **That test is what stands between this optimisation and a shape divergence visible only in production.**

That test exists and is good — a table of row shapes across both dialects, compared by deep equality *and* by `JSON.stringify` so key **order** is pinned too, plus the relation cases and the aliasing hazard.

## What it does not do

It only ever compares **successful output**.

`DecodeError` is raised from inside `dialect.decode`, and the compiled shaper **inlines** what the interpreted one calls — a generated `d.decode(row[3], f[3])` against a closure calling the same method. A divergence there is one path throwing while the other returns something plausible, on exactly the malformed input that made it matter.

The repo already carries this lesson: `differential.ts` compares failure *kind* rather than only values, because two clients that agree when things work and disagree when they do not have not been shown to agree. The same argument applies here and had not been applied. Three decoders can refuse — `BigInt` (`BigInt(3.5)` throws a RangeError), `Json` (unparseable), `DateTime` — and none was compared across the two paths, on either dialect.

## A dialect gap in the existing table

`reading` — the fixture carrying `Bytes` — was in the table for **postgres only**. On SQLite `Bytes` has no decode branch at all and falls through untouched, so a divergence confined to the passthrough side would not have shown. Added.

## Measured

**No divergence.** All seven cases agree today, on both dialects. The assertions were absent, not the behaviour.

## Sensitivity, in both directions

An equivalence test is worthless if it cannot see one side break, so I broke each:

| break | result |
| --- | --- |
| the **compiled** shaper stops decoding | 5 existing cases fail |
| the **interpreted** shaper stops decoding | 4 existing cases fail, **plus the new failure cases** |

The second row is the point. With only the old table, breaking the interpreted path is caught as an *output* difference; the new cases catch it as a **failure divergence** — the specific thing that otherwise reaches production as "it throws on my machine".

- 1219 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 599 passed on SQLite, 864 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)