### PR TITLE
Merging #95 and #100 made the multi-field-relations entry stale

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1081,12 +1081,12 @@ Stated so you can plan around them rather than discover them:
   an identity map is worse than none.
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
   touched.
-- **No multi-field relations.** `@relation(fields: [a, b], references: [c, d])` is refused wherever
-  a relation is correlated — `include` under either strategy, a relation filter, `_count`, an
-  `orderBy` through a relation, and nested writes — rather than joining on the first field and
-  returning plausible wrong rows. The error names the fields on both sides and the operation it came
-  from. This one *is* pending rather than declined; it needs a composite key comparison on both
-  sides (a tuple `in` for the batched strategy, a conjunction for the lateral one).
+- **No multi-field relations in a nested write.** `@relation(fields: [a, b], references: [c, d])`
+  now works everywhere a relation is *read* — `include` under either strategy, a relation filter,
+  `_count`, and an `orderBy` through a relation all correlate on every field. What is still refused
+  is reaching one from a nested write, and the error names the fields on both sides and the
+  operation it came from, rather than joining on the first field and writing plausible wrong rows.
+  Pending rather than declined.
 - **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
 - **No `groupBy` or `aggregate`.** These land in [Raw SQL](#raw-sql), which exists so that "not
   implemented" has an answer rather than a shrug.

--- a/packages/gemi/orm/composite-surfaces.test.ts
+++ b/packages/gemi/orm/composite-surfaces.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { lateralStrategy } from "./compile/lateral";
+import { compileRead } from "./compile/read";
+import { compileWrite } from "./compile/write";
+import { PostgresDialect } from "./dialect/postgres";
+import { SqliteDialect } from "./dialect/sqlite";
+import { UnsupportedQueryError } from "./errors";
+import { ledger, ledgerEntry } from "./fixtures";
+import * as registry from "./registry";
+
+const sqlite = new SqliteDialect();
+const postgres = new PostgresDialect();
+
+/**
+ * Which surfaces a **multi-field relation** reaches, stated as a table.
+ *
+ * `docs/orm.md`'s *Not in scope* list said a composite relation "is refused
+ * wherever a relation is correlated — `include` under either strategy, a
+ * relation filter, `_count`, an `orderBy` through a relation, and nested
+ * writes". Four of those five stopped being true when #95 and #100 landed, and
+ * the entry did not move with them.
+ *
+ * That is the direction #145 was about: a *Not in scope* list is written so a
+ * reader can plan around it, and one that names something already implemented
+ * sends them to write raw SQL for a query that works. It drifted here because
+ * the boundary moved rather than because the text was wrong when written —
+ * which is exactly the case a test catches and review does not.
+ *
+ * `ledgerEntry.ledger` joins on `tenantId` **and** `ledgerCode`, so every case
+ * below asserts *both* columns appear. One would be enough for the query to
+ * compile and would silently return the wrong rows, which is the failure the
+ * refusal existed to prevent.
+ */
+describe("a relation that joins on two fields", () => {
+  beforeEach(() => {
+    registry.clearRegistry();
+    registry.register("Ledger", class { static $schema = ledger });
+    registry.register("LedgerEntry", class { static $schema = ledgerEntry });
+  });
+
+  /** Both sides of the composite key, as the compiler spells them. */
+  const correlatesOnBoth = (sql: string) => {
+    expect(sql).toMatch(/"tenantId"/);
+    expect(sql).toMatch(/"ledgerCode"/);
+  };
+
+  test("include, batched", () => {
+    const plan = compileRead(
+      ledger,
+      "findMany",
+      { include: { entries: true } } as never,
+      sqlite,
+    );
+
+    // Under batching the child is a second statement, so what the parent's plan
+    // carries is the key it will correlate on. Asserted on the plan rather than
+    // on SQL text: `parentFields` is the thing that would silently shrink to one
+    // field, and it names the parent's side (`code`), not the child's column.
+    const [entries] = plan.relations ?? [];
+    expect(entries).toBeDefined();
+    expect(entries.parentFields).toEqual(["tenantId", "code"]);
+  });
+
+  test("include, lateral", () => {
+    const plan = compileRead(
+      ledger,
+      "findMany",
+      { include: { entries: true } } as never,
+      postgres,
+      lateralStrategy,
+    );
+    expect(plan.text).toMatch(/lateral/i);
+    correlatesOnBoth(plan.text);
+  });
+
+  test("a relation filter", () => {
+    const { text } = compileRead(
+      ledgerEntry,
+      "findMany",
+      { where: { ledger: { is: {} } } } as never,
+      sqlite,
+    );
+    expect(text).toContain("exists");
+    correlatesOnBoth(text);
+  });
+
+  test("_count", () => {
+    const { text } = compileRead(
+      ledger,
+      "findMany",
+      { include: { _count: { select: { entries: true } } } } as never,
+      sqlite,
+    );
+    expect(text).toContain("count(*)");
+    correlatesOnBoth(text);
+  });
+
+  test("orderBy through the relation", () => {
+    const { text } = compileRead(
+      ledger,
+      "findMany",
+      { orderBy: { entries: { _count: "asc" } } } as never,
+      sqlite,
+    );
+    expect(text).toContain("order by");
+    correlatesOnBoth(text);
+  });
+
+  /**
+   * The one still refused, and the reason the docs entry is narrowed rather
+   * than deleted. When this starts compiling, this test fails — which is the
+   * prompt to move the entry again.
+   */
+  test("a nested write is still refused, by name", () => {
+    let error: UnsupportedQueryError | null = null;
+    try {
+      compileWrite(
+        ledger,
+        "update",
+        {
+          where: { tenantId_code: { tenantId: 1, code: "x" } },
+          data: { entries: { connect: { id: 1 } } },
+        } as never,
+        sqlite,
+      );
+    } catch (raised) {
+      error = raised as UnsupportedQueryError;
+    }
+
+    expect(error).toBeInstanceOf(UnsupportedQueryError);
+    // The message names the count and the fields, which is what makes it
+    // actionable rather than a shrug.
+    expect(error!.message).toMatch(/joins on 2 fields/);
+    expect(error!.message).toContain("tenantId");
+  });
+});


### PR DESCRIPTION
Closes #157. **Based on `feat/orm` directly**, not on the review stack — it corrects something the recent merges caused, so it should be mergeable on its own.

`docs/orm.md`'s **Not in scope** list says:

> **No multi-field relations.** … is refused wherever a relation is correlated — `include` under either strategy, a relation filter, `_count`, an `orderBy` through a relation, and nested writes.

**Four of those five stopped being true** when #95 and #100 merged. The entry did not move with them.

## Measured on `feat/orm` at b4884c3

`ledgerEntry.ledger` joins on `tenantId` **and** `ledgerCode`:

| surface | state |
| --- | --- |
| `include`, batched | works — plan carries `parentFields: ["tenantId", "code"]` |
| `include`, lateral | works — both columns inside the subquery |
| relation filter | works — `exists (… "_r0"."tenantId" = … and "_r0"."ledgerCode" = …)` |
| `_count` | works — both columns |
| `orderBy` through a relation | works — both columns |
| **nested write** | **still refused**, by name: *"entries joins on 2 fields"* |

So the entry is **narrowed**, not deleted.

## Why this differs from #145

#145 was the same shape — a *Not in scope* entry naming something implemented — but it had been wrong since it was written. **This one became wrong during the session**, because the boundary moved underneath it.

That is the case a test catches and review does not: nothing in #95 or #100 touched this paragraph, so there was no diff to notice it against.

It is also **not** caught by #146's guard, which asserts the section never names an implemented *operation*. A multi-field relation is a capability rather than one of the fifteen, so there is nothing for that check to match. A capability needs its own assertion, which is what this adds.

## The test

Each surface asserts **both** fields. One field would still compile and would silently return the wrong rows — the exact failure the original refusal existed to prevent.

The nested-write refusal is asserted **by name**, so when it lands this test fails and prompts moving the entry again.

**Verified** by truncating the composite link to its first field: four of the six cases fail.

- 1032 unit tests, `tsc --noEmit` clean, `oxlint` clean (its two warnings are pre-existing in `where.ts`).
- Template suite on this base: 571 passed on SQLite, 427 passed on Postgres 16 — no failures on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)