### PR TITLE
Assert the compile-time guarantee ScopedPolicy exists for

### DIFF
--- a/templates/saas-starter/app/models/scoped-policy.test-d.ts
+++ b/templates/saas-starter/app/models/scoped-policy.test-d.ts
@@ -47,9 +47,41 @@ describe("a generated ScopedPolicy demands all three members", () => {
       }
     }
 
-    expectTypeOf(new Complete()).toBeObject();
+    // Instantiating is one of the two things being asserted: a class with an
+    // unimplemented abstract member cannot be `new`ed, so this line is the
+    // positive case the three `@ts-expect-error` tests below are the negatives
+    // of. `expectTypeOf(new Complete()).toBeObject()` stood here and asserted
+    // nothing — every class instance is an object — while reading as though it
+    // checked something about the class.
+    void new Complete();
+
+    // The other thing: the members are bound to *this model's* Prisma types.
+    // That binding is what `emit.ts` contributes and the only part of the base
+    // a hand-written `ScopedPolicy<any, any, any>` would get wrong — the
+    // abstract-ness above would survive it intact.
+    expectTypeOf<AccountScopedPolicy["scope"]>().returns.toEqualTypeOf<
+      Prisma.AccountWhereInput | undefined
+    >();
+    expectTypeOf<AccountScopedPolicy["onCreate"]>()
+      .parameter(1)
+      .toEqualTypeOf<Prisma.AccountCreateInput>();
+    expectTypeOf<AccountScopedPolicy["onUpdate"]>()
+      .parameter(1)
+      .toEqualTypeOf<Partial<Prisma.AccountCreateInput>>();
   });
 
