### PR TITLE
Setup's generator-ordering reason does not hold

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2726,8 +2726,11 @@ and never ships in a bundle.
 
 ## Setup
 
-Add the gemi generator to `schema.prisma`, *after* the `client` block — the emitted bases
-type-import `@prisma/client`, and Prisma runs generators in declaration order.
+Add the gemi generator to `schema.prisma`. Conventionally after the `client` block, though the
+order does not matter: the generator reads its models from Prisma's generator protocol and never
+imports `@prisma/client` itself, so it emits the same three files either way. The emitted bases do
+`import type { Prisma }`, but that is erased at build and only has to resolve when you typecheck —
+by which point one `prisma generate` has produced both.
 
 ```prisma
 generator client {

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -31,8 +31,11 @@ and never ships in a bundle.
 
 ## Setup
 
-Add the gemi generator to `schema.prisma`, *after* the `client` block — the emitted bases
-type-import `@prisma/client`, and Prisma runs generators in declaration order.
+Add the gemi generator to `schema.prisma`. Conventionally after the `client` block, though the
+order does not matter: the generator reads its models from Prisma's generator protocol and never
+imports `@prisma/client` itself, so it emits the same three files either way. The emitted bases do
+`import type { Prisma }`, but that is erased at build and only has to resolve when you typecheck —
+by which point one `prisma generate` has produced both.
 
 ```prisma
 generator client {

--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import type { DMMF } from "@prisma/generator-helper";
 import { describe, expect, test } from "vitest";
 
@@ -423,6 +426,50 @@ describe("buildModelSchemas()", () => {
 
     // ...and the composite primary key it references survives too.
     expect(ledger.primaryKey).toEqual(["tenantId", "code"]);
+  });
+});
+
+/**
+ * **The generator never imports `@prisma/client`**, which is what makes the
+ * generator block's position in `schema.prisma` a matter of convention.
+ *
+ * `docs/orm.md` used to say the gemi block had to come *after* the `client`
+ * one, because "the emitted bases type-import `@prisma/client`, and Prisma runs
+ * generators in declaration order". The premise is true and the conclusion does
+ * not follow: the emitted import is a **type** import, erased at build, and it
+ * only has to resolve when someone typechecks — by which point a single
+ * `prisma generate` has produced both outputs whatever order it ran them in.
+ *
+ * Measured before rewording: swapping the two blocks produces byte-identical
+ * `schema.ts`, `models.ts` and `index.ts`.
+ *
+ * This is the fact the corrected sentence rests on, so it is asserted rather
+ * than trusted. If the generator ever does need the client at generation time,
+ * the ordering advice comes back — and this fails first.
+ */
+describe("the generator's own dependencies", () => {
+  const sources = ["bin/orm/emit.ts", "bin/orm-generator.ts"];
+
+  test.each(sources)("%s does not import @prisma/client", (relative) => {
+    const source = readFileSync(join(import.meta.dirname, "../..", relative), "utf8");
+
+    const imports = [...source.matchAll(/^\s*import\s[^;]*?from\s+"([^"]+)"/gm)].map(
+      (match) => match[1],
+    );
+
+    // `@prisma/generator-helper` is the protocol and is expected; the client is
+    // the thing that must not be needed.
+    expect(imports).not.toContain("@prisma/client");
+    expect(imports.some((name) => name.startsWith("@prisma/"))).toBe(true);
+  });
+
+  /** ...while the *emitted* base does import it, as a type. */
+  test("the emitted models file imports Prisma as a type only", () => {
+    const models = emitArtifacts([USER, POST])["models.ts"];
+
+    expect(models).toContain('import type { Prisma } from "@prisma/client"');
+    // ...and never as a value import, which would make it a runtime dependency.
+    expect(models).not.toMatch(/^import \{[^}]*\} from "@prisma\/client"/m);
   });
 });
 


### PR DESCRIPTION
Closes #185. Based on `feat/orm` directly.

`docs/orm.md`'s **Setup** section opens:

> Add the gemi generator to `schema.prisma`, *after* the `client` block — the emitted bases type-import `@prisma/client`, and Prisma runs generators in declaration order.

The premise is true and **the conclusion does not follow**.

## Measured

| | |
| --- | --- |
| the generator never imports `@prisma/client` | `orm-generator.ts` and `emit.ts` import only `@prisma/generator-helper`, the protocol Prisma hands the models over — there is nothing for the client to be ready *for* |
| the emitted import is a **type** import | erased at build; it only has to resolve when someone typechecks, by which point one `prisma generate` has produced both outputs whatever order it ran them in |
| swapping the blocks | produces **byte-identical** `schema.ts`, `models.ts` and `index.ts`, and generation succeeds |

## Why correct it rather than leave it

The advice is harmless; the **reason** is not. It tells a reader that gemi's output depends on the client existing first, which makes ordering a thing to check when something goes wrong — and it is not. Someone debugging a real generation problem could spend time there.

**What I measured and what I did not:** I did not run this on a machine where `@prisma/client` had never been generated. That cannot change the answer, because the generator does not read the client at all — which is the fact worth pinning rather than the experiment.

## The guard

Asserts the generator imports nothing from `@prisma/client`, and that the emitted base imports `Prisma` **as a type only** — never as a value, which would make it a runtime dependency. If either stops being true, the ordering advice comes back and this fails first.

Verified by adding a value import to `orm-generator.ts`: the test names the file.

## Two process notes

- `emitArtifacts` returns an object keyed by filename, not an array. My first draft assumed an array; the run caught it.
- Editing `orm.md` **failed the verbatim guard from #181** until `llms-full.txt` was re-synced — the guard working on its own author, which is the best evidence I can offer that it was worth adding.

- `typecheck` clean, 1374 unit tests, `oxlint orm --deny-warnings` exit 0.
- Template suite: 616 on SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)