### PR TITLE
Correct the reasoning left behind by #179

### DIFF
--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -356,18 +356,24 @@ describe("buildModelSchemas()", () => {
    * **A relation that joins on more than one field**, which every other case
    * here declares with exactly one.
    *
-   * The compiler handles this shape and is well tested for it — but against
-   * *hand-written* fixtures, and the starter template declares no composite
-   * relation, so nothing exercised the generator that produces the real
-   * artifact.
+   * **Correcting the reason this was added (#178, #179).** It was justified on
+   * two claims that are both false: that the starter template declares no
+   * composite relation, and that the artifact's zero-diff test would not catch
+   * a truncating generator. The template declares
+   * `LedgerEntry.ledger @relation(fields: [tenantId, ledgerCode], …)`, and
+   * truncating `emit.ts` to the first field **does** fail that test — the
+   * committed artifact holds the right value, so regenerating diverges from it.
    *
-   * The failure that leaves open is the quiet one. A generator that kept only
-   * the first field would emit `from: ["tenantId"]`, every compiler test would
-   * still pass because they build their own schemas, the template suite would
-   * still pass because it has no such relation — and an application with one
-   * would correlate on a single column and return plausible wrong rows. That is
-   * precisely what the compiler's own refusal was written to prevent, so it is
-   * worth checking that the input reaches it intact.
+   * The measurement behind "only this test notices" was `vitest run orm
+   * database`, which is the package suite and excludes the template. Reported
+   * as though it were general, it was not.
+   *
+   * What is still true, and is reason enough on its own: the compiler's
+   * composite tests build their own `ModelSchema` fixtures and never run the
+   * generator, so this is the only *direct* check of it. It also fails
+   * differently — naming the field that went missing, rather than reporting
+   * that `prisma generate` produced a diff, which is a slower thing to read and
+   * one that a stale committed artifact could mask.
    *
    * Both sides are asserted: `from` and `to` are positional pairs, and a
    * truncation or a reorder on either side is the same bug.


### PR DESCRIPTION
Based on `feat/orm` directly. Corrects a comment I wrote, not behaviour.

#179 added a generator test for composite relations and justified it on **two claims that are both false**. Re-measured on `feat/orm` at f207120:

| claim | reality |
| --- | --- |
| "the starter template declares no composite relation" | it declares `LedgerEntry.ledger @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])`, with `@@id([tenantId, code])` on `Ledger` |
| "the artifact diff test … a consistently wrong generator satisfies" | truncating `emit.ts` to `slice(0, 1)` and rebuilding **fails** `running prisma generate again produces a zero-line diff` |

The composite relation arrived with the work that merged during this series. The "16 relations, 0 composite" figure I quoted was taken much earlier and I carried it forward without re-running it.

And the "**only the new test notices** — 1367 others pass" measurement was `vitest run orm database`. That is the package suite and **excludes the template**, so it could not have seen the diff test. I reported a scoped result as a general one.

## The test stays

The remaining reason holds and is enough on its own: the compiler's composite tests build their own `ModelSchema` fixtures and never run the generator, so this is the only **direct** check of it. It also fails differently — naming the field that went missing, rather than reporting that regeneration produced a diff, which is slower to read and which a stale committed artifact could mask.

What does not stay is the comment arguing for it, because it would have told the next reader two things that are not true.

Corrections are posted on #178 and #179 as well, so the record is not only in the source.

- `typecheck` clean, 1371 unit tests, `oxlint orm --deny-warnings` exit 0.
- Template suite: 616 on SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)