### PR TITLE
A bare JSON scalar diverges from Prisma, not just between dialects

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1067,16 +1067,22 @@ matters.
 
 ## `Json` columns
 
-A `Json` column round-trips whatever you give it: an object, an array, a string, a number, `null`.
-The value is stored as JSON and comes back as the same JavaScript value, on both dialects and
-whether it is read at the root or nested inside an `include`.
+A `Json` column round-trips whatever you give it: an object, an array, a string, `null` — and a
+number or boolean on SQLite, with the one exception below. The value is stored as JSON and comes
+back as the same JavaScript value, on both dialects and whether it is read at the root or nested
+inside an `include`.
 
 Two things are worth knowing:
 
 - **A bare JSON number or boolean is refused on Postgres.** `metadata: 42` raises rather than being
   stored, because the driver binds it as an integer and the column is `jsonb`. Wrap it — `{ value:
-  42 }` — or store it as a string. SQLite has no such limit. This is the one shape where the two
-  dialects disagree, and it fails loudly rather than storing the wrong thing.
+  42 }` — or store it as a string. SQLite has no such limit.
+
+  **This is the one shape where gemi diverges from Prisma**, which stores it on both dialects, so it
+  is worth knowing if you are porting code rather than writing it fresh. It is a trade rather than
+  an oversight: the encoder that accepted it serialised first, which stored `42` as the jsonb
+  *string* `"42"` — and only looked correct because the decoder re-parsed it on the way out, so the
+  value was wrong in the database the whole time. Failing loudly beats storing the wrong thing.
 - **A string is a string.** `metadata: "42"` stores the JSON string `"42"`, not the number, and
   `metadata: '{"a":1}'` stores that text as a string rather than as an object. If you want an
   object, pass an object.

--- a/packages/gemi/orm/json-encode.test.ts
+++ b/packages/gemi/orm/json-encode.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+
+import { PostgresDialect } from "./dialect/postgres";
+import { SqliteDialect } from "./dialect/sqlite";
+import type { FieldSchema } from "./schema";
+
+const postgres = new PostgresDialect();
+const sqlite = new SqliteDialect();
+
+const metadata = {
+  name: "metadata",
+  column: "metadata",
+  type: "Json",
+  nullable: true,
+  isId: false,
+  isUpdatedAt: false,
+} as FieldSchema;
+
+/**
+ * How a `Json` value is bound, and the one shape where that **diverges from
+ * Prisma**.
+ *
+ * `dialect/postgres.ts` hands `Json` over raw, for a measured reason: the
+ * encoder that serialised first stored `42` as the jsonb *string* `"42"` —
+ * confirmed with `jsonb_typeof` — and only looked correct because the decoder
+ * re-parsed it on the way out. Raising beats storing the wrong thing, and that
+ * trade is not what this file questions.
+ *
+ * What it pins is the consequence, which nothing asserted. Binding raw means a
+ * bare number or boolean reaches Postgres as its own type, and `jsonb` will not
+ * take it:
+ *
+ *     column "metadata" is of type jsonb but expression is of type integer
+ *
+ * **Prisma stores it.** Measured against Prisma 6.19 and Postgres 16 through the
+ * differential harness: `metadata: 42` succeeds under Prisma on both dialects
+ * and raises under gemi on Postgres. So the divergence a caller meets is from
+ * *Prisma*, not between the two dialects as `docs/orm.md` described it — which
+ * is the part of that section this change corrects.
+ *
+ * Asserted here rather than end-to-end because an end-to-end version has to
+ * write through both clients into the harness's shared Postgres database, and
+ * doing so perturbs the suites that share it. The encoder is where the
+ * behaviour lives, and it is the thing that would have to change.
+ */
+describe("a Json value is bound raw", () => {
+  const shapes: [string, unknown][] = [
+    ["an object", { a: 1 }],
+    ["an array", [1, 2]],
+    ["a string", "42"],
+    ["a bare number", 42],
+    ["a bare boolean", true],
+  ];
+
+  test.each(shapes)("%s is handed to the driver unchanged — postgres", (_label, value) => {
+    expect(postgres.encode(value, metadata)).toBe(value);
+  });
+
+  test.each(shapes)("%s is handed to the driver unchanged — sqlite", (_label, value) => {
+    // SQLite serialises rather than binding raw, so this asserts the round trip
+    // instead: whatever it does on the way in, `decode` has to undo.
+    expect(sqlite.decode(sqlite.encode(value, metadata), metadata)).toEqual(value);
+  });
+
+  /**
+   * Null is the one value both dialects normalise, and it has to stay `null`
+   * rather than becoming the JSON text `"null"` — the difference between a
+   * column that is empty and one holding a JSON null.
+   */
+  test.each([
+    ["postgres", postgres],
+    ["sqlite", sqlite],
+  ])("null stays null — %s", (_name, dialect) => {
+    expect(dialect.encode(null, metadata)).toBeNull();
+    expect(dialect.encode(undefined, metadata)).toBeNull();
+  });
+
+  /**
+   * The one that documents the divergence. A bare scalar arriving at the driver
+   * as a JS number or boolean is precisely why `jsonb` rejects it — if this ever
+   * starts returning a string, the refusal is gone and `docs/orm.md` needs
+   * changing with it.
+   */
+  test.each([
+    ["a number", 42],
+    ["a boolean", true],
+  ])("%s reaches postgres as its own type, which is why jsonb refuses it", (_label, value) => {
+    const encoded = postgres.encode(value, metadata);
+
+    expect(typeof encoded).toBe(typeof value);
+    expect(typeof encoded).not.toBe("string");
+  });
+
+  /**
+   * ...and the string case, which is what the raw binding exists to protect: a
+   * JSON string that looks like a number must not become the number.
+   */
+  test("a JSON string is not turned into a number", () => {
+    expect(postgres.encode("42", metadata)).toBe("42");
+    expect(sqlite.decode(sqlite.encode("42", metadata), metadata)).toBe("42");
+  });
+});

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -133,6 +133,26 @@ const CASES: Case[] = [
       password: "secret",
     },
   }],
+  /**
+   * Bare JSON scalars — the one shape `docs/orm.md` says the two dialects
+   * disagree on: refused on Postgres because the driver binds the value as an
+   * integer against a `jsonb` column, accepted on SQLite.
+   *
+   * Nothing wrote one. The seed carries objects, an empty object, an array and
+   * a JSON *string*, so every Json case the harness had was a shape where the
+   * dialects agree — which is how a documented divergence went unmeasured.
+   *
+   * The harness compares failure *kind*, so these assert the interesting
+   * thing without the test needing to know which dialect it is on: whatever
+   * Postgres does, gemi and Prisma have to do the same.
+   */
+  // The two bare-scalar shapes are *not* here: on Postgres gemi raises where
+  // Prisma succeeds, which the harness would report as a divergence because it
+  // is one. It is pinned as such in `json-scalars.test.ts` instead, so it stays
+  // visible without weakening this table.
+  ["create with a wrapped JSON number", "create", {
+    data: { email: "json-wrapped@example.dev", metadata: { value: 42 } },
+  }],
   // A nullable column explicitly set to null must stay null, not fall back to
   // a default — the difference between `?? default` and a key-presence check.
   ["create with an explicit null", "create", {


### PR DESCRIPTION
Closes #151. Stacked on #150.

`docs/orm.md`'s **`Json` columns** section said:

> A bare JSON number or boolean is refused on Postgres. … SQLite has no such limit. **This is the one shape where the two dialects disagree**, and it fails loudly rather than storing the wrong thing.

True, and not the sharp part.

## Measured

Added the shape to the differential table and ran it against Postgres 16:

```
User.create({"data":{"email":"…","metadata":42}}):
  prisma returned but gemi threw —
  column "metadata" is of type jsonb but expression is of type integer
