### PR TITLE
The template's 15 type assertions were never run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,22 @@ jobs:
         env:
           TZ: UTC
 
+      # `.test-d.ts` files do not match vitest's default `include`, so the step
+      # above collects none of them: 15 type assertions in `wrap.test-d.ts` and
+      # `aggregate.test-d.ts` ran nowhere, locally or here. They are the only
+      # check on the compile-time half of the ORM's pitch — that `wrap` refuses
+      # a partial row, and that a narrowed `select` narrows the result type.
+      #
+      # `ignoreSourceErrors` because the template's own app code has 276 type
+      # errors unrelated to the ORM. Without it this step reports them and
+      # fails, which is why it could not simply be switched on; with it, the
+      # scope is exactly the assertions in the `.test-d.ts` files.
+      - name: Template type tests
+        run: bun run test:types
+        working-directory: templates/saas-starter
+        env:
+          TZ: UTC
+
       # Two lints, because the package and the ORM are in different states.
       #
       # `bun run lint` is `oxlint` over the whole package: 88 warnings, 0

--- a/packages/gemi/orm/type-tests-run.test.ts
+++ b/packages/gemi/orm/type-tests-run.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * The template's type assertions are actually executed by something.
+ *
+ * `wrap.test-d.ts` and `aggregate.test-d.ts` hold 15 assertions — and ran
+ * nowhere. Vitest's default `include` is `**‍/*.test.ts`, which `.test-d.ts`
+ * does not match, so `vitest run app/models` collected none of them; there was
+ * no `--typecheck` invocation in any script or in CI. `vitest list app/models`
+ * reported 0 of them, and `--typecheck` reported 15.
+ *
+ * They are the only check on the compile-time half of the ORM's pitch. The
+ * runtime suite cannot express what they assert:
+ *
+ *     // @ts-expect-error a partial row is missing columns a method could read
+ *     UserModel.wrap(partial);
+ *
+ * which is the claim `docs/orm-rows-and-entities.md` makes in as many words —
+ * "`wrap` requires a **complete** row. A partial one is a compile error" — and
+ * the reason the page gives for why narrowing and behaviour can coexist at all.
+ *
+ * `@ts-expect-error` fails when the error it expects stops happening, so these
+ * are load-bearing rather than decorative: making `wrap` accept what it should
+ * refuse turns the directive into `Unused '@ts-expect-error' directive`. That
+ * was checked rather than assumed.
+ *
+ * This guards the wiring, not the assertions — the failure was that nothing ran
+ * them, and nothing would have noticed if the step were deleted again.
+ */
+const ROOT = join(import.meta.dirname, "../../..");
+
+const workflow = readFileSync(join(ROOT, ".github/workflows/ci.yml"), "utf8");
+const templatePackage = JSON.parse(
+  readFileSync(join(ROOT, "templates/saas-starter/package.json"), "utf8"),
+) as { scripts?: Record<string, string> };
+
+describe("the template's type tests are wired to something that runs them", () => {
+  test("the template has a script that runs vitest in typecheck mode", () => {
+    const script = templatePackage.scripts?.["test:types"];
+    expect(script, "templates/saas-starter has no test:types script").toBeDefined();
+    expect(script).toContain("--typecheck");
+  });
+
+  /**
+   * The template's own app code has type errors unrelated to the ORM, so a
+   * plain typecheck run fails on them and the step would have to be removed
+   * again. Pinned so the reason survives: without this flag the assertions
+   * cannot be run at all.
+   */
+  test("it reports only the assertions, not the template's unrelated errors", () => {
+    expect(templatePackage.scripts?.["test:types"]).toContain("ignoreSourceErrors");
+  });
+
+  test("CI runs it", () => {
+    expect(
+      workflow,
+      "no CI step invokes the template's type tests, so they run nowhere again",
+    ).toContain("bun run test:types");
+  });
+
+  /**
+   * The files it exists to run. If both are deleted the script passes over an
+   * empty set, which is the same silence this whole test exists to break.
+   */
+  test.each(["wrap.test-d.ts", "aggregate.test-d.ts"])("%s is still there", (file) => {
+    const source = readFileSync(
+      join(ROOT, "templates/saas-starter/app/models", file),
+      "utf8",
+    );
+    expect(source).toContain("@ts-expect-error");
+  });
+});

--- a/templates/saas-starter/package.json
+++ b/templates/saas-starter/package.json
@@ -4,7 +4,8 @@
     "dev": "gemi dev",
     "build": "gemi build",
     "start": "gemi start",
-    "test": "bun --bun vitest"
+    "test": "bun --bun vitest",
+    "test:types": "bun --bun vitest run --typecheck.only --typecheck.ignoreSourceErrors"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.6",


### PR DESCRIPTION
Closes #201.

`wrap.test-d.ts` and `aggregate.test-d.ts` hold 15 type-level assertions and ran nowhere — not in CI, not from any script, not locally.

Vitest's default `include` is `**/*.test.ts`, which `.test-d.ts` does not match, and type tests need `--typecheck` to be collected at all. Nothing in the repository passed it. Measured rather than inferred:

```
vitest list app/models              →  0 tests from .test-d.ts
vitest list app/models --typecheck  → 15
```

## Why it matters

They are the only check on the compile-time half of the ORM's pitch, and the runtime suite cannot express what they assert:

```ts
// @ts-expect-error a partial row is missing columns a method could read
UserModel.wrap(partial);
```

That is the claim `docs/orm-rows-and-entities.md` makes in as many words — *"`wrap` requires a **complete** row. A partial one is a compile error"* — and the reason the page gives for why narrowing and behaviour can coexist: *"the type system, not a runtime check, is what guarantees it"*. Documented, and unverified, since iteration 8.

Load-bearing rather than decorative, checked rather than assumed: `@ts-expect-error` fails when the error it expects stops happening, so making `wrap` accept what it should refuse produces

```
TypeCheckError: Unused '@ts-expect-error' directive.
```

## Why it could not simply be switched on

A plain typecheck run of the template reports **276 type errors in its own app code**, unrelated to the ORM, and exits 1 — the same shape as #163, where `packages/gemi`'s full suite is red for reasons outside this work. That is presumably why the step never existed.

`--typecheck.ignoreSourceErrors` scopes the run to errors inside the `.test-d.ts` files. With it the 15 pass and the run exits 0. The 276 are left alone: out of ORM scope, same call as #163.

## The guard

On the **wiring**, not the assertions — the failure was that nothing ran them, and nothing would have noticed if the step were removed again. It pins the script, the `ignoreSourceErrors` flag *and its reason*, the CI step, and that both files still contain assertions, so deleting them fails rather than passing over an empty set.

Verified against the pre-fix state:

```
× the template has a script that runs vitest in typecheck mode
× it reports only the assertions, not the template's unrelated errors
× CI runs it
```

## Checks

- `bun --bun vitest run orm database` — 1407 passed
- `bun run test:types` (the new step, as CI runs it) — 2 files, 15 passed, exit 0
- template runtime suite unchanged at 17 files / 616 tests, confirmed against `feat/orm`
- `bunx tsc --noEmit -p tsconfig.json` — clean
- `bunx oxlint orm --deny-warnings` — 0 warnings, 0 errors

One honest note: an early run of the template suite reported a collection failure. It did not reproduce across three consecutive runs and the counts match `feat/orm` exactly, so it was a flake rather than this change — recording it in case it resurfaces.

Touches `.github/workflows/ci.yml`, the template's `package.json`, and one new test file. No overlap with #194, #196, #198 or #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)