### PR TITLE
Compare a Prisma enum against Prisma, and say how it sorts

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3815,6 +3815,32 @@ The direction is the awkward one: a `DB.sql` write inside a transaction rolls ba
 development on SQLite and survives the rollback in production on Postgres. `DB.query` and
 `DB.execute` join the transaction on both.
 
+## Enums
+
+A Prisma `enum` is a **string** at runtime, on both dialects, exactly as it is through Prisma:
+
+```ts
+await Organization.findMany({ where: { plan: { in: ["pro", "enterprise"] } } })
+```
+
+The generated schema records the enum's name beside the field, but the value you write and the
+value you read back are the plain member name. Equality, `not`, `in`, `orderBy` and `groupBy` all
+work on it and are compared against Prisma by the differential suite.
+
+One consequence worth stating, because it is the one thing that surprises: **`orderBy` on an enum
+sorts differently on the two dialects.** Postgres creates a real enum type and sorts by
+*declaration* order; SQLite stores the member as `TEXT` and sorts *alphabetically*. For
+`enum OrganizationPlan { free pro enterprise }`, measured:
+
+```
+postgres   free, pro, enterprise      (declaration order)
+sqlite     enterprise, free, pro      (alphabetical)
+```
+
+gemi matches Prisma on each dialect rather than inventing a uniformity Prisma does not have — the
+same call as `contains` being case-sensitive on Postgres and not on SQLite. If you need one order
+everywhere, sort in the application or store an explicit rank column.
+
 ## `Json` columns
 
 A `Json` column round-trips whatever you give it: an object, an array, a string, `null` — and a

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1120,6 +1120,32 @@ The direction is the awkward one: a `DB.sql` write inside a transaction rolls ba
 development on SQLite and survives the rollback in production on Postgres. `DB.query` and
 `DB.execute` join the transaction on both.
 
