### PR TITLE
InvalidArgumentError is exported but missing from the Errors table

### DIFF
--- a/docs/orm.md
+++ b/docs/orm.md
@@ -967,6 +967,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `MissingRequiredValueError` | A write leaving a required column with no value and no default. |
 | `DecodeError` | A column the driver returned that cannot be read as its declared type. |
 | `UnsupportedByDesignError` | A subclass of `UnsupportedQueryError` for the arguments under [Not in scope](#not-in-scope) — it says *decision*, where the parent says *not yet*. Catch this one to tell them apart. |
+| `InvalidArgumentError` | The other subclass: the argument exists and the *value* cannot mean anything — `take: "-2"`. Says what a good value looks like, rather than that the argument is unsupported. |
 | `UnsupportedDialectError` | A model operation on a dialect with no compiler — MySQL and MariaDB. See [Dialects](#dialects). |
 | `ReturningUnsupportedError` | A write on a dialect without `RETURNING`, which is the same gap seen from the write path. |
 | `StaleSchemaArtifactError` | Generated files predate the running gemi. Re-run `prisma generate`. |


### PR DESCRIPTION
Closes #166. Based on `feat/orm` directly — it fixes a failing test on the integration branch.

`feat/orm` at 22eacb8:

```
× InvalidArgumentError is in the table
  Tests  1 failed | 1338 passed (1339)
```

That is the guard from #149/#150 doing its job — and it is failing because of **my own PR**, in the same way #159 happened.

## How

| | |
| --- | --- |
| **#103** | added `InvalidArgumentError` and exported it |
| **#150** | added a check that every exported `Error` subclass appears in the **Errors** table |

#150's branch was cut before #103 merged, so on that branch the class did not exist and the check passed. On the merge result it exists, is exported, and is not in the table.

**Neither PR could see it.** #103 never touched the check; #150 never touched the class; each was green alone. Same class as #159 — a break that exists only in the combination — and the **second instance in this series**. #162 exists precisely for this and would have caught both the moment they landed.

## The document is not wrong, exactly

`docs/orm.md` *does* describe the class, in the refusal-taxonomy table #103 added:

> | `InvalidArgumentError` | the argument exists, the value cannot mean anything | fix the value |

What it is missing from is the **Errors** catalogue — the section that opens *"Every failure is a typed error from `gemi/orm`"* and is where a reader looks to find out what there is to catch. Described in one place, absent from the index.

That distinction is what the check tests, and why it reads that section rather than the whole file.

## The change

One row, saying what distinguishes it from its sibling: the argument exists and the **value** is the problem, so the message says what a good value looks like rather than that the argument is unsupported.

**No change to the check.** It was right.

- 1339 unit tests pass (was 1 failed | 1338 passed).
- Template suite: 611 on SQLite. `oxlint` unchanged.
- `tsc` still shows the separate #159 failure, which #160 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)