### PR TITLE
The soft-delete "field" guarantee holds for one of three spellings

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3649,8 +3649,22 @@ static $policies: UserPolicy[] = [softDeletes<User>(), new TenantPolicy()]
 the policy scopes on and something has to say that is intended. That permission is **per policy**:
 a tenant policy sitting beside it in the same list still has to answer for its own column.
 
-`field` is constrained to the model's own keys, so pointing it at a column that does not exist is a
-compile error rather than a `no such column` on the first read.
+`field` is constrained to the model's own keys **when the model type is given** —
+`softDeletes<User>({ field: … })`, as above — so a typo there is a compile error rather than a
+`no such column` on the first read.
+
+`softDelete(User)` and `softDeleteMany(User)` take the model as a *value*, and its row type is not
+recoverable from it, so their `field` is unchecked. Spell it once and share it if you override the
+default:
+
+```ts
+const archived = { field: "archivedAt" } as const
+
+export class User extends UserModel {
+  static $policies = [softDeletes<User>(archived)]   // checked here
+  static delete = softDelete(User, archived)          // and therefore correct here
+}
+```
 
 ## Errors
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -954,8 +954,22 @@ static $policies: UserPolicy[] = [softDeletes<User>(), new TenantPolicy()]
 the policy scopes on and something has to say that is intended. That permission is **per policy**:
 a tenant policy sitting beside it in the same list still has to answer for its own column.
 
-`field` is constrained to the model's own keys, so pointing it at a column that does not exist is a
-compile error rather than a `no such column` on the first read.
+`field` is constrained to the model's own keys **when the model type is given** —
+`softDeletes<User>({ field: … })`, as above — so a typo there is a compile error rather than a
+`no such column` on the first read.
+
+`softDelete(User)` and `softDeleteMany(User)` take the model as a *value*, and its row type is not
+recoverable from it, so their `field` is unchecked. Spell it once and share it if you override the
+default:
+
+```ts
+const archived = { field: "archivedAt" } as const
+
+export class User extends UserModel {
+  static $policies = [softDeletes<User>(archived)]   // checked here
+  static delete = softDelete(User, archived)          // and therefore correct here
+}
+```
 
 ## Errors
 

--- a/templates/saas-starter/app/models/soft-delete.test-d.ts
+++ b/templates/saas-starter/app/models/soft-delete.test-d.ts
@@ -1,0 +1,65 @@
+import { test, describe } from "vitest";
+
+import { softDelete, softDeleteMany, softDeletes } from "gemi/orm";
+
+import { UserModel } from "./generated";
+
+/**
+ * Where the `field` option is checked, and where it is not.
+ *
+ * `docs/orm.md` claimed it flatly — "`field` is constrained to the model's own
+ * keys, so pointing it at a column that does not exist is a compile error
+ * rather than a `no such column` on the first read" — and that is true of one of
+ * the three functions it appears to describe.
+ *
+ * `SoftDeleteOptions<M>` constrains `field` to `keyof M & string`, and `M`
+ * defaults to `any`. `softDeletes<User>()` supplies it, so the constraint bites.
+ * `softDelete(User)` and `softDeleteMany(User)` take the model as a *value*;
+ * `M` stays `any`, `keyof any & string` is `string`, and any typo is accepted —
+ * arriving as `no such column` on the first read, which is the failure the
+ * sentence promised was impossible.
+ *
+ * Defaulting `M = T` does not fix it. The row type is only recoverable from the
+ * model's `update` signature, which is generic, so `T` infers too loosely to
+ * constrain anything — tried, and it changed nothing. Recording that here so the
+ * next person does not spend the same half hour on it.
+ *
+ * So this pins the boundary rather than asserting a guarantee that does not
+ * hold. The unchecked calls are written without `@ts-expect-error` on purpose:
+ * if the inference is ever tightened, they become errors, this file stops
+ * type-checking, and the note above needs revisiting — which is the outcome
+ * worth having.
+ */
+type User = { id: number; email: string | null; deletedAt: Date | null };
+
+describe("softDeletes checks `field` when the model type is given", () => {
+  test("a real column is accepted", () => {
+    softDeletes<User>({ field: "deletedAt" });
+  });
+
+  test("a column the model does not have is a compile error", () => {
+    // @ts-expect-error `nope` is not a key of User
+    softDeletes<User>({ field: "nope" });
+  });
+
+  /**
+   * Without the type parameter there is nothing to check against: `M` is `any`,
+   * so `keyof M & string` is `string`. Pinned because the documented sentence
+   * reads as though it applied here too.
+   */
+  test("without the type parameter it is unchecked", () => {
+    softDeletes({ field: "nope" });
+  });
+});
+
+describe("softDelete and softDeleteMany do not check it", () => {
+  test("the model arrives as a value, so `field` is unconstrained", () => {
+    softDelete(UserModel, { field: "nope" });
+    softDeleteMany(UserModel, { field: "nope" });
+  });
+
+  test("the correct spelling compiles, which is all that is asserted", () => {
+    softDelete(UserModel, { field: "deletedAt" });
+    softDeleteMany(UserModel, { field: "deletedAt" });
+  });
+});


### PR DESCRIPTION
Closes #242.

`docs/orm.md` claimed it flatly:

> `field` is constrained to the model's own keys, so pointing it at a column that does not exist is a compile error rather than a `no such column` on the first read.

That is true of **one** of the three functions it appears to describe.

| call | `field` checked? |
| --- | --- |
| `softDeletes<User>({ field: "nope" })` | **yes** — the type parameter supplies `M` |
| `softDeletes({ field: "nope" })` | no — `M` is `any`, so `keyof any & string` is `string` |
| `softDelete(User, { field: "nope" })` | no — the model arrives as a *value* |
| `softDeleteMany(User, { field: "nope" })` | no |

The docs' own example puts the two spellings two lines apart:

```ts
static $policies = [softDeletes<User>()]  // checked
static delete = softDelete(User)          // not checked
```

so a typo in the second produces exactly the `no such column` the sentence promises is impossible.

## `M = T` does not fix it

Worth recording, because it is the obvious first attempt and I made it. `SoftDeletable<T, Op>` makes `T` the row type, so defaulting `M = T` looks like it should recover the constraint. It does not — `T` is only inferred from the model's `update` signature, which is generic, so it infers too loosely to constrain anything and both calls stayed legal. Reverted, and recorded in the test file.

## The fix

The sentence is narrowed to what holds, and the example gains the spelling that makes the unchecked call correct by construction: name the options once where they *are* checked, and pass the same object to the call that cannot check them.

The type tests pin the boundary rather than a guarantee that does not exist. **The unchecked calls are written without `@ts-expect-error` on purpose** — if the inference is ever tightened they become errors, the file stops type-checking, and the note has to be revisited. That is the outcome worth having, and it is the opposite of what a `@ts-expect-error` would give.

## How it was found

By sweeping the docs for compile-time claims. There are exactly three: `wrap`'s complete-row requirement (covered by `wrap.test-d.ts`), `ScopedPolicy`'s abstract members (covered by #241), and this one — which turned out to be the only one that was not simply untested but partly untrue.

## Checks

- `bun run test:types` — **29 passed**, no type errors
- template runtime suite — 17 passed / 3 skipped, 640 tests
- `bun --bun vitest run orm database` — 57 files, **1499 passed**
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings
- `docs/llms-full.txt` re-synced

Independent of #237, #239 and #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)