### PR TITLE
DB.sql joins the ambient transaction on SQLite

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1062,8 +1062,17 @@ same applies to identifiers and sort directions, which cannot be parameters in S
 is the same for those, and it is about where the value came from, not what it is.
 
 `DB.sql` is unchanged and still Bun's own tagged template, for a single self-contained statement
-that needs none of this. It does **not** join the ambient transaction — use `DB.query` when that
-matters.
+that needs none of this. **Whether it joins the ambient transaction depends on the dialect**, so use
+`DB.query` when that matters:
+
+- On **Postgres** it does not. The pool hands it a different connection, so a `Model.transaction`
+  that rolls back leaves a `DB.sql` write behind.
+- On **SQLite** it does, because `DatabaseManager` gives SQLite a single connection and the
+  statement is therefore inside the open transaction.
+
+The direction is the awkward one: a `DB.sql` write inside a transaction rolls back correctly in
+development on SQLite and survives the rollback in production on Postgres. `DB.query` and
+`DB.execute` join the transaction on both.
 
 ## `Json` columns
 

--- a/templates/saas-starter/app/models/raw-sql.test.ts
+++ b/templates/saas-starter/app/models/raw-sql.test.ts
@@ -369,6 +369,87 @@ function suite(label: string, url?: string) {
       expect([...rows]).toHaveLength(1);
     });
 
+    /**
+     * **`DB.sql` does not join the ambient transaction**, which the docs state
+     * and nothing asserted — only that the template still works.
+     *
+     * It is the consequential half. A write issued through it inside a
+     * `Model.transaction` is on a different connection, so a rollback does not
+     * take it back: the transaction reports failure and the row is still there.
+     *
+     * Worth pinning in both directions rather than as a caveat, because the two
+     * calls look interchangeable at the call site and only one of them is safe
+     * to mix with a transaction.
+     */
+    /**
+     * **`DB.sql` and the ambient transaction — and the two dialects disagree.**
+     *
+     * `docs/orm.md` says it plainly and unconditionally: "It does **not** join
+     * the ambient transaction — use `DB.query` when that matters."
+     *
+     * Measured, that holds on Postgres and **not** on SQLite. `DatabaseManager`
+     * gives SQLite a single connection, so a `DB.sql` statement issued inside a
+     * `Model.transaction` is on the same connection and therefore inside the
+     * transaction — it rolls back with everything else. Postgres has a pool, so
+     * the statement takes a different connection and escapes.
+     *
+     * The direction matters. A developer who tests on SQLite watches a `DB.sql`
+     * write roll back correctly and ships it; on Postgres the rollback leaves
+     * that write behind. It is the same hazard the transactions section already
+     * warns about for a caught statement — "passes in development on SQLite and
+     * takes out the transaction in production on Postgres" — reached by a
+     * different door.
+     *
+     * Both halves are asserted per dialect rather than skipping the one that is
+     * inconvenient: the point is that they genuinely differ.
+     */
+    test("whether a DB.sql write survives a rollback depends on the dialect", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await DB.sql`update "User" set "name" = ${"escaped"} where "email" = ${"ada@x.test"}`;
+          throw new Error("rolled back");
+        }),
+      ).rejects.toThrow("rolled back");
+
+      const after = await DB.query<{ name: string | null }>(
+        sql`select "name" from "User" where "email" = ${"ada@x.test"}`,
+      );
+
+      if (url) {
+        // Postgres: a different connection from the pool, so the transaction
+        // never contained it and the rollback did not reach it.
+        expect(after[0].name).toBe("escaped");
+        await DB.execute(
+          sql`update "User" set "name" = null where "email" = ${"ada@x.test"}`,
+        );
+      } else {
+        // SQLite: one connection, so it was inside the transaction after all.
+        expect(after[0].name).toBeNull();
+      }
+    });
+
+    /**
+     * ...and `DB.query` / `DB.execute`, which the docs point to instead, roll
+     * back on **both**. Without this the test above says only that something
+     * survived a failed transaction, which a transaction that never opened
+     * would satisfy too.
+     */
+    test("a DB.execute write in the same place rolls back on either dialect", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await DB.execute(
+            sql`update "User" set "name" = ${"joined"} where "email" = ${"ada@x.test"}`,
+          );
+          throw new Error("rolled back");
+        }),
+      ).rejects.toThrow("rolled back");
+
+      const after = await DB.query<{ name: string | null }>(
+        sql`select "name" from "User" where "email" = ${"ada@x.test"}`,
+      );
+      expect(after[0].name).not.toBe("joined");
+    });
+
     test("a plain string is refused rather than run", async () => {
       await expect(
         DB.query(`select * from "User"` as never),


### PR DESCRIPTION
Closes #155. Stacked on #154.

`docs/orm.md`'s **Raw SQL** section stated it plainly and unconditionally:

> `DB.sql` is unchanged and still Bun's own tagged template… It does **not** join the ambient transaction — use `DB.query` when that matters.

## Measured

Inside a `Model.transaction` that then throws, a `DB.sql` update against a seeded row:

| dialect | after the rollback |
| --- | --- |
| Postgres 16 | `"escaped"` — the write **survived** |
| SQLite | `null` — the write **rolled back** |

A control in the same run confirms the statement works outside a transaction on both, so this is the transaction and not the statement.

The mechanism is `DatabaseManager`: SQLite gets a **single connection**, so a `DB.sql` statement issued inside an open transaction is on that same connection and therefore inside it. Postgres has a pool, so the statement takes a different connection and escapes.

**The doc is right about Postgres and wrong about SQLite.**

## The direction is the bad one

A `DB.sql` write inside a transaction **rolls back correctly in development on SQLite and survives the rollback in production on Postgres.**

That is the same hazard the **Transactions** section already documents at length for a different door — "a bug that passes in development on SQLite and takes out the transaction in production on Postgres" — reached here without doing anything the docs warn against.

The current text makes it worse rather than neutral: a reader told `DB.sql` never joins will test on SQLite, watch it roll back, and conclude the warning is over-careful.

## Why it was not caught

`raw-sql.test.ts` has exactly one `DB.sql` test — *"DB.sql is untouched, and still Bun's own tagged template"* — which asserts the template **works**. The transactional claim, which is the reason that paragraph exists, had nothing.

## The change

- The doc says which dialect does what, with the reason, and names the awkward direction.
- Both behaviours pinned **per dialect**, asserted rather than skipped on the inconvenient one — the point is that they differ.
- `DB.execute` asserted to roll back on **both**, so the first test cannot pass by way of a transaction that never opened.

- 1307 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite: 602 passed on SQLite, 869 on Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)