### PR TITLE
The design record still calls shipped API future

### DIFF
--- a/packages/gemi/orm/plan-record.test.ts
+++ b/packages/gemi/orm/plan-record.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { Model } from "./Model";
+import * as orm from "./index";
+
+/**
+ * The design record does not call shipped API "future".
+ *
+ * `plans/orm/README.md` is the ORM's design record — the document the invariants
+ * come from, cited by name from `strategy.ts`, `lateral.ts`, `nested-writes.ts`
+ * and `order-relation.ts`. It is a living document: it has a "Where it actually
+ * is now" section, and line 496 reads "Both are now in all four".
+ *
+ * Two of its invariants still described shipped API as forthcoming:
+ *
+ *   invariant 3   a future `ActiveRecordModel` base overrides `$shape`
+ *   invariant 5   enabling a future `User.save(row)` that diffs against …
+ *                 Iterations 1–7 only need the seam to exist; iteration 8
+ *                 fills it in.
+ *
+ * `ActiveRecordModel` is exported from `orm/index.ts:2`. `Model.save` is a
+ * static at `Model.ts:204`. Iteration 8 landed, and the same document's own
+ * status table says so — "#53 … opt-in provenance, `save(row)`, `wrap`".
+ *
+ * So the document contradicts itself, and the half a reader is more likely to
+ * act on is the invariant: someone reading it to find out whether provenance
+ * exists is told it is a seam awaiting a later iteration, and would go and build
+ * what is already there.
+ *
+ * This is guardable rather than merely fixable because the claim names the API.
+ * A sentence calling `X` future can be checked against whether `X` exists.
+ */
+const RECORD = join(import.meta.dirname, "../../../plans/orm/README.md");
+
+/**
+ * `a future \`ActiveRecordModel\``, `a future \`User.save(row)\`` — a backticked
+ * identifier the prose puts in the future.
+ *
+ * Only this phrasing, deliberately. "every future tier becomes a rewrite" two
+ * lines below one of these names no API and is not a claim about what exists;
+ * matching loosely on the word would flag it and teach the next person to work
+ * around the guard.
+ */
+const FUTURE = /a future `([A-Za-z_][\w.]*)(\([^`]*\))?`/g;
+
+const claimed = [...readFileSync(RECORD, "utf8").matchAll(FUTURE)].map(
+  (match) => ({ name: match[1], quote: match[0] }),
+);
+
+/**
+ * Is the ORM already shipping this?
+ *
+ * Two forms appear: a bare export (`ActiveRecordModel`) and a call on a model
+ * (`User.save(row)`), which names a static on the model base rather than a
+ * member of any particular model.
+ */
+const ships = (name: string) => {
+  if (name in orm) return true;
+  const [, member] = name.split(".");
+  return Boolean(member) && typeof (Model as never as Record<string, unknown>)[member] === "function";
+};
+
+describe("plans/orm/README.md does not call shipped API future", () => {
+  /**
+   * The two the fix removed are the only two the phrasing ever had, so an empty
+   * sweep is the expected state — but a *silently* empty one would also be what
+   * a moved or reworded file produces. Anchored on a line that has to survive
+   * any rewording of the invariants for the document to still be that document.
+   */
+  test("the record was found and read", () => {
+    const source = readFileSync(RECORD, "utf8");
+    expect(source).toContain("# gemi ORM");
+    expect(source.length).toBeGreaterThan(10_000);
+  });
+
+  test("the sweep is anchored on a real pattern", () => {
+    const sample = "enabling a future `User.save(row)` that diffs";
+    expect([...sample.matchAll(FUTURE)].map((m) => m[1])).toEqual(["User.save"]);
+  });
+
+  test.each(claimed.map((claim) => [claim.quote, claim] as const))(
+    "%s is not something the ORM already ships",
+    (_quote, claim) => {
+      expect(
+        ships(claim.name),
+        `the design record calls ${claim.name} future, but the ORM exports it`,
+      ).toBe(false);
+    },
+  );
+});

--- a/plans/orm/README.md
+++ b/plans/orm/README.md
@@ -213,7 +213,7 @@ lets the entire compiler be unit-tested with no database at all.
 ### 3. `shape` is a static on the model class
 
 The result-shaping stage is `static $shape` on the model base, not a module-level
-function. Subclassing is the extension mechanism: a future `ActiveRecordModel`
+function. Subclassing is the extension mechanism: the `ActiveRecordModel`
 base overrides `$shape` to build instances, and every model extending it gets
 that with zero changes to the twelve operations. As a free function, every future
 tier becomes a rewrite.
@@ -279,15 +279,15 @@ dialect *and* strategy.
 
 ### 5. Row provenance is opt-in
 
-`$shape` is the place a `WeakMap<row, { model, pk, snapshot }>` would be
-populated, enabling a future `User.save(row)` that diffs against the snapshot and
+`$shape` is the place the `WeakMap<row, { model, pk, snapshot }>` is
+populated, enabling `User.save(row)`, which diffs against the snapshot and
 writes only changed columns — Eloquent-style writes with POJO return types, no
 proxies, no type changes.
 
 It costs a WeakMap insert and a snapshot clone **per row**, which contradicts the
 performance priority on large reads. So it is off by default and opted into per
-query or per model. Iterations 1–7 only need the seam to exist; iteration 8 fills
-it in.
+query or per model. Iterations 1–7 only needed the seam to exist; iteration 8
+filled it in.
 
 ### 6. Lazy, name-keyed model registry
 


### PR DESCRIPTION
Closes #197.

`plans/orm/README.md` is the ORM's design record — where the invariants come from, cited by name from `strategy.ts`, `lateral.ts`, `nested-writes.ts` and `order-relation.ts`. It is a *living* document: it has a "Where it actually is now" section, and line 496 reads "Both are now in all four".

Two invariants still described shipped API as forthcoming:

```
invariant 3   a future `ActiveRecordModel` base overrides `$shape`
invariant 5   enabling a future `User.save(row)` that diffs against the snapshot …
              Iterations 1–7 only need the seam to exist; iteration 8 fills it in.
