### PR TITLE
Every cuid invariant except length and prefix was unguarded

### DIFF
--- a/packages/gemi/orm/defaults.test.ts
+++ b/packages/gemi/orm/defaults.test.ts
@@ -1,0 +1,365 @@
+import { beforeAll, describe, expect, test, vi } from "vitest";
+
+import {
+  clientSideValue,
+  createCuid,
+  hasClientSideValue,
+  isClientSideDefault,
+} from "./defaults";
+import type { DefaultKind, FieldSchema } from "./schema";
+
+/**
+ * `defaults.ts` had four exports and no test naming any of them (#258).
+ *
+ * `createCuid` ran — making it throw failed ten tests in `compile/write.test.ts`
+ * — but exactly one assertion constrained what it produced, incidental to a
+ * plan-cache test about something else:
+ *
+ * ```
+ * expect(String(first[0])).toMatch(/^c[a-z0-9]{24}$/);
+ * ```
+ *
+ * Prefix, charset, length. Five mutations run against the unit suite and the
+ * template suite; the two the regex can see died, and three lived:
+ *
+ * | mutation                                         |          |
+ * |--------------------------------------------------|----------|
+ * | drop the `c` prefix                              | killed   |
+ * | halve the random suffix                          | killed   |
+ * | `counter++` becomes `0`                          | survived |
+ * | fingerprint per-call rather than per-process     | survived |
+ * | `byte >= 252` becomes `byte >= 256`              | survived |
+ *
+ * Every mutation that stayed 25 characters of lowercase alphanumeric survived
+ * both suites. None of the three is a collision risk on its own — that is the
+ * point. They are the layers that are there *because* the other layers are
+ * probabilistic, and each could be removed without a single test changing
+ * colour.
+ *
+ * This file is not a proposal to change `defaults.ts`. The module looks right:
+ * the resample bound is correct, the counter is module-scoped, the fingerprint
+ * is per-process. This is about noticing if that stops being true.
+ */
+
+// The block widths are fixed, so a cuid can be taken apart by position. Sliced
+// from the *end* rather than the front, because the timestamp is the one block
+// whose width is not a constant — `Date.now().toString(36)` is eight characters
+// until 2059 and nine after it, and a test that would start failing on a date is
+// not a test of anything here.
+const RANDOM = -8;
+const FINGERPRINT = -12;
+const COUNTER = -16;
+
+const fingerprintOf = (cuid: string) => cuid.slice(FINGERPRINT, RANDOM);
+const randomOf = (cuid: string) => cuid.slice(RANDOM);
+const counterOf = (cuid: string) =>
+  Number.parseInt(cuid.slice(COUNTER, FINGERPRINT), 36);
+
+describe("createCuid emits the shape Prisma 6.19.2 emits", () => {
+  test("prefix, charset and length", () => {
+    expect(createCuid()).toMatch(/^c[0-9a-z]{24}$/);
+  });
+
+  /**
+   * The timestamp is the only block with a meaning outside the id, and the only
+   * one that pins where the other three start. A cuid minted now decodes to now.
+   */
+  test("the timestamp block is base-36 milliseconds", () => {
+    const before = Date.now();
+    const cuid = createCuid();
+    const after = Date.now();
+
+    const timestamp = Number.parseInt(cuid.slice(1, COUNTER), 36);
+
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+});
+
+/**
+ * The counter's own comment states the invariant:
+ *
+ * > is what keeps two cuids minted in the same millisecond distinct, so it must
+ * > not be reset or made per-call.
+ *
+ * Nothing checked it. Freezing it at `0` does not by itself produce a collision
+ * — eight characters of randomness follow it — which is exactly why no existing
+ * assertion could see the difference. What it removes is the one field in the id
+ * that is *not* probabilistic, silently.
+ */
+describe("the counter is monotonic within the process", () => {
+  test("it advances by one between consecutive ids", () => {
+    const counters = Array.from({ length: 5 }, () => counterOf(createCuid()));
+
+    for (let i = 1; i < counters.length; i++) {
+      expect(counters[i]).toBe(counters[i - 1] + 1);
+    }
+  });
+
+  /**
+   * The failure being guarded is two ids minted in the same millisecond, so mint
+   * them in the same millisecond: with the clock held still the counter is the
+   * only field that has to keep them apart, and it is compared on its own rather
+   * than through the whole id, which the random blocks would carry regardless.
+   */
+  test("ids minted in one millisecond differ in the counter", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    try {
+      const first = createCuid();
+      const second = createCuid();
+
+      expect(first.slice(1, COUNTER)).toBe(second.slice(1, COUNTER));
+      expect(counterOf(second)).toBe(counterOf(first) + 1);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  /** Rolls over at one block's worth of values, so it always pads to four. */
+  test("the counter block is four characters", () => {
+    expect(createCuid().slice(COUNTER, FINGERPRINT)).toHaveLength(4);
+  });
+});
+
+/**
+ * Per-call randomness in the fingerprint's position carries the same entropy, so
+ * this is not a collision risk either. What it destroys is process identity —
+ * the field someone diagnosing a duplicate reads first, and the one the module
+ * chose deliberately over cuid v1's pid+hostname and explains at length. Made
+ * per-call it would still be four characters of the right alphabet, and it would
+ * be lying.
+ */
+describe("the fingerprint identifies the process", () => {
+  test("it is the same across every id in this process", () => {
+    const fingerprints = new Set(
+      Array.from({ length: 100 }, () => fingerprintOf(createCuid())),
+    );
+
+    expect(fingerprints.size).toBe(1);
+  });
+
+  /**
+   * The other half: constant is not enough, it has to be *this process's*. A
+   * literal would satisfy the test above forever.
+   *
+   * Fresh module instances stand in for fresh processes. Five of them, asserting
+   * only that they are not all equal — two would be a one-in-1.68-million flake,
+   * five is (1/36^4)^4, and a hardcoded fingerprint still yields exactly one
+   * distinct value.
+   */
+  test("a fresh process gets a different one", async () => {
+    const fingerprints = new Set<string>();
+    for (let i = 0; i < 5; i++) {
+      vi.resetModules();
+      const fresh = await import("./defaults");
+      fingerprints.add(fingerprintOf(fresh.createCuid()));
+    }
+
+    expect(fingerprints.size).toBeGreaterThan(1);
+  });
+});
+
+/**
+ * 256 is not a multiple of 36 — it is 7*36 + 4 — so `byte % 36` without the
+ * resample delivers the first four symbols of the alphabet 8 times in 256 and
+ * the other thirty-two 7 times in 256. That is 12.5% above uniform for `0123`,
+ * and it is invisible to any assertion about a single id.
+ *
+ * The exact kind of loop that gets "simplified" by someone reading
+ * `while (byte >= 252)` as arbitrary, which is why it is worth a frequency test.
+ */
+describe("the random blocks are not biased toward the low symbols", () => {
+  // Two random blocks per id, four symbols each. The fingerprint is drawn from
+  // the same generator but is one fixed sample, so counting it would swamp the
+  // distribution with a single draw repeated 25,000 times.
+  const IDS = 25_000;
+  const SYMBOLS = IDS * 8;
+  const BIASED = "0123";
+
+  let counts: Map<string, number>;
+  let lowShare: number;
+
+  beforeAll(() => {
+    counts = new Map();
+    for (let i = 0; i < IDS; i++) {
+      for (const symbol of randomOf(createCuid())) {
+        counts.set(symbol, (counts.get(symbol) ?? 0) + 1);
+      }
+    }
+
+    const low = [...BIASED].reduce((sum, s) => sum + (counts.get(s) ?? 0), 0);
+    lowShare = low / SYMBOLS;
+  });
+
+  /**
+   * Sized so it is not a flaky test rather than sized to just catch the mutant.
+   * Under a uniform draw the share of `0123` is 4/36 = 0.1111 with a standard
+   * deviation of 0.00031 over 200,000 symbols; the unresampled distribution sits
+   * at 32/256 = 0.125, which is 44 standard deviations away. A window of ±0.004
+   * is 12.7 sd of headroom in each direction and still nowhere near the mutant.
+   */
+  test("the four low symbols hold their uniform share", () => {
+    expect(lowShare).toBeGreaterThan(4 / 36 - 0.004);
+    expect(lowShare).toBeLessThan(4 / 36 + 0.004);
+  });
+
+  /** Nothing is dropped either: the resample must not truncate the alphabet. */
+  test("all 36 symbols appear", () => {
+    expect(counts.size).toBe(36);
+  });
+});
+
+/**
+ * `autoincrement()` and `dbgenerated(...)` stay with the database; everything
+ * else gemi supplies. Written as an exhaustive record so that adding a
+ * `DefaultKind` without deciding which side of the split it falls on is a type
+ * error rather than an untested branch.
+ */
+describe("isClientSideDefault splits gemi's defaults from the database's", () => {
+  const expected: Record<DefaultKind, boolean> = {
+    autoincrement: false,
+    dbgenerated: false,
+    cuid: true,
+    uuid: true,
+    now: true,
+    value: true,
+  };
+
+  test.each(Object.entries(expected))("%s -> %s", (kind, isClientSide) => {
+    expect(isClientSideDefault({ kind: kind as DefaultKind })).toBe(
+      isClientSide,
+    );
+  });
+});
+
+const field = (over: Partial<FieldSchema> = {}): FieldSchema => ({
+  name: "field",
+  column: "field",
+  type: "String",
+  nullable: false,
+  isId: false,
+  isUpdatedAt: false,
+  ...over,
+});
+
+describe("hasClientSideValue asks which fields gemi must fill in", () => {
+  test("a client-side default", () => {
+    expect(hasClientSideValue(field({ default: { kind: "cuid" } }))).toBe(true);
+  });
+
+  test("a database-side default", () => {
+    expect(
+      hasClientSideValue(
+        field({ type: "Int", isId: true, default: { kind: "autoincrement" } }),
+      ),
+    ).toBe(false);
+  });
+
+  test("no default at all", () => {
+    expect(hasClientSideValue(field({ nullable: true }))).toBe(false);
+  });
+
+  /**
+   * `@updatedAt` carries no `@default` and no database default — Prisma sets it
+   * in the client, on create as well as on update, so a row inserted without it
+   * violates a NOT NULL constraint. It is the one field here that has to be
+   * recognised by its attribute rather than by its default.
+   */
+  test("@updatedAt, which has no default", () => {
+    expect(
+      hasClientSideValue(field({ type: "DateTime", isUpdatedAt: true })),
+    ).toBe(true);
+  });
+});
+
+describe("clientSideValue produces one field's value", () => {
+  const now = new Date("2024-03-01T12:00:00.000Z");
+
+  test("cuid", () => {
+    expect(
+      String(clientSideValue(field({ default: { kind: "cuid" } }), now)),
+    ).toMatch(/^c[0-9a-z]{24}$/);
+  });
+
+  test("uuid", () => {
+    expect(
+      String(clientSideValue(field({ default: { kind: "uuid" } }), now)),
+    ).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test.each(["cuid", "uuid"] as const)("a %s is minted per call", (kind) => {
+    const one = clientSideValue(field({ default: { kind } }), now);
+    const two = clientSideValue(field({ default: { kind } }), now);
+
+    expect(one).not.toBe(two);
+  });
+
+  test("a literal is passed through", () => {
+    const spec = { kind: "value", value: false } as const;
+
+    expect(
+      clientSideValue(field({ type: "Boolean", default: spec }), now),
+    ).toBe(false);
+  });
+
+  test.each(["autoincrement", "dbgenerated"] as const)(
+    "%s is the database's business",
+    (kind) => {
+      expect(
+        clientSideValue(field({ default: { kind } }), now),
+      ).toBeUndefined();
+    },
+  );
+
+  test("a field with no default and no @updatedAt", () => {
+    expect(clientSideValue(field({ nullable: true }), now)).toBeUndefined();
+  });
+
+  /**
+   * The comment in `defaults.ts` says so in as many words — "`@updatedAt` wins
+   * over any `@default`: Prisma stamps it on every write, which is the entire
+   * point of the attribute" — and nothing checked it. A field carrying both
+   * would have silently taken the default's value instead.
+   */
+  test("@updatedAt beats a @default on the same field", () => {
+    const both = field({
+      type: "DateTime",
+      isUpdatedAt: true,
+      default: { kind: "now" },
+    });
+
+    expect(clientSideValue(both, now)).toBe(now);
+  });
+
+  test("@updatedAt beats even a @default that is not a timestamp", () => {
+    const both = field({
+      type: "DateTime",
+      isUpdatedAt: true,
+      default: { kind: "value", value: "never" },
+    });
+
+    expect(clientSideValue(both, now)).toBe(now);
+  });
+
+  /**
+   * The behaviour the module header records as verified against Prisma 6.19.2
+   * rather than assumed: a `create` there returns `createdAt` and `updatedAt` as
+   * the *same instant*. That is why `now` is resolved once per logical operation
+   * and passed in, and it was the reason with no test behind it.
+   *
+   * Identity, not equality — reading the clock per field would still produce
+   * two dates that compare equal most of the time, and differ under load.
+   */
+  test("now is one instant across every field of an operation", () => {
+    const createdAt = field({ type: "DateTime", default: { kind: "now" } });
+    const updatedAt = field({ type: "DateTime", isUpdatedAt: true });
+
+    expect(clientSideValue(createdAt, now)).toBe(now);
+    expect(clientSideValue(updatedAt, now)).toBe(now);
+    expect(clientSideValue(createdAt, now)).toBe(
+      clientSideValue(updatedAt, now),
+    );
+  });
+});


### PR DESCRIPTION
Closes #258.

`defaults.ts` had four exports and no test naming any of them. `createCuid` was covered *indirectly* — making it throw fails ten tests in `compile/write.test.ts` — so it ran. What ran **on** it was one assertion, incidental to a plan-cache test that is really about something else:

```
expect(String(first[0])).toMatch(/^c[a-z0-9]{24}$/);
```

Prefix, charset, length. Nothing about the structure those 24 characters have, which is the part the module documents at length.

## Reproduced before writing anything

Five mutations, each run against the unit suite and the template suite:

| mutation | unit | template |
|---|---|---|
| drop the `c` prefix | killed | — |
| halve the random suffix | killed | — |
| **`counter++` → `0`** | **1579 passed** | **640 passed** |
| **fingerprint per-call, not per-process** | **1579 passed** | **640 passed** |
| **`byte >= 252` → `byte >= 256`** | **1579 passed** | **640 passed** |

The two that die are the two the regex can see. Every mutation that stays 25 characters of lowercase alphanumeric survives both suites untouched — same counts as a clean run.

Worth being precise about severity, because none of the three is a collision on its own:

- **The counter** is the one field in the id that is *not* probabilistic, and its own comment states the invariant — *"must not be reset or made per-call"*. Freezing it does not by itself collide; eight characters of randomness follow. It removes a layer that is there *because* the other layers are probabilistic, silently.
- **The fingerprint** carries the same entropy per-call as per-process. What per-call destroys is process identity — the field someone diagnosing a duplicate reads first, chosen deliberately over cuid v1's pid+hostname and explained at length. Made per-call it would still be four right-looking characters, and it would be lying.
- **The bias resample.** 256 is 7×36+4, so without it the first four symbols of the alphabet arrive 8 times in 256 against the others' 7 — 12.5% above uniform. Invisible to any assertion about a single id, and exactly the loop that gets "simplified" by someone reading `while (byte >= 252)` as arbitrary.

## What the new file pins

`defaults.test.ts`, 30 tests, no change to `defaults.ts`. The module is right — the resample bound is correct, the counter is module-scoped, the fingerprint is per-process. This is about noticing if that stops being true.

The block widths are fixed, so the id is taken apart by position — **from the end**, not the front. The timestamp is the one block whose width is not a constant (`Date.now().toString(36)` is eight characters until 2059 and nine after), and a test that starts failing on a date is not a test of anything here.

- **counter** — advances by exactly one between consecutive ids; and with `Date.now` held still, two ids minted in the same millisecond share a timestamp block and differ in the counter, which is the failure the field exists for. Compared on the counter alone rather than through the whole id, which the random blocks would keep distinct regardless.
- **fingerprint** — identical across 100 ids in this process, *and* different in a fresh one. Constant is not enough: a hardcoded literal satisfies the first half forever. Five `vi.resetModules()` instances stand in for five processes, asserting only that they are not all equal — a hardcoded value yields exactly one distinct fingerprint, and the flake probability is (1/36⁴)⁴.
- **bias** — a frequency check over 200,000 random symbols (25,000 ids × 8; the fingerprint is excluded, being one draw repeated). Sized not to be flaky rather than sized to just catch the mutant: uniform puts the share of `0123` at 4/36 = 0.1111 with sd 0.00031, the unresampled distribution sits at 0.125 — **44 sd away** — so the window is ±0.004, 12.7 sd of headroom each way. Over 40 sampling runs the observed share ranged **0.1095–0.1125**; the mutant measured **0.1242**. Plus: all 36 symbols still appear, so the resample cannot truncate the alphabet.
- **timestamp** — decodes to base-36 milliseconds bracketed by `Date.now()` either side of the call, which is what pins where the other three blocks start.
- **`isClientSideDefault`** — an exhaustive `Record<DefaultKind, boolean>`, so a new kind added without deciding which side of the split it falls on is a type error rather than an untested branch.
- **`hasClientSideValue`** — client-side default, database-side default, no default, and `@updatedAt`, which is the one field recognised by its attribute rather than by its default.
- **`clientSideValue`** — that **`@updatedAt` beats a `@default`** on the same field (the code says so in a comment; nothing checked it), and that **`now` is the same instant** across every field of an operation — identity, not equality, since reading the clock per field would compare equal most of the time and differ under load. That is the behaviour the module header records as verified against Prisma 6.19.2, and it was the reason with no test behind it.

## Verification

Each mutation re-applied with the new file in place:

| mutation | `defaults.test.ts` |
|---|---|
| `counter++` → `0` | 2 failed |
| fingerprint per-call | 1 failed |
| fingerprint hardcoded | 1 failed |
| resample removed | 1 failed — `expected 0.124205 to be less than 0.1151` |
| timestamp not the clock | 1 failed |
| `dbgenerated` dropped from the split | 1 failed |
| `@updatedAt` early return removed | 2 failed |

The file was also run 15 times consecutively to check the frequency test is not flaky: 30/30 every time.

## Checks

- `bun --bun vitest run` (CI's exclusion set) — 67 files, **1609 passed** / 1 skipped
- template SQLite, `TZ=UTC` — 17 passed / 3 skipped, **640 tests**
- `bunx tsc --noEmit` exit 0, `bunx oxlint orm --deny-warnings` 0 warnings

One new file. Touches nothing else, so it is independent of anything else in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvWT1rfjgjbowF7Axua4fd
