### PR TITLE
Document the two Json nulls, which shipped without a word

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3844,14 +3844,37 @@ everywhere, sort in the application or store an explicit rank column.
 ## `Json` columns
 
 A `Json` column round-trips whatever you give it: an object, an array, a string, a number, a
-boolean, `null`. The value is stored as JSON and comes back as the same JavaScript value, on both
+boolean. The value is stored as JSON and comes back as the same JavaScript value, on both
 dialects and whether it is read at the root or nested inside an `include`.
 
-One thing is worth knowing:
+Two things are worth knowing:
 
 - **A string is a string.** `metadata: "42"` stores the JSON string `"42"`, not the number, and
   `metadata: '{"a":1}'` stores that text as a string rather than as an object. If you want an
   object, pass an object.
+
+- **Empty is two values, and you have to say which.** `metadata: null` does not type-check —
+  Prisma's types do not allow it and gemi takes them verbatim — because a `Json` column has two
+  distinct empty states and guessing between them is what the sentinels exist to prevent:
+
+  ```ts
+  import { Prisma } from "@prisma/client"
+
+  await User.create({ data: { …, metadata: Prisma.DbNull } })    // the column is SQL NULL
+  await User.create({ data: { …, metadata: Prisma.JsonNull } })  // the column holds JSON null
+  ```
+
+  Both read back as `null`, so the difference is invisible from JavaScript and entirely visible to
+  anything else that reads the column — `psql`, a report, Prisma itself. Filtering takes the same
+  pair, and takes them as an explicit comparison:
+
+  ```ts
+  await User.findMany({ where: { metadata: { equals: Prisma.DbNull } } })   // the SQL NULLs
+  await User.findMany({ where: { metadata: { equals: Prisma.JsonNull } } }) // the JSON nulls
+  ```
+
+  A bare `where: { metadata: Prisma.DbNull }` raises `InvalidArgumentError` naming the explicit
+  form. Prisma rejects that spelling too, so this is parity rather than a gemi restriction.
 
 On Postgres the parameter is cast — `$1::text::jsonb` — and the value serialised to match, which
 is what lets a bare number or boolean through. Binding it raw makes the driver send an `integer` to

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1149,14 +1149,37 @@ everywhere, sort in the application or store an explicit rank column.
 ## `Json` columns
 
 A `Json` column round-trips whatever you give it: an object, an array, a string, a number, a
-boolean, `null`. The value is stored as JSON and comes back as the same JavaScript value, on both
+boolean. The value is stored as JSON and comes back as the same JavaScript value, on both
 dialects and whether it is read at the root or nested inside an `include`.
 
-One thing is worth knowing:
+Two things are worth knowing:
 
 - **A string is a string.** `metadata: "42"` stores the JSON string `"42"`, not the number, and
   `metadata: '{"a":1}'` stores that text as a string rather than as an object. If you want an
   object, pass an object.
+
+- **Empty is two values, and you have to say which.** `metadata: null` does not type-check —
+  Prisma's types do not allow it and gemi takes them verbatim — because a `Json` column has two
+  distinct empty states and guessing between them is what the sentinels exist to prevent:
+
+  ```ts
+  import { Prisma } from "@prisma/client"
+
+  await User.create({ data: { …, metadata: Prisma.DbNull } })    // the column is SQL NULL
+  await User.create({ data: { …, metadata: Prisma.JsonNull } })  // the column holds JSON null
+  ```
+
+  Both read back as `null`, so the difference is invisible from JavaScript and entirely visible to
+  anything else that reads the column — `psql`, a report, Prisma itself. Filtering takes the same
+  pair, and takes them as an explicit comparison:
+
+  ```ts
+  await User.findMany({ where: { metadata: { equals: Prisma.DbNull } } })   // the SQL NULLs
+  await User.findMany({ where: { metadata: { equals: Prisma.JsonNull } } }) // the JSON nulls
+  ```
+
+  A bare `where: { metadata: Prisma.DbNull }` raises `InvalidArgumentError` naming the explicit
+  form. Prisma rejects that spelling too, so this is parity rather than a gemi restriction.
 
 On Postgres the parameter is cast — `$1::text::jsonb` — and the value serialised to match, which
 is what lets a bare number or boolean through. Binding it raw makes the driver send an `integer` to