```

**Prisma stores it. gemi raises.** The divergence a caller meets is from *Prisma*, not between the two dialects — and parity with Prisma is this ORM's premise. Someone porting code hits it; someone reading the docs is told only that SQLite and Postgres differ.

The section's opening sentence made it worse, listing "a number" among the values a `Json` column "round-trips whatever you give it".

## The behaviour is right, and is not changed here

`dialect/postgres.ts` sets out the trade at length. The encoder that accepted bare scalars serialised first, which stored `42` as the jsonb **string** `"42"` — confirmed there with `jsonb_typeof` — and only looked correct because the decoder re-parsed it on the way out. The value was wrong in the database the whole time. Raising beats that.

What was missing is that the trade was **invisible**. The differential table had objects, an empty object, an array and a JSON *string* — every Json shape where the two agree. The one shape that does not agree was the one nobody wrote.

## Why this is a unit test

A decision rather than convenience, and worth stating.

I wrote the end-to-end version first and it perturbed the suite. The harness's Postgres runs share one database, and a file that writes through both clients into it made two unrelated nested-write cases fail — reproducibly, and cleanly gone when the file was removed (865 passed without it, 867/2 with it). Weakening a shared harness to hold a regression test for a documented decision is the wrong trade, so the assertion sits on the encoder, which is where the behaviour lives and what would have to change. The Prisma half of the comparison is recorded in #151, where it was measured.

## What is pinned

- Every `Json` shape's encoding, on both dialects.
- That a bare scalar reaches Postgres **as its own type** — which is *why* `jsonb` refuses it. If that ever starts returning a string, the refusal is gone and the docs need changing with it.
- That `"42"` is not turned into `42` — the corruption the raw binding exists to prevent.
- That `null` stays `null` rather than becoming the JSON text `"null"`.

**Verified** by making the encoder serialise again: five cases fail.

- 1302 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 600 passed on SQLite, 865 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)