### PR TITLE
Compare resolved paths for a link's data-pending

### DIFF
--- a/packages/gemi/client/Link.ssr.test.tsx
+++ b/packages/gemi/client/Link.ssr.test.tsx
@@ -1,0 +1,116 @@
+/** @vitest-environment node */
+import { describe, expect, test } from "vitest";
+import { renderToString } from "react-dom/server";
+
+import { Link } from "./Link";
+import {
+  RouteStateProvider,
+  type PageData,
+  type RouteState,
+} from "./RouteStateContext";
+import { RouteTransitionProvider } from "./RouteTransitionProvider";
+
+/**
+ * `data-pending` is what a link's spinner or dimmed state hangs off, and it is
+ * only readable from the markup — hence rendering rather than asserting on the
+ * comparison itself.
+ */
+function renderLink(
+  ui: React.ReactNode,
+  transitionTarget: string,
+  state: Partial<RouteState & PageData> = {},
+) {
+  return renderToString(
+    <RouteStateProvider
+      state={
+        {
+          pathname: "/",
+          search: "",
+          hash: "",
+          params: {},
+          locale: null,
+          ...state,
+        } as RouteState & PageData
+      }
+    >
+      <RouteTransitionProvider
+        isPending
+        isFetching={false}
+        transitionPath={["/", transitionTarget]}
+      >
+        {ui}
+      </RouteTransitionProvider>
+    </RouteStateProvider>,
+  );
+}
+
+describe("Link data-pending", () => {
+  test("marks the parameterised link the navigation is heading to", () => {
+    const html = renderLink(
+      <Link href={"/app/:orgId/lists" as never} params={{ orgId: "f-An0" }}>
+        Lists
+      </Link>,
+      "/app/f-An0/lists",
+    );
+
+    expect(html).toContain('data-pending="true"');
+  });
+
+  test("leaves the other rows of a shared template alone", () => {
+    const html = renderLink(
+      <>
+        <Link
+          href={"/app/:orgId/lists/:listId" as never}
+          params={{ orgId: "f-An0", listId: "one" }}
+        >
+          One
+        </Link>
+        <Link
+          href={"/app/:orgId/lists/:listId" as never}
+          params={{ orgId: "f-An0", listId: "two" }}
+        >
+          Two
+        </Link>
+      </>,
+      "/app/f-An0/lists/two",
+    );
+
+    const pending = html.match(/data-pending="true"/g) ?? [];
+    expect(pending).toHaveLength(1);
+    expect(html).toMatch(/data-pending="true"[^>]*>Two</);
+  });
+
+  test("handles the root route, whose resolved path is empty", () => {
+    const html = renderLink(<Link href={"/" as never}>Home</Link>, "/");
+
+    expect(html).toContain('data-pending="true"');
+  });
+
+  test("stays false while nothing is in flight", () => {
+    const html = renderToString(
+      <RouteStateProvider
+        state={
+          {
+            pathname: "/",
+            search: "",
+            hash: "",
+            params: {},
+            locale: null,
+          } as RouteState & PageData
+        }
+      >
+        <RouteTransitionProvider
+          isPending={false}
+          isFetching={false}
+          transitionPath={["/", "/app/f-An0/lists"]}
+        >
+          <Link href={"/app/:orgId/lists" as never} params={{ orgId: "f-An0" }}>
+            Lists
+          </Link>
+        </RouteTransitionProvider>
+      </RouteStateProvider>,
+    );
+
+    expect(html).toContain('data-pending="false"');
+  });
+});

--- a/packages/gemi/client/Link.tsx
+++ b/packages/gemi/client/Link.tsx
@@ -109,6 +109,9 @@ export const Link = memo(<T extends keyof Views>(props: LinkProps<T>) => {
   const searchParams = new URLSearchParams(normalizeSearch(search));
 
   const path = applyParams(href, params);
+  // `applyParams` drops the trailing slash, so the root route comes back empty
+  // where every pathname the router reports says `/`.
+  const resolvedPath = path || "/";
   let urlLocaleSegment = location.locale;
   if (urlLocaleSegment === defaultLocale) {
     urlLocaleSegment = "";
@@ -137,7 +140,7 @@ export const Link = memo(<T extends keyof Views>(props: LinkProps<T>) => {
 
   // Clicking through to the path we are already on is a shallow navigation —
   // it moves the URL without fetching, so there is nothing to warm.
-  const isShallowTarget = (path || "/") === location.pathname;
+  const isShallowTarget = resolvedPath === location.pathname;
 
   const strategies = !prefetch
     ? []
@@ -249,7 +252,9 @@ export const Link = memo(<T extends keyof Views>(props: LinkProps<T>) => {
     <a
       ref={setAnchorRef}
       data-active={active || currentHref === targetHref}
-      data-pending={href === targetPath && isTransitioning}
+      // The resolved path, not the template: one template can back a whole list
+      // of rows, and only the row that was clicked is heading anywhere.
+      data-pending={isTransitioning && resolvedPath === targetPath}
       href={targetHref === '' ? '/' : targetHref}
       onClick={(e) => {
         if (typeof window !== "undefined") {


### PR DESCRIPTION
Fixes #283.

`Link` renders `data-pending` to mark the link a navigation is heading to. It compared `href` — the route template as authored — against `targetPath`, which the router reports as a resolved pathname:

```
"/app/:orgId/lists" === "/app/f-An0/lists"   // false, always
```

So it could only ever be true for a param-less route where the template happens to equal the resolved path. There is nothing to notice when it fails — the attribute is present, just permanently `false`, and a `data-[pending=true]:…` rule silently does nothing.

## The fix

Compare the resolved path `Link` already computes one line earlier:

```diff
-      data-pending={href === targetPath && isTransitioning}
+      data-pending={isTransitioning && resolvedPath === targetPath}
```

Comparing templates instead — exposing `routePath` from `useRouteTransition` — looks equivalent but marks *every* row of a list sharing one template as pending, rather than the row that was clicked. Resolved paths distinguish them.

One wrinkle the one-liner in the issue misses: `applyParams` strips the trailing slash, so the root route resolves to `""` where `routerState.pathname` is normalised to `"/"` (`ClientRouterContext.tsx:204`). A bare `path === targetPath` would leave `/` broken, so the normalisation lives in one `resolvedPath` const — which the shallow-target check a few lines down already spelled out inline and now reuses.

## Tests

New `packages/gemi/client/Link.ssr.test.tsx`, following the existing `useQuery.ssr.test.tsx` render-to-string pattern, since `data-pending` is only readable from the markup:

- a parameterised link goes pending
- two rows sharing one template mark only the one being navigated to
- the root route, whose resolved path is empty
- nothing is pending while no navigation is in flight

The two meaningful cases fail against the old comparison. The suite has 6 pre-existing failures across 7 files (route-manifest and others) — identical on a clean `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)