### PR TITLE
Eleven template suites loaded a Prisma client to read an env var

### DIFF
--- a/packages/gemi/orm/template-import-graph.test.ts
+++ b/packages/gemi/orm/template-import-graph.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * A template suite loads a Prisma client at collection time only if it uses one.
+ *
+ * **The cost this exists to keep off the collection phase.** `differential.ts`
+ * imports `@prisma/client` at module scope — it has to; it *is* the harness that
+ * compares against Prisma. It also used to export `POSTGRES_URL`, which is
+ *
+ *     export const POSTGRES_URL = process.env.TEST_POSTGRES_URL;
+ *
+ * and `applyMigrations`, which needs `bun`'s `SQL` and two node builtins. Eleven
+ * of the thirteen suites that imported the module wanted only those two things,
+ * so eleven workers loaded a query engine, before any `describe` ran, to read an
+ * environment variable. Both now live in `app/models/scratch.ts`, whose import
+ * list is `bun`, `node:fs`, `node:path`.
+ *
+ * **Why it is asserted rather than left to reviewers.** The regression is
+ * invisible: adding `POSTGRES_URL` to an existing `./differential` import is one
+ * word in a diff, nothing fails, and the suite is a little slower to collect. It
+ * is also the kind of edit an author makes for a good local reason — the symbol
+ * is right there in a module they already import.
+ *
+ * **The failure it removes a suspect for is #217**, where
+ * `relations.many-to-many.test.ts` intermittently fails *collection* in the
+ * SQLite job. That the failure is at import rather than in `beforeAll` is
+ * measurable from the run's own counts rather than inferred from vitest's
+ * formatting — injecting each shape into that file and running the directory:
+ *
+ *     a hook that times out    625 passed | 47 skipped (672)
+ *     a module that throws     625 passed | 32 skipped (657)
+ *
+ * A failed hook still contributes the file's 15 tests, as *skipped*. A module
+ * that throws leaves them absent and the total short. #217 reports
+ * `605 passed | 32 skipped (637)`, so it is the second, and the 60s hook timeout
+ * that reads as the obvious suspect is not the mechanism.
+ *
+ * This does not claim to be that bug's cause; it has never been reproduced, and
+ * a check that passes today would have passed the day it happened. It makes the
+ * import surface where such a failure can live smaller, and keeps it that way.
+ */
+const MODELS = join(
+  import.meta.dirname,
+  "../../../templates/saas-starter/app/models",
+);
+
+/** The module whose import pulls in `@prisma/client`, and what earns importing it. */
+const HARNESS = "./differential";
+const HARNESS_API = "createDifferential";
+
+const suites = readdirSync(MODELS)
+  .filter((file) => file.endsWith(".test.ts"))
+  .map((file) => ({ file, source: readFileSync(join(MODELS, file), "utf8") }));
+
+describe("the template's model suites", () => {
+  /**
+   * Both halves of the comparison have to be readable. A rename that made the
+   * regex match nothing would turn every assertion below into a tautology, which
+   * is precisely how a check that has stopped checking looks from the outside.
+   */
+  test("the suites were found", () => {
+    expect(suites.length).toBeGreaterThan(10);
+    expect(
+      suites.filter(({ source }) => source.includes(`from "${HARNESS}"`)).length,
+      `no suite imports ${HARNESS} — has it been renamed?`,
+    ).toBeGreaterThan(0);
+  });
+
+  test(`${HARNESS} still imports @prisma/client, which is why this test exists`, () => {
+    const source = readFileSync(join(MODELS, "differential.ts"), "utf8");
+    expect(source).toMatch(/^import .*from "@prisma\/client";$/m);
+  });
+
+  test.each(suites.map(({ file, source }) => [file, source] as const))(
+    "%s imports the differential harness only to use it",
+    (file, source) => {
+      if (!source.includes(`from "${HARNESS}"`)) return;
+
+      expect(
+        source.includes(HARNESS_API),
+        `${file} imports ${HARNESS} but never calls ${HARNESS_API}, so it pays ` +
+          `for @prisma/client at collection time and gets nothing for it. ` +
+          `POSTGRES_URL and applyMigrations live in ./scratch.`,
+      ).toBe(true);
+    },
+  );
+
+  /**
+   * The other direction: `scratch.ts` is only worth having if it stays cheap, and
+   * one import of the harness from it would put every suite back where it was
+   * while leaving every assertion above green.
+   */
+  test("scratch.ts pulls in nothing a suite would not want at import", () => {
+    const source = readFileSync(join(MODELS, "scratch.ts"), "utf8");
+    const imported = [...source.matchAll(/^import .*from "([^"]+)";$/gm)].map(
+      (match) => match[1],
+    );
+
+    expect(imported.sort()).toEqual(["bun", "node:fs", "node:path"]);
+  });
+});

