### PR TITLE
Assert that select and include narrow the result type

### DIFF
--- a/templates/saas-starter/app/models/select.test-d.ts
+++ b/templates/saas-starter/app/models/select.test-d.ts
@@ -1,0 +1,126 @@
+import { expectTypeOf, test, describe } from "vitest";
+
+import { OrganizationModel, UserModel } from "./generated";
+
+/**
+ * **`select` and `include` narrow the result type**, which is the claim the
+ * plain-object default exists to make good on.
+ *
+ * `docs/orm-rows-and-entities.md` leads with it — the level table's first row is
+ * "POJOs *(default)* | Plain objects, full `select` narrowing | Nothing" — and
+ * gives it as the reason that level is the default: "a narrowed row is a
+ * narrowed *type*, so there is nothing on it that could read a field the query
+ * did not fetch."
+ *
+ * Nothing asserted it. `wrap.test-d.ts` constructs narrowed rows in order to
+ * reject them, and `aggregate.test-d.ts` covers the aggregate payloads, but no
+ * test claimed that a narrowed *query* has a narrowed *result* — the property
+ * both of those depend on. And until #201 the type tests ran nowhere at all, so
+ * the headline guarantee was unverified twice over.
+ *
+ * This can only be a type test. Every assertion below is about code that never
+ * runs: at runtime the object simply lacks the key, and reading it is
+ * `undefined` rather than an error. The compile error *is* the feature.
+ */
+describe("select narrows the result type", () => {
+  test("a selected column is present and correctly typed", async () => {
+    const [user] = await UserModel.findMany({ select: { id: true, email: true } });
+
+    expectTypeOf(user.id).toEqualTypeOf<number>();
+    // Nullability survives the narrowing rather than being widened away.
+    expectTypeOf(user.email).toEqualTypeOf<string | null>();
+  });
+
+  test("a column the query did not fetch is a compile error", async () => {
+    const [user] = await UserModel.findMany({ select: { id: true } });
+
+    // @ts-expect-error `name` was not selected, so it is not on the row
+    user.name;
+  });
+
+  test("selecting nothing but a relation still narrows the scalars away", async () => {
+    const [user] = await UserModel.findMany({
+      select: { accounts: { select: { id: true } } },
+    });
+
+    expectTypeOf(user.accounts[0].id).toEqualTypeOf<number>();
+
+    // @ts-expect-error the parent's own columns were not selected
+    user.id;
+    // @ts-expect-error and neither were the child's, beyond the one named
+    user.accounts[0].provider;
+  });
+
+  test("the default selection carries every scalar", async () => {
+    const [user] = await UserModel.findMany();
+
+    expectTypeOf(user.id).toEqualTypeOf<number>();
+    expectTypeOf(user.email).toEqualTypeOf<string | null>();
+  });
+
+  /**
+   * The narrowing has to survive the operation's own nullability, which is a
+   * separate axis: `findFirst` returns `T | null` whatever the selection is.
+   */
+  test("findFirst is nullable, and still narrowed", async () => {
+    const user = await UserModel.findFirst({ select: { id: true } });
+
+    expectTypeOf(user).toEqualTypeOf<{ id: number } | null>();
+  });
+});
+
+describe("include adds the relation to the type", () => {
+  test("an included to-many is an array of full rows", async () => {
+    const [user] = await UserModel.findMany({ include: { accounts: true } });
+
+    expectTypeOf(user.accounts).toBeArray();
+    expectTypeOf(user.accounts[0].id).toEqualTypeOf<number>();
+    // `include` keeps the parent's scalars, unlike `select`.
+    expectTypeOf(user.id).toEqualTypeOf<number>();
+  });
+
+  test("a relation that was not included is absent from the type", async () => {
+    const [user] = await UserModel.findMany({ include: { accounts: true } });
+
+    // @ts-expect-error `organization` was not included
+    user.organization;
+  });
+
+  test("a nested select inside an include narrows the child", async () => {
+    const [org] = await OrganizationModel.findMany({
+      include: { users: { select: { email: true } } },
+    });
+
+    expectTypeOf(org.users[0].email).toEqualTypeOf<string | null>();
+
+    // @ts-expect-error the child's other columns were not selected
+    org.users[0].id;
+  });
+
+  /**
+   * `select` **and** `include` together type-check, and are refused at runtime.
+   *
+   * That reads like a gap and is parity. Prisma's own generated args accept the
+   * pair — verified against `Prisma.UserFindManyArgs` rather than assumed, by
+   * putting a `@ts-expect-error` on it and watching the directive go unused —
+   * and gemi's contract is Prisma's argument types verbatim, so narrowing it
+   * here would make valid Prisma code a compile error in gemi.
+   *
+   * It is also why `resolveSelection` raises on the pair at runtime, and why
+   * that check is not redundant with the type system: the types cannot catch
+   * it, on either library. Asserted rather than left implicit, so a later change
+   * that tightens the generated types has to notice it is diverging from Prisma
+   * on purpose.
+   */
+  test("select and include together type-check, as they do in Prisma", async () => {
+    const rows = await UserModel.findMany({
+      select: { id: true },
+      include: { accounts: true },
+    });
+
+    // The result type follows `select`, which is the shape Prisma describes too.
+    // The disagreement between the two arguments is resolved at runtime, where
+    // `resolveSelection` raises `UnsupportedQueryError` naming both.
+    expectTypeOf(rows).toBeArray();
+  });
+});


