### PR TITLE
Lift the Json boundary: bare numbers and booleans write on Postgres

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3817,25 +3817,20 @@ development on SQLite and survives the rollback in production on Postgres. `DB.q
 
 ## `Json` columns
 
-A `Json` column round-trips whatever you give it: an object, an array, a string, `null` — and a
-number or boolean on SQLite, with the one exception below. The value is stored as JSON and comes
-back as the same JavaScript value, on both dialects and whether it is read at the root or nested
-inside an `include`.
+A `Json` column round-trips whatever you give it: an object, an array, a string, a number, a
+boolean, `null`. The value is stored as JSON and comes back as the same JavaScript value, on both
+dialects and whether it is read at the root or nested inside an `include`.
 
-Two things are worth knowing:
+One thing is worth knowing:
 
-- **A bare JSON number or boolean is refused on Postgres.** `metadata: 42` raises rather than being
-  stored, because the driver binds it as an integer and the column is `jsonb`. Wrap it — `{ value:
-  42 }` — or store it as a string. SQLite has no such limit.
-
-  **This is the one shape where gemi diverges from Prisma**, which stores it on both dialects, so it
-  is worth knowing if you are porting code rather than writing it fresh. It is a trade rather than
-  an oversight: the encoder that accepted it serialised first, which stored `42` as the jsonb
-  *string* `"42"` — and only looked correct because the decoder re-parsed it on the way out, so the
-  value was wrong in the database the whole time. Failing loudly beats storing the wrong thing.
 - **A string is a string.** `metadata: "42"` stores the JSON string `"42"`, not the number, and
   `metadata: '{"a":1}'` stores that text as a string rather than as an object. If you want an
   object, pass an object.
+
+On Postgres the parameter is cast — `$1::text::jsonb` — and the value serialised to match, which
+is what lets a bare number or boolean through. Binding it raw makes the driver send an `integer` to
+a `jsonb` column, and serialising *without* the cast stores the jsonb string `"42"` instead of the
+number, which is worse than refusing it. SQLite needs neither: it stores JSON as text.
 
 > **Upgrading:** `Json` values written by a *pre-release* build of this ORM on Postgres were stored
 > as JSON **strings** rather than as objects — `{ a: 1 }` landed as `"{\"a\":1}"`. Reads undid it,
@@ -3905,7 +3900,6 @@ might lift next release.
   starter template still points at the Prisma adapter; switching it is a per-application call.
 - **[Authorization](./authorization.md)** — route-level authorization, which policies complement
   rather than replace.
-
 ---
 
 ## Rows and entities

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1122,25 +1122,20 @@ development on SQLite and survives the rollback in production on Postgres. `DB.q
 
 ## `Json` columns
 
-A `Json` column round-trips whatever you give it: an object, an array, a string, `null` — and a
-number or boolean on SQLite, with the one exception below. The value is stored as JSON and comes
-back as the same JavaScript value, on both dialects and whether it is read at the root or nested
-inside an `include`.
+A `Json` column round-trips whatever you give it: an object, an array, a string, a number, a
+boolean, `null`. The value is stored as JSON and comes back as the same JavaScript value, on both
+dialects and whether it is read at the root or nested inside an `include`.
 
-Two things are worth knowing:
+One thing is worth knowing:
 
-- **A bare JSON number or boolean is refused on Postgres.** `metadata: 42` raises rather than being
-  stored, because the driver binds it as an integer and the column is `jsonb`. Wrap it — `{ value:
-  42 }` — or store it as a string. SQLite has no such limit.
-
-  **This is the one shape where gemi diverges from Prisma**, which stores it on both dialects, so it
-  is worth knowing if you are porting code rather than writing it fresh. It is a trade rather than
-  an oversight: the encoder that accepted it serialised first, which stored `42` as the jsonb
-  *string* `"42"` — and only looked correct because the decoder re-parsed it on the way out, so the
-  value was wrong in the database the whole time. Failing loudly beats storing the wrong thing.
 - **A string is a string.** `metadata: "42"` stores the JSON string `"42"`, not the number, and
   `metadata: '{"a":1}'` stores that text as a string rather than as an object. If you want an
   object, pass an object.
