### PR TITLE
The Json null sentinel was forgeable, and could make a write throw

### DIFF
--- a/packages/gemi/orm/json-null.test.ts
+++ b/packages/gemi/orm/json-null.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+
+import { jsonNullKind } from "./json-null";
+
+/**
+ * What may and may not be mistaken for one of Prisma's `Json` null sentinels.
+ *
+ * The first version recognised them by `toString` alone, which had two faults
+ * and neither showed up in the differential suite, because no reasonable corpus
+ * contains the values that trigger them:
+ *
+ *   { a: 1, toString: () => "Prisma.DbNull" }   read as the sentinel -> stored
+ *                                               as SQL NULL, losing the object
+ *   { a: 1, toString() { throw … } }            the *bind* threw, for a value
+ *                                               Prisma stores without ever
+ *                                               calling `toString`
+ *
+ * The first is the serious one: a forgeable sentinel whose failure is silent
+ * data loss. `policy.ts` makes the same point in the other direction — its
+ * provenance marker is a module-private `Symbol` precisely so "an application
+ * cannot forge it".
+ *
+ * The fix is structural rather than textual: a sentinel carries **no data**, so
+ * anything with a property in it is not one and never reaches `String`. These
+ * cases are the boundary of that rule, written as a table because the
+ * interesting ones are the values that look like sentinels and are not.
+ *
+ * The real `Prisma.DbNull` and `Prisma.JsonNull` cannot be constructed here —
+ * the ORM runtime may not import the Prisma client package, which
+ * `runtime-isolation.test.ts` enforces against comments too — so they are
+ * modelled by their shape: no own properties, no enumerable keys, and a
+ * `toString` on the prototype. That is exactly how the real ones are built, and
+ * the template's suites exercise the genuine articles end to end.
+ */
+const sentinelShaped = (tag: string): object => {
+  // A **class** instance, not `Object.create({ toString() {…} })`. A method in
+  // an object literal is enumerable, so `for…in` walks it and the shape check
+  // rejects it — which is how the first version of this helper failed while the
+  // real sentinels passed. Prisma builds them as classes, where the prototype's
+  // `toString` is non-enumerable, and that difference is the whole reason the
+  // structural test is safe to apply.
+  class Sentinel {
+    toString() {
+      return tag;
+    }
+  }
+  return new Sentinel();
+};
+
+describe("jsonNullKind recognises a sentinel and nothing else", () => {
+  test.each([
+    ["Prisma.DbNull", "db"],
+    ["Prisma.JsonNull", "json"],
+  ] as const)("%s is recognised", (tag, kind) => {
+    expect(jsonNullKind(sentinelShaped(tag))).toBe(kind);
+  });
+
+  /**
+   * `AnyNull` is a filter-only value that Prisma rejects in a write, so mapping
+   * it would quietly accept something Prisma does not. Pinned as an omission
+   * rather than left to be inferred from its absence.
+   */
+  test("Prisma.AnyNull is deliberately not one", () => {
+    expect(jsonNullKind(sentinelShaped("Prisma.AnyNull"))).toBeNull();
+  });
+
+  test.each([
+    ["a plain object", { a: 1 }],
+    ["an array", [1, 2]],
+    ["an empty object", {}],
+    ["an empty array", []],
+    ["a string", "Prisma.DbNull"],
+    ["a number", 42],
+    ["a boolean", true],
+    ["null", null],
+    ["undefined", undefined],
+    ["a Date", new Date(0)],
+  ])("%s is not a sentinel", (_label, value) => {
+    expect(jsonNullKind(value)).toBeNull();
+  });
+
+  /**
+   * The forgery. An object that answers `Prisma.DbNull` was written as SQL NULL
+   * and the object was lost — silently, because both are legal values for the
+   * column.
+   */
+  test("an object carrying data cannot forge a sentinel", () => {
+    const forged = { a: 1, toString: () => "Prisma.DbNull" };
+
+    expect(jsonNullKind(forged)).toBeNull();
+  });
+
+  /** And the throw: `JSON.stringify` never calls `toString`, so nor may this. */
+  test("a value whose toString throws is data, not an error", () => {
+    const hostile = {
+      a: 1,
+      toString() {
+        throw new Error("toString should not have been called");
+      },
+    };
+
+    expect(() => jsonNullKind(hostile)).not.toThrow();
+    expect(jsonNullKind(hostile)).toBeNull();
+  });
+
+  /**
+   * A null-prototype object has no `toString` at all, and `String` throws on
+   * it. It is a legitimate Json value — `JSON.stringify` handles it — so the
+   * answer is "not a sentinel" rather than a failed write.
+   */
+  test("a null-prototype object does not fail the write", () => {
+    const bare = Object.assign(Object.create(null), { a: 1 });
+
+    expect(() => jsonNullKind(bare)).not.toThrow();
+    expect(jsonNullKind(bare)).toBeNull();
+    expect(jsonNullKind(Object.create(null))).toBeNull();
+  });
+});

