### PR TITLE
Seed useQuery from the cache alone, without a null sentinel

### DIFF
--- a/packages/gemi/client/useQuery.ssr.test.tsx
+++ b/packages/gemi/client/useQuery.ssr.test.tsx
@@ -1,0 +1,100 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+
+import { QueryManagerProvider } from "./QueryManagerContext";
+import { RouteStateProvider, type PageData, type RouteState } from "./RouteStateContext";
+import { useQuery } from "./useQuery";
+
+/**
+ * These render on the server, where `window` is undefined — the same conditions
+ * as `renderToString` in a real request. `resolveVariant` bails out there, so
+ * whatever `useQuery` seeds its state with is what the markup is built from.
+ */
+function renderWithRouteState(
+  ui: React.ReactNode,
+  state: Partial<RouteState & PageData> = {},
+) {
+  return renderToString(
+    <QueryManagerProvider>
+      <RouteStateProvider state={state as RouteState & PageData}>
+        {ui}
+      </RouteStateProvider>
+    </QueryManagerProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useQuery during SSR", () => {
+  test("an uncached query yields `undefined`, so destructuring defaults apply", () => {
+    function View() {
+      // The idiomatic list pattern: the default only fires on `undefined`, so a
+      // `null` seed would make this throw in `renderToString`.
+      const { data: items = [], loading } = useQuery("/uncached" as any);
+      return <div>{`${items.length}:${loading}`}</div>;
+    }
+
+    expect(renderWithRouteState(<View />)).toContain("0:true");
+  });
+
+  test("a prefetched query renders the server's data instead of a loading state", () => {
+    function View() {
+      const { data: items = [], loading } = useQuery("/lists" as any);
+      return <div>{`${items.length}:${loading}`}</div>;
+    }
+
+    const html = renderWithRouteState(<View />, {
+      // What `Query.prefetch` puts on the page: keyed by resolved path, then by
+      // the query's variant (sorted search params, empty when there are none).
+      prefetchedData: { "/lists": { "": [{ id: 1 }, { id: 2 }] } },
+    });
+
+    expect(html).toContain("2:false");
+  });
+
+  test("prefetched data is matched by search-param variant", () => {
+    function View() {
+      const { data: items = [] } = useQuery("/lists" as any, {
+        search: { page: "2" },
+      });
+      return <div>{`${items.length}`}</div>;
+    }
+
+    const html = renderWithRouteState(<View />, {
+      prefetchedData: { "/lists": { "page=2": [{ id: 3 }] } },
+    });
+
+    expect(html).toContain("1");
+  });
+
+  test("route params are applied before the prefetch payload is looked up", () => {
+    function View() {
+      const { data: items = [] } = useQuery("/orgs/:orgId/lists" as any, {
+        params: { orgId: "42" },
+      });
+      return <div>{`${items.length}`}</div>;
+    }
+
+    const html = renderWithRouteState(<View />, {
+      prefetchedData: { "/orgs/42/lists": { "": [{ id: 1 }] } },
+    });
+
+    expect(html).toContain("1");
+  });
+
+  test("no request is made from the render phase", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    function View() {
+      const { data: items = [] } = useQuery("/uncached" as any);
+      return <div>{items.length}</div>;
+    }
+
+    renderWithRouteState(<View />);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -111,14 +111,13 @@ export function useQuery<T extends keyof GetRPC>(
     // once per suspending descendant, and each attempt gets fresh hook state,
     // including a fresh `QueryResource`, so the in-flight guard cannot dedupe
     // them.
-    return (
-      resource.peek(variantKey) ?? {
-        loading: true,
-        data: null,
-        error: null,
-        version: 0,
-      }
-    );
+    //
+    // An uncached variant seeds `undefined`, not a `{ data: null }` sentinel:
+    // the returned `data` has to stay `undefined` so destructuring defaults
+    // (`const { data: items = [] } = useQuery(...)`) still fire. The return
+    // block below already reads through with `state?.` and defaults `loading`
+    // to `true`.
+    return resource.peek(variantKey);
   });
 
   const retry = useCallback(

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemi",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "private": false,
   "license": "MIT",
   "author": "Enes Tufekci <enes@gemijs.dev>",


### PR DESCRIPTION
Fixes #278.

0.46.0 seeded an uncached query with `{ loading: true, data: null, error: null, version: 0 }`. `null` is a value, so every `const { data: items = [] } = useQuery(...)` stopped defaulting, and because an uncached query never resolves on the server, the first render of a route nobody prefetched hit `items.length` on null — a 500 out of `renderToString`, with a type signature that still claims the data is non-nullable.

The `peek` read #277 introduced — the part that actually stopped the duplicate fetches — already returns `undefined` for an uncached variant. This drops the fallback object and lets that through, which is exactly 0.45.0's output: the return block reads with `state?.` and defaults `loading` to `true`, and `handleStateUpdate`'s `setState((s) => ({ ...s, loading: true }))` is safe on an undefined previous state. No change to the dedup behaviour and no type change.

## Tests

`client/useQuery.ssr.test.tsx` renders through `renderToString` with `window` undefined — the same conditions as a real request — and pins both halves of the contract:

- an uncached query yields `undefined` + `loading: true`, so a destructuring default applies;
- a prefetched query renders the server's data (`loading: false`), for a plain path, a search-param variant (`page=2`), and a path with route params;
- nothing is fetched from the render phase.

Reverting the one-line change fails the two uncached tests with the reported `TypeError`. Also checked by hand against the `/partial` demo in `saas-starter`: the layout-prefetched `/partial-render/org/:orgId` and the view-prefetched `/partial-render/reports?page=1` both come back in the SSR HTML with their data, and only the endpoint nobody prefetches renders as loading.

The seven unrelated test files failing on this branch (route manifest / component tree / redis / `parseTranslation`) fail the same way on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)