+
+On Postgres the parameter is cast — `$1::text::jsonb` — and the value serialised to match, which
+is what lets a bare number or boolean through. Binding it raw makes the driver send an `integer` to
+a `jsonb` column, and serialising *without* the cast stores the jsonb string `"42"` instead of the
+number, which is worse than refusing it. SQLite needs neither: it stores JSON as text.
 
 > **Upgrading:** `Json` values written by a *pre-release* build of this ORM on Postgres were stored
 > as JSON **strings** rather than as objects — `{ a: 1 }` landed as `"{\"a\":1}"`. Reads undid it,

--- a/packages/gemi/orm/compile/cast.ts
+++ b/packages/gemi/orm/compile/cast.ts
@@ -1,0 +1,47 @@
+import type { SqlDialect } from "../dialect";
+import type { FieldSchema } from "../schema";
+import { type Binder, type Fragment, param } from "./fragment";
+
+/**
+ * Binds a field's value, letting the dialect add a cast to the placeholder.
+ *
+ * Only `Json` on Postgres needs one today, and the reason is the whole of #209.
+ * Bun serialises a JS value bound to a `jsonb` parameter, so an object arrives
+ * correctly and a bare number arrives as `integer` and is rejected. Serialising
+ * first does not help on its own — the string is then serialised again and the
+ * column ends up holding the jsonb *string* `"42"`, which is the silent
+ * mis-store the refusal existed to prevent. Measured against Postgres 16:
+ *
+ *   values ($1)                 42        integer vs jsonb
+ *   values ($1::jsonb)          "42"      jsonb_typeof -> string
+ *   values (to_jsonb($1))       {a:1}     could not determine polymorphic type
+ *   values ($1::text::jsonb)    "42"      jsonb_typeof -> number
+ *
+ * The last is the only form that carries all six shapes, so it is the one the
+ * dialect asks for.
+ *
+ * **A site that does not use this keeps today's behaviour**, which is the point
+ * of putting the serialisation here rather than in `encode`. Moving it into
+ * `encode` would serialise at every binding site whether or not that site
+ * emitted the cast — and a site that serialises without casting is exactly the
+ * mis-store above, arrived at silently. Here, a binding site nobody converted
+ * still binds raw: objects work, a bare number is still refused, and the
+ * failure stays loud.
+ */
+export function fieldParam(
+  field: FieldSchema,
+  dialect: SqlDialect,
+  binder: Binder,
+): Fragment {
+  const cast = dialect.castParameter(field);
+  if (!cast) return param(binder);
+
+  return param((args, context) => {
+    const value = binder(args, context);
+    // `null` stays SQL NULL rather than becoming the JSON value `null`:
+    // `JSON.stringify(null)` is `"null"`, and `'null'::jsonb` is a jsonb null,
+    // which is a different thing from an absent value and would diverge from
+    // Prisma on every nullable Json column.
+    return value === null || value === undefined ? null : JSON.stringify(value);
+  }, cast);
+}

--- a/packages/gemi/orm/compile/fragment.ts
+++ b/packages/gemi/orm/compile/fragment.ts
@@ -80,9 +80,20 @@ export function sql(text: string): Fragment {
   return { text, binders: [] };
 }
 
