### PR TITLE
feat/orm does not typecheck: one call site missed when `detail` became required

### DIFF
--- a/packages/gemi/orm/compile/group-by.test.ts
+++ b/packages/gemi/orm/compile/group-by.test.ts
@@ -373,4 +373,32 @@ describe("shaping", () => {
   test("no groups is an empty array, not null", () => {
     expect(plan({ by: ["globalRole"], _count: true }).shape([])).toEqual([]);
   });
+
+  /**
+   * An argument `groupBy` does not take, refused **with the set it does**.
+   *
+   * This one call site was left with three arguments when #102 made `detail`
+   * required, so `feat/orm` stopped typechecking the moment that merged
+   * alongside `groupBy`. Neither PR could see it: #92 added the call, #102
+   * changed the signature, and each typechecked on its own branch.
+   *
+   * `tsc` is what catches the signature; this is what catches the *message*,
+   * which is the thing #61's second half was actually about — an argument the
+   * operation does not accept is the path a typo takes, and naming the set is
+   * the whole of the answer.
+   */
+  test("an unknown argument names the ones groupBy takes", () => {
+    let message = "";
+    try {
+      plan({ by: ["globalRole"], _count: true, nope: 1 } as never);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).toContain("'nope'");
+    // The set, sorted, exactly as `read.ts` words the same refusal.
+    expect(message).toMatch(/groupBy takes .*\bby\b.*/);
+    expect(message).toContain("having");
+    expect(message).toContain("orderBy");
+  });
 });

--- a/packages/gemi/orm/compile/group-by.ts
+++ b/packages/gemi/orm/compile/group-by.ts
@@ -671,7 +671,15 @@ function assertArgs(schema: ModelSchema, op: string, args: any): void {
   for (const key of Object.keys(args).sort()) {
     if (args[key] === undefined) continue;
     if (GROUP_BY_ARGS.has(key)) continue;
-    throw new UnsupportedQueryError(key, schema.name, op);
+    // The same wording `read.ts` uses for an argument an operation does not
+    // take, and for the reason #61's second half gives: this is the path a
+    // typo arrives on, so naming the set is the whole of the answer.
+    throw new UnsupportedQueryError(
+      key,
+      schema.name,
+      op,
+      `${op} takes ${[...GROUP_BY_ARGS].sort().join(", ")}.`,
+    );
   }
 
   if (args.by === undefined) {


### PR DESCRIPTION
Closes #159. **Based on `feat/orm` directly** — it fixes the integration branch, so it should not sit behind the review stack.

`feat/orm` at 279778a fails `tsc`:

```
orm/compile/group-by.ts(674,11): error TS2554: Expected 4 arguments, but got 3.
```

Verified on a **clean checkout of `origin/feat/orm`**, not on a working branch.

## How it got there

A semantic merge conflict — the kind neither PR can see.

| | |
| --- | --- |
| **#92** | added `throw new UnsupportedQueryError(key, schema.name, op)` in `groupBy`'s `assertArgs`, while `detail` was optional |
| **#102** | made `detail` **required** — the second half of #61 — and fixed the call sites on its own branch |

Each typechecked alone. #102 never touched `group-by.ts` and #92 never touched `errors.ts`, so there was no textual conflict to resolve and **no diff for either reviewer to look at**. The break exists only in the combination.

## Why it matters beyond the error

Every branch stacked on `feat/orm` inherits it, so `tsc` now fails for reasons unrelated to whatever a contributor is working on — which is exactly the condition under which people stop reading it.

I found it while merging `feat/orm` into #103 to clear that PR's conflict: the merge produced exactly one `tsc` error, and both files involved turned out **byte-identical to `feat/orm`**, which is what pointed at the base rather than at the merge.

## The fix

The wording `read.ts` already uses for the same refusal:

```ts
`${op} takes ${[...GROUP_BY_ARGS].sort().join(", ")}.`
```

That is the case #61's second half was actually about — an argument the operation does not accept is the path a typo arrives on, and naming the set is the whole of the answer.

## The test asserts the message, not the arity

`tsc` catches the signature. Nothing would have caught a `detail` that said *nothing useful*, which is the failure #102 set out to prevent — so the test checks that the refusal names the argument and the set.

- `tsc --noEmit` **clean** on this branch, 1044 unit tests, `oxlint` clean.
- Template suite: 595 passed on SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)