### PR TITLE
Stream lifecycle hooks: onStreamComplete on body close, streamed query failures through onRequestFail

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -205,6 +205,7 @@ The router providers expose request lifecycle hooks you can override for cross-c
 - **`onRequestStart(req)`** — before a matched request is handled (API path).
 - **`onRequestEnd(req)`** — after a request is handled successfully.
 - **`onRequestFail(req, error)`** — when handling throws.
+- **`onStreamComplete(req, summary)`** — view provider only; when a response body actually closes, after the last streamed chunk (see [Instrumenting streamed responses](#instrumenting-streamed-responses)).
 
 A real-world example from a production app reports failures to Sentry:
 
@@ -229,6 +230,40 @@ export default class extends ApiRouterServiceProvider {
 Other providers expose their own hooks — for example the logging provider has `onLogCreated(logEntry)` and `onLogFileClosed(file)`, the i18n provider has `onLocaleChange(locale)`, and the authentication provider has `onSignUp`, `onForgotPassword`, and `onMagicLinkCreated`.
 
 > **Gotcha:** On the view path, gemi does not call `onRequestStart`. If you need per-request setup for views, use `onRequestEnd` / `onRequestFail`, which both fire on the view path.
+
+### Instrumenting streamed responses
+
+View responses stream: the handler returns at time-to-shell while query payloads keep streaming for as long as the slowest query takes. A span that ends when the handler returns (or in a `finally` around `app.fetch`) therefore records ~milliseconds for a request whose body stayed open for a second — the duration of the shell, not the response.
+
+The view router provider's `onStreamComplete(req, summary)` fires when the response body actually closes — after the last streamed chunk, or when the stream deadline aborts rendering. The `summary` reports:
+
+- **`shellAt`** — ms from request start to the response's first byte.
+- **`settledAt`** — ms to the last chunk, when the body closed.
+- **`aborted`** — whether the stream deadline cut rendering short.
+- **`queries`** — per-query `path`, `variantKey`, `startedAt`, `settledAt`, `status`, and `source` (`"prefetch"` or `"render"`).
+
+Non-streamed responses (`.json` navigation payloads, `"no-stream"` routes, bot requests) report `shellAt === settledAt`.
+
+Start the span where you already do, and end it here instead:
+
+```typescript
+import { ViewRouterServiceProvider } from "gemi/services";
+import type { StreamSummary } from "gemi/services";
+import type { HttpRequest } from "gemi/http";
+
+export default class extends ViewRouterServiceProvider {
+  // ...
+
+  onStreamComplete(req: HttpRequest, summary: StreamSummary) {
+    // e.g. end the Sentry span opened for this request:
+    // span.setAttribute("gemi.shell_ms", summary.shellAt);
+    // span.setAttribute("gemi.aborted", summary.aborted);
+    // span.end(); // now measures the full streamed response
+  }
+}
+```
+
+Query failures during the streamed render are routed through `onRequestFail(req, error)` exactly once per rejected query, with a `QueryError` carrying the query's path, variant, and status — so error tracking wired to `onRequestFail` keeps seeing server-side failures that React quietly hands over to client rendering. (`Query.instant` rethrows into the handler; that rejection is still reported only once.)
 
 ## App bootstrap
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -242,7 +242,9 @@ The view router provider's `onStreamComplete(req, summary)` fires when the respo
 - **`aborted`** — whether the stream deadline cut rendering short.
 - **`queries`** — per-query `path`, `variantKey`, `startedAt`, `settledAt`, `status`, and `source` (`"prefetch"` or `"render"`).
 
-Non-streamed responses (`.json` navigation payloads, `"no-stream"` routes, bot requests) report `shellAt === settledAt`.
+Non-streamed responses (`.json` navigation payloads, `"no-stream"` routes, bot requests) report `shellAt === settledAt`. The hook also fires when a shell render crashes (or the deadline aborts it before the shell resolved) — the fallback error document's body still closes, so the span still ends.
+
+> **Scope:** `onStreamComplete` fires for document and `.json` navigation bodies — the responses that stream. Responses without a query lifecycle (OG images, `FILE` routes, redirects and error responses produced by `RequestBreakerError`) do not fire it, so a span opened unconditionally in instrumentation needs a fallback end (e.g. also ending it in `onRequestEnd` / `onRequestFail` when no stream ever started).
 
 Start the span where you already do, and end it here instead:
 
@@ -263,7 +265,9 @@ export default class extends ViewRouterServiceProvider {
 }
 ```
 
-Query failures during the streamed render are routed through `onRequestFail(req, error)` exactly once per rejected query, with a `QueryError` carrying the query's path, variant, and status — so error tracking wired to `onRequestFail` keeps seeing server-side failures that React quietly hands over to client rendering. (`Query.instant` rethrows into the handler; that rejection is still reported only once.)
+Query failures during the streamed render are routed through `onRequestFail(req, error)` exactly once per rejected query, with a `QueryError` carrying the query's path, variant, and status — so error tracking wired to `onRequestFail` keeps seeing server-side failures that React quietly hands over to client rendering. (`Query.instant` rethrows into the handler; that rejection is still reported only once.) An api handler that fails with a `RequestBreakerError` (or an error `Response`) yields a `QueryError` with that response's status; a raw `throw` inside the handler yields a status-500 `QueryError` with the original error on `cause`.
+
+> **Gotcha:** a raw `throw` inside an api handler also fires the **api** provider's `onRequestFail` — the query runs the api handler in-process, and the api router reports its own failures. If both providers report to the same error tracker, dedupe there (the view provider's error is the `QueryError` wrapper, the api provider's is the original error on its `cause`).
 
 ## App bootstrap
 

--- a/packages/gemi/http/requestContext.ts
+++ b/packages/gemi/http/requestContext.ts
@@ -117,4 +117,15 @@ export class RequestContext {
   static run<T>(httpRequest: HttpRequest, fn: () => T): T {
     return requestContext.run(new Store(httpRequest), fn);
   }
+
+  /**
+   * Re-enters an *existing* request scope. Stream lifecycle callbacks fire
+   * after the HTTP server has taken over the response body — outside the
+   * AsyncLocalStorage scope the request ran in — so the view router captures
+   * the live store and re-enters it around user-facing hooks, keeping
+   * `req.ctx()` (and everything context-backed) working inside them.
+   */
+  static runWith<T>(store: Store, fn: () => T): T {
+    return requestContext.run(store, fn);
+  }
 }

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -50,6 +50,11 @@ export { BroadcastingServiceProvider } from "./pubsub/BroadcastingServiceProvide
 // Router
 export { ViewRouterServiceProvider } from "./router/ViewRouterServiceProvider";
 export { ApiRouterServiceProvider } from "./router/ApiRouterServiceProvider";
+// What `onStreamComplete` receives when a response body closes.
+export type {
+  StreamSummary,
+  StreamQuerySummary,
+} from "./router/ServerQueryStore";
 
 // Logging
 

--- a/packages/gemi/services/router/ServerQueryStore.test.ts
+++ b/packages/gemi/services/router/ServerQueryStore.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { ServerQueryStore, type ServerQueryFetcher } from "./ServerQueryStore";
+import {
+  ServerQueryStore,
+  type ServerQueryFetcher,
+  type StreamSummary,
+} from "./ServerQueryStore";
 import {
   htmlSafeJson,
   injectQueryPayloads,
   isBotUserAgent,
   queryPayloadScript,
 } from "./streamQueryInjection";
+import { QueryError } from "../../client/QueryError";
 
 /** A hand-cranked source standing in for React's SSR stream. */
 function createSource() {
@@ -249,6 +254,55 @@ describe("ServerQueryStore", () => {
     await muted.promise;
     expect(warn).not.toHaveBeenCalled();
   });
+
+  test("a rejected query fires the fail listener exactly once, with the error", async () => {
+    const { fetcher, calls } = createDeferredFetcher();
+    const store = new ServerQueryStore(fetcher);
+    const failures: any[] = [];
+    store.onQueryFail((entry) => failures.push(entry.error));
+
+    const entry = store.ensure("/broken", { search: { page: 3 } });
+    // React discards and retries suspended renders — repeated discovery must
+    // not multiply the report.
+    store.ensure("/broken", { search: { page: 3 } });
+    const ok = store.ensure("/fine");
+
+    const error = new QueryError("/broken", "page=3", 500, { message: "boom" });
+    calls[0].reject(error);
+    calls[1].resolve({ ok: true });
+    await Promise.all([entry.promise, ok.promise]);
+
+    expect(failures).toEqual([error]);
+    expect(failures[0]).toBeInstanceOf(QueryError);
+  });
+
+  test("a summary without a shell mark reports shellAt === settledAt", async () => {
+    const { fetcher, calls } = createDeferredFetcher();
+    let clock = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const store = new ServerQueryStore(fetcher);
+
+    const entry = store.ensure("/data", {}, "prefetch");
+    clock = 120;
+    calls[0].resolve({ d: 1 });
+    await entry.promise;
+
+    clock = 130;
+    const summary = store.summarize(false);
+    expect(summary.shellAt).toBe(130);
+    expect(summary.settledAt).toBe(130);
+    expect(summary.aborted).toBe(false);
+    expect(summary.queries).toEqual([
+      {
+        path: "/data",
+        variantKey: "",
+        startedAt: 0,
+        settledAt: 120,
+        status: "resolved",
+        source: "prefetch",
+      },
+    ]);
+  });
 });
 
 describe("stream injection", () => {
@@ -341,6 +395,74 @@ describe("stream injection", () => {
     await finished;
 
     expect(chunks.join("")).toBe("<!doctype html>");
+  });
+
+  test("onClose fires after the last injected chunk; shellAt ≪ settledAt for a suspending page", async () => {
+    const { fetcher, calls } = createDeferredFetcher();
+    let clock = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const store = new ServerQueryStore(fetcher);
+    const source = createSource();
+
+    let summary: StreamSummary | null = null;
+    let closes = 0;
+    const { chunks, finished } = collect(
+      injectQueryPayloads(source.stream, store, {
+        onShell: () => store.markShell(),
+        onClose: () => {
+          closes += 1;
+          summary = store.summarize(false);
+        },
+      }),
+    );
+
+    const slow = store.ensure("/slow", {}, "prefetch");
+    clock = 15;
+    source.write("<!doctype html><div>shell</div>");
+    // Let the pump forward the shell before the clock moves on.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(closes).toBe(0);
+
+    // The slowest query settles long after the shell went out.
+    clock = 900;
+    calls[0].resolve({ rows: [1] });
+    await slow.promise;
+    source.write("<div hidden>revealed segment</div>");
+    source.close();
+    await finished;
+
+    expect(closes).toBe(1);
+    expect(summary!.shellAt).toBe(15);
+    expect(summary!.settledAt).toBe(900);
+    expect(summary!.aborted).toBe(false);
+    expect(summary!.queries).toEqual([
+      {
+        path: "/slow",
+        variantKey: "",
+        startedAt: 0,
+        settledAt: 900,
+        status: "resolved",
+        source: "prefetch",
+      },
+    ]);
+    // The payload chunk was injected before the body closed.
+    expect(chunks.join("")).toContain('"/slow"');
+  });
+
+  test("a cancelled response body fires onClose exactly once", async () => {
+    const { fetcher } = createDeferredFetcher();
+    const store = new ServerQueryStore(fetcher);
+    const source = createSource();
+
+    let closes = 0;
+    const stream = injectQueryPayloads(source.stream, store, {
+      onClose: () => {
+        closes += 1;
+      },
+    });
+
+    await stream.getReader().cancel(new Error("client went away"));
+    expect(closes).toBe(1);
   });
 });
 

--- a/packages/gemi/services/router/ServerQueryStore.test.ts
+++ b/packages/gemi/services/router/ServerQueryStore.test.ts
@@ -449,6 +449,31 @@ describe("stream injection", () => {
     expect(chunks.join("")).toContain('"/slow"');
   });
 
+  test("an erroring source stream fires onClose exactly once", async () => {
+    const { fetcher } = createDeferredFetcher();
+    const store = new ServerQueryStore(fetcher);
+    let errorSource!: (reason: unknown) => void;
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("<!doctype html>"));
+        errorSource = (reason) => controller.error(reason);
+      },
+    });
+
+    let closes = 0;
+    const stream = injectQueryPayloads(source, store, {
+      onClose: () => {
+        closes += 1;
+      },
+    });
+
+    const reader = stream.getReader();
+    await reader.read();
+    errorSource(new Error("render crashed mid-stream"));
+    await expect(reader.read()).rejects.toThrow("render crashed mid-stream");
+    expect(closes).toBe(1);
+  });
+
   test("a cancelled response body fires onClose exactly once", async () => {
     const { fetcher } = createDeferredFetcher();
     const store = new ServerQueryStore(fetcher);

--- a/packages/gemi/services/router/ServerQueryStore.ts
+++ b/packages/gemi/services/router/ServerQueryStore.ts
@@ -45,6 +45,34 @@ export type ServerQueryFetcher = (
   searchParams: URLSearchParams,
 ) => Promise<any>;
 
+/** One query's timings in a `StreamSummary` — a serialization of its entry. */
+export interface StreamQuerySummary {
+  path: string;
+  variantKey: string;
+  /** ms since the request started. */
+  startedAt: number;
+  /** Absent when the stream closed (deadline) with the query still pending. */
+  settledAt?: number;
+  status: "pending" | "resolved" | "rejected";
+  source: ServerQuerySource;
+}
+
+/**
+ * What `onStreamComplete` receives when the response body actually closes —
+ * the numbers an APM span wrapped around the *handler* gets wrong under
+ * streaming, where the handler returns at time-to-shell while the body keeps
+ * streaming.
+ */
+export interface StreamSummary {
+  /** ms from request start to the response's first byte. */
+  shellAt: number;
+  /** ms from request start to the last chunk — when the body closed. */
+  settledAt: number;
+  /** The stream deadline cut rendering short. */
+  aborted: boolean;
+  queries: StreamQuerySummary[];
+}
+
 /**
  * When a render-discovered query starts this long after the render began, it
  * was blocked behind another suspended segment (or conditional data) — the
@@ -67,6 +95,9 @@ const LATE_DISCOVERY_THRESHOLD_MS = 50;
 export class ServerQueryStore {
   private entries = new Map<string, ServerQueryEntry>();
   private settleListener: ((entry: ServerQueryEntry) => void) | null = null;
+  private failListener: ((entry: ServerQueryEntry) => void) | null = null;
+  /** ms to the response's first byte — set only for progressive responses. */
+  private shellAt: number | null = null;
   /** Entries settled before the stream injector subscribed. */
   private settledBacklog: ServerQueryEntry[] = [];
   /** Variants already serialized into `__GEMI_DATA__` — not streamed again. */
@@ -91,6 +122,52 @@ export class ServerQueryStore {
     if (this.renderStartedAt === null) {
       this.renderStartedAt = performance.now();
     }
+  }
+
+  /**
+   * Marks the response's first byte — time-to-shell. Only progressive
+   * responses mark it; a response that never does (settled documents for bots
+   * and `no-stream` routes, `.json` navigation payloads) reports
+   * `shellAt === settledAt` in its summary, because its body has no
+   * shell-then-stream phase to distinguish.
+   */
+  markShell() {
+    if (this.shellAt === null) {
+      this.shellAt = this.elapsed();
+    }
+  }
+
+  /**
+   * The stream lifecycle summary for `onStreamComplete`. `settledAt` is "now",
+   * so call it at the moment the response body actually closes.
+   */
+  summarize(aborted: boolean): StreamSummary {
+    const settledAt = this.elapsed();
+    return {
+      shellAt: this.shellAt ?? settledAt,
+      settledAt,
+      aborted,
+      queries: Array.from(this.entries.values(), (entry) => ({
+        path: entry.path,
+        variantKey: entry.variantKey,
+        startedAt: entry.startedAt,
+        settledAt: entry.settledAt,
+        status: entry.status,
+        source: entry.source,
+      })),
+    };
+  }
+
+  /**
+   * Single-subscriber rejection feed. A query that rejects during the
+   * streamed render never throws the handler — React client-renders the
+   * segment and moves on — so without this the failure is invisible to
+   * `onRequestFail`-style error reporting. Fires once per rejected entry
+   * (`ensure` dedupes, so a query rejects at most once per request), before
+   * the entry's promise wakes any awaiter.
+   */
+  onQueryFail(listener: (entry: ServerQueryEntry) => void) {
+    this.failListener = listener;
   }
 
   /**
@@ -210,6 +287,9 @@ export class ServerQueryStore {
       .then(() => {
         entry.settledAt = this.elapsed();
         this.maybeLogLateDiscovery(entry);
+        if (entry.status === "rejected" && this.failListener) {
+          this.failListener(entry);
+        }
         // Listener first, wake second: the payload script must be queued for
         // injection before React resumes the suspended segment, so the data
         // always precedes the segment's reveal in the stream.

--- a/packages/gemi/services/router/ViewRouterServiceContainer.ts
+++ b/packages/gemi/services/router/ViewRouterServiceContainer.ts
@@ -31,6 +31,7 @@ import { Log } from "../../facades/Log";
 import { I18n } from "../../facades/I18n";
 import { AuthViewRouter } from "../../auth/AuthenticationServiceProvider";
 import { KernelIdServiceContainer } from "../kernel-id/KernelIdServiceContainer";
+import { kernelContext } from "../../kernel/context";
 import { ServerQueryStore, type StreamSummary } from "./ServerQueryStore";
 import { createServerQueryFetcher } from "./serverQueryFetcher";
 import { injectQueryPayloads, isBotUserAgent } from "./streamQueryInjection";
@@ -149,6 +150,12 @@ export class ViewRouterServiceContainer extends ServiceContainer {
    * Fires the provider's `onStreamComplete` from a stream callback — an
    * observability hook must never break the response body it observes, so
    * sync throws and rejections are logged and swallowed.
+   *
+   * Call sites must invoke this inside the request scope (see
+   * `runInRequestScope` in `handleViewRequest`): stream callbacks are driven
+   * by the HTTP server after the handler returned, outside the kernel
+   * AsyncLocalStorage — where both the user's hook and this very `Log.error`
+   * guard would break.
    */
   private completeStream(req: HttpRequest, summary: StreamSummary) {
     const logError = (err: any) => {
@@ -165,6 +172,13 @@ export class ViewRouterServiceContainer extends ServiceContainer {
 
   private async render(props: {
     req: HttpRequest;
+    /**
+     * Re-enters the kernel + request AsyncLocalStorage scopes captured while
+     * the request was live. Every stream lifecycle callback below runs after
+     * the handler returned — driven by the HTTP server, outside both scopes —
+     * so user hooks are always invoked through this.
+     */
+    runInRequestScope: <T>(fn: () => T) => T;
     viewData: any;
     pathname: string;
     currentPathName: string;
@@ -185,6 +199,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
   }) {
     const {
       req,
+      runInRequestScope,
       csrfTokenHMAC,
       currentPathName,
       headers,
@@ -389,9 +404,10 @@ export class ViewRouterServiceContainer extends ServiceContainer {
             onShell: settled ? undefined : () => serverQueries.markShell(),
             // The APM-visible end of the request: the body closed, not the
             // handler returned (that was at time-to-shell).
-            onClose: () => {
-              this.completeStream(req, serverQueries.summarize(deadline.signal.aborted));
-            },
+            onClose: () =>
+              runInRequestScope(() =>
+                this.completeStream(req, serverQueries.summarize(deadline.signal.aborted)),
+              ),
           }),
           {
             status: !currentPathName ? 404 : 200,
@@ -407,10 +423,22 @@ export class ViewRouterServiceContainer extends ServiceContainer {
               ? ["/render-error.js", ...bootstrapModules]
               : bootstrapModules,
         });
-        return new Response(stream, {
-          status: !currentPathName ? 404 : 200,
-          headers,
-        });
+        // The failed-render body still closes, and the span-ending hook is
+        // pinned to the body closing, not the render succeeding — a span that
+        // only ends on happy paths leaks for exactly the requests worth
+        // seeing. No shell mark: this body is one settled error document.
+        return new Response(
+          injectQueryPayloads(stream, serverQueries, {
+            onClose: () =>
+              runInRequestScope(() =>
+                this.completeStream(req, serverQueries.summarize(deadline.signal.aborted)),
+              ),
+          }),
+          {
+            status: !currentPathName ? 404 : 200,
+            headers,
+          },
+        );
       }
     };
   }
@@ -514,6 +542,16 @@ export class ViewRouterServiceContainer extends ServiceContainer {
         appId: string;
       } | null = null;
       const ctx = RequestContext.getStore();
+      // The HTTP server drives the response body — and therefore every stream
+      // lifecycle callback — after `app.fetch` returned, outside the kernel
+      // AsyncLocalStorage scope and outside this request's context (the same
+      // phenomenon `createServerQueryFetcher` documents for render-discovered
+      // fetches). Facades and `req.ctx()` inside `onStreamComplete` /
+      // `onRequestFail` would break there, so capture both scopes while they
+      // are live and re-enter them around every hook invocation below.
+      const kernelStore = kernelContext.getStore();
+      const runInRequestScope = <T>(fn: () => T): T =>
+        kernelContext.run(kernelStore, () => RequestContext.runWith(ctx, fn));
       // Before middleware and handlers, so every `Query.prefetch` along the
       // way lands in one live, request-scoped store.
       ctx.serverQueries = new ServerQueryStore(createServerQueryFetcher(req));
@@ -527,8 +565,13 @@ export class ViewRouterServiceContainer extends ServiceContainer {
       ctx.serverQueries.onQueryFail((entry) => {
         reportedQueryErrors.add(entry.error);
         try {
-          Promise.resolve(this.service.onRequestFail(httpRequest, entry.error)).catch(
-            () => {},
+          // In scope, and with the rejection handler attached *inside* the
+          // scope, so a facade-using hook works for render-phase failures
+          // exactly as it does for handler-phase ones.
+          runInRequestScope(() =>
+            Promise.resolve(this.service.onRequestFail(httpRequest, entry.error)).catch(
+              () => {},
+            ),
           );
         } catch {
           // An error-reporting hook must not break the settle chain it
@@ -668,7 +711,9 @@ export class ViewRouterServiceContainer extends ServiceContainer {
               // No shell was marked, so the summary reports
               // `shellAt === settledAt` — the NDJSON body is one payload, not
               // a shell followed by streamed content.
-              this.completeStream(httpRequest, ctx.serverQueries.summarize(aborted)),
+              runInRequestScope(() =>
+                this.completeStream(httpRequest, ctx.serverQueries.summarize(aborted)),
+              ),
             ),
             {
               headers,
@@ -710,6 +755,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
 
         return await this.render({
           req: httpRequest,
+          runInRequestScope,
           csrfTokenHMAC: Buffer.from(""),
           currentPathName,
           headers,

--- a/packages/gemi/services/router/ViewRouterServiceContainer.ts
+++ b/packages/gemi/services/router/ViewRouterServiceContainer.ts
@@ -31,7 +31,7 @@ import { Log } from "../../facades/Log";
 import { I18n } from "../../facades/I18n";
 import { AuthViewRouter } from "../../auth/AuthenticationServiceProvider";
 import { KernelIdServiceContainer } from "../kernel-id/KernelIdServiceContainer";
-import { ServerQueryStore } from "./ServerQueryStore";
+import { ServerQueryStore, type StreamSummary } from "./ServerQueryStore";
 import { createServerQueryFetcher } from "./serverQueryFetcher";
 import { injectQueryPayloads, isBotUserAgent } from "./streamQueryInjection";
 import { createRoutePayloadStream } from "./routePayloadStream";
@@ -145,7 +145,26 @@ export class ViewRouterServiceContainer extends ServiceContainer {
     return await this.service.onRequestEnd(req);
   }
 
+  /**
+   * Fires the provider's `onStreamComplete` from a stream callback — an
+   * observability hook must never break the response body it observes, so
+   * sync throws and rejections are logged and swallowed.
+   */
+  private completeStream(req: HttpRequest, summary: StreamSummary) {
+    const logError = (err: any) => {
+      Log.error(err?.message ?? 'Error in "onStreamComplete" event handler', {
+        err: JSON.stringify(err),
+      });
+    };
+    try {
+      Promise.resolve(this.service.onStreamComplete(req, summary)).catch(logError);
+    } catch (err) {
+      logError(err);
+    }
+  }
+
   private async render(props: {
+    req: HttpRequest;
     viewData: any;
     pathname: string;
     currentPathName: string;
@@ -165,6 +184,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
     appId: string;
   }) {
     const {
+      req,
       csrfTokenHMAC,
       currentPathName,
       headers,
@@ -360,10 +380,24 @@ export class ViewRouterServiceContainer extends ServiceContainer {
           await stream.allReady.catch(() => {});
         }
 
-        return new Response(injectQueryPayloads(stream, serverQueries), {
-          status: !currentPathName ? 404 : 200,
-          headers,
-        });
+        return new Response(
+          injectQueryPayloads(stream, serverQueries, {
+            // A settled body has no shell-then-stream phase — its first byte
+            // already carries everything — so only progressive responses mark
+            // one; the summary then reports `shellAt === settledAt` for the
+            // settled ones.
+            onShell: settled ? undefined : () => serverQueries.markShell(),
+            // The APM-visible end of the request: the body closed, not the
+            // handler returned (that was at time-to-shell).
+            onClose: () => {
+              this.completeStream(req, serverQueries.summarize(deadline.signal.aborted));
+            },
+          }),
+          {
+            status: !currentPathName ? 404 : 200,
+            headers,
+          },
+        );
       } catch (err) {
         clearTimeout(deadlineTimer);
         const stream = await renderToReadableStream(createElement("div"), {
@@ -483,6 +517,24 @@ export class ViewRouterServiceContainer extends ServiceContainer {
       // Before middleware and handlers, so every `Query.prefetch` along the
       // way lands in one live, request-scoped store.
       ctx.serverQueries = new ServerQueryStore(createServerQueryFetcher(req));
+      // A query rejecting during the streamed render (or a fire-and-forget
+      // prefetch) never throws the handler, so the catch below can't see it —
+      // error tracking wired to `onRequestFail` would miss server-side work
+      // that failed. Route rejections through the hook here. The identity set
+      // keeps `Query.instant` rethrows — which DO reach the catch — from
+      // reporting the same error twice.
+      const reportedQueryErrors = new Set<any>();
+      ctx.serverQueries.onQueryFail((entry) => {
+        reportedQueryErrors.add(entry.error);
+        try {
+          Promise.resolve(this.service.onRequestFail(httpRequest, entry.error)).catch(
+            () => {},
+          );
+        } catch {
+          // An error-reporting hook must not break the settle chain it
+          // observes — a suspended segment is waiting on it.
+        }
+      });
 
       if (urlLocale) {
         const locale = urlLocale.replaceAll("/", "");
@@ -612,7 +664,12 @@ export class ViewRouterServiceContainer extends ServiceContainer {
           };
 
           return new Response(
-            createRoutePayloadStream(envelope, ctx.serverQueries),
+            createRoutePayloadStream(envelope, ctx.serverQueries, undefined, ({ aborted }) =>
+              // No shell was marked, so the summary reports
+              // `shellAt === settledAt` — the NDJSON body is one payload, not
+              // a shell followed by streamed content.
+              this.completeStream(httpRequest, ctx.serverQueries.summarize(aborted)),
+            ),
             {
               headers,
             },
@@ -652,6 +709,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
         }
 
         return await this.render({
+          req: httpRequest,
           csrfTokenHMAC: Buffer.from(""),
           currentPathName,
           headers,
@@ -686,7 +744,11 @@ export class ViewRouterServiceContainer extends ServiceContainer {
             });
           }
         }
-        this.service.onRequestFail(httpRequest, err);
+        // `Query.instant` rethrows the entry's error object into this catch —
+        // already reported when the rejection settled, so skip the duplicate.
+        if (!reportedQueryErrors.has(err)) {
+          this.service.onRequestFail(httpRequest, err);
+        }
         throw err;
       }
     });

--- a/packages/gemi/services/router/ViewRouterServiceProvider.ts
+++ b/packages/gemi/services/router/ViewRouterServiceProvider.ts
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 import type { HttpRequest } from "../../http";
 import type { ViewRouter } from "../../http/ViewRouter";
 import { ServiceProvider } from "../ServiceProvider";
+import type { StreamSummary } from "./ServerQueryStore";
 
 export class ViewRouterServiceProvider extends ServiceProvider {
   root: (props: any) => JSX.Element;
@@ -23,4 +24,20 @@ export class ViewRouterServiceProvider extends ServiceProvider {
   onRequestStart(_req: HttpRequest): void | Promise<void> {}
   onRequestEnd(_req: HttpRequest): void | Promise<void> {}
   onRequestFail(_req: HttpRequest, _error: any): void | Promise<void> {}
+
+  /**
+   * Fires when the response body actually closes — after the last streamed
+   * chunk, not when the handler returns. Under streaming those are very
+   * different moments: the handler returns at time-to-shell while queries
+   * keep streaming for as long as the slowest one takes, so an APM span
+   * ended in the handler under-reports every streamed request. End it here
+   * instead; `summary` carries `shellAt`/`settledAt`, whether the stream
+   * deadline aborted rendering, and per-query timings. Non-streamed
+   * responses (`.json` payloads, `no-stream` routes, bot requests) report
+   * `shellAt === settledAt`.
+   */
+  onStreamComplete(
+    _req: HttpRequest,
+    _summary: StreamSummary,
+  ): void | Promise<void> {}
 }

--- a/packages/gemi/services/router/ViewRouterServiceProvider.ts
+++ b/packages/gemi/services/router/ViewRouterServiceProvider.ts
@@ -35,6 +35,10 @@ export class ViewRouterServiceProvider extends ServiceProvider {
    * deadline aborted rendering, and per-query timings. Non-streamed
    * responses (`.json` payloads, `no-stream` routes, bot requests) report
    * `shellAt === settledAt`.
+   *
+   * Although the body closes long after the handler returned, the router
+   * re-enters the request's scopes around this hook — facades and
+   * `req.ctx()` work here exactly as they do in the other lifecycle hooks.
    */
   onStreamComplete(
     _req: HttpRequest,

--- a/packages/gemi/services/router/routePayloadStream.test.ts
+++ b/packages/gemi/services/router/routePayloadStream.test.ts
@@ -118,4 +118,61 @@ describe("createRoutePayloadStream", () => {
     await slow.promise;
     expect(slow.status).toBe("resolved");
   });
+
+  test("onClose fires once when the last query has streamed; the summary has shellAt === settledAt", async () => {
+    const { fetcher, calls } = createDeferredFetcher();
+    const store = new ServerQueryStore(fetcher);
+    store.ensure("/pending", {}, "prefetch");
+
+    const closes: Array<{ aborted: boolean }> = [];
+    const { lines, finished } = collectLines(
+      createRoutePayloadStream({ ok: true }, store, undefined, (info) => {
+        closes.push(info);
+      }),
+    );
+
+    // The envelope alone does not complete the stream.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(closes).toHaveLength(0);
+
+    calls[0].resolve({ p: 1 });
+    await finished;
+
+    expect(lines).toHaveLength(2);
+    expect(closes).toEqual([{ aborted: false }]);
+    // The NDJSON body is one payload, never a shell followed by streamed
+    // content — no shell mark, so the summary collapses the two times.
+    const summary = store.summarize(closes[0].aborted);
+    expect(summary.shellAt).toBe(summary.settledAt);
+    expect(summary.aborted).toBe(false);
+  });
+
+  test("onClose reports aborted when the deadline cut a hung query loose", async () => {
+    const { fetcher } = createDeferredFetcher();
+    const store = new ServerQueryStore(fetcher);
+    store.ensure("/hung", {}, "prefetch");
+
+    const closes: Array<{ aborted: boolean }> = [];
+    const { finished } = collectLines(
+      createRoutePayloadStream({ ok: true }, store, 20, (info) => {
+        closes.push(info);
+      }),
+    );
+
+    await finished;
+    expect(closes).toEqual([{ aborted: true }]);
+
+    const summary = store.summarize(true);
+    expect(summary.aborted).toBe(true);
+    expect(summary.queries).toEqual([
+      {
+        path: "/hung",
+        variantKey: "",
+        startedAt: expect.any(Number),
+        settledAt: undefined,
+        status: "pending",
+        source: "prefetch",
+      },
+    ]);
+  });
 });

--- a/packages/gemi/services/router/routePayloadStream.ts
+++ b/packages/gemi/services/router/routePayloadStream.ts
@@ -30,20 +30,29 @@ export function createRoutePayloadStream(
   envelope: unknown,
   store: ServerQueryStore,
   deadlineMs: number = PAYLOAD_STREAM_DEADLINE_MS,
+  /**
+   * The body actually closed — every settled query streamed, the deadline
+   * fired (`aborted: true`), or the client went away. Fires exactly once;
+   * the stream-lifecycle mirror of the document injector's `onClose`.
+   */
+  onClose?: (info: { aborted: boolean }) => void,
 ): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
+  let closeStream: (aborted: boolean) => void = () => {};
 
   return new ReadableStream<Uint8Array>({
     start(controller) {
       let closed = false;
-      const close = () => {
+      const close = (aborted: boolean) => {
         if (closed) return;
         closed = true;
         clearTimeout(deadline);
         try {
           controller.close();
         } catch {}
+        onClose?.({ aborted });
       };
+      closeStream = close;
 
       controller.enqueue(encoder.encode(`${JSON.stringify(envelope)}\n`));
 
@@ -58,8 +67,14 @@ export function createRoutePayloadStream(
         );
       });
 
-      const deadline = setTimeout(close, deadlineMs);
-      store.allSettled().then(close, close);
+      const deadline = setTimeout(() => close(true), deadlineMs);
+      store.allSettled().then(
+        () => close(false),
+        () => close(false),
+      );
+    },
+    cancel() {
+      closeStream(false);
     },
   });
 }

--- a/packages/gemi/services/router/serverQueryFetcher.ts
+++ b/packages/gemi/services/router/serverQueryFetcher.ts
@@ -33,24 +33,44 @@ export function createServerQueryFetcher(req: Request): ServerQueryFetcher {
     const httpRequest = new HttpRequest(newReq, params);
     return kernelContext.run(kernelStore, () =>
       RequestContext.run(httpRequest, async () => {
-        const data = await ApiRouterServiceContainer.use().getRouteData(patternPath);
-        // A handler that broke (`RequestBreakerError`) comes back as an error
-        // `Response`, not a throw. Surface it as the same `QueryError` the
-        // browser's fetch would produce — otherwise the entry "resolves" and
-        // the view renders with a Response object for data.
-        if (data instanceof Response) {
-          const body = await data.json().catch(() => null);
-          if (!data.ok) {
-            throw new QueryError(
-              applyParams(patternPath, params),
-              searchParams.toString(),
-              data.status,
-              body,
-            );
+        try {
+          const data = await ApiRouterServiceContainer.use().getRouteData(patternPath);
+          // A handler that broke (`RequestBreakerError`) comes back as an
+          // error `Response`, not a throw. Surface it as the same
+          // `QueryError` the browser's fetch would produce — otherwise the
+          // entry "resolves" and the view renders with a Response object for
+          // data.
+          if (data instanceof Response) {
+            const body = await data.json().catch(() => null);
+            if (!data.ok) {
+              throw new QueryError(
+                applyParams(patternPath, params),
+                searchParams.toString(),
+                data.status,
+                body,
+              );
+            }
+            return body;
           }
-          return body;
+          return data;
+        } catch (err) {
+          if (err instanceof QueryError) throw err;
+          // A raw throw inside the api handler (not a `RequestBreakerError`)
+          // would otherwise leave this boundary unwrapped, so `onRequestFail`
+          // would see an error with no path/variant/status attached — the
+          // browser's fetch for the same failure produces a 500 `QueryError`.
+          // Wrapping here keeps the two paths interchangeable and keeps the
+          // error identity stable for the router's rethrow dedupe
+          // (`Query.instant` rethrows the entry's — now wrapped — error).
+          const wrapped = new QueryError(
+            applyParams(patternPath, params),
+            searchParams.toString(),
+            500,
+            { message: err instanceof Error ? err.message : String(err) },
+          );
+          wrapped.cause = err;
+          throw wrapped;
         }
-        return data;
       }),
     );
   };

--- a/packages/gemi/services/router/streamLifecycle.test.ts
+++ b/packages/gemi/services/router/streamLifecycle.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createElement, Suspense } from "react";
+
+import { App } from "../../app/App";
+import { ApiRouter } from "../../http/ApiRouter";
+import { ViewRouter } from "../../http/ViewRouter";
+import { Kernel } from "../../kernel";
+import { kernelContext } from "../../kernel/context";
+import { RequestContext } from "../../http/requestContext";
+import { Query } from "../../facades/Prefetch";
+import { QueryError } from "../../client/QueryError";
+import { ApiRouterServiceProvider } from "./ApiRouterServiceProvider";
+import { ViewRouterServiceProvider } from "./ViewRouterServiceProvider";
+import type { ServerQueryStore, StreamSummary } from "./ServerQueryStore";
+
+/**
+ * Container-level coverage for the stream lifecycle hooks (#293): full
+ * requests through `app.fetch`, with the response body consumed *after*
+ * `app.fetch` resolved — outside `kernel.run`, exactly the shape the HTTP
+ * server produces in production. The unit tests cover the store and stream
+ * primitives; these cover the provider wiring the acceptance criteria name.
+ */
+
+process.env.SECRET ??= "stream-lifecycle-test-secret";
+
+const SLOW_QUERY_MS = 60;
+
+/** What the provider hooks observed, including whether the scopes were live. */
+const streamCompletions: Array<{
+  summary: StreamSummary;
+  hasKernelScope: boolean;
+  hasRequestCtx: boolean;
+}> = [];
+const requestFailures: Array<{
+  error: any;
+  hasKernelScope: boolean;
+  hasRequestCtx: boolean;
+}> = [];
+
+class TestApiRouter extends ApiRouter {
+  routes = {
+    "/slow": this.get(async () => {
+      await new Promise((resolve) => setTimeout(resolve, SLOW_QUERY_MS));
+      return { rows: [1, 2, 3] };
+    }),
+    "/broken": this.get(() => {
+      throw new Error("boom");
+    }),
+  };
+}
+
+class TestViewRouter extends ViewRouter {
+  routes = {
+    "/": this.view("Home", () => {
+      (Query as any).prefetch("/slow");
+      return { Home: { title: "home" } };
+    }),
+    "/fails": this.view("Fails", () => {
+      (Query as any).prefetch("/broken");
+      return { Fails: {} };
+    }),
+    "/instant": this.view("Instant", async () => {
+      return { Instant: { data: await (Query as any).instant("/broken") } };
+    }),
+    "/crash": this.view("Crash", () => {
+      return { Crash: {} };
+    }),
+  };
+}
+
+/** Suspends on the slow query the way a server-rendered `useQuery` does. */
+function SlowSegment({ entry }: any) {
+  if (entry.status === "pending") throw entry.promise;
+  return createElement("div", null, JSON.stringify(entry.data));
+}
+
+function TestRoot(props: any) {
+  if (props.data?.router?.pathname === "/crash") {
+    throw new Error("shell crashed");
+  }
+  const store: ServerQueryStore | undefined = props.serverQueries;
+  const entry = store?.read("/slow", "");
+  if (!entry) return createElement("div", null, "static");
+  // The Suspense boundary sits under a host element, like any real root
+  // layout — a boundary at the very root makes React defer the shell flush
+  // until the boundary settles, which would hide the shell/stream split this
+  // suite exists to observe.
+  return createElement(
+    "div",
+    null,
+    createElement(
+      Suspense,
+      { fallback: createElement("div", null, "loading") },
+      createElement(SlowSegment, { entry }),
+    ),
+  );
+}
+
+class TestApiProvider extends ApiRouterServiceProvider {
+  rootRouter = TestApiRouter;
+}
+
+class TestViewProvider extends ViewRouterServiceProvider {
+  root = TestRoot;
+  rootRouter = TestViewRouter;
+
+  onStreamComplete(_req: any, summary: StreamSummary) {
+    streamCompletions.push({
+      summary,
+      hasKernelScope: Boolean(kernelContext.getStore()),
+      hasRequestCtx: Boolean(RequestContext.getStore()?.req),
+    });
+  }
+
+  onRequestFail(_req: any, error: any) {
+    requestFailures.push({
+      error,
+      hasKernelScope: Boolean(kernelContext.getStore()),
+      hasRequestCtx: Boolean(RequestContext.getStore()?.req),
+    });
+  }
+}
+
+class TestKernel extends Kernel {
+  protected apiRouterServiceProvider = TestApiProvider;
+  protected viewRouterServiceProvider = TestViewProvider;
+}
+
+const app = new App({ kernel: TestKernel });
+
+/** The build-artifact params the dev/prod servers pass to the render fn. */
+const renderParams = {
+  getStyles: async () => [],
+  viewImportMap: {},
+  viewModules: {},
+  bootstrapModules: [],
+  loaders: "{}",
+  cssManifest: {},
+  ogMap: {},
+};
+
+/**
+ * Fetches a document route and consumes its body the way the HTTP server
+ * does: the render fn is invoked, and the body read, only after `app.fetch`
+ * resolved — outside the kernel scope.
+ */
+async function fetchDocument(path: string) {
+  const result = await app.fetch(
+    new Request(`http://gemi.dev${path}`, {
+      headers: { "User-Agent": "Mozilla/5.0 (Macintosh) TestBrowser/1.0" },
+    }),
+  );
+  expect(typeof result).toBe("function");
+  const res: Response = await (result as any)(renderParams);
+  return res;
+}
+
+async function readAll(body: ReadableStream<Uint8Array>) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value);
+  }
+  return text;
+}
+
+beforeEach(() => {
+  streamCompletions.length = 0;
+  requestFailures.length = 0;
+});
+
+describe("stream lifecycle hooks through app.fetch", () => {
+  test("onStreamComplete fires once after the streamed document body closes, inside the request scopes", async () => {
+    const res = await fetchDocument("/");
+
+    // The handler has returned, but the body hasn't been consumed — the
+    // hook is pinned to the body closing, so it must not have fired yet.
+    expect(streamCompletions).toHaveLength(0);
+
+    const html = await readAll(res.body!);
+
+    expect(streamCompletions).toHaveLength(1);
+    const { summary, hasKernelScope, hasRequestCtx } = streamCompletions[0];
+
+    // The body is driven outside `kernel.run`; the router must have
+    // re-entered the scopes so facades and `req.ctx()` work in the hook.
+    expect(hasKernelScope).toBe(true);
+    expect(hasRequestCtx).toBe(true);
+
+    // Suspending page: first byte at time-to-shell, body open until the
+    // slowest query streamed.
+    expect(summary.aborted).toBe(false);
+    expect(summary.shellAt).toBeLessThan(summary.settledAt);
+    expect(summary.settledAt).toBeGreaterThanOrEqual(SLOW_QUERY_MS - 10);
+    expect(summary.queries).toEqual([
+      expect.objectContaining({
+        path: "/slow",
+        status: "resolved",
+        source: "prefetch",
+      }),
+    ]);
+
+    // The query payload streamed into the body before it closed.
+    expect(html).toContain("__GEMI_STREAM__");
+    expect(html).toContain('"/slow"');
+  });
+
+  test(".json navigation payloads report shellAt === settledAt", async () => {
+    const res = await app.fetch(new Request("http://gemi.dev/.json"));
+    expect(res).toBeInstanceOf(Response);
+
+    const body = await readAll((res as Response).body!);
+
+    expect(streamCompletions).toHaveLength(1);
+    const { summary, hasKernelScope, hasRequestCtx } = streamCompletions[0];
+    expect(hasKernelScope).toBe(true);
+    expect(hasRequestCtx).toBe(true);
+    expect(summary.shellAt).toBe(summary.settledAt);
+    expect(summary.aborted).toBe(false);
+    expect(summary.queries).toEqual([
+      expect.objectContaining({ path: "/slow", status: "resolved" }),
+    ]);
+    // Envelope line plus one streamed payload line.
+    expect(body.trimEnd().split("\n")).toHaveLength(2);
+  });
+
+  test("a rejected streamed prefetch invokes onRequestFail exactly once, with a QueryError, in scope", async () => {
+    const res = await fetchDocument("/fails");
+    await readAll(res.body!);
+
+    // The rejection settles independently of the body; wait for the report.
+    await vi.waitFor(() => expect(requestFailures).toHaveLength(1));
+    // Give a hypothetical duplicate report a chance to land before asserting
+    // exactly-once.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(requestFailures).toHaveLength(1);
+    const { error, hasKernelScope, hasRequestCtx } = requestFailures[0];
+    expect(hasKernelScope).toBe(true);
+    expect(hasRequestCtx).toBe(true);
+
+    // Raw api-handler throws arrive wrapped: path/variant/status attached,
+    // original error on `cause`.
+    expect(error).toBeInstanceOf(QueryError);
+    expect(error.path).toBe("/broken");
+    expect(error.status).toBe(500);
+    expect((error.cause as Error).message).toBe("boom");
+
+    // The body still closed and reported the rejected query.
+    expect(streamCompletions).toHaveLength(1);
+    expect(streamCompletions[0].summary.queries).toEqual([
+      expect.objectContaining({ path: "/broken", status: "rejected" }),
+    ]);
+  });
+
+  test("a Query.instant rethrow into the handler is reported exactly once", async () => {
+    await expect(
+      app.fetch(new Request("http://gemi.dev/instant.json")),
+    ).rejects.toThrow("boom");
+
+    await vi.waitFor(() => expect(requestFailures.length).toBeGreaterThan(0));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // The settle-time report and the handler rethrow are the same error
+    // object; the identity dedupe must collapse them to one report.
+    expect(requestFailures).toHaveLength(1);
+    expect(requestFailures[0].error).toBeInstanceOf(QueryError);
+  });
+
+  test("onStreamComplete still fires when the shell render crashes", async () => {
+    const res = await fetchDocument("/crash");
+    const html = await readAll(res.body!);
+
+    expect(streamCompletions).toHaveLength(1);
+    const { summary, hasKernelScope } = streamCompletions[0];
+    expect(hasKernelScope).toBe(true);
+    expect(summary.aborted).toBe(false);
+    // The fallback error document carries the crash for the client runtime.
+    expect(html).toContain("shell crashed");
+  });
+});

