### PR TITLE
Provider-level queryConfig: app-wide useQuery defaults, one line instead of ~120 edits

### DIFF
--- a/packages/gemi/client/ClientRouter.tsx
+++ b/packages/gemi/client/ClientRouter.tsx
@@ -29,6 +29,7 @@ import {
 import {
   QueryManagerContext,
   QueryManagerProvider,
+  type QueryConfig,
 } from "./QueryManagerContext";
 import { I18nProvider } from "./I18nContext";
 import { WebSocketContextProvider } from "./WebsocketContext";
@@ -391,6 +392,8 @@ export const ClientRouter = (props: {
   /** Server only: full view modules for `Loading`/`Error` fallbacks. */
   viewModules?: Record<string, Record<string, any>>;
   RootLayout: ComponentType<{ children: ReactNode; locale: string }>;
+  /** App-wide `useQuery` defaults; per-call config always wins. */
+  queryConfig?: QueryConfig;
 }) => {
   const { RootLayout } = props;
   const {
@@ -407,7 +410,7 @@ export const ClientRouter = (props: {
     <ThemeProvider>
       <I18nProvider>
         <WebSocketContextProvider>
-          <QueryManagerProvider>
+          <QueryManagerProvider queryConfig={props.queryConfig}>
             <ComponentsProvider
               viewImportMap={props.viewImportMap}
               modules={props.viewModules}

--- a/packages/gemi/client/QueryManagerContext.tsx
+++ b/packages/gemi/client/QueryManagerContext.tsx
@@ -10,6 +10,31 @@ import { QueryResource } from "./QueryResource";
 /** One streamed query payload: `[path, variantKey, data]`. */
 type StreamedQueryPayload = [string, string, any];
 
+/**
+ * App-wide `useQuery` defaults, threaded from `createRoot(RootLayout, {
+ * queryConfig })` (and `init` on the client). Resolution order is per-call
+ * config → these defaults → framework defaults, so a call site always wins.
+ * Only keys with app-wide meaning are accepted — `lazy`, `fallbackData` and
+ * `refetchUntil` stay call-site-only. Framework-internal hooks (`useUser`,
+ * `useSignIn`) never see these.
+ */
+export interface QueryConfig {
+  /**
+   * App-wide suspense switch. `suspense: false` makes every unconfigured
+   * `useQuery` behave like pre-0.49: `loading` flags instead of suspension,
+   * errors returned instead of thrown. Pair it with the `GemiQueryDefaults`
+   * module augmentation so `data`'s nullability matches.
+   */
+  suspense?: boolean;
+  /** How long cached data stays fresh before a read revalidates it, in ms. */
+  staleTime?: number;
+  keepPreviousData?: boolean;
+  retryIntervalOnError?: number;
+  refreshInterval?: number;
+}
+
+export const QueryConfigContext = createContext<QueryConfig | null>(null);
+
 export type PrefetchedData = Record<string, Record<string, any>>;
 
 export interface QueryManagerContextValue {
@@ -29,7 +54,10 @@ export const QueryManagerContext = createContext<QueryManagerContextValue>({
   clearErrors: () => {},
 });
 
-export const QueryManagerProvider = ({ children }: PropsWithChildren<{}>) => {
+export const QueryManagerProvider = ({
+  children,
+  queryConfig = null,
+}: PropsWithChildren<{ queryConfig?: QueryConfig | null }>) => {
   const resourcesRef = useRef<Map<string, QueryResource>>(new Map());
 
   const getResource = useCallback(
@@ -107,7 +135,9 @@ export const QueryManagerProvider = ({ children }: PropsWithChildren<{}>) => {
 
   return (
     <QueryManagerContext.Provider value={value}>
-      {children}
+      <QueryConfigContext.Provider value={queryConfig}>
+        {children}
+      </QueryConfigContext.Provider>
     </QueryManagerContext.Provider>
   );
 };

--- a/packages/gemi/client/QueryManagerContext.tsx
+++ b/packages/gemi/client/QueryManagerContext.tsx
@@ -35,6 +35,36 @@ export interface QueryConfig {
 
 export const QueryConfigContext = createContext<QueryConfig | null>(null);
 
+/**
+ * The runtime mirror of the `QueryConfig` type: TS excess-property checking
+ * only fires on fresh object literals, so a dynamically built (or plain-JS)
+ * config could smuggle call-site-only keys (`lazy`, `fallbackData`,
+ * `refetchUntil`) into every query. The provider picks these keys — and only
+ * these — before the value enters the context. Keys whose value is
+ * `undefined` are dropped too, so an absent value (e.g. an unset env-derived
+ * `staleTime`) falls through to the framework default instead of shadowing it.
+ */
+const APP_WIDE_QUERY_CONFIG_KEYS = [
+  "suspense",
+  "staleTime",
+  "keepPreviousData",
+  "retryIntervalOnError",
+  "refreshInterval",
+] as const satisfies ReadonlyArray<keyof QueryConfig>;
+
+export function pickAppWideQueryConfig(
+  queryConfig: QueryConfig | null | undefined,
+): QueryConfig | null {
+  if (!queryConfig) return null;
+  const picked: QueryConfig = {};
+  for (const key of APP_WIDE_QUERY_CONFIG_KEYS) {
+    if (queryConfig[key] !== undefined) {
+      (picked as Record<string, unknown>)[key] = queryConfig[key];
+    }
+  }
+  return picked;
+}
+
 export type PrefetchedData = Record<string, Record<string, any>>;
 
 export interface QueryManagerContextValue {
@@ -59,6 +89,13 @@ export const QueryManagerProvider = ({
   queryConfig = null,
 }: PropsWithChildren<{ queryConfig?: QueryConfig | null }>) => {
   const resourcesRef = useRef<Map<string, QueryResource>>(new Map());
+
+  // Sanitized once at the choke point every query reads through, so the
+  // "only app-wide keys" contract holds at runtime, not just in the types.
+  const appQueryConfig = useMemo(
+    () => pickAppWideQueryConfig(queryConfig),
+    [queryConfig],
+  );
 
   const getResource = useCallback(
     (key: string, initialState?: Record<string, any>) => {
@@ -135,7 +172,7 @@ export const QueryManagerProvider = ({
 
   return (
     <QueryManagerContext.Provider value={value}>
-      <QueryConfigContext.Provider value={queryConfig}>
+      <QueryConfigContext.Provider value={appQueryConfig}>
         {children}
       </QueryConfigContext.Provider>
     </QueryManagerContext.Provider>

--- a/packages/gemi/client/auth/useSignIn.tsx
+++ b/packages/gemi/client/auth/useSignIn.tsx
@@ -1,5 +1,5 @@
 import { usePost } from "../useMutation";
-import { useQuery } from "../useQuery";
+import { useFrameworkQuery } from "../useQuery";
 
 interface UseSignInArgs {
   onSuccess?: (data: any) => void;
@@ -11,8 +11,9 @@ const defaultArgs: UseSignInArgs = {
 
 export function useSignIn(args: UseSignInArgs = defaultArgs) {
   // Only here for `mutate` — `lazy` so the sign-in form neither fetches nor
-  // suspends on a user it does not have yet.
-  const { mutate } = useQuery("/auth/me", {}, { lazy: true });
+  // suspends on a user it does not have yet. `useFrameworkQuery` keeps that
+  // pinned regardless of the app's `queryConfig`.
+  const { mutate } = useFrameworkQuery("/auth/me", {}, { lazy: true });
   return usePost(
     "/auth/sign-in",
     {},

--- a/packages/gemi/client/auth/useUser.ts
+++ b/packages/gemi/client/auth/useUser.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { ServerDataContext } from "../ServerDataProvider";
-import { useQuery } from "../useQuery";
+import { useFrameworkQuery } from "../useQuery";
 
 export function useUser() {
   const { auth } = useContext(ServerDataContext);
@@ -8,7 +8,9 @@ export function useUser() {
     data: user,
     loading,
     error,
-  } = useQuery(
+    // `useFrameworkQuery`: the semantics below are pinned, so an app-wide
+    // `queryConfig` must not leak in.
+  } = useFrameworkQuery(
     "/auth/me",
     {},
     {

--- a/packages/gemi/client/createRoot.tsx
+++ b/packages/gemi/client/createRoot.tsx
@@ -1,10 +1,21 @@
 import type { ComponentType } from "react";
 import { ClientRouter } from "./ClientRouter";
+import type { QueryConfig } from "./QueryManagerContext";
 import { ServerDataProvider } from "./ServerDataProvider";
 import { ServerQueryContext } from "./ServerQueryContext";
 
+export interface CreateRootOptions {
+  /**
+   * App-wide `useQuery` defaults (per-call config always wins). Set the same
+   * value in the client entry's `init` call so hydration matches the server
+   * render.
+   */
+  queryConfig?: QueryConfig;
+}
+
 export function createRoot(
   RootLayout: ComponentType<{ children: React.ReactNode; locale: string }>,
+  options: CreateRootOptions = {},
 ) {
   // `serverQueries` and `viewModules` exist only when the view router renders
   // this on the server — the browser mounts with both absent.
@@ -15,6 +26,7 @@ export function createRoot(
           RootLayout={RootLayout}
           viewImportMap={props.viewImportMap}
           viewModules={props.viewModules}
+          queryConfig={options.queryConfig}
         />
       </ServerQueryContext.Provider>
     </ServerDataProvider>

--- a/packages/gemi/client/index.ts
+++ b/packages/gemi/client/index.ts
@@ -1,5 +1,5 @@
 export { useQuery } from "./useQuery";
-export type { QueryResult } from "./useQuery";
+export type { QueryResult, GemiQueryDefaults } from "./useQuery";
 export { QueryError } from "./QueryError";
 export {
   useMutation,
@@ -20,6 +20,7 @@ export {
   ValidationErrors,
 } from "./Mutation";
 export { QueryManagerProvider } from "./QueryManagerContext";
+export type { QueryConfig } from "./QueryManagerContext";
 export { useParams } from "./useParams";
 export { useLocation } from "./useLocation";
 export { useSearchParams } from "./useSearchParams";

--- a/packages/gemi/client/init.tsx
+++ b/packages/gemi/client/init.tsx
@@ -2,7 +2,17 @@ import { useEffect, type ComponentType } from "react";
 import { hydrateRoot, createRoot } from "react-dom/client";
 import { ServerDataProvider } from "./ServerDataProvider";
 import { ClientRouter } from "./ClientRouter";
+import type { QueryConfig } from "./QueryManagerContext";
 import { ErrorBoundary } from "react-error-boundary";
+
+export interface InitOptions {
+  /**
+   * App-wide `useQuery` defaults (per-call config always wins). Mirror the
+   * value passed to `createRoot` in the view router's service provider so the
+   * server render and hydration agree.
+   */
+  queryConfig?: QueryConfig;
+}
 
 const StackTrace = () => {
   useEffect(() => {
@@ -22,7 +32,10 @@ const StackTrace = () => {
   return <div id="overlay" />;
 };
 
-export function init(RootLayout: ComponentType<any>) {
+export function init(
+  RootLayout: ComponentType<any>,
+  options: InitOptions = {},
+) {
   if (typeof window !== "undefined" && (window as any).render_error) {
     createRoot(document.body).render(<StackTrace />);
   } else {
@@ -33,7 +46,10 @@ export function init(RootLayout: ComponentType<any>) {
         <></>
         <ErrorBoundary fallback={<div />}>
           <ServerDataProvider>
-            <ClientRouter RootLayout={RootLayout} />
+            <ClientRouter
+              RootLayout={RootLayout}
+              queryConfig={options.queryConfig}
+            />
           </ServerDataProvider>
         </ErrorBoundary>
       </>,
@@ -59,7 +75,16 @@ export function init(RootLayout: ComponentType<any>) {
 
 export function create(
   RootLayout: ComponentType<any>,
-  { componentTree, loaders, routeManifest, router, i18n, auth, prefetchedData, viewImportMap }: any,
+  {
+    componentTree,
+    loaders,
+    routeManifest,
+    router,
+    i18n,
+    auth,
+    prefetchedData,
+    viewImportMap,
+  }: any,
 ) {
   (window as any).__GEMI_DATA__ = {
     componentTree,

--- a/packages/gemi/client/useQuery.queryConfig.test.tsx
+++ b/packages/gemi/client/useQuery.queryConfig.test.tsx
@@ -200,6 +200,52 @@ describe("per-call config wins over provider defaults", () => {
     expect(screen.queryByText("loading:false")).not.toBeNull();
   });
 
+  test("a per-call key explicitly set to undefined falls through to the provider default", async () => {
+    // The common conditional / prop-forwarding shape: the key is *present*
+    // but `undefined`. It must not clobber the provider's `suspense: false`
+    // (which would fall through to the framework default and suspend).
+    function View() {
+      const { loading } = useQuery(
+        "/todos" as any,
+        {},
+        { suspense: undefined as any },
+      );
+      return <div>{`loading:${loading}`}</div>;
+    }
+
+    const screen = render(
+      <Providers queryConfig={{ suspense: false }}>
+        <View />
+      </Providers>,
+    );
+
+    expect(screen.queryByText("suspense-fallback")).toBeNull();
+    expect(screen.queryByText("loading:true")).not.toBeNull();
+
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("loading:false")).not.toBeNull();
+  });
+
+  test("a provider key explicitly set to undefined falls through to the framework default", async () => {
+    // `queryConfig: { suspense: env.SUSPENSE }` with the env value absent:
+    // the framework default (suspense: true) must apply.
+    function View() {
+      const { data } = useQuery("/todos" as any);
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    const screen = render(
+      <Providers queryConfig={{ suspense: undefined }}>
+        <View />
+      </Providers>,
+    );
+
+    expect(screen.queryByText("suspense-fallback")).not.toBeNull();
+
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("items:1")).not.toBeNull();
+  });
+
   test("keepPreviousData: true at the call site overrides an app-wide false", async () => {
     function PagedList(props: { config?: Record<string, any> }) {
       const [page, setPage] = useState(1);
@@ -278,6 +324,43 @@ describe("numeric provider defaults flow through", () => {
     });
 
     expect(net.fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("only app-wide keys pass the provider at runtime", () => {
+  test("call-site-only keys smuggled through a non-literal config are dropped", async () => {
+    // TS excess-property checking doesn't fire on non-literal values, so this
+    // typechecks in user land. `lazy: true` leaking app-wide would stop every
+    // unconfigured query from fetching; `fallbackData` would seed every query
+    // with the same value.
+    const smuggled = {
+      suspense: false,
+      lazy: true,
+      fallbackData: [{ id: 99 }],
+    };
+
+    const states: Array<{ data: any; loading: boolean }> = [];
+    function View() {
+      const { data, loading } = useQuery("/todos" as any);
+      states.push({ data, loading });
+      return <div>{`loading:${loading}`}</div>;
+    }
+
+    const screen = render(
+      <Providers queryConfig={smuggled as QueryConfig}>
+        <View />
+      </Providers>,
+    );
+
+    // `suspense: false` (an app-wide key) applies; `lazy` does not — the
+    // query fetches on mount — and `fallbackData` does not seed the cache.
+    expect(screen.queryByText("suspense-fallback")).toBeNull();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+    expect(states[0]).toEqual({ data: undefined, loading: true });
+
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("loading:false")).not.toBeNull();
+    expect(states.at(-1)!.data).toEqual([{ id: 1 }]);
   });
 });
 

--- a/packages/gemi/client/useQuery.queryConfig.test.tsx
+++ b/packages/gemi/client/useQuery.queryConfig.test.tsx
@@ -1,0 +1,315 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { Suspense, act, useState } from "react";
+import type { PropsWithChildren } from "react";
+import { cleanup, render } from "@testing-library/react";
+
+import { QueryManagerProvider, type QueryConfig } from "./QueryManagerContext";
+import {
+  RouteStateProvider,
+  type PageData,
+  type RouteState,
+} from "./RouteStateContext";
+import { useQuery } from "./useQuery";
+import { useUser } from "./auth/useUser";
+
+/**
+ * Provider-level `queryConfig` (issue #292): app-wide `useQuery` defaults set
+ * once where the root is created. Resolution order is per-call config →
+ * provider defaults → framework defaults, and framework-internal hooks never
+ * see the app's config. The headline acceptance: an app with zero per-call
+ * configs and `queryConfig: { suspense: false }` behaves like 0.48 useQuery —
+ * the non-suspense assertions from `useQuery.suspense.test.tsx` re-run here
+ * under the flag with the per-call config removed.
+ */
+
+function createFetch() {
+  const pending: Array<(value: { ok: boolean; body: any }) => void> = [];
+  const fetchMock = vi.fn((_url: string, _init?: RequestInit) => {
+    return new Promise((resolve) => {
+      pending.push(({ ok, body }) =>
+        resolve({
+          ok,
+          status: ok ? 200 : 500,
+          json: async () => body,
+        } as Response),
+      );
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  return {
+    fetchMock,
+    async resolve(body: any, ok = true) {
+      const settle = pending.shift();
+      if (!settle) throw new Error("No pending fetch to resolve");
+      await act(async () => {
+        settle({ ok, body });
+      });
+    },
+    pendingCount: () => pending.length,
+  };
+}
+
+function Providers(
+  props: PropsWithChildren<{
+    queryConfig?: QueryConfig;
+    routeState?: Partial<RouteState & PageData>;
+  }>,
+) {
+  return (
+    <QueryManagerProvider queryConfig={props.queryConfig}>
+      <RouteStateProvider
+        state={(props.routeState ?? {}) as RouteState & PageData}
+      >
+        <Suspense fallback={<div>suspense-fallback</div>}>
+          {props.children}
+        </Suspense>
+      </RouteStateProvider>
+    </QueryManagerProvider>
+  );
+}
+
+let net: ReturnType<typeof createFetch>;
+
+beforeEach(() => {
+  net = createFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("queryConfig: { suspense: false } with zero per-call configs", () => {
+  test("reproduces the loading-flag sequence", async () => {
+    const states: Array<{ data: any; loading: boolean }> = [];
+    function View() {
+      const { data, loading } = useQuery("/todos" as any);
+      states.push({ data, loading });
+      return <div>{`loading:${loading}`}</div>;
+    }
+
+    const screen = render(
+      <Providers queryConfig={{ suspense: false }}>
+        <View />
+      </Providers>,
+    );
+
+    expect(screen.queryByText("suspense-fallback")).toBeNull();
+    expect(screen.queryByText("loading:true")).not.toBeNull();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+
+    await net.resolve([{ id: 1 }]);
+
+    expect(screen.queryByText("loading:false")).not.toBeNull();
+    expect(states[0]).toEqual({ data: undefined, loading: true });
+    expect(states.at(-1)!.data).toEqual([{ id: 1 }]);
+  });
+
+  test("an HTTP failure is returned, not thrown", async () => {
+    function View() {
+      const { error, loading } = useQuery("/todos" as any);
+      return (
+        <div>{`error:${(error as any)?.name ?? "none"} loading:${loading}`}</div>
+      );
+    }
+
+    const screen = render(
+      <Providers queryConfig={{ suspense: false }}>
+        <View />
+      </Providers>,
+    );
+
+    await net.resolve({ message: "boom" }, false);
+
+    expect(screen.queryByText("error:QueryError loading:false")).not.toBeNull();
+  });
+
+  test("a variant change keeps the previous rows (0.48 keepPreviousData path)", async () => {
+    function PagedList() {
+      const [page, setPage] = useState(1);
+      const { data, loading } = useQuery("/todos" as any, { search: { page } });
+      return (
+        <button type="button" onClick={() => setPage((p) => p + 1)}>
+          {`ids:${((data as any[]) ?? []).map((t: any) => t.id).join(",")} loading:${loading}`}
+        </button>
+      );
+    }
+
+    const screen = render(
+      <Providers queryConfig={{ suspense: false }}>
+        <PagedList />
+      </Providers>,
+    );
+
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("ids:1 loading:false")).not.toBeNull();
+
+    await act(async () => {
+      screen.getByRole("button").click();
+    });
+
+    // No fallback (nothing suspends app-wide) and no empty flash: the
+    // previous page's rows stay up while page 2 loads.
+    expect(screen.queryByText("suspense-fallback")).toBeNull();
+    expect(screen.queryByText("ids:1 loading:true")).not.toBeNull();
+
+    await net.resolve([{ id: 2 }]);
+    expect(screen.queryByText("ids:2 loading:false")).not.toBeNull();
+  });
+});
+
+describe("per-call config wins over provider defaults", () => {
+  test("suspense: true at the call site overrides an app-wide suspense: false", async () => {
+    function View() {
+      const { data } = useQuery("/todos" as any, {}, { suspense: true });
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    const screen = render(
+      <Providers queryConfig={{ suspense: false }}>
+        <View />
+      </Providers>,
+    );
+
+    expect(screen.queryByText("suspense-fallback")).not.toBeNull();
+
+    await net.resolve([{ id: 1 }]);
+
+    expect(screen.queryByText("items:1")).not.toBeNull();
+  });
+
+  test("suspense: false at the call site overrides an app-wide suspense: true", async () => {
+    function View() {
+      const { loading } = useQuery("/todos" as any, {}, { suspense: false });
+      return <div>{`loading:${loading}`}</div>;
+    }
+
+    const screen = render(
+      <Providers queryConfig={{ suspense: true }}>
+        <View />
+      </Providers>,
+    );
+
+    expect(screen.queryByText("suspense-fallback")).toBeNull();
+    expect(screen.queryByText("loading:true")).not.toBeNull();
+
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("loading:false")).not.toBeNull();
+  });
+
+  test("keepPreviousData: true at the call site overrides an app-wide false", async () => {
+    function PagedList(props: { config?: Record<string, any> }) {
+      const [page, setPage] = useState(1);
+      const { data } = useQuery(
+        "/todos" as any,
+        { search: { page } },
+        props.config ?? {},
+      );
+      return (
+        <button type="button" onClick={() => setPage((p) => p + 1)}>
+          {`ids:${(data as any[]).map((t: any) => t.id).join(",")}`}
+        </button>
+      );
+    }
+
+    // Provider default `keepPreviousData: false`: a variant change suspends.
+    const suspending = render(
+      <Providers queryConfig={{ keepPreviousData: false }}>
+        <PagedList />
+      </Providers>,
+    );
+    await net.resolve([{ id: 1 }]);
+    expect(suspending.queryByText("ids:1")).not.toBeNull();
+
+    await act(async () => {
+      suspending.getByRole("button").click();
+    });
+    expect(suspending.queryByText("suspense-fallback")).not.toBeNull();
+    await net.resolve([{ id: 2 }]);
+    expect(suspending.queryByText("ids:2")).not.toBeNull();
+    suspending.unmount();
+
+    // Same provider default, per-call `keepPreviousData: true`: the previous
+    // rows stay committed through the variant change.
+    const keeping = render(
+      <Providers queryConfig={{ keepPreviousData: false }}>
+        <PagedList config={{ keepPreviousData: true }} />
+      </Providers>,
+    );
+    await net.resolve([{ id: 3 }]);
+    expect(keeping.queryByText("ids:3")).not.toBeNull();
+
+    await act(async () => {
+      keeping.getByRole("button").click();
+    });
+    expect(keeping.queryByText("suspense-fallback")).toBeNull();
+    expect(keeping.queryByText("ids:3")).not.toBeNull();
+
+    await net.resolve([{ id: 4 }]);
+    expect(keeping.queryByText("ids:4")).not.toBeNull();
+  });
+});
+
+describe("numeric provider defaults flow through", () => {
+  test("retryIntervalOnError from the provider drives the retry timer", async () => {
+    function View() {
+      const { error, loading } = useQuery("/todos" as any);
+      return (
+        <div>{`error:${(error as any)?.name ?? "none"} loading:${loading}`}</div>
+      );
+    }
+
+    const screen = render(
+      <Providers queryConfig={{ suspense: false, retryIntervalOnError: 5 }}>
+        <View />
+      </Providers>,
+    );
+
+    await net.resolve({ message: "boom" }, false);
+    expect(screen.queryByText("error:QueryError loading:false")).not.toBeNull();
+
+    // The framework default is 10s; the provider's 5ms retry must fire well
+    // within this window.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(net.fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("framework internals ignore the app's queryConfig", () => {
+  test("useUser keeps its own defaults under an aggressive queryConfig", async () => {
+    function View() {
+      const { user, loading } = useUser();
+      return (
+        <div>{`user:${(user as any)?.id ?? "none"} loading:${loading}`}</div>
+      );
+    }
+
+    // `refreshInterval: 5` + `staleTime: 0` would refetch `/auth/me` every
+    // few milliseconds if the app config leaked into `useUser`.
+    const screen = render(
+      <Providers queryConfig={{ refreshInterval: 5, staleTime: 0 }}>
+        <View />
+      </Providers>,
+    );
+
+    // `suspense: false` semantics are pinned inside the hook: no fallback,
+    // `user: null` while loading.
+    expect(screen.queryByText("suspense-fallback")).toBeNull();
+    expect(screen.queryByText("user:none loading:true")).not.toBeNull();
+
+    await net.resolve({ id: "u1" });
+    expect(screen.queryByText("user:u1 loading:false")).not.toBeNull();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -174,8 +174,21 @@ export function useQuery<T extends keyof GetRPC>(
   const [options, config] = args;
   // Resolution order: per-call config → provider `queryConfig` → framework
   // defaults. The first two merge here; `useFrameworkQuery` applies the last.
+  // Only *defined* per-call keys participate: a key explicitly set to
+  // `undefined` (`{ suspense: cond ? true : undefined }`, forwarding an
+  // optional prop) must fall through to the provider default, not clobber it
+  // — a plain spread would copy the `undefined` over it. The provider value
+  // is already sanitized at the provider (see `QueryManagerProvider`).
   const queryConfig = useContext(QueryConfigContext);
-  return useFrameworkQuery(url, options, { ...queryConfig, ...config });
+  const merged: Config<Data<T>> = { ...queryConfig };
+  if (config) {
+    for (const key of Object.keys(config) as Array<keyof Config<Data<T>>>) {
+      if (config[key] !== undefined) {
+        (merged as Record<string, unknown>)[key] = config[key];
+      }
+    }
+  }
+  return useFrameworkQuery(url, options, merged);
 }
 
 /**

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -11,7 +11,7 @@ import type { NestedPrettify } from "../utils/type";
 
 import type { ApiRouterHandler } from "../http/ApiRouter";
 import type { UnwrapPromise } from "../utils/type";
-import { QueryManagerContext } from "./QueryManagerContext";
+import { QueryConfigContext, QueryManagerContext } from "./QueryManagerContext";
 import { ServerQueryContext } from "./ServerQueryContext";
 import { DEFAULT_STALE_TIME } from "./QueryResource";
 import { applyParams } from "../utils/applyParams";
@@ -118,11 +118,50 @@ interface SuspenseConfig<T> extends Omit<Config<T>, "suspense" | "lazy"> {
   lazy?: false;
 }
 
+/** A per-call `suspense: true` opt-in — wins over an app-wide `suspense: false`. */
+interface ExplicitSuspenseConfig<T> extends Omit<
+  Config<T>,
+  "suspense" | "lazy"
+> {
+  suspense: true;
+  lazy?: false;
+}
+
+/**
+ * The type-level mirror of a provider-level `queryConfig: { suspense: false }`.
+ * The `useQuery` overloads reflect the call site only — they cannot see the
+ * value threaded through `createRoot` — so an app that turns suspense off
+ * app-wide flips the default `data` nullability with the same
+ * module-augmentation switch RPC types use:
+ *
+ * ```ts
+ * declare module "gemi/client" {
+ *   interface GemiQueryDefaults {
+ *     suspense: false;
+ *   }
+ * }
+ * ```
+ *
+ * A per-call `suspense: true` still narrows `data` back to non-nullable.
+ */
+export interface GemiQueryDefaults {}
+
+type DefaultData<T extends keyof GetRPC> = GemiQueryDefaults extends {
+  suspense: false;
+}
+  ? NestedPrettify<Data<T>> | undefined
+  : NestedPrettify<Data<T>>;
+
+export function useQuery<T extends keyof GetRPC>(
+  url: T,
+  options: Options<T> | undefined,
+  config: ExplicitSuspenseConfig<Data<T>>,
+): QueryReturn<T, NestedPrettify<Data<T>>>;
 export function useQuery<T extends keyof GetRPC>(
   url: T,
   options?: Options<T>,
   config?: SuspenseConfig<Data<T>>,
-): QueryReturn<T, NestedPrettify<Data<T>>>;
+): QueryReturn<T, DefaultData<T>>;
 export function useQuery<T extends keyof GetRPC>(
   url: T,
   options?: Options<T>,
@@ -132,6 +171,24 @@ export function useQuery<T extends keyof GetRPC>(
   url: T,
   ...args: [options?: Options<T>, config?: Config<Data<T>>]
 ) {
+  const [options, config] = args;
+  // Resolution order: per-call config → provider `queryConfig` → framework
+  // defaults. The first two merge here; `useFrameworkQuery` applies the last.
+  const queryConfig = useContext(QueryConfigContext);
+  return useFrameworkQuery(url, options, { ...queryConfig, ...config });
+}
+
+/**
+ * `useQuery` minus the app's provider-level `queryConfig`: per-call config
+ * resolves straight against the framework defaults. Framework-internal hooks
+ * (`useUser`'s `suspense: false`, `useSignIn`'s `lazy`) build on this so an
+ * app-wide `queryConfig` can never change their semantics. Deliberately not
+ * exported from the package root.
+ */
+export function useFrameworkQuery<T extends keyof GetRPC>(
+  url: T,
+  ...args: [options?: Options<T>, config?: Config<Data<T>>]
+): QueryReturn<T, NestedPrettify<Data<T>> | undefined> {
   const _params = useParams();
   const [_options = defaultOptions, _config = defaultConfig] = args;
   const options = { ...defaultOptions, ..._options };


### PR DESCRIPTION
Closes #292

> Stacked on #295 (branch `feat/291-suspense-keep-previous-data`).

## Approach

`useQuery` defaults can now be set once, app-wide, where the roots are created:

```ts
// server entry (ViewRouterServiceProvider)
root = createRoot(RootLayout, { queryConfig: { suspense: false } });
// client entry (app/client.tsx)
init(RootLayout, { queryConfig: { suspense: false } });
```

- **Resolution order**: per-call config → provider `queryConfig` → framework defaults. Implemented as a single spread merge: `useQuery` becomes a thin wrapper that reads a new `QueryConfigContext` (provided by `QueryManagerProvider` via a `queryConfig` prop, threaded from `createRoot`/`init` through `ClientRouter`) and delegates to `useFrameworkQuery`, which holds the previous implementation unchanged.
- **Only app-wide keys are accepted**: `suspense`, `staleTime`, `keepPreviousData`, `retryIntervalOnError`, `refreshInterval`. `lazy`, `fallbackData`, and `refetchUntil` stay call-site-only (the `QueryConfig` type simply doesn't have them).
- **Framework internals are insulated**: `useUser` and `useSignIn` now call `useFrameworkQuery` directly (not exported from the package root), so their pinned semantics (`suspense: false`, `lazy`) can never be changed by an app's `queryConfig` — including keys they don't set themselves, like `refreshInterval`.
- **Typing**: the overloads keep reflecting the call site only. An app that sets `queryConfig: { suspense: false }` flips the default `data` nullability with the same module-augmentation switch RPC types use — `declare module "gemi/client" { interface GemiQueryDefaults { suspense: false } }` — and a new explicit-literal overload keeps a per-call `suspense: true` non-nullable either way. With no augmentation, all existing call sites type exactly as before.

## Tests

`packages/gemi/client/useQuery.queryConfig.test.tsx` (8 tests):
- The acceptance freeze: `queryConfig: { suspense: false }` with **zero per-call configs** re-runs the non-suspense assertions from `useQuery.suspense.test.tsx` — loading-flag sequence, errors returned not thrown, and the 0.48 `keepPreviousData` path on variant changes.
- Per-call config wins in both directions (`suspense: true` over app-wide `false` and vice versa; `keepPreviousData: true` over app-wide `false`).
- A numeric provider key flows through (`retryIntervalOnError` drives the retry timer).
- `useUser` under an aggressive `queryConfig` (`refreshInterval: 5, staleTime: 0`): still resolves `user: null` semantics without suspending and never refetches — one fetch total.

`bun run vitest run client/` → 14 files, 131 tests pass. `tsc --noEmit` on both `tsconfig.json` and `tsconfig.browser.json` clean; `test:types` clean; oxlint clean. (7 pre-existing failures in `app/`/`services/`/`utils/` reproduce identically on the base branch without this change.)

Note on type tests: the package's own tsconfig has `strict: false`, under which `| undefined` unions collapse and nullability assertions are vacuous — the `GemiQueryDefaults` contract was verified manually under `--strict`, which is what consuming apps use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWrgZ7fXNHCjJMV53o3qPK