### PR TITLE
Adopt prefetched data on navigation and make staleness configurable

### DIFF
--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -75,7 +75,7 @@ so a typo in a param or a wrong field type is a compile error.
 | `mutate(fn?)` | Optimistically update the cached data (see below), or refetch when called with no argument. |
 | `trigger()` | Kick off the fetch for a `lazy` query. |
 | `prefetch()` | Fetch once, eagerly, without subscribing to loading state (e.g. on hover). |
-| `version` | Monotonic counter that increments on each successful update. |
+| `version` | Timestamp that changes every time the cache receives data from the server, including a refetch that returns an identical payload and prefetched data adopted on navigation. |
 
 > The exported `QueryResult<T>` type is the inferred **data** type for endpoint
 > `T` (i.e. the type of `data`), not the whole hook return.
@@ -88,9 +88,17 @@ const { data } = useQuery("/feed", {}, {
   keepPreviousData: true,  // keep old data visible while refetching (default true)
   refreshInterval: 5000,   // poll every 5s
   retryIntervalOnError: 10000,
+  staleTime: 5000,         // how long cached data stays fresh (default 5000ms)
   lazy: false,             // when true, no fetch until trigger()/refetch()
 });
 ```
+
+`staleTime` controls when reading the cache triggers a background revalidation.
+Once cached data is older than `staleTime`, the next component that mounts and
+reads it kicks off a silent refetch. Raise it for data that rarely changes
+(`staleTime: 60_000`) to stop it being re-requested on every navigation, or set
+`staleTime: 0` to always revalidate. `Infinity` disables age-based revalidation
+entirely — `mutate()` and `refetch()` still fetch, since those are explicit.
 
 ### Optimistic updates with `mutate`
 
@@ -147,7 +155,11 @@ import { Query } from "gemi/facades";
   to resolve alongside the rest of the page, without returning the data for use here.
 
 Both take the same `{ params, search }` options as `useQuery`, and the stored data
-is matched to the client query by path + search key.
+is matched to the client query by path + search key. The stored data is adopted on
+every client-side navigation, not just the initial server render, so a layout that
+prefetches its endpoints keeps serving them from the payload without the browser
+re-requesting them over `/api`. Data currently being fetched — including the
+refetch behind an optimistic `mutate()` — is left alone rather than overwritten.
 
 > **Gotcha:** The `Query` facade can only be used from a **view/page request**, not
 > from an API request — calling it during an API request throws.

--- a/packages/gemi/client/ClientRouter.tsx
+++ b/packages/gemi/client/ClientRouter.tsx
@@ -16,7 +16,10 @@ import {
 } from "./ClientRouterContext";
 import type { ComponentTree } from "./types";
 import { ComponentsContext, ComponentsProvider } from "./ComponentContext";
-import { QueryManagerProvider } from "./QueryManagerContext";
+import {
+  QueryManagerContext,
+  QueryManagerProvider,
+} from "./QueryManagerContext";
 import { I18nProvider } from "./I18nContext";
 import { WebSocketContextProvider } from "./WebsocketContext";
 import { useNavigate } from "./useNavigate";
@@ -144,6 +147,7 @@ const Routes = (props: { componentTree: ComponentTree }) => {
   const [isPending, startTransition] = useTransition();
   const [isFetching, setIsFetching] = useState(false);
   const { routerSubject, fetchRouteCSS } = useContext(ClientRouterContext);
+  const { hydrate } = useContext(QueryManagerContext);
 
   const [transitionPath, setTransitionPath] = useState<[string, string]>([
     null,
@@ -255,6 +259,11 @@ const Routes = (props: { componentTree: ComponentTree }) => {
           });
         }
 
+        // Adopt what the server just prefetched before the new surface mounts
+        // and its queries read the cache, otherwise they refetch it over /api.
+        // Safe here: this callback is async, so we are past the render phase.
+        hydrate(prefetchedData);
+
         startTransition(() => {
           setRouteState({
             ...routerState,
@@ -268,7 +277,7 @@ const Routes = (props: { componentTree: ComponentTree }) => {
       }
       setIsFetching(false);
     });
-  }, [routerSubject, fetchRouteCSS, replace]);
+  }, [routerSubject, fetchRouteCSS, replace, hydrate]);
 
   return (
     <RouteTransitionProvider

--- a/packages/gemi/client/QueryManagerContext.tsx
+++ b/packages/gemi/client/QueryManagerContext.tsx
@@ -1,34 +1,68 @@
 import {
   createContext,
   type PropsWithChildren,
-  useContext,
+  useCallback,
+  useMemo,
   useRef,
 } from "react";
 import { QueryResource } from "./QueryResource";
 
-export const QueryManagerContext = createContext({
+export type PrefetchedData = Record<string, Record<string, any>>;
+
+export interface QueryManagerContextValue {
+  getResource: (
+    key: string,
+    initialState?: Record<string, any>,
+  ) => QueryResource;
+  hydrate: (prefetchedData?: PrefetchedData | null) => void;
+}
+
+export const QueryManagerContext = createContext<QueryManagerContextValue>({
   getResource: (key: string, initialState: Record<string, any> = {}) => {
     return new QueryResource(key, initialState);
   },
+  hydrate: () => {},
 });
 
 export const QueryManagerProvider = ({ children }: PropsWithChildren<{}>) => {
   const resourcesRef = useRef<Map<string, QueryResource>>(new Map());
 
+  const getResource = useCallback(
+    (key: string, initialState?: Record<string, any>) => {
+      let resource = resourcesRef.current.get(key);
+      if (!resource) {
+        resource = new QueryResource(key, initialState ?? {});
+        resourcesRef.current.set(key, resource);
+      }
+      return resource;
+    },
+    [],
+  );
+
+  // Resources are cached by path for the lifetime of the app, so `initialState`
+  // above only ever applies to the first load. Every navigation ships a fresh
+  // `prefetchedData` payload that has to be pushed into the existing resources,
+  // otherwise the components mounting on the new surface refetch it over `/api`.
+  const hydrate = useCallback((prefetchedData?: PrefetchedData | null) => {
+    if (!prefetchedData) return;
+    for (const [key, initialState] of Object.entries(prefetchedData)) {
+      if (!initialState || typeof initialState !== "object") continue;
+      const resource = resourcesRef.current.get(key);
+      if (resource) {
+        resource.hydrate(initialState);
+      } else {
+        resourcesRef.current.set(key, new QueryResource(key, initialState));
+      }
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ getResource, hydrate }),
+    [getResource, hydrate],
+  );
+
   return (
-    <QueryManagerContext.Provider
-      value={{
-        getResource: (key: string, initialState?: Record<string, any>) => {
-          if (!resourcesRef.current.has(key)) {
-            resourcesRef.current.set(
-              key,
-              new QueryResource(key, initialState ?? {}),
-            );
-          }
-          return resourcesRef.current.get(key);
-        },
-      }}
-    >
+    <QueryManagerContext.Provider value={value}>
       {children}
     </QueryManagerContext.Provider>
   );

--- a/packages/gemi/client/QueryResource.test.ts
+++ b/packages/gemi/client/QueryResource.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { DEFAULT_STALE_TIME, QueryResource } from "./QueryResource";
+
+const START = 1_700_000_000_000;
+
+/**
+ * `resolveVariant` bails out when `window` is undefined, and vitest runs with
+ * the default node environment, so every test needs a stub. `mutate` also reads
+ * `window.location.origin` while building its CacheStorage key.
+ */
+function stubWindow() {
+  (globalThis as any).window = { location: { origin: "https://example.test" } };
+}
+
+/**
+ * A `fetch` stub whose responses are resolved by the test, so the window
+ * between "request started" and "request landed" can be inspected.
+ */
+function createFetch() {
+  const pending: Array<(value: { ok: boolean; body: any }) => void> = [];
+  const fetchMock = vi.fn((_url: string, _init?: RequestInit) => {
+    return new Promise((resolve) => {
+      pending.push(({ ok, body }) =>
+        resolve({ ok, json: async () => body } as Response),
+      );
+    });
+  });
+  (globalThis as any).fetch = fetchMock;
+
+  return {
+    fetchMock,
+    urls: () => fetchMock.mock.calls.map(([url]) => url as string),
+    /** Resolve the oldest in-flight request and let the microtask queue drain. */
+    async resolve(body: any, ok = true) {
+      const settle = pending.shift();
+      if (!settle) throw new Error("No pending fetch to resolve");
+      settle({ ok, body });
+      await vi.waitFor(() => {});
+    },
+    pendingCount: () => pending.length,
+  };
+}
+
+/** Seed a resource the way SSR does, then let its initial fetch settle. */
+function seeded(key: string, initialState: Record<string, any>) {
+  return new QueryResource(key, initialState);
+}
+
+let net: ReturnType<typeof createFetch>;
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(START);
+  stubWindow();
+  net = createFetch();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete (globalThis as any).window;
+  delete (globalThis as any).fetch;
+});
+
+describe("getVariant staleTime", () => {
+  test("does not revalidate within the default window", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+
+    vi.setSystemTime(START + DEFAULT_STALE_TIME - 1);
+    resource.getVariant("");
+
+    expect(net.fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("revalidates once the default window elapses", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+
+    vi.setSystemTime(START + DEFAULT_STALE_TIME + 1);
+    resource.getVariant("");
+
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+    expect(net.urls()).toEqual(["/api/todos"]);
+  });
+
+  test("builds the variant into the request url", () => {
+    const resource = seeded("/todos", { "page=2": [{ id: 2 }] });
+
+    vi.setSystemTime(START + DEFAULT_STALE_TIME + 1);
+    resource.getVariant("page=2");
+
+    expect(net.urls()).toEqual(["/api/todos?page=2"]);
+  });
+
+  test("a larger staleTime suppresses the revalidation", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+
+    vi.setSystemTime(START + 30_000);
+    resource.getVariant("", 60_000);
+
+    expect(net.fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("a smaller staleTime triggers the revalidation", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+
+    vi.setSystemTime(START + 30_000);
+    resource.getVariant("", 10_000);
+
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("staleTime 0 always revalidates, even in the same tick", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+
+    resource.getVariant("", 0);
+
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("staleTime Infinity never revalidates on age", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+
+    vi.setSystemTime(START + 10_000_000);
+    resource.getVariant("", Number.POSITIVE_INFINITY);
+
+    expect(net.fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("staleTime gates only the age branch, not explicit staleness", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+    resource.staleVariants.add("");
+
+    resource.getVariant("", Number.POSITIVE_INFINITY);
+
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("hydrate", () => {
+  test("adopting fresh prefetched data prevents the refetch (issue #272)", async () => {
+    const resource = seeded("/organization", { "": { name: "Acme" } });
+
+    // Data ages past the stale window, as it does between two navigations.
+    vi.setSystemTime(START + 10_000);
+    resource.hydrate({ "": { name: "Acme Corp" } });
+
+    const state = resource.getVariant("");
+
+    expect(net.fetchMock).not.toHaveBeenCalled();
+    expect(state.data).toEqual({ name: "Acme Corp" });
+  });
+
+  test("writes every variant and notifies subscribers exactly once", () => {
+    const resource = seeded("/todos", {});
+    const subscriber = vi.fn();
+    resource.store.subscribe(subscriber);
+
+    resource.hydrate({ "": [{ id: 1 }], "page=2": [{ id: 2 }] });
+
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    const store = resource.store.getValue();
+    expect(store.get("")!.data).toEqual([{ id: 1 }]);
+    expect(store.get("page=2")!.data).toEqual([{ id: 2 }]);
+  });
+
+  test("skips a variant with a fetch in flight, and the network value wins", async () => {
+    const resource = seeded("/todos", {});
+
+    // Cold read starts a fetch and leaves the variant `loading`.
+    resource.getVariant("");
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+
+    resource.hydrate({ "": [{ id: "hydrated" }] });
+    expect(resource.store.getValue().get("")!.loading).toBe(true);
+    expect(resource.store.getValue().get("")!.data).toBeUndefined();
+
+    await net.resolve([{ id: "network" }]);
+    expect(resource.store.getValue().get("")!.data).toEqual([
+      { id: "network" },
+    ]);
+  });
+
+  test("skips a variant with an optimistic mutate in flight", () => {
+    const resource = seeded("/todos", { "": [{ id: 1, done: false }] });
+
+    resource.mutate("", (todos: any[]) =>
+      todos.map((t) => ({ ...t, done: true })),
+    );
+
+    resource.hydrate({ "": [{ id: 1, done: false }] });
+
+    const state = resource.store.getValue().get("")!;
+    expect(state.data).toEqual([{ id: 1, done: true }]);
+    // The pending refetch still needs to reconcile, so staleness must survive.
+    expect(resource.staleVariants.has("")).toBe(true);
+  });
+
+  test("clears the error and the stale flag for variants it writes", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+    const store = resource.store.getValue();
+    store.set("", {
+      loading: false,
+      data: [{ id: 1 }],
+      error: { message: "boom" },
+      version: 1,
+    });
+    resource.staleVariants.add("");
+
+    resource.hydrate({ "": [{ id: 2 }] });
+
+    expect(resource.store.getValue().get("")!.error).toBeNull();
+    expect(resource.staleVariants.has("")).toBe(false);
+  });
+
+  test("resets lastFetchRecord and stamps a fresh version", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+    const originalVersion = resource.store.getValue().get("")!.version;
+
+    vi.setSystemTime(START + 60_000);
+    resource.hydrate({ "": [{ id: 2 }] });
+
+    expect(resource.lastFetchRecord.get("")).toBe(START + 60_000);
+    expect(resource.store.getValue().get("")!.version).toBe(START + 60_000);
+    expect(resource.store.getValue().get("")!.version).not.toBe(
+      originalVersion,
+    );
+  });
+
+  test("ignores empty, nullish and falsy payloads without notifying", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+    const subscriber = vi.fn();
+    resource.store.subscribe(subscriber);
+
+    resource.hydrate(undefined);
+    resource.hydrate(null);
+    resource.hydrate({});
+    resource.hydrate({ "": null });
+
+    expect(subscriber).not.toHaveBeenCalled();
+    expect(resource.store.getValue().get("")!.data).toEqual([{ id: 1 }]);
+  });
+
+  test("re-hydrating the identical data reference is a no-op", () => {
+    const data = [{ id: 1 }];
+    const resource = seeded("/todos", { "": data });
+    const subscriber = vi.fn();
+    resource.store.subscribe(subscriber);
+
+    resource.hydrate({ "": data });
+
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  test("matches the constructor, which now delegates to it", () => {
+    const initialState = { "": [{ id: 1 }], "page=2": [{ id: 2 }] };
+
+    const viaConstructor = new QueryResource("/todos", initialState);
+    const viaHydrate = new QueryResource("/todos", {});
+    viaHydrate.hydrate(initialState);
+
+    expect([...viaHydrate.store.getValue()]).toEqual([
+      ...viaConstructor.store.getValue(),
+    ]);
+    expect([...viaHydrate.lastFetchRecord]).toEqual([
+      ...viaConstructor.lastFetchRecord,
+    ]);
+  });
+});

--- a/packages/gemi/client/QueryResource.ts
+++ b/packages/gemi/client/QueryResource.ts
@@ -7,6 +7,8 @@ type State = {
   version: number;
 };
 
+export const DEFAULT_STALE_TIME = 5000;
+
 export class QueryResource {
   store: Subject<Map<string, State>>;
   staleVariants = new Set<string>();
@@ -15,23 +17,50 @@ export class QueryResource {
 
   constructor(key: string, initialState: Record<string, any>) {
     this.key = key;
-    const store = new Map();
-    const now = Date.now();
-    for (const [variantKey, data] of Object.entries(initialState ?? {})) {
-      if (data) {
-        store.set(variantKey, {
-          loading: false,
-          data,
-          error: null,
-        });
-        this.lastFetchRecord.set(variantKey, now);
-      }
-    }
-
-    this.store = new Subject(store);
+    this.store = new Subject(new Map());
+    this.hydrate(initialState);
   }
 
-  getVariant(variantKey: string) {
+  /**
+   * Adopt server-prefetched data into the cache.
+   *
+   * Called once from the constructor for the SSR payload, and again on every
+   * client-side navigation with the `prefetchedData` the server just produced —
+   * otherwise the resource cache (which is keyed by path for the lifetime of
+   * the app) would keep serving the first payload and revalidate it over `/api`.
+   */
+  hydrate(initialState: Record<string, any> | null | undefined) {
+    const store = this.store.getValue();
+    const now = Date.now();
+    let changed = false;
+
+    for (const [variantKey, data] of Object.entries(initialState ?? {})) {
+      if (!data) continue;
+      const current = store.get(variantKey);
+      // Never clobber an in-flight fetch — `resolveVariant` flips `loading`
+      // before its first await, so this also covers an optimistic `mutate`
+      // whose refetch hasn't landed yet.
+      if (current?.loading) continue;
+      // Idempotent re-hydration (e.g. StrictMode's double invoke).
+      if (current && current.data === data) continue;
+
+      store.set(variantKey, {
+        loading: false,
+        data,
+        error: null,
+        version: now,
+      });
+      this.staleVariants.delete(variantKey);
+      this.lastFetchRecord.set(variantKey, now);
+      changed = true;
+    }
+
+    if (changed) {
+      this.store.next(store);
+    }
+  }
+
+  getVariant(variantKey: string, staleTime: number = DEFAULT_STALE_TIME) {
     const store = this.store.getValue();
     if (!store.has(variantKey)) {
       this.resolveVariant(variantKey);
@@ -47,9 +76,10 @@ export class QueryResource {
         if (variant.data) {
           const stale = this.staleVariants.has(variantKey);
           const now = Date.now();
-          // TODO: age must be dynamic
+          // `>=` so `staleTime: 0` means "always revalidate" and
+          // `staleTime: Infinity` means "never".
           const old =
-            now - (this.lastFetchRecord.get(variantKey) ?? now) > 5000;
+            now - (this.lastFetchRecord.get(variantKey) ?? now) >= staleTime;
           if (stale || old) {
             this.lastFetchRecord.set(variantKey, now);
             this.resolveVariant(variantKey, true);

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -5,6 +5,7 @@ import type { NestedPrettify } from "../utils/type";
 import type { ApiRouterHandler } from "../http/ApiRouter";
 import type { UnwrapPromise } from "../utils/type";
 import { QueryManagerContext } from "./QueryManagerContext";
+import { DEFAULT_STALE_TIME } from "./QueryResource";
 import { applyParams } from "../utils/applyParams";
 import type { UrlParser } from "./types";
 import { omitNullishValues } from "../utils/omitNullishValues";
@@ -17,6 +18,8 @@ interface Config<T> {
   keepPreviousData?: boolean;
   retryIntervalOnError?: number;
   refreshInterval?: number;
+  /** How long cached data stays fresh before a read revalidates it, in ms. */
+  staleTime?: number;
   debug?: boolean;
   lazy?: boolean;
   refetchUntil?: (data: T, duration: number) => number;
@@ -31,6 +34,7 @@ const defaultConfig: Config<any> = {
   keepPreviousData: true,
   retryIntervalOnError: 10000,
   refreshInterval: 999999,
+  staleTime: DEFAULT_STALE_TIME,
   debug: false,
   lazy: false,
 };
@@ -101,7 +105,7 @@ export function useQuery<T extends keyof GetRPC>(
     if (lazy) {
       return { loading: false, data: null, error: null, version: 0 };
     }
-    return resource.getVariant(variantKey);
+    return resource.getVariant(variantKey, config.staleTime);
   });
 
   const retry = useCallback(
@@ -110,7 +114,7 @@ export function useQuery<T extends keyof GetRPC>(
         if (configRef.current.debug) console.log("retrying", vk);
         retryingMap.current.set(vk, true);
         retryIntervalRef.current = setTimeout(() => {
-          resource.getVariant(vk);
+          resource.getVariant(vk, configRef.current.staleTime);
           retryingMap.current.set(vk, false);
         }, configRef.current.retryIntervalOnError);
       }
@@ -120,19 +124,29 @@ export function useQuery<T extends keyof GetRPC>(
 
   useEffect(() => {
     if (paramsKey !== paramsRef.current) {
-      setResource(getResource(normalPath));
+      // Pass `fallbackData` so a params change into a route the server already
+      // prefetched is served from the payload instead of a fresh request, and
+      // read the variant off the *next* resource — `resource` still points at
+      // the previous params' resource until React applies `setResource`.
+      const nextResource = getResource(normalPath, fallbackData);
+      setResource(nextResource);
       if (fetchedRef.current) {
-        setState(resource.getVariant(variantKey));
+        setState(
+          nextResource.getVariant(variantKey, configRef.current.staleTime),
+        );
       }
       paramsRef.current = paramsKey;
     }
-  }, [paramsKey, normalPath, variantKey, getResource, resource]);
+  }, [paramsKey, normalPath, variantKey, getResource, fallbackData]);
 
   const handleReload = useCallback(() => {
     if (configRef.current.debug) {
       console.log("Reloading query for", variantKey);
     }
-    const data = resource.getVariant(variantKey).data;
+    const data = resource.getVariant(
+      variantKey,
+      configRef.current.staleTime,
+    ).data;
     resource.mutate(variantKey, () => data);
   }, [variantKey, resource]);
 
@@ -201,7 +215,9 @@ export function useQuery<T extends keyof GetRPC>(
 
   useEffect(() => {
     if (fetchedRef.current) {
-      handleStateUpdate(resource.getVariant(variantKey));
+      handleStateUpdate(
+        resource.getVariant(variantKey, configRef.current.staleTime),
+      );
     }
     const unsub = resource.store.subscribe((store) => {
       const variant = store.get(variantKey);


### PR DESCRIPTION
Fixes #272.

Layout prefetches were only ever useful on the initial SSR load. After that the client threw the payload away and re-fetched it over `/api` on essentially every navigation — so the app paid for the data on the server and then paid again in the browser, with the `/api` calls starting only *after* the nav JSON landed and the new view mounted.

Scope note: this is fixes **1 and 2** from the issue. Both are client-only with no wire-protocol change. Fix 3 (server-side partial rendering — skipping unchanged `exec[]` segments) is left for a separate PR.

## Cause 1 — the client discarded `prefetchedData` after the first load

`prefetchedData` only entered the query cache through the `QueryResource` **constructor**, and `QueryManagerProvider` caches resources by path for the lifetime of the app. So on every navigation after the first, `getResource(key, initialState)` found an existing resource and dropped the freshly-prefetched payload.

- `QueryResource#hydrate(initialState)` writes a payload into an already-live resource: it stamps `lastFetchRecord`, clears `staleVariants`, and emits a single `store.next()` so components that persist across the navigation (a layout-level `useQuery` whose path and variant didn't change) actually see the new data — they never re-run their state initializer, so the subscription is their only channel.
- The constructor now delegates to `hydrate`. Free fix: SSR-seeded variants previously omitted `version` entirely, despite `State.version` being declared required.
- `QueryManagerContext` exposes `hydrate(prefetchedData)`, fanning out to `resourcesRef` and creating resources it doesn't have yet. Both members are `useCallback`-stable and the value memoized — required, since `hydrate` is now a dependency of the router subscription effect.
- `ClientRouter` calls it in the `routerSubject.subscribe` callback, immediately before `startTransition`. That's after the redirect early-return, and past the render phase because the callback is async — so it lands before the new surface mounts and reads the cache.

