### PR TITLE
Keep the template's foreign keys indexed, which the docs promise

### DIFF
--- a/templates/saas-starter/app/models/foreign-key-indexes.test.ts
+++ b/templates/saas-starter/app/models/foreign-key-indexes.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * **Every relation's foreign key is indexed**, which `docs/orm.md` promises on
+ * this template's behalf.
+ *
+ * The promise is not decorative. A relation `_count`, a relation filter and a
+ * relation ordering all compile to a correlated subquery that runs **once per
+ * parent row**, so without an index each run scans the child table — and Prisma
+ * declares no index for a relation's foreign key on either dialect, so by
+ * default there is none.
+ *
+ * The docs put a number on it: on SQLite the index is worth enough to *flip*
+ * the advice. Unindexed, `_count` is slower than loading the children and
+ * counting them in JavaScript; indexed, it is comfortably faster. So a model
+ * added without one does not make the template a little slower — it makes a
+ * documented recommendation wrong.
+ *
+ * > The starter template indexes every foreign key for this reason, so a new
+ * > application starts on the right side of it.
+ *
+ * That sentence is what this asserts. It held when written and holds now; what
+ * it lacked was anything to keep it true as models are added, which is the same
+ * drift #157 caught in the prose and #164 in the export surface.
+ */
+const SCHEMA = join(import.meta.dirname, "../../prisma/schema.prisma");
+
+/** A model's body, keyed by name. */
+function models(source: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const match of source.matchAll(/^model (\w+) \{(.*?)^\}/gms)) {
+    out.set(match[1], match[2]);
+  }
+  return out;
+}
+
+/** The local columns each `@relation(fields: [...])` uses. */
+function foreignKeys(body: string): string[][] {
+  return [...body.matchAll(/@relation\([^)]*fields:\s*\[([^\]]*)\]/g)].map((match) =>
+    match[1].split(",").map((name) => name.trim()).filter(Boolean),
+  );
+}
+
+/**
+ * Every column list the database will have an index for.
+ *
+ * `@@index`, `@@unique` and `@@id` all produce one, and so does a single-field
+ * `@unique` or `@id` — a foreign key that is also the primary key needs no
+ * separate index, which is the shape a one-to-one takes.
+ */
+function indexed(body: string): string[][] {
+  const lists: string[][] = [];
+
+  for (const pattern of [/@@index\(\[([^\]]*)\]/g, /@@unique\(\[([^\]]*)\]/g, /@@id\(\[([^\]]*)\]/g]) {
+    for (const match of body.matchAll(pattern)) {
+      lists.push(match[1].split(",").map((name) => name.trim()).filter(Boolean));
+    }
+  }
+
+  for (const match of body.matchAll(/^\s*(\w+)\s+\S+[^\n]*@(?:unique|id)\b/gm)) {
+    lists.push([match[1]]);
+  }
+
+  return lists;
+}
+
+describe("the template's foreign keys", () => {
+  const source = readFileSync(SCHEMA, "utf8");
+  const declared = models(source);
+
+  test("the schema was parsed, or this asserts nothing", () => {
+    expect(declared.size).toBeGreaterThan(5);
+    expect([...declared.values()].some((body) => foreignKeys(body).length > 0)).toBe(true);
+  });
+
+  test("every relation's foreign key is covered by an index", () => {
+    const uncovered: string[] = [];
+
+    for (const [name, body] of declared) {
+      const available = indexed(body);
+
+      for (const key of foreignKeys(body)) {
+        // A **prefix** match, because that is what a composite index serves: an
+        // index on [a, b] answers a lookup on [a], and one on [b] does not.
+        const covered = available.some(
+          (list) =>
+            list.length >= key.length &&
+            key.every((column, position) => list[position] === column),
+        );
+
+        if (!covered) {
+          uncovered.push(
+            `${name}: @relation(fields: [${key.join(", ")}]) has no index with that prefix`,
+          );
+        }
+      }
+    }
+
+    expect(uncovered, uncovered.join("\n")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #176. Based on `feat/orm` directly.

`docs/orm.md` makes a promise on this template's behalf:

> The starter template indexes every foreign key for this reason, so a new application starts on the right side of it.

And the reason is measured, and not small:

> On SQLite that one line is worth several times the query — enough to **flip** the advice: unindexed, `_count` is slower than loading the children and counting them in JavaScript; indexed, it is comfortably faster.

A relation `_count`, a relation filter and a relation ordering all compile to a correlated subquery that runs **once per parent row**. Prisma declares no index for a relation's foreign key on either dialect, so unless the schema says so, there is none.

## Measured

**13 models, 0 unindexed foreign keys.** The promise holds today.

What it lacks is anything to keep it true. A model added later with a `@relation` and no `@@index` does not make the template slightly slower — it makes a **documented recommendation wrong**, silently, for every application generated from it.

Same drift as #157, where a *Not in scope* entry stopped being true because the boundary moved underneath it, and #164, where the export surface widened without anyone deciding to.

## What the check gets right

- **Prefix** matching, because that is what a composite index serves: an index on `[a, b]` answers a lookup on `[a]`, and one on `[b]` does not.
- `@@index`, `@@unique`, `@@id` **and** a single-field `@unique`/`@id` all count — a foreign key that is also the primary key needs no separate index, which is the shape a one-to-one takes.
- A guard that the parse found models and foreign keys **at all**, so a schema that stops matching the pattern fails loudly rather than passing over nothing.

## Verification

Deleting one `@@index` fails with the model and field named:

```
Account: @relation(fields: [userId]) has no index with that prefix
```

- Template suite: 616 passed on SQLite (up 2).
- 1367 unit tests, `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)