### PR TITLE
The Errors table was checked in one direction only

### DIFF
--- a/packages/gemi/orm/docs-scope.test.ts
+++ b/packages/gemi/orm/docs-scope.test.ts
@@ -152,6 +152,37 @@ describe("docs/orm.md lists every error an application can catch", () => {
   test.each(exported)("%s is in the table", (name) => {
     expect(errorsTable).toContain(`\`${name}\``);
   });
+
+  /**
+   * ...and the other direction, which nothing checked.
+   *
+   * The assertion above catches an error class the table forgot. It cannot
+   * catch a row naming a class that no longer exists — and that is the half a
+   * reader acts on, because the table is where you look to find out what there
+   * is to catch. A row for a deleted error sends them to write a `catch` for
+   * something no longer importable.
+   *
+   * The same asymmetry the operations list had until #226: a hand-written list
+   * verified in one direction reads as though it were verified in both. Both
+   * sets happen to agree today, at 21 — which is exactly when to pin it, rather
+   * than after they stop agreeing.
+   */
+  test("the table names no error the ORM does not export", () => {
+    const named = [...errorsTable.matchAll(/`([A-Z]\w*Error)`/g)].map(
+      (match) => match[1],
+    );
+
+    expect(named.length, "no error names found — the table format moved").toBeGreaterThan(10);
+
+    const unknown = [...new Set(named)].filter(
+      (name) => !exported.includes(name),
+    );
+
+    expect(
+      unknown,
+      `the Errors table names ${unknown.join(", ")}, which gemi/orm does not export`,
+    ).toEqual([]);
+  });
 });
 
 /**


### PR DESCRIPTION
Closes #228.

`docs-scope.test.ts` asserts every exported `Error` subclass appears in the Errors table. Nothing asserted the converse, so a row naming a class that no longer exists would have stayed there.

That is the half a reader acts on: the section opens *"Every failure is a typed error from `gemi/orm`"*, and the table is where you look to find out what there is to catch. A row for a deleted error sends someone to write a `catch` for something no longer importable.

The same asymmetry the operations list carried until #226 — a list verified in one direction reads as though it were verified in both. Both sets agree today, at 21, which is when to pin it rather than after they stop agreeing.

## Verified that it adds coverage, not duplication

**Renaming** a row trips both assertions — the old one sees the name go missing, the new one sees the name that replaced it. So the discriminating case is a row **added** with none removed:

```
× the table names no error the ORM does not export

AssertionError: the Errors table names PhantomError, which gemi/orm does not
export: expected [ 'PhantomError' ] to deeply equal []
```

Only the new assertion fails there. Worth checking rather than assuming — a second assertion that fires only when an existing one already has adds nothing.

## Also verified this round, and found correct

Recording so they are not re-investigated:

- **All six of CI's excluded files still fail.** #204 merged this iteration, so the exclusion list is now the only thing keeping them out — and a *stale* exclusion would silently narrow coverage, which `ci-coverage.test.ts` cannot see (it checks the paths exist, not that they still fail). Five fail with assertions; `parseTranslation.test.tsx` still fails at collection. The list is accurate.
- **`feat/orm` is green** on the new whole-package filter after #204 landed.
- The `ScalarType` union and the generator's `SCALAR_TYPES` table agree exactly; the dialect `encode`/`decode` gaps are genuine pass-throughs already round-tripped by `writes.coercion`.

## Checks

- `bun --bun vitest run orm database` — 55 files, **1460 passed**
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings

One assertion in an existing file; independent of #225 and #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)