Hydration **skips any variant with a request in flight**, which also covers the refetch behind an optimistic `mutate`: `resolveVariant` flips `loading` synchronously before its first `await`, so from the moment `mutate()` returns, hydrate leaves that variant alone and the optimistic value survives.

## Cause 2 — the hardcoded 5s revalidation

`getVariant` revalidated anything older than a hardcoded `5000` (the standing `// TODO: age must be dynamic`), so any component mounting on the newly-entered surface fired a request from its `useState` initializer.

That threshold is now the `staleTime` config option on `useQuery`, defaulting to the same `5000` so existing behavior is unchanged. It's per-call rather than per-resource: a `QueryResource` is shared by every component querying that path, so per-resource storage would be "whichever component mounted first wins". The comparison is `>=` so `staleTime: 0` means "always revalidate" and `Infinity` means "never"; `refetch()` and `mutate()` still fetch regardless, since those are explicit.

## Also fixed

The params-changed effect in `useQuery` dropped `fallbackData` entirely (so navigating to a params variant the server *had* prefetched still triggered a request) and read the variant off the **previous** params' resource, seeding the new render with the old path's data and kicking off a background refetch of a URL nobody was looking at.

## Testing

New `packages/gemi/client/QueryResource.test.ts` — 17 tests, the first under `client/`. `QueryResource` is a plain class with no React dependency, so it covers the whole logic change directly.