+  /**
+   * The three negatives below. Read them for what they assert and no more: a
+   * `@ts-expect-error` on a `class X extends Y {` line accepts **any**
+   * diagnostic on that line, not specifically the `TS2515` the comments name.
+   * A different error on the declaration — a renamed base, a base that stopped
+   * being a class — would satisfy the directive just as well.
+   *
+   * What pins them to the real thing is mutation rather than the directive:
+   * deleting each `abstract` member from `ScopedPolicy` in turn fails exactly
+   * its own test here, by name, and leaves the other five green. Re-run that if
+   * you change these — the directive alone will not tell you.
+   */
   test("omitting onCreate is a compile error", () => {
     // @ts-expect-error `onCreate` is abstract and unimplemented
     class ScopeOnly extends AccountScopedPolicy {
@@ -90,18 +122,42 @@ describe("a generated ScopedPolicy demands all three members", () => {
   });
 
   /**
-   * The columns are checked too — in both spellings, but the error lands in
-   * different places, which is the whole reason this is two tests.
+   * The columns are checked too. **These two tests are not one check written
+   * twice** — an earlier version of this comment said they were "the same
+   * assertion landing in different places", and mutating the binding in
+   * `generated/models.ts` disproves it. They assert different things, and each
+   * one passes under the mutation the other catches:
    *
-   * With the return type **annotated**, the object literal is checked directly
-   * and the error is on the literal. With it **inferred**, the method's own type
-   * stops being assignable to the abstract member and the error is on the
-   * *method declaration* — so a `@ts-expect-error` on the `return` line matches
-   * nothing and reads as though the check does not exist.
+   * - `ScopedPolicy<any, …>` on `UserScopedPolicy` — binding widened, model
+   *   forgotten. The **inferred** test fails (`Unused '@ts-expect-error'`); the
+   *   annotated test passes, because its excess-property error comes from the
+   *   author's own `: Prisma.UserWhereInput` annotation and would still be
+   *   there if the class extended nothing at all.
+   * - `ScopedPolicy<Prisma.AccountWhereInput, …>` on `UserScopedPolicy` — the
+   *   plausible `emit.ts` bug, right shape, wrong model. The **annotated** test
+   *   fails, on `Property 'scope' … is not assignable to the same property in
+   *   base type 'UserScopedPolicy'` at the method declaration; the inferred
+   *   test passes, because `{ nonexistentColumn: 1 }` is not on
+   *   `AccountWhereInput` either, so its directive is still used.
    *
-   * That is how the first version of this file concluded there was no column
-   * checking at all: the directive was in the wrong place, the diagnostic was
-   * real, and "unused directive" looks identical to "no error here".
+   * So: the **inferred** form pins that a binding exists at all — that the base
+   * is what constrains the return type. The **annotated** form pins the
+   * *identity* of the bound `where` type, by requiring the method to stay
+   * assignable to the abstract member.
+   *
+   * Placement follows from that, and is the other thing worth knowing here.
+   * Annotated, the literal is checked against the annotation and the error is
+   * on the `return`. Inferred, the method's own type stops being assignable and
+   * the error is on the *method declaration* — a `@ts-expect-error` on the
+   * `return` line then matches nothing and reads exactly like "there is no
+   * check here". That is how the first version of this file concluded there was
+   * no column checking at all: the directive was in the wrong place, the
+   * diagnostic was real, and "unused directive" looks identical to "no error".
+   *
+   * Note what each test does *not* prove. Neither failure above is an unused
+   * directive on the annotated test — under the wrong-model mutation it fails
+   * on an unexpected diagnostic instead, catching the bug but not via the error
+   * it names.
    */
   test("an annotated scope rejects a column the model does not have", () => {
     class Annotated extends UserScopedPolicy {

--- a/templates/saas-starter/app/models/scoped-policy.test-d.ts
+++ b/templates/saas-starter/app/models/scoped-policy.test-d.ts
@@ -1,0 +1,137 @@
+import { expectTypeOf, test, describe } from "vitest";
+
+import type { Prisma } from "@prisma/client";
+import type { PolicyContext } from "gemi/orm";
+
+import { AccountScopedPolicy, UserScopedPolicy } from "./generated";
+
+/**
+ * **A policy that scopes reads but forgets the write halves is a compile
+ * error**, which is the whole reason the generated `…ScopedPolicy` exists.
+ *
+ * `docs/orm.md` states it as the reason to extend the class rather than write an
+ * object literal:
+ *
+ * > extending the generated `AccountScopedPolicy` makes `scope`, `onCreate` and
+ * > `onUpdate` abstract members — so a policy that scopes reads but forgets the
+ * > write halves is a compile error rather than a runtime refusal
+ *
+ * and `policy.ts` says the same from the other end: `assertCreateCovered` and
+ * `assertNoScopeEscape` enforce it at runtime "and have to: an object literal
+ * can always omit a key", while extending the class "moves the same rule to
+ * compile time … a missing `onCreate` becomes `TS2515` at the class declaration
+ * rather than an error on the first `create` that reaches production".
+ *
+ * Nothing asserted it. The class was not named in any test — the runtime halves
+ * are covered thoroughly by `policies.test.ts`, but the *compile-time* half is
+ * the part this class exists for, and it can only be checked here. The same
+ * shape as #220, where `select` narrowing was the headline guarantee and had no
+ * type test either.
+ *
+ * The failure this catches is silent in the worst way: the class keeps working
+ * as a base, the runtime guards still fire, and the only thing lost is that the
+ * mistake moves from the class declaration to the first `create` in production
+ * — which is precisely the trade the class was added to make.
+ */
+describe("a generated ScopedPolicy demands all three members", () => {
+  test("a policy implementing all three compiles", () => {
+    class Complete extends AccountScopedPolicy {
+      scope() {
+        return { organizationId: 1 };
+      }
+      onCreate(_ctx: PolicyContext, data: Prisma.AccountCreateInput) {
+        return data;
+      }
+      onUpdate(_ctx: PolicyContext, data: Partial<Prisma.AccountCreateInput>) {
+        return data;
+      }
+    }
+
+    expectTypeOf(new Complete()).toBeObject();
+  });
+
+  test("omitting onCreate is a compile error", () => {
+    // @ts-expect-error `onCreate` is abstract and unimplemented
+    class ScopeOnly extends AccountScopedPolicy {
+      scope() {
+        return { organizationId: 1 };
+      }
+      onUpdate(_ctx: PolicyContext, data: Partial<Prisma.AccountCreateInput>) {
+        return data;
+      }
+    }
+    void ScopeOnly;
+  });
+
+  test("omitting onUpdate is a compile error", () => {
+    // @ts-expect-error `onUpdate` is abstract and unimplemented
+    class NoUpdate extends AccountScopedPolicy {
+      scope() {
+        return { organizationId: 1 };
+      }
+      onCreate(_ctx: PolicyContext, data: Prisma.AccountCreateInput) {
+        return data;
+      }
+    }
+    void NoUpdate;
+  });
+
+  test("omitting scope is a compile error too", () => {
+    // @ts-expect-error `scope` is abstract and unimplemented
+    class NoScope extends AccountScopedPolicy {
+      onCreate(_ctx: PolicyContext, data: Prisma.AccountCreateInput) {
+        return data;
+      }
+      onUpdate(_ctx: PolicyContext, data: Partial<Prisma.AccountCreateInput>) {
+        return data;
+      }
+    }
+    void NoScope;
+  });
+
+  /**
+   * The columns are checked too — in both spellings, but the error lands in
+   * different places, which is the whole reason this is two tests.
+   *
+   * With the return type **annotated**, the object literal is checked directly
+   * and the error is on the literal. With it **inferred**, the method's own type
+   * stops being assignable to the abstract member and the error is on the
+   * *method declaration* — so a `@ts-expect-error` on the `return` line matches
+   * nothing and reads as though the check does not exist.
+   *
+   * That is how the first version of this file concluded there was no column
+   * checking at all: the directive was in the wrong place, the diagnostic was
+   * real, and "unused directive" looks identical to "no error here".
+   */
+  test("an annotated scope rejects a column the model does not have", () => {
+    class Annotated extends UserScopedPolicy {
+      scope(): Prisma.UserWhereInput {
+        // @ts-expect-error `nonexistentColumn` is not on UserWhereInput
+        return { nonexistentColumn: 1 };
+      }
+      onCreate(_ctx: PolicyContext, data: Prisma.UserCreateInput) {
+        return data;
+      }
+      onUpdate(_ctx: PolicyContext, data: Partial<Prisma.UserCreateInput>) {
+        return data;
+      }
+    }
+    void Annotated;
+  });
+
+  test("an inferred scope rejects it at the method instead", () => {
+    class Inferred extends UserScopedPolicy {
+      // @ts-expect-error the method's inferred type no longer matches the base
+      scope() {
+        return { nonexistentColumn: 1 };
+      }
+      onCreate(_ctx: PolicyContext, data: Prisma.UserCreateInput) {
+        return data;
+      }
+      onUpdate(_ctx: PolicyContext, data: Partial<Prisma.UserCreateInput>) {
+        return data;
+      }
+    }
+    void Inferred;
+  });
+});


### PR DESCRIPTION
Closes #240.

`docs/orm.md` gives one reason to extend the generated `…ScopedPolicy` rather than write an object literal:

> a policy that scopes reads but forgets the write halves is **a compile error rather than a runtime refusal**

and `policy.ts` says the same from the other end — the runtime guards *"have to"* exist because "an object literal can always omit a key", while the class *"moves the same rule to compile time … a missing `onCreate` becomes `TS2515` at the class declaration rather than an error on the first `create` that reaches production"*.

Nothing asserted it. `ScopedPolicy` was not named in any test: the runtime halves are covered thoroughly by `policies.test.ts`, but the compile-time half is the part the class exists for and can only be checked by a type test. Same shape as #220.

Six assertions: all three members required, each omission separately, and the columns checked in both spellings — which, as the review below establishes, are two *different* checks rather than one written twice. See the "Addressed" comment.

## Three of my own assertions were wrong before they were right

This is the part worth reading, because the last one is why the file is worth having.

1. **`scope()` returning the model's where type** — I asserted it against `new Subclass().scope(…)`, which has the *subclass's inferred* return type, not the abstract signature. Wrong question, so a passing or failing answer meant nothing.
2. **"an unknown column is not caught"** — concluded from an unused `@ts-expect-error` on the `return` line. The diagnostic was real; with an inferred return it lands on the **method declaration**, so the directive matched nothing. *"Unused directive"* and *"no error here"* look identical, and only the second is a finding.
3. **The correction to that** — "annotated catches it, inferred does not" — was wrong the same way in reverse. Both spellings catch it, in different places. That is now two tests with the placement written down. **And a fourth, from review:** "the same check in two places" was itself wrong. Mutating the binding shows the annotated test pins the *identity* of the bound `where` type while the inferred one pins that a binding exists at all — each passes under the mutation the other catches. Fixed in b345608.

## How it was found

By asking which public exports no test mentions. That sweep needs a **recursive** walk: a first pass reading only the top level of each directory missed `orm/compile/*.test.ts` and reported 25 untested exports where the answer is 12. I re-measured before drawing anything from it.

## Checks

- `bun run test:types` — **30 passed**, no type errors
- template runtime suite — 17 passed / 3 skipped, 640 tests
- `bun --bun vitest run orm database` — 57 files, **1499 passed**
- `bunx tsc --noEmit` exit 0 **in `packages/gemi`** — corrected from review: the bullet did not name a directory, and read as though it covered `templates/saas-starter`, where this file actually lives. It does not. The template has ~276 pre-existing type errors in its own app code (`ci.yml:137`), which is exactly why its gate is `bun run test:types` with `--typecheck.ignoreSourceErrors` rather than a bare `tsc`. Neither number moves with this PR.
- `bunx oxlint orm --deny-warnings` 0 warnings

Adds one file; independent of #237 and #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
