### PR TITLE
Scope the client route manifest to the current session

### DIFF
--- a/packages/gemi/app/App.ts
+++ b/packages/gemi/app/App.ts
@@ -56,6 +56,14 @@ export class App {
     return this.useViewRouter().routeManifest;
   }
 
+  /**
+   * Hand the view -> module URL map (built by the http layer from Vite's
+   * manifests) to the router container, which filters it per audience.
+   */
+  public setViewLoaders(viewLoaders: Record<string, string>) {
+    this.useViewRouter().setViewLoaders(viewLoaders);
+  }
+
   public async fetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
     return this.kernel.run.call(this.kernel, async () => {

--- a/packages/gemi/client/ClientRouter.tsx
+++ b/packages/gemi/client/ClientRouter.tsx
@@ -16,6 +16,7 @@ import {
 } from "./ClientRouterContext";
 import type { ComponentTree } from "./types";
 import { ComponentsContext, ComponentsProvider } from "./ComponentContext";
+import { RouteRegistry, useRouteBundle } from "./RouteRegistry";
 import { QueryManagerProvider } from "./QueryManagerContext";
 import { I18nProvider } from "./I18nContext";
 import { WebSocketContextProvider } from "./WebsocketContext";
@@ -139,8 +140,8 @@ const Tree = memo(
   },
 );
 
-const Routes = (props: { componentTree: ComponentTree }) => {
-  const { componentTree } = props;
+const Routes = (props: { routeRegistry: RouteRegistry }) => {
+  const { componentTree } = useRouteBundle(props.routeRegistry);
   const [isPending, startTransition] = useTransition();
   const [isFetching, setIsFetching] = useState(false);
   const { routerSubject, fetchRouteCSS } = useContext(ClientRouterContext);
@@ -303,12 +304,21 @@ export const ClientRouter = (props: {
     i18n,
   } = useContext(ServerDataContext);
 
+  // The server ships only the routes this visitor may see. The registry seeds
+  // from that and refreshes itself when the visitor's access changes.
+  const [routeRegistry] = useState(
+    () => new RouteRegistry({ routeManifest, componentTree, loaders: {} }),
+  );
+
   return (
     <ThemeProvider>
       <I18nProvider>
         <WebSocketContextProvider>
           <QueryManagerProvider>
-            <ComponentsProvider viewImportMap={props.viewImportMap}>
+            <ComponentsProvider
+              viewImportMap={props.viewImportMap}
+              routeRegistry={routeRegistry}
+            >
               <ClientRouterProvider
                 cssManifest={cssManifest}
                 searchParams={router.searchParams}
@@ -318,13 +328,13 @@ export const ClientRouter = (props: {
                 is500={false}
                 pathname={router.pathname}
                 currentPath={router.currentPath}
-                routeManifest={routeManifest}
+                routeRegistry={routeRegistry}
                 breadcrumbs={breadcrumbs}
                 urlLocaleSegment={router.urlLocaleSegment}
               >
                 <StrictMode>
                   <RootLayout locale={i18n.currentLocale}>
-                    <Routes componentTree={componentTree} />
+                    <Routes routeRegistry={routeRegistry} />
                   </RootLayout>
                 </StrictMode>
               </ClientRouterProvider>

--- a/packages/gemi/client/ClientRouterContext.tsx
+++ b/packages/gemi/client/ClientRouterContext.tsx
@@ -12,6 +12,7 @@ import { Subject } from "../utils/Subject";
 // @ts-ignore
 import { URLPattern } from "urlpattern-polyfill";
 import { ProgressManager } from "./ProgressManager";
+import type { RouteRegistry } from "./RouteRegistry";
 import { HttpReload } from "./HttpReload";
 import type { Breadcrumb } from "./useBreadcrumbs";
 import type { RouteState } from "./RouteStateContext";
@@ -41,6 +42,7 @@ interface ClientRouterContextValue {
   breadcrumbsCache: Map<string, Breadcrumb>;
   routerSubject: Subject<RouteState>;
   urlLocaleSegment: string | null;
+  routeRegistry: RouteRegistry;
 }
 
 export const ClientRouterContext = createContext(
@@ -49,7 +51,7 @@ export const ClientRouterContext = createContext(
 
 interface ClientRouterProviderProps {
   pathname: string;
-  routeManifest: Record<string, string[]>;
+  routeRegistry: RouteRegistry;
   cssManifest: Record<string, string[]>;
   pageData: Record<string, unknown>;
   currentPath: string;
@@ -70,7 +72,7 @@ export const ClientRouterProvider = (
     currentPath,
     is404,
     is500,
-    routeManifest,
+    routeRegistry,
     cssManifest,
     pageData,
     params,
@@ -79,6 +81,8 @@ export const ClientRouterProvider = (
     urlLocaleSegment,
   } = props;
   const navigationAbortControllerRef = useRef(new AbortController());
+  /** Discriminates a stale manifest refresh from the navigation in flight. */
+  const navigationIdRef = useRef(0);
   const [isNavigatingSubject] = useState(() => {
     return new Subject<boolean>(false);
   });
@@ -96,7 +100,7 @@ export const ClientRouterProvider = (
     ? ["404"]
     : is500
       ? ["500"]
-      : (routeManifest[pathname] ?? ["404"]);
+      : (routeRegistry.routeManifest[pathname] ?? ["404"]);
   const viewEntriesSubject = useRef(new Subject<string[]>(initalViewEntries));
 
   const [routerSubject] = useState(() => {
@@ -122,34 +126,23 @@ export const ClientRouterProvider = (
     return history;
   });
 
+  // These read the registry live rather than closing over a manifest snapshot,
+  // so they stay referentially stable when the set of known routes changes —
+  // in particular the `history.listen` effect below never re-subscribes.
   const findMatchingRouteFromParams = useMemo(
     () => (pathname: string) => {
-      let routePath = pathname.replace("/en-US", "").replace("/tr-TR", "");
-      routePath = routePath === "" ? "/" : routePath;
-      const candidates: string[] = [];
-      for (const route of Object.keys(routeManifest)) {
-        const urlPattern = new URLPattern({ pathname: route });
-        if (urlPattern.test({ pathname: routePath })) {
-          candidates.push(route);
-        }
-      }
-      const sortedCandidates = candidates.sort((a, b) => {
-        const x = a.split("/").length + a.split(":").length;
-        const y = b.split("/").length + b.split(":").length;
-        return x - y;
-      });
-
-      return (sortedCandidates ?? [])[0];
+      const routePath = pathname.replace("/en-US", "").replace("/tr-TR", "");
+      return routeRegistry.match(routePath);
     },
-    [routeManifest],
+    [routeRegistry],
   );
 
   const getViewPathsFromPathname = useMemo(
     () => (pathname: string) => {
       const route = findMatchingRouteFromParams(pathname);
-      return routeManifest[route] ?? [];
+      return routeRegistry.routeManifest[route] ?? [];
     },
-    [findMatchingRouteFromParams, routeManifest],
+    [findMatchingRouteFromParams, routeRegistry],
   );
 
   const getRoutePathnameFromHref = useMemo(
@@ -163,6 +156,9 @@ export const ClientRouterProvider = (
   const getParams = useMemo(
     () => (pathname: string) => {
       const route = findMatchingRouteFromParams(pathname);
+      if (!route) {
+        return {};
+      }
       const urlPattern = new URLPattern({ pathname: route });
       return urlPattern.exec({ pathname })?.pathname.groups ?? {};
     },
@@ -170,7 +166,7 @@ export const ClientRouterProvider = (
   );
 
   useEffect(() => {
-    history?.listen(({ location, action }) => {
+    return history?.listen(({ location, action }) => {
       if (!window.scrollHistory) {
         window.scrollHistory = new Map();
       }
@@ -187,26 +183,46 @@ export const ClientRouterProvider = (
         }
       }
       _pathname = _pathname === "" ? "/" : _pathname;
-      const routePath = getRoutePathnameFromHref(_pathname);
-      routerSubject.next({
-        views: getViewPathsFromPathname(_pathname),
-        params: getParams(_pathname),
-        search: location.search,
-        state: location.state as Record<string, unknown>,
-        pathname: _pathname,
-        action,
-        routePath,
-        hash: location.hash,
-        locale: _locale,
+
+      const navigationId = ++navigationIdRef.current;
+      const commit = () =>
+        routerSubject.next({
+          views: getViewPathsFromPathname(_pathname),
+          params: getParams(_pathname),
+          search: location.search,
+          state: location.state as Record<string, unknown>,
+          pathname: _pathname,
+          action,
+          routePath: getRoutePathnameFromHref(_pathname),
+          hash: location.hash,
+          locale: _locale,
+        });
+
+      if (findMatchingRouteFromParams(_pathname)) {
+        commit();
+        return;
+      }
+
+      // The target may be a route this page was never told about — the
+      // manifest only carries what the visitor was allowed to see when the
+      // document was rendered. Signing in is the common case: let the registry
+      // pick up the newly reachable routes before calling this a 404.
+      void routeRegistry.ensureRoute(_pathname).then(() => {
+        // A newer navigation started while we were waiting — that one wins.
+        if (navigationId === navigationIdRef.current) {
+          commit();
+        }
       });
     });
   }, [
     supportedLocales,
     history,
     routerSubject,
+    routeRegistry,
     getParams,
     getRoutePathnameFromHref,
     getViewPathsFromPathname,
+    findMatchingRouteFromParams,
   ]);
 
   const updatePageData = (
@@ -234,7 +250,7 @@ export const ClientRouterProvider = (
   };
 
   const fetchRouteCSS = async (routePath: string) => {
-    const views = routeManifest[routePath];
+    const views = routeRegistry.routeManifest[routePath];
     if (!views) {
       return;
     }
@@ -285,6 +301,7 @@ export const ClientRouterProvider = (
         breadcrumbsCache: breadcrumbsCache.current,
         routerSubject,
         urlLocaleSegment,
+        routeRegistry,
       }}
     >
       {children}

--- a/packages/gemi/client/ComponentContext.tsx
+++ b/packages/gemi/client/ComponentContext.tsx
@@ -1,5 +1,7 @@
-import { createContext, lazy, type PropsWithChildren } from "react";
+import { createContext, lazy, useMemo, type PropsWithChildren } from "react";
 import { flattenComponentTree } from "./helpers/flattenComponentTree";
+import { useRouteBundle, type RouteRegistry } from "./RouteRegistry";
+import type { ComponentTree } from "./types";
 import type { ServerDataContextValue } from "./ServerDataProvider";
 
 declare const window: {
@@ -12,25 +14,59 @@ declare const window: {
   >;
 } & Window;
 
-let viewImportMap: Record<string, ReturnType<typeof lazy>> | null = null;
-if (typeof window !== "undefined" && process.env.NODE_ENV !== "test") {
-  viewImportMap = {};
-  const { componentTree = [] } = window.__GEMI_DATA__ ?? {};
+type ViewImportMap = Record<string, ReturnType<typeof lazy>>;
+
+/**
+ * `lazy()` mints a new component type on every call, and React remounts when a
+ * type changes. The component map is rebuilt whenever the route registry gains
+ * views, so hold onto the wrappers — otherwise picking up one new route would
+ * remount the entire page.
+ */
+const lazyViewCache = new Map<string, ReturnType<typeof lazy>>();
+
+function buildViewImportMap(componentTree: ComponentTree): ViewImportMap {
+  const viewImportMap: ViewImportMap = {};
+  if (typeof window === "undefined" || process.env.NODE_ENV === "test") {
+    return viewImportMap;
+  }
 
   for (const viewName of flattenComponentTree(componentTree)) {
-    viewImportMap[viewName] = lazy(window.loaders[viewName]);
+    const loader = window.loaders?.[viewName];
+    if (!loader) {
+      continue;
+    }
+    if (!lazyViewCache.has(viewName)) {
+      lazyViewCache.set(viewName, lazy(loader));
+    }
+    viewImportMap[viewName] = lazyViewCache.get(viewName)!;
   }
+
+  return viewImportMap;
 }
 
-export const ComponentsContext = createContext({ viewImportMap });
+export const ComponentsContext = createContext({
+  viewImportMap: {} as ViewImportMap,
+});
 
 export const ComponentsProvider = (
-  props: PropsWithChildren<{ viewImportMap: typeof viewImportMap }>,
+  props: PropsWithChildren<{
+    viewImportMap?: ViewImportMap;
+    routeRegistry: RouteRegistry;
+  }>,
 ) => {
+  const { componentTree } = useRouteBundle(props.routeRegistry);
+
+  const value = useMemo(
+    () => ({
+      // SSR passes the map in directly; on the client it is derived from
+      // whatever views the registry currently knows about.
+      viewImportMap: props.viewImportMap ?? buildViewImportMap(componentTree),
+    }),
+    [props.viewImportMap, componentTree],
+  );
+
   return (
-    <ComponentsContext.Provider
-      value={{ viewImportMap: props.viewImportMap ?? viewImportMap }}
-    >
+    <ComponentsContext.Provider value={value}>
       {props.children}
     </ComponentsContext.Provider>
   );

--- a/packages/gemi/client/RouteRegistry.test.ts
+++ b/packages/gemi/client/RouteRegistry.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { RouteRegistry, ROUTE_MANIFEST_ENDPOINT } from "./RouteRegistry";
+
+const anonymous = {
+  routeManifest: {
+    "/": ["PublicLayout", "Home"],
+    "/pricing": ["PublicLayout", "Pricing"],
+    "/auth/sign-in": ["auth/SignIn"],
+  },
+  componentTree: [["404", []], ["PublicLayout", [["Home", []], ["Pricing", []]]]] as any,
+  loaders: { "404": "/app/views/404.tsx" },
+};
+
+const authenticated = {
+  routeManifest: {
+    ...anonymous.routeManifest,
+    "/dashboard": ["AppLayout", "Dashboard"],
+    "/products/:id": ["AppLayout", "Product"],
+  },
+  componentTree: [
+    ...anonymous.componentTree,
+    ["AppLayout", [["Dashboard", []], ["Product", []]]],
+  ] as any,
+  loaders: {
+    ...anonymous.loaders,
+    AppLayout: "/app/views/AppLayout.tsx",
+    Dashboard: "/app/views/Dashboard.tsx",
+  },
+};
+
+function mockFetch(bundle: unknown, { ok = true } = {}) {
+  const fetchMock = vi.fn(async () => ({ ok, json: async () => bundle }) as any);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("match()", () => {
+  test("prefers the most specific pattern", () => {
+    const registry = new RouteRegistry({
+      ...anonymous,
+      routeManifest: {
+        "/products/:id": ["Product"],
+        "/products/:id/reviews": ["Reviews"],
+      },
+    });
+
+    expect(registry.match("/products/1")).toBe("/products/:id");
+    expect(registry.match("/products/1/reviews")).toBe("/products/:id/reviews");
+  });
+
+  test("treats the empty pathname as the root", () => {
+    expect(new RouteRegistry(anonymous).match("")).toBe("/");
+  });
+
+  test("returns undefined for a path that isn't in the manifest", () => {
+    expect(new RouteRegistry(anonymous).match("/dashboard")).toBeUndefined();
+  });
+});
+
+describe("ensureRoute()", () => {
+  test("resolves a known route without asking the server", async () => {
+    const fetchMock = mockFetch(authenticated);
+    const registry = new RouteRegistry(anonymous);
+
+    expect(await registry.ensureRoute("/pricing")).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("picks up routes unlocked by signing in", async () => {
+    const fetchMock = mockFetch(authenticated);
+    const registry = new RouteRegistry(anonymous);
+
+    // What `push("/dashboard")` right after sign-in hits.
+    expect(await registry.ensureRoute("/dashboard")).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(ROUTE_MANIFEST_ENDPOINT, expect.anything());
+    expect(registry.routeManifest["/dashboard"]).toEqual(["AppLayout", "Dashboard"]);
+    expect(registry.componentTree).toEqual(authenticated.componentTree);
+  });
+
+  test("refreshes once for a path the server also doesn't know", async () => {
+    const fetchMock = mockFetch(anonymous);
+    const registry = new RouteRegistry(anonymous);
+
+    expect(await registry.ensureRoute("/nope")).toBe(false);
+    expect(await registry.ensureRoute("/nope")).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a later refresh reconsiders a path that missed before", async () => {
+    const fetchMock = mockFetch(anonymous);
+    const registry = new RouteRegistry(anonymous);
+    expect(await registry.ensureRoute("/dashboard")).toBe(false);
+
+    mockFetch(authenticated);
+    await registry.refresh();
+
+    expect(registry.match("/dashboard")).toBe("/dashboard");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("concurrent misses share a single request", async () => {
+    const fetchMock = mockFetch(authenticated);
+    const registry = new RouteRegistry(anonymous);
+
+    const results = await Promise.all([
+      registry.ensureRoute("/dashboard"),
+      registry.ensureRoute("/products/9"),
+    ]);
+
+    expect(results).toEqual([true, true]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("refresh()", () => {
+  test("takes routes away again on sign-out", async () => {
+    mockFetch(authenticated);
+    const registry = new RouteRegistry(anonymous);
+    await registry.ensureRoute("/dashboard");
+
+    mockFetch(anonymous);
+    await registry.refresh();
+
+    expect(registry.match("/dashboard")).toBeUndefined();
+    expect(registry.componentTree).toEqual(anonymous.componentTree);
+  });
+
+  test("notifies subscribers exactly once per change", async () => {
+    mockFetch(authenticated);
+    const registry = new RouteRegistry(anonymous);
+    const subscriber = vi.fn();
+    registry.subscribe(subscriber);
+
+    await registry.refresh();
+
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(registry.getBundle().routeManifest).toEqual(authenticated.routeManifest);
+  });
+
+  test("keeps the current bundle when the request fails", async () => {
+    mockFetch(authenticated, { ok: false });
+    const registry = new RouteRegistry(anonymous);
+
+    await registry.refresh();
+
+    expect(registry.routeManifest).toEqual(anonymous.routeManifest);
+  });
+
+  test("keeps the current bundle when the network throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    const registry = new RouteRegistry(anonymous);
+
+    await expect(registry.refresh()).resolves.toBeDefined();
+    expect(registry.routeManifest).toEqual(anonymous.routeManifest);
+  });
+});

--- a/packages/gemi/client/RouteRegistry.ts
+++ b/packages/gemi/client/RouteRegistry.ts
@@ -1,0 +1,174 @@
+import { useCallback, useSyncExternalStore } from "react";
+// @ts-ignore
+import { URLPattern } from "urlpattern-polyfill";
+import { Subject } from "../utils/Subject";
+import type { ComponentTree } from "./types";
+
+export interface RouteBundle {
+  routeManifest: Record<string, string[]>;
+  componentTree: ComponentTree;
+  loaders: Record<string, string>;
+}
+
+/** Where the server serves the current session's bundle from. */
+export const ROUTE_MANIFEST_ENDPOINT = "/api/__gemi__/router/manifest";
+
+declare const window: {
+  loaders: Record<string, () => Promise<{ default: unknown }>>;
+} & Window;
+
+/**
+ * The client's view of which routes exist.
+ *
+ * The server only ships the routes the current visitor is allowed to know
+ * about, so this is not fixed for the lifetime of the page: signing in unlocks
+ * routes, signing out takes them away. Everything that needs to know about
+ * routes — the router, the lazy component map, CSS prefetching — reads from
+ * here and subscribes, so one refresh updates all of them at once.
+ */
+export class RouteRegistry {
+  private bundleSubject: Subject<RouteBundle>;
+  private inFlight: Promise<RouteBundle> | null = null;
+  /**
+   * Paths a refresh already failed to explain. Without this a genuine 404
+   * would refetch the manifest on every single navigation to it.
+   */
+  private knownMisses = new Set<string>();
+
+  constructor(bundle: RouteBundle) {
+    this.bundleSubject = new Subject<RouteBundle>(bundle);
+  }
+
+  get routeManifest() {
+    return this.bundleSubject.getValue().routeManifest;
+  }
+
+  get componentTree() {
+    return this.bundleSubject.getValue().componentTree;
+  }
+
+  /** Stable snapshot — the reference only changes when the bundle does. */
+  getBundle = () => this.bundleSubject.getValue();
+
+  subscribe = (subscriber: (bundle: RouteBundle) => void) =>
+    this.bundleSubject.subscribe(subscriber);
+
+  /**
+   * The most specific route pattern matching `pathname`, or undefined. Mirrors
+   * the server's own resolution order in `createFlatViewRoutes`.
+   */
+  match(pathname: string) {
+    const routePath = pathname === "" ? "/" : pathname;
+    const candidates: string[] = [];
+
+    for (const route of Object.keys(this.routeManifest)) {
+      try {
+        if (new URLPattern({ pathname: route }).test({ pathname: routePath })) {
+          candidates.push(route);
+        }
+      } catch {
+        // A pattern the browser's URLPattern can't parse simply doesn't match.
+      }
+    }
+
+    return candidates.sort((a, b) => {
+      const x = a.split("/").length + a.split(":").length;
+      const y = b.split("/").length + b.split(":").length;
+      return x - y;
+    })[0];
+  }
+
+  /**
+   * Make sure `pathname` is resolvable, refreshing from the server once if it
+   * isn't. Resolves to true when the path is now known.
+   *
+   * This is what carries a client-side navigation across a change in auth
+   * state: right after signing in, `push("/dashboard")` targets a route the
+   * page was never told about, and the refreshed bundle supplies it.
+   */
+  async ensureRoute(pathname: string) {
+    if (this.match(pathname)) {
+      return true;
+    }
+    if (this.knownMisses.has(pathname)) {
+      return false;
+    }
+
+    await this.refresh();
+
+    const matched = Boolean(this.match(pathname));
+    if (!matched) {
+      this.knownMisses.add(pathname);
+    }
+    return matched;
+  }
+
+  /** Pull the bundle for the current session and merge it in. */
+  refresh() {
+    if (this.inFlight) {
+      return this.inFlight;
+    }
+
+    this.inFlight = fetch(ROUTE_MANIFEST_ENDPOINT, {
+      headers: { Accept: "application/json" },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((bundle: RouteBundle | null) => {
+        if (bundle?.routeManifest) {
+          this.replace(bundle);
+        }
+        return this.bundleSubject.getValue();
+      })
+      .catch(() => this.bundleSubject.getValue())
+      .finally(() => {
+        this.inFlight = null;
+      });
+
+    return this.inFlight;
+  }
+
+  /**
+   * Swap in a server bundle wholesale rather than merging into the old one:
+   * signing out has to *remove* routes, not just fail to add any.
+   */
+  private replace(bundle: RouteBundle) {
+    registerViewLoaders(bundle.loaders);
+    // A path that didn't resolve before may resolve now, and vice versa.
+    this.knownMisses.clear();
+    this.bundleSubject.next({
+      routeManifest: bundle.routeManifest ?? {},
+      componentTree: bundle.componentTree ?? [],
+      loaders: bundle.loaders ?? {},
+    });
+  }
+}
+
+/** Re-render whenever the set of known routes changes. */
+export function useRouteBundle(routeRegistry: RouteRegistry) {
+  return useSyncExternalStore(
+    useCallback(
+      (onStoreChange: () => void) => routeRegistry.subscribe(onStoreChange),
+      [routeRegistry],
+    ),
+    routeRegistry.getBundle,
+    routeRegistry.getBundle,
+  );
+}
+
+/**
+ * Extend `window.loaders` with views that weren't in the page's initial bundle.
+ * The server hands us module URLs; the browser needs thunks.
+ */
+function registerViewLoaders(loaders: Record<string, string> = {}) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (!window.loaders) {
+    window.loaders = {};
+  }
+  for (const [viewName, url] of Object.entries(loaders)) {
+    if (!window.loaders[viewName]) {
+      window.loaders[viewName] = () => import(/* @vite-ignore */ url);
+    }
+  }
+}

--- a/packages/gemi/client/auth/useSignOut.ts
+++ b/packages/gemi/client/auth/useSignOut.ts
@@ -1,3 +1,5 @@
+import { useContext } from "react";
+import { ClientRouterContext } from "../ClientRouterContext";
 import { useMutate } from "../useMutate";
 import { usePost } from "../useMutation";
 
@@ -11,6 +13,7 @@ const defaultArgs: UseSignOutArgs = {
 
 export function useSignOut(args: UseSignOutArgs = defaultArgs) {
   const mutator = useMutate();
+  const { routeRegistry } = useContext(ClientRouterContext);
   return usePost(
     "/auth/sign-out",
     {},
@@ -18,6 +21,9 @@ export function useSignOut(args: UseSignOutArgs = defaultArgs) {
       onSuccess: () => {
         args.onSuccess();
         mutator({ path: "/auth/me" });
+        // The in-memory manifest still lists the routes this session could
+        // reach. Drop back to the anonymous one so they stop resolving.
+        routeRegistry?.refresh();
       },
     },
   );

--- a/packages/gemi/http/AuthenticationMiddlware.ts
+++ b/packages/gemi/http/AuthenticationMiddlware.ts
@@ -5,6 +5,8 @@ import { AuthenticationError } from "./errors";
 import { AuthenticationServiceContainer } from "../auth/AuthenticationServiceContainer";
 
 export class AuthenticationMiddleware extends Middleware {
+  static isPrivate = true;
+
   async run(_req: HttpRequest) {
     const requestContextStore = RequestContext.getStore();
     const accessTokenCookie =

--- a/packages/gemi/http/Middleware.ts
+++ b/packages/gemi/http/Middleware.ts
@@ -1,6 +1,17 @@
 import { HttpRequest } from "./HttpRequest";
 
 export class Middleware<T extends Record<string, any> = Record<string, any>> {
+  /**
+   * Marks a middleware as gating access to the routes it is attached to. Routes
+   * behind such a middleware are stripped from the route manifest, component
+   * tree and view loader map that get shipped to anonymous visitors, so the
+   * client never learns about pages it cannot reach.
+   *
+   * `configure()` returns a subclass, and subclasses inherit statics, so both
+   * survive the alias lookup in `MiddlewareServiceContainer.isPrivateChain`.
+   */
+  static isPrivate = false;
+
   config: T = {} as T;
   constructor(protected req: HttpRequest) {}
   run(..._args: any[]): Promise<any> | any {

--- a/packages/gemi/server/httpDev.ts
+++ b/packages/gemi/server/httpDev.ts
@@ -200,6 +200,18 @@ export async function httpDev(app: App, instrumentation: Instrumentation) {
   process.env.ROOT_DIR = rootDir;
   process.env.APP_DIR = appDir;
 
+  // Dev view URLs are fixed (`/app/views/<name>.tsx`), so the loader map can be
+  // built once here rather than per request. It must stay root-relative — see
+  // the note on the SSR loop below.
+  app.setViewLoaders(
+    Object.fromEntries(
+      ["404", ...app.getFlatComponentTree.call(app)].map((fileName) => [
+        fileName,
+        `/app/views/${fileName}.tsx`,
+      ]),
+    ),
+  );
+
   const server = Bun.serve({
     port: 5173,
     fetch: async (req) => {
@@ -237,10 +249,13 @@ export async function httpDev(app: App, instrumentation: Instrumentation) {
 
           const viewImportMap = {};
           const ogMap = {};
-          const template = (viewName: string, path: string) =>
-            `"${viewName}": () => import("${path}")`;
-          const templates = [];
 
+          // The browser's `window.loaders` map is built from the URLs registered
+          // via `setViewLoaders` above; this loop only resolves the *server*
+          // modules for SSR, per request so HMR picks up edits. The two must
+          // agree on the root-relative URL (`/app/views/Foo.tsx`), NOT the
+          // absolute filesystem path used here — otherwise Vite serves the
+          // module under two URLs and instantiates the view twice.
           for (const fileName of ["404", ...app.getFlatComponentTree.call(app)]) {
             if (process.env.NODE_ENV === "test") {
               break;
@@ -252,16 +267,7 @@ export async function httpDev(app: App, instrumentation: Instrumentation) {
 
             viewImportMap[fileName] = mod.default;
             ogMap[fileName] = mod?.OpenGraph;
-            // Emit a root-relative URL (`/app/views/Foo.tsx`), NOT the absolute
-            // filesystem path used for `ssrLoadModule` above. The browser's
-            // `window.loaders` preload and `client.tsx`'s `import.meta.glob` map
-            // must import the exact same URL — otherwise Vite serves the module
-            // under two URLs (`/app/views/Foo.tsx` vs `/Users/.../app/views/Foo.tsx`)
-            // and loads/instantiates the view twice.
-            templates.push(template(fileName, `/app/views/${fileName}.tsx`));
           }
-
-          const loaders = `{${templates.join(",")}}`;
 
           return await result({
             getStyles: async (currentViews: string[]) =>
@@ -269,7 +275,6 @@ export async function httpDev(app: App, instrumentation: Instrumentation) {
             bootstrapModules: ["/refresh.js", "/app/client.tsx", "/@vite/client"],
             viewImportMap,
             ogMap,
-            loaders,
             cssManifest: {},
           });
         } catch (err: any) {

--- a/packages/gemi/server/httpProd.ts
+++ b/packages/gemi/server/httpProd.ts
@@ -29,8 +29,7 @@ export async function httpProd(app: App, instrumentation: Instrumentation) {
   const viewImportMap = {};
   const ogMap = {};
   const cssManifest = {};
-  const template = (viewName: string, path: string) => `"${viewName}": () => import("${path}")`;
-  const templates = [];
+  const viewLoaders: Record<string, string> = {};
 
   for (const fileName of ["404", ...app.getFlatComponentTree.call(app)]) {
     const serverFile = serverManifest[`app/views/${fileName}.tsx`];
@@ -51,11 +50,13 @@ export async function httpProd(app: App, instrumentation: Instrumentation) {
       cssManifest[fileName] = clientFile?.css;
     }
     if (clientFile) {
-      templates.push(template(fileName, `/${clientFile?.file}`));
+      viewLoaders[fileName] = `/${clientFile?.file}`;
     }
   }
 
-  const loaders = `{${templates.join(",")}}`;
+  // The container owns the loader map from here: it filters it per audience for
+  // both the rendered page and the route manifest endpoint.
+  app.setViewLoaders(viewLoaders);
 
   // Vite's manifest `css` field is a `string[]` — a client entry can emit more
   // than one CSS chunk. Read and concatenate them all instead of interpolating
@@ -171,7 +172,6 @@ export async function httpProd(app: App, instrumentation: Instrumentation) {
         return await result({
           getStyles,
           bootstrapModules: [`/${manifest["app/client.tsx"].file}`],
-          loaders,
           viewImportMap,
           ogMap,
           cssManifest,

--- a/packages/gemi/services/middleware/MiddlewareServiceContainer.ts
+++ b/packages/gemi/services/middleware/MiddlewareServiceContainer.ts
@@ -29,6 +29,32 @@ export class MiddlewareServiceContainer extends ServiceContainer {
     super();
   }
 
+  /**
+   * Does this middleware chain gate access behind authentication?
+   *
+   * Runs the same `transformMiddleware` normalisation as `runMiddleware`, so a
+   * `-auth` further down the chain cancels an earlier `auth` exactly the way it
+   * does at request time. Aliases that aren't registered resolve to nothing and
+   * are ignored, matching `runMiddleware`'s behaviour.
+   */
+  public isPrivateChain(
+    middleware: (
+      | string
+      | RouterMiddleware
+      | (new (req: HttpRequest) => Middleware)
+    )[],
+  ) {
+    for (const key of transformMiddleware(middleware).keys()) {
+      const Middleware =
+        typeof key === "string" ? this.service.aliases[key] : key;
+
+      if (isConstructor(Middleware) && (Middleware as any).isPrivate === true) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public runMiddleware(
     middleware: (
       | string

--- a/packages/gemi/services/middleware/isPrivateChain.test.ts
+++ b/packages/gemi/services/middleware/isPrivateChain.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "vitest";
+import { MiddlewareServiceContainer } from "./MiddlewareServiceContainer";
+import { MiddlewareServiceProvider } from "../../http/MiddlewareServiceProvider";
+import { Middleware } from "../../http/Middleware";
+import { AuthenticationMiddleware } from "../../http/AuthenticationMiddlware";
+import { CacheMiddleware } from "../../http/CacheMiddleware";
+
+class TenantMiddleware extends Middleware {
+  static isPrivate = true;
+}
+
+class Provider extends MiddlewareServiceProvider {
+  aliases = {
+    auth: AuthenticationMiddleware,
+    cache: CacheMiddleware,
+    tenant: TenantMiddleware,
+  } as any;
+}
+
+const container = new MiddlewareServiceContainer(new Provider());
+
+describe("isPrivateChain()", () => {
+  test("an auth-gated chain is private regardless of what else is on it", () => {
+    expect(container.isPrivateChain(["cache:public,12840", "auth"])).toBe(true);
+  });
+
+  test("a chain with no auth-gating middleware is public", () => {
+    expect(container.isPrivateChain(["cache:public,12840"])).toBe(false);
+    expect(container.isPrivateChain([])).toBe(false);
+  });
+
+  test("cancelling the alias with `-auth` makes the route public again", () => {
+    expect(container.isPrivateChain(["auth", "-auth"])).toBe(false);
+    // Order matters the same way it does when the chain actually runs.
+    expect(container.isPrivateChain(["-auth", "auth"])).toBe(true);
+  });
+
+  test("an unregistered alias resolves to nothing, exactly like at request time", () => {
+    expect(container.isPrivateChain(["not-a-real-alias"])).toBe(false);
+  });
+
+  test("params on the alias don't hide it", () => {
+    expect(container.isPrivateChain(["auth:admin"])).toBe(true);
+  });
+
+  test("any middleware can opt in with the static flag", () => {
+    expect(container.isPrivateChain(["tenant"])).toBe(true);
+  });
+
+  test("a middleware class passed inline is resolved too", () => {
+    expect(container.isPrivateChain([AuthenticationMiddleware])).toBe(true);
+    expect(container.isPrivateChain([CacheMiddleware])).toBe(false);
+  });
+
+  test("`configure()` subclasses inherit the flag", () => {
+    expect(container.isPrivateChain([AuthenticationMiddleware.configure({})])).toBe(true);
+  });
+});

--- a/packages/gemi/services/router/ApiRouterServiceContainer.ts
+++ b/packages/gemi/services/router/ApiRouterServiceContainer.ts
@@ -12,6 +12,29 @@ import { createFlatApiRoutes, type FlatApiRoutes } from "./createFlatApiRoutes";
 import { ViewRouterServiceContainer } from "./ViewRouterServiceContainer";
 import { I18nServiceContainer } from "../../i18n/I18nServiceContainer";
 
+/**
+ * Serves the route manifest, component tree and view loader map the *current
+ * session* is allowed to see.
+ *
+ * Anonymous visitors get a manifest with the auth-gated routes stripped out, so
+ * the client can't resolve a private path on its own. When that changes — after
+ * signing in — the client hits this endpoint to pick up the routes it can now
+ * reach, instead of having to reload the page.
+ */
+class RouterManifestRouter extends ApiRouter {
+  routes = {
+    "/manifest": this.get(async () => {
+      const viewRouter = ViewRouterServiceContainer.use();
+      const viewer = await viewRouter.resolveViewer();
+
+      // Per-session content — never let a shared cache hold on to it.
+      RequestContext.getStore()?.setHeaders("Cache-Control", "private, no-store");
+
+      return viewRouter.getClientBundle(!!viewer);
+    }),
+  };
+}
+
 class DebugRouter extends ApiRouter {
   routes = {
     "/api-routes": this.get(() => {
@@ -49,7 +72,11 @@ export class ApiRouterServiceContainer extends ServiceContainer {
       "/__gemi__/services/i18n": I18nRouter,
       "/__gemi__/services/logs": LoggingRouter,
       "/__gemi__/services/image": ImageOptimizationRouter,
-      "/__gemi__/debug": DebugRouter,
+      "/__gemi__/router": RouterManifestRouter,
+      // `DebugRouter` dumps every route path, view and middleware with no auth
+      // of its own — that's the whole route table, including the private routes
+      // deliberately kept out of the client manifest. Dev-only.
+      ...(process.env.NODE_ENV === "production" ? {} : { "/__gemi__/debug": DebugRouter }),
     });
   }
 

--- a/packages/gemi/services/router/ViewRouterServiceContainer.ts
+++ b/packages/gemi/services/router/ViewRouterServiceContainer.ts
@@ -21,7 +21,13 @@ import { URLPattern } from "urlpattern-polyfill/urlpattern";
 import { ServiceContainer } from "../ServiceContainer";
 import { createFileResponse, type FileOutput, type ViewRoutes } from "../../http/ViewRouter";
 import { createRouteManifest } from "./createRouteManifest";
+import {
+  type ClientBundle,
+  createClientBundle,
+  serializeViewLoaders,
+} from "./createClientBundle";
 import { createComponentTree } from "./createComponentTree";
+import { downgradePublicCacheControl } from "./downgradePublicCacheControl";
 import { flattenComponentTree } from "../../client/helpers/flattenComponentTree";
 import type { ComponentTree } from "../../client/types";
 import { I18nServiceContainer } from "../../i18n/I18nServiceContainer";
@@ -29,6 +35,7 @@ import { MiddlewareServiceContainer } from "../middleware/MiddlewareServiceConta
 import { Log } from "../../facades/Log";
 import { I18n } from "../../facades/I18n";
 import { AuthViewRouter } from "../../auth/AuthenticationServiceProvider";
+import { AuthenticationServiceContainer } from "../../auth/AuthenticationServiceContainer";
 import { KernelIdServiceContainer } from "../kernel-id/KernelIdServiceContainer";
 
 const themeScript = `
@@ -99,7 +106,12 @@ export class ViewRouterServiceContainer extends ServiceContainer {
   clientRouteManifest: Record<string, string[]> = {};
   componentTree: ComponentTree = [];
   flatComponentTree: string[] = [];
+  /** View name -> module URL the browser imports it from. Set by the http layer at boot. */
+  viewLoaders: Record<string, string> = {};
   root: any = null;
+
+  private privateRoutePaths: Set<string> | null = null;
+  private clientBundles = new Map<boolean, ClientBundle>();
 
   constructor(public service: ViewRouterServiceProvider) {
     super();
@@ -119,6 +131,99 @@ export class ViewRouterServiceContainer extends ServiceContainer {
   }
 
   boot() {}
+
+  /**
+   * The http layer owns the view -> module URL mapping (Vite's manifest in
+   * production, a fixed `/app/views/*` URL in dev). Handing it to the container
+   * lets both the render path and the manifest endpoint serve the same,
+   * audience-filtered map.
+   */
+  setViewLoaders(viewLoaders: Record<string, string>) {
+    this.viewLoaders = viewLoaders;
+    this.clientBundles.clear();
+  }
+
+  /**
+   * Route paths sitting behind an auth-gating middleware.
+   *
+   * Computed lazily, not in the constructor: `Kernel.boot()` builds every
+   * container inside a single object literal, outside `kernelContext.run`, so
+   * `MiddlewareServiceContainer.use()` isn't reachable yet at construction time.
+   */
+  getPrivateRoutePaths() {
+    if (this.privateRoutePaths === null) {
+      const middlewareServiceContainer = MiddlewareServiceContainer.use();
+      this.privateRoutePaths = new Set(
+        Object.entries(this.flatViewRoutes)
+          .filter(([, { middleware }]) => middlewareServiceContainer.isPrivateChain(middleware))
+          .map(([routePath]) => routePath),
+      );
+    }
+    return this.privateRoutePaths;
+  }
+
+  /**
+   * What this request's visitor is allowed to know about the app's routes.
+   * Both variants are built once and cached — there is no per-request work.
+   */
+  getClientBundle(isAuthenticated: boolean): ClientBundle {
+    const cached = this.clientBundles.get(isAuthenticated);
+    if (cached) {
+      return cached;
+    }
+
+    const full: ClientBundle = {
+      routeManifest: this.clientRouteManifest,
+      componentTree: [["404", []], ...this.componentTree],
+      loaders: this.viewLoaders,
+    };
+
+    const bundle = isAuthenticated
+      ? full
+      : createClientBundle(full, this.getPrivateRoutePaths());
+
+    this.clientBundles.set(isAuthenticated, bundle);
+    return bundle;
+  }
+
+  /**
+   * Resolve the visitor's session for the sole purpose of deciding which
+   * bundle to ship. Deliberately does not call `ctx.setUser()` — `auth.user` in
+   * the page payload stays exactly as populated (or not) by the route's own
+   * middleware and handlers.
+   */
+  async resolveViewer() {
+    if (this.getPrivateRoutePaths().size === 0) {
+      return null;
+    }
+
+    const ctx = RequestContext.getStore();
+
+    // Private routes run the auth middleware, which already resolved the
+    // session — no second lookup for them.
+    if (ctx?.user) {
+      return ctx.user;
+    }
+
+    const accessToken =
+      ctx?.req?.cookies.get("access_token") || ctx?.req?.headers.get("access_token");
+
+    if (!accessToken) {
+      return null;
+    }
+
+    try {
+      const session = await AuthenticationServiceContainer.use().getSession(
+        accessToken,
+        ctx.req.headers.get("User-Agent"),
+      );
+      return session?.user ?? null;
+    } catch {
+      // A bad or expired token just means "anonymous" here — the route's own
+      // middleware is what actually enforces access.
+      return null;
+    }
+  }
 
   async onRequestEnd(req: HttpRequest) {
     if (!req.cookies.has("session_id")) {
@@ -149,6 +254,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
     meta: any;
     isOgRequest?: boolean;
     appId: string;
+    isAuthenticated: boolean;
   }) {
     const {
       csrfTokenHMAC,
@@ -166,9 +272,11 @@ export class ViewRouterServiceContainer extends ServiceContainer {
       meta,
       isOgRequest,
       appId,
+      isAuthenticated,
     } = props;
 
     const pageDataKey = pathname.replace(`/${urlLocaleSegment}`, "");
+    const clientBundle = this.getClientBundle(isAuthenticated);
 
     const result = {
       kind: "view",
@@ -181,7 +289,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
         prefetchedData,
         i18n,
         auth: { user },
-        routeManifest: this.clientRouteManifest,
+        routeManifest: clientBundle.routeManifest,
         breadcrumbs,
         router: {
           urlLocaleSegment,
@@ -192,7 +300,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
           is404: !currentPathName ? true : false,
         },
         appId,
-        componentTree: [["404", []], ...this.componentTree],
+        componentTree: clientBundle.componentTree,
       },
       head: {},
     };
@@ -203,11 +311,11 @@ export class ViewRouterServiceContainer extends ServiceContainer {
       getStyles: (p: string[]) => Promise<any[]>;
       viewImportMap: any;
       bootstrapModules: string[];
-      loaders: string;
       cssManifest: Record<string, string[]>;
       ogMap: Record<string, any>;
     }) => {
-      const { bootstrapModules, loaders, getStyles, viewImportMap, cssManifest, ogMap } = params;
+      const { bootstrapModules, getStyles, viewImportMap, cssManifest, ogMap } = params;
+      const loaders = serializeViewLoaders(clientBundle.loaders);
 
       if (isOgRequest) {
         let ogHandler = null;
@@ -499,6 +607,14 @@ export class ViewRouterServiceContainer extends ServiceContainer {
 
         headers.set("Content-Type", "text/html; charset=utf-8");
 
+        // The HTML now embeds an audience-specific route manifest, so a
+        // response built for a signed-in visitor must never be reused from a
+        // shared cache for an anonymous one.
+        const viewer = await this.resolveViewer();
+        if (viewer) {
+          downgradePublicCacheControl(headers);
+        }
+
         for (const cookie of cookies) {
           headers.append("Set-Cookie", cookie.toString());
         }
@@ -535,6 +651,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
           meta: pageData.meta,
           appId: pageData.appId,
           isOgRequest,
+          isAuthenticated: !!viewer,
         });
       } catch (err) {
         if (err.kind === GEMI_REQUEST_BREAKER_ERROR) {

--- a/packages/gemi/services/router/createClientBundle.test.ts
+++ b/packages/gemi/services/router/createClientBundle.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from "vitest";
+import { ViewRouter } from "../../http/ViewRouter";
+import { createRouteManifest } from "./createRouteManifest";
+import { createComponentTree } from "./createComponentTree";
+import { createFlatViewRoutes } from "./createFlatViewRoutes";
+import {
+  collectVisibleViews,
+  createClientBundle,
+  pruneComponentTree,
+  serializeViewLoaders,
+  type ClientBundle,
+} from "./createClientBundle";
+
+class AppRouter extends ViewRouter {
+  middlewares = ["auth"];
+  routes = {
+    "/": this.layout("AppLayout", {
+      "/dashboard": this.view("Dashboard"),
+      "/inbox": this.view("Inbox"),
+    }),
+  };
+}
+
+class MixedRouter extends ViewRouter {
+  routes = {
+    "/": this.layout("SettingsLayout", {
+      "/help": this.view("Help"),
+      "/billing": this.view("Billing").middleware(["auth"]),
+    }),
+  };
+}
+
+/** Shaped like the saas-starter template: a public tree plus a guarded group. */
+class RootRouter extends ViewRouter {
+  middlewares = ["cache:public,12840"];
+  routes = {
+    "/": this.layout("PublicLayout", {
+      "/": this.view("Home"),
+      "/pricing": this.view("Pricing"),
+    }),
+    "/settings": MixedRouter,
+    "(app)/": AppRouter,
+  };
+}
+
+/**
+ * Stands in for `MiddlewareServiceContainer.isPrivateChain` — this suite is
+ * about what gets pruned, not about how a chain is classified (see
+ * `isPrivateChain.test.ts` for that).
+ */
+function buildFull(routes: any) {
+  const routeManifest = createRouteManifest(routes);
+  const flatViewRoutes = createFlatViewRoutes(routes);
+  const hiddenRoutePaths = new Set(
+    Object.entries(flatViewRoutes)
+      .filter(([, { middleware }]) => middleware.includes("auth"))
+      .map(([routePath]) => routePath),
+  );
+
+  const full: ClientBundle = {
+    routeManifest,
+    componentTree: [["404", []], ...createComponentTree(routes)],
+    loaders: Object.fromEntries(
+      ["404", "PublicLayout", "Home", "Pricing", "SettingsLayout", "Help", "Billing", "AppLayout", "Dashboard", "Inbox"].map(
+        (view) => [view, `/app/views/${view}.tsx`],
+      ),
+    ),
+  };
+
+  return { full, hiddenRoutePaths };
+}
+
+describe("createClientBundle()", () => {
+  test("hiding by route path lines up with the manifest's keys", () => {
+    const { hiddenRoutePaths, full } = buildFull({ "/": RootRouter });
+
+    // If these two ever drifted, hiding would silently do nothing.
+    expect(hiddenRoutePaths).toEqual(new Set(["/dashboard", "/inbox", "/settings/billing"]));
+    for (const routePath of hiddenRoutePaths) {
+      expect(full.routeManifest).toHaveProperty([routePath]);
+    }
+  });
+
+  test("a layout whose children are all private disappears entirely", () => {
+    const { full, hiddenRoutePaths } = buildFull({ "/": RootRouter });
+    const bundle = createClientBundle(full, hiddenRoutePaths);
+
+    expect(Object.keys(bundle.routeManifest).sort()).toEqual([
+      "/",
+      "/pricing",
+      "/settings/help",
+    ]);
+    // AppLayout only ever reached the manifest through /dashboard and /inbox.
+    expect(bundle.componentTree).toEqual([
+      ["404", []],
+      [
+        "PublicLayout",
+        [
+          ["Home", []],
+          ["Pricing", []],
+        ],
+      ],
+      ["SettingsLayout", [["Help", []]]],
+    ]);
+    expect(bundle.loaders).not.toHaveProperty("AppLayout");
+    expect(bundle.loaders).not.toHaveProperty("Dashboard");
+    expect(bundle.loaders).not.toHaveProperty("Billing");
+  });
+
+  test("a layout with mixed children keeps only its public chains", () => {
+    const { full, hiddenRoutePaths } = buildFull({ "/": RootRouter });
+    const bundle = createClientBundle(full, hiddenRoutePaths);
+
+    expect(bundle.routeManifest["/settings/help"]).toEqual(["SettingsLayout", "Help"]);
+    expect(bundle.loaders).toHaveProperty("SettingsLayout");
+    expect(bundle.loaders).toHaveProperty("Help");
+  });
+
+  test("`404` stays reachable even though no route points at it", () => {
+    const { full, hiddenRoutePaths } = buildFull({ "/": RootRouter });
+    const bundle = createClientBundle(full, hiddenRoutePaths);
+
+    expect(bundle.componentTree[0]).toEqual(["404", []]);
+    expect(bundle.loaders["404"]).toBe("/app/views/404.tsx");
+  });
+
+  test("an app with no private routes gets the identical bundle", () => {
+    const { full } = buildFull({ "/": RootRouter });
+
+    expect(createClientBundle(full, new Set())).toBe(full);
+  });
+});
+
+describe("collectVisibleViews()", () => {
+  test("flattens every chain and always includes 404", () => {
+    expect(
+      collectVisibleViews({
+        "/": ["Layout", "Home"],
+        "/about": ["Layout", "About"],
+      }),
+    ).toEqual(new Set(["404", "Layout", "Home", "About"]));
+  });
+});
+
+describe("pruneComponentTree()", () => {
+  test("drops a branch as soon as its root view is hidden", () => {
+    const tree: any = [
+      ["Layout", [["Home", []]]],
+      ["AppLayout", [["Dashboard", [["Widget", []]]]]],
+    ];
+
+    expect(pruneComponentTree(tree, new Set(["Layout", "Home", "Widget"]))).toEqual([
+      ["Layout", [["Home", []]]],
+    ]);
+  });
+});
+
+describe("serializeViewLoaders()", () => {
+  test("emits an object literal of dynamic imports", () => {
+    expect(serializeViewLoaders({ Home: "/app/views/Home.tsx" })).toBe(
+      `{"Home": () => import("/app/views/Home.tsx")}`,
+    );
+  });
+
+  test("emits a valid empty literal", () => {
+    expect(serializeViewLoaders({})).toBe("{}");
+  });
+});

--- a/packages/gemi/services/router/createClientBundle.ts
+++ b/packages/gemi/services/router/createClientBundle.ts
@@ -1,0 +1,91 @@
+import type { ComponentTree } from "../../client/types";
+
+export type RouteManifest = Record<string, string[]>;
+
+/** What the browser is told about the app's routes, for one audience. */
+export interface ClientBundle {
+  routeManifest: RouteManifest;
+  componentTree: ComponentTree;
+  loaders: Record<string, string>;
+}
+
+/**
+ * Every view name reachable through a manifest. `404` is always reachable — the
+ * client falls back to it for any path it can't match.
+ */
+export function collectVisibleViews(routeManifest: RouteManifest) {
+  const visibleViews = new Set<string>(["404"]);
+  for (const viewPaths of Object.values(routeManifest)) {
+    for (const viewPath of viewPaths) {
+      visibleViews.add(viewPath);
+    }
+  }
+  return visibleViews;
+}
+
+/**
+ * Drop nodes whose view isn't visible. A layout only ever reaches the manifest
+ * through its children, so a layout whose children are all hidden is itself
+ * hidden and its whole branch disappears.
+ */
+export function pruneComponentTree(
+  componentTree: ComponentTree,
+  visibleViews: Set<string>,
+): ComponentTree {
+  const out: ComponentTree = [];
+  for (const [viewPath, children] of componentTree) {
+    if (!visibleViews.has(viewPath)) {
+      continue;
+    }
+    out.push([viewPath, pruneComponentTree(children, visibleViews)]);
+  }
+  return out;
+}
+
+export function pruneViewLoaders(
+  loaders: Record<string, string>,
+  visibleViews: Set<string>,
+) {
+  return Object.fromEntries(
+    Object.entries(loaders).filter(([viewName]) => visibleViews.has(viewName)),
+  );
+}
+
+/**
+ * Build the bundle for an audience that may not see `hiddenRoutePaths`.
+ *
+ * Hiding is driven by route paths (that's what middleware is attached to); the
+ * component tree and loader map are then narrowed to whatever views the
+ * surviving routes still reference, so no private view name or chunk URL is
+ * left behind.
+ */
+export function createClientBundle(
+  full: ClientBundle,
+  hiddenRoutePaths: Set<string>,
+): ClientBundle {
+  if (hiddenRoutePaths.size === 0) {
+    return full;
+  }
+
+  const routeManifest = Object.fromEntries(
+    Object.entries(full.routeManifest).filter(
+      ([routePath]) => !hiddenRoutePaths.has(routePath),
+    ),
+  );
+  const visibleViews = collectVisibleViews(routeManifest);
+
+  return {
+    routeManifest,
+    componentTree: pruneComponentTree(full.componentTree, visibleViews),
+    loaders: pruneViewLoaders(full.loaders, visibleViews),
+  };
+}
+
+/** Serialize a loader map into the `window.loaders` object literal. */
+export function serializeViewLoaders(loaders: Record<string, string>) {
+  const entries = Object.entries(loaders).map(
+    ([viewName, url]) =>
+      `${JSON.stringify(viewName)}: () => import(${JSON.stringify(url)})`,
+  );
+  return `{${entries.join(",")}}`;
+}

--- a/packages/gemi/services/router/downgradePublicCacheControl.test.ts
+++ b/packages/gemi/services/router/downgradePublicCacheControl.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "vitest";
+import { downgradePublicCacheControl } from "./downgradePublicCacheControl";
+
+function downgrade(cacheControl?: string) {
+  const headers = new Headers();
+  if (cacheControl !== undefined) {
+    headers.set("Cache-Control", cacheControl);
+  }
+  downgradePublicCacheControl(headers);
+  return headers.get("Cache-Control");
+}
+
+describe("downgradePublicCacheControl()", () => {
+  test("swaps `public` for `private` and keeps the rest of the header", () => {
+    // What the saas-starter's `cache:public,12840,must-revalidate` produces.
+    expect(downgrade("public, max-age=12840, must-revalidate")).toBe(
+      "private, max-age=12840, must-revalidate",
+    );
+  });
+
+  test("drops `s-maxage`, which only shared caches honour", () => {
+    expect(downgrade("public, max-age=60, s-maxage=3600")).toBe("private, max-age=60");
+  });
+
+  test("adds `private` when no scope was stated", () => {
+    expect(downgrade("max-age=60")).toBe("private, max-age=60");
+  });
+
+  test("leaves an already-private header's scope alone", () => {
+    expect(downgrade("private, max-age=0, must-revalidate")).toBe(
+      "private, max-age=0, must-revalidate",
+    );
+  });
+
+  test("does not invent a header where there was none", () => {
+    expect(downgrade()).toBe(null);
+  });
+
+  test("is case-insensitive about the directive", () => {
+    expect(downgrade("PUBLIC, max-age=60")).toBe("private, max-age=60");
+  });
+});

--- a/packages/gemi/services/router/downgradePublicCacheControl.ts
+++ b/packages/gemi/services/router/downgradePublicCacheControl.ts
@@ -1,0 +1,34 @@
+/**
+ * Turn a shared-cache directive into a per-visitor one, leaving the rest of the
+ * header (`max-age`, `must-revalidate`, ...) alone. `s-maxage` only applies to
+ * shared caches, so it goes too.
+ *
+ * Rendered HTML embeds a route manifest scoped to who is asking, so a response
+ * built for a signed-in visitor must never be reused for an anonymous one.
+ */
+export function downgradePublicCacheControl(headers: Headers) {
+  const cacheControl = headers.get("Cache-Control");
+  if (!cacheControl) {
+    return;
+  }
+
+  const directives = cacheControl
+    .split(",")
+    .map((directive) => directive.trim())
+    .filter(Boolean)
+    .filter((directive) => !/^s-maxage=/i.test(directive));
+
+  if (directives.some((directive) => /^private$/i.test(directive))) {
+    headers.set("Cache-Control", directives.join(", "));
+    return;
+  }
+
+  const publicIndex = directives.findIndex((directive) => /^public$/i.test(directive));
+  if (publicIndex === -1) {
+    directives.unshift("private");
+  } else {
+    directives[publicIndex] = "private";
+  }
+
+  headers.set("Cache-Control", directives.join(", "));
+}


### PR DESCRIPTION
## Problem

Every page shipped the **entire** route table to the browser regardless of who was asking. `ViewRouterServiceContainer` built `clientRouteManifest` and `componentTree` once at boot and inlined both into `window.__GEMI_DATA__` on every render; `window.loaders` additionally mapped every view name to its module URL.

So an anonymous visitor to `/` received the URL patterns of every `auth`-guarded route (`/dashboard`, `/inbox`, …), the names of their views (`AppLayout`, `Dashboard`), and in production the hashed chunk URL to download each one.

## Approach

**Classification is automatic, from middleware.** `Middleware` gained `static isPrivate` (true on `AuthenticationMiddleware`); `MiddlewareServiceContainer.isPrivateChain()` resolves a route's flattened chain through the app's aliases. `middlewares = ["auth"]` just works — no per-route annotation. Custom guards opt in with the same flag. Alias resolution reuses the existing `transformMiddleware`, so a `-auth` cancellation behaves exactly as it does at request time.

**Hiding covers all three structures.** `getClientBundle(isAuthenticated)` returns cached anonymous/authenticated variants. Hiding is driven by route path (that's what middleware attaches to), then the component tree and loader map are narrowed to the views the surviving routes still reference — so private view *names* and chunk URLs go too, not just URL patterns. Both variants are computed once; there is no per-request work. Apps with no private routes get one identical bundle and skip session resolution entirely.

The loader map moved out of `httpDev`/`httpProd` into the container (`setViewLoaders`) so the render path and the manifest endpoint filter the same source.

**The client stays a SPA across auth changes.** A new `RouteRegistry` owns the manifest, component tree and loaders client-side. When a navigation targets a path it can't match, it refreshes once from `GET /api/__gemi__/router/manifest` and retries — which is what carries the template's `push("/dashboard")` immediately after sign-in. `useSignOut` refreshes back down to the anonymous bundle. Concurrent misses share one request, and a genuine 404 refetches at most once.

## Two related leaks fixed along the way

- **`/api/__gemi__/debug/view-routes`** was mounted unconditionally with no auth and dumped the full path + viewPath + middleware table in production. Filtering the manifest is pointless while that is reachable — it is now dev-only.
- **Caching.** HTML embedding an audience-specific manifest cannot stay publicly cacheable (the saas-starter root router uses `cache:public,12840,must-revalidate`). When a viewer resolves, `Cache-Control: public` is downgraded to `private` and `s-maxage` is dropped.

## Verification

Against `templates/saas-starter` in **both dev and a production build**, driving real Chrome over CDP:

| | anonymous | signed in |
|---|---|---|
| `routeManifest` | no `/dashboard`, `/inbox` | both present |
| `componentTree` / `window.loaders` | no `AppLayout`, `Dashboard`, `Inbox` | present |
| `Cache-Control` on `/` | `public, max-age=12840` | `private, max-age=12840` |

- `/dashboard` while anonymous still 302s to `/auth/sign-in` — the middleware path is untouched.
- Sign in → `push("/dashboard")` renders the real Dashboard, not the 404 view, with one `GET /api/__gemi__/router/manifest` and the subsequent chunk load. No console errors.
- Sign out → back on `/auth/sign-in`, and the server serves the anonymous bundle again.
- `/api/__gemi__/debug/view-routes`: 200 in dev, 404 in production.

Typecheck clean, lint 0 errors, 35 new tests across `createClientBundle`, `isPrivateChain`, `downgradePublicCacheControl` and `RouteRegistry`.

## Notes for review

- The 7 pre-existing suite failures (`createRouteManifest`, `createComponentTree`, `createFlatViewRoutes`) and 3 import-level failures (`bun`-only modules under vitest) are untouched by this branch — none of those source files are in the diff.
- `resolveViewer()` adds one session lookup per **public** page request that carries an `access_token`. It deliberately does *not* call `ctx.setUser()`, so `auth.user` in the page payload is unchanged from today.
- The `history.listen` effect now returns its unlisten function; previously it leaked a listener on every dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)