### PR TITLE
The Errors table listed 12 of the ORM's 20 classes

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -922,7 +922,13 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |
 | `RelationDepthExceededError` | An include tree past `MAX_RELATION_DEPTH`. |
 | `ParameterLimitError` | A statement exceeding the dialect's parameter ceiling. |
+| `MissingRequiredValueError` | A write leaving a required column with no value and no default. |
+| `DecodeError` | A column the driver returned that cannot be read as its declared type. |
+| `UnsupportedByDesignError` | A subclass of `UnsupportedQueryError` for the arguments under [Not in scope](#not-in-scope) — it says *decision*, where the parent says *not yet*. Catch this one to tell them apart. |
+| `UnsupportedDialectError` | A model operation on a dialect with no compiler — MySQL and MariaDB. See [Dialects](#dialects). |
+| `ReturningUnsupportedError` | A write on a dialect without `RETURNING`, which is the same gap seen from the write path. |
 | `StaleSchemaArtifactError` | Generated files predate the running gemi. Re-run `prisma generate`. |
+| `MalformedRelationError` / `MissingModelSchemaError` / `UnregisteredRelationTargetError` | The generated artifact and the registry disagree — the same family as the two above, and the same fix. |
 
 ## Performance
 

--- a/packages/gemi/orm/docs-scope.test.ts
+++ b/packages/gemi/orm/docs-scope.test.ts
@@ -6,6 +6,7 @@ import { isAggregateOperation } from "./compile/aggregate";
 import { isGroupByOperation } from "./compile/group-by";
 import { isReadOperation } from "./compile/read";
 import { isWriteOperation } from "./compile/write";
+import * as orm from "./index";
 import type { Operation } from "./plan";
 
 /**
@@ -98,5 +99,57 @@ describe("docs/orm.md and the runtime agree", () => {
    */
   test.each(["distinct", "cursor"])("%s is still listed, because it is still refused", (argument) => {
     expect(notInScope).toContain(`\`${argument}\``);
+  });
+});
+
+/**
+ * The **Errors** table, checked for completeness.
+ *
+ * The section opens "Every failure is a typed error from `gemi/orm`" and then
+ * gives a table, which a reader takes as the catalogue — it is where you look
+ * to find out what there is to catch.
+ *
+ * It listed 12 of the ORM's 20. The costly omission was `UnsupportedByDesignError`:
+ * the **Not in scope** section tells you the deliberate refusals throw it and
+ * that telling *decision* from *not yet* is the whole point of the split (#68),
+ * and then the place you would look for the class did not mention it.
+ *
+ * Derived from the module's own exports rather than a hand-written list. The
+ * list in this file for operations had to be verified against the compiler's
+ * predicates for the same reason; here the exports *are* the source, so there is
+ * nothing to keep in step.
+ */
+describe("docs/orm.md lists every error an application can catch", () => {
+  const source = readFileSync(DOC, "utf8");
+
+  const errorsTable = (() => {
+    const start = source.indexOf("\n## Errors");
+    expect(start, "the Errors section moved or was renamed").toBeGreaterThan(0);
+    const end = source.indexOf("\n## ", start + 1);
+    return source.slice(start, end === -1 ? undefined : end);
+  })();
+
+  /**
+   * Every export that is an `Error` subclass. `instanceof` on the prototype
+   * rather than a name test, so a class that stopped extending `Error` — and
+   * therefore stopped being catchable the documented way — drops out here
+   * rather than being counted.
+   */
+  const exported = Object.entries(orm)
+    .filter(
+      ([, value]) =>
+        typeof value === "function" &&
+        value.prototype instanceof Error,
+    )
+    .map(([name]) => name)
+    .sort();
+
+  test("the exports are found", () => {
+    expect(exported.length).toBeGreaterThan(15);
+    expect(exported).toContain("UnsupportedQueryError");
+  });
+
+  test.each(exported)("%s is in the table", (name) => {
+    expect(errorsTable).toContain(`\`${name}\``);
   });
 });


### PR DESCRIPTION
Closes #149. Stacked on #148.

`docs/orm.md`'s **Errors** section opens

> Every failure is a typed error from `gemi/orm`, not a driver string.

and then gives a table. A reader takes that as the catalogue — it is where you look to find out what there is to catch.

## Measured

All **20** error classes in `orm/` are exported from `gemi/orm`. The table listed **12**:

| exported but undocumented |
| --- |
| `UnsupportedByDesignError` |
| `UnsupportedDialectError` |
| `ReturningUnsupportedError` |
| `MissingRequiredValueError` |
| `DecodeError` |
| `MalformedRelationError` |
| `MissingModelSchemaError` |
| `UnregisteredRelationTargetError` |

Nothing was documented-but-missing, so the table was a *subset* rather than out of step.

## The costly one

`UnsupportedByDesignError`. The **Not in scope** section says the deliberate refusals throw it, and that this is the point:

> which says *"and this is a decision rather than a gap"* rather than *"yet"* — so a refusal you can plan around reads differently from one that might lift next release.

That distinction is #68's entire subject, and acting on it means catching the subclass. The place a reader looks for the class did not mention it — told the difference matters, then not told how to observe it.

Two more are named elsewhere in the same document and were absent here: `UnsupportedDialectError` (**Dialects**) and `ReturningUnsupportedError`, the same MySQL gap seen from the write path.

## The guard

It drifted the way #145 did — written once, code kept moving. `StaleSchemaArtifactError` *is* in the table, so it has been maintained, just not completely.

The check derives the class list from **the module's own exports**, filtered by `value.prototype instanceof Error` rather than by name — so a class that stopped extending `Error`, and therefore stopped being catchable the documented way, drops out rather than being counted. There is no second list to keep in step, which is the failure mode the operations check in the same file has to work around by verifying its hardcoded list against the compiler's predicates.

## Verification

| change | result |
| --- | --- |
| remove `UnsupportedByDesignError` from the table | its case fails |
| add a new exported error class without documenting it | its case fails — which is how this drifted originally |

- 1287 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 599 passed on SQLite, 864 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)