### PR TITLE
The benchmark report says Postgres both was and was not measured

### DIFF
--- a/packages/gemi/orm/benchmarks-report.test.ts
+++ b/packages/gemi/orm/benchmarks-report.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * `plans/orm/benchmarks.md` and its `.json` have to agree about which dialects
+ * were actually measured.
+ *
+ * The report is generated — its own header says "Regenerate rather than
+ * editing" — and `docs/orm.md` sends readers to it twice, once for "exact
+ * multipliers, the method, and what the measurement does **not** establish"
+ * and once for "the reasoning behind the lateral default". `lateral.ts` and
+ * `strategy.ts` cite it from source as well.
+ *
+ * The committed report claimed both sides of the same question. Three lines
+ * apart it said *"Deliverable 2 (lateral + `json_agg`) **was not evaluated**:
+ * Postgres was not measured"* and *"**Postgres was measured over loopback**,
+ * so every Postgres round trip here is optimistic"*, and it quoted a Postgres
+ * point read and depth-2 include "at 0.82× and 0.94×" — while `benchmarks.json`
+ * held nine results, every one of them `"dialect": "sqlite"`, and the tables
+ * contained no Postgres row at all.
+ *
+ * Only the first of those was generated conditionally. The rest were static
+ * strings in the report array, emitted whether or not Postgres ran — which is
+ * exactly the failure `docs/orm.md` describes as the reason the numbers are not
+ * repeated there: "a number copied into prose drifts from its source the first
+ * time the source is re-run, which happened three times inside that report
+ * before its own sentences were derived rather than written." These were the
+ * sentences that never made that transition.
+ *
+ * A reader cannot resolve a report that contradicts itself, and the half that
+ * is wrong is the confident half. So this asserts the property directly against
+ * the committed artifacts rather than against the generator: whatever code path
+ * emitted a claim, a claim about a dialect that has no data is caught here.
+ */
+const PLANS = join(import.meta.dirname, "../../../plans/orm");
+
+/** The dialects the run actually produced results for. */
+const measured = (() => {
+  const results = JSON.parse(
+    readFileSync(join(PLANS, "benchmarks.json"), "utf8"),
+  ) as Array<{ dialect?: string }>;
+
+  expect(Array.isArray(results), "benchmarks.json is not an array").toBe(true);
+  expect(results.length).toBeGreaterThan(0);
+
+  return new Set(results.map((result) => result.dialect).filter(Boolean));
+})();
+
+const report = readFileSync(join(PLANS, "benchmarks.md"), "utf8");
+
+describe("plans/orm/benchmarks.md reports only dialects it measured", () => {
+  test("the data names at least one dialect", () => {
+    expect(measured.size).toBeGreaterThan(0);
+  });
+
+  /**
+   * Every dialect appearing in a table row has to be one the data knows about.
+   * The rows are the part a reader trusts most, so a row for an unmeasured
+   * dialect is the worst version of this.
+   */
+  test("no table row names a dialect the data does not have", () => {
+    const rows = report
+      .split("\n")
+      .filter((line) => /^\|\s*(sqlite|postgres)\b/.test(line))
+      .map((line) => line.split("|")[1].trim());
+
+    expect(rows.length, "no dialect rows found — the table format moved").toBeGreaterThan(0);
+
+    for (const dialect of new Set(rows)) {
+      expect(measured, `benchmarks.md has ${dialect} rows`).toContain(dialect);
+    }
+  });
+
+  /**
+   * ...and the prose has to hold the same line.
+   *
+   * A line is read as *asserting a measurement* when it names the dialect
+   * alongside a figure (`0.82×`, `+350µs`, `17%`) or says it "was measured".
+   * Lines about the measurement's **absence** are what the report should say
+   * when a dialect did not run, so they are excluded by their own wording —
+   * "was not measured", "not evaluated", "not in this run", and the instruction
+   * to set the URL that would make it run.
+   *
+   * Deliberately not a whole-document regex: reporting the offending line is
+   * what makes the failure actionable, since the fix is always to gate that one
+   * sentence in `bench/run.ts` the way the deliverable-2 caveat already is.
+   */
+  test.each([...(["sqlite", "postgres"] as const)])(
+    "no sentence claims a %s figure unless that dialect ran",
+    (dialect) => {
+      if (measured.has(dialect)) return;
+
+      const absence =
+        /not measured|not evaluated|not in this run|require|set `BENCH_/i;
+      const figure = /\d+(\.\d+)?\s*(µs|×|%)|\bwas measured\b/;
+
+      const claims = report
+        .split("\n")
+        .filter((line) => new RegExp(dialect, "i").test(line))
+        .filter((line) => figure.test(line) && !absence.test(line));
+
+      expect(claims, `${dialect} has no data, but the report states figures for it`).toEqual([]);
+    },
+  );
+});

--- a/plans/orm/benchmarks.md
+++ b/plans/orm/benchmarks.md
@@ -122,13 +122,6 @@ would produce two identical columns and a derived sentence reading "the
 index is worth 1.0x", which is a measurement answering a different question
 than its own heading.
 
-**A ratio near 1 on Postgres here is a limit of this fixture, not a finding
-about Postgres.** The child table is 200 rows and the connection is
-loopback, so the round trip dominates and a scan of 200 rows is free either
-way — the numbers below can go either side of 1.0x on noise alone. This
-table says the index is decisive on SQLite and says *nothing* about how a
-real child table behaves over a real socket.
-
 | Dialect | Parents | plain µs | `_count` µs | `_count` +index µs | include+`.length` µs | `exists` µs | `exists` +index µs |
 | --- | --: | --: | --: | --: | --: | --: | --: |
 | sqlite | 100 | 72.1 | 631.0 | 96.5 | 253.5 | 337.3 | 94.5 |
@@ -171,19 +164,19 @@ gets built:
 
    **The positional-row half stays unjustified.** `.values()` exists — that
    much is verified rather than assumed — but it measured 14% *slower* on
-   SQLite and 17% faster on Postgres, and the sign flipped between runs at
-   lower sample counts. With p95 near double p50 on Postgres, this workload
-   cannot resolve it, so it was not taken.
+   SQLite, and the sign flipped between runs at lower sample counts. The
+   Postgres side of that comparison is not in this run's data, so nothing
+   here resolves it and it was not taken.
 3. **Deliverable 2 (lateral + `json_agg`) was not evaluated**: Postgres
    was not measured, and it is the only dialect where the case can be
    made. Set `BENCH_POSTGRES_URL`.
 4. **A transaction costs one extra round trip pair, and that is the whole
-   cost.** +12µs on SQLite, +350µs on Postgres — against a ~25ns ALS read.
+   cost.** +12µs on SQLite — against a ~25ns ALS read.
    Iteration 5's second `AsyncLocalStorage` is nowhere in the number; the
    `BEGIN`/`COMMIT` are. Worth knowing before anyone optimises the store.
-5. **Policies are free at this resolution.** +1µs on a SQLite point read,
-   and within run-to-run variance on Postgres. Iteration 6's deferred
-   question is answered: dispatch is not worth memoising.
+5. **Policies are free at this resolution.** +1µs on a SQLite point read.
+   Iteration 6's deferred question is answered for the dialect that ran:
+   dispatch is not worth memoising.
 6. **The plan cache earns ~10× on compile** — 5.7µs to compile a point read
    against 0.9µs to look one up — and compile is a single-digit percentage
    of any scenario's total, so it is not where the remaining time is.
@@ -192,13 +185,9 @@ gets built:
 
 - **Ratios below 1.00× are noise, not a win.** gemi cannot be faster than
   hand-written SQL doing the same work; it *is* the same driver call plus
-  overhead. The Postgres point read and depth-2 include come out at 0.82×
-  and 0.94× because a ~150µs loopback round trip varies by more than the
-  difference being measured, and because the `raw` baseline is a second
-  `SQL` instance with its own prepared-statement state. Read them as "at
-  the floor", not as better than it.
-- Postgres was measured over loopback, so every Postgres round trip here is
-  optimistic — see the note below.
+  overhead. Where one appears, read it as "at the floor" rather than as a
+  win: the `raw` baseline is a second `SQL` instance with its own
+  prepared-statement state.
 
 ## Notes
 

--- a/templates/saas-starter/app/models/bench/run.ts
+++ b/templates/saas-starter/app/models/bench/run.ts
@@ -139,6 +139,17 @@ async function main() {
   // and the report says which is which.
   await carryForward(results);
 
+  // Whether this run has Postgres data at all. Every sentence below that cites
+  // a Postgres figure is gated on it.
+  //
+  // One of them already was — the deliverable-2 caveat — and the rest were
+  // written rather than derived, so a SQLite-only run emitted "Postgres was
+  // measured over loopback" and a pair of ratios three lines under its own
+  // "Postgres was not measured". The header of this file says to regenerate
+  // rather than edit, which means a static sentence about a dialect that may
+  // not have run is a bug in the generator, not in the report.
+  const measuredPostgres = anchors.postgres !== undefined;
+
   const report = [
     "# ORM benchmarks",
     "",
@@ -228,13 +239,17 @@ async function main() {
     "index is worth 1.0x\", which is a measurement answering a different question",
     "than its own heading.",
     "",
-    "**A ratio near 1 on Postgres here is a limit of this fixture, not a finding",
-    "about Postgres.** The child table is 200 rows and the connection is",
-    "loopback, so the round trip dominates and a scan of 200 rows is free either",
-    "way — the numbers below can go either side of 1.0x on noise alone. This",
-    "table says the index is decisive on SQLite and says *nothing* about how a",
-    "real child table behaves over a real socket.",
-    "",
+    ...(measuredPostgres
+      ? [
+          "**A ratio near 1 on Postgres here is a limit of this fixture, not a finding",
+          "about Postgres.** The child table is 200 rows and the connection is",
+          "loopback, so the round trip dominates and a scan of 200 rows is free either",
+          "way — the numbers below can go either side of 1.0x on noise alone. This",
+          "table says the index is decisive on SQLite and says *nothing* about how a",
+          "real child table behaves over a real socket.",
+          "",
+        ]
+      : []),
     "| Dialect | Parents | plain µs | `_count` µs | `_count` +index µs | include+`.length` µs | `exists` µs | `exists` +index µs |",
     "| --- | --: | --: | --: | --: | --: | --: | --: |",
     ...subqueries,
@@ -277,9 +292,17 @@ async function main() {
     "",
     "   **The positional-row half stays unjustified.** `.values()` exists — that",
     "   much is verified rather than assumed — but it measured 14% *slower* on",
-    "   SQLite and 17% faster on Postgres, and the sign flipped between runs at",
-    "   lower sample counts. With p95 near double p50 on Postgres, this workload",
-    "   cannot resolve it, so it was not taken.",
+    ...(measuredPostgres
+      ? [
+          "   SQLite and 17% faster on Postgres, and the sign flipped between runs at",
+          "   lower sample counts. With p95 near double p50 on Postgres, this workload",
+          "   cannot resolve it, so it was not taken.",
+        ]
+      : [
+          "   SQLite, and the sign flipped between runs at lower sample counts. The",
+          "   Postgres side of that comparison is not in this run's data, so nothing",
+          "   here resolves it and it was not taken.",
+        ]),
     ...(anchors.postgres === undefined
       ? [
           "3. **Deliverable 2 (lateral + `json_agg`) was not evaluated**: Postgres",
@@ -292,12 +315,22 @@ async function main() {
           statementCounts.postgres ?? {},
         )),
     "4. **A transaction costs one extra round trip pair, and that is the whole",
-    "   cost.** +12µs on SQLite, +350µs on Postgres — against a ~25ns ALS read.",
+    ...(measuredPostgres
+      ? ["   cost.** +12µs on SQLite, +350µs on Postgres — against a ~25ns ALS read."]
+      : ["   cost.** +12µs on SQLite — against a ~25ns ALS read."]),
     "   Iteration 5's second `AsyncLocalStorage` is nowhere in the number; the",
     "   `BEGIN`/`COMMIT` are. Worth knowing before anyone optimises the store.",
-    "5. **Policies are free at this resolution.** +1µs on a SQLite point read,",
-    "   and within run-to-run variance on Postgres. Iteration 6's deferred",
-    "   question is answered: dispatch is not worth memoising.",
+    ...(measuredPostgres
+      ? [
+          "5. **Policies are free at this resolution.** +1µs on a SQLite point read,",
+          "   and within run-to-run variance on Postgres. Iteration 6's deferred",
+          "   question is answered: dispatch is not worth memoising.",
+        ]
+      : [
+          "5. **Policies are free at this resolution.** +1µs on a SQLite point read.",
+          "   Iteration 6's deferred question is answered for the dialect that ran:",
+          "   dispatch is not worth memoising.",
+        ]),
     "6. **The plan cache earns ~10× on compile** — 5.7µs to compile a point read",
     "   against 0.9µs to look one up — and compile is a single-digit percentage",
     "   of any scenario's total, so it is not where the remaining time is.",
@@ -306,13 +339,21 @@ async function main() {
     "",
     "- **Ratios below 1.00× are noise, not a win.** gemi cannot be faster than",
     "  hand-written SQL doing the same work; it *is* the same driver call plus",
-    "  overhead. The Postgres point read and depth-2 include come out at 0.82×",
-    "  and 0.94× because a ~150µs loopback round trip varies by more than the",
-    "  difference being measured, and because the `raw` baseline is a second",
-    "  `SQL` instance with its own prepared-statement state. Read them as \"at",
-    "  the floor\", not as better than it.",
-    "- Postgres was measured over loopback, so every Postgres round trip here is",
-    "  optimistic — see the note below.",
+    ...(measuredPostgres
+      ? [
+          "  overhead. The Postgres point read and depth-2 include come out at 0.82×",
+          "  and 0.94× because a ~150µs loopback round trip varies by more than the",
+          "  difference being measured, and because the `raw` baseline is a second",
+          "  `SQL` instance with its own prepared-statement state. Read them as \"at",
+          "  the floor\", not as better than it.",
+          "- Postgres was measured over loopback, so every Postgres round trip here is",
+          "  optimistic — see the note below.",
+        ]
+      : [
+          "  overhead. Where one appears, read it as \"at the floor\" rather than as a",
+          "  win: the `raw` baseline is a second `SQL` instance with its own",
+          "  prepared-statement state.",
+        ]),
     "",
     ...(notes.length > 0 ? ["## Notes", "", ...notes.map((n) => `- ${n}`)] : []),
     "",


### PR DESCRIPTION
Closes #187.

`plans/orm/benchmarks.md` claimed both sides of the same question, three lines apart — *"Deliverable 2 (lateral + `json_agg`) **was not evaluated**: Postgres was not measured"* and *"**Postgres was measured over loopback**, so every Postgres round trip here is optimistic"* — and quoted "the Postgres point read and depth-2 include come out at 0.82× and 0.94×", while the data behind it was nine results, every one `"dialect": "sqlite"`, with no Postgres row in any table.

Only the first was generated conditionally. The rest were static strings in `run.ts`'s report array: the positional-row comparison, the transaction cost, the policy overhead, the sub-1.0× ratios, "Postgres was measured over loopback", and the `_count` caveat explaining how to read rows the table does not have.

Each is now gated on `measuredPostgres`, the same way the deliverable-2 caveat already was, and the committed report is regenerated in line with its data. Every remaining mention of Postgres is about its absence.

## Why this one is worth a test

`docs/orm.md` refuses to repeat any benchmark number and says why:

> a number copied into prose drifts from its source the first time the source is re-run, which happened three times inside that report before its own sentences were derived rather than written.

These are the sentences that never made that transition — the same failure, in the document held up as the reason to avoid it. And the report is cited as the evidence three times: `docs/orm.md` for "what the measurement does **not** establish" and for "the reasoning behind the lateral default", plus `lateral.ts` and `strategy.ts` from source.

Both source citations turned out to be **accurate** and are untouched: they cite statement counts (present at `benchmarks.md:84-85`) and both say "counted rather than timed". The defect was confined to the report's prose.

## The guard

`packages/gemi/orm/benchmarks-report.test.ts` asserts the property against the committed artifacts rather than the generator — `main()` does I/O, and what matters is what a reader sees, whichever code path emitted it:

- no table row names a dialect absent from `benchmarks.json`
- no sentence citing a figure (`0.82×`, `+350µs`, `17%`) or saying "was measured" names a dialect with no data — with lines about *absence* excluded by their own wording, since those are what the report should say

**Verified to fail on the report as it stood**, naming the offending line:

```
× no sentence claims a postgres figure unless that dialect ran
+   "  overhead. The Postgres point read and depth-2 include come out at 0.82×",
```

It runs under CI's existing `orm` filter.

## Checks

- `bun --bun vitest run orm database` — 44 files, 1377 passed
- `bunx tsc --noEmit -p tsconfig.json` — clean, both `packages/gemi` and the template
- `bunx oxlint orm --deny-warnings` — 0 warnings, 0 errors

## Not fixed here

The 0.82×/0.94× ratios are still *written* rather than derived when Postgres does run. Gating removes the contradiction; deriving them from `results` is the remaining half, and I have left it out rather than guess at numbers I cannot currently measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)