### PR TITLE
The Relations section understated its own coverage by a third

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3057,8 +3057,9 @@ back to batching for that node alone. It declines:
 
 A declined node still runs under this strategy one level down, so a decline costs one statement, not
 the subtree. A mixed include tree therefore uses both, which is fine — the results are the same
-either way, and there are tests asserting exactly that against Prisma across thirty relation
-shapes.
+either way, and there are tests asserting exactly that against Prisma across every relation shape
+in the differential corpus — **48** of them today, and the suite fails if this number stops
+matching the corpus.
 
 Override per call when you need to:
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -362,8 +362,9 @@ back to batching for that node alone. It declines:
 
 A declined node still runs under this strategy one level down, so a decline costs one statement, not
 the subtree. A mixed include tree therefore uses both, which is fine — the results are the same
-either way, and there are tests asserting exactly that against Prisma across thirty relation
-shapes.
+either way, and there are tests asserting exactly that against Prisma across every relation shape
+in the differential corpus — **48** of them today, and the suite fails if this number stops
+matching the corpus.
 
 Override per call when you need to:
 

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { Prisma as PrismaNS, type PrismaClient } from "@prisma/client";
 import { Model } from "gemi/orm";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
@@ -1128,6 +1131,29 @@ function suite(label: string, url?: string) {
         select !== undefined &&
         Object.keys(select).some((key) => key === "accounts" || key === "organization" || key === "session")
       );
+    });
+
+      /**
+     * `docs/orm.md` quotes this number — "across every relation shape in the
+     * differential corpus, **48** of them today" — and it had said "thirty"
+     * while the corpus grew to 48, understating its own coverage by a third.
+     *
+     * A count in prose drifts from its source the first time the source
+     * moves; #182 and #195 found the operation count wrong in six places for
+     * exactly that reason. This is the cheapest possible fix for the class:
+     * the corpus is the source, so the corpus asserts the sentence.
+     */
+    test("the shape count in docs/orm.md matches the corpus", () => {
+      const doc = readFileSync(
+        join(import.meta.dirname, "../../../../docs/orm.md"),
+        "utf8",
+      );
+      const stated = doc.match(
+        /differential corpus — \*\*(\d+)\*\* of them today/,
+      );
+
+      expect(stated, "the sentence in docs/orm.md moved or was reworded").not.toBeNull();
+      expect(Number(stated![1])).toBe(RELATION_CASES.length);
     });
 
     if (url) {


### PR DESCRIPTION
Closes #232.

`docs/orm.md` said the two strategies are checked against Prisma "across **thirty** relation shapes". The corpus holds **48** — measured at runtime, since `RELATION_CASES` is derived by filtering `CASES` and no static count is authoritative (two static parses said ~50; the runtime value is 48).

The same drift as the operation count in #182 and #195, in the other direction. Understating coverage is the harmless direction and it is the same defect — and the docs' own benchmarks section already names the principle: *"a number copied into prose drifts from its source the first time the source is re-run."*

So rather than correct thirty to forty-eight and wait for it to rot again, **the corpus now asserts the sentence**: the test reads `docs/orm.md`, extracts the number, and compares it to `RELATION_CASES.length`. The sentence is worded so there is something to extract, and says the number is a snapshot.

Verified by setting it back:

```
× the shape count in docs/orm.md matches the corpus
AssertionError: expected 30 to be 48
```

## The placement was nearly the bug I fixed in #206

`RELATION_CASES` is used inside `if (url) { … }`, so that is where the assertion first went. That would have been **#205 exactly**: the block only exists when `TEST_POSTGRES_URL` is set, and the Postgres job filters with `-t postgres`, which this test's name does not match — so it would have run in *neither* job while looking like coverage.

It needs no database, so it sits outside the gate where every run sees it. Confirmed by running the SQLite suite, where it now executes.

## Checked and found correct

The five declines the section lists — implicit many-to-many, self-relation, `_count`, relation ordering, and any node with one of those below it — are exactly the reasons `decline()` returns, plus the dialect condition stated separately. No drift there, recorded so it is not re-checked.

## Checks

- template suite — 17 passed / 3 skipped, **640 tests**
- `bun --bun vitest run orm database` — 55 files, **1459 passed**
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings
- `docs/llms-full.txt` re-synced

Independent of #227, #229 and #231 — and I verified those three still merge cleanly in sequence with a green combined suite (56 files, 1497 tests) before starting this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)