### PR TITLE
CI skipped eight passing test files to avoid six failing ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,17 +87,38 @@ jobs:
         run: bun run typecheck
         working-directory: packages/gemi
 
-      # `orm database`, not `orm`. The package has 47 test files and only 32
-      # have "orm" in their path — `database/DatabaseManager.test.ts` is the
-      # ORM's own SQLite foreign-key pragma test and would have been skipped by
-      # the narrower filter.
+      # Everything except a named red set, rather than a path filter.
       #
-      # Not the whole package: `app/`'s router tests fail on `feat/orm` today
-      # and are unrelated to this. Widening to everything would put CI red for a
-      # reason nobody here can act on, which is how a red board stops being
-      # read. Reported separately.
+      # This step used to run `vitest run orm database`, chosen so
+      # `database/DatabaseManager.test.ts` — the ORM's own SQLite foreign-key
+      # pragma test — was not skipped by the narrower `orm`. The reason given
+      # for not running the whole package was that `app/`'s router tests fail on
+      # `feat/orm` and are unrelated (#163), and a board that is red for a
+      # reason nobody here can act on stops being read.
+      #
+      # That reason covers six files. The filter excluded fourteen: `container`,
+      # `foundation`, `http`, `support`, `app/App` and three of the router
+      # tests all pass and were never run — 55 of the package's 61 files are
+      # green, and CI was running 47 of them.
+      #
+      # An inclusive filter also fails silently in one direction: a new test
+      # file outside those two words is skipped and nothing says so. That is how
+      # #201's type assertions went unnoticed. Naming what is broken instead
+      # means anything added is covered by default, and the exclusions have to
+      # be deleted for CI to stop being honest rather than merely left alone.
+      #
+      # These six are #163. They are excluded here rather than in a vitest
+      # config so a local `vitest run` still shows them: CI stays green without
+      # the failures becoming invisible to the person who could fix them.
       - name: Unit tests
-        run: bun --bun vitest run orm database
+        run: |
+          bun --bun vitest run \
+            --exclude '**/app/createComponentTree.test.ts' \
+            --exclude '**/app/createFlatViewRoutes.test.ts' \
+            --exclude '**/app/createRouteManifest.test.ts' \
+            --exclude '**/services/router/createFlatViewRoutes.test.ts' \
+            --exclude '**/services/router/createRouteManifest.test.ts' \
+            --exclude '**/utils/parseTranslation.test.tsx'
         working-directory: packages/gemi
 
       - name: Template tests

