### PR TITLE
The operation count is documented three different ways, all wrong

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2743,7 +2743,7 @@ generator gemi {
 Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 - `schema.ts` — runtime metadata: tables, columns, types, defaults, relations.
-- `models.ts` — a typed base class per model, carrying the fourteen operations.
+- `models.ts` — a typed base class per model, carrying every operation.
 - `index.ts` — registers every model by name.
 
 **The output is committed on purpose.** Diffs stay reviewable and CI needs no codegen step.
@@ -2792,7 +2792,7 @@ read. It can only see modules you hand it, so it does not replace the `register`
 
 ## Querying
 
-Fourteen operations, with Prisma's argument types verbatim:
+Fifteen operations, with Prisma's argument types verbatim:
 
 ```
 findMany   findFirst   findFirstOrThrow   findUnique   findUniqueOrThrow   count   aggregate   groupBy
@@ -4057,7 +4057,7 @@ There is an `ActiveRecordModel` base in the ORM that makes every query return in
 overriding one method. It ships as a **documented example rather than a supported tier**, for
 exactly the reason above plus one more: the return *types* do not change, so the methods are
 invisible to TypeScript at the call site even though they exist at runtime. Fixing that means
-conditional return types across all twelve operations, which is the complexity the plain-object
+conditional return types across every operation, which is the complexity the plain-object
 default was chosen to avoid.
 
 Use it if you want to see the seam work. Reach for `wrap` if you want the guarantee.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,7 +28,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 
 ## Data
 
-- [ORM](https://nstfkc.github.io/gemi/orm.md): the Prisma-typed, gemi-executed query layer — the Prisma generator block, the thirteen operations, relations and the batched/lateral strategies, ambient transactions, policies that apply to nested reads, soft deletes.
+- [ORM](https://nstfkc.github.io/gemi/orm.md): the Prisma-typed, gemi-executed query layer — the Prisma generator block, every operation, relations and the batched/lateral strategies, ambient transactions, policies that apply to nested reads, soft deletes.
 - [Rows & Entities](https://nstfkc.github.io/gemi/orm-rows-and-entities.md): plain objects by default, opt-in provenance with track + save, and wrap for methods on a record.
 
 ## Auth

--- a/docs/orm-rows-and-entities.md
+++ b/docs/orm-rows-and-entities.md
@@ -150,7 +150,7 @@ There is an `ActiveRecordModel` base in the ORM that makes every query return in
 overriding one method. It ships as a **documented example rather than a supported tier**, for
 exactly the reason above plus one more: the return *types* do not change, so the methods are
 invisible to TypeScript at the call site even though they exist at runtime. Fixing that means
-conditional return types across all twelve operations, which is the complexity the plain-object
+conditional return types across every operation, which is the complexity the plain-object
 default was chosen to avoid.
 
 Use it if you want to see the seam work. Reach for `wrap` if you want the guarantee.

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -48,7 +48,7 @@ generator gemi {
 Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 - `schema.ts` — runtime metadata: tables, columns, types, defaults, relations.
-- `models.ts` — a typed base class per model, carrying the fourteen operations.
+- `models.ts` — a typed base class per model, carrying every operation.
 - `index.ts` — registers every model by name.
 
 **The output is committed on purpose.** Diffs stay reviewable and CI needs no codegen step.
@@ -97,7 +97,7 @@ read. It can only see modules you hand it, so it does not replace the `register`
 
 ## Querying
 
-Fourteen operations, with Prisma's argument types verbatim:
+Fifteen operations, with Prisma's argument types verbatim:
 
 ```
 findMany   findFirst   findFirstOrThrow   findUnique   findUniqueOrThrow   count   aggregate   groupBy

--- a/packages/gemi/orm/active-record.test.ts
+++ b/packages/gemi/orm/active-record.test.ts
@@ -63,7 +63,7 @@ describe("ActiveRecordModel", () => {
    * The cases that must fall *through* untouched. Hydrating either would be the
    * kind of per-operation special case this override exists to show is
    * unnecessary — `$shape` sees rows or it sees something that is not a row, and
-   * it does not need to know which of the twelve operations produced it.
+   * it does not need to know which operation produced it.
    */
   test("a no-match single-row operation stays null", () => {
     expect(Entity.$shape(planFor([], true), [])).toBeNull();

--- a/packages/gemi/orm/active-record.ts
+++ b/packages/gemi/orm/active-record.ts
@@ -7,7 +7,7 @@ import type { QueryPlan } from "./plan";
  * This is iteration 8's deliverable 4, and its job is to prove invariant 3 was
  * worth holding: `$shape` is a static on the model base rather than a
  * module-level function, so a subclass can change what a query *returns* without
- * any of the twelve operations knowing. If that had required touching an
+ * any operation knowing. If that had required touching an
  * operation, it would have been a design defect to fix while the cost was still
  * small.
  *
@@ -34,7 +34,7 @@ import type { QueryPlan } from "./plan";
  * 2. The return *types* do not change. `findMany` is still typed as returning
  *    `Prisma.PostGetPayload<T>[]`, so the instance methods are invisible to
  *    TypeScript at the call site even though they are there at runtime. Fixing
- *    that means conditional return types across all twelve operations, which is
+ *    that means conditional return types across every operation, which is
  *    exactly the complexity the POJO baseline was chosen to avoid.
  *
  * So this file is evidence that the seam works, and a warning about what using
@@ -49,7 +49,7 @@ export abstract class ActiveRecordModel extends Model {
    * data is *carried in*.
    *
    * Note what is not here: no per-operation branching, no knowledge of which of
-   * the twelve operations is running, and no second code path for writes. A
+   * the operations is running, and no second code path for writes. A
    * `count` returns a number and an `updateMany` returns `{ count }`; both fall
    * through untouched because they are not rows.
    */

--- a/packages/gemi/orm/architecture.test.ts
+++ b/packages/gemi/orm/architecture.test.ts
@@ -196,7 +196,7 @@ describe("the ORM's seams", () => {
    *
    * `$shape` is a static on the model base precisely so that
    * `ActiveRecordModel` can override it and every model extending it gets rows
-   * as instances "with zero changes to the twelve operations". That only holds
+   * as instances "with zero changes to the operations". That only holds
    * while `$exec` is the thing calling it.
    *
    * The failure is quiet and partial: one operation calling `plan.shape(rows)`

--- a/packages/gemi/orm/compile/strategy.test.ts
+++ b/packages/gemi/orm/compile/strategy.test.ts
@@ -15,7 +15,7 @@ const origin = { model: "User", operation: "findMany" };
 /**
  * `resolveStrategy` had no test, and its refusal reported `"Model"` as the
  * model and `"$exec"` as the operation — a base class, and something that is
- * not one of the thirteen operations (#112). Its one caller has both in scope.
+ * not one of the operations (#112). Its one caller has both in scope.
  */
 describe("resolveStrategy", () => {
   test("the default is per dialect: lateral on postgres, batched on sqlite", () => {

--- a/packages/gemi/orm/compile/strategy.ts
+++ b/packages/gemi/orm/compile/strategy.ts
@@ -58,7 +58,7 @@ export function resolveStrategy(
   dialect: SqlDialect,
   // Required, so the caller cannot fall back to a placeholder without saying
   // so. This used to report `"Model"` and `"$exec"` — a base class and
-  // something that is not one of the thirteen operations — while `$exec`, its
+  // something that is not one of the operations — while `$exec`, its
   // only caller, had both in scope (#112).
   origin: { model: string; operation: string },
 ): RelationStrategy {

--- a/packages/gemi/orm/docs-scope.test.ts
+++ b/packages/gemi/orm/docs-scope.test.ts
@@ -199,3 +199,46 @@ describe("docs/llms-full.txt carries the ORM pages", () => {
     expect(embedded(title.replace(/^#\s*/, ""))).toBe(expected);
   });
 });
+
+/**
+ * **The operations `docs/orm.md` lists are the operations that exist.**
+ *
+ * The page introduces them with a count and a code block. The count had been
+ * wrong, and had been wrong in three different ways at once across the
+ * repository — "twelve" in `active-record.ts`, "thirteen" in `strategy.ts` and
+ * `llms.txt`, "fourteen" in the page itself, against a union of **fifteen**.
+ * Each was right when written and none moved when `count`, `aggregate` and
+ * `groupBy` arrived.
+ *
+ * The list was complete throughout; only the prose around it drifted. That is
+ * the milder failure, but it is the one a reader meets first, and I contributed
+ * to it myself — #144 copied "thirteen" out of a comment without checking.
+ *
+ * So the guard is on the **list**, not the number: a count can only be wrong by
+ * one word, while a missing operation is a documented surface that does not
+ * exist, or an existing one nobody is told about.
+ */
+describe("docs/orm.md lists every operation", () => {
+  const source = readFileSync(DOC, "utf8");
+
+  /** The fenced block that follows the introduction. */
+  const listed = (() => {
+    const at = source.search(/^\w+ operations, with Prisma's argument types verbatim:$/m);
+    expect(at, "the operations block moved or was reworded").toBeGreaterThan(0);
+    const fence = source.indexOf("```", at);
+    const end = source.indexOf("```", fence + 3);
+    return source
+      .slice(fence + 3, end)
+      .split(/\s+/)
+      .map((word) => word.trim())
+      .filter(Boolean);
+  })();
+
+  test("the block was found and holds names", () => {
+    expect(listed.length).toBeGreaterThan(10);
+  });
+
+  test("it names exactly the operations the compiler implements", () => {
+    expect([...listed].sort()).toEqual([...IMPLEMENTED].sort());
+  });
+});


### PR DESCRIPTION
Closes #182. Stacked on #181, because `llms.txt` and `llms-full.txt` carry the same sentences and that PR is already rewriting one of them.

`Operation` declares **fifteen** operations. The repository states the count in fourteen places, in three different wrong numbers:

| count | where |
| --- | --- |
| **twelve** | `active-record.ts` (×3), `active-record.test.ts`, `architecture.test.ts`, `orm-rows-and-entities.md`, `plans/` (×2) |
| **thirteen** | `strategy.ts`, `strategy.test.ts`, `llms.txt`, `plans/` |
| **fourteen** | `docs/orm.md` (×2) |

Each was right when written. None moved when `count`, `aggregate` and `groupBy` arrived — twelve plus those three is fifteen.

**I contributed to it.** #144 wrote *"not one of the thirteen operations"* in `strategy.test.ts`, copied out of the comment beside it without checking.

## The list itself is fine

`docs/orm.md`'s code block names all fifteen. Only the prose introducing it says "Fourteen". That is the milder failure — but it is the sentence a reader meets first, and a number that has drifted three times will drift again.

So the counts become phrasing that cannot drift — "every operation", "the operations" — except in `orm.md`'s introduction, where the number does real work and is now correct.

## The guard is on the list, not the number

A wrong count is one word out of date. A wrong **list** is a documented surface that does not exist, or an existing one nobody is told about.

It asserts the code block names exactly the operations the compiler implements, checked against the same predicate-verified set #146 uses — so the list cannot quietly name something that is not an operation either.

**Verified** by deleting `groupBy` from the block: the guard names it (and the verbatim check from #181 catches it too).

## `plans/` is deliberately untouched

That directory records what was believed at each iteration, and says so:

> The claim is left standing above with this correction beneath it rather than quietly rewritten, because the gap between what an invariant promised and what it delivered is the useful part.

- `typecheck` clean, 1372 unit tests, `oxlint orm --deny-warnings` exit 0.
- Template suite: 614 on SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)