### PR TITLE
keepPreviousData under suspense: defer the variant key so variant changes never flash the fallback

### DIFF
--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -90,6 +90,15 @@ How it composes with the rest of the framework:
   a suspended query immediately, without waiting on its own request.
 - **Stale data never suspends.** A query with cached data always renders it and
   revalidates in the background (`staleTime` semantics are unchanged).
+- **Variant changes don't re-suspend.** With `keepPreviousData` (the default),
+  changing a query's `search` or `params` keeps the previous variant's rows
+  rendered while the new one loads in the background — no fallback flash, no
+  `startTransition` at the call site — and the pending window is reported as
+  `loading: true` for pager UI. Set `keepPreviousData: false` to restore
+  suspend-into-the-fallback on variant change (e.g. tab-like switches where
+  stale rows would mislead). If the new variant's fetch *fails* during the
+  window, the failure throws into the segment's error boundary as usual — the
+  previous rows don't mask it.
 - **Errors throw.** With suspense on, an HTTP failure throws a `QueryError`
   (with `status`, `body`, `path`) into the segment's error boundary instead of
   being returned. Resetting the boundary clears the stored errors and retries.
@@ -104,9 +113,11 @@ if (loading) return <p>Loading…</p>;
 if (error) return <p>Something went wrong.</p>;
 ```
 
-Use the opt-out when the loading state itself is UI you want to control inline
-(e.g. paging inside a mounted view), or when the data legitimately may never
-exist (an anonymous visitor's `/auth/me`).
+Use the opt-out when the loading state itself is UI you want to control inline,
+or when the data legitimately may never exist (an anonymous visitor's
+`/auth/me`). Pagination, search, and filters do **not** need it: a variant
+change under suspense keeps the previous rows on screen and reports
+`loading: true` (see "Variant changes don't re-suspend" above).
 
 ### Params and search
 
@@ -137,8 +148,8 @@ so a typo in a param or a wrong field type is a compile error.
 | field | description |
 | --- | --- |
 | `data` | The response body, typed from the endpoint. Non-nullable under suspense (the default); `undefined` until first load with `suspense: false` / `lazy: true`. |
-| `loading` | `true` while a request is in flight. Only meaningful with `suspense: false` — a suspense query doesn't render until data exists. |
-| `error` | Error record if the request failed, otherwise `null`. Under suspense a failure only *throws* (a `QueryError`, into the segment's error boundary) when there is no data to show — a background revalidation that fails while cached data is on screen keeps rendering the data and returns the `error` here instead. With `suspense: false` it is always returned, never thrown. |
+| `loading` | `true` while a request is in flight. Under suspense (the default) a query never renders without data, so this is `false` in steady state — it flips to `true` during a variant change's pending window: with `keepPreviousData` on, changing `search`/`params` keeps the previous variant's rows rendered and reports the new variant's in-flight fetch here. This is the flag pager UI consumes. With `suspense: false` it is the plain in-flight flag, `true` from the first render until the first load settles. |
+| `error` | Error record if the request failed, otherwise `null`. Under suspense a failure only *throws* (a `QueryError`, into the segment's error boundary) when there is no data to show for the requested variant — a background revalidation that fails while that variant's data is on screen keeps rendering the data and returns the `error` here instead. A variant change whose fetch fails still throws, even though the *previous* variant's rows are on screen during the pending window. With `suspense: false` it is always returned, never thrown. |
 | `refetch()` | Force a fresh fetch of the current variant. |
 | `mutate(fn?)` | Optimistically update the cached data (see below), or refetch when called with no argument. |
 | `trigger()` | Kick off the fetch for a `lazy` query. |
@@ -154,13 +165,22 @@ so a typo in a param or a wrong field type is a compile error.
 const { data } = useQuery("/feed", {}, {
   suspense: true,          // default; false restores the loading/error flags
   fallbackData: [],        // initial data before the first fetch
-  keepPreviousData: true,  // keep old data visible while refetching (default true)
+  keepPreviousData: true,  // keep the previous variant's data on screen while a new one loads (default true)
   refreshInterval: 5000,   // poll every 5s
   retryIntervalOnError: 10000, // background retry — suspense: false only
   staleTime: 5000,         // how long cached data stays fresh (default 5000ms)
   lazy: false,             // when true, no fetch until trigger()/refetch(); implies suspense: false
 });
 ```