--- a/packages/gemi/orm/json-null.test.ts
+++ b/packages/gemi/orm/json-null.test.ts
@@ -25,12 +25,27 @@ import { jsonNullKind } from "./json-null";
  * cases are the boundary of that rule, written as a table because the
  * interesting ones are the values that look like sentinels and are not.
  *
- * The real `Prisma.DbNull` and `Prisma.JsonNull` cannot be constructed here —
- * the ORM runtime may not import the Prisma client package, which
- * `runtime-isolation.test.ts` enforces against comments too — so they are
- * modelled by their shape: no own properties, no enumerable keys, and a
- * `toString` on the prototype. That is exactly how the real ones are built, and
- * the template's suites exercise the genuine articles end to end.
+ * **The real objects are not exercised here, and this file does not own that
+ * guarantee.** `Prisma.DbNull` and `Prisma.JsonNull` cannot be constructed in
+ * this package — the ORM runtime may not import the Prisma client package,
+ * which `runtime-isolation.test.ts` enforces against comments too, and the
+ * package has no generated client to import one from — so they are modelled by
+ * their shape: no own properties, no enumerable keys, and a `toString` on the
+ * prototype. That is exactly how the real ones are built.
+ *
+ * The genuine articles are covered end to end in the template, against a live
+ * database and both dialects:
+ *
+ *   templates/saas-starter/app/models/writes.differential.test.ts
+ *     `create with Prisma.DbNull` / `create with Prisma.JsonNull`
+ *   templates/saas-starter/app/models/differential.test.ts
+ *     `equals` / bare / `not` for both sentinels
+ *
+ * Worth naming, because the structural check is *tighter* than the `toString`
+ * one it replaced: a Prisma release that gave its sentinels any own property
+ * would stop them being recognised, and the failure would be a silent return to
+ * #222's `{}` mis-store. Nothing in this package would see it — only those two
+ * suites would, and they need a database, so a SQLite-only run does not.
  */
 const sentinelShaped = (tag: string): object => {
   // A **class** instance, not `Object.create({ toString() {…} })`. A method in
@@ -56,11 +71,18 @@ describe("jsonNullKind recognises a sentinel and nothing else", () => {
   });
 
   /**
-   * `AnyNull` is a filter-only value that Prisma rejects in a write, so mapping
-   * it would quietly accept something Prisma does not. Pinned as an omission
-   * rather than left to be inferred from its absence.
+   * `AnyNull` is not mapped — and this pins only that, because **not mapped is
+   * not refused**. It falls through to the data path, where a write stores it
+   * as the jsonb object `{}` and `{ equals: AnyNull }` compiles to `= '{}'`,
+   * returning the exact complement of the rows it asks for; Prisma raises on
+   * the first and answers both kinds of null on the second.
+   *
+   * So the assertion below says what the function does, not that the omission
+   * bought parity. Closing the gap means recognising `AnyNull` and refusing it
+   * in a write the way #225 refuses a bare sentinel in a filter, and deciding
+   * the filter half separately — #259.
    */
-  test("Prisma.AnyNull is deliberately not one", () => {
+  test("Prisma.AnyNull is not mapped to a kind (and is not refused either — #259)", () => {
     expect(jsonNullKind(sentinelShaped("Prisma.AnyNull"))).toBeNull();
   });
 

--- a/packages/gemi/orm/json-null.ts
+++ b/packages/gemi/orm/json-null.ts
@@ -37,9 +37,12 @@ const SENTINELS: Record<string, JsonNullKind> = {
 /**
  * Which sentinel this is, or `null` for any ordinary value.
  *
- * `Prisma.AnyNull` is deliberately absent: it means "either of the two" and is
- * only legal in a *filter*. Prisma rejects it in a write, and mapping it here
- * would quietly accept something Prisma does not.
+ * `Prisma.AnyNull` is absent, and **absent is not the same as refused** — it
+ * falls through to the data path, where a write stores it as the jsonb object
+ * `{}` and a filter compiles to `= '{}'`, returning the complement of the rows
+ * `AnyNull` asks for. Prisma raises on the write and answers both kinds of null
+ * on the filter. That gap is #259; it is stated here rather than left to be
+ * read off the omission as though the omission delivered a parity.
  */
 export function jsonNullKind(value: unknown): JsonNullKind | null {
   if (typeof value !== "object" || value === null) return null;

--- a/packages/gemi/orm/json-null.ts
+++ b/packages/gemi/orm/json-null.ts
@@ -44,11 +44,32 @@ const SENTINELS: Record<string, JsonNullKind> = {
 export function jsonNullKind(value: unknown): JsonNullKind | null {
   if (typeof value !== "object" || value === null) return null;
 
-  // Guarded because a plain object from `JSON.parse` has `Object.prototype`'s
-  // `toString`, and a caller's object may have thrown one of its own on.
-  const tag = Object.prototype.hasOwnProperty.call(value.constructor ?? {}, "name")
-    ? String(value)
-    : "";
+  // **A sentinel carries no data**, and checking that before anything else is
+  // what makes this safe rather than merely usually-right.
+  //
+  // Recognising by `toString` alone is forgeable: an object whose `toString`
+  // happens to return `Prisma.DbNull` was read as the sentinel and written as
+  // SQL NULL, losing the object. It also made the bind *throw* for a value
+  // whose `toString` throws — something Prisma stores without ever calling it,
+  // since `JSON.stringify` does not consult `toString`.
+  //
+  // Both reach `String` only for an object with nothing in it, which no
+  // application stores on purpose. The enumerable check runs first because it
+  // allocates nothing and exits on the first key, which is the common case; the
+  // own-property scan is for the handful of values that get past it, and is
+  // what keeps `[]` and `{}` out — an empty array is a legitimate Json value.
+  for (const _key in value) return null;
+  if (Object.getOwnPropertyNames(value).length > 0) return null;
+
+  // A null-prototype object has no `toString` at all and `String` throws on it.
+  // It is a legitimate Json value, so this answers "not a sentinel" rather than
+  // failing the write.
+  let tag: string;
+  try {
+    tag = String(value);
+  } catch {
+    return null;
+  }
 
   return SENTINELS[tag] ?? null;
 }


### PR DESCRIPTION
Closes #238.

`jsonNullKind` (added in #223, mine) recognised Prisma's sentinels by `toString` alone. Two faults followed, and the differential suite could not have found either — no reasonable corpus contains the values that trigger them:

```
{ a: 1, toString: () => "Prisma.DbNull" }   read as the sentinel, stored as SQL
                                            NULL — the object lost, silently
{ a: 1, toString() { throw … } }            the bind threw, for a value Prisma
                                            stores without ever calling toString
```

The first is the serious one: a **forgeable sentinel whose failure is silent data loss**, both outcomes being legal values for the column. `policy.ts` makes the same point from the other side — its provenance marker is a module-private `Symbol` precisely so *"an application cannot forge it"* — and this had no such property.

## The fix is structural

**A sentinel carries no data.** Anything with a property in it is not one and never reaches `String`, which closes the forgery and the throw together.

Order matters, since this runs per bound Json value: the enumerable scan first — it allocates nothing and exits on the first key, which is every real Json object — then the own-property check, which is what keeps `[]` and `{}` out, an empty array being a legitimate value. `String` is guarded because a null-prototype object has no `toString` at all, and throwing on one would fail a write Prisma accepts.

Verified against the **genuine** `Prisma.DbNull` and `Prisma.JsonNull`, not only the model: both still recognised, `AnyNull` still deliberately not, `{}` / `[]` / null-prototype objects all treated as data.

## The test helper was wrong in the same way the code was

Worth reporting, because it nearly shipped as a passing test.

The first helper built the sentinel with `Object.create({ toString() {…} })`. A method in an object literal is **enumerable**, so `for…in` walks it and the shape check rejects it — the helper failed while the real sentinels passed. Prisma builds them as classes, where the prototype's `toString` is non-enumerable, and that difference is the entire reason the structural test is safe to apply. Modelled as a class now, with the reasoning written down beside it.

## Residual, stated rather than hidden

An empty class instance whose `toString` returns the exact string remains indistinguishable from the real sentinel without importing Prisma, which the runtime may not do. It carries no data, so nothing is lost by treating it as one.

## Checks

- `bun --bun vitest run orm database` — 57 files, **1508 passed**
- template SQLite — 17 passed / 3 skipped, 639 tests
- Postgres differential — 13 files, **668 passed**, unchanged
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings

Touches `json-null.ts` plus a new test file; independent of #233, #235 and #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)