### PR TITLE
The generator was never tested on a composite relation

### DIFF
--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -351,6 +351,79 @@ describe("buildModelSchemas()", () => {
     const [, user] = buildModelSchemas([USER, POST]);
     expect(user.relations.posts.joinTable).toBeUndefined();
   });
+
+  /**
+   * **A relation that joins on more than one field**, which every other case
+   * here declares with exactly one.
+   *
+   * The compiler handles this shape and is well tested for it — but against
+   * *hand-written* fixtures, and the starter template declares no composite
+   * relation, so nothing exercised the generator that produces the real
+   * artifact.
+   *
+   * The failure that leaves open is the quiet one. A generator that kept only
+   * the first field would emit `from: ["tenantId"]`, every compiler test would
+   * still pass because they build their own schemas, the template suite would
+   * still pass because it has no such relation — and an application with one
+   * would correlate on a single column and return plausible wrong rows. That is
+   * precisely what the compiler's own refusal was written to prevent, so it is
+   * worth checking that the input reaches it intact.
+   *
+   * Both sides are asserted: `from` and `to` are positional pairs, and a
+   * truncation or a reorder on either side is the same bug.
+   */
+  test("carries every field of a composite relation, on both sides", () => {
+    const LEDGER = model({
+      name: "Ledger",
+      fields: [
+        field({ name: "tenantId" }),
+        field({ name: "code", type: "String" }),
+        field({
+          kind: "object",
+          name: "entries",
+          type: "Entry",
+          isList: true,
+          relationName: "EntryToLedger",
+          relationFromFields: [],
+          relationToFields: [],
+        }),
+      ],
+      primaryKey: { name: null, fields: ["tenantId", "code"] } as never,
+    });
+
+    const ENTRY = model({
+      name: "Entry",
+      fields: [
+        field({ name: "id", isId: true }),
+        field({ name: "tenantId" }),
+        field({ name: "ledgerCode", type: "String" }),
+        field({
+          kind: "object",
+          name: "ledger",
+          type: "Ledger",
+          isRequired: true,
+          relationName: "EntryToLedger",
+          relationFromFields: ["tenantId", "ledgerCode"],
+          relationToFields: ["tenantId", "code"],
+        }),
+      ],
+    });
+
+    const [entry, ledger] = buildModelSchemas([ENTRY, LEDGER]);
+
+    // The owning side names both of its own columns and both of the target's,
+    // in declaration order — the pairing is positional.
+    expect(entry.relations.ledger.from).toEqual(["tenantId", "ledgerCode"]);
+    expect(entry.relations.ledger.to).toEqual(["tenantId", "code"]);
+
+    // The far side names neither, and is resolved through this one at plan
+    // time — which is why a truncation here would not show up as a missing key.
+    expect(ledger.relations.entries.from).toEqual([]);
+    expect(ledger.relations.entries.to).toEqual([]);
+
+    // ...and the composite primary key it references survives too.
+    expect(ledger.primaryKey).toEqual(["tenantId", "code"]);
+  });
 });
 
 describe("emitArtifacts()", () => {


### PR DESCRIPTION
Closes #178. Based on `feat/orm` directly.

Composite relations landed in #95 and #100, and the compiler is thoroughly tested for them. The **generator** that produces the artifact those tests stand in for is not — every relation in `emit.test.ts` declares exactly one field:

```ts
relationFromFields: ["authorId"],
relationToFields: ["id"],
```

## Why the gap is quiet rather than loud

Three things would each have caught a truncation, and **none of them can**:

| | |
| --- | --- |
| the compiler's composite tests | build their own `ModelSchema` fixtures by hand — they never run the generator |
| the starter template | declares no composite relation (16 relations, 0 composite), so its suite exercises nothing here |
| the artifact diff test | asserts a second `prisma generate` matches the first, which a *consistently* wrong generator satisfies |

So a generator keeping only the first field would emit `from: ["tenantId"]`, every suite would stay green, and an application with a composite relation would correlate on **one column** and return plausible wrong rows — exactly what the compiler's own refusal was written to prevent, back when the shape was unsupported.

## Measured

The generator is **correct**: a two-field relation comes through as `from: ["tenantId", "ledgerCode"]`, `to: ["tenantId", "code"]`, far side empty, composite primary key intact.

The gap is in what would notice if it stopped being. Truncating `emit.ts` to `slice(0, 1)`:

```
bin/orm/emit.test.ts     1 failed | 26 passed
orm database             1 failed | 1367 passed
```

**Only the new test notices.**

## What it asserts

- **Both sides.** `from` and `to` are positional pairs, so a truncation *or* a reorder on either is the same bug.
- **The far side empty**, since it is resolved through the owning side at plan time — and is therefore where a missing key would *not* show up.
- **The composite primary key** it references, being the same shape.

- `typecheck` clean, 1368 unit tests, `oxlint orm --deny-warnings` exit 0.
- Template suite: 614 on SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)