### PR TITLE
Prisma's Json null sentinels were stored as the object {}

### DIFF
--- a/packages/gemi/orm/compile/cast.ts
+++ b/packages/gemi/orm/compile/cast.ts
@@ -1,4 +1,5 @@
 import type { SqlDialect } from "../dialect";
+import { jsonNullKind } from "../json-null";
 import type { FieldSchema } from "../schema";
 import { type Binder, type Fragment, param } from "./fragment";
 
@@ -42,6 +43,14 @@ export function fieldParam(
     // `JSON.stringify(null)` is `"null"`, and `'null'::jsonb` is a jsonb null,
     // which is a different thing from an absent value and would diverge from
     // Prisma on every nullable Json column.
-    return value === null || value === undefined ? null : JSON.stringify(value);
+    if (value === null || value === undefined) return null;
+
+    // Prisma's sentinels, which serialise to `{}` if left to `JSON.stringify`.
+    // `'null'::text::jsonb` is the JSON value; a bound `null` is SQL NULL.
+    const kind = jsonNullKind(value);
+    if (kind === "db") return null;
+    if (kind === "json") return "null";
+
+    return JSON.stringify(value);
   }, cast);
 }

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -8,6 +8,7 @@ import {
   sql,
 } from "../compile/fragment";
 import { DecodeError } from "../errors";
+import { jsonNullKind } from "../json-null";
 import type { FieldSchema } from "../schema";
 import type { ConstraintViolation, SqlDialect } from "./index";
 
