### PR TITLE
The section correcting a stale diagram had itself gone stale

### DIFF
--- a/packages/gemi/orm/plan-record.test.ts
+++ b/packages/gemi/orm/plan-record.test.ts
@@ -10,8 +10,8 @@ import * as orm from "./index";
  *
  * `plans/orm/README.md` is the ORM's design record — the document the invariants
  * come from, cited by name from `strategy.ts`, `lateral.ts`, `nested-writes.ts`
- * and `order-relation.ts`. It is a living document: it has a "Where it actually
- * is now" section, and line 496 reads "Both are now in all four".
+ * and `order-relation.ts`. It is a living document: it has a "How the stack
+ * landed" section, and a later line reads "Both are now in all four".
  *
  * Two of its invariants still described shipped API as forthcoming:
  *

--- a/plans/orm/README.md
+++ b/plans/orm/README.md
@@ -27,12 +27,20 @@ Nine levels, not three. Recorded because the diagram above described the state o
 the day this plan was written and a reader following it would branch under work
 that has since landed on top.
 
-**All six merged on 2026-07-28**, in the order below. This is written as history
-rather than as status on purpose: the section it replaces said "**Every one of
-these is `MERGEABLE`/`CLEAN`**", which was true when measured and false a day
-later — the same way the diagram above it went stale, in the section written to
-correct that diagram. A date cannot rot; a merge state can, and this document
-has no way to notice.
+**All six merged on 2026-07-28**, listed below in **stack order** — each row's
+branch is the base of the row under it, except #58, which targeted `feat/orm`
+directly. That is not quite merge order: #55 (`docs/orm`) merged at `08:11:11`,
+seventeen seconds *before* its own base #56 (`fix/orm-bytes-container`) at
+`08:11:28`. It is the one place here a child landed before its parent went
+upward, and it is a concrete instance of the pooling described two sections
+down. Stack order is the more useful ordering for a reader deciding where to
+branch, so the table keeps it and names it.
+
+This is written as history rather than as status on purpose: the section it
+replaces said "**Every one of these is `MERGEABLE`/`CLEAN`**", which was true
+when measured and false a day later — the same way the diagram above it went
+stale, in the section written to correct that diagram. A date cannot rot; a
+merge state can, and this document has no way to notice.
 
 | PR | Branch | What it adds |
 | --- | --- | --- |

--- a/plans/orm/README.md
+++ b/plans/orm/README.md
@@ -18,15 +18,21 @@ This work is a **third level in an open PR stack**. Branch from
 main
  └── refactor/laravel-container-architecture   PR #30, OPEN — container/providers
       └── feat/database-layer                  PR #33, OPEN — DatabaseManager, DB facade
-           └── feat/orm                        PR #45, OPEN — iterations 1-6
+           └── feat/orm                        PR #45, OPEN — iterations 1-9 and after
 ```
 
-### Where it actually is now
+### How the stack landed
 
 Nine levels, not three. Recorded because the diagram above described the state on
 the day this plan was written and a reader following it would branch under work
-that has since landed on top. **Every one of these is `MERGEABLE`/`CLEAN`** and
-each was verified at its own tip; they are listed in merge order.
+that has since landed on top.
+
+**All six merged on 2026-07-28**, in the order below. This is written as history
+rather than as status on purpose: the section it replaces said "**Every one of
+these is `MERGEABLE`/`CLEAN`**", which was true when measured and false a day
+later — the same way the diagram above it went stale, in the section written to
+correct that diagram. A date cannot rot; a merge state can, and this document
+has no way to notice.
 
 | PR | Branch | What it adds |
 | --- | --- | --- |


### PR DESCRIPTION
Closes #244.

`plans/orm/README.md` carries a section headed **"Where it actually is now"**, written for a stated reason:

> Recorded because the diagram above described the state on the day this plan was written and a reader following it would branch under work that has since landed on top.

It then says **"Every one of these is `MERGEABLE`/`CLEAN`"** of six PRs — #53 through #58 — all of which merged on 2026-07-28. The correction went stale in exactly the way it was written to prevent, one section below the diagram it was correcting.

Rewritten as **history rather than status**: the six landed, on that date, in that order. The table is worth keeping — it is the only place recording what each PR added — but the claim about their state is not.

That framing is the fix rather than a fresher number. Updating "MERGEABLE" to "merged" would put the next reader in the same position the day something else changes. A date cannot rot; a merge state can, and this document has no way to notice when it does.

## Stack order, named as such

The table's rows are `#53, #54, #56, #55, #57, #58`, which is the base chain, not the merge clock — `#55` (`docs/orm`) merged at `08:11:11`, seventeen seconds before its own base `#56` (`fix/orm-bytes-container`) at `08:11:28`. The original text called it merge order and this PR re-asserted that while re-checking only the date beside it; review caught it.

Relabelled rather than reordered, and the inversion is now named where it happens. Stack order is what a reader deciding where to branch wants, and that one child-before-parent landing is a concrete instance of the pooling the "had the Bytes fix / had the docs / had the audit" table two sections down records.

## No guard, deliberately

The naive local signal — whether each branch is an ancestor of `feat/orm` — does not work here:

```
feat/orm-08-eloquent-doorway   NOT merged into feat/orm
feat/orm-09-lateral-strategy   NOT merged into feat/orm
fix/orm-bytes-container        NOT merged into feat/orm
docs/orm                       NOT merged into feat/orm
feat/orm-registration-audit    merged into feat/orm
feat/orm-relation-filters      merged into feat/orm
```

Four of the six merged into their **own parents** rather than into the trunk — the stacked-PR behaviour this same document explains two sections down.

But that is a fact about *that* signal, not about local signals in general, and an earlier revision of this description overstated it into "I would rather ship no guard than one that is confidently wrong". Review pointed out the correction: `git rev-list --no-merges --count origin/feat/orm..origin/<branch>` returns `0` for all four, because every commit they hold over the trunk is a merge commit. It is right six times out of six — and it is the runbook this very file prescribes about forty lines below the edited section. A guard *could* be built locally.

The reason there is none is narrower: a claim that is a date rather than a state has nothing to guard. Building the check anyway is a change to what this document verifies about itself, which is not what #244 asks for, so it stays out of a docs-only PR. (A guard that asks GitHub fails for reasons unrelated to the code, which #235 already settled.)

## Also corrected

The diagram above annotates `feat/orm` as "iterations 1-6"; it carries iterations 1-9 and everything since. #30, #33 and #45 are genuinely still open, so the rest of that diagram is accurate and untouched.

`packages/gemi/orm/plan-record.test.ts` described this document as having a "Where it actually is now" section — the heading this PR renames. The string is wrapped across two lines, so nothing asserts on it and the suite stayed green with the reference wrong; a PR whose thesis is that this file contains claims which rot should not leave one behind. The neighbouring `line 496` citation went with it, for the same reason.

## Checks

- `bun --bun vitest run orm database` — 57 files, **1499 passed** (the plan is read by `plan-record.test.ts` from #198 and `operation-count.test.ts` from #196; neither claim is affected). Worth stating plainly, as review did: the suite is insensitive to this edit, so this is evidence of no breakage, not evidence the correction is correct. The correctness evidence is the `mergedAt` table.
- `bunx oxlint orm --deny-warnings` — 0 warnings

Documentation only; independent of #237, #239, #241 and #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
