### PR TITLE
docs/orm.md listed groupBy and aggregate as out of scope

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1121,8 +1121,6 @@ Stated so you can plan around them rather than discover them:
   from. This one *is* pending rather than declined; it needs a composite key comparison on both
   sides (a tuple `in` for the batched strategy, a conjunction for the lateral one).
 - **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
-- **No `groupBy` or `aggregate`.** These land in [Raw SQL](#raw-sql), which exists so that "not
-  implemented" has an answer rather than a shrug.
 - **No `distinct`, and this one is deliberate rather than pending.** Prisma applies it **in
   memory** — its query log shows no `DISTINCT` at all, so `take` neither reduces the rows pulled
   nor paginates by group. Reproducing that faithfully would mean reading the whole result set and

--- a/packages/gemi/orm/docs-scope.test.ts
+++ b/packages/gemi/orm/docs-scope.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { isAggregateOperation } from "./compile/aggregate";
+import { isGroupByOperation } from "./compile/group-by";
+import { isReadOperation } from "./compile/read";
+import { isWriteOperation } from "./compile/write";
+import type { Operation } from "./plan";
+
+/**
+ * `docs/orm.md`'s **Not in scope** list, checked against the runtime.
+ *
+ * `read.test.ts` already guards one direction: `cursor` and `distinct` raise
+ * `UnsupportedByDesignError` rather than "yet", and its comment names why —
+ * "which is how `docs/orm.md` came to list an argument under *Not in scope*
+ * while the runtime said 'yet'."
+ *
+ * Nothing guarded the **other** direction, and the doc had drifted that way
+ * instead: it listed *"No `groupBy` or `aggregate`. These land in Raw SQL"*
+ * while the same document documents both with worked examples, the compiler
+ * implements both, and the differential harness compares both against Prisma.
+ *
+ * That is worse than the failure #68 fixed. "Refused, but actually works" tells
+ * a reader to go and write raw SQL for a query the ORM would have answered, and
+ * unlike a runtime refusal there is nothing to bump into that corrects them.
+ *
+ * The section is prose, so this does not try to parse the reasons — only to
+ * assert that it never names an operation the ORM implements.
+ */
+const DOC = join(import.meta.dirname, "../../../docs/orm.md");
+
+/**
+ * The operations the ORM implements. Listed here because `Operation` is a type
+ * and erased — but every entry is then **verified** against the compiler's own
+ * predicates, so this cannot quietly name something that does not exist.
+ */
+const IMPLEMENTED: Operation[] = [
+  "findUnique",
+  "findUniqueOrThrow",
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+  "count",
+  "aggregate",
+  "groupBy",
+  "create",
+  "createMany",
+  "update",
+  "updateMany",
+  "upsert",
+  "delete",
+  "deleteMany",
+];
+
+describe("docs/orm.md and the runtime agree", () => {
+  const source = readFileSync(DOC, "utf8");
+
+  const notInScope = (() => {
+    const start = source.indexOf("\n## Not in scope");
+    expect(start, "the Not in scope section moved or was renamed").toBeGreaterThan(0);
+    const end = source.indexOf("\n## ", start + 1);
+    return source.slice(start, end === -1 ? undefined : end);
+  })();
+
+  test("the list is found, and is not empty", () => {
+    expect(notInScope.length).toBeGreaterThan(200);
+  });
+
+  /** The list itself has to be real operations, or the check below means little. */
+  test.each(IMPLEMENTED)("%s is an operation the compiler recognises", (operation) => {
+    expect(
+      isReadOperation(operation) ||
+        isWriteOperation(operation) ||
+        isAggregateOperation(operation) ||
+        isGroupByOperation(operation),
+    ).toBe(true);
+  });
+
+  /**
+   * The assertion. An implemented operation named in this section is a
+   * contradiction a reader has no way to resolve — and the reader who believes
+   * it writes raw SQL for a query that already works.
+   *
+   * Matched on the backticked spelling, which is how the section names an API
+   * surface. Prose like "no lazy loading" is deliberately not matched: it names
+   * a feature rather than an operation, and there is nothing to check it
+   * against.
+   */
+  test.each(IMPLEMENTED)("%s is not listed as out of scope", (operation) => {
+    expect(notInScope).not.toContain(`\`${operation}\``);
+  });
+
+  /**
+   * ...and the two that genuinely are refused by design stay named, so removing
+   * them from the doc while leaving the runtime refusing is caught too. That is
+   * the direction #68 fixed, kept honest from this side as well.
+   */
+  test.each(["distinct", "cursor"])("%s is still listed, because it is still refused", (argument) => {
+    expect(notInScope).toContain(`\`${argument}\``);
+  });
+});


### PR DESCRIPTION
Closes #145. Stacked on #144.

`docs/orm.md`'s **Not in scope** list opens with *"Stated so you can plan around them rather than discover them"*, and contained:

> - **No `groupBy` or `aggregate`.** These land in [Raw SQL](#raw-sql), which exists so that "not implemented" has an answer rather than a shrug.

The same document has a `### Aggregates` section and a `### groupBy` section, both with worked examples — the second running to four documented rules and a named Prisma divergence.

## Measured

Both compile:

```
aggregate   select count(*) as "_count_0" from "User"
groupBy     select "name" as "_by_0", count(*) as "_count_0" from "User" group by …
```

and both are compared against Prisma by the differential harness — 15 distinct argument-key sets for `aggregate`, 8 for `groupBy`. The bullet predates the implementation and was never removed.

## Worse than the failure #68 fixed

#68 was the mirror image: docs saying *Not in scope* while the runtime said *"yet"*. `read.test.ts` guards that direction now, and its comment names it exactly.

This drift runs the other way, and is worse in one specific respect. A runtime refusal that contradicts the docs gets corrected the moment someone runs the query. **"Refused, but actually works" has nothing to bump into** — the reader believes it, goes and writes raw SQL for a query the ORM would have answered, and never finds out.

## The rest of the list checks out

Verified against the runtime rather than assumed:

| entry | state |
| --- | --- |
| no identity map / unit of work | accurate |
| no lazy loading | accurate |
| no multi-field relations | accurate — refused as *"yet"* on all four correlated surfaces |
| no migrations / schema DSL | accurate |
| no `distinct` | accurate — `UnsupportedByDesignError` |
| no `cursor` | accurate — `UnsupportedByDesignError` |

## The guard

The section may never name an operation the ORM implements. Matched on the **backticked** spelling, since that is how the section names an API surface — prose like "no lazy loading" names a *feature* and has nothing to check against.

The operation list in the test is **verified against the compiler's own predicates** rather than asserted, so it cannot quietly name something that does not exist. That check earned its keep immediately: it caught my own list, because `groupBy` has its own predicate rather than falling under the aggregate one.

And the opposite drift is guarded too — `distinct` and `cursor` must stay listed while they are still refused.

## Verification

| change | result |
| --- | --- |
| put the stale bullet back | `aggregate` and `groupBy` cases fail |
| delete `distinct` from the list | the still-listed case fails |

- 1260 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 599 passed on SQLite, 864 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)