--- a/packages/gemi/orm/docs-scope.test.ts
+++ b/packages/gemi/orm/docs-scope.test.ts
@@ -155,6 +155,51 @@ describe("docs/orm.md lists every error an application can catch", () => {
 });
 
 /**
+ * The two `Json` null sentinels are documented, because they are the only way
+ * to write an empty `Json` column and were shipped without a word.
+ *
+ * #223 taught the runtime to store `Prisma.DbNull` and `Prisma.JsonNull`
+ * correctly and #225 taught the filter path to read them; neither told anybody.
+ * The page went further than silence — it said a `Json` column round-trips
+ * "an object, an array, a string, a number, a boolean, `null`", and a bare
+ * `null` does not type-check on a `Json` field, on Prisma or here.
+ *
+ * So the documented way to write one was a type error and the real way was
+ * unmentioned. The distinction is not cosmetic: the two sentinels produce
+ * *different rows*, both read back as `null` from JavaScript, and the
+ * difference is entirely visible to anything else reading the column — which is
+ * the failure `differential.test.ts`'s seed comment describes as returning "the
+ * wrong one of two legal answers".
+ *
+ * Pinned by name rather than by prose, so the feature cannot go silent again.
+ */
+describe("docs/orm.md documents the Json null sentinels", () => {
+  const source = readFileSync(DOC, "utf8");
+
+  test.each(["Prisma.DbNull", "Prisma.JsonNull"])("%s is named", (sentinel) => {
+    expect(source).toContain(sentinel);
+  });
+
+  test("it says which one is SQL NULL and which is the JSON value", () => {
+    expect(source).toMatch(/DbNull[^\n]*\n?[^\n]*SQL NULL|SQL NULL[^\n]*DbNull/);
+    expect(source).toMatch(/JsonNull[^\n]*JSON null|JSON null[^\n]*JsonNull/);
+  });
+
+  /**
+   * And that a bare `null` is not the third option a reader would reach for
+   * first — the sentence that used to say it was is the reason this exists.
+   */
+  test("it does not offer a bare null as a way to write one", () => {
+    const section = source.slice(source.indexOf("## `Json` columns"));
+    const json = section.slice(0, section.indexOf("\n## ", 1));
+    // Across the line break, because that is where the sentence wrapped — the
+    // first version of this matched `a boolean, \`null\`` on one line and could
+    // never have failed, which is the same defect it is here to catch.
+    expect(json).not.toMatch(/boolean,\s+`null`/);
+  });
+});
+
+/**
  * **`docs/llms-full.txt` carries the ORM pages verbatim**, and had stopped.
  *
  * That file is "every page concatenated for one-shot LLM context", served


### PR DESCRIPTION
Closes #230.

#223 taught the runtime to store `Prisma.DbNull` and `Prisma.JsonNull` correctly and #225 taught the filter path to read them. Neither told anybody — both ORM pages contained **zero** mentions of either name, and they are the only way to write an empty `Json` column.

The page went further than silence. It said a `Json` column round-trips *"an object, an array, a string, a number, a boolean, `null`"* — and a bare `null` does **not** type-check on a `Json` field, on Prisma or here. So the documented way to write one was a type error and the real way was unmentioned. That sentence arrived in #216, which is mine.

The distinction is not cosmetic: the two sentinels produce **different rows**, both read back as `null` from JavaScript, and the difference is entirely visible to anything else reading the column — which is what `differential.test.ts`'s seed comment calls *"the wrong one of two legal answers"*.

Now documented on writes and on filters, including the `InvalidArgumentError` #225 added for the bare spelling — noting Prisma rejects that spelling too, so it is parity rather than a gemi restriction. Pinned **by name**, so the feature cannot go silent again.

## One of the four new assertions could not fail

Worth reporting, because the way it surfaced is the only reason it did.

`it does not offer a bare null` matched ``a boolean, `null` `` on a single line. The sentence wraps between "a" and "boolean", so the pattern never matched anything and passed on the old page exactly as happily as on the new one — a guard that cannot fail, in a commit about a guard that was missing.

It turned up because I ran the new guard against the page **as it stood** and only three of the four assertions failed. Now matched across the wrap, and verified to fail on the old page:

```
× it does not offer a bare null as a way to write one
```

## Checks

- `bun --bun vitest run orm database` — 55 files, **1463 passed**
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings
- `docs/llms-full.txt` re-synced, so #181's verbatim guard stays green

## Also verified this round, and found correct

- Prisma's `UserCountArgs` rejects `omit` and `distinct`, so gemi's narrower `count` argument set matches Prisma — not an undocumented refusal.
- All six of CI's excluded files still fail, so #204's exclusion list is not stale.

Independent of #227 and #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)