### PR TITLE
A disconnect through a join table reported itself as a connect

### DIFF
--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1578,7 +1578,12 @@ function planJoinTable(
 
   out.after.push({
     relation: relation.name,
-    operation: key === "create" ? "create" : "connect",
+    // The operand this step implements, not a two-way split of it. This read
+    // `key === "create" ? "create" : "connect"`, which labelled `disconnect`,
+    // `set` and `connectOrCreate` as `connect` — the first of those being the
+    // opposite operation. The field exists so a plan is legible from the
+    // outside, so a wrong label is the whole of its cost.
+    operation: key as NestedWriteStep["operation"],
     async run(args, _context, executor, rows) {
       const parent = rows[0];
       if (!parent) return;

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -1299,6 +1299,55 @@ describe("nested writes", () => {
       ).toThrow(/means something different through a join table/);
     });
 
+    /**
+     * **The step says which operand it is**, which is what the field is for.
+     *
+     * `NestedWriteStep.operation` is documented as the thing that "makes a plan
+     * legible from the outside: to a test, and to whatever logs queries later"
+     * — two steps on the same relation can produce byte-identical SQL and
+     * differ only in what the step does.
+     *
+     * Nothing on the join-table path asserted it. Mutation found the hole:
+     * flipping
+     *
+     *     operation: key === "create" ? "create" : "connect"
+     *
+     * survives the unit suite *and* the template suite, so a `create` step
+     * could report itself as a `connect` and the only reader would be a human
+     * debugging a plan.
+     *
+     * `plan.writes.discrimination.test.ts` does read the label, but folds it
+     * into a plan-identity string and asserts two plans *differ*. Swapping the
+     * two labels swaps both identities and they stay distinct, so that test
+     * passes either way — the difference between checking a value and checking
+     * that values are not equal.
+     */
+    test.each([
+      ["create", { create: { label: "new" } }],
+      ["connect", { connect: { id: 1 } }],
+      ["connectOrCreate", { connectOrCreate: { where: { id: 1 }, create: { label: "new" } } }],
+      ["disconnect", { disconnect: { id: 1 } }],
+      ["set", { set: [{ id: 1 }] }],
+    ] as [string, Record<string, unknown>][])(
+      "a %s through a join table is labelled as one",
+      (operand, payload) => {
+        const plan = compileWrite(
+          post,
+          "update",
+          { where: { id: 1 }, data: { tags: payload } } as never,
+          sqlite,
+        );
+
+        const steps = [...(plan.before ?? []), ...(plan.after ?? [])];
+        const labels = steps
+          .filter((step) => step.relation === "tags")
+          .map((step) => step.operation);
+
+        expect(labels, `no step was planned for ${operand}`).not.toHaveLength(0);
+        expect(labels).toContain(operand);
+      },
+    );
+
     test("the operands both paths implement are not refused there", () => {
       for (const operand of BOTH) {
         expect(() =>


### PR DESCRIPTION
Closes #254.

`NestedWriteStep.operation` is documented as the thing that "makes a plan legible from the outside: to a test, and to whatever logs queries later" — two steps on the same relation can produce byte-identical SQL and differ only in what the step does.

On the join-table path it was a two-way split:

```ts
operation: key === "create" ? "create" : "connect",
```

so every operand that is not `create` was labelled `connect`. Three of the five that reach that push are wrong:

| operand | was | now |
| --- | --- | --- |
| `create` | `create` | `create` |
| `connect` | `connect` | `connect` |
| `connectOrCreate` | **`connect`** | `connectOrCreate` |
| `disconnect` | **`connect`** | `disconnect` |
| `set` | **`connect`** | `set` |

`disconnect` reported itself as its opposite. The union already permitted all five, so this is simply the label not being the operand.

## The existing test that reads this field cannot see it

`plan.writes.discrimination.test.ts` **does** read `step.operation` — but folds it into a plan-identity string and asserts two plans *differ*. Swapping two labels swaps both identities and they stay distinct, so it passes either way.

That is the difference between checking a value and checking that values are not equal, and it is exactly why mutation found this where the suite could not.

**Verified by reverting the fix with the tests in place:** the three wrong labels fail, the two correct ones pass.

## From the same run, and not defects

Mutating `nested-writes.ts`: 72 sites, 13 re-checked against the template suite, **9 killed there** — the operand dispatch for `set`, `create`, `connectOrCreate` and `disconnect`, the empty-items guard, the filter validation and the required-field check all have real coverage. Of the four surviving both, three are `x === undefined || x === null` guards whose halves no caller can distinguish; left alone deliberately.

## Checks

- `bun --bun vitest run orm database` — 57 files, **1504 passed**
- template suite — 17 passed / 3 skipped, 640 tests
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings

Independent of the other nine open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)