+## Enums
+
+A Prisma `enum` is a **string** at runtime, on both dialects, exactly as it is through Prisma:
+
+```ts
+await Organization.findMany({ where: { plan: { in: ["pro", "enterprise"] } } })
+```
+
+The generated schema records the enum's name beside the field, but the value you write and the
+value you read back are the plain member name. Equality, `not`, `in`, `orderBy` and `groupBy` all
+work on it and are compared against Prisma by the differential suite.
+
+One consequence worth stating, because it is the one thing that surprises: **`orderBy` on an enum
+sorts differently on the two dialects.** Postgres creates a real enum type and sorts by
+*declaration* order; SQLite stores the member as `TEXT` and sorts *alphabetically*. For
+`enum OrganizationPlan { free pro enterprise }`, measured:
+
+```
+postgres   free, pro, enterprise      (declaration order)
+sqlite     enterprise, free, pro      (alphabetical)
+```
+
+gemi matches Prisma on each dialect rather than inventing a uniformity Prisma does not have — the
+same call as `contains` being case-sensitive on Postgres and not on SQLite. If you need one order
+everywhere, sort in the application or store an explicit rank column.
+
 ## `Json` columns
 
 A `Json` column round-trips whatever you give it: an object, an array, a string, `null` — and a

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -45,10 +45,16 @@ async function seed(prisma: PrismaClient) {
 
   // Two organizations so a to-one include has something to discriminate, and
   // so `organization.users` is a to-many with more than one member.
+  //
+  // Their `plan` values differ, and neither is the column's default. An enum
+  // seeded to one value compares equal under every ordering and every grouping,
+  // so the cases that exercise it would pass without discriminating anything —
+  // and `free` on both would additionally never distinguish the stored value
+  // from the default the migration writes.
   await prisma.organization.createMany({
     data: [
-      { publicId: "o1", name: "Acme", description: "the first one" },
-      { publicId: "o2", name: "Globex" },
+      { publicId: "o1", name: "Acme", description: "the first one", plan: "pro" },
+      { publicId: "o2", name: "Globex", plan: "enterprise" },
     ],
   });
   const [acme, globex] = await prisma.organization.findMany({
@@ -1212,6 +1218,57 @@ function suite(label: string, url?: string) {
         await differential.expectSame(model, operation, args);
       },
     );
+
+    /**
+     * A Prisma **enum**, compared against Prisma on both dialects.
+     *
+     * The generator maps an enum field to `String` and records the enum's name
+     * separately, and that mapping had a unit test in `bin/orm/emit.test.ts`
+     * and nothing that ran it against a database. The template's schema carried
+     * no enum, so the harness had never seen one — the same reason its comment
+     * gives for `Json` and `Bytes` being there.
+     *
+     * Read, filtered, ordered and grouped, because "it is a string underneath"
+     * predicts all four and is worth checking rather than assuming: an enum
+     * arrives as a plain string from both drivers, but `orderBy` sorts by that
+     * string rather than by declaration order, and Prisma does the same.
+     */
+    test.each([
+      ["everything", "findMany", { orderBy: { id: "asc" } }],
+      ["selected alone", "findMany", { select: { plan: true }, orderBy: { id: "asc" } }],
+      ["equality", "findMany", { where: { plan: "free" }, orderBy: { id: "asc" } }],
+      ["not", "findMany", { where: { plan: { not: "free" } }, orderBy: { id: "asc" } }],
+      ["in a list", "findMany", { where: { plan: { in: ["free", "pro"] } }, orderBy: { id: "asc" } }],
+      ["no match", "findMany", { where: { plan: "enterprise" } }],
+      ["ordered by the enum", "findMany", { orderBy: [{ plan: "asc" }, { id: "asc" }] }],
+      ["counted by the enum", "groupBy", { by: ["plan"], _count: { _all: true }, orderBy: { plan: "asc" } }],
+    ] as [string, string, unknown][])(
+      "an enum column: %s",
+      async (_label, operation, args) => {
+        await differential.expectSame("Organization", operation, args);
+      },
+    );
+
+    /**
+     * ...and the data those cases run against discriminates.
+     *
+     * Every case above compares gemi to Prisma, so both agreeing on nothing is
+     * a pass. If the seed drifted to one plan — or to the column's default —
+     * the ordering, `in` and `groupBy` cases would still be green while
+     * distinguishing nothing, which is how #124's `having` corpus went vacuous.
+     * Asserted on the rows `expectSame` hands back, so it checks the values the
+     * comparison actually saw.
+     */
+    test("the seeded enum values are distinct and not the default", async () => {
+      const rows = (await differential.expectSame("Organization", "findMany", {
+        orderBy: { id: "asc" },
+      })) as { plan: string }[];
+
+      const plans = rows.map((row) => row.plan);
+      expect(plans.length).toBeGreaterThan(1);
+      expect(new Set(plans).size).toBe(plans.length);
+      expect(plans).not.toContain("free");
+    });
 
     // One query per *node* in the include tree, not per row. Depth 2 with two
     // branches over five users is 4 queries, not 20 — and the count is what

--- a/templates/saas-starter/app/models/generated/schema.ts
+++ b/templates/saas-starter/app/models/generated/schema.ts
@@ -432,6 +432,19 @@ export const Organization: ModelSchema = {
       "nullable": true,
       "isId": false,
       "isUpdatedAt": false
+    },
+    "plan": {
+      "name": "plan",
+      "column": "plan",
+      "type": "String",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false,
+      "enum": "OrganizationPlan",
+      "default": {
+        "kind": "value",
+        "value": "free"
+      }
     }
   },
   "primaryKey": [

--- a/templates/saas-starter/prisma/migrations/20260729120000_organization_plan_enum/migration.sql
+++ b/templates/saas-starter/prisma/migrations/20260729120000_organization_plan_enum/migration.sql
@@ -1,0 +1,18 @@
+-- An enum column, so the differential harness can compare one against Prisma.
+--
+-- The generator maps a Prisma enum to `String` and records the enum's name
+-- alongside it. That mapping had a unit test in `bin/orm/emit.test.ts` and
+-- nothing that ran it against a database, because the schema carried no enum —
+-- the same gap `20260728120000_json_and_bytes_columns` closed for Json and
+-- Bytes, and for the same reason.
+--
+-- `NOT NULL DEFAULT 'free'` rather than nullable: an enum's interesting cases
+-- are equality, `in` and ordering across several values, and a column that is
+-- null half the time tests the null path again instead. The default is what
+-- lets existing rows and every insert that predates this column keep working
+-- without a backfill.
+--
+-- TEXT, since `migration_lock.toml` pins this directory to the sqlite provider
+-- and Prisma stores an enum as TEXT there. On Postgres the schema is applied
+-- with `prisma db push`, which creates the real enum type instead.
+ALTER TABLE "Organization" ADD COLUMN "plan" TEXT NOT NULL DEFAULT 'free';

--- a/templates/saas-starter/prisma/schema.prisma
+++ b/templates/saas-starter/prisma/schema.prisma
@@ -26,6 +26,12 @@ model Organization {
   name        String
   logoUrl     String?
   description String?
+  // An enum exists here for the same reason Json and Bytes do: so the
+  // differential harness compares one against Prisma. Prisma enums travel as
+  // strings on the wire, and the generator maps them to `String` while
+  // recording the enum's name — that mapping had a unit test and no end-to-end
+  // check on either dialect.
+  plan        OrganizationPlan         @default(free)
   users       User[]
   accounts    Account[]
   invitations OrganizationInvitation[]
@@ -235,4 +241,10 @@ model LedgerEntry {
   ledger Ledger @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])
 
   @@index([tenantId, ledgerCode])
+}
+
+enum OrganizationPlan {
+  free
+  pro
+  enterprise
 }


### PR DESCRIPTION
Closes #218.

The generator maps a Prisma `enum` field to `String` and records the enum's name beside it. `bin/orm/emit.test.ts` covers that mapping; nothing ran it against a database, because the template's schema carried no enum — so the differential harness had never seen one. The schema's own comment states the principle it was missing: *"Json and Bytes exist here so the differential harness sees them."*

Not a connector limitation, which was my first guess and wrong: Prisma 6.19 validates an enum against the sqlite provider.

## What coverage found

**The two dialects sort an enum differently** — and this is the part I nearly got wrong. I wrote "sorts alphabetically, not by declaration order" into the docs from memory, then measured it:

```
postgres   free, pro, enterprise      (real enum type -> declaration order)
sqlite     enterprise, free, pro      (TEXT -> alphabetical)
```

Both match Prisma on their own dialect, so it is parity rather than a gemi decision — the same call the codebase already makes for `contains`. But an application that sorts by an enum and is developed on SQLite orders differently in production, and nothing said so. `docs/orm.md` had no `Enums` section at all; it now has one, carrying the measured table rather than the sentence I first wrote.

## The change

`Organization.plan` with a default, so no existing insert changes, plus a migration. `Organization` is shadowed by no test fixture, so #208's guard stays quiet. Eight differential cases: read, `select`, equality, `not`, `in`, no-match, `orderBy`, `groupBy`.

## Guarding against a vacuous pass

The seed gives the two organizations **different** plans, neither of them the column's default. An enum seeded to one value compares equal under every ordering and grouping, so those cases would stay green while discriminating nothing — which is how #124's `having` corpus went vacuous.

A ninth test asserts that directly, on the rows `expectSame` hands back:

```ts
expect(new Set(plans).size).toBe(plans.length);
expect(plans).not.toContain("free");
```

## Checks

| | before | after |
| --- | --: | --: |
| Postgres differential | 649 | **657 passed, 0 failed** |
| SQLite suite | 620 | **626 passed** |
| `packages/gemi` | 1441 | **1450 passed** |

`bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings — both read in full this time, after last iteration's `tail -1` hid a warning.

Scratch container removed; the template's schema and Prisma client restored to SQLite. Independent of #204 and #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)