@@ -235,6 +236,15 @@ export class SqliteDialect implements SqlDialect {
         // `JSON.stringify` on every value is unambiguous: a string becomes
         // `"42"` with its quotes, which is what `JSON.parse` needs to hand back
         // a string. The mirror of `decode`, which parses unconditionally.
+        //
+        // Except Prisma's two null sentinels, which have no enumerable
+        // properties and would serialise to `{}` — see `json-null.ts`.
+        // `DbNull` is the column being NULL; `JsonNull` is the JSON value.
+        {
+          const kind = jsonNullKind(value);
+          if (kind === "db") return null;
+          if (kind === "json") return "null";
+        }
         return JSON.stringify(value);
       default:
         // BigInt passes through. Bun's driver truncates integers above 2^53 on

--- a/packages/gemi/orm/json-null.ts
+++ b/packages/gemi/orm/json-null.ts
@@ -1,0 +1,54 @@
+/**
+ * Prisma's two null sentinels for a `Json` column, recognised without importing
+ * Prisma.
+ *
+ * A nullable `Json` column has *two* legal empty values and Prisma makes the
+ * caller choose between them, because they are different rows:
+ *
+ *   Prisma.DbNull     the column is SQL NULL
+ *   Prisma.JsonNull   the column holds the JSON value `null`
+ *
+ * A bare `null` is a type error on both libraries — gemi takes Prisma's
+ * argument types verbatim, so the sentinels are what type-checks here too, and
+ * `differential.test.ts` already notes that "a decoder that conflates them
+ * returns the wrong one of two legal answers".
+ *
+ * Nothing translated them. Both are ordinary objects with no enumerable
+ * properties, so every path that serialises a Json value turned them into the
+ * jsonb object `{}` — a plausible-looking value, silently wrong, on both
+ * dialects and with nothing raised. That is the same silent mis-store the
+ * bare-scalar refusal existed to prevent.
+ *
+ * **Recognised by `toString`, not by `instanceof` or the constructor's name.**
+ * The ORM runtime may not import the Prisma client package at all —
+ * `runtime-isolation.test.ts` greps for the name, comments included — so
+ * `instanceof` is unavailable. Prisma implements
+ * `toString` on these deliberately, returning `Prisma.DbNull` and
+ * `Prisma.JsonNull`; a constructor name would be the other candidate and is the
+ * one a minifier is free to rewrite.
+ */
+export type JsonNullKind = "db" | "json";
+
+const SENTINELS: Record<string, JsonNullKind> = {
+  "Prisma.DbNull": "db",
+  "Prisma.JsonNull": "json",
+};
+
+/**
+ * Which sentinel this is, or `null` for any ordinary value.
+ *
+ * `Prisma.AnyNull` is deliberately absent: it means "either of the two" and is
+ * only legal in a *filter*. Prisma rejects it in a write, and mapping it here
+ * would quietly accept something Prisma does not.
+ */
+export function jsonNullKind(value: unknown): JsonNullKind | null {
+  if (typeof value !== "object" || value === null) return null;
+
+  // Guarded because a plain object from `JSON.parse` has `Object.prototype`'s
+  // `toString`, and a caller's object may have thrown one of its own on.
+  const tag = Object.prototype.hasOwnProperty.call(value.constructor ?? {}, "name")
+    ? String(value)
+    : "";
+
+  return SENTINELS[tag] ?? null;
+}

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from "@prisma/client";
+import { Prisma as PrismaNamespace, type PrismaClient } from "@prisma/client";
 import { UniqueConstraintError } from "gemi/orm";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
@@ -146,12 +146,31 @@ const CASES: Case[] = [
    * thing without the test needing to know which dialect it is on: whatever
    * Postgres does, gemi and Prisma have to do the same.
    */
-  // The two bare-scalar shapes are *not* here: on Postgres gemi raises where
-  // Prisma succeeds, which the harness would report as a divergence because it
-  // is one. It is pinned as such in `json-scalars.test.ts` instead, so it stays
-  // visible without weakening this table.
   ["create with a wrapped JSON number", "create", {
     data: { email: "json-wrapped@example.dev", metadata: { value: 42 } },
+  }],
+  // The bare scalars, which used to be excluded here because gemi raised on
+  // Postgres where Prisma stored. #216 lifted that, so they belong in the table
+  // like every other shape. (The note that replaced them pointed at a
+  // `json-scalars.test.ts` that has never existed; the boundary was pinned in
+  // `writes.coercion.test.ts`.)
+  ["create with a bare JSON number", "create", {
+    data: { email: "json-number@example.dev", metadata: 42 },
+  }],
+  ["create with a bare JSON boolean", "create", {
+    data: { email: "json-boolean@example.dev", metadata: true },
+  }],
+  // Prisma's two null sentinels, which are *different rows*: `DbNull` leaves
+  // the column SQL NULL, `JsonNull` stores the JSON value `null`. Both are
+  // ordinary objects with no enumerable properties, so anything that reaches
+  // `JSON.stringify` turns them into `{}` — which is what gemi stored, on both
+  // dialects, silently. The harness compares table contents, so conflating them
+  // again fails here.
+  ["create with Prisma.DbNull", "create", {
+    data: { email: "json-dbnull@example.dev", metadata: PrismaNamespace.DbNull },
+  }],
+  ["create with Prisma.JsonNull", "create", {
+    data: { email: "json-jsonnull@example.dev", metadata: PrismaNamespace.JsonNull },
   }],
   // A nullable column explicitly set to null must stay null, not fall back to
   // a default — the difference between `?? default` and a key-presence check.


### PR DESCRIPTION
Closes #222.

A nullable `Json` column has two legal empty values and Prisma makes the caller choose between them: `Prisma.DbNull` leaves the column SQL NULL, `Prisma.JsonNull` stores the JSON value `null`. A bare `null` is a type error on both libraries — checked, not assumed — so the sentinels are what type-checks here, and they are the input Prisma's own types point you at.

Nothing translated them. Both are ordinary objects with no enumerable properties, so every path that serialises a Json value turned them into the jsonb object `{}`:

```
PRISMA DbNull    -> sqlnull=true  typeof=null
PRISMA JsonNull  -> sqlnull=false typeof=null
GEMI   DbNull    -> sqlnull=false typeof=object   value={}      <- wrong
GEMI   JsonNull  -> sqlnull=false typeof=object   value={}      <- wrong
```

Two different wrong rows, both plausible-looking, neither raising — the silent mis-store the bare-scalar refusal existed to prevent, reached through the documented API. After:

```
GEMI   DbNull    -> sqlnull=true  typeof=null     matches Prisma
GEMI   JsonNull  -> sqlnull=false typeof=null     matches Prisma
```

## How it was found

Auditing my own #216. I had added a `null` branch to `fieldParam` and wanted to know whether it was covered — it was not, and following that thread showed the branch is a *floor* (a bare `null` does not type-check), which then raised the question of what the values that *do* type-check actually do.

## Two constraints the implementation had to meet

- **Recognised by `toString`, not `instanceof`.** The ORM runtime may not import the Prisma client package, and `runtime-isolation.test.ts` enforces that against **comments** as well as imports — which this learned the hard way when a doc comment naming the package failed the suite. Prisma implements `toString` on the sentinels deliberately; a constructor name is what a minifier may rewrite.
- **`AnyNull` is deliberately not mapped.** It means "either of the two" and is legal only in a filter. Prisma rejects it in a write, so mapping it would quietly accept something Prisma does not.

Both write paths are covered: the Postgres cast from #216, and SQLite's `encode`.

## Coverage, and a stale note it replaced

The cases go in the **write differential**, which compares table contents, so conflating the sentinels again fails there rather than passing quietly.

Two more went in alongside them — the bare JSON number and boolean. That table excluded them with a note saying gemi raised where Prisma stored; #216 lifted that, and the note pointed at a `json-scalars.test.ts` **that has never existed** (the boundary was pinned in `writes.coercion.test.ts`). Both the exclusion and its justification are gone.

## Checks

- Postgres differential — 13 files, **653 passed**, 0 failed
- SQLite suite — 17 passed / 3 skipped, **624 tests**
- `bun --bun vitest run orm database` — 54 files, **1450 passed**
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings
- the ORM runtime still contains zero references to the Prisma client package

Scratch container removed; template restored to SQLite. Independent of #204, #219 and #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)