### PR TITLE
Three exports nothing outside their file uses, and one dead local

### DIFF
--- a/packages/gemi/orm/architecture.test.ts
+++ b/packages/gemi/orm/architecture.test.ts
@@ -224,6 +224,69 @@ describe("the ORM's seams", () => {
   });
 
   /**
+   * **Nothing is exported that only its own file uses.**
+   *
+   * `orm/index.ts` is the public surface and is curated — the `PRE_SCOPED`
+   * symbol is deliberately absent from it so an application cannot forge one.
+   * A module-level `export` is a smaller version of the same decision: it is
+   * how a helper becomes something another file may reach for, and exporting
+   * one that nothing imports widens the surface for nothing.
+   *
+   * Three had drifted that way — `relation-filters.ts`'s two operator tuples,
+   * used only by the function directly beneath them, and `corpus.ts`'s
+   * `LITERAL`, which I exported when extracting that corpus and never needed
+   * to. None was reachable from `index.ts`, so none was public; they were just
+   * wider than they had to be.
+   *
+   * Test files count as references, because an export existing *for* a test is
+   * a real reason — `isTracked` says so in as many words.
+   */
+  const MAY_BE_EXPORTED_UNUSED: string[] = [
+    // Nothing today. An entry here is a deliberate exception with a reason
+    // beside it, not a place to put whatever this test happens to flag.
+  ];
+
+  test("no export is referenced only inside its own file", () => {
+    const declared = new Map<string, string>();
+    const sources = new Map<string, string>();
+
+    for (const [name, path] of FILES) {
+      const content = read(path);
+      sources.set(name, content);
+      if (name === "index.ts") continue;
+
+      for (const match of content.matchAll(
+        /^export (?:async )?function (\w+)|^export const (\w+)|^export class (\w+)/gm,
+      )) {
+        const exported = match[1] ?? match[2] ?? match[3];
+        // A name declared in two files is ambiguous to a text scan; skip rather
+        // than guess, since a false positive here reads as a real finding.
+        declared.set(exported, declared.has(exported) ? "" : name);
+      }
+    }
+
+    // Tests are references: an export that exists for a test is justified.
+    for (const path of readdirSync(ROOT, { recursive: true, withFileTypes: true })) {
+      if (!path.name.endsWith(".test.ts")) continue;
+      const full = join((path as { parentPath?: string }).parentPath ?? ROOT, path.name);
+      sources.set(`test:${full}`, read(full));
+    }
+
+    const unreferenced: string[] = [];
+    for (const [name, home] of declared) {
+      if (home === "" || MAY_BE_EXPORTED_UNUSED.includes(name)) continue;
+
+      const used = [...sources.entries()].some(
+        ([file, content]) =>
+          file !== home && new RegExp(`\\b${name}\\b`).test(content),
+      );
+      if (!used) unreferenced.push(`${home} exports ${name}, and nothing else uses it`);
+    }
+
+    expect(unreferenced, unreferenced.join("\n")).toEqual([]);
+  });
+
+  /**
    * ...and the allow-list cannot go stale: each entry has to still contain the
    * thing it excuses. An exception that stops being needed should be removed,
    * not left standing as permission.

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -198,8 +198,6 @@ function compileRelationFilter(
   context: WhereContext,
   locate: (args: any) => any,
 ): Fragment | null {
-  const path = `where.${relation.name}`;
-
   // Shape before environment: `readOperators` only reads the relation's own
   // `kind`, so a malformed filter is reported as one even when the registry is
   // empty. The other order let a missing `register` call mask a plain typo.

--- a/packages/gemi/orm/corpus.ts
+++ b/packages/gemi/orm/corpus.ts
@@ -122,7 +122,7 @@ export const GROUPS: unknown[] = [
  * structural rather than bound. Kept here rather than imported so that
  * widening `LITERAL_KEYS` without thinking does not silently widen this too.
  */
-export const LITERAL = new Set([
+const LITERAL = new Set([
   "orderBy",
   "select",
   "omit",

--- a/packages/gemi/orm/relation-filters.ts
+++ b/packages/gemi/orm/relation-filters.ts
@@ -23,8 +23,8 @@
  */
 
 /** Prisma's operators, per relation kind. Sorted, because callers iterate them. */
-export const MANY_FILTER_OPERATORS = ["every", "none", "some"] as const;
-export const ONE_FILTER_OPERATORS = ["is", "isNot"] as const;
+const MANY_FILTER_OPERATORS = ["every", "none", "some"] as const;
+const ONE_FILTER_OPERATORS = ["is", "isNot"] as const;
 
 export function relationFilterOperators(
   kind: "one" | "many",


### PR DESCRIPTION
Closes #164. Based on `feat/orm` directly.

`orm/` has sat at "1 warning" for this whole series and I kept reporting it as *pre-existing* rather than looking at it.

## The local

`compile/where.ts:201`, in `compileRelationFilter`:

```ts
const path = `where.${relation.name}`;
```

Never read. The identical line thirty lines down **is** used — it feeds the `argument` of three refusals — so this one is a leftover from when those moved. Removing it takes `oxlint packages/gemi/orm` from 1 warning to **0**.

Worth checking rather than assuming, because the interesting version would have been the opposite: a refusal that *should* carry the path and does not, which is the #108 / #112 shape. It is not that — this function delegates its refusals to the one that computes its own path.

## The exports

Exported names referenced nowhere outside their own file — three of 162:

| file | export |
| --- | --- |
| `relation-filters.ts` | `MANY_FILTER_OPERATORS` |
| `relation-filters.ts` | `ONE_FILTER_OPERATORS` |
| `corpus.ts` | `LITERAL` |

The two tuples are used only by the function directly beneath them. `LITERAL` is mine — exported when I extracted the shared corpus, never needed.

**None is reachable from `orm/index.ts`**, so none was public. They were just wider than they had to be.

## Why it matters at all

`orm/index.ts` is a curated surface — the `PRE_SCOPED` symbol is deliberately absent from it so an application cannot forge one. A module-level `export` is a smaller version of the same decision: it is how a helper becomes something another file may reach for. Exporting one nothing imports invites a reach that was never intended — the same class as the dead `relationKeys` parameter removed in #136: surface implying a use it does not have.

## The check

Lives with the other structural ones in `architecture.test.ts`, with an allow-list so a deliberate exception is something someone writes down rather than a silent pass.

**Test files count as references.** An export existing *for* a test is a real reason, and `isTracked` says so in as many words.

A name declared in two files is skipped rather than guessed at — a false positive here would read as a real finding, which is worse than a miss.

**Verified** by re-exporting one of the tuples: the check names it exactly.

- `oxlint` on `orm/`: **0 warnings**, 0 errors.
- 1312 unit tests, template suite 611 on SQLite.
- `tsc` shows only the known #159 failure, which #160 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)