### PR TITLE
CI: typecheck, tests and lint, on the merge result as well as the proposal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+# Typecheck, tests and lint for the ORM and the template that exercises it.
+#
+# **Why this exists.** `feat/orm` stopped typechecking at #102 and stayed broken
+# across six merges (#101–#109) with every test green the whole time. The break
+# was a *semantic* merge conflict: #92 added a three-argument
+# `UnsupportedQueryError` while `detail` was optional, #102 made `detail`
+# required and fixed the call sites on its own branch. Neither touched the
+# other's file, so there was no textual conflict, no diff for a reviewer to look
+# at, and nothing that runs on the result of merging them.
+#
+# That is a class a per-PR check cannot cover on its own — it only appears once
+# both are on the same branch — which is why this runs on pushes to the
+# integration branches as well as on pull requests.
+#
+# Postgres is deliberately not here yet. The differential harness runs against
+# it when `TEST_POSTGRES_URL` is set and skips loudly otherwise, so a run
+# without it is honest about covering SQLite only. Adding a service container is
+# a sensible next step and a separate decision.
+on:
+  pull_request:
+  push:
+    branches: [main, feat/orm]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # Not pinned to `packageManager` (bun@1.1.3), which is behind what the
+          # repo is actually developed against.
+          bun-version: latest
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      # The ORM generator is resolved by bin name, and in this repo that symlink
+      # points at built output — so `prisma generate` below needs it to exist.
+      - name: Build the binaries
+        run: bun run build:bin
+        working-directory: packages/gemi
+
+      # The template's committed artifact is what its suite runs against, and
+      # `generated.test.ts` asserts a second run produces a zero-line diff.
+      - name: Generate the template's model artifact
+        run: bunx prisma generate
+        working-directory: templates/saas-starter
+
+      # The step that would have caught #159. Kept before the tests, because a
+      # type error is cheaper to read than a suite that still passes around it.
+      - name: Typecheck
+        run: bun run typecheck
+        working-directory: packages/gemi
+
+      - name: Unit tests
+        run: bun --bun vitest run orm
+        working-directory: packages/gemi
+
+      - name: Template tests
+        run: bun --bun vitest run app/models
+        working-directory: templates/saas-starter
+        env:
+          TZ: UTC
+
+      - name: Lint
+        run: bun run lint
+        working-directory: packages/gemi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,17 @@ jobs:
         run: bun run typecheck
         working-directory: packages/gemi
 
+      # `orm database`, not `orm`. The package has 47 test files and only 32
+      # have "orm" in their path — `database/DatabaseManager.test.ts` is the
+      # ORM's own SQLite foreign-key pragma test and would have been skipped by
+      # the narrower filter.
+      #
+      # Not the whole package: `app/`'s router tests fail on `feat/orm` today
+      # and are unrelated to this. Widening to everything would put CI red for a
+      # reason nobody here can act on, which is how a red board stops being
+      # read. Reported separately.
       - name: Unit tests
-        run: bun --bun vitest run orm
+        run: bun --bun vitest run orm database
         working-directory: packages/gemi
 
       - name: Template tests

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -41,6 +41,7 @@
   },
   "scripts": {
     "lint": "oxlint",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "NODE_ENV=production bun run build:core && bun run build:bin && bun run build:types && bun run build:client && bun run build:plugin && bun run build:client-types",
     "build:core": "bun ./scripts/build.ts",
     "build:bin": "bun build --outdir=./dist/bin --target=bun --external=vite --external=react-dom --external=react/jsx-runtime --external=bun --external=sharp --sourcemap ./bin/gemi.ts ./bin/orm-generator.ts && bun ./scripts/prepare-bin.ts",


### PR DESCRIPTION
Closes #161. Based on `feat/orm` directly.

**This one is a proposal rather than a fix** — it adds a workflow, which is a decision about how the repository is run, not just about the ORM. The evidence for it is concrete, but the call is yours.

## The evidence

`feat/orm` stopped typechecking at #102 and is still broken at fea6fbb — across **#101 through #109**, six merges. On a clean checkout of the current head:

| check | result |
| --- | --- |
| `tsc --noEmit` | **fails** — `group-by.ts(674,11): Expected 4 arguments, but got 3` |
| unit tests | 1088 pass |
| template tests | 604 pass, 32 skipped |
| `oxlint` | 1 warning, 0 errors |

**Everything green except the one thing that was broken.** That is why it survived: a contributor running the suite sees a clean board.

`.github/workflows/` currently holds `docs.yml` and `publish.yml`. Nothing runs `tsc`, `vitest` or `oxlint` on a push or a pull request.

## Why per-PR checking would not have been enough

#159 is a **semantic** merge conflict. #92 added a three-argument `UnsupportedQueryError` while `detail` was optional; #102 made `detail` required and fixed the call sites on its own branch. Neither touched the other's file — no textual conflict, no diff for either reviewer, and **each branch typechecked alone**.

It exists only once both are on the same branch. So the check has to run on the *result of merging*, which is why this triggers on pushes to `main` and `feat/orm` as well as on pull requests.

## What it runs

The sequence I have been running by hand each iteration: install → build the binaries (the generator is resolved by bin name, and `prisma generate` needs it) → generate the template artifact → **typecheck** → unit tests → template tests → lint.

Also adds a `typecheck` script, so the command has one spelling for CI and for people rather than being a raw `bunx` invocation you have to know.

## Two things stated rather than hidden

- **It will fail on `feat/orm` until #160 merges.** That is the point rather than a snag — the branch is broken and nothing currently says so.
- **Postgres is not included.** The differential harness runs against it when `TEST_POSTGRES_URL` is set and skips loudly otherwise, so a run without it is honest about covering SQLite only. A service container is a sensible next step and a separate decision.

`packageManager` says `bun@1.1.3`, well behind what the repo is developed against, so the workflow takes `latest` rather than pinning to something stale — worth reconciling separately.

## Verification

Every step was run locally against this branch. `bun run typecheck` reproduces the `feat/orm` failure exactly; `bun run lint` exits 0; the two suites pass at 1088 and 604. The workflow file was checked for tab characters and step structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)