### PR TITLE
The docs still describe #98 as a known gap; it landed

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3134,11 +3134,15 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 `connectOrCreate` succeeded would together tell you a row with that key exists in someone else's
 tenant.
 
-> **Known gap (#98).** A child whose policy *scopes on the foreign key itself* — `scope: () => ({
-> folderId: mine })` — cannot use any relation operand that writes that key, including `connect`,
-> unless it also declares an `onUpdate`. The scope-escape guard reads the payload and cannot tell a
-> column you supplied from one the nested step put there. Pre-existing rather than new to
-> `disconnect`, and tracked separately because the decision affects `connect` too.
+A child whose policy *scopes on the foreign key itself* — `scope: () => ({ folderId: mine })` — can
+still use the relation operands that write that key. `connect`, `disconnect` and the rest go
+through without an `onUpdate`, because the scope-escape guard judges **the columns you supplied**
+rather than the ones the nested step put there: the ORM records which columns it wrote and exempts
+those from the check.
+
+The exemption is provenance, not permission. A column *you* name is refused exactly as before —
+writing `folderId` yourself on a model scoped by it is still a scope escape, and still needs an
+`onUpdate` to say so deliberately.
 
 `disconnect` and `delete` only exist on an `update` — a `create` has nothing linked to it yet, and
 Prisma reports them as an unknown argument there too. They differ on a row that is **not** linked to

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -439,11 +439,15 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 `connectOrCreate` succeeded would together tell you a row with that key exists in someone else's
 tenant.
 
-> **Known gap (#98).** A child whose policy *scopes on the foreign key itself* — `scope: () => ({
-> folderId: mine })` — cannot use any relation operand that writes that key, including `connect`,
-> unless it also declares an `onUpdate`. The scope-escape guard reads the payload and cannot tell a
-> column you supplied from one the nested step put there. Pre-existing rather than new to
-> `disconnect`, and tracked separately because the decision affects `connect` too.
+A child whose policy *scopes on the foreign key itself* — `scope: () => ({ folderId: mine })` — can
+still use the relation operands that write that key. `connect`, `disconnect` and the rest go
+through without an `onUpdate`, because the scope-escape guard judges **the columns you supplied**
+rather than the ones the nested step put there: the ORM records which columns it wrote and exempts
+those from the check.
+
+The exemption is provenance, not permission. A column *you* name is refused exactly as before —
+writing `folderId` yourself on a model scoped by it is still a scope escape, and still needs an
+`onUpdate` to say so deliberately.
 
 `disconnect` and `delete` only exist on an `update` — a `create` has nothing linked to it yet, and
 Prisma reports them as an unknown argument there too. They differ on a row that is **not** linked to

--- a/packages/gemi/orm/docs-gaps.test.ts
+++ b/packages/gemi/orm/docs-gaps.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * A gap the documentation names by issue number has not already been closed.
+ *
+ * `docs/orm.md` carried a callout headed **Known gap (#98)**: a child scoped on
+ * its own foreign key "cannot use any relation operand that writes that key,
+ * including `connect`, unless it also declares an `onUpdate`".
+ *
+ * #98 had landed. `nested-write-policies.test.ts` says so in as many words —
+ * *"**#98 has landed, so this flipped** — as the pin it replaces said it
+ * should"* — and pins both operands succeeding. So the page told a reader to
+ * work around something the suite had already proved was fixed, which is #145's
+ * failure with the sign reversed: there, the docs called an implemented
+ * operation out of scope; here, they call a closed gap open.
+ *
+ * The costly direction, because a documented limitation is *believed*. A reader
+ * does not try `connect` to see whether the note is stale — they restructure
+ * around it, or add an `onUpdate` that grants more than they meant to.
+ *
+ * This cannot ask GitHub whether an issue is closed, and should not: a test
+ * that needs the network fails for reasons that have nothing to do with the
+ * code. It checks the contradiction *inside the repository* instead — a gap the
+ * docs name, and a test asserting that same number has landed, cannot both be
+ * right.
+ */
+const ROOT = join(import.meta.dirname, "../../..");
+
+/** Issue numbers `docs/orm.md` presents as an open gap. */
+const claimedGaps = (() => {
+  const pages = ["orm.md", "orm-rows-and-entities.md"].map((name) =>
+    readFileSync(join(ROOT, "docs", name), "utf8"),
+  );
+
+  return pages.flatMap((page) =>
+    [...page.matchAll(/known gap \(#(\d+)\)/gi)].map((match) => match[1]),
+  );
+})();
+
+/** Issue numbers a test says have landed. */
+const landed = (() => {
+  const roots = [
+    join(ROOT, "packages/gemi/orm"),
+    join(ROOT, "templates/saas-starter/app/models"),
+  ];
+
+  const found = new Set<string>();
+  for (const dir of roots) {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".test.ts")) continue;
+      const source = readFileSync(join(dir, file), "utf8");
+      for (const match of source.matchAll(/#(\d+) has landed/g)) {
+        found.add(match[1]);
+      }
+    }
+  }
+  return found;
+})();
+
+describe("the docs do not name a gap the suite says is closed", () => {
+  /**
+   * Both sides have to be readable for the comparison to mean anything. An
+   * empty `landed` set would make this pass by finding nothing — which is how
+   * the state it exists to catch would look.
+   */
+  test("the phrase a test uses to record a landing is still in use", () => {
+    expect(landed.size).toBeGreaterThan(0);
+  });
+
+  test("no documented gap has a test saying it landed", () => {
+    const contradicted = claimedGaps.filter((issue) => landed.has(issue));
+
+    expect(
+      contradicted,
+      `docs/orm.md calls #${contradicted.join(", #")} an open gap, but a test ` +
+        `in this repository says it has landed`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #234.