--- a/packages/gemi/orm/ci-coverage.test.ts
+++ b/packages/gemi/orm/ci-coverage.test.ts
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * CI runs the whole package except a named red set, and the names are real.
+ *
+ * The unit-test step used to be `vitest run orm database` — an *inclusive* path
+ * filter. The stated reason for not running everything was that `app/`'s router
+ * tests fail on `feat/orm` and are unrelated to this work (#163).
+ *
+ * That reason covers six files. The filter excluded fourteen: `container`,
+ * `foundation`, `http`, `support`, `app/App` and three of the router tests all
+ * pass and were never run. 55 of the package's 61 test files are green; CI was
+ * running 47.
+ *
+ * The direction matters more than the count. An inclusive filter fails silently
+ * one way — a test file added outside those two words is skipped, and nothing
+ * reports it. That is exactly how #201's fifteen type assertions went unnoticed.
+ * A named exclusion list is the opposite: anything added is covered by default,
+ * and narrowing coverage means deleting a line rather than merely not writing
+ * one.
+ *
+ * What that leaves is a new way to be wrong — an exclusion that outlives the
+ * file it names. Rename or fix one of the six and the pattern matches nothing,
+ * which is invisible in a passing run. So each is checked to still exist.
+ */
+const ROOT = join(import.meta.dirname, "../../..");
+const PACKAGE = join(import.meta.dirname, "..");
+
+const workflow = readFileSync(join(ROOT, ".github/workflows/ci.yml"), "utf8");
+
+/**
+ * The workflow with its comments stripped.
+ *
+ * Checked against this rather than the raw file because the comment explaining
+ * the change quotes the command it replaced — the first version of the test
+ * below read the whole file and failed on its own prose. A guard that cannot
+ * tell a command from a sentence about a command would be satisfied by deleting
+ * the explanation.
+ */
+const commands = workflow
+  .split("\n")
+  .filter((line) => !line.trimStart().startsWith("#"))
+  .join("\n");
+
+/** The `--exclude '**‍/path'` arguments of the unit-test step. */
+const excluded = [...workflow.matchAll(/--exclude '\*\*\/([^']+)'/g)].map(
+  (match) => match[1],
+);
+
+describe("CI's unit step covers the package", () => {
+  test("it no longer uses an inclusive path filter", () => {
+    expect(
+      commands,
+      "the unit step is back to a path filter, which skips new files silently",
+    ).not.toContain("vitest run orm database");
+  });
+
+  test("it excludes a named set", () => {
+    expect(excluded.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * A pattern that matches nothing excludes nothing, and reads as though it
+   * still does. That is the failure this list introduces, so it is the one
+   * checked.
+   */
+  test.each(excluded)("%s still exists", (path) => {
+    expect(
+      existsSync(join(PACKAGE, path)),
+      `CI excludes ${path}, which is not there — the exclusion is stale`,
+    ).toBe(true);
+  });
+
+  /**
+   * The exclusions are #163's failures. If one is fixed it should be run, not
+   * left excluded — so the list is pinned to the reason, and the reason has to
+   * be findable.
+   */
+  test("the reason is recorded next to them", () => {
+    expect(workflow).toContain("#163");
+  });
+});


### PR DESCRIPTION
Closes #203.

The unit step ran `vitest run orm database` — an inclusive path filter. The recorded reason for not running the whole package was that `app/`'s router tests fail on `feat/orm` and are unrelated to this work (#163), and a board red for a reason nobody here can act on stops being read.

That reason is sound and it covers **six** files. The filter excluded **fourteen** — the other eight pass and had never run:

```
container/Container.test.ts                         passes
foundation/Application.test.ts                      passes
http/FileRoute.test.ts                              passes
support/withDefaults.test.ts                        passes
app/App.test.ts                                     passes
services/router/assertNoReservedRoutePaths.test.ts  passes
services/router/createComponentTree.test.ts         passes
services/router/createFlatApiRoutes.test.ts         passes
```

**55 of the package's 61 test files are green; CI was running 47.**

## The direction matters more than the count

An inclusive filter fails silently in one direction: a test file added outside those two words is skipped and nothing reports it. That is exactly how #201's fifteen type assertions went unnoticed. Naming what is broken instead means anything added is covered by default, and narrowing coverage takes deleting a line rather than merely not writing one.

Measured rather than assumed — full suite is 6 failed / 55 passed, and the new command is **56 passed / 1474 tests** with the new guard included.

The six are excluded in the workflow rather than in a vitest config, so a local `vitest run` still shows them. CI stays green without the failures becoming invisible to the person who could fix them. They remain #163's; this does not propose fixing them.

## The guard, and two things it caught

Excluding by name introduces a new way to be wrong: an exclusion that outlives the file it names matches nothing, reads as though it still excludes something, and is invisible in a passing run. Each is checked to still exist — verified by renaming one:

```
AssertionError: CI excludes utils/renamed.test.tsx, which is not there
— the exclusion is stale
```

It also caught a mistake of mine while I was writing it. The first version read the whole workflow and asserted it no longer contained `vitest run orm database` — and failed, because the comment explaining the change *quotes the command it replaced*. It now strips comment lines first: a guard that cannot tell a command from a sentence about a command would be satisfied by deleting the explanation.

## Checks

- the exact CI command — 56 files, 1474 passed, 1 skipped, exit 0
- `bun --bun vitest run orm database` — 48 files, 1419 passed
- `bunx tsc --noEmit -p tsconfig.json` — clean
- `bunx oxlint orm --deny-warnings` — 0 warnings, 0 errors
- CI has three vitest invocations total; the postgres job runs the differential suite, not package units, so there is no second copy of this filter

Touches `.github/workflows/ci.yml`, which #202 also edits — #202 adds a step after *Template tests*, this rewrites *Unit tests* about ten lines above, so they should not collide, but whichever merges second is worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)