```

`ActiveRecordModel` is exported from `orm/index.ts:2`; `Model.save` is a static at `Model.ts:204`; and the document's own status table (line 33) records iteration 8 as landed — "#53 … opt-in provenance, `save(row)`, `wrap`".

So it contradicts itself, and the half a reader is more likely to act on is the invariant: someone reading invariant 5 to find out whether provenance exists is told it is a seam awaiting a later iteration, and would go build what is already there.

## The guard

Guardable rather than merely fixable, because the claim names the API — a sentence calling `X` future can be checked against whether `X` is exported from `gemi/orm` or is a static on `Model`.

Verified against the record as it stood, naming both:

```
× a future `ActiveRecordModel` is not something the ORM already ships
× a future `User.save(row)` is not something the ORM already ships

AssertionError: the design record calls ActiveRecordModel future,
but the ORM exports it
```

The pattern matches only ``a future `identifier` ``, deliberately. "every future tier becomes a rewrite" sits two lines from one of these and names no API; matching loosely on the word would flag it and teach the next person to route around the guard. Two anchor tests come with it, so a moved or reworded file fails loudly rather than sweeping up nothing and passing.

## Also checked this round, and found correct

Three things I expected to be gaps and were not — recording them so they are not re-investigated:

- **the differential harness covers all fifteen operations.** `aggregate` (20 cases) and `groupBy` (16) are compared against Prisma, contrary to what a grep for `.aggregate(` suggests — the harness takes the operation as a *string*, so the cases live in `CASES`/`PER_PARENT`/… tables.
- **invariant 6 is guarded**, by `generated.test.ts`'s "the artifact has no import graph", which quotes the invariant and asserts the generated artifact has no runtime imports between models.
- **invariant 5's off-by-default claim is guarded**, by `save.test.ts:86`.

## Checks

- `bun --bun vitest run orm database` — 1386 passed
- `bunx tsc --noEmit -p tsconfig.json` — clean
- `bunx oxlint orm --deny-warnings` — 0 warnings, 0 errors

Touches `plans/orm/README.md:216`, two lines from #196's change to line 218, so whichever merges second needs a one-line rebase. Kept separate because they are different findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)