`docs/orm.md` carried a callout headed **Known gap (#98)**: a child scoped on its own foreign key "cannot use any relation operand that writes that key, including `connect`, unless it also declares an `onUpdate`".

**#98 has landed.** `nested-write-policies.test.ts:694` says so in as many words — *"**#98 has landed, so this flipped** — as the pin it replaces said it should"* — and pins both `connect` and `disconnect` succeeding. The mechanism is in `policy.ts`: the ORM records which columns it wrote under a module-private `Symbol`, and the scope-escape guard exempts those, judging the caller's columns rather than its own.

So the page told a reader to work around something the suite had already proved was fixed.

## The costlier direction

This is #145's failure with the sign reversed. There the docs called an implemented operation *out of scope*, and a reader who believed it wrote raw SQL for a query that worked. Here they call a closed gap *open* — and a documented limitation is **believed**. Nobody tries `connect` to find out whether the note is stale; they restructure around it, or add an `onUpdate` that grants more than they meant to.

Replaced with what the guard actually does, including the part that has **not** changed: the exemption is provenance, not permission. A column *you* name is still a scope escape and still needs an `onUpdate`.

## The guard does not ask GitHub

A test that needs the network fails for reasons that have nothing to do with the code. The contradiction is already inside the repository — a gap the docs name by number, and a test asserting that same number landed, cannot both be right.

It carries one safeguard of its own: an assertion that the "has landed" phrase is still in use, because an empty set on that side would make it pass by finding nothing, which is precisely what the state it catches looks like.

Verified against the page as it stood:

```
AssertionError: docs/orm.md calls #98 an open gap, but a test in this
repository says it has landed: expected [ '98' ] to deeply equal []
```

## Checks

- `bun --bun vitest run orm database` — 56 files, **1461 passed**
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings
- `docs/llms-full.txt` re-synced

New file plus a docs edit, so it does not touch `docs-scope.test.ts` — deliberately, since #229 and #231 both do. I re-verified those two and #233 still merge cleanly onto the current `feat/orm` with a green combined suite (56 files, 1497 tests) before starting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)