### PR TITLE
Dev-mode hint when a streamed route ships near-zero shell-readable text

### DIFF
--- a/packages/gemi/services/router/ViewRouterServiceContainer.ts
+++ b/packages/gemi/services/router/ViewRouterServiceContainer.ts
@@ -34,11 +34,7 @@ import { KernelIdServiceContainer } from "../kernel-id/KernelIdServiceContainer"
 import { ServerQueryStore, type StreamSummary } from "./ServerQueryStore";
 import { createServerQueryFetcher } from "./serverQueryFetcher";
 import { injectQueryPayloads, isBotUserAgent } from "./streamQueryInjection";
-import {
-  createShellContentObserver,
-  shellContentHint,
-  type ShellContentMeasurement,
-} from "./shellContentReport";
+import { createShellContentObserver, createShellContentReporter } from "./shellContentReport";
 import { createRoutePayloadStream } from "./routePayloadStream";
 
 /**
@@ -118,10 +114,14 @@ export class ViewRouterServiceContainer extends ServiceContainer {
   flatComponentTree: string[] = [];
   root: any = null;
   /**
-   * Routes already hinted for near-blank shell text — the hint fires once per
-   * route per boot (#294) so a hot route doesn't spam the dev console.
+   * The shell-content hint (#294): React defers any boundary over
+   * `progressiveChunkSize` on size alone, so a page that reads fine without
+   * JS can go blank the day one more section pushes it over the budget — and
+   * nothing else notices the transition (#289 was found by hand-measuring).
+   * The reporter owns the once-per-route-per-boot dedup so a hot route
+   * doesn't spam the dev console.
    */