Notable cases: the #272 regression itself (hydrate past the stale window ⇒ no refetch), each `staleTime` boundary including `0` and `Infinity`, `staleTime` gating only the age branch and not explicit staleness, the skip-if-loading rule with the network value still winning afterwards, the optimistic-mutate interaction (value survives **and** `staleVariants` is left intact), and constructor/`hydrate` equivalence to guard the delegation refactor.

Verification: 17/17 pass. `tsc` and `tsc -p tsconfig.browser.json` are clean. The 7 pre-existing test failures under `app/`, `services/router/`, and `utils/` are unchanged — confirmed identical against a pristine `HEAD` worktree (179 → 196 passing, same 7 failures).

React-level tests for the context, router call site, and hook wiring would need `jsdom` + `@testing-library/react` plus a vitest config file; that's separate infrastructure work.

## Worth a follow-up

- `facades/Prefetch.ts:59-61` **replaces** rather than merges the variant record: `prefetchedResources.set(path, { [variantKey]: data })`. Two prefetches of the same path with different `search` leave only the last, which caps how much `hydrate` can deliver for multi-variant prefetches. One-line server-side fix.
- `useQuery.ts:85` conflates two shapes — `config.fallbackData ?? prefetchedData?.[normalPath]` is passed as `initialState` (a `Record<variantKey, data>`), but a user-supplied `fallbackData` is the raw data, so `fallbackData: { items: [...] }` registers a bogus variant named `"items"`. Pre-existing.
- A `lazy` query that has never been triggered will now receive hydrated data via the subscription. Consistent with existing shared-cache behavior (another component's fetch of the same resource already does this), but noting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)