### PR TITLE
Three branches of where.ts that nothing distinguished

### DIFF
--- a/packages/gemi/orm/compile/where-mutants.test.ts
+++ b/packages/gemi/orm/compile/where-mutants.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { SqliteDialect } from "../dialect/sqlite";
+import { InvalidArgumentError } from "../errors";
+import { account, mapped, user } from "../fixtures";
+import * as registry from "../registry";
+import { compileRead } from "./read";
+
+/**
+ * Three branches of `where.ts` that nothing distinguished, found by mutation.
+ *
+ * Flipping each operator in the file and running the unit suite killed 44 of 49
+ * mutants. Of the five that lived, one is a floor by the file's own account —
+ * `the planner built a 'compositeIn' with no fields` sits under a comment saying
+ * "these are its bugs rather than a caller's", so no caller can reach it — and
+ * the other three were genuine: a guard, a skip, and an error message, each
+ * doing something no assertion cared about.
+ *
+ * A survivor is a question rather than a defect, so each is written here as the
+ * behaviour it protects rather than as "line N is uncovered".
+ */
+const sqlite = new SqliteDialect();
+
+const text = (args: unknown) =>
+  compileRead(user, "findMany" as never, args as never, sqlite).text;
+
+/** `AuditLog.payload` is the fixtures' only `Json` column. */
+const json = (args: unknown) =>
+  compileRead(mapped, "findMany" as never, args as never, sqlite).text;
+
+class DbNull {
+  toString() {
+    return "Prisma.DbNull";
+  }
+}
+
+class JsonNull {
+  toString() {
+    return "Prisma.JsonNull";
+  }
+}
+
+describe("branches of where.ts that mutation found unguarded", () => {
+  beforeEach(() => {
+    registry.clearRegistry();
+    registry.register("User", class { static $schema = user });
+    registry.register("Account", class { static $schema = account });
+    registry.register("AuditLog", class { static $schema = mapped });
+  });
+
+  /**
+   * `typeof value !== "object" || Array.isArray(value)` — the array half was
+   * covered and the scalar half was not, so `!==` could become `&&` and a
+   * number would reach the relation planner as if it were a filter object.
+   */
+  test("a relation filter given a scalar is refused, not planned", () => {
+    expect(() => text({ where: { accounts: 42 } })).toThrow(InvalidArgumentError);
+    expect(() => text({ where: { accounts: "some" } })).toThrow(InvalidArgumentError);
+  });
+
+  /**
+   * `operand === undefined || key === "mode"` — the `mode` half was covered.
+   * Without the other, an explicitly `undefined` operand stops being skipped
+   * and falls through to the unknown-operator check, turning a filter Prisma
+   * treats as absent into an error.
+   *
+   * Prisma's rule is that `undefined` means "not supplied" wherever it appears,
+   * which is what lets a caller build a filter conditionally without deleting
+   * keys.
+   */
+  test("an explicitly undefined operand is absent, not an error", () => {
+    expect(() => text({ where: { email: { contains: undefined } } })).not.toThrow();
+
+    // ...and contributes no SQL, which is the half that says it was skipped
+    // rather than compiled to something vacuous.
+    expect(text({ where: { email: { contains: undefined } } })).not.toContain("like");
+  });
+
+  /**
+   * The refusal for a bare `Json` sentinel names **which** sentinel it got, in
+   * both places the message spells one. Mutation flipped the two ternaries
+   * independently and nothing failed: a caller passing `JsonNull` could be told
+   * to write `equals: Prisma.DbNull`, which stores a different value — advice
+   * that is worse than no advice, since following it writes SQL NULL where the
+   * caller meant a JSON null.
+   */
+  test.each([
+    ["DbNull", new DbNull(), "JsonNull"],
+    ["JsonNull", new JsonNull(), "DbNull"],
+  ])("a bare %s is refused naming %s, not the other one", (name, value, other) => {
+    let message = "";
+    try {
+      json({ where: { payload: value } });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).toContain(`Prisma.${name}`);
+    expect(message).not.toContain(`Prisma.${other}`);
+    // Both spellings in the sentence, so flipping either ternary is caught.
+    expect(message.match(new RegExp(`Prisma\\.${name}`, "g"))).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #248.

Found by mutation rather than by reading: flipping every operator in `compile/where.ts` and running the unit suite killed **44 of 49**. Of the five that lived, one is a floor and three were genuine.

## The error message is the one that matters

`where: { payload: Prisma.JsonNull }` is refused, and the refusal names the sentinel **twice**, both times through a ternary. Flipping either changed nothing — so a caller passing `JsonNull` could be told:

> `Prisma.DbNull` is not a filter on its own … Write it as `{ payload: { equals: Prisma.DbNull } }`

Worse than no advice: following it writes SQL NULL where they meant a JSON null, and the two are different rows. That message is mine, from #225, and the test that pinned the refusal never looked at *which* sentinel it named.

## The other two

- **A relation filter given a scalar.** `where: { accounts: 42 }` was refused only by the half of the guard that catches arrays; the scalar half had no test.
- **An explicitly `undefined` operand.** Skipped by a condition whose other half (`key === "mode"`) was covered, so nothing asserted Prisma's rule that `undefined` means "not supplied" wherever it appears — the rule that lets a filter be built conditionally without deleting keys.

## The one that is not a defect

`!Array.isArray(fields) || fields.length === 0` sits under a comment saying *"these are its bugs rather than a caller's"* — planner-internal, unreachable from a caller. A floor in the sense #114 established, left alone and documented as such.

Each test is written as the behaviour it protects rather than as "line N is uncovered", because a survivor is a question and only three of five turned out to be defects.

## Verified by re-running the mutants

A test that does not kill the mutant it was written for has not closed the gap:

```
line  327 || -> &&   KILLED
line  693 === -> !==  KILLED
line  736 || -> &&   KILLED
```

## Checks

- `bun --bun vitest run orm database` — 58 files, **1503 passed**
- template suite — 17 passed / 3 skipped, 640 tests
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings

One new test file; independent of #237, #239, #241, #243, #245 and #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)