### PR TITLE
Compress SSR HTML responses in the production server

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 ### Foundations
 - **[Getting Started](./getting-started.md)** — install, scaffold, dev/build/start, your first route + view.
 - **[Project Structure & the Kernel](./project-structure.md)** — the `app/` layout, the Kernel, service providers, and app bootstrap.
-- **[Configuration](./configuration.md)** — `gemi.config.ts`, `.env` handling, `app/preload.ts`, Vite config.
+- **[Configuration](./configuration.md)** — `gemi.config.ts`, `.env` handling, HTML compression, `app/preload.ts`, Vite config.
 - **[CLI](./cli.md)** — `gemi dev`, `build`, `start`, and the codegen/inspection commands.
 
 ### HTTP layer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,42 @@ Bun reads `.env` only once at startup and does not reload it — even under `--h
 
 > **Gotcha:** The reload updates `process.env`, so config read **per request** picks up the new value immediately. But a value a service reads **once at boot** (e.g. a client constructed from an env var) is already cached and won't change until that code re-runs — a hot reload in dev, or a full restart in production. Also, a key you delete from the file keeps its last value until the next full restart; the watcher only adds and updates keys, never clears them.
 
+## HTML compression
+
+In **production only** (`gemi start`), gemi compresses SSR HTML responses at the edge of the server, after your instrumentation runs. Nothing to configure — a client that sends `Accept-Encoding: br` or `gzip` gets an encoded document, and one that doesn't gets the same bytes it always did.
+
+An SSR document is mostly critical CSS, markup, and the `window.__GEMI_DATA__` hydration payload, so it compresses extremely well. On a representative page (177 kB of HTML):
+
+| Encoding | Transferred | Reduction | Cost |
+| --- | ---: | ---: | ---: |
+| identity | 177,072 B | — | — |
+| `gzip` (level 6) | 31,514 B | 82.2% | ~2 ms |
+| `br` (quality 5) | 27,911 B | 84.2% | ~2 ms |
+
+Brotli is preferred when the client accepts both. gemi runs it at quality 5 rather than the default 11: on a streamed document, quality 11 costs ~175 ms for ~12% more savings, which is the wrong trade for content compressed once per request instead of once per build.
+
+### What is and isn't compressed
+
+- **`text/html` responses only.** JSON view-data responses (`.json`), API routes, static assets from `dist/`, and OG images are untouched — same response object, same headers.
+- **Streaming is preserved.** The compressor flushes on every write, so React's shell still reaches the browser before the rest of the document is rendered. Compression does not cost you time to first byte.
+- **The transport layer only.** What the browser decodes is byte-for-byte the HTML React rendered, so hydration sees exactly what it would have without compression.
+- Responses are left alone when they are already encoded, carry `Cache-Control: no-transform`, are a `206` byte range, or answer a `HEAD`.
+- `Content-Length` is dropped from an encoded response (it described the identity body), and `Vary: Accept-Encoding` is added to **every** HTML response — including the identity ones — so a shared cache can never hand an encoded variant to a client that didn't ask for one.
+
+### Why the framework and not the CDN
+
+Compression could live at the edge, in the runtime, or in the app. gemi puts it in the runtime because it is the only layer where the behaviour is portable: every gemi app serves the same shape of response, so the win doesn't depend on each deployment configuring a CDN to compress on the origin's behalf. It also cuts **origin→edge** bandwidth, which edge compression cannot do. Edge compression still composes on top of it — the `Vary` header is what makes that safe.
+
+### Opting out
+
+If a layer in front of the origin already compresses HTML and you'd rather not spend origin CPU on it:
+
+```bash
+GEMI_COMPRESSION=off
+```
+
+Any other value (or none) leaves compression on.
+
 ## `app/preload.ts`
 
 `app/preload.ts` is an optional [Bun `--preload`](https://bun.sh/docs/runtime/bunfig#preload) script that runs **once, before the server starts**, for both `gemi dev` and `gemi start`. Use it for process-wide setup that must happen before any request is handled:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -34,7 +34,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 ### Foundations
 - **[Getting Started](./getting-started.md)** — install, scaffold, dev/build/start, your first route + view.
 - **[Project Structure & the Kernel](./project-structure.md)** — the `app/` layout, the Kernel, service providers, and app bootstrap.
-- **[Configuration](./configuration.md)** — `gemi.config.ts`, `.env` handling, `app/preload.ts`, Vite config.
+- **[Configuration](./configuration.md)** — `gemi.config.ts`, `.env` handling, HTML compression, `app/preload.ts`, Vite config.
 - **[CLI](./cli.md)** — `gemi dev`, `build`, `start`, and the codegen/inspection commands.
 
 ### HTTP layer
@@ -599,6 +599,42 @@ Bun reads `.env` only once at startup and does not reload it — even under `--h
 ```
 
 > **Gotcha:** The reload updates `process.env`, so config read **per request** picks up the new value immediately. But a value a service reads **once at boot** (e.g. a client constructed from an env var) is already cached and won't change until that code re-runs — a hot reload in dev, or a full restart in production. Also, a key you delete from the file keeps its last value until the next full restart; the watcher only adds and updates keys, never clears them.
+
+## HTML compression
+
+In **production only** (`gemi start`), gemi compresses SSR HTML responses at the edge of the server, after your instrumentation runs. Nothing to configure — a client that sends `Accept-Encoding: br` or `gzip` gets an encoded document, and one that doesn't gets the same bytes it always did.
+
+An SSR document is mostly critical CSS, markup, and the `window.__GEMI_DATA__` hydration payload, so it compresses extremely well. On a representative page (177 kB of HTML):
+
+| Encoding | Transferred | Reduction | Cost |
+| --- | ---: | ---: | ---: |
+| identity | 177,072 B | — | — |
+| `gzip` (level 6) | 31,514 B | 82.2% | ~2 ms |
+| `br` (quality 5) | 27,911 B | 84.2% | ~2 ms |
+
+Brotli is preferred when the client accepts both. gemi runs it at quality 5 rather than the default 11: on a streamed document, quality 11 costs ~175 ms for ~12% more savings, which is the wrong trade for content compressed once per request instead of once per build.
+
+### What is and isn't compressed
+
+- **`text/html` responses only.** JSON view-data responses (`.json`), API routes, static assets from `dist/`, and OG images are untouched — same response object, same headers.
+- **Streaming is preserved.** The compressor flushes on every write, so React's shell still reaches the browser before the rest of the document is rendered. Compression does not cost you time to first byte.
+- **The transport layer only.** What the browser decodes is byte-for-byte the HTML React rendered, so hydration sees exactly what it would have without compression.
+- Responses are left alone when they are already encoded, carry `Cache-Control: no-transform`, are a `206` byte range, or answer a `HEAD`.
+- `Content-Length` is dropped from an encoded response (it described the identity body), and `Vary: Accept-Encoding` is added to **every** HTML response — including the identity ones — so a shared cache can never hand an encoded variant to a client that didn't ask for one.
+
+### Why the framework and not the CDN
+
+Compression could live at the edge, in the runtime, or in the app. gemi puts it in the runtime because it is the only layer where the behaviour is portable: every gemi app serves the same shape of response, so the win doesn't depend on each deployment configuring a CDN to compress on the origin's behalf. It also cuts **origin→edge** bandwidth, which edge compression cannot do. Edge compression still composes on top of it — the `Vary` header is what makes that safe.
+
+### Opting out
+
+If a layer in front of the origin already compresses HTML and you'd rather not spend origin CPU on it:
+
+```bash
+GEMI_COMPRESSION=off
+```
+
+Any other value (or none) leaves compression on.
 
 ## `app/preload.ts`
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,7 +10,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 
 - [Getting Started](https://nstfkc.github.io/gemi/getting-started.md): install, scaffold with create-gemi-app, dev/build/start, a first route + view.
 - [Project Structure & the Kernel](https://nstfkc.github.io/gemi/project-structure.md): the app/ layout, the Kernel, service providers, and app bootstrap.
-- [Configuration](https://nstfkc.github.io/gemi/configuration.md): gemi.config.ts, .env handling, app/preload.ts, Vite config.
+- [Configuration](https://nstfkc.github.io/gemi/configuration.md): gemi.config.ts, .env handling, HTML compression, app/preload.ts, Vite config.
 - [CLI](https://nstfkc.github.io/gemi/cli.md): gemi dev/build/start plus codegen and inspection commands.
 
 ## HTTP layer

--- a/packages/gemi/server/compression.test.ts
+++ b/packages/gemi/server/compression.test.ts
@@ -1,0 +1,292 @@
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { describe, expect, test } from "vitest";
+
+import {
+  compressResponse,
+  isCompressible,
+  negotiateEncoding,
+  parseAcceptEncoding,
+} from "./compression";
+
+const HTML = `<!doctype html><html><head><title>gemi</title></head><body>${"<div>hello</div>".repeat(200)}</body></html>`;
+
+function htmlResponse(
+  body: BodyInit | null = HTML,
+  init: ResponseInit & { headers?: Record<string, string> } = {},
+) {
+  const { headers, ...rest } = init;
+  return new Response(body, {
+    ...rest,
+    headers: { "Content-Type": "text/html; charset=utf-8", ...headers },
+  });
+}
+
+/** Streams the body in several chunks, the way a streamed SSR render does. */
+function chunkedHtml(content = HTML, chunks = 4) {
+  const bytes = new TextEncoder().encode(content);
+  const size = Math.ceil(bytes.length / chunks);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let offset = 0; offset < bytes.length; offset += size) {
+        controller.enqueue(bytes.subarray(offset, offset + size));
+      }
+      controller.close();
+    },
+  });
+}
+
+async function decode(res: Response) {
+  const encoded = Buffer.from(await res.arrayBuffer());
+  switch (res.headers.get("Content-Encoding")) {
+    case "br":
+      return brotliDecompressSync(encoded).toString();
+    case "gzip":
+      return gunzipSync(encoded).toString();
+    default:
+      return encoded.toString();
+  }
+}
+
+const get = (acceptEncoding?: string) =>
+  new Request("https://example.com/", {
+    headers: acceptEncoding === undefined ? {} : { "Accept-Encoding": acceptEncoding },
+  });
+
+describe("parseAcceptEncoding()", () => {
+  test("distinguishes an absent header from an empty one", () => {
+    expect(parseAcceptEncoding(null)).toBeNull();
+    expect(parseAcceptEncoding(undefined)).toBeNull();
+    expect(parseAcceptEncoding("")).toEqual(new Map());
+  });
+
+  test("parses codings and q-values, case insensitively", () => {
+    expect(parseAcceptEncoding("GZIP, br;q=0.8, *;q=0.1")).toEqual(
+      new Map([
+        ["gzip", 1],
+        ["br", 0.8],
+        ["*", 0.1],
+      ]),
+    );
+  });
+
+  test("tolerates whitespace and accept-ext parameters", () => {
+    expect(parseAcceptEncoding("  br ; foo=bar ; q=0.5  ")).toEqual(new Map([["br", 0.5]]));
+  });
+
+  test("treats a malformed q-value as unqualified rather than dropping the coding", () => {
+    expect(parseAcceptEncoding("gzip;q=high")).toEqual(new Map([["gzip", 1]]));
+    expect(parseAcceptEncoding("gzip;q=2")).toEqual(new Map([["gzip", 1]]));
+  });
+
+  test("keeps q=0, which is a refusal and not an absence", () => {
+    expect(parseAcceptEncoding("gzip;q=0")).toEqual(new Map([["gzip", 0]]));
+  });
+});
+
+describe("negotiateEncoding()", () => {
+  test("falls back to identity when the client says nothing", () => {
+    expect(negotiateEncoding(null)).toBeNull();
+    expect(negotiateEncoding("")).toBeNull();
+    expect(negotiateEncoding("identity")).toBeNull();
+    expect(negotiateEncoding("zstd, compress")).toBeNull();
+  });
+
+  test("picks what the client offers", () => {
+    expect(negotiateEncoding("gzip")).toBe("gzip");
+    expect(negotiateEncoding("br")).toBe("br");
+  });
+
+  test("breaks q-value ties on server preference, not client order", () => {
+    expect(negotiateEncoding("gzip, br")).toBe("br");
+    expect(negotiateEncoding("br, gzip")).toBe("br");
+  });
+
+  test("honours a higher q-value over the server preference", () => {
+    expect(negotiateEncoding("gzip, br;q=0.5")).toBe("gzip");
+  });
+
+  test("treats q=0 as a refusal", () => {
+    expect(negotiateEncoding("br;q=0, gzip")).toBe("gzip");
+    expect(negotiateEncoding("br;q=0, gzip;q=0")).toBeNull();
+  });
+
+  test("applies the wildcard only to codings the client did not name", () => {
+    expect(negotiateEncoding("*")).toBe("br");
+    expect(negotiateEncoding("br;q=0, *")).toBe("gzip");
+    expect(negotiateEncoding("*;q=0, gzip")).toBe("gzip");
+    expect(negotiateEncoding("*;q=0")).toBeNull();
+  });
+});
+
+describe("isCompressible()", () => {
+  test("accepts a streamed HTML response", () => {
+    expect(isCompressible("GET", htmlResponse())).toBe(true);
+  });
+
+  test("accepts the SSR 404, which is still an HTML document", () => {
+    expect(isCompressible("GET", htmlResponse(HTML, { status: 404 }))).toBe(true);
+  });
+
+  test("leaves everything that isn't HTML alone", () => {
+    const json = new Response("{}", {
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    });
+    expect(isCompressible("GET", json)).toBe(false);
+    expect(isCompressible("GET", new Response(HTML))).toBe(false);
+    expect(
+      isCompressible("GET", new Response("x", { headers: { "Content-Type": "text/html+evil" } })),
+    ).toBe(false);
+  });
+
+  test("skips HEAD, which has no body to describe", () => {
+    expect(isCompressible("HEAD", htmlResponse())).toBe(false);
+  });
+
+  test("skips bodyless and partial statuses", () => {
+    expect(isCompressible("GET", htmlResponse(null, { status: 204 }))).toBe(false);
+    expect(isCompressible("GET", htmlResponse(null, { status: 304 }))).toBe(false);
+    expect(isCompressible("GET", htmlResponse(HTML, { status: 206 }))).toBe(false);
+  });
+
+  test("skips a range response even if the status was left at 200", () => {
+    expect(
+      isCompressible("GET", htmlResponse(HTML, { headers: { "Content-Range": "bytes 0-9/100" } })),
+    ).toBe(false);
+  });
+
+  test("never re-encodes an already encoded body", () => {
+    expect(
+      isCompressible("GET", htmlResponse(HTML, { headers: { "Content-Encoding": "gzip" } })),
+    ).toBe(false);
+    // `identity` is the one value that means "not encoded".
+    expect(
+      isCompressible("GET", htmlResponse(HTML, { headers: { "Content-Encoding": "identity" } })),
+    ).toBe(true);
+  });
+
+  test("honours Cache-Control: no-transform", () => {
+    expect(
+      isCompressible(
+        "GET",
+        htmlResponse(HTML, { headers: { "Cache-Control": "public, no-transform" } }),
+      ),
+    ).toBe(false);
+    // Token match — a directive that merely contains the word does not count.
+    expect(
+      isCompressible("GET", htmlResponse(HTML, { headers: { "Cache-Control": "x-no-transform" } })),
+    ).toBe(true);
+  });
+
+  test("skips a declared body too small to be worth encoding", () => {
+    expect(
+      isCompressible("GET", htmlResponse("<p>hi</p>", { headers: { "Content-Length": "9" } })),
+    ).toBe(false);
+    // A streamed response declares no length, so the threshold cannot apply —
+    // which is the normal case for an SSR render.
+    expect(isCompressible("GET", htmlResponse(chunkedHtml("<p>hi</p>", 1)))).toBe(true);
+  });
+});
+
+describe("compressResponse()", () => {
+  test("encodes a streamed HTML body to exactly the same bytes", async () => {
+    const res = compressResponse(get("br, gzip"), htmlResponse(chunkedHtml()));
+
+    expect(res.headers.get("Content-Encoding")).toBe("br");
+    expect(await decode(res)).toBe(HTML);
+  });
+
+  test("produces the same document under gzip", async () => {
+    const res = compressResponse(get("gzip"), htmlResponse(chunkedHtml()));
+
+    expect(res.headers.get("Content-Encoding")).toBe("gzip");
+    expect(await decode(res)).toBe(HTML);
+  });
+
+  test("actually shrinks the payload", async () => {
+    const raw = new TextEncoder().encode(HTML).byteLength;
+    for (const encoding of ["br", "gzip"]) {
+      const res = compressResponse(get(encoding), htmlResponse(chunkedHtml()));
+      const encoded = (await res.arrayBuffer()).byteLength;
+      expect(encoded).toBeLessThan(raw / 2);
+    }
+  });
+
+  test("drops a Content-Length that described the identity body", async () => {
+    const res = compressResponse(
+      get("gzip"),
+      htmlResponse(HTML, { headers: { "Content-Length": String(HTML.length) } }),
+    );
+
+    expect(res.headers.get("Content-Length")).toBeNull();
+    expect(await decode(res)).toBe(HTML);
+  });
+
+  test("preserves status, statusText and the other headers", async () => {
+    const source = htmlResponse(chunkedHtml(), {
+      status: 404,
+      statusText: "Not Found",
+      headers: { "Cache-Control": "public, max-age=60", "X-Gemi": "1" },
+    });
+    source.headers.append("Set-Cookie", "session_id=a; HttpOnly");
+    source.headers.append("Set-Cookie", "csrf_token=b; HttpOnly");
+
+    const res = compressResponse(get("br"), source);
+
+    expect(res.status).toBe(404);
+    expect(res.statusText).toBe("Not Found");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(res.headers.get("X-Gemi")).toBe("1");
+    expect(res.headers.getSetCookie()).toEqual([
+      "session_id=a; HttpOnly",
+      "csrf_token=b; HttpOnly",
+    ]);
+    expect(await decode(res)).toBe(HTML);
+  });
+
+  test("marks HTML as varying by Accept-Encoding even when it sends identity", async () => {
+    const res = compressResponse(get(), htmlResponse(chunkedHtml()));
+
+    expect(res.headers.get("Content-Encoding")).toBeNull();
+    expect(res.headers.get("Vary")).toBe("Accept-Encoding");
+    expect(await res.text()).toBe(HTML);
+  });
+
+  test("adds Accept-Encoding to an existing Vary without duplicating it", () => {
+    const varyOnHeader = compressResponse(
+      get("gzip"),
+      htmlResponse(chunkedHtml(), { headers: { Vary: "x-gemi-partial-render" } }),
+    );
+    expect(varyOnHeader.headers.get("Vary")).toBe("x-gemi-partial-render, Accept-Encoding");
+
+    const alreadyVaries = compressResponse(
+      get("gzip"),
+      htmlResponse(chunkedHtml(), { headers: { Vary: "accept-encoding" } }),
+    );
+    expect(alreadyVaries.headers.get("Vary")).toBe("accept-encoding");
+
+    const varyAll = compressResponse(
+      get("gzip"),
+      htmlResponse(chunkedHtml(), { headers: { Vary: "*" } }),
+    );
+    expect(varyAll.headers.get("Vary")).toBe("*");
+  });
+
+  test("returns non-HTML responses untouched, down to the identity of the object", async () => {
+    const json = new Response(JSON.stringify({ data: 1 }), {
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    });
+
+    const res = compressResponse(get("br, gzip"), json);
+
+    expect(res).toBe(json);
+    expect(res.headers.get("Content-Encoding")).toBeNull();
+    expect(res.headers.get("Vary")).toBeNull();
+    expect(await res.json()).toEqual({ data: 1 });
+  });
+
+  test("leaves an already encoded HTML body exactly as it was", () => {
+    const encoded = htmlResponse(chunkedHtml(), { headers: { "Content-Encoding": "gzip" } });
+
+    expect(compressResponse(get("br, gzip"), encoded)).toBe(encoded);
+  });
+});

--- a/packages/gemi/server/compression.ts
+++ b/packages/gemi/server/compression.ts
@@ -1,0 +1,298 @@
+/**
+ * Transport-level compression for SSR HTML responses.
+ *
+ * This lives in the runtime rather than in an app, because every gemi app
+ * serves the same shape of response: a streamed `text/html` document whose
+ * bulk is critical CSS, markup and the `window.__GEMI_DATA__` hydration
+ * payload. Compressing it here means the win is portable across deployments —
+ * it does not depend on a CDN being configured to compress on the origin's
+ * behalf — and it also cuts origin→edge bandwidth, which edge compression
+ * cannot.
+ *
+ * Compression stays strictly at the transport layer: what the client decodes
+ * is byte-for-byte the HTML React rendered, so hydration is unaffected.
+ *
+ * Deliberately dependency-free apart from `node:zlib`/`node:stream` so it can
+ * be unit tested without booting a server.
+ */
+
+import { Duplex } from "node:stream";
+import { constants, createBrotliCompress, createGzip } from "node:zlib";
+
+/** The content codings we can produce, in the order we prefer them. */
+export type ContentEncoding = "br" | "gzip";
+
+/**
+ * Server preference, used to break q-value ties. Brotli comes first: at the
+ * quality we use it is both smaller *and* no more expensive than gzip on a
+ * representative SSR document (~177 kB → 28.0 kB in ~2.0 ms, versus 31.6 kB in
+ * ~2.0 ms for gzip).
+ */
+const SERVER_PREFERENCE: ContentEncoding[] = ["br", "gzip"];
+
+/**
+ * Below this, an encoded body plus its framing overhead is not worth the CPU.
+ * Only applied when the response declares a `Content-Length` — a streamed SSR
+ * response does not, and buffering one just to measure it would defeat the
+ * streaming render.
+ */
+const MIN_COMPRESSIBLE_BYTES = 1024;
+
+/**
+ * Brotli quality 5 (of 11). The default, 11, is meant for static assets
+ * compressed once at build time — on a streamed document it costs ~175 ms,
+ * two orders of magnitude more than quality 5 for ~12% more savings. Quality 5
+ * is the usual choice for dynamic content.
+ *
+ * `LGWIN` 19 caps the window at 512 kB rather than the default 16 MB. An SSR
+ * document is far smaller than that, so the ratio is unchanged, and the bound
+ * matters under concurrency: the window is allocated per in-flight response.
+ */
+const BROTLI_QUALITY = 5;
+const BROTLI_WINDOW_BITS = 19;
+
+/** zlib's default level. Level 9 costs measurably more for ~1% on HTML. */
+const GZIP_LEVEL = 6;
+
+function parseQValue(raw: string | undefined): number {
+  if (raw === undefined) {
+    return 1;
+  }
+  // `q` is a fixed-point number with at most three decimals (RFC 9110 §12.4.2).
+  // Anything else is malformed; treat it as an unqualified "acceptable" rather
+  // than dropping the encoding, matching what tolerant servers do.
+  if (!/^\d+(\.\d{0,3})?$/.test(raw.trim())) {
+    return 1;
+  }
+  const value = Number(raw.trim());
+  return Number.isFinite(value) ? Math.min(value, 1) : 1;
+}
+
+/**
+ * Parses a request `Accept-Encoding` into `coding -> qvalue`.
+ *
+ * Returns `null` when the header is *absent*, which is distinct from an empty
+ * one. RFC 9110 §12.5.3 says an absent header means any coding is acceptable,
+ * but a client that cannot decode and forgets to say so is a broken page, not
+ * a slow one — so we treat "absent" as "identity" and only encode when a
+ * client has explicitly opted in. An empty header (`Accept-Encoding:`) is a
+ * deliberate "identity only" and parses to an empty map.
+ */
+export function parseAcceptEncoding(header: string | null | undefined): Map<string, number> | null {
+  if (header === null || header === undefined) {
+    return null;
+  }
+
+  const accepted = new Map<string, number>();
+  for (const part of header.split(",")) {
+    const [rawCoding, ...params] = part.split(";");
+    const coding = rawCoding.trim().toLowerCase();
+    if (coding === "") {
+      continue;
+    }
+
+    let q = 1;
+    for (const param of params) {
+      const separator = param.indexOf("=");
+      if (separator === -1) {
+        continue;
+      }
+      if (param.slice(0, separator).trim().toLowerCase() === "q") {
+        q = parseQValue(param.slice(separator + 1));
+        break;
+      }
+    }
+
+    accepted.set(coding, q);
+  }
+
+  return accepted;
+}
+
+/**
+ * Picks the coding to use, or `null` for identity.
+ *
+ * A `q=0` is a refusal, `*` covers codings the client did not name, and ties
+ * fall back to `available`'s order — so a plain `Accept-Encoding: gzip, br`
+ * (equal q of 1) resolves to our preference rather than the client's.
+ */
+export function negotiateEncoding(
+  header: string | null | undefined,
+  available: ContentEncoding[] = SERVER_PREFERENCE,
+): ContentEncoding | null {
+  const accepted = parseAcceptEncoding(header);
+  if (!accepted) {
+    return null;
+  }
+
+  const wildcard = accepted.get("*");
+  let best: ContentEncoding | null = null;
+  let bestQ = 0;
+
+  for (const coding of available) {
+    const q = accepted.get(coding) ?? wildcard ?? 0;
+    if (q > bestQ) {
+      best = coding;
+      bestQ = q;
+    }
+  }
+
+  return best;
+}
+
+function hasDirective(headerValue: string | null, directive: string): boolean {
+  if (!headerValue) {
+    return false;
+  }
+  // Token match, not substring: `no-transform` must not be found inside
+  // something like `x-no-transform`.
+  return headerValue
+    .split(",")
+    .some((token) => token.trim().toLowerCase().split("=")[0].trim() === directive);
+}
+
+/**
+ * Whether this response's representation is one we may encode — and therefore
+ * one that varies by `Accept-Encoding`, even on the requests where we end up
+ * sending identity.
+ *
+ * HTML only, on purpose. JSON view-data and API responses are left alone so
+ * that this change cannot alter how they are produced, framed or cached;
+ * widening the set is a separate decision.
+ */
+export function isCompressible(method: string, res: Response): boolean {
+  // A HEAD response carries no body to encode, and emitting `Content-Encoding`
+  // without one would describe a body the client never receives.
+  if (method === "HEAD") {
+    return false;
+  }
+
+  if (!res.body) {
+    return false;
+  }
+
+  // 204/304 are bodyless; 206 is a byte range of an already-committed
+  // representation and re-encoding it would invalidate its `Content-Range`.
+  if (res.status < 200 || res.status === 204 || res.status === 206 || res.status === 304) {
+    return false;
+  }
+
+  if (res.headers.has("Content-Range")) {
+    return false;
+  }
+
+  const contentType = res.headers.get("Content-Type");
+  if (!contentType || !/^\s*text\/html\s*(;|$)/i.test(contentType)) {
+    return false;
+  }
+
+  // Already encoded upstream — `identity` is the one value that means "not
+  // encoded" and is safe to replace.
+  const contentEncoding = res.headers.get("Content-Encoding");
+  if (contentEncoding && contentEncoding.trim().toLowerCase() !== "identity") {
+    return false;
+  }
+
+  // RFC 9110 §5.2.2.6: `no-transform` forbids intermediaries *and* us from
+  // changing the representation's encoding.
+  if (hasDirective(res.headers.get("Cache-Control"), "no-transform")) {
+    return false;
+  }
+
+  const contentLength = res.headers.get("Content-Length");
+  if (contentLength !== null && Number(contentLength) < MIN_COMPRESSIBLE_BYTES) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Builds the encoder as a web `TransformStream`-shaped pair.
+ *
+ * Both codings are driven through `node:zlib` with an explicit per-write flush.
+ * Without it the compressor holds output until its internal buffer fills,
+ * which would sit on React's shell flush and turn a streamed render into a
+ * buffered one — the compression win would be paid for in time to first byte.
+ */
+export function createEncoderStream(encoding: ContentEncoding) {
+  const compressor =
+    encoding === "br"
+      ? createBrotliCompress({
+          params: {
+            [constants.BROTLI_PARAM_QUALITY]: BROTLI_QUALITY,
+            [constants.BROTLI_PARAM_LGWIN]: BROTLI_WINDOW_BITS,
+          },
+          flush: constants.BROTLI_OPERATION_FLUSH,
+        })
+      : createGzip({ level: GZIP_LEVEL, flush: constants.Z_SYNC_FLUSH });
+
+  return Duplex.toWeb(compressor) as unknown as ReadableWritablePair<Uint8Array, Uint8Array>;
+}
+
+function withVaryAcceptEncoding(headers: Headers) {
+  const vary = headers.get("Vary");
+  if (!vary) {
+    headers.set("Vary", "Accept-Encoding");
+    return;
+  }
+  const tokens = vary.split(",").map((token) => token.trim().toLowerCase());
+  // `Vary: *` already means "never reuse for another request"; narrowing it
+  // would be a downgrade.
+  if (tokens.includes("*") || tokens.includes("accept-encoding")) {
+    return;
+  }
+  headers.append("Vary", "Accept-Encoding");
+}
+
+/**
+ * Compresses an SSR HTML response when the client asked for it.
+ *
+ * Non-HTML responses are returned untouched — same object, same body, so this
+ * is safe to apply at the edge of the server for every request.
+ *
+ * HTML responses always gain `Vary: Accept-Encoding`, whether or not this
+ * particular request got an encoded body: without it a shared cache could
+ * serve a stored encoded variant to a client that cannot decode it.
+ */
+export function compressResponse(req: Request, res: Response): Response {
+  if (!isCompressible(req.method, res)) {
+    return res;
+  }
+
+  const headers = new Headers(res.headers);
+  withVaryAcceptEncoding(headers);
+
+  const encoding = negotiateEncoding(req.headers.get("Accept-Encoding"));
+  if (!encoding) {
+    return new Response(res.body, {
+      status: res.status,
+      statusText: res.statusText,
+      headers,
+    });
+  }
+
+  let encoder: ReadableWritablePair<Uint8Array, Uint8Array>;
+  try {
+    encoder = createEncoderStream(encoding);
+  } catch {
+    // A compressor we cannot construct is not worth failing a page render
+    // over. Serve identity — with the `Vary` we already added.
+    return new Response(res.body, {
+      status: res.status,
+      statusText: res.statusText,
+      headers,
+    });
+  }
+
+  headers.set("Content-Encoding", encoding);
+  // The length of the identity representation says nothing about the encoded
+  // body, and a stale one would truncate the response.
+  headers.delete("Content-Length");
+
+  return new Response(res.body!.pipeThrough(encoder), {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+}

--- a/packages/gemi/server/httpProd.ts
+++ b/packages/gemi/server/httpProd.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { compressResponse } from "./compression";
 import { generateETag } from "./generateEtag";
 import { URLPattern } from "urlpattern-polyfill";
 import { exists } from "node:fs/promises";
@@ -190,6 +191,11 @@ export async function httpProd(app: App, instrumentation: Instrumentation) {
     }
   }
 
+  // Compression is on unless the deployment opts out — set `GEMI_COMPRESSION=off`
+  // when a layer in front of the origin already compresses HTML and you would
+  // rather not spend origin CPU on it.
+  const compressionEnabled = (process.env.GEMI_COMPRESSION ?? "auto").toLowerCase() !== "off";
+
   const server = Bun.serve({
     maxRequestBodySize: 10 * 1024 * 1024 * 1024, // 10 GB
     fetch: async (req, server) => {
@@ -199,7 +205,12 @@ export async function httpProd(app: App, instrumentation: Instrumentation) {
         const ip = server.requestIP(req);
         if (ip) req.headers.set("x-forwarded-for", ip.address);
       }
-      return await instrumentation(req, requestHandler);
+      const res = await instrumentation(req, requestHandler);
+      // Applied at the very edge, after instrumentation, so every HTML response
+      // goes through the same negotiation — including the ones an app's
+      // instrumentation produced itself. Anything that isn't HTML comes back
+      // untouched.
+      return compressionEnabled ? compressResponse(req, res) : res;
     },
     idleTimeout: Number(process.env.SERVER_IDLE_TIMEOUT ?? 10),
     port: process.env.PORT || 5173,


### PR DESCRIPTION
Closes Quantus-Labs/folioai.com#583

## Problem

Production SSR HTML is served uncompressed no matter what the client advertises. Reproduced against production today:

```
$ curl -sS --http1.1 -H "Accept-Encoding: gzip, br" -D - -o /dev/null https://folioai.com/tr-TR/auth/sign-in
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Transfer-Encoding: chunked
X-Cache: TCP_REMOTE_HIT
```

177,072 B, no `Content-Encoding`, no `Vary`.

## Which layer owns it

The issue left this open between Azure Front Door, the gemi runtime, and the app. This PR puts it in **the gemi runtime**:

- Every gemi app serves the same shape of response — a streamed `text/html` document that is mostly critical CSS, markup and the `window.__GEMI_DATA__` hydration payload. Owning it here makes the win portable instead of something each deployment has to configure a CDN for.
- It also cuts **origin→edge** bandwidth, which edge compression cannot.
- Edge compression still composes on top; the `Vary` header is what makes that safe.
- An app-level wrapper (the #580 prototype) would have solved it for one app while every other SSR response in the framework stayed uncompressed.

`GEMI_COMPRESSION=off` opts out, for deployments that would rather spend the CPU at the edge.

## Numbers

Measured on the real 177 kB production document, streamed in 8 chunks:

| Encoding | Transferred | Reduction | CPU |
| --- | ---: | ---: | ---: |
| identity | 177,072 B | — | — |
| `gzip` (level 6) | 31,514 B | 82.2% | ~2.0 ms |
| `br` (quality 5) | 27,911 B | **84.2%** | ~2.0 ms |

Brotli is preferred when the client accepts both — at quality 5 it is both smaller *and* no more expensive than gzip. The default quality 11 is meant for assets compressed once at build time; on a streamed document it costs **~175 ms** for ~12% more savings, so it is not used.

## What changed

- **`server/compression.ts`** (new) — `Accept-Encoding` negotiation and the response transform. Dependency-free apart from `node:zlib`/`node:stream`.
- **`server/httpProd.ts`** — wraps the `Bun.serve` fetch *after* instrumentation, so it sees every HTML response including ones an app's own instrumentation produced.
- **`docs/configuration.md`** — the behaviour, the layer decision and its rationale, and the opt-out.

Two details worth calling out:

**Streaming is preserved.** Both codings run through `node:zlib` with an explicit per-write flush (`Z_SYNC_FLUSH` / `BROTLI_OPERATION_FLUSH`). Without it the compressor holds output until its internal buffer fills, which sits on React's shell flush and turns a streamed render into a buffered one — the transfer win would be paid straight back in TTFB. Verified against a handler that emits the shell then pauses 300 ms:

```
br:       first_byte=0.00099s  total=0.312s
identity: first_byte=0.00086s  total=0.302s
```

**HTML only.** JSON view-data (`.json`), API routes, static assets and OG images come back as the *same response object*, untouched — this change cannot alter how they are produced, framed or cached.

## Correctness

Compression stays at the transport layer: what the browser decodes is byte-for-byte the HTML React rendered, so hydration sees exactly what it saw before. Handled explicitly:

- `q=0` is a refusal; `*` covers only codings the client didn't name; ties resolve to server preference (RFC 9110 §12.5.3).
- An **absent** `Accept-Encoding` is treated as identity rather than "anything goes" — a client that can't decode and forgets to say so is a broken page, not a slow one.
- Never re-encodes a body that already has a `Content-Encoding`; honours `Cache-Control: no-transform`; skips `206`/`Content-Range` and `HEAD`.
- Drops the `Content-Length` that described the identity body.
- Adds `Vary: Accept-Encoding` to **every** HTML response, including the identity ones, so a shared cache can't hand an encoded variant to a client that didn't ask for one. Appends to an existing `Vary` without duplicating, and leaves `Vary: *` alone.
- Brotli runs with `LGWIN` 19 (512 kB window instead of the default 16 MB) — no ratio change at this document size, and the window is allocated per in-flight response.

## Verification

- 29 new unit tests in `server/compression.test.ts` (negotiation, the skip rules, header handling, byte-identical round trips under both codings). Suite goes 243 → 272 passing; the 6 pre-existing failures on `main` are unchanged.
- End-to-end against `templates/saas-starter` under `gemi start`:
  - `/` → `Content-Encoding: br`, `Vary: Accept-Encoding`, 39,714 B → 8,718 B, decoded body byte-identical to the identity response.
  - identity request → same 39,714 B, `Vary` still present, no `Content-Encoding`.
  - `/.json` → untouched, keeps its own `Vary: x-gemi-from`.
  - static `/assets/*.js` → untouched.
  - `GEMI_COMPRESSION=off` → no `Content-Encoding`, no `Vary`, full 39,714 B.
- `oxlint` and `tsc` clean; `bun run build` succeeds.

## Left to the deployment

Two acceptance criteria on the issue can only be closed against production, not here:

- CPU cost and transfer gain under production-like load.
- Azure Front Door cache HIT/MISS behaviour across the compressed variants, before rollout. The `Vary: Accept-Encoding` this PR adds is the prerequisite for that being safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
