### PR TITLE
Postgres deployments need TZ=UTC and the docs never said so

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3828,8 +3828,10 @@ Two things are worth knowing:
   stored, because the driver binds it as an integer and the column is `jsonb`. Wrap it — `{ value:
   42 }` — or store it as a string. SQLite has no such limit.
 
-  **This is the one shape where gemi diverges from Prisma**, which stores it on both dialects, so it
-  is worth knowing if you are porting code rather than writing it fresh. It is a trade rather than
+  **This is the one *write* shape where gemi diverges from Prisma**, which stores it on both
+  dialects, so it is worth knowing if you are porting code rather than writing it fresh. (The other
+  divergence is on reads, and is a deployment requirement rather than an API difference — see
+  [Run Postgres deployments with `TZ=UTC`](#run-postgres-deployments-with-tzutc).) It is a trade rather than
   an oversight: the encoder that accepted it serialised first, which stored `42` as the jsonb
   *string* `"42"` — and only looked correct because the decoder re-parsed it on the way out, so the
   value was wrong in the database the whole time. Failing loudly beats storing the wrong thing.
@@ -3842,6 +3844,34 @@ Two things are worth knowing:
 > so nothing looked wrong from inside the ORM, but the column was wrong for anything else that read
 > it. Those rows now read back as strings. Re-seed development databases; there is no released
 > version affected.
+
+## Run Postgres deployments with `TZ=UTC`
+
+**A deployment requirement, not a preference.** Prisma maps `DateTime` to `timestamp(3)` — no time
+zone — and stores UTC in it. Bun's driver decodes that column differently depending on which wire
+protocol carried the statement, and *which protocol is used depends on whether the query binds a
+parameter*:
+
+```ts
+await User.findMany()                      // no parameters -> simple protocol
+await User.findMany({ where: { id } })     // one parameter -> extended protocol
+```
+
+The first comes back as zoneless text and is parsed as **local** time; the second comes back in
+binary and is correct. Same row, same column, two different instants — off by your machine's UTC
+offset. Measured against Postgres 16:
+
+```
+TZ=UTC                no parameters -> 2021-03-04T05:06:07.008Z    where id = $1 -> 05:06:07.008Z
+TZ=America/New_York   no parameters -> 2021-03-04T10:06:07.008Z    where id = $1 -> 05:06:07.008Z
+```
+
+Set `TZ=UTC` on any process that talks to Postgres and both paths agree. This is the setting the
+test suites and CI already run under.
+
+The ORM cannot correct it below the query: the decoded value alone does not say which protocol
+produced it. SQLite is unaffected — it stores `DateTime` as milliseconds and there is no text
+representation to reinterpret.
 
 ## Dialects
 
@@ -3905,7 +3935,6 @@ might lift next release.
   starter template still points at the Prisma adapter; switching it is a per-application call.
 - **[Authorization](./authorization.md)** — route-level authorization, which policies complement
   rather than replace.
-
 ---
 
 ## Rows and entities

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1133,8 +1133,10 @@ Two things are worth knowing:
   stored, because the driver binds it as an integer and the column is `jsonb`. Wrap it — `{ value:
   42 }` — or store it as a string. SQLite has no such limit.
 
-  **This is the one shape where gemi diverges from Prisma**, which stores it on both dialects, so it
-  is worth knowing if you are porting code rather than writing it fresh. It is a trade rather than
+  **This is the one *write* shape where gemi diverges from Prisma**, which stores it on both
+  dialects, so it is worth knowing if you are porting code rather than writing it fresh. (The other
+  divergence is on reads, and is a deployment requirement rather than an API difference — see
+  [Run Postgres deployments with `TZ=UTC`](#run-postgres-deployments-with-tzutc).) It is a trade rather than
   an oversight: the encoder that accepted it serialised first, which stored `42` as the jsonb
   *string* `"42"` — and only looked correct because the decoder re-parsed it on the way out, so the
   value was wrong in the database the whole time. Failing loudly beats storing the wrong thing.
@@ -1147,6 +1149,34 @@ Two things are worth knowing:
 > so nothing looked wrong from inside the ORM, but the column was wrong for anything else that read
 > it. Those rows now read back as strings. Re-seed development databases; there is no released
 > version affected.
+
+## Run Postgres deployments with `TZ=UTC`
+
+**A deployment requirement, not a preference.** Prisma maps `DateTime` to `timestamp(3)` — no time
+zone — and stores UTC in it. Bun's driver decodes that column differently depending on which wire
+protocol carried the statement, and *which protocol is used depends on whether the query binds a
+parameter*:
+
+```ts
+await User.findMany()                      // no parameters -> simple protocol
+await User.findMany({ where: { id } })     // one parameter -> extended protocol
+```
+
+The first comes back as zoneless text and is parsed as **local** time; the second comes back in
+binary and is correct. Same row, same column, two different instants — off by your machine's UTC
+offset. Measured against Postgres 16:
+
+```
+TZ=UTC                no parameters -> 2021-03-04T05:06:07.008Z    where id = $1 -> 05:06:07.008Z
+TZ=America/New_York   no parameters -> 2021-03-04T10:06:07.008Z    where id = $1 -> 05:06:07.008Z
+```
+
+Set `TZ=UTC` on any process that talks to Postgres and both paths agree. This is the setting the
+test suites and CI already run under.
+
+The ORM cannot correct it below the query: the decoded value alone does not say which protocol
+produced it. SQLite is unaffected — it stores `DateTime` as milliseconds and there is no text
+representation to reinterpret.
 
 ## Dialects
 

--- a/packages/gemi/orm/known-divergences.test.ts
+++ b/packages/gemi/orm/known-divergences.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * A divergence from Prisma that the source records is also told to the reader.
+ *
+ * `dialect/postgres.ts` carries a comment headed **KNOWN DIVERGENCE**: Prisma
+ * maps `DateTime` to `timestamp(3)`, and Bun's driver decodes that column
+ * differently depending on which wire protocol carried the statement — which in
+ * turn depends on whether the query binds a parameter. Measured against
+ * Postgres 16:
+ *
+ *     TZ=UTC               findMany()            -> 2021-03-04T05:06:07.008Z
+ *                          where id = $1         -> 2021-03-04T05:06:07.008Z
+ *     TZ=America/New_York  findMany()            -> 2021-03-04T10:06:07.008Z
+ *                          where id = $1         -> 2021-03-04T05:06:07.008Z
+ *
+ * Same row, same column, two instants, off by the machine's UTC offset. The
+ * mitigation is a deployment setting — `TZ=UTC` — and `docs/orm.md` did not
+ * mention `TZ`, `UTC` or time zones anywhere, while telling the reader that the
+ * bare-JSON-number refusal was "the one shape where gemi diverges from Prisma".
+ *
+ * So the more severe of the two divergences was recorded only where the people
+ * affected by it would never look, and the page that would have told them said
+ * there was nothing else to know. CI runs under `TZ=UTC`, which is correct and
+ * also means no test would ever have noticed.
+ *
+ * This does not try to detect divergences — it pins the two that exist to the
+ * section that documents each, so removing the documentation fails rather than
+ * quietly restoring the state above.
+ */
+const ROOT = join(import.meta.dirname, "../../..");
+const DOC = readFileSync(join(ROOT, "docs/orm.md"), "utf8");
+
+describe("divergences the source knows about are documented", () => {
+  test("the page documents the Postgres TZ requirement", () => {
+    expect(DOC).toMatch(/TZ=UTC/);
+    // Named as a requirement rather than mentioned in passing: the failure is
+    // silent and the reader has to act before they see it.
+    expect(DOC).toMatch(/##\s+Run Postgres deployments with `TZ=UTC`/);
+  });
+
+  test("it says which queries are affected, not just that some are", () => {
+    const section = DOC.slice(DOC.indexOf("## Run Postgres deployments"));
+    // The distinction is the actionable part: whether the query binds a
+    // parameter is what selects the protocol, and it is not otherwise guessable.
+    expect(section).toMatch(/parameter/);
+    expect(section).toMatch(/simple protocol/);
+    expect(section).toMatch(/extended protocol/);
+  });
+
+  /**
+   * The claim that started this. It is true of *writes*, and was written as
+   * though it were true of everything.
+   */
+  test("the Json refusal is not called the only divergence", () => {
+    expect(DOC).not.toMatch(/the one shape where gemi diverges from Prisma\*\*,/);
+    expect(DOC).toMatch(/one \*write\* shape where gemi diverges/);
+  });
+
+  /**
+   * And the source comment stays the authority it claims to be: if the
+   * `KNOWN DIVERGENCE` note is deleted or moved, this stops matching and the
+   * documentation above is left describing something nothing records.
+   */
+  test("the dialect still carries the note the docs are derived from", () => {
+    const dialects = join(ROOT, "packages/gemi/orm/dialect");
+    const sources = readdirSync(dialects)
+      .filter((file) => file.endsWith(".ts"))
+      .map((file) => readFileSync(join(dialects, file), "utf8"));
+
+    expect(sources.some((source) => source.includes("KNOWN DIVERGENCE"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #211.

`dialect/postgres.ts` carries a comment headed **KNOWN DIVERGENCE**: Prisma maps `DateTime` to `timestamp(3)`, and Bun's driver decodes that column differently depending on which wire protocol carried the statement — which depends on whether the query binds a parameter.

`docs/orm.md` did not contain `TZ`, `UTC`, "timezone" or "time zone" anywhere. What it *did* say, of the bare-JSON-number refusal, was that it is "**the one shape where gemi diverges from Prisma**".

So the more severe of the two divergences was recorded only where the people affected by it would never look, and the page that would have told them said there was nothing else to know.

## Reproduced, not quoted

```
TZ=UTC                no parameters -> 2021-03-04T05:06:07.008Z    where id = $1 -> 05:06:07.008Z
TZ=America/New_York   no parameters -> 2021-03-04T10:06:07.008Z    where id = $1 -> 05:06:07.008Z
```

In ORM terms:

```ts
await User.findMany()                    // binds nothing -> simple protocol   -> wrong instant
await User.findMany({ where: { id } })   // binds one     -> extended protocol -> correct
```

Same row, same column, two instants, off by the machine's UTC offset, and nothing raises. Which queries are affected is the part a reader cannot guess, so the new section leads with it.

The Json sentence is narrowed to "the one **write** shape" and points at the new section — it was accurate about writes and read as though it covered everything.

## No behaviour change

The ORM cannot correct it below the query: the decoded value alone does not say which protocol produced it. That is the dialect's own assessment and I have not revisited it here — though the same comment says "nothing *below the plan* does", and the plan knows its own binder count, so a fix one level up may exist. Recorded in #211 as its own piece of work rather than attempted alongside a docs change.

## Why nothing caught it

CI and both suites run under `TZ=UTC` — the correct setting, and also the one where the two paths agree. No test would ever have failed. It was found by reading the comment.

## The guard

Pins each divergence to the section documenting it, asserts the section names *which* queries are affected rather than only that some are, and checks the dialect still carries the `KNOWN DIVERGENCE` note the docs are derived from — so deleting the source of truth fails rather than leaving prose describing nothing.

Verified against the docs as they stood:

```
× the page documents the Postgres TZ requirement
× it says which queries are affected, not just that some are
× the Json refusal is not called the only divergence
```

`docs/llms-full.txt` is re-synced, so #181's verbatim guard stays green — it caught the drift as intended while I was writing this.

## Checks

- `bun --bun vitest run orm database` — 52 files, 1436 passed
- `bunx tsc --noEmit` and `bunx oxlint orm --deny-warnings` — clean
- scratch Postgres container removed

Independent of #204, #208 and #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)