### PR TITLE
An upsert on a Bytes key was only tested for the case it refuses

### DIFF
--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -469,6 +469,46 @@ describe("delete", () => {
 });
 
 describe("upsert", () => {
+  /**
+   * A one-field unique whose key type varies — the shape the conflict-key
+   * agreement tests below need. They differ only in that type, so this is a
+   * factory rather than a fixture copied per test.
+   */
+  const digestSchema = (keyType: string): any => ({
+    name: "Digest",
+    table: "Digest",
+    fields: {
+      id: {
+        name: "id",
+        column: "id",
+        type: "Int",
+        nullable: false,
+        isId: true,
+        isUpdatedAt: false,
+        default: { kind: "autoincrement" },
+      },
+      key: {
+        name: "key",
+        column: "key",
+        type: keyType,
+        nullable: false,
+        isId: false,
+        isUpdatedAt: false,
+      },
+      note: {
+        name: "note",
+        column: "note",
+        type: "String",
+        nullable: true,
+        isId: false,
+        isUpdatedAt: false,
+      },
+    },
+    primaryKey: ["id"],
+    uniques: [["key"]],
+    relations: {},
+  });
+
   test("one statement: insert with on-conflict do update", () => {
     expect(
       text("upsert", {
@@ -675,40 +715,7 @@ describe("upsert", () => {
     ["sqlite", sqlite],
     ["postgres", postgres],
   ])("a Bytes conflict key compares by value on %s", (_name, dialect) => {
-    const digest: any = {
-      name: "Digest",
-      table: "Digest",
-      fields: {
-        id: {
-          name: "id",
-          column: "id",
-          type: "Int",
-          nullable: false,
-          isId: true,
-          isUpdatedAt: false,
-          default: { kind: "autoincrement" },
-        },
-        key: {
-          name: "key",
-          column: "key",
-          type: "Bytes",
-          nullable: false,
-          isId: false,
-          isUpdatedAt: false,
-        },
-        note: {
-          name: "note",
-          column: "note",
-          type: "String",
-          nullable: true,
-          isId: false,
-          isUpdatedAt: false,
-        },
-      },
-      primaryKey: ["id"],
-      uniques: [["key"]],
-      relations: {},
-    };
+    const digest = digestSchema("Bytes");
 
     // Equal bytes, two distinct objects — which is how they arrive from a
     // caller who built the `where` and the `create` separately.
@@ -719,7 +726,12 @@ describe("upsert", () => {
     };
 
     const compiled = compileWrite(digest, "upsert", args, dialect);
-    expect(() => compiled.bind(args, createBindContext())).not.toThrow();
+
+    // Binding the values is the assertion: it does not throw, *and* the bytes
+    // survive the check into the parameter list rather than being dropped or
+    // replaced by whatever the agreement check compared.
+    const values = compiled.bind(args, createBindContext());
+    expect(values).toContainEqual(new Uint8Array([1, 2, 3]));
   });
 
   test("a DateTime conflict key that genuinely differs is still refused", () => {
@@ -739,75 +751,55 @@ describe("upsert", () => {
    * "'x' is A ... but A" and looks like a framework bug rather than a wrong
    * argument. Fixing the `Date` case is easy to half-do: `String()` collapses
    * two different `Bytes` of the same length, and collapses `1n` against `1`.
+   *
+   * The last row is also what holds `sameEncoded`'s two-sided view test to
+   * `&&`. The `where` value and the `create` value are supplied independently
+   * and neither is type-checked before it arrives, so a mixed pair — one view,
+   * one not — is reachable, exactly as the `1n`/`1` row is. Under `||` the
+   * non-view side is rebuilt as `new Uint8Array(undefined, undefined,
+   * undefined)`, which is empty, and an empty `Bytes` key would then match a
+   * wrong-typed `create` and be silently accepted on a write.
    */
   test.each([
     [
       "Bytes of the same length",
       new Uint8Array([1, 2]),
       new Uint8Array([3, 4]),
+      "Bytes",
     ],
-    ["a bigint against a number", 1n, 1],
-  ])("a mismatched %s is described distinguishably", (_label, a, b) => {
-    const digest: any = {
-      name: "Digest",
-      table: "Digest",
-      fields: {
-        id: {
-          name: "id",
-          column: "id",
-          type: "Int",
-          nullable: false,
-          isId: true,
-          isUpdatedAt: false,
-          default: { kind: "autoincrement" },
-        },
-        key: {
-          name: "key",
-          column: "key",
-          type: typeof a === "bigint" ? "BigInt" : "Bytes",
-          nullable: false,
-          isId: false,
-          isUpdatedAt: false,
-        },
-        note: {
-          name: "note",
-          column: "note",
-          type: "String",
-          nullable: true,
-          isId: false,
-          isUpdatedAt: false,
-        },
-      },
-      primaryKey: ["id"],
-      uniques: [["key"]],
-      relations: {},
-    };
+    ["a bigint against a number", 1n, 1, "BigInt"],
+    ["an empty Bytes against a string", new Uint8Array([]), "abc", "Bytes"],
+  ])(
+    "a mismatched %s is described distinguishably",
+    (_label, a, b, keyType) => {
+      const digest = digestSchema(keyType as string);
 
-    const args = {
-      where: { key: a },
-      create: { key: b },
-      update: { note: "n" },
-    };
-    const compiled = compileWrite(digest, "upsert", args, postgres);
+      const args = {
+        where: { key: a },
+        create: { key: b },
+        update: { note: "n" },
+      };
+      const compiled = compileWrite(digest, "upsert", args, postgres);
 
-    let message = "";
-    try {
-      compiled.bind(args, createBindContext());
-    } catch (error: any) {
-      message = error.message;
-    }
+      let message = "";
+      try {
+        compiled.bind(args, createBindContext());
+      } catch (error: any) {
+        message = error.message;
+      }
 
-    expect(message).toMatch(/must agree on the key/);
+      expect(message).toMatch(/must agree on the key/);
 
-    // The two halves of "is X in the where clause but Y in 'create'" must not
-    // be the same string.
-    const [, left, right] =
-      /'key' is (.+?) in the where clause but (.+?) in 'create'/s.exec(
-        message,
-      ) ?? [];
-    expect(left).toBeDefined();
-    expect(left).not.toBe(right);
-  });
+      // The two halves of "is X in the where clause but Y in 'create'" must
+      // not be the same string.
+      const [, left, right] =
+        /'key' is (.+?) in the where clause but (.+?) in 'create'/s.exec(
+          message,
+        ) ?? [];
+      expect(left).toBeDefined();
+      expect(left).not.toBe(right);
+    },
+  );
 
   // Deliberate strictness, recorded in the plan's known-differences list:
   // Prisma accepts a `where` naming two unique keys, but `on conflict` takes

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -652,6 +652,76 @@ describe("upsert", () => {
     expect(() => compiled.bind(args, createBindContext())).not.toThrow();
   });
 
+  /**
+   * The same for `Bytes`, which is the other type `encode` hands over as an
+   * object and the other half of why `sameEncoded` is not `===`.
+   *
+   * Its doc gives both: "Postgres passes a `DateTime` through as the `Date` it
+   * was given, and **both dialects** pass `Bytes` through as a `Uint8Array` —
+   * so the same instant and the same bytes arrive here as two distinct objects,
+   * and identity refuses a correct upsert".
+   *
+   * `DateTime` had a test in each direction. `Bytes` had only the refusal —
+   * that a *mismatched* pair is described distinguishably — so the branch that
+   * makes a *matching* pair work was never exercised. Mutation found it:
+   * inverting the length check inside that branch makes every equal pair
+   * compare unequal, and nothing failed.
+   *
+   * Both dialects, unlike the `Date` case which is Postgres-only: SQLite
+   * encodes a `DateTime` to a number and never reaches this, but it passes
+   * `Bytes` through as an object exactly as Postgres does.
+   */
+  test.each([
+    ["sqlite", sqlite],
+    ["postgres", postgres],
+  ])("a Bytes conflict key compares by value on %s", (_name, dialect) => {
+    const digest: any = {
+      name: "Digest",
+      table: "Digest",
+      fields: {
+        id: {
+          name: "id",
+          column: "id",
+          type: "Int",
+          nullable: false,
+          isId: true,
+          isUpdatedAt: false,
+          default: { kind: "autoincrement" },
+        },
+        key: {
+          name: "key",
+          column: "key",
+          type: "Bytes",
+          nullable: false,
+          isId: false,
+          isUpdatedAt: false,
+        },
+        note: {
+          name: "note",
+          column: "note",
+          type: "String",
+          nullable: true,
+          isId: false,
+          isUpdatedAt: false,
+        },
+      },
+      primaryKey: ["id"],
+      uniques: [["key"]],
+      relations: {},
+    };
+
+    // Equal bytes, two distinct objects — which is how they arrive from a
+    // caller who built the `where` and the `create` separately.
+    const args = {
+      where: { key: new Uint8Array([1, 2, 3]) },
+      create: { key: new Uint8Array([1, 2, 3]) },
+      update: { note: "n" },
+    };
+
+    const compiled = compileWrite(digest, "upsert", args, dialect);
+    expect(() => compiled.bind(args, createBindContext())).not.toThrow();
+  });
+
   test("a DateTime conflict key that genuinely differs is still refused", () => {
     const args = {
       where: { at: new Date("2024-01-01T00:00:00Z") },


### PR DESCRIPTION
Closes #256.

`sameEncoded` exists because `encode` is a per-dialect pass-through and what a driver binds natively is not always a primitive. Its own doc names both types:

> Postgres passes a `DateTime` through as the `Date` it was given, and **both dialects** pass `Bytes` through as a `Uint8Array` — so the same instant and the same bytes arrive here as two distinct objects, and identity refuses a correct upsert.

`DateTime` has a test in each direction — equal-but-distinct accepted, genuinely different refused. `Bytes` had only the refusal, so the branch that makes a **matching** pair work was never exercised.

Mutation found it: inverting the length check inside that branch makes every equal pair compare unequal, and nothing failed. In effect a correct upsert on a `Bytes` unique key would be refused with a message printing two equal-looking values — the exact failure the function was written to prevent.

Both dialects, unlike the `Date` case which is Postgres-only: SQLite encodes a `DateTime` to a number and never reaches this, but it passes `Bytes` through as an object exactly as Postgres does.

**Verified by re-running the mutant:**

```
mutant 824 !== -> ===  KILLED
    × a Bytes conflict key compares by value on sqlite
    × a Bytes conflict key compares by value on postgres
```

## The `&&` mutant is killed too — it was not equivalent

An earlier version of this description recorded `ArrayBuffer.isView(a) && ArrayBuffer.isView(b)` → `||` as an equivalent survivor, on the grounds that both values come from the same field through the same encoder and are therefore either both views or neither. **That reasoning is wrong**, and review caught it: `a` is the `create` value and `b` is the `where` value, supplied independently, and neither is type-checked before it reaches `sameEncoded` — the neighbouring `1n`-against-`1` row is standing proof that a mixed pair arrives. Under `||` the non-view side is rebuilt as `new Uint8Array(undefined, undefined, undefined)`, length 0, so an empty `Bytes` key matches a wrong-typed `create` and a mismatched key is **silently accepted on a write** — the same class of divergence the function exists to stop.

So it is killed rather than excused, by one row on the existing "described distinguishably" case: an empty `Bytes` where clause against an `"abc"` create.

```
mutant 821 && -> ||  KILLED
    × a mismatched an empty Bytes against a string is described distinguishably
```

The length-guard mutant still fails both `Bytes` tests, so the new row does not displace the original coverage.

The `Date` pair a line above has the same shape and is presumably killable the same way; that is a separate line and not this PR's issue.

## Also from review

- The `Digest` fixture was copied verbatim into two tests that differ only in the key's type — now one `digestSchema(keyType)` factory at the top of the `upsert` describe.
- The new `Bytes` test binds and asserts the bytes reach the parameter list (`toContainEqual(new Uint8Array([1, 2, 3]))`) rather than resting on `not.toThrow()` alone.

## Checks

- `bun --bun vitest run orm database` — 57 files, **1502 passed**
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings

Tests in an existing describe; independent of the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
