### PR TITLE
The lateral strategy's tests ran in neither CI job

### DIFF
--- a/packages/gemi/orm/postgres-suite-selection.test.ts
+++ b/packages/gemi/orm/postgres-suite-selection.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Every Postgres-gated suite is named so CI's filter selects it.
+ *
+ * The Postgres job runs `vitest run app/models --no-file-parallelism -t
+ * postgres`. The filter is not tidiness — without it the job fails, because the
+ * harness refuses the dialect its Prisma client was not generated for. But `-t`
+ * matches on the test's full name, and it is **case-sensitive**, so a
+ * Postgres-only suite whose name does not contain the exact string `postgres`
+ * is selected by nothing.
+ *
+ * Three files were in that position, and because they gate themselves with
+ *
+ *     const RUN = POSTGRES_URL ? describe : describe.skip;
+ *
+ * they were skipped in the SQLite job too — for want of a URL there, and for
+ * want of a matching name here. 24 tests ran in neither:
+ *
+ *     lateral.test.ts             13   "lateral vs batched, on Postgres"
+ *                                      "strategy selection"
+ *     lateral.coercion.test.ts     7   "every scalar through a relation, …"
+ *     redact-strategies.test.ts    4   "redact on a nested model, both …"
+ *
+ * Eight of those were missed by a capital P alone. `-t postgres` collected 0
+ * tests from `lateral.test.ts`; `-t Postgres` collected 8.
+ *
+ * The cost was concentrated: two of the three files are the `LATERAL` +
+ * `json_agg` strategy, which is Postgres-only and the *default* there, and
+ * whose acceptance criterion in `plans/orm/README.md` is that the full nested
+ * differential matrix runs against it. It ran nowhere.
+ *
+ * The suites that do run announce their absence — "⚠ Postgres differential
+ * tests did NOT run. Set TEST_POSTGRES_URL". A `describe.skip` says nothing, so
+ * these three were silent in exactly the way that mechanism exists to prevent.
+ */
+const MODELS = join(import.meta.dirname, "../../../templates/saas-starter/app/models");
+const WORKFLOW = join(import.meta.dirname, "../../../.github/workflows/ci.yml");
+
+const workflow = readFileSync(WORKFLOW, "utf8");
+
+/**
+ * The exact string the Postgres job filters on, read from the workflow rather
+ * than assumed — if the job changes filter, this test should follow it or fail,
+ * not keep checking a word nobody greps for any more.
+ */
+const filter = (() => {
+  const match = workflow.match(/vitest run app\/models[^\n]*-t (\S+)/);
+  expect(match, "the Postgres job's -t filter was not found").not.toBeNull();
+  return match![1];
+})();
+
+/** Files that gate a suite behind `POSTGRES_URL`, and the suite names they use. */
+const gated = readdirSync(MODELS)
+  .filter((file) => file.endsWith(".test.ts"))
+  .map((file) => ({ file, source: readFileSync(join(MODELS, file), "utf8") }))
+  .filter(({ source }) => /POSTGRES_URL \? describe : describe\.skip/.test(source))
+  .map(({ file, source }) => ({
+    file,
+    suites: [...source.matchAll(/^RUN\(\s*"([^"]+)"/gm)].map((match) => match[1]),
+  }));
+
+describe("Postgres-only suites are selected by the Postgres job", () => {
+  test("the filter was read from the workflow", () => {
+    expect(filter).toBe("postgres");
+  });
+
+  test("the gated files were found", () => {
+    expect(gated.length).toBeGreaterThan(0);
+    for (const { file, suites } of gated) {
+      expect(suites.length, `${file} gates on POSTGRES_URL but declares no RUN suite`).toBeGreaterThan(0);
+    }
+  });
+
+  /**
+   * Case-sensitively, because that is how `-t` compares. "on Postgres" reads as
+   * though it is covered and is not, which is the whole failure.
+   */
+  test.each(gated.flatMap(({ file, suites }) => suites.map((name) => [file, name] as const)))(
+    "%s: %s",
+    (file, name) => {
+      expect(
+        name.includes(filter),
+        `${file} runs only with a Postgres URL, but "${name}" does not contain ` +
+          `"${filter}" — the Postgres job's -t filter is case-sensitive, so this ` +
+          `suite is selected by neither job`,
+      ).toBe(true);
+    },
+  );
+});

--- a/templates/saas-starter/app/models/lateral.coercion.test.ts
+++ b/templates/saas-starter/app/models/lateral.coercion.test.ts
@@ -157,7 +157,7 @@ const VALUES = {
 
 const RUN = POSTGRES_URL ? describe : describe.skip;
 
-RUN("every scalar through a relation, lateral vs batched", () => {
+RUN("every scalar through a relation, lateral vs batched — postgres", () => {
   let database: DatabaseManager;
   let raw: SQL;
   let previous: Application | undefined;

--- a/templates/saas-starter/app/models/lateral.test.ts
+++ b/templates/saas-starter/app/models/lateral.test.ts
@@ -31,7 +31,7 @@ import { AccountModel, OrganizationModel, UserModel } from "./generated";
 
 const RUN = POSTGRES_URL ? describe : describe.skip;
 
-RUN("lateral vs batched, on Postgres", () => {
+RUN("lateral vs batched — postgres", () => {
   let database: DatabaseManager;
   let raw: SQL;
   let previous: Application | undefined;
@@ -239,7 +239,7 @@ RUN("lateral vs batched, on Postgres", () => {
  * Deliverable 6: selection is observable, overridable, and — the part that is a
  * correctness property rather than an ergonomic one — **does not share a plan**.
  */
-RUN("strategy selection", () => {
+RUN("strategy selection — postgres", () => {
   let database: DatabaseManager;
   let raw: SQL;
   let previous: Application | undefined;

--- a/templates/saas-starter/app/models/redact-strategies.test.ts
+++ b/templates/saas-starter/app/models/redact-strategies.test.ts
@@ -35,16 +35,16 @@ import { POSTGRES_URL } from "./differential";
  */
 
 const DDL = [
-  `DROP TABLE IF EXISTS "Ledger"`,
-  `DROP TABLE IF EXISTS "Book"`,
-  `CREATE TABLE "Book" (
+  `DROP TABLE IF EXISTS "RedactLedger"`,
+  `DROP TABLE IF EXISTS "RedactBook"`,
+  `CREATE TABLE "RedactBook" (
      "id" SERIAL NOT NULL PRIMARY KEY,
      "title" TEXT NOT NULL,
      "note" TEXT
    )`,
-  `CREATE TABLE "Ledger" (
+  `CREATE TABLE "RedactLedger" (
      "id" SERIAL NOT NULL PRIMARY KEY,
-     "bookId" INTEGER NOT NULL REFERENCES "Book"("id"),
+     "bookId" INTEGER NOT NULL REFERENCES "RedactBook"("id"),
      "label" TEXT NOT NULL,
      "secret" TEXT
    )`,
@@ -63,8 +63,8 @@ function field(name: string, type: any, extra: Record<string, unknown> = {}) {
 }
 
 const bookSchema: ModelSchema = {
-  name: "Book",
-  table: "Book",
+  name: "RedactBook",
+  table: "RedactBook",
   fields: {
     id: field("id", "Int", { isId: true, default: { kind: "autoincrement" } }),
     title: field("title", "String"),
@@ -75,9 +75,9 @@ const bookSchema: ModelSchema = {
   relations: {
     ledgers: {
       name: "ledgers",
-      model: "Ledger",
+      model: "RedactLedger",
       kind: "many",
-      relationName: "BookToLedger",
+      relationName: "RedactBookToRedactLedger",
       from: [],
       to: [],
       nullable: false,
@@ -86,8 +86,8 @@ const bookSchema: ModelSchema = {
 };
 
 const ledgerSchema: ModelSchema = {
-  name: "Ledger",
-  table: "Ledger",
+  name: "RedactLedger",
+  table: "RedactLedger",
   fields: {
     id: field("id", "Int", { isId: true, default: { kind: "autoincrement" } }),
     bookId: field("bookId", "Int"),
@@ -101,9 +101,9 @@ const ledgerSchema: ModelSchema = {
   relations: {
     book: {
       name: "book",
-      model: "Book",
+      model: "RedactBook",
       kind: "one",
-      relationName: "BookToLedger",
+      relationName: "RedactBookToRedactLedger",
       from: ["bookId"],
       to: ["id"],
       nullable: false,
@@ -123,21 +123,21 @@ const hideNote: ModelPolicy = {
   },
 };
 
-class Book extends Model {
+class RedactBook extends Model {
   static $schema = bookSchema;
   // A policy on the *to-one* side, so the fold can be checked in the direction
   // where the folded value is a single object rather than an array.
   static $policies = [hideNote];
 }
 
-class Ledger extends Model {
+class RedactLedger extends Model {
   static $schema = ledgerSchema;
   static $policies = [hideSecret];
 }
 
 const RUN = POSTGRES_URL ? describe : describe.skip;
 
-RUN("redact on a nested model, both strategies", () => {
+RUN("redact on a nested model, both strategies — postgres", () => {
   let database: DatabaseManager;
   let raw: SQL;
   let previous: Application | undefined;
@@ -152,13 +152,13 @@ RUN("redact on a nested model, both strategies", () => {
     application.instance(DatabaseManager, database as never);
     Application.setInstance(application);
 
-    register("Book", Book);
-    register("Ledger", Ledger);
+    register("RedactBook", RedactBook);
+    register("RedactLedger", RedactLedger);
   }, 120_000);
 
   afterAll(async () => {
-    await raw?.unsafe(`DROP TABLE IF EXISTS "Ledger"`).catch(() => {});
-    await raw?.unsafe(`DROP TABLE IF EXISTS "Book"`).catch(() => {});
+    await raw?.unsafe(`DROP TABLE IF EXISTS "RedactLedger"`).catch(() => {});
+    await raw?.unsafe(`DROP TABLE IF EXISTS "RedactBook"`).catch(() => {});
     await raw?.close();
     await database?.close();
     if (previous) Application.setInstance(previous);
@@ -166,12 +166,12 @@ RUN("redact on a nested model, both strategies", () => {
 
   beforeEach(async () => {
     clearPlanCache();
-    await raw.unsafe(`TRUNCATE "Ledger", "Book" RESTART IDENTITY CASCADE`);
+    await raw.unsafe(`TRUNCATE "RedactLedger", "RedactBook" RESTART IDENTITY CASCADE`);
     await raw.unsafe(
-      `INSERT INTO "Book" ("title", "note") VALUES ('ours', 'private')`,
+      `INSERT INTO "RedactBook" ("title", "note") VALUES ('ours', 'private')`,
     );
     await raw.unsafe(
-      `INSERT INTO "Ledger" ("bookId", "label", "secret")
+      `INSERT INTO "RedactLedger" ("bookId", "label", "secret")
        VALUES (1, 'a', 'classified'), (1, 'b', 'classified')`,
     );
   });
@@ -184,10 +184,10 @@ RUN("redact on a nested model, both strategies", () => {
 
   async function bothStrategies(args: any) {
     const batched = (await Model.asUser(READER, () =>
-      Book.$exec("findMany", args, { strategy: "batched" } as never),
+      RedactBook.$exec("findMany", args, { strategy: "batched" } as never),
     )) as any[];
     const lateral = (await Model.asUser(READER, () =>
-      Book.$exec("findMany", args, { strategy: "lateral" } as never),
+      RedactBook.$exec("findMany", args, { strategy: "lateral" } as never),
     )) as any[];
     return { batched, lateral };
   }
@@ -195,7 +195,7 @@ RUN("redact on a nested model, both strategies", () => {
   /** A root read is redacted under either strategy — nothing folds. */
   test("the child's own query is redacted", async () => {
     const rows = (await Model.asUser(READER, () =>
-      Ledger.$exec("findMany", {}),
+      RedactLedger.$exec("findMany", {}),
     )) as any[];
 
     expect(rows).toHaveLength(2);
@@ -224,12 +224,12 @@ RUN("redact on a nested model, both strategies", () => {
    */
   test("a folded to-one is redacted too", async () => {
     const batched = (await Model.asUser(READER, () =>
-      Ledger.$exec("findMany", { include: { book: true } }, {
+      RedactLedger.$exec("findMany", { include: { book: true } }, {
         strategy: "batched",
       } as never),
     )) as any[];
     const lateral = (await Model.asUser(READER, () =>
-      Ledger.$exec("findMany", { include: { book: true } }, {
+      RedactLedger.$exec("findMany", { include: { book: true } }, {
         strategy: "lateral",
       } as never),
     )) as any[];


### PR DESCRIPTION
Closes #205.

The Postgres job runs `vitest run app/models --no-file-parallelism -t postgres`. `-t` matches the test's full name and is **case-sensitive**, so a Postgres-only suite whose name does not contain the exact string `postgres` is selected by nothing.

Three files were in that position, and because they gate themselves with `const RUN = POSTGRES_URL ? describe : describe.skip` they were skipped in the SQLite job too — for want of a URL there, and for want of a matching name in the other. **24 tests ran in neither:**

```
lateral.test.ts            13   "lateral vs batched, on Postgres" / "strategy selection"
lateral.coercion.test.ts    7   "every scalar through a relation, lateral vs batched"
redact-strategies.test.ts   4   "redact on a nested model, both strategies"
```

Eight were missed by a capital P alone — `-t postgres` collects 0 from `lateral.test.ts`, `-t Postgres` collects 8.

Two of the three files are `LATERAL` + `json_agg`: Postgres-only, the **default** strategy there, and the thing `plans/orm/README.md` accepts on the grounds that "the full nested differential matrix runs against it — that is iteration 9's acceptance criterion 2". It ran nowhere.

The suites that do run announce their absence — `⚠ Postgres differential tests did NOT run`. A `describe.skip` says nothing, so these three were silent in exactly the way that mechanism exists to prevent.

## Verified against a real Postgres, not assumed

Postgres 16 in Docker, following the job's own steps (flip the provider, `prisma generate`, `db push`):

| | selected | result |
| --- | --: | --- |
| before | 622 | pass |
| after | 646 | pass |

Exactly +24, all green on a clean database. The SQLite job is unchanged at 616 passed / 32 skipped.

## One of the 24 was broken

`redact-strategies.test.ts` builds a fixture table called `Ledger` — also a real model in the template's schema, with `LedgerEntry` holding a foreign key to it:

```
PostgresError: cannot drop table "Ledger" because other objects depend on it
```

It also registered its fixture under the name `Ledger`, over the template's own model, for the rest of a `--no-file-parallelism` run. I renamed the fixture rather than using `DROP ... CASCADE`, which would have taken the real table and `LedgerEntry`'s foreign key with it. It could never have passed on Postgres, which is why nobody noticed that it could not.

A second failure appeared on the first re-run and did **not** reproduce on a clean database: it was state left behind by the aborted run above, not this change.

## The guard

Every suite gated behind `POSTGRES_URL` must contain the filter string. It reads the filter out of the workflow rather than assuming `postgres`, and compares **case-sensitively**, because that is how `-t` compares — "on Postgres" reads as though it is covered and is not.

Verified against the original names:

```
× lateral.test.ts: lateral vs batched, on Postgres
× lateral.test.ts: strategy selection
```

## Checks

- `bun --bun vitest run orm database` — 48 files, 1416 passed
- template SQLite suite — 17 passed / 3 skipped, 616 tests, unchanged
- template Postgres suite — 13 files, 646 passed, 0 failed
- `bunx tsc --noEmit` and `bunx oxlint orm --deny-warnings` — clean

The scratch Postgres container was removed and the template's schema and Prisma client restored to SQLite.

Touches three template test files and adds one guard — no overlap with #198, #200, #202 or #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)