### PR TITLE
CI: hold `orm/` at zero warnings, since a new one would be the 89th

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,23 @@ jobs:
         env:
           TZ: UTC
 
+      # Two lints, because the package and the ORM are in different states.
+      #
+      # `bun run lint` is `oxlint` over the whole package: 88 warnings, 0
+      # errors, so it passes — and a new warning in `orm/` would be one of 89.
+      # Kept, because the errors it would catch are worth catching.
+      #
+      # `orm/` is at zero after #165, so it can be held there. `--deny-warnings`
+      # makes that a build failure rather than a line nobody reads. Scoped to
+      # `orm/` deliberately: the rest of the package is not this series' to
+      # clean up, and a check that is red for someone else's reasons stops
+      # being read — the argument #163 makes about the suite.
       - name: Lint
         run: bun run lint
+        working-directory: packages/gemi
+
+      - name: Lint the ORM at zero warnings
+        run: bunx oxlint orm --deny-warnings
         working-directory: packages/gemi
 
   # The other half of the differential harness, which is the repository's actual


### PR DESCRIPTION
Closes #174. Stacked on #173.

CI runs `bun run lint`, which is `oxlint` over all of `packages/gemi`: **88 warnings, 0 errors**. It passes, correctly — but a warning introduced in `orm/` would be the **89th**, and nothing would distinguish it from the 88 already there.

`orm/` is at **0 warnings** since #165 removed the last one. That state is worth holding, and holding it is cheap.

## The asymmetry is deliberate

The rest of the package is not this series' to clean up. Widening the gate would put CI red for reasons nobody reviewing an ORM change can act on — the same argument #163 makes about the router suite, and the reason the test job runs `orm database` rather than everything.

So the package-wide lint stays, for the **errors** it would catch anywhere; a second step holds `orm/` specifically at zero.

## Measured

| | |
| --- | --- |
| `oxlint orm --deny-warnings` | exit **0** |
| ...with one dead local added | exit **1** |
| ...restored | exit **0** |

The regression it catches is exactly the one #165 fixed: an unused variable that sat in `where.ts` for the whole of this series while I reported it as "pre-existing" in every iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)