### PR TITLE
Postgres had no identifier-quoting or placeholder test

### DIFF
--- a/packages/gemi/orm/dialect/postgres.test.ts
+++ b/packages/gemi/orm/dialect/postgres.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from "vitest";
 import { user } from "../fixtures";
 import { compileRead } from "../compile/read";
 import { PostgresDialect } from "./postgres";
+import { SqliteDialect } from "./sqlite";
 
 const postgres = new PostgresDialect();
+const sqlite = new SqliteDialect();
 
 /**
  * The array parameter behind `= any($1)`.
@@ -24,6 +26,60 @@ function literal(values: unknown[]): unknown {
   const fragment = postgres.inList('"x"', false, values.length, () => values);
   return fragment.binders[0](undefined);
 }
+
+/**
+ * Identifier quoting and placeholder numbering — the block `sqlite.test.ts` has
+ * had and this file did not.
+ *
+ * The asymmetry mattered in a specific way. SQLite's version asserts the NUL
+ * refusal and says why: NUL is the parameter sentinel in `compile/fragment.ts`,
+ * so it is "the one character that could shift a placeholder's position rather
+ * than merely produce broken SQL", and it is asserted "so the invariant is
+ * unconditional rather than argued".
+ *
+ * It was conditional — on the dialect. And Postgres is the side where a shifted
+ * position is worse, because its placeholders are **numbered**: SQLite's `?` is
+ * positional, so a shift breaks the statement, while `$7` silently addresses a
+ * different value.
+ *
+ * Unreachable from a generated schema on either dialect. Asserted anyway, for
+ * the reason the SQLite file already gives.
+ */
+describe("identifiers and placeholders", () => {
+  test("quotes with double quotes", () => {
+    expect(postgres.quoteIdent("id")).toBe('"id"');
+  });
+
+  test("escapes an embedded quote", () => {
+    expect(postgres.quoteIdent('we"ird')).toBe('"we""ird"');
+  });
+
+  test.each([
+    ["at the end", `id\u0000`],
+    ["in the middle", `a\u0000b`],
+    ["on its own", `\u0000`],
+  ])("refuses an identifier containing the parameter sentinel — %s", (_label, name) => {
+    expect(() => postgres.quoteIdent(name)).toThrow(/NUL byte/);
+  });
+
+  /**
+   * The numbering itself, which is what the whole `Fragment` sentinel machinery
+   * exists to get right: placeholders cannot be rendered until a fragment's
+   * position in the finished statement is fixed.
+   *
+   * Asserted against SQLite's answer for the same index, because "they differ"
+   * is the property — a shared implementation would pass a test that only
+   * looked at one.
+   */
+  test.each([
+    [0, "$1"],
+    [1, "$2"],
+    [41, "$42"],
+  ])("index %i is %s, one-based", (index, expected) => {
+    expect(postgres.placeholder(index)).toBe(expected);
+    expect(sqlite.placeholder(index)).toBe("?");
+  });
+});
 
 describe("in-list array literals", () => {
   test("numbers are quoted, and Postgres casts them back", () => {


### PR DESCRIPTION
Closes #143. Stacked on #142.

`sqlite.test.ts` opens with `describe("identifiers and placeholders")` — quoting, escaping an embedded quote, refusing the parameter sentinel, and the positional `?`. **`postgres.test.ts` has no such block at all.**

## The missing one is the one that matters more

The SQLite test says why the sentinel case is there:

> NUL is the parameter sentinel in `compile/fragment.ts`, so it is the one character that could shift a placeholder's position rather than merely produce broken SQL. Unreachable from a generated schema — asserted anyway, **so the invariant is unconditional rather than argued**.

It was conditional — on the dialect. And Postgres is the side where a shifted position is **worse**: SQLite's `?` is positional, so a shift produces a broken statement, while Postgres's `$7` silently addresses a *different value*. Same class of bug, one loud and one quiet, and the quiet one had no test.

`postgres.ts` implements the guard already, with a comment pointing at the SQLite implementation. Only the assertion was missing.

## Numbering, too

`placeholder(index)` → `$1`, `$2` is the dialect seam's clearest difference, and the whole `Fragment` sentinel machinery exists because a placeholder cannot be rendered until its fragment's position in the finished statement is fixed.

It is exercised *indirectly* — `write.test.ts` asserts `values ($1, $2, $3, $4, $5, $6)` — but the dialect contract itself was never asserted, so a change to it fails somewhere else, with a message about a statement rather than about numbering.

Asserted here **against SQLite's answer for the same index**, because "they differ" is the property: a shared implementation would pass a test that only looked at one.

## Measured

Postgres behaves correctly throughout — `"id"`, `"we""ird"`, NUL refused at the end, in the middle and alone, `$1` through `$42`. **No defect**; the assertions were absent.

Sensitivity checked on both halves:

| break | result |
| --- | --- |
| remove the NUL guard from `postgres.ts` | 3 cases fail |
| make `placeholder` zero-based | 3 cases fail, plus an in-list case |

- 1227 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 599 passed on SQLite, 864 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)