--- a/packages/gemi/services/router/streamQueryInjection.ts
+++ b/packages/gemi/services/router/streamQueryInjection.ts
@@ -20,6 +20,21 @@ export function queryPayloadScript(entry: ServerQueryEntry): string {
 }
 
 /**
+ * The injector sits at the end of the response pipe, so it is the one place
+ * that knows when the body's first byte goes out and when the body actually
+ * closes — the two marks a handler-scoped span gets wrong under streaming.
+ */
+export interface StreamLifecycleHooks {
+  /** The response's first chunk was enqueued — time-to-shell. */
+  onShell?: () => void;
+  /**
+   * The body closed: the last chunk (and any leftover payload scripts)
+   * flushed, or the client went away. Fires exactly once.
+   */
+  onClose?: () => void;
+}
+
+/**
  * Interleaves resolved query payloads with React's streamed HTML.
  *
  * A manual pull-pump around the source, not a `pipeThrough` — React's SSR
@@ -47,10 +62,17 @@ export function queryPayloadScript(entry: ServerQueryEntry): string {
 export function injectQueryPayloads(
   source: ReadableStream<Uint8Array>,
   store: ServerQueryStore,
+  hooks: StreamLifecycleHooks = {},
 ): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   const queue: string[] = [];
   let sentFirstChunk = false;
+  let closed = false;
+  const closeOnce = () => {
+    if (closed) return;
+    closed = true;
+    hooks.onClose?.();
+  };
 
   store.onSettle((entry) => {
     // Rejected entries stream nothing: React client-renders that segment and
@@ -74,11 +96,13 @@ export function injectQueryPayloads(
         // last chunk — they still belong in the client cache.
         flush(controller);
         controller.close();
+        closeOnce();
         return;
       }
       if (!sentFirstChunk) {
         sentFirstChunk = true;
         controller.enqueue(value);
+        hooks.onShell?.();
         flush(controller);
         return;
       }
@@ -86,6 +110,7 @@ export function injectQueryPayloads(
       controller.enqueue(value);
     },
     cancel(reason) {
+      closeOnce();
       return reader.cancel(reason);
     },
   });

--- a/packages/gemi/services/router/streamQueryInjection.ts
+++ b/packages/gemi/services/router/streamQueryInjection.ts
@@ -29,7 +29,8 @@ export interface StreamLifecycleHooks {
   onShell?: () => void;
   /**
    * The body closed: the last chunk (and any leftover payload scripts)
-   * flushed, or the client went away. Fires exactly once.
+   * flushed, the client went away, or the source stream errored. Fires
+   * exactly once.
    */
   onClose?: () => void;
 }
@@ -90,7 +91,17 @@ export function injectQueryPayloads(
 
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
-      const { done, value } = await reader.read();
+      let result: Awaited<ReturnType<typeof reader.read>>;
+      try {
+        result = await reader.read();
+      } catch (err) {
+        // A source error (React's stream failing post-shell) still ends the
+        // body — without this, "fires exactly once" would be zero times on
+        // the error exit, leaking whatever span `onClose` was meant to end.
+        closeOnce();
+        throw err;
+      }
+      const { done, value } = result;
       if (done) {
         // Queries nothing rendered (an unused prefetch) settle after React's
         // last chunk — they still belong in the client cache.


### PR DESCRIPTION
-