### PR TITLE
Warn once when a Postgres read will return the wrong instant

### DIFF
--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -20,6 +20,7 @@ import { resolveStrategy } from "./compile/strategy";
 import { matchUniqueKey } from "./compile/unique";
 import { upsertAbsentConflictKey } from "./compile/write";
 import { dialectFor, type SqlDialect } from "./dialect";
+import { protocolSkewWarning } from "./protocol-skew";
 import {
   MissingModelSchemaError,
   RecordNotFoundError,
@@ -956,6 +957,9 @@ async function runSteps(
   }
 }
 
+/** Set the first time `protocolSkewWarning` fires; see the call site below. */
+let warnedProtocolSkew = false;
+
 /**
  * Runs the statement and translates the failures that have a typed home.
  *
@@ -974,6 +978,24 @@ async function execute(
   text: string,
   values: unknown[],
 ): Promise<unknown> {
+  // Said once per process, and only for the configuration that silently returns
+  // the wrong instant — see `protocol-skew.ts`. Behind `warnedProtocolSkew` so
+  // the check disappears after it fires, and ordered so a correctly configured
+  // process pays one boolean.
+  if (!warnedProtocolSkew) {
+    const warning = protocolSkewWarning(
+      dialect.name,
+      schema,
+      text,
+      values,
+      new Date().getTimezoneOffset(),
+    );
+    if (warning) {
+      warnedProtocolSkew = true;
+      console.warn(warning);
+    }
+  }
+
   try {
     return await conn.unsafe(text, values);
   } catch (error) {

--- a/packages/gemi/orm/protocol-skew.test.ts
+++ b/packages/gemi/orm/protocol-skew.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+
+import { protocolSkewWarning } from "./protocol-skew";
+import type { ModelSchema } from "./schema";
+
+/**
+ * The conditions under which a `DateTime` read is silently wrong, asserted one
+ * at a time.
+ *
+ * Every one of them has to hold, and the reason to test them individually is
+ * that three of the four are cheap comparisons which a later edit could reorder
+ * or drop without any behavioural test noticing: the warning not firing is what
+ * a correctly configured process looks like, so "no warning" cannot distinguish
+ * a working guard from a deleted one.
+ *
+ * `offsetMinutes` is a parameter rather than read from the clock so these run
+ * the same in CI — which sets `TZ=UTC`, the configuration where the fault does
+ * not occur, and would otherwise be the one environment unable to test it.
+ */
+const field = (name: string, type: string) => ({
+  name,
+  column: name,
+  type: type as never,
+  nullable: false,
+  isId: false,
+  isUpdatedAt: false,
+});
+
+const withDates: ModelSchema = {
+  name: "User",
+  table: "User",
+  fields: {
+    id: field("id", "Int"),
+    createdAt: field("createdAt", "DateTime"),
+    updatedAt: field("updatedAt", "DateTime"),
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {},
+};
+
+const noDates: ModelSchema = {
+  ...withDates,
+  name: "Tag",
+  fields: { id: field("id", "Int"), label: field("label", "String") },
+};
+
+/** New York in March: five hours behind UTC. */
+const NEW_YORK = 300;
+
+describe("the protocol-skew warning fires only when the read is wrong", () => {
+  test("a parameterless Postgres select of a DateTime, off UTC", () => {
+    const warning = protocolSkewWarning(
+      "postgres",
+      withDates,
+      `select "id", "createdAt" from "User"`,
+      [],
+      NEW_YORK,
+    );
+
+    expect(warning).toContain("User");
+    expect(warning).toContain("createdAt");
+    // The actionable half. A warning that only says something is wrong costs
+    // the reader the same search this note exists to save them.
+    expect(warning).toContain("TZ=UTC");
+    expect(warning).toContain("binds no parameters");
+  });
+
+  test.each([
+    ["SQLite is unaffected — it stores milliseconds", "sqlite", withDates, `select "createdAt" from "User"`, [], NEW_YORK],
+    ["a bound parameter takes the extended protocol", "postgres", withDates, `select "createdAt" from "User" where "id" = $1`, [1], NEW_YORK],
+    ["a UTC process decodes both paths alike", "postgres", withDates, `select "createdAt" from "User"`, [], 0],
+    ["a model with no DateTime has nothing to skew", "postgres", noDates, `select "label" from "Tag"`, [], NEW_YORK],
+    ["a write binds its values, and returns none unasked", "postgres", withDates, `delete from "User"`, [], NEW_YORK],
+  ])("silent: %s", (_label, dialect, schema, text, values, offset) => {
+    expect(
+      protocolSkewWarning(dialect as string, schema as ModelSchema, text as string, values as unknown[], offset as number),
+    ).toBeNull();
+  });
+
+  /** East of UTC as well as west: the sign is not what decides it. */
+  test("fires for a positive offset too", () => {
+    expect(
+      protocolSkewWarning("postgres", withDates, `select "createdAt" from "User"`, [], -60),
+    ).not.toBeNull();
+  });
+});

--- a/packages/gemi/orm/protocol-skew.ts
+++ b/packages/gemi/orm/protocol-skew.ts
@@ -1,0 +1,73 @@
+import type { ModelSchema } from "./schema";
+
+/**
+ * The one configuration where a `DateTime` read comes back as the wrong instant.
+ *
+ * `dialect/postgres.ts` records it as a KNOWN DIVERGENCE and `docs/orm.md` now
+ * states the requirement — run Postgres deployments with `TZ=UTC`. Prisma maps
+ * `DateTime` to `timestamp(3)`, and Bun decodes that column differently
+ * depending on which wire protocol carried the statement, which in turn depends
+ * on whether the query bound a parameter:
+ *
+ *     TZ=America/New_York   findMany()            -> 2021-03-04T10:06:07.008Z
+ *                           where id = $1         -> 2021-03-04T05:06:07.008Z
+ *
+ * A reader who has seen the documentation sets `TZ=UTC` and never meets this. A
+ * reader who has not gets two different instants for the same row and no signal
+ * at all — the values look plausible, nothing raises, and the difference is
+ * exactly the machine's UTC offset, which is the kind of wrongness that reaches
+ * a report or an invoice before anyone notices.
+ *
+ * So this says it once. The project's stated trade, from the `Json` encoder that
+ * had the same shape of bug, is that "a loud failure replaces a silent
+ * mis-store"; a warning is the most that can be done here, because the value is
+ * already decoded by the time anything in this package sees it and it does not
+ * carry which protocol produced it.
+ *
+ * **Not gated on `NODE_ENV`, unlike the slow-transaction warning.** That one is
+ * a performance hint, and a hint is worth having only where somebody is
+ * watching. This is a correctness fault, and production is exactly where an
+ * unnoticed wrong timestamp costs something. It fires once per process, and
+ * only when every condition below holds, so a correctly configured deployment
+ * never sees it.
+ *
+ * Pure, and returns the message rather than printing it, so the conditions can
+ * be tested without capturing console output or depending on the machine's
+ * clock — `offsetMinutes` is a parameter for exactly that reason.
+ */
+export function protocolSkewWarning(
+  dialect: string,
+  schema: ModelSchema,
+  text: string,
+  values: readonly unknown[],
+  offsetMinutes: number,
+): string | null {
+  // Cheapest discriminators first: three of the four are a comparison, and the
+  // field scan only runs for a parameterless Postgres select on a machine that
+  // is not already UTC.
+  if (dialect !== "postgres") return null;
+  if (values.length > 0) return null;
+  if (offsetMinutes === 0) return null;
+
+  // A statement that binds nothing and returns no rows cannot show the skew.
+  // `RETURNING` writes always bind at least the values they write, so in
+  // practice this is the parameterless read.
+  if (!/^\s*select/i.test(text)) return null;
+
+  const columns = Object.values(schema.fields)
+    .filter((field) => field.type === "DateTime")
+    .map((field) => field.name);
+
+  if (columns.length === 0) return null;
+
+  return (
+    `[gemi] ${schema.name} was read with a query that binds no parameters, on ` +
+    `Postgres, in a process whose clock is not UTC. Bun decodes ` +
+    `timestamp(3) over the simple query protocol as local time, so ` +
+    `${columns.length === 1 ? "the column" : "columns"} ` +
+    `${columns.join(", ")} will be off by this machine's UTC offset — the same ` +
+    `row read through a query that binds a parameter returns a different ` +
+    `instant. Set TZ=UTC on this process. See "Run Postgres deployments with ` +
+    `TZ=UTC" in docs/orm.md. (Warned once.)`
+  );
+}


### PR DESCRIPTION
Closes #213. The follow-up #211 records — #212 documents the requirement, this tells the process that is not meeting it.

Bun decodes `timestamp(3)` over the simple query protocol as local time, and a query that binds no parameters takes that protocol. On a non-UTC machine `User.findMany()` and `User.findMany({ where: { id } })` return **different instants for the same row**, off by the machine's UTC offset, with nothing raised and both values looking plausible.

A reader who has seen the documentation sets `TZ=UTC` and never meets this. One who has not gets wrong timestamps and no signal — the kind of wrongness that reaches a report before anyone notices.

## Not a correction, a signal

The value is already decoded before anything in this package sees it, and does not carry which protocol produced it. That is the dialect's own assessment and it holds.

But the *condition* is visible: `execute()` — the single point every statement runs through — has the dialect, the schema, the text and the bound values, and `values.length === 0` is exactly the discriminator. So the fault is detectable where it is not fixable.

The project's stated trade, from the `Json` encoder that had the same shape of bug, is that "a loud failure replaces a silent mis-store".

## The debatable part, stated plainly

**It is not gated on `NODE_ENV`**, unlike the slow-transaction warning beside it. That one is a performance hint, worth having only where somebody is watching; this is a correctness fault, and production is exactly where an unnoticed wrong timestamp costs something.

It fires at most once per process and only when every condition holds — Postgres, no bound parameters, a `select`, a `DateTime` column, and a clock that is not UTC — so a correctly configured deployment never sees it and pays one boolean. Easy to make dev-only if you would rather; it is one condition.

## Testing something CI cannot reproduce

CI runs under `TZ=UTC` — the configuration where the fault does not occur, and otherwise the one environment unable to test it. So the helper is pure, returns the message rather than printing it, and takes the UTC offset as a parameter.

Each condition is asserted separately, because three of the four are cheap comparisons a later edit could drop without any behavioural test noticing: "no warning" is what a correctly configured process looks like, so it cannot distinguish a working guard from a deleted one.

Verified end to end against Postgres 16 as well as by unit test:

```
TZ=UTC               two findMany() calls -> 0 warnings
TZ=America/New_York  two findMany() calls -> 1 warning
```

The second confirms both halves: that it fires, and that it fires once.

## Checks

- `bun --bun vitest run orm database` — 53 files, 1444 passed
- template suite — 17 passed / 3 skipped, 616 tests
- `bunx tsc --noEmit` and `bunx oxlint orm --deny-warnings` — clean
- scratch container removed

Builds on #212's documentation but does not depend on it to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)