### PR DESCRIPTION
Closes #220.

The plain-object default exists to make one claim, and nothing asserted it. `docs/orm-rows-and-entities.md` leads with it — "POJOs *(default)* | Plain objects, **full `select` narrowing** | Nothing" — and gives it as the reason that level is the default: *"a narrowed row is a narrowed type, so there is nothing on it that could read a field the query did not fetch."*

`wrap.test-d.ts` constructs narrowed rows in order to **reject** them and `aggregate.test-d.ts` covers the aggregate payloads, but no test claimed that a narrowed *query* has a narrowed *result* — the property both of those depend on. Until #201 the type tests ran nowhere at all, so it was unverified twice over.

Twelve assertions across `select`, `include`, a nested `select` inside an `include`, the default selection, and `findFirst`'s nullability as an axis separate from narrowing. Only a type test can make them: at runtime the object simply lacks the key and reading it is `undefined` rather than an error, so the compile error *is* the feature.

## One assertion I got wrong, and the correction is the interesting part

I asserted that `select` and `include` together are a compile error — the runtime refuses the pair and the docs document the refusal, so it seemed safe.

**It is not, and neither is it in Prisma.** Checked rather than assumed, by putting the same `@ts-expect-error` on `Prisma.UserFindManyArgs` and watching that directive go unused too:

```
FAIL  zz-prismacheck.test-d.ts > does Prisma's own args type reject select + include?
TypeCheckError: Unused '@ts-expect-error' directive.
```

So gemi matches Prisma exactly, which is the contract — "Prisma's argument types verbatim" — and tightening it would make valid Prisma code a compile error here. The test now pins the **parity** instead, which also records why `resolveSelection`'s runtime check is not redundant with the type system: the types cannot catch it, on either library.

That check is the one in `select.ts` already documented as "the floor under a fifth caller". This gives it a second reason to exist.

## Load-bearing, verified

Removing a `select` so the field is present turns its directive into `Unused '@ts-expect-error' directive` — the suite discriminates rather than passing on anything.

## Checks

- `bun run test:types` — 3 files, **24 passed**, no type errors
- template runtime suite — 17 passed / 3 skipped, 620 tests
- `bun --bun vitest run orm database` — 54 files, 1449 passed
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings

Adds one file and touches nothing else, so it is independent of #204 and #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)