### PR TITLE
A relation filter inside AND or OR had no scoping test

### DIFF
--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -1054,6 +1054,49 @@ describe("relation filters in where", () => {
     });
   });
 
+  /**
+   * **Inside a boolean combinator**, which nothing reached.
+   *
+   * `scopeRelationFilters` recurses into `AND` / `OR` / `NOT` arrays and shares
+   * structure on the way out — `changed ? out : where`, so an untouched tree
+   * comes back as the same object and the plan key does not move. Every test
+   * above puts the relation filter at the top level, where that array branch is
+   * never entered.
+   *
+   * Mutation found it: inverting `if (scoped !== entry)` survives the unit suite
+   * *and* the template suite. Under that mutant an entry that **was** scoped
+   * leaves `changed` false, so the function returns the original `where` and the
+   * child's scope is dropped — a policy bypass for any relation filter written
+   * inside an `AND`, which is how anyone composes two conditions.
+   *
+   * Both spellings, because `OR` reaches the same branch by a different key and
+   * a guard that only covers `AND` would leave half the combinator untested.
+   */
+  test("a relation filter inside AND is scoped like one at the top level", () => {
+    expect(
+      scoped({ AND: [{ accounts: { some: { organizationRole: 0 } } }] }, {
+        Account: [tenant],
+      }),
+    ).toEqual({
+      AND: [
+        { accounts: { some: { organizationRole: 0, AND: [{ organizationId: 7 }] } } },
+      ],
+    });
+  });
+
+  test("and inside OR, beside a plain condition it must not disturb", () => {
+    expect(
+      scoped({ OR: [{ email: "a@b.c" }, { accounts: { some: {} } }] }, {
+        Account: [tenant],
+      }),
+    ).toEqual({
+      OR: [
+        { email: "a@b.c" },
+        { accounts: { some: { AND: [{ organizationId: 7 }] } } },
+      ],
+    });
+  });
+
   test("none is narrowed the same way", () => {
     expect(scoped({ accounts: { none: {} } }, { Account: [tenant] })).toEqual({
       accounts: { none: { AND: [{ organizationId: 7 }] } },


### PR DESCRIPTION
Closes #250.

Mutation on `policy.ts`: 76 sites, **17 surviving the unit suite**, **12 surviving the template suite as well**. Most of those twelve are `x === undefined || x === null` guards whose halves cannot be told apart by any observable behaviour. One is not.

`scopeRelationFilters` recurses into `AND` / `OR` / `NOT` arrays and shares structure on the way out — `changed ? out : where`, so an untouched tree comes back as the same object and the plan key does not move. Inverting the line that sets `changed`:

```ts
if (scoped !== entry) changed = true;
```

survives both suites. Under that mutant an entry that **was** scoped leaves `changed` false, the function returns the original `where`, and the child's scope is dropped — a policy bypass for any relation filter written inside an `AND`, which is how anyone composes two conditions.

Every existing test in `relation filters in where` puts the filter at the **top level**, where the array branch is never entered. The branch is reachable from ordinary code and had no assertion.

## Two tests, and why two

Inside `AND`, and inside `OR` beside a plain condition it must leave alone. `OR` reaches the same branch by a different key, so covering only `AND` would leave half the combinator untested.

**Verified by re-running the mutant** — killed, by the first of them:

```
mutant 1345 !== -> ===: KILLED
    × a relation filter inside AND is scoped like one at the top level
```

## The other eleven survivors are left alone

Deliberately. They are questions, not defects, and for most the honest answer is that flipping `||` to `&&` between `=== undefined` and `=== null` cannot change what any caller sees. Writing tests to kill those would be writing tests to satisfy a tool — which is the opposite of what the exercise is for.

## Checks

- `bun --bun vitest run orm database` — 57 files, **1501 passed**
- template suite — 17 passed / 3 skipped, 640 tests
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings

Adds two tests to an existing describe; independent of the other seven open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)