### PR TITLE
The benchmark report's sub-1.00× ratios are still quoted from memory

### DIFF
--- a/packages/gemi/orm/benchmarks-report.test.ts
+++ b/packages/gemi/orm/benchmarks-report.test.ts
@@ -103,4 +103,47 @@ describe("plans/orm/benchmarks.md reports only dialects it measured", () => {
       expect(claims, `${dialect} has no data, but the report states figures for it`).toEqual([]);
     },
   );
+
+  /**
+   * ...and a ratio the prose quotes has to be a ratio the run produced.
+   *
+   * The dialect check above is necessary and not sufficient. The report said
+   * "the Postgres point read and depth-2 include come out at **0.82× and
+   * 0.94×**"; gating that sentence on whether Postgres ran stops it appearing
+   * beside "Postgres was not measured", but a run that *did* measure Postgres
+   * would still have been handed those two numbers whatever it measured. The
+   * gate fixes the contradiction; only deriving the figure fixes the figure.
+   *
+   * Restricted to ratios **below 1.00×**, which is the precise claim worth
+   * pinning: "gemi came out faster than hand-written SQL here" is the one
+   * conclusion the report explicitly says is never real, so a sub-1 ratio in
+   * prose is either a live measurement worth reading or a leftover. Ratios
+   * above 1 are ordinary results and quoting them is not this failure mode.
+   *
+   * Table cells are skipped — they *are* the data, so checking them against
+   * the data they were rendered from proves nothing.
+   */
+  test("every sub-1.00× ratio in the prose is one the run measured", () => {
+    const ratios = new Set(
+      (
+        JSON.parse(
+          readFileSync(join(PLANS, "benchmarks.json"), "utf8"),
+        ) as Array<{ raw?: { p50: number }; gemi: { total: { p50: number } } }>
+      )
+        .filter((result) => (result.raw?.p50 ?? 0) > 0)
+        .map((result) => (result.gemi.total.p50 / result.raw!.p50).toFixed(2)),
+    );
+
+    const quoted = report
+      .split("\n")
+      .filter((line) => !line.trimStart().startsWith("|"))
+      .flatMap((line) => [...line.matchAll(/\b0\.\d{2}×/g)].map((m) => m[0]));
+
+    for (const ratio of quoted) {
+      expect(
+        [...ratios],
+        `the report quotes ${ratio}, which no result in benchmarks.json produces`,
+      ).toContain(ratio.replace("×", ""));
+    }
+  });
 });

