### PR TITLE
The comment justifying -t postgres cited numbers that had drifted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,14 +240,19 @@ jobs:
 
       # `-t postgres` selects the dialect-labelled suites, and it is required
       # rather than tidy. With `TEST_POSTGRES_URL` set, the harness makes the
-      # *SQLite* half **fail** rather than skip — deliberately, so a client
-      # generated for the wrong provider cannot look like a pass. Run unfiltered,
-      # this job reports "877 passed" and still exits 1, because three suites
-      # error at collection.
+      # *SQLite* half of each differential suite **fail** rather than skip —
+      # deliberately, so a client generated for the wrong provider cannot look
+      # like a pass. So an unfiltered run here exits 1 no matter how many tests
+      # pass, and the failures are the ones the setup above guarantees.
+      #
+      # Stated as the mechanism rather than as a count. It read "877 passed …
+      # three suites error at collection", measured once and true then; the same
+      # run is now 911 and two, and neither number was ever the reason.
       #
       # So this job runs the Postgres-labelled suites and the `sqlite` job runs
       # the rest. The dialect-agnostic tests are that job's business; nothing is
-      # left uncovered between them.
+      # left uncovered between them — which was false for three files until
+      # #206, and is guarded now by `postgres-suite-selection.test.ts`.
       #
       # Serially: the harness truncates shared tables between cases, so parallel
       # files clobber each other's fixtures. Measured — the parallel run fails

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,15 +239,14 @@ jobs:
         working-directory: templates/saas-starter
 
       # `-t postgres` selects the dialect-labelled suites, and it is required
-      # rather than tidy. With `TEST_POSTGRES_URL` set, the harness makes the
-      # *SQLite* half of each differential suite **fail** rather than skip —
-      # deliberately, so a client generated for the wrong provider cannot look
-      # like a pass. So an unfiltered run here exits 1 no matter how many tests
-      # pass, and the failures are the ones the setup above guarantees.
-      #
-      # Stated as the mechanism rather than as a count. It read "877 passed …
-      # three suites error at collection", measured once and true then; the same
-      # run is now 911 and two, and neither number was ever the reason.
+      # rather than tidy. `@prisma/client` speaks one provider at a time, and
+      # `Generate for Postgres` above makes it Postgres — so the *SQLite* half
+      # of each differential suite **fails** rather than skips, deliberately,
+      # so a client generated for the wrong provider cannot look like a pass.
+      # `TEST_POSTGRES_URL` decides only whether the Postgres half runs at all;
+      # the generate step is what decides which half dies. So an unfiltered run
+      # here exits 1 no matter how many tests pass, and the failures are the
+      # ones the setup above guarantees.
       #
       # So this job runs the Postgres-labelled suites and the `sqlite` job runs
       # the rest. The dialect-agnostic tests are that job's business; nothing is


### PR DESCRIPTION
Closes #246.

The Postgres job explains its filter with a measurement:

> Run unfiltered, this job reports "877 passed" and still exits 1, because **three suites error at collection**.

Both halves are stale. Measured again against Postgres 16 on the current tree: **911 passed, and two suites fail** — not 877 and three.

## The reasoning is intact, and that is what I set out to check

I ran the unfiltered job to find out whether the filter is needed **at all**, not to correct its numbers. `-t postgres` is what made three suites invisible in #205, and dropping it would have prevented that — so it is worth knowing whether it still earns its place.

It does. `@prisma/client` speaks one provider at a time, and the `Generate for Postgres` step above generates it for Postgres — so the SQLite half of each differential suite *fails* rather than skips, deliberately, so a client generated for the wrong provider cannot look like a pass. An unfiltered run exits 1 however many tests pass.

## The fix is the framing

Stated as the mechanism rather than the count, and **no numbers survive in the comment** — not the stale pair, and not the fresh pair either. `911` and `two` have exactly the shelf life `877` and `three` had; the next suite added to `app/models` moves them. Neither number was ever the reason, so the record of them belongs here, which is permanent, and not in the comment, which has to stay true.

The mechanism is attributed to the **generate step**, not to `TEST_POSTGRES_URL`. The env var only decides whether the Postgres half runs at all: `differential.ts:188` asks for the provider implied by the URL it was handed, and `assertPrismaSpeaks` throws when the generated client disagrees. Measured — with `TEST_POSTGRES_URL` set and the client generated for sqlite, the SQLite half passes and the *Postgres* half fails. Naming the step keeps the comment true if the variable ever moves.

The claim beside it — *"nothing is left uncovered between them"* — now points at the guard that makes it true. It was **false for three files** until #206, which is worth recording next to a sentence that asserts it.

## Checks

- unfiltered Postgres run, to establish the mechanism still holds — 2 suites fail, exits 1
- the same run with the client generated for sqlite instead — the Postgres half fails, the SQLite half passes; this is what fixed the attribution
- CI's unit step verbatim, the exclusion list rather than a path filter — 65 files, **1554 passed**, 1 skipped
- `bunx oxlint orm --deny-warnings` — 0 warnings
- workflow parses; `git diff feat/orm -- .github/workflows/ci.yml` is **0 non-comment lines**
- scratch container removed, template restored to SQLite

## On tests

None are added and none are possible: this is prose, and prose is what the workflow's guards deliberately cannot see. `ci-coverage.test.ts` strips comment lines before asserting — a guard that could not tell a command from a sentence about a command would be satisfied by deleting the explanation — and `postgres-suite-selection.test.ts` reads the `-t` filter off the command line. Both pass (15 tests), but neither covers this diff, and an earlier revision of this description wrongly listed them as if they did.

`ci.yml:17-20` still says Postgres is not in CI, 160 lines above the job that runs it. Separate claim, separate paragraph, filed as #261.

Comment-only change to `ci.yml`; independent of #237, #239, #241, #243 and #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
