### PR TITLE
Composite-in's field lookup had no test, and paired()'s empty guard is a floor

### DIFF
--- a/packages/gemi/orm/compile/composite-relations.test.ts
+++ b/packages/gemi/orm/compile/composite-relations.test.ts
@@ -342,6 +342,32 @@ describe("the composite-in key is the planner's alone", () => {
     ).toThrow(/the planner built/);
   });
 
+  /**
+   * ...and a planner operand naming a field the model does not have.
+   *
+   * The shape checks above pass it — `["nosuchfield"]` is a non-empty array of
+   * strings with matching tuples — so the only thing that catches it is the
+   * field lookup in `compileCompositeIn`, and that lookup was the one guard in
+   * this family with no test. Found by re-running the construction-site
+   * coverage from #114 against the merged composite work.
+   *
+   * `UnknownFieldError` rather than the "planner built" wording, and that is
+   * right: the shape is fine and the *name* is wrong, which is the same thing
+   * the caller-facing path reports for the same mistake.
+   */
+  test("a planner operand naming a field that is not there", () => {
+    const planners = plannerCompositeIn(["nosuchfield"], [[1]]);
+
+    expect(() =>
+      compileRead(ledgerEntry, "findMany", { where: { $compositeIn: planners } }, postgres),
+    ).toThrow(UnknownFieldError);
+
+    // The known fields are listed, which is what makes it actionable.
+    expect(() =>
+      compileRead(ledgerEntry, "findMany", { where: { $compositeIn: planners } }, postgres),
+    ).toThrow(/is not a field on model LedgerEntry/);
+  });
+
   /** ...and the planner's own still compiles, on the dialect that binds it. */
   test("the planner's own is accepted", () => {
     const plan = compileRead(ledgerEntry, "findMany", { include: { ledger: true } }, postgres);

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -832,6 +832,15 @@ function paired(
   operation: string,
 ): Link {
   if (parentFields.length === 0) {
+    // **No caller reaches this.** A relation with no fields on either side is
+    // refused earlier — `resolveLink` raises `MalformedRelationError` naming
+    // both sides — and a lopsided pairing is refused by the length check below
+    // it. Measured by feeding both shapes through an `include` and a relation
+    // filter: all four paths stop before here.
+    //
+    // Kept as the floor under a future caller that builds a `Link` some other
+    // way, not deleted — the same distinction `select.ts`'s `select + include`
+    // guard records, and for the same reason.
     throw new UnsupportedQueryError(
       relation.name,
       parent.name,


### PR DESCRIPTION
Closes #168. Based on `feat/orm` directly.

Re-ran the construction-site coverage from #114 against `feat/orm` at 24c836b, now that the composite-relation work (#95, #100) and everything through #160 has merged.

**21 error classes, 195 construction sites** — up from 20 and 188. Three genuinely unreached, after discounting two my own instrumentation missed: I recorded through a `globalThis` hook I never defined for the two classes outside `errors.ts`, and both are in fact covered (verified in #147/#148).

| site | verdict |
| --- | --- |
| `write.ts:1325` (`fieldOf`) | floor, already documented in #120 |
| `plan-relations.ts:835` (`paired`) | **floor** — newly measured |
| `where.ts:570` (`compileCompositeIn`) | **gap** |

## The gap

`assertCompositeInOperand` checks a planner-built `$compositeIn` has a non-empty array of string fields and tuples of matching length — four guards, all tested. It does **not** check that each name is a field on the model. The only thing that does is the lookup in `compileCompositeIn`, and that one had no test.

Reachable exactly the way its siblings are, through the exported `plannerCompositeIn` helper:

```
plannerCompositeIn(["nosuchfield"], [[1]])
  → UnknownFieldError: 'nosuchfield' is not a field on model LedgerEntry. Known fields: …
```

`UnknownFieldError` rather than the "planner built" wording, and that is right: the **shape** is fine and the **name** is wrong, which is what the caller-facing path reports for the same mistake.

## The floor

`paired()` refuses a relation naming no join fields. I fed both malformed shapes — empty `from`/`to` on both sides, and a lopsided one-to-two pairing — through an `include` and a relation filter. All four paths stop earlier, at `resolveLink`'s `MalformedRelationError` or the length check below it.

Fifth instance of this shape, after `select.ts:28`, `parseOrderBy`'s relation guard, `registry.get` and `fieldOf`. Kept rather than deleted, for the reason the others are — and now **commented with what pre-empts it**, because I have re-triaged `fieldOf` twice and that is twice too many.

## Verification

Removing the field lookup fails the new test by name.

- `tsc --noEmit` clean. 1366 unit tests pass, up one.
- Template suite: 614 on SQLite.

Two known conditions inherited from the base, both already fixed in open PRs: the `InvalidArgumentError is in the table` failure (#167) and the single `oxlint` warning in `where.ts` (#165).

🤖 Generated with [Claude Code](https://claude.com/claude-code)