--- a/templates/saas-starter/app/models/bench/run.ts
+++ b/templates/saas-starter/app/models/bench/run.ts
@@ -150,6 +150,35 @@ async function main() {
   // not have run is a bug in the generator, not in the report.
   const measuredPostgres = anchors.postgres !== undefined;
 
+  /**
+   * Scenarios that came out *below* hand-written SQL, named from `results`
+   * rather than remembered.
+   *
+   * The sentence about them was the last written-rather-than-derived
+   * measurement in this file. #187 gated it on whether Postgres ran, which
+   * stopped it contradicting a SQLite-only run — but a run that *did* measure
+   * Postgres would still have been handed "the Postgres point read and depth-2
+   * include come out at 0.82× and 0.94×", whatever it actually measured. A
+   * gate fixes the contradiction; only deriving it fixes the number.
+   *
+   * Derived, it also stops being Postgres-only. A SQLite scenario that dips
+   * under 1.00× is the same observation and now gets named the same way,
+   * instead of leaving the reader to wonder why the caveat named one dialect.
+   */
+  const belowFloor = results
+    .filter((result) => (result.raw?.p50 ?? 0) > 0)
+    .map((result) => ({
+      result,
+      ratio: result.gemi.total.p50 / result.raw!.p50,
+    }))
+    .filter(({ ratio }) => ratio < 1)
+    .map(
+      ({ result, ratio }) =>
+        // The scenario's leading number belongs to the table, not to a sentence.
+        `${result.dialect} ${result.scenario.replace(/^\d+[a-z]?\.\s*/, "")} ` +
+        `at ${ratio.toFixed(2)}×`,
+    );
+
   const report = [
     "# ORM benchmarks",
     "",
@@ -339,21 +368,24 @@ async function main() {
     "",
     "- **Ratios below 1.00× are noise, not a win.** gemi cannot be faster than",
     "  hand-written SQL doing the same work; it *is* the same driver call plus",
-    ...(measuredPostgres
+    ...(belowFloor.length > 0
       ? [
-          "  overhead. The Postgres point read and depth-2 include come out at 0.82×",
-          "  and 0.94× because a ~150µs loopback round trip varies by more than the",
-          "  difference being measured, and because the `raw` baseline is a second",
-          "  `SQL` instance with its own prepared-statement state. Read them as \"at",
-          "  the floor\", not as better than it.",
-          "- Postgres was measured over loopback, so every Postgres round trip here is",
-          "  optimistic — see the note below.",
+          `  overhead. This run has ${belowFloor.join(", ")} — read those as \"at`,
+          "  the floor\", not as better than it. The `raw` baseline is a second",
+          "  `SQL` instance with its own prepared-statement state, and where a round",
+          "  trip dominates it varies by more than the difference being measured.",
         ]
       : [
           "  overhead. Where one appears, read it as \"at the floor\" rather than as a",
           "  win: the `raw` baseline is a second `SQL` instance with its own",
           "  prepared-statement state.",
         ]),
+    ...(measuredPostgres
+      ? [
+          "- Postgres was measured over loopback, so every Postgres round trip here is",
+          "  optimistic — see the note below.",
+        ]
+      : []),
     "",
     ...(notes.length > 0 ? ["## Notes", "", ...notes.map((n) => `- ${n}`)] : []),
     "",


### PR DESCRIPTION
Closes #193. The follow-up #188 named and deliberately left open.

#188 gated the report's Postgres sentences on whether Postgres ran, so it no longer says "Postgres was measured over loopback" three lines under "Postgres was not measured". But one gated sentence still carried its numbers:

> The Postgres point read and depth-2 include come out at **0.82×** and **0.94×**

Gating decides *whether* that prints. It does not make the ratios belong to the run printing them — a run that did measure Postgres would be handed those two figures whatever it measured. The gate fixes the contradiction; only deriving the figure fixes the figure. This was the last written-rather-than-derived measurement in `bench/run.ts`, and "Regenerate rather than editing" only means something if regenerating changes the numbers.

Deriving also stops the caveat being Postgres-only. It is about ratios below 1.00× — gemi appearing *faster* than hand-written SQL, which the report says is never real — and nothing about that is dialect-specific. A SQLite scenario that dips under 1.00× now gets named the same way.

## The report is unchanged, and that is checked rather than assumed

No committed result is below 1.00× — the nine range from 1.18× to 1.98× — so the generated output is byte-identical and `plans/orm/benchmarks.md` is not in this diff. That is evidence the refactor is faithful, not evidence it does nothing: run against synthetic results at the old ratios, the derivation produces

```
postgres point read by pk at 0.82×, postgres depth-2 include, 100 parents at 0.94×
```

— the sentence it replaces, reconstructed from the data that sentence claimed to describe.

## Guard

Extends #188's test rather than adding another, because the dialect check there is necessary and not sufficient: it catches a figure attributed to a dialect with **no** data, not a stale figure attributed to the right one.

Restricted to ratios below 1.00×, which is the precise claim worth pinning — that is the one conclusion the report says is never real, so a sub-1 ratio in prose is either a live measurement or a leftover. Ratios above 1 are ordinary results and quoting them is not this failure mode. Table cells are skipped: they *are* the data, so checking them against it proves nothing.

Verified by re-injecting the original sentence:

```
× every sub-1.00× ratio in the prose is one the run measured

AssertionError: the report quotes 0.82×, which no result in benchmarks.json
produces: expected [ '1.88', '1.18', '1.98', '1.80' ] to include '0.82'
```

## Checks

- `bun --bun vitest run orm database` — 1381 passed
- `bunx tsc --noEmit -p tsconfig.json` — clean, both `packages/gemi` and the template
- `bunx oxlint orm --deny-warnings` — 0 warnings, 0 errors

Touches `benchmarks-report.test.ts` (added by #188, now merged) and `bench/run.ts`; independent of #190 and #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)