### PR TITLE
Stop useQuery fetching from the render phase

### DIFF
--- a/packages/gemi/client/QueryResource.test.ts
+++ b/packages/gemi/client/QueryResource.test.ts
@@ -267,3 +267,60 @@ describe("hydrate", () => {
     ]);
   });
 });
+
+describe("peek", () => {
+  test("returns the cached state", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+
+    expect(resource.peek("")).toEqual(resource.store.getValue().get(""));
+  });
+
+  test("returns undefined for a variant that was never fetched", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+
+    expect(resource.peek("page=2")).toBeUndefined();
+    expect(net.fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("does not fetch for a cold variant, where getVariant would", () => {
+    const resource = seeded("/todos", {});
+
+    resource.peek("");
+    expect(net.fetchMock).not.toHaveBeenCalled();
+
+    resource.getVariant("");
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not revalidate data past its stale window, where getVariant would", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+    vi.setSystemTime(START + DEFAULT_STALE_TIME + 1);
+
+    expect(resource.peek("")!.data).toEqual([{ id: 1 }]);
+    expect(net.fetchMock).not.toHaveBeenCalled();
+
+    resource.getVariant("");
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not revalidate a variant flagged stale, where getVariant would", () => {
+    const resource = seeded("/todos", { "": [{ id: 1 }] });
+    resource.staleVariants.add("");
+
+    resource.peek("");
+    expect(net.fetchMock).not.toHaveBeenCalled();
+    expect(resource.staleVariants.has("")).toBe(true);
+  });
+
+  test("never writes to the store", () => {
+    const resource = seeded("/todos", {});
+    const subscriber = vi.fn();
+    resource.store.subscribe(subscriber);
+
+    resource.peek("");
+    resource.peek("page=2");
+
+    expect(resource.store.getValue().size).toBe(0);
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gemi/client/QueryResource.ts
+++ b/packages/gemi/client/QueryResource.ts
@@ -60,6 +60,21 @@ export class QueryResource {
     }
   }
 
+  /**
+   * The cached state for a variant, or `undefined` — a plain read that never
+   * fetches and never revalidates.
+   *
+   * `getVariant` is the read that keeps the cache honest, and it starts a
+   * request when it has to. That makes it the wrong thing to call while
+   * rendering: React throws away a render whose subtree suspends and retries
+   * it, so every discarded attempt would leak a request. Renders read with
+   * this; effects, which only run for a render that committed, use
+   * `getVariant`.
+   */
+  peek(variantKey: string) {
+    return this.store.getValue().get(variantKey);
+  }
+
   getVariant(variantKey: string, staleTime: number = DEFAULT_STALE_TIME) {
     const store = this.store.getValue();
     if (!store.has(variantKey)) {

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -105,7 +105,20 @@ export function useQuery<T extends keyof GetRPC>(
     if (lazy) {
       return { loading: false, data: null, error: null, version: 0 };
     }
-    return resource.getVariant(variantKey, config.staleTime);
+    // Seed from the cache without touching the network — the mount effect below
+    // calls `getVariant`, which is what fetches and revalidates. Fetching here
+    // instead would fire a request for renders React discards: a layout renders
+    // once per suspending descendant, and each attempt gets fresh hook state,
+    // including a fresh `QueryResource`, so the in-flight guard cannot dedupe
+    // them.
+    return (
+      resource.peek(variantKey) ?? {
+        loading: true,
+        data: null,
+        error: null,
+        version: 0,
+      }
+    );
   });
 
   const retry = useCallback(


### PR DESCRIPTION
A `useQuery` in a layout component hits the server once per suspending descendant, on every page load, in production. Found while building the partial-rendering demo in #275; independent of it, so it goes on its own branch off main.

## Cause

`useQuery` seeded its state with `resource.getVariant(...)` inside a `useState` initializer — the render phase. `getVariant` is the read that keeps the cache honest, so it starts a request when the variant is cold or stale.

React throws away a render whose subtree suspends and retries it. Views are lazy, so a layout renders once per suspending descendant, and **each attempt leaks a request**. Worse, an attempt that never commits still gets fresh hook state, including `QueryManagerProvider`'s `useRef(new Map())` — so `getResource` hands back a *different* `QueryResource` per attempt, and the in-flight guard inside `resolveVariant` never sees a sibling attempt's request.

Instrumenting the demo layout with a per-resource id showed three distinct resources and **one** mount effect — two renders were discarded after already fetching:

```
LAYOUT MOUNT xlmsp   ids seen: funrj,funrj,d3ge2,d3ge2,xlmsp,xlmsp
```

(Each id twice is StrictMode's double render; that pair shares a resource and costs nothing.) The count tracks lazy depth: 2 views → 3 attempts, 3 views → 5. A view-level query is unaffected — nothing below it suspends.

## Fix

The mount effect at `useQuery.ts:216` already calls `getVariant` for every non-lazy query, so the render-phase call was never what made fetching work — it only seeded state. It now reads through a new `QueryResource#peek()`, which returns the cached variant and never fetches or revalidates.

Observable state is unchanged: a cold query is still `loading: true`, prefetched data is already in the store via the constructor's `hydrate`, and a stale variant still revalidates — from the effect, a tick later, where a render that never commits costs nothing.

## Measurement

`useQuery("/test", { search: { probe: "layout" } })` added to the saas-starter's `PublicLayout`, counting hits **in the API handler** across one load each of `/`, `/about` and `/pricing`:

| | server hits |
| --- | --- |
| before | 10 |
| after | 4 |

Four is the floor: one per cold query (`/about` has a second one of its own in the view). Per page, `/pricing` went 3 → 1. I also built the template and ran `gemi start` — the duplicates were identical in the production build, so this was never a dev-only artifact.

Six unit tests for `peek` (returns cache, no fetch when cold, no revalidation when stale or past `staleTime`, never writes to the store), each paired against `getVariant` so the difference is the assertion. The hook-level regression only reproduces through a React render and the suite has no renderer wired up, so the browser measurement above is what covers that part.

Suite goes from 196 to 202 passing with the same 7 pre-existing failures (the stale fixtures in `app/`, #163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