+
+`keepPreviousData` governs what a variant change (a new `search`/`params`
+combination) renders while the new variant loads. Under suspense it keeps the
+previous variant's rows on screen and reports the window as `loading: true` —
+no `startTransition` needed at the call site (see "Variant changes don't
+re-suspend"). With `suspense: false` it substitutes the previous variant's
+`data` while `loading` is `true` instead of handing you `undefined`. Either
+way, set it to `false` to drop the previous data the moment the variant
+changes.
 
 `staleTime` controls when reading the cache triggers a background revalidation.
 Once cached data is older than `staleTime`, the next component that mounts and

--- a/packages/gemi/client/useQuery.suspense.test.tsx
+++ b/packages/gemi/client/useQuery.suspense.test.tsx
@@ -333,6 +333,95 @@ describe("keepPreviousData under suspense", () => {
     expect(mounts).toBe(1);
   });
 
+  test("a params change swaps the resource but keeps the same contract — previous rows, pending flag, no remount", async () => {
+    // Unlike a `search` change (one resource, new variant key), a `params`
+    // change swaps the entire `QueryResource`: new store, new subscription,
+    // new read promise. The committed tree stays subscribed to the *old*
+    // resource for the whole pending window and the background render is
+    // woken by the new resource's thrown promise — the invariants must hold
+    // across that swap too.
+    function ListTodos() {
+      const [listId, setListId] = useState(1);
+      const { data, loading } = useQuery("/lists/:listId/todos" as any, {
+        params: { listId } as any,
+      });
+      useEffect(() => {
+        mounts += 1;
+      }, []);
+      return (
+        <button type="button" onClick={() => setListId((id) => id + 1)}>
+          {`ids:${(data as any[]).map((t: any) => t.id).join(",")} loading:${loading}`}
+        </button>
+      );
+    }
+
+    const screen = render(
+      <Providers>
+        <ListTodos />
+      </Providers>,
+    );
+
+    // First mount is unchanged: suspend into the fallback.
+    expect(screen.queryByText("suspense-fallback")).not.toBeNull();
+    expect(net.fetchMock).toHaveBeenLastCalledWith("/api/lists/1/todos", {
+      cache: "default",
+    });
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("ids:1 loading:false")).not.toBeNull();
+
+    // Switch lists — a plain urgent state update.
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+
+    // The old list's rows stay committed, the pending window is flagged, and
+    // the new resource's request went on the wire immediately.
+    expect(screen.queryByText("suspense-fallback")).toBeNull();
+    expect(screen.queryByText("ids:1 loading:true")).not.toBeNull();
+    expect(net.fetchMock).toHaveBeenLastCalledWith("/api/lists/2/todos", {
+      cache: "default",
+    });
+
+    await net.resolve([{ id: 2 }]);
+
+    expect(screen.queryByText("ids:2 loading:false")).not.toBeNull();
+    expect(mounts).toBe(1);
+  });
+
+  test("a fetch failure during the pending window throws into the error boundary", async () => {
+    // Pins the error path of the deferral: the background render suspends on
+    // the new variant, the fetch fails, and the retry render throws the
+    // stored error — the boundary replaces the previous rows. The previous
+    // variant's data does NOT mask the failure: under suspense the caller
+    // writes no error branch, so silently returning `error` while keeping
+    // the old page on screen would leave a failed page change with no
+    // visible signal at all. The boundary is the suspense contract's error
+    // channel, exactly as it was for a suspended variant change before the
+    // deferral existed.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const screen = render(
+      <Providers>
+        <Boundary>
+          <PagedList />
+        </Boundary>
+      </Providers>,
+    );
+
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("ids:1 loading:false")).not.toBeNull();
+
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+    // Pending window: previous rows visible, page 2 in flight.
+    expect(screen.queryByText("ids:1 loading:true")).not.toBeNull();
+
+    await net.resolve({ message: "boom" }, false);
+
+    expect(screen.queryByText("caught:QueryError")).not.toBeNull();
+    expect(screen.queryByText("ids:1 loading:true")).toBeNull();
+  });
+
   test("keepPreviousData: false restores suspend-on-variant-change", async () => {
     const screen = render(
       <Providers>

--- a/packages/gemi/client/useQuery.suspense.test.tsx
+++ b/packages/gemi/client/useQuery.suspense.test.tsx
@@ -1,6 +1,13 @@
 /** @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { Component, Suspense, act, useContext } from "react";
+import {
+  Component,
+  Suspense,
+  act,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import type { PropsWithChildren, ReactNode } from "react";
 import { cleanup, render } from "@testing-library/react";
 
@@ -28,7 +35,11 @@ function createFetch() {
   const fetchMock = vi.fn((_url: string, _init?: RequestInit) => {
     return new Promise((resolve) => {
       pending.push(({ ok, body }) =>
-        resolve({ ok, status: ok ? 200 : 500, json: async () => body } as Response),
+        resolve({
+          ok,
+          status: ok ? 200 : 500,
+          json: async () => body,
+        } as Response),
       );
     });
   });
@@ -265,6 +276,84 @@ describe("useQuery with suspense (the default)", () => {
   });
 });
 
+describe("keepPreviousData under suspense", () => {
+  let mounts = 0;
+  beforeEach(() => {
+    mounts = 0;
+  });
+
+  function PagedList(props: { keepPreviousData?: boolean }) {
+    const [page, setPage] = useState(1);
+    const { data, loading } = useQuery(
+      "/todos" as any,
+      { search: { page } },
+      props.keepPreviousData === false ? { keepPreviousData: false } : {},
+    );
+    useEffect(() => {
+      mounts += 1;
+    }, []);
+    return (
+      <button type="button" onClick={() => setPage((p) => p + 1)}>
+        {`ids:${(data as any[]).map((t: any) => t.id).join(",")} loading:${loading}`}
+      </button>
+    );
+  }
+
+  test("a variant change keeps the previous rows and flags pending — no startTransition in app code", async () => {
+    const screen = render(
+      <Providers>
+        <PagedList />
+      </Providers>,
+    );
+
+    // First mount is unchanged: nothing cached yet, suspend into the fallback.
+    expect(screen.queryByText("suspense-fallback")).not.toBeNull();
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("ids:1 loading:false")).not.toBeNull();
+
+    // Next page — a plain urgent state update, no transition at the call site.
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+
+    // The previous page's rows stay committed — the fallback never flashes in
+    // — and the pending window is exposed as `loading: true` for pager UI.
+    expect(screen.queryByText("suspense-fallback")).toBeNull();
+    expect(screen.queryByText("ids:1 loading:true")).not.toBeNull();
+    // The new variant's request went on the wire immediately.
+    expect(net.fetchMock).toHaveBeenLastCalledWith("/api/todos?page=2", {
+      cache: "default",
+    });
+
+    await net.resolve([{ id: 2 }]);
+
+    // The deferred render committed the new rows, and the component was never
+    // unmounted along the way.
+    expect(screen.queryByText("ids:2 loading:false")).not.toBeNull();
+    expect(mounts).toBe(1);
+  });
+
+  test("keepPreviousData: false restores suspend-on-variant-change", async () => {
+    const screen = render(
+      <Providers>
+        <PagedList keepPreviousData={false} />
+      </Providers>,
+    );
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("ids:1 loading:false")).not.toBeNull();
+
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+
+    // The caller opted back into the fallback: the segment suspends in place.
+    expect(screen.queryByText("suspense-fallback")).not.toBeNull();
+
+    await net.resolve([{ id: 2 }]);
+    expect(screen.queryByText("ids:2 loading:false")).not.toBeNull();
+  });
+});
+
 describe("useQuery with suspense: false", () => {
   test("reproduces the loading-flag sequence", async () => {
     const states: Array<{ data: any; loading: boolean }> = [];
@@ -302,7 +391,9 @@ describe("useQuery with suspense: false", () => {
         {},
         { suspense: false },
       );
-      return <div>{`error:${(error as any)?.name ?? "none"} loading:${loading}`}</div>;
+      return (
+        <div>{`error:${(error as any)?.name ?? "none"} loading:${loading}`}</div>
+      );
     }
 
     const screen = render(

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -155,6 +155,13 @@ export function useQuery<T extends keyof GetRPC>(
   // an uncached query suspends into the segment fallback as today. Both hooks
   // run unconditionally (hook order); the values are only *used* when
   // deferring applies.
+  //
+  // Deliberate: during the pending window the imperative callbacks
+  // (`mutate`/`refetch`/`trigger`/`prefetch`) and the revalidation effects
+  // close over the deferred — i.e. *visible* — variant and resource, so they
+  // act on the data the user is looking at, not the variant still loading in
+  // the background. The window ends when the deferred render commits, at
+  // which point they re-bind to the new keys.
   const deferredPath = useDeferredValue(currentPath);
   const deferredVariantKey = useDeferredValue(currentVariantKey);
   const deferVariant = suspense && config.keepPreviousData;

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useContext,
+  useDeferredValue,
   useEffect,
   useRef,
   useSyncExternalStore,
@@ -22,6 +23,15 @@ import { isPlainObject } from "./isPlainObject";
 
 interface Config<T> {
   fallbackData?: T;
+  /**
+   * When true (the default), a variant change keeps rendering the previous
+   * variant's data while the new one loads. Under suspense this reads through
+   * a deferred variant key, so changing `search`/`params` never flashes the
+   * segment fallback and needs no `startTransition` at the call site — the
+   * pending window is exposed as `loading: true`. Set to `false` to get the
+   * suspend-on-variant-change semantics back (e.g. tab-like switches where
+   * stale rows would mislead). First mount always suspends either way.
+   */
   keepPreviousData?: boolean;
   retryIntervalOnError?: number;
   refreshInterval?: number;
@@ -132,10 +142,28 @@ export function useQuery<T extends keyof GetRPC>(
   const search = "search" in options ? (options.search ?? {}) : {};
   const { getResource } = useContext(QueryManagerContext);
   const serverQueries = useContext(ServerQueryContext);
-  const normalPath = applyParams(url, params);
+  const currentPath = applyParams(url, params);
   const searchParams = new URLSearchParams(omitNullishValues(search));
   searchParams.sort();
-  const variantKey = searchParams.toString();
+  const currentVariantKey = searchParams.toString();
+  // `keepPreviousData` under suspense: read through deferred keys so a
+  // variant change never suspends the committed tree. The urgent render keeps
+  // showing the previous variant's data; React re-renders in the background
+  // with the new keys, suspends *that* attempt only (no fallback flash), and
+  // commits when the data lands — no `startTransition` needed at the call
+  // site. First mount is unchanged: deferred and current keys are equal, so
+  // an uncached query suspends into the segment fallback as today. Both hooks
+  // run unconditionally (hook order); the values are only *used* when
+  // deferring applies.
+  const deferredPath = useDeferredValue(currentPath);
+  const deferredVariantKey = useDeferredValue(currentVariantKey);
+  const deferVariant = suspense && config.keepPreviousData;
+  const normalPath = deferVariant ? deferredPath : currentPath;
+  const variantKey = deferVariant ? deferredVariantKey : currentVariantKey;
+  // The pending signal for pager UI: true while the visible data belongs to
+  // the previous variant and the new one is still loading in the background.
+  const isDeferred =
+    normalPath !== currentPath || variantKey !== currentVariantKey;
   const { prefetchedData } = useRouteData();
   // `fallbackData` is a single variant's value, so it seeds under this
   // query's variant key; `prefetchedData[normalPath]` is already the full
@@ -457,7 +485,7 @@ export function useQuery<T extends keyof GetRPC>(
 
   return {
     data: state?.data as NestedPrettify<Data<T>>,
-    loading: state?.loading ?? !lazy,
+    loading: isDeferred || (state?.loading ?? !lazy),
     error: state?.error as Error,
     mutate,
     trigger,


### PR DESCRIPTION
Closes #291

Stacked on `main`.

## Approach

`useQuery` now reads the store through `useDeferredValue` when `keepPreviousData` (the default) is combined with suspense (also the default). Both the resource path and the variant key are deferred together, so a `search` *or* `params` change:

- keeps rendering the previous variant's data in the urgent pass — the committed tree never re-suspends, so the segment fallback never flashes and no `startTransition` is needed at the call site;
- suspends only React's background re-render with the new keys (the new variant's fetch starts immediately via the render-phase `read`), and commits when the data lands;
- exposes the pending window through the existing `loading` flag (`deferred !== current`), which under suspense previously never reflected a variant change — pager UI gets its signal without owning a transition.

First mount is unchanged: deferred and current keys are equal, so an uncached query suspends into the segment fallback as before. The escape hatch also stays: `keepPreviousData: false` + suspense restores suspend-on-variant-change for callers who want the fallback (e.g. tab-like switches). Both `useDeferredValue` hooks run unconditionally to keep hook order stable; the deferred values are only used when deferring applies. No new dependencies — `useDeferredValue` is already in the React 19 budget.

## Tests

New `keepPreviousData under suspense` describe block in `packages/gemi/client/useQuery.suspense.test.tsx` (jsdom):

- a paginated list: first mount suspends into the fallback; clicking next page (plain `setState`, no transition) keeps the previous rows committed with `loading: true`, never shows the fallback, fires the `page=2` request immediately, commits the new rows on resolve, and never unmounts the component along the way;
- `keepPreviousData: false` restores suspend-on-variant-change (fallback shown in place).

`bun run test -- run client` — 13 files, 123 tests pass; `test:types` and `tsc --noEmit` clean; oxlint 0 errors. The 6 failing tests in `app/`/`services/`/`utils/` fail identically on `main` (verified via stash) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWrgZ7fXNHCjJMV53o3qPK