--- a/templates/saas-starter/app/models/auth-adapter.test.ts
+++ b/templates/saas-starter/app/models/auth-adapter.test.ts
@@ -9,7 +9,7 @@ import { Application } from "gemi/foundation";
 import { clearPlanCache } from "gemi/orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-import { POSTGRES_URL, applyMigrations } from "./differential";
+import { POSTGRES_URL, applyMigrations } from "./scratch";
 import {
   AccountModel,
   MagicLinkTokenModel,

--- a/templates/saas-starter/app/models/delete-include.test.ts
+++ b/templates/saas-starter/app/models/delete-include.test.ts
@@ -15,7 +15,7 @@ import {
 } from "gemi/orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-import { POSTGRES_URL } from "./differential";
+import { POSTGRES_URL } from "./scratch";
 
 /**
  * `delete` with an `include` on a **cascading** relation.

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -5,11 +5,7 @@ import { Prisma as PrismaNS, type PrismaClient } from "@prisma/client";
 import { Model } from "gemi/orm";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 
-import {
-  POSTGRES_URL,
-  createDifferential,
-  type Differential,
-} from "./differential";
+import { createDifferential, type Differential } from "./differential";
 import {
   AccountModel,
   LedgerEntryModel,
@@ -18,6 +14,7 @@ import {
   SocialAccountModel,
   UserModel,
 } from "./generated";
+import { POSTGRES_URL } from "./scratch";
 
 // Rows chosen so that every case below actually discriminates: nullable columns
 // that are null on some rows and not others, names that tie under `orderBy`,

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -1,5 +1,4 @@
-import { SQL } from "bun";
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -8,6 +7,8 @@ import { DatabaseManager } from "gemi/database";
 import { Application } from "gemi/foundation";
 import { Model, clearPlanCache, type ExecOptions } from "gemi/orm";
 import { expect } from "vitest";
+
+import { applyMigrations } from "./scratch";
 
 /**
  * The safety net for every later iteration: run the same query through Prisma
@@ -22,6 +23,13 @@ import { expect } from "vitest";
  *
  * Postgres runs too when `TEST_POSTGRES_URL` is set. The skip is deliberately
  * loud: a silently skipped dialect reads as a passing one.
+ *
+ * **This module imports `@prisma/client`, so importing it is not free.** Only a
+ * suite that actually compares against Prisma should reach for it; `POSTGRES_URL`
+ * and `applyMigrations` moved to `./scratch`, which imports nothing but `bun`
+ * and two node builtins, precisely so the other eleven suites in this directory
+ * stop loading a query engine at collection time to read an environment
+ * variable. `packages/gemi/orm/template-import-graph.test.ts` holds that line.
  */
 
 /**
@@ -80,8 +88,6 @@ export interface Differential {
   resetQueries(): void;
   dispose(): Promise<void>;
 }
-
-export const POSTGRES_URL = process.env.TEST_POSTGRES_URL;
 
 /**
  * Redaction is the one policy capability that makes gemi's result *deliberately*
@@ -424,35 +430,6 @@ export async function createDifferential(options: {
       rmSync(workspace, { recursive: true, force: true });
     },
   };
-}
-
-/**
- * Replays the committed migrations into a fresh SQLite file, in name order —
- * which is Prisma's own ordering, since it prefixes every directory with a
- * timestamp. Statements are split on `;` at end of line, which is enough for
- * the DDL Prisma emits and involves no SQL parsing.
- */
-export async function applyMigrations(path: string): Promise<void> {
-  const root = join(import.meta.dirname, "../../prisma/migrations");
-  const sql = new SQL(`sqlite://${path}`);
-
-  try {
-    const directories = readdirSync(root, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name)
-      .sort();
-
-    for (const directory of directories) {
-      const file = join(root, directory, "migration.sql");
-      const source = readFileSync(file, "utf8");
-      for (const statement of source.split(/;\s*$/m)) {
-        if (statement.trim() === "") continue;
-        await sql.unsafe(statement);
-      }
-    }
-  } finally {
-    await sql.close();
-  }
 }
 
 /**

--- a/templates/saas-starter/app/models/lateral.coercion.test.ts
+++ b/templates/saas-starter/app/models/lateral.coercion.test.ts
@@ -10,7 +10,7 @@ import {
 } from "gemi/orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-import { POSTGRES_URL } from "./differential";
+import { POSTGRES_URL } from "./scratch";
 
 /**
  * Every scalar type, through a **relation**, under both strategies.

--- a/templates/saas-starter/app/models/lateral.test.ts
+++ b/templates/saas-starter/app/models/lateral.test.ts
@@ -11,7 +11,7 @@ import {
 } from "gemi/orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-import { POSTGRES_URL } from "./differential";
+import { POSTGRES_URL } from "./scratch";
 import { AccountModel, OrganizationModel, UserModel } from "./generated";
 
 /**

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -29,7 +29,7 @@ import {
   test,
 } from "vitest";
 
-import { POSTGRES_URL, applyMigrations } from "./differential";
+import { POSTGRES_URL, applyMigrations } from "./scratch";
 import {
   AccountModel,
   OrganizationModel,

--- a/templates/saas-starter/app/models/raw-sql.test.ts
+++ b/templates/saas-starter/app/models/raw-sql.test.ts
@@ -16,7 +16,7 @@ import {
   test,
 } from "vitest";
 
-import { POSTGRES_URL, applyMigrations } from "./differential";
+import { POSTGRES_URL, applyMigrations } from "./scratch";
 import { User } from "./User";
 
 /**

--- a/templates/saas-starter/app/models/redact-strategies.test.ts
+++ b/templates/saas-starter/app/models/redact-strategies.test.ts
@@ -11,7 +11,7 @@ import {
 } from "gemi/orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-import { POSTGRES_URL } from "./differential";
+import { POSTGRES_URL } from "./scratch";
 
 /**
  * `redact` on a **nested** model, under both relation strategies.

--- a/templates/saas-starter/app/models/relations.many-to-many.test.ts
+++ b/templates/saas-starter/app/models/relations.many-to-many.test.ts
@@ -8,7 +8,7 @@ import { Application } from "gemi/foundation";
 import { Model, clearPlanCache, register, type ModelSchema } from "gemi/orm";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 
-import { POSTGRES_URL } from "./differential";
+import { POSTGRES_URL } from "./scratch";
 
 /**
  * Prisma's *implicit* many-to-many, which the template's own schema cannot
@@ -310,6 +310,27 @@ async function teardown() {
 
 function suite(label: string, start: () => Promise<void>) {
   describe(label, () => {
+    /**
+     * **60s, and it is not #217.** This is the shortest hook timeout in the
+     * directory — its neighbours use 120s — so it is the first thing anyone
+     * reading #217 reaches for, and it is the wrong thing.
+     *
+     * The two failure shapes are distinguishable from the run's own counts,
+     * which is what settles it. Injecting each into this file and running the
+     * directory:
+     *
+     *   a hook that times out   FAIL <file> > <suite>      625 passed | 47 skipped (672)
+     *   a module that throws    FAIL <file> [ <file> ]     625 passed | 32 skipped (657)
+     *
+     * A failed hook still contributes its file's 15 tests to the run, as
+     * *skipped*; a module that throws before `describe` runs leaves them absent
+     * and the total 15 short. #217 reports `605 passed | 32 skipped (637)` —
+     * total short, skipped unchanged — so the failure is at import, and nothing
+     * this number does could have caused it or can prevent it.
+     *
+     * Raising it would only make a genuine hang slower to report. Left alone
+     * deliberately.
+     */
     beforeAll(start, 60_000);
     afterAll(teardown);
     cases();

--- a/templates/saas-starter/app/models/save.test.ts
+++ b/templates/saas-starter/app/models/save.test.ts
@@ -15,7 +15,7 @@ import {
 } from "gemi/orm";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-import { POSTGRES_URL, applyMigrations } from "./differential";
+import { POSTGRES_URL, applyMigrations } from "./scratch";
 import { AccountModel, UserModel } from "./generated";
 
 /**

--- a/templates/saas-starter/app/models/scratch.ts
+++ b/templates/saas-starter/app/models/scratch.ts
@@ -1,0 +1,75 @@
+import { SQL } from "bun";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * How a model suite gets a database to run against, and nothing else.
+ *
+ * **Why this is not in `differential.ts`.** Both exports below used to live
+ * there, next to `createDifferential`. Thirteen of the twenty suites in this
+ * directory import from that module and only two of them want the differential
+ * harness — the other eleven want an environment variable and a `CREATE TABLE`
+ * runner. But `differential.ts` imports `@prisma/client` at module scope, so
+ * every one of those eleven pulled a Prisma client into its worker *at
+ * collection time*, before a single `describe` ran, to read
+ * `process.env.TEST_POSTGRES_URL`.
+ *
+ * That is worth undoing on its own merits — the import is pure cost, paid once
+ * per worker, in the phase where a failure takes the whole file's tests out of
+ * the run rather than failing one of them. It is also the last removable
+ * suspect for #217, whose failure is at import: a file whose 15 tests are
+ * *absent* from the total rather than counted as skipped did not get as far as
+ * a hook. This does not claim to be that bug's cause. It makes the surface it
+ * could hide in eleven files smaller instead of thirteen.
+ *
+ * The rule that keeps it that way is asserted, not just written down here:
+ * `packages/gemi/orm/template-import-graph.test.ts` fails if a suite imports
+ * `./differential` without using `createDifferential`.
+ *
+ * So the constraint on this file is its import list: `bun`, `node:fs`,
+ * `node:path`. Anything that needs a Prisma client belongs in `differential.ts`.
+ */
+
+/**
+ * The scratch Postgres database the Postgres suites run against, or `undefined`
+ * when only SQLite is being covered.
+ *
+ * The contract is that it names a database the suites may truncate: they clear
+ * the tables they seed between cases, and several drop and recreate tables of
+ * their own. Every suite gated on this skips loudly when it is unset — a
+ * silently skipped dialect reads as a passing one.
+ */
+export const POSTGRES_URL = process.env.TEST_POSTGRES_URL;
+
+/**
+ * Replays the committed migrations into a fresh SQLite file, in name order —
+ * which is Prisma's own ordering, since it prefixes every directory with a
+ * timestamp. Statements are split on `;` at end of line, which is enough for
+ * the DDL Prisma emits and involves no SQL parsing.
+ *
+ * Deliberately not `prisma db push --force-reset`: that command is destructive
+ * by design, and a test has no business running it — this way there is never a
+ * database that could be harmed, only one that is created.
+ */
+export async function applyMigrations(path: string): Promise<void> {
+  const root = join(import.meta.dirname, "../../prisma/migrations");
+  const sql = new SQL(`sqlite://${path}`);
+
+  try {
+    const directories = readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+
+    for (const directory of directories) {
+      const file = join(root, directory, "migration.sql");
+      const source = readFileSync(file, "utf8");
+      for (const statement of source.split(/;\s*$/m)) {
+        if (statement.trim() === "") continue;
+        await sql.unsafe(statement);
+      }
+    }
+  } finally {
+    await sql.close();
+  }
+}

--- a/templates/saas-starter/app/models/transactions.test.ts
+++ b/templates/saas-starter/app/models/transactions.test.ts
@@ -23,7 +23,7 @@ import {
   test,
 } from "vitest";
 
-import { POSTGRES_URL, applyMigrations } from "./differential";
+import { POSTGRES_URL, applyMigrations } from "./scratch";
 import { AccountModel } from "./generated";
 import { User } from "./User";
 

--- a/templates/saas-starter/app/models/writes.coercion.test.ts
+++ b/templates/saas-starter/app/models/writes.coercion.test.ts
@@ -8,7 +8,7 @@ import { Application } from "gemi/foundation";
 import { Model, clearPlanCache, register, type ModelSchema } from "gemi/orm";
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-import { POSTGRES_URL } from "./differential";
+import { POSTGRES_URL } from "./scratch";
 
 /**
  * Round-tripping every scalar type: write a value, read it back, and get the

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -2,11 +2,7 @@ import { Prisma as PrismaNamespace, type PrismaClient } from "@prisma/client";
 import { UniqueConstraintError } from "gemi/orm";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
-import {
-  POSTGRES_URL,
-  createDifferential,
-  type Differential,
-} from "./differential";
+import { createDifferential, type Differential } from "./differential";
 import {
   AccountModel,
   MembershipModel,
@@ -16,6 +12,7 @@ import {
   SocialAccountModel,
   UserModel,
 } from "./generated";
+import { POSTGRES_URL } from "./scratch";
 
 /**
  * The write surface, run through Prisma and through gemi against the same


### PR DESCRIPTION
Closes #217.

## The failure shape is measurable, and it rules out the hook

#217 asks which of two shapes the failure is, and the thread settles it from vitest's output formatting — the bracketed `FAIL  <file> [ <file> ]` is the import-error form. That is right, and there is a second signal in the same paste that does not depend on reading vitest's printer: **the counts**.

Injecting each candidate into `relations.many-to-many.test.ts` and running `vitest run app/models` (clean baseline on this branch is `640 passed | 32 skipped (672)`):

```
injected                  reported as                totals
a hook that times out     FAIL <file> > <suite>      625 passed | 47 skipped (672)
a module that throws      FAIL <file> [ <file> ]     625 passed | 32 skipped (657)
```

A failed hook still contributes the file's 15 tests to the run, as **skipped** — the total is unchanged and `skipped` goes 32 → 47. A module that throws before `describe` runs leaves them **absent** — `skipped` stays 32 and the total drops by 15.

#217 reports `605 passed | 32 skipped (637)`: total short, skipped unchanged. So it is the second row, and **`beforeAll(start, 60_000)` cannot be the mechanism** — a fact rather than the judgement call the thread was left making. That line is the shortest hook timeout in the directory and the first thing anyone picking this up reads; it now carries the measurement in a comment, and is otherwise left exactly as it was.

## What that leaves, and the one part of it that was pure cost

The suspect surface is the import graph. `differential.ts` imports `@prisma/client` at module scope — it has to; it *is* the harness that compares against Prisma. It also exported

```ts
export const POSTGRES_URL = process.env.TEST_POSTGRES_URL;
```

and `applyMigrations`, which needs `bun`'s `SQL` and two node builtins.

Thirteen of the twenty suites in `app/models` imported that module. **Eleven of them wanted only those two things** — so eleven workers loaded a Prisma query engine, before a single `describe` ran, to read an environment variable. Both exports now live in `app/models/scratch.ts`, whose entire import list is `bun`, `node:fs`, `node:path`. The two suites that genuinely compare against Prisma (`differential.test.ts`, `writes.differential.test.ts`) still import the harness, because they use it.

**This does not claim to be the cause.** It has not been reproduced — not in the ~45 runs #217 records, and not in 50 more this round (30 plain, 15 under 2× CPU oversubscription, 20 after the change), which is why the issue's own recommendation was to stop guessing. It is the one suspect that could be removed for free, in the phase where a failure costs the whole file's tests rather than one of them, and it is worth doing whether or not it is the fault: eleven workers now do not open a query engine to read `process.env`.

Honest about the size: in isolation the removed `require` is ~19ms per worker, and the suite's own `import` total is too noisy for that to show (5.0–6.1s before, 4.8–6.3s after, ten runs each). The exact claim is countable rather than timed — **eleven of thirteen suites no longer reach `@prisma/client` at collection**.

## Why the rule is asserted rather than written down

The regression is invisible. Adding `POSTGRES_URL` back to an existing `./differential` import is one word in a diff, nothing fails, and collection gets a little slower — and it is the edit an author makes for a good local reason, because the symbol is in a module they already import. So `packages/gemi/orm/template-import-graph.test.ts` fails if a suite imports the harness without calling `createDifferential`, and if `scratch.ts` ever imports anything beyond those three.

Mutation-checked in the direction that matters, by putting the old import back on the one file #217 is about:

```
FAIL  orm/template-import-graph.test.ts > the template's model suites >
      relations.many-to-many.test.ts imports the differential harness only to use it

AssertionError: relations.many-to-many.test.ts imports ./differential but never
calls createDifferential, so it pays for @prisma/client at collection time and
gets nothing for it. POSTGRES_URL and applyMigrations live in ./scratch.
```

It also asserts its own premises — that suites were found at all, and that `differential.ts` still imports `@prisma/client` — so a rename cannot quietly turn it into a tautology.

## If it recurs

The counts above are the diagnostic. The file-level line names the file; the **`Tests` line says which half of the run to look in**, and a job that greps for failing tests will see neither. The error text is in the log immediately under the `FAIL` line — that is what is still missing, and nothing here substitutes for it.

## Checks

- `bun --bun vitest run app/models` (template, `TZ=UTC`) — **17 passed | 3 skipped (20)**, `640 passed | 32 skipped (672)`; 20 consecutive runs clean
- `bun --bun vitest run` with CI's six exclusions (`packages/gemi`) — **66 files, 1579 passed | 1 skipped**
- `bun run test:types` (template) — 24 passed, no type errors
- `bun run typecheck` (`packages/gemi`) exit 0; `oxlint` clean on both new files (the 6 warnings in `app/models` are pre-existing, in `bench/run.ts` and `select.test-d.ts`)

Postgres was not run — no scratch database here. The change is import-graph only and the gating expressions are untouched, so `postgres-suite-selection.test.ts` still matches all three gated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