-  private shellHintedRoutes = new Set<string>();
+  private shellReporter = createShellContentReporter();
 
   constructor(public service: ViewRouterServiceProvider) {
     super();
@@ -171,22 +171,6 @@ export class ViewRouterServiceContainer extends ServiceContainer {
     } catch (err) {
       logError(err);
     }
-  }
-
-  /**
-   * The shell-content hint (#294): React defers any boundary over
-   * `progressiveChunkSize` on size alone, so a page that reads fine without
-   * JS can go blank the day one more section pushes it over the budget — and
-   * nothing else notices the transition (#289 was found by hand-measuring).
-   * The injector's `onChunk` collected the exact bytes the visitor got;
-   * measured here once the body closed, hinted once per route per boot.
-   */
-  private maybeReportShellContent(routePath: string, measurement: ShellContentMeasurement) {
-    if (this.shellHintedRoutes.has(routePath)) return;
-    const hint = shellContentHint(routePath, measurement);
-    if (!hint) return;
-    this.shellHintedRoutes.add(routePath);
-    console.warn(hint);
   }
 
   private async render(props: {
@@ -366,7 +350,7 @@ export class ViewRouterServiceContainer extends ServiceContainer {
         process.env.NODE_ENV !== "production" &&
         !settled &&
         currentPathName &&
-        !this.shellHintedRoutes.has(currentPathName)
+        this.shellReporter.shouldObserve(currentPathName)
           ? createShellContentObserver()
           : null;
 
@@ -431,7 +415,9 @@ export class ViewRouterServiceContainer extends ServiceContainer {
             onClose: () => {
               this.completeStream(req, serverQueries.summarize(deadline.signal.aborted));
               if (shellObserver) {
-                this.maybeReportShellContent(currentPathName, shellObserver.measure());
+                // The injector's `onChunk` collected the exact bytes the
+                // visitor got; measured once the body closed (#294).
+                this.shellReporter.report(currentPathName, shellObserver.measure());
               }
             },
           }),

--- a/packages/gemi/services/router/ViewRouterServiceContainer.ts
+++ b/packages/gemi/services/router/ViewRouterServiceContainer.ts
@@ -34,6 +34,11 @@ import { KernelIdServiceContainer } from "../kernel-id/KernelIdServiceContainer"
 import { ServerQueryStore, type StreamSummary } from "./ServerQueryStore";
 import { createServerQueryFetcher } from "./serverQueryFetcher";
 import { injectQueryPayloads, isBotUserAgent } from "./streamQueryInjection";
+import {
+  createShellContentObserver,
+  shellContentHint,
+  type ShellContentMeasurement,
+} from "./shellContentReport";
 import { createRoutePayloadStream } from "./routePayloadStream";
 
 /**
@@ -112,6 +117,11 @@ export class ViewRouterServiceContainer extends ServiceContainer {
   componentTree: ComponentTree = [];
   flatComponentTree: string[] = [];
   root: any = null;
+  /**
+   * Routes already hinted for near-blank shell text — the hint fires once per
+   * route per boot (#294) so a hot route doesn't spam the dev console.
+   */
+  private shellHintedRoutes = new Set<string>();
 
   constructor(public service: ViewRouterServiceProvider) {
     super();
@@ -161,6 +171,22 @@ export class ViewRouterServiceContainer extends ServiceContainer {
     } catch (err) {
       logError(err);
     }
+  }
+
+  /**
+   * The shell-content hint (#294): React defers any boundary over
+   * `progressiveChunkSize` on size alone, so a page that reads fine without
+   * JS can go blank the day one more section pushes it over the budget — and
+   * nothing else notices the transition (#289 was found by hand-measuring).
+   * The injector's `onChunk` collected the exact bytes the visitor got;
+   * measured here once the body closed, hinted once per route per boot.
+   */
+  private maybeReportShellContent(routePath: string, measurement: ShellContentMeasurement) {
+    if (this.shellHintedRoutes.has(routePath)) return;
+    const hint = shellContentHint(routePath, measurement);
+    if (!hint) return;
+    this.shellHintedRoutes.add(routePath);
+    console.warn(hint);
   }
 
   private async render(props: {
@@ -332,6 +358,18 @@ export class ViewRouterServiceContainer extends ServiceContainer {
       // JS-disabled humans, text browsers, and failed-script loads too).
       const settled = isBotUserAgent(userAgent) || noStream;
 
+      // Dev-only: collect the streamed bytes so the close hook can measure
+      // what a no-JS reader gets (#294). A settled document carries its
+      // content inline by construction — nothing to measure — and a route
+      // already hinted this boot skips the collection entirely.
+      const shellObserver =
+        process.env.NODE_ENV !== "production" &&
+        !settled &&
+        currentPathName &&
+        !this.shellHintedRoutes.has(currentPathName)
+          ? createShellContentObserver()
+          : null;
+
       try {
         const stream = await renderToReadableStream(
           createElement(Fragment, {
@@ -387,10 +425,14 @@ export class ViewRouterServiceContainer extends ServiceContainer {
             // one; the summary then reports `shellAt === settledAt` for the
             // settled ones.
             onShell: settled ? undefined : () => serverQueries.markShell(),
+            onChunk: shellObserver?.onChunk,
             // The APM-visible end of the request: the body closed, not the
             // handler returned (that was at time-to-shell).
             onClose: () => {
               this.completeStream(req, serverQueries.summarize(deadline.signal.aborted));
+              if (shellObserver) {
+                this.maybeReportShellContent(currentPathName, shellObserver.measure());
+              }
             },
           }),
           {

--- a/packages/gemi/services/router/shellContentReport.test.ts
+++ b/packages/gemi/services/router/shellContentReport.test.ts
@@ -1,0 +1,155 @@
+/** @vitest-environment node */
+import { describe, expect, test } from "vitest";
+import { createElement, Suspense } from "react";
+// @ts-ignore — same untyped entry the view router renders with.
+import { renderToReadableStream } from "react-dom/server.browser";
+
+import {
+  createShellContentObserver,
+  DEFERRED_TEXT_FLOOR,
+  measureShellContent,
+  SHELL_TEXT_NEAR_ZERO,
+  shellContentHint,
+} from "./shellContentReport";
+import { injectQueryPayloads } from "./streamQueryInjection";
+import { ServerQueryStore } from "./ServerQueryStore";
+
+describe("measureShellContent", () => {
+  test("counts readable text, not markup, scripts, styles, titles, or comments", () => {
+    const { shellChars, deferredChars } = measureShellContent(
+      `<!doctype html><html><head><title>Site title</title>` +
+        `<style>.a{color:red}</style>` +
+        `<script>window.__GEMI_DATA__ = {"k":"vvvvvv"}</script></head>` +
+        `<body><!--$?--><template id="B:0"></template><!--/$-->` +
+        `<h1 class="big">Hello</h1> <p data-x="attr text">world</p></body></html>`,
+    );
+    expect(shellChars).toBe("Hello".length + "world".length);
+    expect(deferredChars).toBe(0);
+  });
+
+  test("text inside `<div hidden>` reveal segments counts as deferred, nested divs included", () => {
+    const { shellChars, deferredChars } = measureShellContent(
+      `<main><p>shell text</p></main>` +
+        `<div hidden id="S:0"><div><p>deep deferred</p></div><span>more</span></div>` +
+        `<script>$RC("B:0","S:0")</script>` +
+        `<p>after</p>`,
+    );
+    expect(shellChars).toBe("shelltext".length + "after".length);
+    expect(deferredChars).toBe("deepdeferred".length + "more".length);
+  });
+
+  test("`hidden` in an attribute value does not open a deferred segment", () => {
+    const { shellChars, deferredChars } = measureShellContent(
+      `<div class="hidden">still readable</div>`,
+    );
+    expect(shellChars).toBe("stillreadable".length);
+    expect(deferredChars).toBe(0);
+  });
+
+  test("whitespace never counts", () => {
+    const { shellChars } = measureShellContent(`<div>\n  a b\t c \n</div>`);
+    expect(shellChars).toBe(3);
+  });
+});
+
+describe("shellContentHint", () => {
+  const deferred = (chars: number) => "x".repeat(chars);
+
+  test("the #289 repro flags: 0 shell chars, 3666 deferred", () => {
+    const measurement = measureShellContent(
+      `<!doctype html><body><!--$?--><template id="B:0"></template><!--/$-->` +
+        `<div hidden id="S:0"><p>${deferred(3666)}</p></div></body>`,
+    );
+    expect(measurement).toEqual({ shellChars: 0, deferredChars: 3666 });
+
+    const hint = shellContentHint("/", measurement);
+    expect(hint).toContain("[gemi] GET / streams 3.7 kB");
+    expect(hint).toContain("a no-JS visitor sees ~0 chars");
+    expect(hint).toContain('add "no-stream" to its middleware');
+  });
+
+  test("a page whose shell carries its own text stays silent: 4150 shell, 0 deferred", () => {
+    const measurement = measureShellContent(`<body><article>${deferred(4150)}</article></body>`);
+    expect(measurement).toEqual({ shellChars: 4150, deferredChars: 0 });
+    expect(shellContentHint("/about-us", measurement)).toBeNull();
+  });
+
+  test("deferred text under the floor stays silent even with a blank shell", () => {
+    expect(
+      shellContentHint("/", { shellChars: 0, deferredChars: DEFERRED_TEXT_FLOOR - 1 }),
+    ).toBeNull();
+    expect(
+      shellContentHint("/", { shellChars: 0, deferredChars: DEFERRED_TEXT_FLOOR }),
+    ).not.toBeNull();
+  });
+
+  test("a shell with readable text stays silent regardless of deferred volume", () => {
+    expect(
+      shellContentHint("/", { shellChars: SHELL_TEXT_NEAR_ZERO, deferredChars: 50_000 }),
+    ).toBeNull();
+    expect(
+      shellContentHint("/", { shellChars: SHELL_TEXT_NEAR_ZERO - 1, deferredChars: 50_000 }),
+    ).not.toBeNull();
+  });
+});
+
+describe("createShellContentObserver", () => {
+  test("decodes multi-byte characters split across chunks", () => {
+    const observer = createShellContentObserver();
+    const bytes = new TextEncoder().encode("<p>héllo</p>");
+    // "é" is two bytes; split right between them.
+    const splitAt = 5;
+    observer.onChunk(bytes.slice(0, splitAt));
+    observer.onChunk(bytes.slice(splitAt));
+    expect(observer.measure()).toEqual({ shellChars: 5, deferredChars: 0 });
+  });
+
+  test("measures a real suspended render through the injector's onChunk hook", async () => {
+    let ready = false;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    gate.then(() => {
+      ready = true;
+    });
+    const content = "deferred ".repeat(500).trim(); // ~4.5 kB of readable text
+    function Late() {
+      if (!ready) throw gate;
+      return createElement("p", null, content);
+    }
+
+    const stream = await renderToReadableStream(
+      createElement(
+        "main",
+        null,
+        createElement(Suspense, { fallback: createElement("div", null, "…") }, createElement(Late)),
+      ),
+      { onError: () => {} },
+    );
+
+    const store = new ServerQueryStore(() => Promise.resolve(null));
+    const observer = createShellContentObserver();
+    const reader = injectQueryPayloads(stream, store, {
+      onChunk: observer.onChunk,
+    }).getReader();
+    const drained = (async () => {
+      while (!(await reader.read()).done) {
+        // Drain — the observer sees every chunk as it is enqueued.
+      }
+    })();
+
+    // Let the shell (with the fallback in place) flush before the segment
+    // resolves — that is what parks the content behind a reveal script.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    release();
+    await drained;
+
+    const measurement = observer.measure();
+    // The shell carries only the fallback; the content is parked in a
+    // `<div hidden id="S:0">` reveal segment.
+    expect(measurement.shellChars).toBeLessThan(SHELL_TEXT_NEAR_ZERO);
+    expect(measurement.deferredChars).toBe(content.replace(/\s/g, "").length);
+    expect(shellContentHint("/", measurement)).toContain("behind reveal scripts");
+  });
+});

--- a/packages/gemi/services/router/shellContentReport.test.ts
+++ b/packages/gemi/services/router/shellContentReport.test.ts
@@ -6,6 +6,7 @@ import { renderToReadableStream } from "react-dom/server.browser";
 
 import {
   createShellContentObserver,
+  createShellContentReporter,
   DEFERRED_TEXT_FLOOR,
   measureShellContent,
   SHELL_TEXT_NEAR_ZERO,
@@ -44,6 +45,39 @@ describe("measureShellContent", () => {
     );
     expect(shellChars).toBe("stillreadable".length);
     expect(deferredChars).toBe(0);
+  });
+
+  test("the word `hidden` inside a quoted attribute value does not open a deferred segment", () => {
+    // Space-delimited mid-value occurrences — prose and Tailwind lists — are
+    // where a bare `\shidden\b` test false-positives.
+    const cases = [
+      `<div title="show hidden files">readable</div>`,
+      `<div title="the hidden cost">readable</div>`,
+      `<div class="a hidden b">readable</div>`,
+      `<div class="mt-2 hidden md:block">readable</div>`,
+      `<div title='show hidden files'>readable</div>`,
+    ];
+    for (const html of cases) {
+      expect(measureShellContent(html)).toEqual({
+        shellChars: "readable".length,
+        deferredChars: 0,
+      });
+    }
+  });
+
+  test("the standalone `hidden` attribute still opens a deferred segment in every spelling", () => {
+    const cases = [
+      `<div hidden id="S:0">deferred</div>`,
+      `<div hidden>deferred</div>`,
+      `<div hidden="">deferred</div>`,
+      `<div id="S:0" hidden>deferred</div>`,
+    ];
+    for (const html of cases) {
+      expect(measureShellContent(html)).toEqual({
+        shellChars: 0,
+        deferredChars: "deferred".length,
+      });
+    }
   });
 
   test("whitespace never counts", () => {
@@ -90,6 +124,42 @@ describe("shellContentHint", () => {
     expect(
       shellContentHint("/", { shellChars: SHELL_TEXT_NEAR_ZERO - 1, deferredChars: 50_000 }),
     ).not.toBeNull();
+  });
+});
+
+describe("createShellContentReporter", () => {
+  const failing = { shellChars: 0, deferredChars: 5000 };
+  const healthy = { shellChars: 5000, deferredChars: 0 };
+
+  test("logs the hint once per route (#294 acceptance)", () => {
+    const warnings: string[] = [];
+    const reporter = createShellContentReporter((hint) => warnings.push(hint));
+
+    reporter.report("/", failing);
+    reporter.report("/", failing);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("[gemi] GET /");
+
+    // Hinted routes need no further observation this boot.
+    expect(reporter.shouldObserve("/")).toBe(false);
+
+    // The dedup keys on the route: another route still gets its own hint.
+    reporter.report("/terms-and-conditions", failing);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[1]).toContain("[gemi] GET /terms-and-conditions");
+  });
+
+  test("a healthy measurement does not consume the route's one hint", () => {
+    const warnings: string[] = [];
+    const reporter = createShellContentReporter((hint) => warnings.push(hint));
+
+    reporter.report("/docs", healthy);
+    expect(warnings).toHaveLength(0);
+    // Still observed, still eligible: the route crossing the threshold later
+    // in the boot must get its hint.
+    expect(reporter.shouldObserve("/docs")).toBe(true);
+    reporter.report("/docs", failing);
+    expect(warnings).toHaveLength(1);
   });
 });
 

--- a/packages/gemi/services/router/shellContentReport.ts
+++ b/packages/gemi/services/router/shellContentReport.ts
@@ -32,10 +32,20 @@ export interface ShellContentMeasurement {
 const RAW_TEXT_TAGS = new Set(["script", "style", "template", "title"]);
 
 /**
- * `hidden` as a standalone attribute (`<div hidden id="S:0">`, `hidden=""`),
- * not a substring of an attribute value like `class="hidden-md"`.
+ * `hidden` as a standalone attribute (`<div hidden id="S:0">`, `hidden=""`).
+ * Tested against the tag with its quoted attribute values blanked out
+ * (`QUOTED_VALUE` below), so the word `hidden` inside a value — a Tailwind
+ * list like `class="mt-2 hidden md:block"` or prose like
+ * `title="show hidden files"` — never opens a deferred segment.
  */
 const HIDDEN_ATTR = /\shidden([\s=/]|$)/i;
+
+/**
+ * Quoted attribute values, to be blanked before the `HIDDEN_ATTR` test. Safe
+ * as a regex because React escapes `"` and `'` inside attribute values, so a
+ * quoted span never contains its own delimiter.
+ */
+const QUOTED_VALUE = /"[^"]*"|'[^']*'/g;
 
 /**
  * Splits a streamed HTML document into shell-readable versus deferred text.
@@ -87,12 +97,15 @@ export function measureShellContent(html: string): ShellContentMeasurement {
       continue;
     }
 
+    // Only `div` is tracked because that is the container React streams
+    // deferred segments in. A hand-written `<section hidden>` still counts as
+    // shell text — a false negative (stays silent), never a false hint.
     if (name !== "div") continue;
     if (isClosing) {
       if (hiddenDepth > 0) hiddenDepth -= 1;
     } else if (hiddenDepth > 0) {
       hiddenDepth += 1;
-    } else if (HIDDEN_ATTR.test(tag)) {
+    } else if (HIDDEN_ATTR.test(tag.replace(QUOTED_VALUE, '""'))) {
       hiddenDepth = 1;
     }
   }
@@ -131,6 +144,38 @@ export function shellContentHint(
     `If this is a public/content route, add "no-stream" to its middleware.`
   );
 }
+
+/**
+ * Owns the once-per-route-per-boot dedup (#294's "logs the hint once"): a hot
+ * route must not spam the dev console, but a route whose measurement is
+ * healthy today must stay eligible for the hint the day it crosses the
+ * threshold — only an actually-emitted hint marks the route as done.
+ *
+ * `warn` is injectable for tests; production callers use the default.
+ */
+export function createShellContentReporter(warn: (hint: string) => void = console.warn) {
+  /** Routes already hinted this boot. */
+  const hintedRoutes = new Set<string>();
+  return {
+    /**
+     * Whether collecting bytes for this route can still lead to a hint —
+     * false once the route has been hinted, so the caller can skip the
+     * observer entirely.
+     */
+    shouldObserve(routePath: string): boolean {
+      return !hintedRoutes.has(routePath);
+    },
+    report(routePath: string, measurement: ShellContentMeasurement): void {
+      if (hintedRoutes.has(routePath)) return;
+      const hint = shellContentHint(routePath, measurement);
+      if (!hint) return;
+      hintedRoutes.add(routePath);
+      warn(hint);
+    },
+  };
+}
+
+export type ShellContentReporter = ReturnType<typeof createShellContentReporter>;
 
 /**
  * Accumulates the response body for a post-close measurement. Wire `onChunk`

--- a/packages/gemi/services/router/shellContentReport.ts
+++ b/packages/gemi/services/router/shellContentReport.ts
@@ -1,0 +1,153 @@
+/**
+ * Dev-mode guard against the silent no-JS blanking threshold (#289, #294).
+ *
+ * React defers any boundary bigger than `progressiveChunkSize` (~12.8 kB) out
+ * of the shell on size alone, so a public page that reads fine without JS
+ * today goes blank the day one more section pushes it over the budget — its
+ * content is parked in `<div hidden>` segments revealed by `$RC()` scripts,
+ * and nothing in typecheck, tests, or CI notices the transition. `"no-stream"`
+ * fixes it, but only for routes someone already knows are affected.
+ *
+ * The measurement is nearly free where the bytes already flow: the stream
+ * injector is the last thing to see the response body, so an observer hung on
+ * its `onChunk` hook holds the document exactly as the visitor received it.
+ * After the body closes, the bytes are split into shell-readable text (what a
+ * no-JS reader can see) versus deferred text (parked behind reveal scripts),
+ * and a route shipping its content deferred while its shell is near-blank gets
+ * a console hint — once per route per boot.
+ */
+
+export interface ShellContentMeasurement {
+  /** Non-whitespace text chars a no-JS reader can see in the shell. */
+  shellChars: number;
+  /** Non-whitespace text chars parked in `<div hidden>` reveal segments. */
+  deferredChars: number;
+}
+
+/**
+ * Their text is code, styling, or metadata — never readable content. React's
+ * `<template id="B:...">` fallback markers are empty anyway; skipping the tag
+ * also covers hand-written templates.
+ */
+const RAW_TEXT_TAGS = new Set(["script", "style", "template", "title"]);
+
+/**
+ * `hidden` as a standalone attribute (`<div hidden id="S:0">`, `hidden=""`),
+ * not a substring of an attribute value like `class="hidden-md"`.
+ */
+const HIDDEN_ATTR = /\shidden([\s=/]|$)/i;
+
+/**
+ * Splits a streamed HTML document into shell-readable versus deferred text.
+ *
+ * A scanner, not a parser: it only needs to tell text from markup, skip the
+ * tags whose text is never content, and track `<div hidden>` nesting — the
+ * container React streams deferred segments in. Attribute text and comments
+ * (including React's `<!--$?-->` boundary marks) never count; whitespace
+ * never counts.
+ */
+export function measureShellContent(html: string): ShellContentMeasurement {
+  let shellChars = 0;
+  let deferredChars = 0;
+  /** `<div>` nesting depth inside the current hidden segment; 0 = in the shell. */
+  let hiddenDepth = 0;
+  let i = 0;
+
+  while (i < html.length) {
+    const lt = html.indexOf("<", i);
+    const textEnd = lt === -1 ? html.length : lt;
+    if (textEnd > i) {
+      const visible = html.slice(i, textEnd).replace(/\s+/g, "").length;
+      if (hiddenDepth > 0) {
+        deferredChars += visible;
+      } else {
+        shellChars += visible;
+      }
+    }
+    if (lt === -1) break;
+
+    if (html.startsWith("<!--", lt)) {
+      const end = html.indexOf("-->", lt + 4);
+      i = end === -1 ? html.length : end + 3;
+      continue;
+    }
+
+    const gt = html.indexOf(">", lt);
+    if (gt === -1) break; // truncated tag — nothing readable follows
+    const tag = html.slice(lt + 1, gt);
+    i = gt + 1;
+
+    const name = /^\/?([a-zA-Z][a-zA-Z0-9-]*)/.exec(tag)?.[1]?.toLowerCase();
+    if (!name) continue;
+    const isClosing = tag.startsWith("/");
+
+    if (!isClosing && RAW_TEXT_TAGS.has(name) && !tag.endsWith("/")) {
+      const close = html.indexOf(`</${name}`, i);
+      i = close === -1 ? html.length : close;
+      continue;
+    }
+
+    if (name !== "div") continue;
+    if (isClosing) {
+      if (hiddenDepth > 0) hiddenDepth -= 1;
+    } else if (hiddenDepth > 0) {
+      hiddenDepth += 1;
+    } else if (HIDDEN_ATTR.test(tag)) {
+      hiddenDepth = 1;
+    }
+  }
+
+  return { shellChars, deferredChars };
+}
+
+/** Below this much deferred text the page isn't relying on reveal scripts. */
+export const DEFERRED_TEXT_FLOOR = 1000;
+
+/**
+ * "Near zero": under this many readable chars the shell is effectively blank
+ * — less than a sentence, no headline worth of content.
+ */
+export const SHELL_TEXT_NEAR_ZERO = 64;
+
+function formatChars(chars: number): string {
+  return chars >= 1000 ? `${(chars / 1000).toFixed(1)} kB` : `${chars} chars`;
+}
+
+/**
+ * The hint for a route whose content streams behind reveal scripts while its
+ * shell is near-blank — exactly the transition #289 was discovered through by
+ * hand-measuring. Null when the measurement is fine: a shell that carries its
+ * own text, or too little deferred text to matter.
+ */
+export function shellContentHint(
+  routePath: string,
+  measurement: ShellContentMeasurement,
+): string | null {
+  if (measurement.deferredChars < DEFERRED_TEXT_FLOOR) return null;
+  if (measurement.shellChars >= SHELL_TEXT_NEAR_ZERO) return null;
+  return (
+    `[gemi] GET ${routePath} streams ${formatChars(measurement.deferredChars)} of its ` +
+    `content behind reveal scripts — a no-JS visitor sees ~${measurement.shellChars} chars. ` +
+    `If this is a public/content route, add "no-stream" to its middleware.`
+  );
+}
+
+/**
+ * Accumulates the response body for a post-close measurement. Wire `onChunk`
+ * into `StreamLifecycleHooks.onChunk`; call `measure` once the body closed.
+ * Decoding is streaming-safe — a multi-byte character split across chunks
+ * still decodes as one character.
+ */
+export function createShellContentObserver() {
+  const decoder = new TextDecoder();
+  let html = "";
+  return {
+    onChunk(chunk: Uint8Array) {
+      html += decoder.decode(chunk, { stream: true });
+    },
+    measure(): ShellContentMeasurement {
+      html += decoder.decode();
+      return measureShellContent(html);
+    },
+  };
+}

--- a/packages/gemi/services/router/streamQueryInjection.ts
+++ b/packages/gemi/services/router/streamQueryInjection.ts
@@ -28,6 +28,12 @@ export interface StreamLifecycleHooks {
   /** The response's first chunk was enqueued — time-to-shell. */
   onShell?: () => void;
   /**
+   * Every chunk enqueued into the response body, in order — the byte stream
+   * exactly as the client receives it, injected payload scripts included.
+   * The dev-mode shell-content measurement (#294) hangs here.
+   */
+  onChunk?: (chunk: Uint8Array) => void;
+  /**
    * The body closed: the last chunk (and any leftover payload scripts)
    * flushed, or the client went away. Fires exactly once.
    */
@@ -82,9 +88,16 @@ export function injectQueryPayloads(
   });
 
   const reader = source.getReader();
+  const forward = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+    chunk: Uint8Array,
+  ) => {
+    controller.enqueue(chunk);
+    hooks.onChunk?.(chunk);
+  };
   const flush = (controller: ReadableStreamDefaultController<Uint8Array>) => {
     while (queue.length > 0) {
-      controller.enqueue(encoder.encode(queue.shift()!));
+      forward(controller, encoder.encode(queue.shift()!));
     }
   };
 
@@ -101,13 +114,13 @@ export function injectQueryPayloads(
       }
       if (!sentFirstChunk) {
         sentFirstChunk = true;
-        controller.enqueue(value);
+        forward(controller, value);
         hooks.onShell?.();
         flush(controller);
         return;
       }
       flush(controller);
-      controller.enqueue(value);
+      forward(controller, value);
     },
     cancel(reason) {
       closeOnce();


### PR DESCRIPTION
Closes #294

Stacked on #297 (branch `feat/293-stream-lifecycle-hooks`) — review only the top commit here until that merges.

## Approach

React defers any boundary over `progressiveChunkSize` (~12.8 kB) on size alone, so a page that reads fine without JS goes blank the day one more section pushes it over the budget — and nothing in typecheck, tests, or CI notices the transition (#289 was found by hand-measuring `/` at 0 readable chars). This adds the dev-mode guard proposed in the issue:

- **`onChunk` lifecycle hook** on the stream injector (`streamQueryInjection.ts`) — the injector is the last thing to see the response body, so an observer hung there holds the document exactly as the visitor received it, injected payload scripts included.
- **`shellContentReport.ts`** — a small HTML scanner that splits the streamed document into shell-readable text (visible text outside `<div hidden>` reveal segments, scripts, styles, templates, and titles; comments and attributes never count) versus deferred text parked behind `$RC()` reveal scripts, plus the hint formatter and a streaming-safe byte accumulator.
- **`ViewRouterServiceContainer`** wires it up dev-only for progressive document responses: when a route ships ≥ 1 kB of deferred text while its shell carries < 64 readable chars, it logs once per route per boot:

  `[gemi] GET / streams 3.7 kB of its content behind reveal scripts — a no-JS visitor sees ~0 chars. If this is a public/content route, add "no-stream" to its middleware.`

Settled documents (bot UAs, `"no-stream"` routes) skip collection entirely — their content is inline by construction — so adding `"no-stream"` (or shrinking the page under the floor) clears the hint, per the acceptance criteria.

## Tests

`services/router/shellContentReport.test.ts` (10 tests, all passing):

- Scanner: readable text vs markup/scripts/styles/titles/comments; nested divs inside `<div hidden>` segments; `hidden` in an attribute value not treated as a segment; whitespace never counts.
- The #289 repro numbers: 0 shell / 3,666 deferred flags (message says `3.7 kB` / `~0 chars`); `/about-us` at 4,150 shell / 0 deferred stays silent; both threshold edges.
- Observer: multi-byte characters split across chunks decode correctly.
- Integration: a real suspended `renderToReadableStream` render piped through `injectQueryPayloads` with `onChunk` wired measures the fallback-only shell and the deferred segment, and trips the hint.

`bunx vitest run` and `tsc --noEmit` are clean apart from failures that pre-exist on the base branch (verified by stashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWrgZ7fXNHCjJMV53o3qPK