-/** A single parameter position, bound from the argument tree at call time. */
-export function param(binder: Binder): Fragment {
-  return { text: PARAM_MARKER, binders: [binder] };
+/**
+ * A single parameter position, bound from the argument tree at call time.
+ *
+ * `cast` is SQL appended immediately after the placeholder — `$1::text::jsonb`.
+ * It rides as ordinary text rather than as a parallel array because the marker
+ * is replaced in place at render, so text following it needs no bookkeeping and
+ * cannot fall out of step with the binders.
+ *
+ * Only a dialect may supply one, and only from a constant: it is the one string
+ * here that reaches the statement without being a parameter. See
+ * `castParameter`.
+ */
+export function param(binder: Binder, cast = ""): Fragment {
+  return { text: PARAM_MARKER + cast, binders: [binder] };
 }
 
 export function concat(...parts: Fragment[]): Fragment {

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -19,6 +19,7 @@ import {
   param,
   sql,
 } from "./fragment";
+import { fieldParam } from "./cast";
 
 /**
  * `where` -> a boolean expression, recursively.
@@ -747,7 +748,7 @@ function compileFieldFilter(
         parts.push(
           concat(
             sql(`${column} ${COMPARISONS[key]} `),
-            param(encoded(field, dialect, at)),
+            fieldParam(field, dialect, encoded(field, dialect, at)),
           ),
         );
         break;
@@ -799,7 +800,7 @@ function compileNot(
   if (!isFilterObject(operand)) {
     return concat(
       sql(`${column} <> `),
-      param(encoded(field, context.dialect, locate)),
+      fieldParam(field, context.dialect, encoded(field, context.dialect, locate)),
     );
   }
 
@@ -821,7 +822,10 @@ function equals(
   // `= ?` with a null parameter matches nothing in SQL, where Prisma means
   // `is null`. This is the difference that would silently return wrong rows.
   if (operand === null) return sql(`${column} is null`);
-  return concat(sql(`${column} = `), param(encoded(field, dialect, locate)));
+  return concat(
+    sql(`${column} = `),
+    fieldParam(field, dialect, encoded(field, dialect, locate)),
+  );
 }
 
 function inList(

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -16,7 +16,6 @@ import {
   type Fragment,
   concat,
   joinFragments,
-  param,
   sql,
 } from "./fragment";
 import { fieldParam } from "./cast";

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -20,6 +20,7 @@ import {
   render,
   sql,
 } from "./fragment";
+import { fieldParam } from "./cast";
 import {
   type ForeignKeyContribution,
   type NestedWritePlanning,
@@ -912,7 +913,10 @@ function valuesClause(grid: WriteColumn[][], dialect: SqlDialect): Fragment {
   const tuples = grid.map((row) =>
     concat(
       sql("("),
-      joinFragments(row.map((column) => param(column.value)), ", "),
+      joinFragments(
+        row.map((column) => fieldParam(column.field, dialect, column.value)),
+        ", ",
+      ),
       sql(")"),
     ),
   );
@@ -1137,7 +1141,10 @@ function updateAssignments(
     // Every write stamps `@updatedAt` — that is the whole of the attribute.
     if (field.isUpdatedAt) {
       out.push(
-        concat(sql(`${column} = `), param(defaultBinder(field, dialect))),
+        concat(
+          sql(`${column} = `),
+          fieldParam(field, dialect, defaultBinder(field, dialect)),
+        ),
       );
     }
   }
@@ -1189,16 +1196,22 @@ function assignment(
     const at = (args: any) => locate(args)?.[key];
 
     if (key === "set") {
-      return concat(sql(`${column} = `), param(valueBinder(field, dialect, at)));
+      return concat(
+        sql(`${column} = `),
+        fieldParam(field, dialect, valueBinder(field, dialect, at)),
+      );
     }
 
     return concat(
       sql(`${column} = ${source} ${ARITHMETIC[key]} `),
-      param(valueBinder(field, dialect, at)),
+      fieldParam(field, dialect, valueBinder(field, dialect, at)),
     );
   }
 
-  return concat(sql(`${column} = `), param(valueBinder(field, dialect, locate)));
+  return concat(
+    sql(`${column} = `),
+    fieldParam(field, dialect, valueBinder(field, dialect, locate)),
+  );
 }
 
 /**

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -106,6 +106,17 @@ export interface SqlDialect {
   encode(value: unknown, field: FieldSchema): unknown;
 
   /**
+   * SQL appended to this field's placeholder, or `""` for none.
+   *
+   * The one string a dialect contributes to the statement that is not a
+   * parameter, so it must be a constant — never derived from a value, and never
+   * from anything an application supplies. `fieldParam` is the only caller, and
+   * a non-empty cast also means it serialises the value; the two travel
+   * together and neither is correct alone (#209).
+   */
+  castParameter(field: FieldSchema): string;
+
+  /**
    * The same, for a value with **no declared column type** — a parameter
    * interpolated into a composed raw fragment, where there is no schema to ask.
    *

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -233,6 +233,16 @@ export class PostgresDialect implements SqlDialect {
   // reads `field` any more — the signature is the interface's, the disuse is
   // this dialect's. `Date`, `boolean`, `bigint` and arrays are Bun's to
   // serialize, and so, it turns out, is JSON.
+  // `$1::text::jsonb` for a `Json` column, and nothing for anything else.
+  //
+  // The value is serialised by `fieldParam`, not by `encode` below, so a
+  // binding site that does not ask for the cast still binds raw and keeps the
+  // loud failure rather than acquiring a silent mis-store. The comment on
+  // `encode` has the measurements.
+  castParameter(field: FieldSchema): string {
+    return field.type === "Json" ? "::text::jsonb" : "";
+  }
+
   encode(value: unknown, _field: FieldSchema): unknown {
     if (value === null || value === undefined) return null;
     // **`Json` is handed over raw**, because Bun serializes it for a `jsonb`
@@ -260,34 +270,22 @@ export class PostgresDialect implements SqlDialect {
     // time, and anything reading that column *other than this ORM* saw a
     // string. A loud failure replaces a silent mis-store.
     //
-    // **Fixing it is not "serialise and cast", which is what this comment used
-    // to say.** Measured through Bun 1.3.14 against Postgres 16, that stores
-    // the jsonb *string* `"42"` — the exact silent mis-store the refusal above
-    // exists to prevent, because Bun serialises a JS string bound to a `jsonb`
-    // parameter, so pre-serialising encodes it twice:
+    // **Fixed, in the compiler rather than here** — see `compile/cast.ts`. The
+    // placeholder carries `::text::jsonb` and `fieldParam` serialises the value
+    // to match, which is the only one of the four forms measured that carries
+    // all six shapes:
     //
-    //   values ($1)                 42        integer vs jsonb — the error above
-    //   values ($1::jsonb)          42        cannot cast integer to jsonb
-    //   values ($1::jsonb)          "42"      jsonb_typeof -> string   <- the old bug
-    //   values (to_jsonb($1))       42        jsonb_typeof -> number
+    //   values ($1)                 42        integer vs jsonb
+    //   values ($1::jsonb)          "42"      jsonb_typeof -> string
+    //   values (to_jsonb($1))       {a:1}     could not determine polymorphic type
     //   values ($1::text::jsonb)    "42"      jsonb_typeof -> number
     //
-    // **`to_jsonb($1)` is not the answer either**, though it looks like one from
-    // that row alone. It works for exactly the shapes Bun binds as a concrete
-    // type — a number and a boolean — and fails for the four that matter more,
-    // because an unannotated parameter leaves the polymorphic argument untyped:
+    // The serialisation deliberately does **not** live here. `encode` runs at
+    // every binding site, and a site that serialises without also emitting the
+    // cast is the second row above — the silent mis-store this whole comment is
+    // about. Keeping the two together in `fieldParam` means a site nobody
+    // converted still binds raw and still fails loudly.
     //
-    //   to_jsonb($1)   {a:1} / [1,2] / "42" / null
-    //                  could not determine polymorphic type
-    //
-    // So there is one form, not two: `JSON.stringify` the value and bind it
-    // through `$1::text::jsonb`, which round-trips all six shapes with the right
-    // `jsonb_typeof` — object, array, string, number, boolean and null.
-    //
-    // It needs the column's type at the *placeholder*, so it still has to reach
-    // the insert, the update's set clause and any `where` on a Json column. Not
-    // done here. `writes.coercion.test.ts` pins every row above, the failing
-    // forms included, so this stays a measurement rather than a memory.
     return value;
   }
 

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -203,6 +203,13 @@ export class SqliteDialect implements SqlDialect {
     return { kind: "unique", columns };
   }
 
+  // Nothing to cast. SQLite stores JSON as text and has no typed jsonb column
+  // to disagree with the parameter, which is why the boundary #209 describes is
+  // a Postgres one.
+  castParameter(_field: FieldSchema): string {
+    return "";
+  }
+
   encode(value: unknown, field: FieldSchema): unknown {
     if (value === null || value === undefined) return null;
 

--- a/templates/saas-starter/app/models/writes.coercion.test.ts
+++ b/templates/saas-starter/app/models/writes.coercion.test.ts
@@ -353,54 +353,50 @@ function suite(label: string, url?: string) {
     });
 
     /**
-     * The one `Json` shape that does **not** work on Postgres, pinned so it is
-     * a known boundary rather than a surprise.
+     * Every `Json` shape round-trips, including the two that used to be refused.
      *
-     * A bare JSON number or boolean is bound as its own type — Bun has no way
-     * to know the parameter is destined for a `jsonb` column — and Postgres
-     * answers `column "payload" is of type jsonb but expression is of type
-     * integer`.
+     * A bare JSON number or boolean was the one shape Bun binds as its own type
+     * — it has no way to know the parameter is destined for a `jsonb` column —
+     * so Postgres answered `column "payload" is of type jsonb but expression is
+     * of type integer`, and the ORM let that through as a loud failure rather
+     * than storing something wrong.
      *
-     * **This reads like a regression and is not one**, which is worth stating
-     * here because a bisect will land on this commit and conclude otherwise.
-     * Under the previous encoder the same call *appeared* to work — but the
-     * stored value was the jsonb **string** `"42"`, not the number.
-     * `jsonb_typeof` answered `string` for a bare number, a bare boolean and an
-     * object alike; it only looked correct because the old decoder re-parsed on
-     * the way out. So the column was wrong in the database the whole time, and
-     * anything reading it other than this ORM — Prisma, `psql`, a report — saw
-     * a string. A loud failure replaces a silent mis-store, which is the trade
-     * this project takes every time.
+     * The compiler now asks the dialect for a cast and serialises the value to
+     * match: `$1::text::jsonb`. That is the only form of the four measured in
+     * #209 that carries all six shapes — the raw bind refuses scalars, a bare
+     * `::jsonb` stores the jsonb *string* `"42"`, and `to_jsonb($1)` cannot type
+     * an object, an array, a string or null.
      *
-     * **Fixing it is not "serialise and cast", which is what this said before.**
-     * That stores the jsonb *string* `"42"` — the very mis-store above — because
-     * Bun serialises a JS string bound to a `jsonb` parameter, so pre-serialising
-     * encodes it twice. Nor is it `to_jsonb($1)`, which carries a number and a
-     * boolean and fails on an object, an array, a string and null. The test below
-     * pins all three, so the one that works is a measurement rather than a pick.
-     *
-     * The working form still needs the column's type at the placeholder, so it
-     * reaches the insert, the update's set clause and any `where` comparing a Json
-     * column: a compiler change with its own differential pass rather than a
-     * dialect tweak. Left out of the change that found it deliberately.
-     *
-     * SQLite has no such limit: it stores JSON as text, so every shape works.
+     * `jsonb_typeof` is asserted as well as the value, because the mis-store
+     * this replaces was a *right-looking value under the wrong type*: `"42"`
+     * reads back as `42` through this ORM and as a string through anything else.
+     * Equality alone could not tell the two apart, which is how it survived.
      */
     test.each([
-      ["a JSON number", 7],
-      ["a JSON boolean", true],
-    ])("%s is a known boundary on postgres", async (_label, payload) => {
-      const write = EverythingModel.$exec("create", {
+      ["a JSON number", 7, "number"],
+      ["a JSON boolean", true, "boolean"],
+      ["a JSON string", "42", "string"],
+      ["an object", { a: 1 }, "object"],
+      ["an array", [1, 2, 3], "array"],
+    ])("%s round-trips", async (_label, payload, kind) => {
+      const created: any = await EverythingModel.$exec("create", {
         data: { ...values, payload },
       });
-
-      if (url) {
-        await expect(write).rejects.toThrow(/jsonb/);
-        return;
-      }
-
-      const created: any = await write;
       expect(created.payload).toEqual(payload);
+
+      const read: any = await EverythingModel.$exec("findFirst", {
+        where: { id: created.id },
+      });
+      expect(read.payload).toEqual(payload);
+
+      if (!url) return;
+
+      // The half the ORM cannot see: what the column actually holds.
+      const rows: any = await raw.unsafe(
+        `SELECT jsonb_typeof("payload") AS kind FROM "Everything" WHERE "id" = $1`,
+        [created.id],
+      );
+      expect([...rows][0].kind).toBe(kind);
     });
 
     /**


### PR DESCRIPTION
Closes #215. The last documented divergence from Prisma, and the half #209 deliberately stopped short of.

A bare JSON number or boolean was refused on Postgres because Bun binds it as its own type and the column is `jsonb`. The compiler now asks the dialect for a cast and serialises to match — `$1::text::jsonb` — the only one of the four forms measured in #209 that carries all six shapes:

```
values ($1)                 42        integer vs jsonb
values ($1::jsonb)          "42"      jsonb_typeof -> string
values (to_jsonb($1))       {a:1}     could not determine polymorphic type
values ($1::text::jsonb)    "42"      jsonb_typeof -> number
```

## The design choice worth reviewing

**The serialisation is deliberately not in `encode`.** That is the obvious place and the wrong one: `encode` runs at every binding site, so a site that serialises without *also* emitting the cast is the second row above — the silent mis-store the refusal existed to prevent.

Keeping both in `fieldParam` means the failure mode of missing a site is that the site keeps binding raw: objects still work, a bare number is still refused, and it stays loud. That is the difference between an incomplete change and a regression.

Eight sites converted — five in `write.ts` (insert values, update set clause, defaults) and three in `where.ts`. `inList` is left alone: an `in` over a Json column would need `::jsonb[]` against a serialised array literal, a different question nobody has asked.

`null` stays SQL NULL rather than becoming the jsonb value `null` — `'null'::jsonb` is a JSON null, a different thing from an absent value, and would diverge from Prisma on every nullable Json column.

The cast rides as text after the placeholder rather than in a parallel array, since the marker is replaced in place at render — text following it needs no bookkeeping and cannot fall out of step with the binders. It is the one string a dialect contributes to the statement that is not a parameter, so the interface says it must be a constant.

## Verification

Through the differential harness, which compares every one of these against Prisma:

| | before | after |
| --- | --: | --: |
| Postgres suite | 646 | **649 passed, 0 failed** |
| SQLite suite | 617 | **620 passed** |
| `packages/gemi` | 1436 | **1437 passed** |

The round-trip test asserts `jsonb_typeof` as well as the value, because the mis-store this replaces was a *right-looking value under the wrong type* — `"42"` reads back as `42` through this ORM and as a string through everything else, which is how it survived.

## Interaction with #212

#212 adds a guard asserting `docs/orm.md` calls the Json refusal "the one **write** shape where gemi diverges from Prisma". This PR removes that divergence, so that sentence is gone and the assertion will need dropping — whichever merges second. Flagging rather than pre-empting, since #212 is unreviewed and the wording may change.

`docs/llms-full.txt` is re-synced. Scratch container removed and the template restored to SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)