### PR TITLE
The docs quote a Postgres provenance cost the benchmarks never measured

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3956,8 +3956,8 @@ describing exactly what the operation accepts.
 ### It is off by default, and that is a measurement
 
 Provenance costs a `WeakMap` insert and a snapshot clone per row. On a 1 000-row read that is
-**about +100% on SQLite and +40% on Postgres** — see `plans/orm/benchmarks.md`. So it is not a
-flag to set out of habit; on a large read it is a real decision.
+**about +100% on SQLite** — see `plans/orm/benchmarks.md`, which has no Postgres measurement to
+set beside it. So it is not a flag to set out of habit; on a large read it is a real decision.
 
 ### Provenance is tied to object identity
 

--- a/docs/orm-rows-and-entities.md
+++ b/docs/orm-rows-and-entities.md
@@ -49,8 +49,8 @@ describing exactly what the operation accepts.
 ### It is off by default, and that is a measurement
 
 Provenance costs a `WeakMap` insert and a snapshot clone per row. On a 1 000-row read that is
-**about +100% on SQLite and +40% on Postgres** — see `plans/orm/benchmarks.md`. So it is not a
-flag to set out of habit; on a large read it is a real decision.
+**about +100% on SQLite** — see `plans/orm/benchmarks.md`, which has no Postgres measurement to
+set beside it. So it is not a flag to set out of habit; on a large read it is a real decision.
 
 ### Provenance is tied to object identity
 

--- a/packages/gemi/orm/docs-benchmark-figures.test.ts
+++ b/packages/gemi/orm/docs-benchmark-figures.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * A benchmark figure quoted in the docs has to exist in the benchmarks.
+ *
+ * `docs/orm-rows-and-entities.md` said provenance costs "**about +100% on
+ * SQLite and +40% on Postgres** — see `plans/orm/benchmarks.md`". The report's
+ * provenance table has exactly one row:
+ *
+ *     | sqlite | 1000 | 418.9 | 833.0 | 99% |
+ *
+ * The SQLite half is right. The Postgres half is a number that appears nowhere
+ * in the file it cites — `grep -rn "40%" plans/` finds nothing — because the
+ * whole report was generated from a SQLite-only run (see #187).
+ *
+ * `docs/orm.md` refuses to quote a benchmark number at all, and says why:
+ * "a number copied into prose drifts from its source the first time the source
+ * is re-run". This page does quote them, which is defensible — the section's
+ * point is that the default was chosen by measurement, and a reader deciding
+ * whether to set `track: true` wants the magnitude. But quoting means the
+ * numbers need checking, and nothing was checking them.
+ *
+ * The cost is concrete rather than cosmetic: `+40% on Postgres` reads as "this
+ * is cheaper on your production database", which is the opposite of a decision
+ * the report supports. This page is also embedded verbatim in
+ * `docs/llms-full.txt`, so a tool repeats it confidently with nothing to bump
+ * into.
+ */
+const ROOT = join(import.meta.dirname, "../../..");
+
+/** The ORM's two documentation pages — the ones `llms-full.txt` embeds. */
+const PAGES = ["orm.md", "orm-rows-and-entities.md"];
+
+/** The dialects the committed run actually produced results for. */
+const measured = new Set(
+  (
+    JSON.parse(
+      readFileSync(join(ROOT, "plans/orm/benchmarks.json"), "utf8"),
+    ) as Array<{ dialect?: string }>
+  )
+    .map((result) => result.dialect)
+    .filter(Boolean),
+);
+
+/**
+ * A figure attributed to a dialect: `+40% on Postgres`, `833µs on SQLite`,
+ * `1.2× on Postgres`.
+ *
+ * Deliberately narrow. Both pages discuss dialect *behaviour* constantly — "a
+ * `Date` binds as milliseconds on SQLite", "fine on SQLite; on Postgres:
+ * current transaction is aborted" — and none of that is a measurement. Only a
+ * number carrying a unit is.
+ */
+const FIGURE = /([+~]?\s*\d+(?:\.\d+)?)\s*(%|µs|×)\s+on\s+(SQLite|Postgres)/gi;
+
+const figures = PAGES.flatMap((name) => {
+  const text = readFileSync(join(ROOT, "docs", name), "utf8");
+  return [...text.matchAll(FIGURE)].map((match) => ({
+    page: name,
+    value: Number(match[1].replace(/[+~\s]/g, "")),
+    unit: match[2],
+    dialect: match[3].toLowerCase(),
+    quote: match[0],
+  }));
+});
+
+describe("benchmark figures quoted in the docs are backed by the report", () => {
+  /**
+   * Without this the suite passes by matching nothing — which is how a guard
+   * survives the deletion of the thing it guards.
+   */
+  test("the docs quote at least one benchmark figure", () => {
+    expect(figures.length).toBeGreaterThan(0);
+  });
+
+  test("the report names at least one dialect", () => {
+    expect(measured.size).toBeGreaterThan(0);
+  });
+
+  test.each(figures.map((figure) => [figure.quote, figure] as const))(
+    "%s names a dialect the report measured",
+    (_quote, figure) => {
+      expect(
+        measured,
+        `${figure.page} quotes "${figure.quote}", but benchmarks.json has no ${figure.dialect} result`,
+      ).toContain(figure.dialect);
+    },
+  );
+
+  /**
+   * ...and the one figure that maps to a table maps to the *right* row. Being
+   * about the correct dialect is not enough: the number still has to be the
+   * number, or a re-run moves the report and leaves the prose behind — which is
+   * the failure `docs/orm.md` says happened three times inside the report
+   * itself.
+   *
+   * Tolerance is 5 points because the prose rounds on purpose: "about +100%"
+   * for a measured 99% is the honest way to quote it, and a doc forced to say
+   * "+99%" would be stale after any re-run.
+   */
+  test("the provenance figure matches the provenance table", () => {
+    const report = readFileSync(join(ROOT, "plans/orm/benchmarks.md"), "utf8");
+
+    const start = report.indexOf("## Row provenance");
+    expect(start, "the Row provenance section moved or was renamed").toBeGreaterThan(0);
+    const section = report.slice(start, report.indexOf("\n## ", start + 1));
+
+    const quoted = figures.filter(
+      (figure) => figure.page === "orm-rows-and-entities.md" && figure.unit === "%",
+    );
+    expect(quoted.length, "the page stopped quoting a provenance percentage").toBeGreaterThan(0);
+
+    for (const figure of quoted) {
+      const row = section
+        .split("\n")
+        .find((line) => new RegExp(`^\\|\\s*${figure.dialect}\\b`).test(line));
+
+      expect(row, `no ${figure.dialect} row in the provenance table`).toBeDefined();
+
+      // The `added` column is the last cell: `| sqlite | 1000 | 418.9 | 833.0 | 99% |`
+      const cells = row!.split("|").map((cell) => cell.trim()).filter(Boolean);
+      const added = Number(cells[cells.length - 1].replace("%", ""));
+
+      expect(
+        Math.abs(added - figure.value),
+        `the page says "${figure.quote}" but the table measured ${added}%`,
+      ).toBeLessThanOrEqual(5);
+    }
+  });
+});


### PR DESCRIPTION
Closes #189.

`docs/orm-rows-and-entities.md` told readers that `track: true` costs "**about +100% on SQLite and +40% on Postgres** — see `plans/orm/benchmarks.md`". That report's provenance table has one row:

```
| sqlite | 1000 | 418.9 | 833.0 | 99% |
```

The SQLite half is right. The Postgres half appears nowhere in the file it cites — `grep -rn "40%" plans/` finds nothing — because the committed run was SQLite-only: nine results, all `"dialect": "sqlite"` (the same root cause as #187).

It matters more than a wrong digit. The sentence exists so a reader can decide whether to set the flag, and "+40% on Postgres" reads as *this is much cheaper on your production database* — which the measurement supports in neither direction, since Postgres was never run. The page is embedded verbatim in `docs/llms-full.txt`, so a tool repeats it with nothing to bump into.

## The guard

`docs/orm.md` quotes no benchmark number at all and says why — "a number copied into prose drifts from its source the first time the source is re-run, which happened three times inside that report". This page *does* quote them, which is defensible: the magnitude is the section's point. But quoting means the numbers need checking, so `docs-benchmark-figures.test.ts` checks both directions rather than just deleting the number:

- a figure carrying a unit and attributed to a dialect (`+40% on Postgres`, `833µs on SQLite`) must name a dialect present in `benchmarks.json`
- the provenance percentage must match the provenance table's own `added` column, within 5 points — the rounding the prose deliberately uses, since "about +100%" for a measured 99% is the honest way to quote it and a doc forced to say "+99%" would be stale after any re-run

Plus a test that the docs quote *at least one* figure, so the guard cannot pass by matching nothing.

**Verified to fail on the page as it stood**, naming the quote:

```
× +40% on Postgres names a dialect the report measured
× the provenance figure matches the provenance table

AssertionError: orm-rows-and-entities.md quotes "+40% on Postgres", but
benchmarks.json has no postgres result: expected [ 'sqlite' ] to include 'postgres'
```

The pattern is narrow on purpose. Both pages discuss dialect *behaviour* constantly — "a `Date` binds as milliseconds on SQLite", "fine on SQLite; on Postgres: current transaction is aborted" — and none of that is a measurement. Only a number with a unit is.

`docs/llms-full.txt` is re-synced, so the verbatim-embedding guard from #181 stays green.

## Checked and left alone

The rest of the page holds up: the `was not fetched` error text matches `provenance.ts:163`, `ActiveRecordModel` is exported from `index.ts:2`, and the unchanged-row no-op and post-save refresh both have tests.

## Checks

- `bun --bun vitest run orm database` — 44 files, 1377 passed
- `bunx tsc --noEmit -p tsconfig.json` — clean
- `bunx oxlint orm --deny-warnings` — 0 warnings, 0 errors

Independent of #188 (that one fixes the report's own prose; this one fixes a doc that cites it), so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)