### PR TITLE
Ship the open ORM issues for 0.51.0

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3694,11 +3694,23 @@ Ships as a policy, which is the proof the hook is expressive enough to be worth 
 import { softDelete, softDeleteMany, softDeletes } from "gemi/orm"
 
 export class User extends UserModel {
-  static $policies = [softDeletes<User>()]  // reads skip rows with a deletedAt
-  static delete = softDelete(User)          // delete becomes an update
-  static deleteMany = softDeleteMany(User)
+  static $policies = [softDeletes<typeof User>()]  // reads skip rows with a deletedAt
+  static expire = softDelete(User)                 // an update that sets deletedAt
+  static expireMany = softDeleteMany(User)
 }
 ```
+
+> **`expire`, not `delete`, and that is a limitation rather than a style.** Naming the wrapper
+> `delete` would be the better recipe — `User.delete()` would transparently become an update — and
+> it cannot be written: the member's type would have to be read off the class the member is being
+> defined on, which TypeScript refuses with *"'delete' implicitly has type 'any' because it does
+> not have a type annotation and is referenced directly or indirectly in its own initializer"*.
+> Annotating it does not help, and passing the generated base instead of your subclass breaks the
+> feature, because policies are resolved per registered class and the base carries none.
+>
+> **So `User.delete()` remains a hard delete.** On a model that soft-deletes, that is a real edge:
+> reads are scoped by the policy, but a `delete` still removes the row. Call `User.expire()`, and
+> if a hard delete should be unreachable, keep the model's `delete` behind a policy of your own.
 
 `deletedAt` must be a nullable `DateTime` on the model (`field` overrides the column name). The
 read half applies to nested reads for the same reason every policy does — a deleted `Account` does
@@ -3708,27 +3720,34 @@ the include site, which is the half ORM-level soft deletes usually get wrong.
 Composing it with your own is one list:
 
 ```ts
-static $policies: UserPolicy[] = [softDeletes<User>(), new TenantPolicy()]
+static $policies: UserPolicy[] = [softDeletes<typeof User>(), new TenantPolicy()]
 ```
 
 `softDeletes()` carries an `onUpdate` pass-through, because `softDelete()` writes the very column
 the policy scopes on and something has to say that is intended. That permission is **per policy**:
 a tenant policy sitting beside it in the same list still has to answer for its own column.
 
-`field` is constrained to the model's own keys **when the model type is given** —
-`softDeletes<User>({ field: … })`, as above — so a typo there is a compile error rather than a
-`no such column` on the first read.
-
-`softDelete(User)` and `softDeleteMany(User)` take the model as a *value*, and its row type is not
-recoverable from it, so their `field` is unchecked. Spell it once and share it if you override the
-default:
+`field` is constrained to the model's **schema columns** — the same list `UnknownFieldError` prints
+— on every spelling that names a model:
 
 ```ts
-const archived = { field: "archivedAt" } as const
+softDeletes<typeof User>({ field: "archivedAt" })   // checked
+softDelete(User, { field: "archivedAt" })           // checked
+softDeleteMany(User, { field: "archivedAt" })       // checked
 
+softDeletes({ field: "archivedAt" })                // unchecked — no model named
+```
+
+Columns rather than keys is the part that matters: the constraint used to be `keyof` the *instance*
+type, so `field: "save"` — a method — compiled clean and failed at runtime. Pass the model as
+`typeof User` and it is a compile error.
+
+Nothing needs spelling twice. If you override the default, each call checks its own argument:
+
+```ts
 export class User extends UserModel {
-  static $policies = [softDeletes<User>(archived)]   // checked here
-  static delete = softDelete(User, archived)          // and therefore correct here
+  static $policies = [softDeletes<typeof User>({ field: "archivedAt" })]
+  static expire = softDelete(User, { field: "archivedAt" })
 }
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3059,6 +3059,23 @@ implementing them there would answer a query the differential harness has no ora
 expression's meaning, and both dialects take it natively — Postgres's `#>` accepts a `text[]`,
 SQLite's `json_extract` a string — so the feature fits inside invariant 2 rather than bending it.
 
+Three things a path filter refuses, each because answering would be silently wrong rather than
+merely unsupported:
+
+- **The null sentinels.** `{ path: […], equals: Prisma.DbNull }` is refused. An extracted value
+  cannot tell an absent key from a JSON `null` — `#>>` yields SQL NULL for both — so the
+  distinction the sentinels exist to make is already gone by the time the comparison happens.
+  Filter the column itself: `{ metadata: { equals: Prisma.DbNull } }`.
+- **A non-string operand to `string_contains` / `string_starts_with` / `string_ends_with`**, for
+  the same reason the scalar `contains` refuses one: the pattern would become `%null%`, which runs
+  and returns the wrong rows.
+- **An object or array under `equals` / `not` / the numeric comparisons.** Prisma accepts one;
+  gemi does not yet. It would bind as `"[object Object]"` on Postgres and match nothing. Use
+  `array_contains` for containment, or narrow the path until it names a scalar.
+
+An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
+document, which is a filter on the column rather than on a path.
+
 ### What a refusal tells you
 
 Three classes, and which one you get says what to do next:
@@ -3541,7 +3558,7 @@ initializer from an inherited static declaration, so without it `ctx` and `data`
 Policies compose by listing them, in the order they apply:
 
 ```ts
-static $policies: AccountPolicy[] = [softDeletes<Account>(), new TenantPolicy()]
+static $policies: AccountPolicy[] = [softDeletes<typeof Account>(), new TenantPolicy()]
 ```
 
 Entries may be objects or classes. A class is instantiated once, and extending the generated

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3029,6 +3029,36 @@ On SQLite the error names the dialect and says so. If a batch is too large for o
 split inside a transaction, and `skipDuplicates` survives the split: the counts sum, and a conflict
 in a later chunk does not roll back an earlier one, because `do nothing` is not an error.
 
+### JSON path filters
+
+```ts
+// postgres
+await User.findMany({ where: { metadata: { path: ["plan"], equals: "pro" } } })
+// sqlite
+await User.findMany({ where: { metadata: { path: "$.plan", equals: "pro" } } })
+```
+
+**The path grammar differs by dialect, and that is Prisma's split rather than this ORM's.** Its
+generated client takes an array of keys on Postgres and a JSONPath string on SQLite, and refuses the
+other form on each — so the argument is dialect-specific before it reaches gemi. The refusal here
+says which form the database you are on wants.
+
+Which filters apply also differs, again following Prisma:
+
+| | SQLite | Postgres |
+| --- | --- | --- |
+| `equals`, `not` | yes | yes |
+| `string_contains`, `string_starts_with`, `string_ends_with` | yes | yes |
+| `array_contains` | no | yes |
+| `lt`, `lte`, `gt`, `gte` | no | yes |
+
+Prisma refuses the bottom two rows on SQLite with *"Unknown argument"*, so gemi refuses them too:
+implementing them there would answer a query the differential harness has no oracle for.
+
+**The path is always a bound parameter.** It is the one place a caller's value decides part of an
+expression's meaning, and both dialects take it natively — Postgres's `#>` accepts a `text[]`,
+SQLite's `json_extract` a string — so the feature fits inside invariant 2 rather than bending it.
+
 ### What a refusal tells you
 
 Three classes, and which one you get says what to do next:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2787,6 +2787,27 @@ Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 **The output is committed on purpose.** Diffs stay reviewable and CI needs no codegen step.
 
+### Columns the generator refuses
+
+Two kinds of column stop generation with an `UnsupportedSchemaError` naming the model and field,
+rather than being skipped:
+
+| Column | Why |
+| --- | --- |
+| A scalar list — `tags String[]` | Postgres-only, and needs array decoding this ORM does not have. |
+| `Decimal` | Prisma types it as `Prisma.Decimal`; SQLite stores a REAL and the driver returns a JS number, so the value would be a float pretending to be an arbitrary-precision decimal. |
+
+**Refused rather than omitted, and the whole generation fails rather than the one field.** Skipping
+the column would generate cleanly and then hand back a row shape that silently disagrees with the
+type Prisma gave you — which is the failure this ORM is built to make impossible. One unsupported
+column means no `schema.ts`, no `models.ts` and no `index.ts` for any model, so the problem is
+visible at the moment you introduce it.
+
+A `Unsupported(...)` column is different and is *not* refused: Prisma's own client omits those from
+its result types, so omitting them is what keeps the shapes identical.
+
+Scalar lists are tracked in [#300](https://github.com/nstfkc/gemi/issues/300).
+
 ### Your model class
 
 The generated base is not the class you write code on. Subclass it, and **re-register it**:
@@ -4078,6 +4099,10 @@ if (!ormSupports(DB.dialect)) throw new Error("this deployment needs Postgres")
 
 Stated so you can plan around them rather than discover them:
 
+- **No scalar lists.** `tags String[]` is refused at *generation* time, so this one stops your build
+  rather than a query — see [Columns the generator refuses](#columns-the-generator-refuses). Prisma
+  itself refuses them on SQLite, so half the supported matrix could never have had them.
+  Pending rather than declined ([#300](https://github.com/nstfkc/gemi/issues/300)).
 - **No identity map and no unit of work.** Two queries for the same row give you two objects. Half
   an identity map is worse than none.
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -298,6 +298,36 @@ On SQLite the error names the dialect and says so. If a batch is too large for o
 split inside a transaction, and `skipDuplicates` survives the split: the counts sum, and a conflict
 in a later chunk does not roll back an earlier one, because `do nothing` is not an error.
 
+### JSON path filters
+
+```ts
+// postgres
+await User.findMany({ where: { metadata: { path: ["plan"], equals: "pro" } } })
+// sqlite
+await User.findMany({ where: { metadata: { path: "$.plan", equals: "pro" } } })
+```
+
+**The path grammar differs by dialect, and that is Prisma's split rather than this ORM's.** Its
+generated client takes an array of keys on Postgres and a JSONPath string on SQLite, and refuses the
+other form on each — so the argument is dialect-specific before it reaches gemi. The refusal here
+says which form the database you are on wants.
+
+Which filters apply also differs, again following Prisma:
+
+| | SQLite | Postgres |
+| --- | --- | --- |
+| `equals`, `not` | yes | yes |
+| `string_contains`, `string_starts_with`, `string_ends_with` | yes | yes |
+| `array_contains` | no | yes |
+| `lt`, `lte`, `gt`, `gte` | no | yes |
+
+Prisma refuses the bottom two rows on SQLite with *"Unknown argument"*, so gemi refuses them too:
+implementing them there would answer a query the differential harness has no oracle for.
+
+**The path is always a bound parameter.** It is the one place a caller's value decides part of an
+expression's meaning, and both dialects take it natively — Postgres's `#>` accepts a `text[]`,
+SQLite's `json_extract` a string — so the feature fits inside invariant 2 rather than bending it.
+
 ### What a refusal tells you
 
 Three classes, and which one you get says what to do next:

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -963,11 +963,23 @@ Ships as a policy, which is the proof the hook is expressive enough to be worth 
 import { softDelete, softDeleteMany, softDeletes } from "gemi/orm"
 
 export class User extends UserModel {
-  static $policies = [softDeletes<User>()]  // reads skip rows with a deletedAt
-  static delete = softDelete(User)          // delete becomes an update
-  static deleteMany = softDeleteMany(User)
+  static $policies = [softDeletes<typeof User>()]  // reads skip rows with a deletedAt
+  static expire = softDelete(User)                 // an update that sets deletedAt
+  static expireMany = softDeleteMany(User)
 }
 ```
+
+> **`expire`, not `delete`, and that is a limitation rather than a style.** Naming the wrapper
+> `delete` would be the better recipe — `User.delete()` would transparently become an update — and
+> it cannot be written: the member's type would have to be read off the class the member is being
+> defined on, which TypeScript refuses with *"'delete' implicitly has type 'any' because it does
+> not have a type annotation and is referenced directly or indirectly in its own initializer"*.
+> Annotating it does not help, and passing the generated base instead of your subclass breaks the
+> feature, because policies are resolved per registered class and the base carries none.
+>
+> **So `User.delete()` remains a hard delete.** On a model that soft-deletes, that is a real edge:
+> reads are scoped by the policy, but a `delete` still removes the row. Call `User.expire()`, and
+> if a hard delete should be unreachable, keep the model's `delete` behind a policy of your own.
 
 `deletedAt` must be a nullable `DateTime` on the model (`field` overrides the column name). The
 read half applies to nested reads for the same reason every policy does — a deleted `Account` does
@@ -977,27 +989,34 @@ the include site, which is the half ORM-level soft deletes usually get wrong.
 Composing it with your own is one list:
 
 ```ts
-static $policies: UserPolicy[] = [softDeletes<User>(), new TenantPolicy()]
+static $policies: UserPolicy[] = [softDeletes<typeof User>(), new TenantPolicy()]
 ```
 
 `softDeletes()` carries an `onUpdate` pass-through, because `softDelete()` writes the very column
 the policy scopes on and something has to say that is intended. That permission is **per policy**:
 a tenant policy sitting beside it in the same list still has to answer for its own column.
 
-`field` is constrained to the model's own keys **when the model type is given** —
-`softDeletes<User>({ field: … })`, as above — so a typo there is a compile error rather than a
-`no such column` on the first read.
-
-`softDelete(User)` and `softDeleteMany(User)` take the model as a *value*, and its row type is not
-recoverable from it, so their `field` is unchecked. Spell it once and share it if you override the
-default:
+`field` is constrained to the model's **schema columns** — the same list `UnknownFieldError` prints
+— on every spelling that names a model:
 
 ```ts
-const archived = { field: "archivedAt" } as const
+softDeletes<typeof User>({ field: "archivedAt" })   // checked
+softDelete(User, { field: "archivedAt" })           // checked
+softDeleteMany(User, { field: "archivedAt" })       // checked
 
+softDeletes({ field: "archivedAt" })                // unchecked — no model named
+```
+
+Columns rather than keys is the part that matters: the constraint used to be `keyof` the *instance*
+type, so `field: "save"` — a method — compiled clean and failed at runtime. Pass the model as
+`typeof User` and it is a compile error.
+
+Nothing needs spelling twice. If you override the default, each call checks its own argument:
+
+```ts
 export class User extends UserModel {
-  static $policies = [softDeletes<User>(archived)]   // checked here
-  static delete = softDelete(User, archived)          // and therefore correct here
+  static $policies = [softDeletes<typeof User>({ field: "archivedAt" })]
+  static expire = softDelete(User, { field: "archivedAt" })
 }
 ```
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -56,6 +56,27 @@ Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 **The output is committed on purpose.** Diffs stay reviewable and CI needs no codegen step.
 
+### Columns the generator refuses
+
+Two kinds of column stop generation with an `UnsupportedSchemaError` naming the model and field,
+rather than being skipped:
+
+| Column | Why |
+| --- | --- |
+| A scalar list — `tags String[]` | Postgres-only, and needs array decoding this ORM does not have. |
+| `Decimal` | Prisma types it as `Prisma.Decimal`; SQLite stores a REAL and the driver returns a JS number, so the value would be a float pretending to be an arbitrary-precision decimal. |
+
+**Refused rather than omitted, and the whole generation fails rather than the one field.** Skipping
+the column would generate cleanly and then hand back a row shape that silently disagrees with the
+type Prisma gave you — which is the failure this ORM is built to make impossible. One unsupported
+column means no `schema.ts`, no `models.ts` and no `index.ts` for any model, so the problem is
+visible at the moment you introduce it.
+
+A `Unsupported(...)` column is different and is *not* refused: Prisma's own client omits those from
+its result types, so omitting them is what keeps the shapes identical.
+
+Scalar lists are tracked in [#300](https://github.com/nstfkc/gemi/issues/300).
+
 ### Your model class
 
 The generated base is not the class you write code on. Subclass it, and **re-register it**:
@@ -1347,6 +1368,10 @@ if (!ormSupports(DB.dialect)) throw new Error("this deployment needs Postgres")
 
 Stated so you can plan around them rather than discover them:
 
+- **No scalar lists.** `tags String[]` is refused at *generation* time, so this one stops your build
+  rather than a query — see [Columns the generator refuses](#columns-the-generator-refuses). Prisma
+  itself refuses them on SQLite, so half the supported matrix could never have had them.
+  Pending rather than declined ([#300](https://github.com/nstfkc/gemi/issues/300)).
 - **No identity map and no unit of work.** Two queries for the same row give you two objects. Half
   an identity map is worse than none.
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -328,6 +328,23 @@ implementing them there would answer a query the differential harness has no ora
 expression's meaning, and both dialects take it natively — Postgres's `#>` accepts a `text[]`,
 SQLite's `json_extract` a string — so the feature fits inside invariant 2 rather than bending it.
 
+Three things a path filter refuses, each because answering would be silently wrong rather than
+merely unsupported:
+
+- **The null sentinels.** `{ path: […], equals: Prisma.DbNull }` is refused. An extracted value
+  cannot tell an absent key from a JSON `null` — `#>>` yields SQL NULL for both — so the
+  distinction the sentinels exist to make is already gone by the time the comparison happens.
+  Filter the column itself: `{ metadata: { equals: Prisma.DbNull } }`.
+- **A non-string operand to `string_contains` / `string_starts_with` / `string_ends_with`**, for
+  the same reason the scalar `contains` refuses one: the pattern would become `%null%`, which runs
+  and returns the wrong rows.
+- **An object or array under `equals` / `not` / the numeric comparisons.** Prisma accepts one;
+  gemi does not yet. It would bind as `"[object Object]"` on Postgres and match nothing. Use
+  `array_contains` for containment, or narrow the path until it names a scalar.
+
+An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
+document, which is a filter on the column rather than on a path.
+
 ### What a refusal tells you
 
 Three classes, and which one you get says what to do next:
@@ -810,7 +827,7 @@ initializer from an inherited static declaration, so without it `ctx` and `data`
 Policies compose by listing them, in the order they apply:
 
 ```ts
-static $policies: AccountPolicy[] = [softDeletes<Account>(), new TenantPolicy()]
+static $policies: AccountPolicy[] = [softDeletes<typeof Account>(), new TenantPolicy()]
 ```
 
 Entries may be objects or classes. A class is instantiated once, and extending the generated

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -320,9 +320,19 @@ export function emitSchemaFile(schemas: ModelSchema[]): string {
     `export const ARTIFACT_VERSION = ${SCHEMA_ARTIFACT_VERSION};\n`,
   ];
 
+  // `satisfies` rather than a `: ModelSchema` annotation, which is the whole of
+  // #262's compile-time half. An annotation *widens*: `fields` becomes
+  // `Record<string, FieldSchema>`, so `keyof` it is `string` and nothing built
+  // on top of it can tell a column from a typo. `satisfies` checks the literal
+  // against the same interface and keeps its keys, so `$schema.fields` carries
+  // the model's real column names into the type system — which is what lets
+  // `softDeletes` constrain `field` to columns rather than to an instance's
+  // keys, where `"save"` is as valid a spelling as `"deletedAt"`.
+  //
+  // Type-level only: the emitted value is byte-identical.
   for (const schema of schemas) {
     parts.push(
-      `\nexport const ${schema.name}: ModelSchema = ${literal(schema)};\n`,
+      `\nexport const ${schema.name} = ${literal(schema)} satisfies ModelSchema;\n`,
     );
   }
 

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -1253,6 +1253,119 @@ describe("json path filters", () => {
   });
 
   /**
+   * The gap review found: `compileFieldFilter` refuses a bare sentinel *above*
+   * the `path` branch and refuses `AnyNull` under a non-`equals`/`not` operator
+   * *below* it, so a sentinel inside a JSON filter reached neither and went
+   * straight to the binder. Postgres compared against the literal text
+   * `Prisma.DbNull`; SQLite bound the sentinel object. Zero rows, no error —
+   * the class #259 and #266 exist to close.
+   *
+   * Refused rather than mapped, because an extracted value cannot tell an
+   * absent key from a JSON null: `#>>` yields NULL for both, so there is no
+   * answer to give that is not silently wrong half the time.
+   */
+  describe("a Json null sentinel inside a path filter is refused", () => {
+    // A class, for the reason `json-null.test.ts` spells out: a method in an
+    // object literal is enumerable, `for…in` walks it, and the recogniser would
+    // reject the fake while accepting Prisma's real one.
+    const sentinel = (tag: string): object => {
+      class Sentinel {
+        toString() {
+          return tag;
+        }
+      }
+      return new Sentinel();
+    };
+
+    const sentinels = [
+      ["DbNull", sentinel("Prisma.DbNull")],
+      ["JsonNull", sentinel("Prisma.JsonNull")],
+      ["AnyNull", sentinel("Prisma.AnyNull")],
+    ] as const;
+
+    test.each(sentinels)("%s on sqlite", (_name, sentinel) => {
+      expect(() =>
+        sqliteText({ where: { metadata: { path: "$.a", equals: sentinel } } }),
+      ).toThrow(InvalidArgumentError);
+    });
+
+    test.each(sentinels)("%s on postgres", (_name, sentinel) => {
+      expect(() =>
+        pgText({ where: { metadata: { path: ["a"], equals: sentinel } } }),
+      ).toThrow(InvalidArgumentError);
+    });
+
+    /** Nothing of the sentinel reaches the SQL, which is the actual defect. */
+    test("it never becomes a bound literal", () => {
+      let text = "";
+      try {
+        text = pgText({
+          where: { metadata: { path: ["a"], equals: sentinel("Prisma.DbNull") } },
+        });
+      } catch {
+        // expected
+      }
+      expect(text).not.toContain("Prisma.DbNull");
+    });
+  });
+
+  /**
+   * The scalar `contains` refuses a non-string operand, with a comment saying
+   * why: `String(null)` makes the pattern `%null%`, "a query that runs and
+   * returns the wrong rows". The JSON string filters reintroduced that shape.
+   * `like NULL` matches nothing and raises nothing.
+   */
+  test.each([
+    ["string_contains", null],
+    ["string_contains", 5],
+    ["string_starts_with", null],
+    ["string_ends_with", { a: 1 }],
+  ])("%s refuses a non-string operand", (key, operand) => {
+    expect(() =>
+      sqliteText({ where: { metadata: { path: "$.a", [key]: operand } } }),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  /**
+   * On Postgres the comparison binds `String(raw)` because `#>>` yields text,
+   * so an object operand became the string `"[object Object]"` and matched
+   * nothing. Refused rather than implemented: answering it properly needs the
+   * `#>` + `::jsonb` form, which is Postgres-only, and a filter that works on
+   * one dialect and silently misses on the other is the thing this file refuses
+   * everywhere else.
+   */
+  test("equals with a non-scalar operand is refused, not bound as a string", () => {
+    for (const operand of [{ b: 1 }, ["a"]]) {
+      expect(() =>
+        pgText({ where: { metadata: { path: ["a"], equals: operand } } }),
+      ).toThrow(UnsupportedQueryError);
+      expect(() =>
+        sqliteText({ where: { metadata: { path: "$.a", not: operand } } }),
+      ).toThrow(UnsupportedQueryError);
+    }
+
+    // `array_contains` is the exception, because containment is precisely the
+    // operator whose right-hand side is a document.
+    expect(() =>
+      pgText({ where: { metadata: { path: ["a"], array_contains: ["x"] } } }),
+    ).not.toThrow();
+  });
+
+  /**
+   * `[]` on Postgres extracts the whole document — `[].every` is vacuously
+   * true, so it passed the grammar check — and `""` on SQLite raises inside
+   * `json_extract` at execution time. Neither is a path.
+   */
+  test("an empty path is refused on both dialects", () => {
+    expect(() =>
+      pgText({ where: { metadata: { path: [], equals: "x" } } }),
+    ).toThrow(/cannot be empty/);
+    expect(() =>
+      sqliteText({ where: { metadata: { path: "", equals: "x" } } }),
+    ).toThrow(/cannot be empty/);
+  });
+
+  /**
    * Both extractions yield text on Postgres, so a numeric comparison has to
    * compare numbers rather than their spellings — otherwise "10" sorts before
    * "9". The cast is structural; the value is still bound.

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -1147,3 +1147,131 @@ describe("root contributions in compileRead", () => {
     expect(withFold).not.toBe(without);
   });
 });
+
+/**
+ * JSON path filters (#70's second half).
+ *
+ * The differential harness owns "does it match Prisma" — and it has to, twice,
+ * because the *path grammar itself* differs between the dialects. What lives
+ * here is the injection invariant and the refusals, neither of which a result
+ * comparison can see.
+ */
+describe("json path filters", () => {
+  const jsonUser: any = {
+    ...user,
+    fields: {
+      ...user.fields,
+      metadata: { name: "metadata", column: "metadata", type: "Json" },
+    },
+  };
+
+  const sqliteText = (args: any) =>
+    compileRead(jsonUser, "findMany", args, sqlite).text;
+  const pgText = (args: any) =>
+    compileRead(jsonUser, "findMany", args, postgres).text;
+
+  /**
+   * The point of the whole feature, and the one place a caller's *value*
+   * decides part of an expression's meaning. Both dialects take the path as a
+   * parameter — Postgres's `#>` a `text[]`, SQLite's `json_extract` a string —
+   * so nothing has to be bent to keep it out of the SQL text.
+   */
+  test("the path is bound, never interpolated", () => {
+    const args = { where: { metadata: { path: "$.plan", equals: "pro" } } };
+    expect(sqliteText(args)).not.toContain("plan");
+    expect(sqliteText(args)).toContain(`json_extract("metadata", ?)`);
+    expect(
+      compileRead(jsonUser, "findMany", args, sqlite).bind(args),
+    ).toEqual(["$.plan", "pro"]);
+
+    const pgArgs = { where: { metadata: { path: ["plan"], equals: "pro" } } };
+    expect(pgText(pgArgs)).not.toContain("plan");
+    expect(pgText(pgArgs)).toContain(`"metadata" #>> $1`);
+  });
+
+  /** A path that is trying to be SQL is a value like any other. */
+  test("a path that looks like SQL stays a parameter", () => {
+    const args = {
+      where: { metadata: { path: `$."a'); drop table User; --"`, equals: "x" } },
+    };
+    expect(sqliteText(args)).not.toContain("drop table");
+    expect(sqliteText(args)).toContain(`json_extract("metadata", ?)`);
+  });
+
+  /**
+   * Prisma's own split, measured on both: the generated client refuses an array
+   * path on SQLite and a string path on Postgres. The refusal here says which
+   * form *this* database wants rather than letting the driver fail.
+   */
+  test("each dialect refuses the other's path grammar", () => {
+    expect(() =>
+      sqliteText({ where: { metadata: { path: ["plan"], equals: "x" } } }),
+    ).toThrow(/JSONPath string/);
+
+    expect(() =>
+      pgText({ where: { metadata: { path: "$.plan", equals: "x" } } }),
+    ).toThrow(/array of keys/);
+  });
+
+  test("a path on a column that is not Json is refused by type", () => {
+    expect(() =>
+      sqliteText({ where: { email: { path: "$.a", equals: "x" } } }),
+    ).toThrow(/is a String column/);
+  });
+
+  test("a bare path with no filter is refused, as Prisma refuses it", () => {
+    expect(() =>
+      sqliteText({ where: { metadata: { path: "$.plan" } } }),
+    ).toThrow(/needs a filter beside it/);
+  });
+
+  /**
+   * `array_contains` and the numeric comparisons are refused by Prisma's own
+   * client on SQLite — *"Unknown argument"* — so implementing them would make
+   * gemi answer a query the oracle cannot check. The message says it is a
+   * difference between the databases rather than a gap.
+   */
+  test("a filter this dialect cannot express names the dialect", () => {
+    for (const filter of [{ array_contains: "a" }, { gt: 2 }, { lte: 9 }]) {
+      expect(() =>
+        sqliteText({ where: { metadata: { path: "$.a", ...filter } } }),
+      ).toThrow(/not available on sqlite/);
+    }
+
+    // ...and all three compile on postgres.
+    for (const filter of [{ array_contains: "a" }, { gt: 2 }, { lte: 9 }]) {
+      expect(() =>
+        pgText({ where: { metadata: { path: ["a"], ...filter } } }),
+      ).not.toThrow();
+    }
+  });
+
+  test("an operator that is not a JSON filter names itself", () => {
+    expect(() =>
+      sqliteText({ where: { metadata: { path: "$.a", startsWith: "x" } } }),
+    ).toThrow(/metadata.startsWith/);
+  });
+
+  /**
+   * Both extractions yield text on Postgres, so a numeric comparison has to
+   * compare numbers rather than their spellings — otherwise "10" sorts before
+   * "9". The cast is structural; the value is still bound.
+   */
+  test("a numeric comparison casts, and still binds its value", () => {
+    const args = { where: { metadata: { path: ["n"], gt: 2 } } };
+    expect(pgText(args)).toContain(`cast(("metadata" #>> $1) as real) > $2`);
+    expect(compileRead(jsonUser, "findMany", args, postgres).bind(args)).toEqual([
+      "{\"n\"}",
+      2,
+    ]);
+  });
+
+  test("two filters on one path are ANDed", () => {
+    const args = {
+      where: {
+        metadata: { path: "$.plan", string_starts_with: "p", not: "pro" },
+      },
+    };
+    expect(sqliteText(args)).toContain(" and ");
+  });
+});

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -16,6 +16,7 @@ import {
   type Fragment,
   concat,
   joinFragments,
+  param,
   sql,
 } from "./fragment";
 import { JSON_NULL, type JsonNullKind, jsonNullKind } from "../json-null";
@@ -664,6 +665,216 @@ function assertCompositeInOperand(
   return fields;
 }
 
+/** The filters Prisma applies to a value extracted from a JSON path. */
+const JSON_FILTERS = new Set([
+  "equals",
+  "not",
+  "string_contains",
+  "string_starts_with",
+  "string_ends_with",
+  "array_contains",
+  "lt",
+  "lte",
+  "gt",
+  "gte",
+]);
+
+/**
+ * `where: { metadata: { path: …, equals: … } }`.
+ *
+ * **Two dialects, two path grammars, and that is Prisma's split rather than
+ * this ORM's.** Measured on both through a generated client: Postgres takes
+ * `path: ["a", "b"]` and refuses a string; SQLite takes `path: "$.a.b"` and
+ * refuses an array. So the argument is dialect-specific before it arrives here,
+ * and `jsonPathSyntax` is what lets the check say which form *this* database
+ * wants instead of failing inside the driver.
+ *
+ * **The path is bound, never interpolated.** This is the one place a caller's
+ * value decides part of an expression's meaning, which makes it the obvious
+ * place to break invariant 2 by accident. Neither dialect needs it in the text:
+ * Postgres's `#>` takes a `text[]` parameter and SQLite's `json_extract` takes
+ * a string, so the whole feature fits inside the existing rule.
+ *
+ * The operator set is the dialect's too. Prisma refuses `array_contains` and
+ * the numeric comparisons on SQLite — *"Unknown argument"* — so refusing them
+ * here is matching it, not falling short: implementing them would make gemi
+ * answer a query the oracle cannot, which is precisely where a differential
+ * test stops being able to check anything.
+ */
+function compileJsonFilter(
+  schema: ModelSchema,
+  field: FieldSchema,
+  column: string,
+  filter: Record<string, unknown>,
+  context: WhereContext,
+  locate: (args: any) => any,
+): Fragment {
+  const { dialect } = context;
+
+  if (field.type !== "Json") {
+    throw new UnsupportedQueryError(
+      `${field.name}.path`,
+      schema.name,
+      context.operation,
+      `A 'path' filter reads inside a JSON document, and '${field.name}' is ` +
+        `a ${field.type} column.`,
+    );
+  }
+
+  assertPathShape(schema, field, filter.path, context);
+
+  const path: Binder = (args) => locate(args)?.path;
+  const applied = Object.keys(filter)
+    .filter((key) => key !== "path")
+    .sort();
+
+  if (applied.length === 0) {
+    // Prisma: "A JSON path cannot be set without a scalar filter." Reproduced
+    // because the alternative is an extraction with nothing to compare it to,
+    // which compiles to a value in a predicate position on one dialect and to
+    // an error on the other.
+    throw new UnsupportedQueryError(
+      `${field.name}.path`,
+      schema.name,
+      context.operation,
+      `A 'path' needs a filter beside it — ${[...JSON_FILTERS].sort().join(", ")}. ` +
+        `Prisma refuses a bare path too.`,
+    );
+  }
+
+  const parts: Fragment[] = [];
+
+  for (const key of applied) {
+    if (!JSON_FILTERS.has(key)) {
+      throw new UnsupportedQueryError(
+        `${field.name}.${key}`,
+        schema.name,
+        context.operation,
+        `A JSON path filter takes ${[...JSON_FILTERS].sort().join(", ")}.`,
+      );
+    }
+
+    if (!dialect.jsonFilters.has(key)) {
+      throw new UnsupportedQueryError(
+        `${field.name}.${key}`,
+        schema.name,
+        context.operation,
+        `'${key}' on a JSON path is not available on ${dialect.name}. Prisma ` +
+          `refuses it here too, so this is a difference between the databases ` +
+          `rather than a gap in the ORM. It works on postgres.`,
+      );
+    }
+
+    parts.push(
+      jsonComparison(key, column, path, field, dialect, (args) =>
+        locate(args)?.[key],
+      ),
+    );
+  }
+
+  return parts.length === 1
+    ? parts[0]
+    : group(parts, " and ");
+}
+
+/** The comparison for one JSON filter key. */
+function jsonComparison(
+  key: string,
+  column: string,
+  path: Binder,
+  field: FieldSchema,
+  dialect: SqlDialect,
+  value: Binder,
+): Fragment {
+  if (key === "array_contains") {
+    return dialect.jsonArrayContains(column, path, value);
+  }
+
+  // The string filters compare *text*, so they need the text-returning
+  // extraction; everything else compares the value.
+  const stringly =
+    key === "string_contains" ||
+    key === "string_starts_with" ||
+    key === "string_ends_with";
+
+  const extracted = dialect.jsonExtract(column, path, true);
+
+  if (stringly) {
+    const wrap =
+      key === "string_contains"
+        ? (text: string) => `%${text}%`
+        : key === "string_starts_with"
+          ? (text: string) => `${text}%`
+          : (text: string) => `%${text}`;
+
+    return concat(
+      sql("("),
+      extracted,
+      sql(") like "),
+      param((args, context) => {
+        const raw = value(args, context);
+        return raw === null || raw === undefined ? null : wrap(String(raw));
+      }),
+    );
+  }
+
+  const operator =
+    key === "equals" ? "=" : key === "not" ? "<>" : COMPARISONS[key];
+
+  // `#>>` and `json_extract` both yield text, so a numeric comparison has to
+  // compare numbers rather than their spellings — otherwise "10" < "9". The
+  // cast is structural, never a value.
+  const numeric = key !== "equals" && key !== "not";
+  const lhs = numeric
+    ? concat(sql("cast(("), extracted, sql(") as real)"))
+    : concat(sql("("), extracted, sql(")"));
+
+  return concat(
+    lhs,
+    sql(` ${operator} `),
+    param((args, context) => {
+      const raw = value(args, context);
+      if (raw === null || raw === undefined) return null;
+      if (numeric) return Number(raw);
+      // Text on Postgres, native on SQLite — see `jsonComparesAsText`. The
+      // wrong one returns no rows on one dialect and raises on the other.
+      return dialect.jsonComparesAsText ? String(raw) : raw;
+    }),
+  );
+}
+
+/** The path is a string on SQLite and an array of keys on Postgres. */
+function assertPathShape(
+  schema: ModelSchema,
+  field: FieldSchema,
+  path: unknown,
+  context: WhereContext,
+): void {
+  const { dialect } = context;
+  const wanted = dialect.jsonPathSyntax === "array" ? "array" : "jsonpath";
+  const got = Array.isArray(path) ? "array" : typeof path === "string" ? "jsonpath" : "other";
+
+  if (got === wanted) {
+    if (wanted !== "array") return;
+    if ((path as unknown[]).every((part) => typeof part === "string" || typeof part === "number")) {
+      return;
+    }
+  }
+
+  throw new UnsupportedQueryError(
+    `${field.name}.path`,
+    schema.name,
+    context.operation,
+    dialect.jsonPathSyntax === "array"
+      ? `On ${dialect.name} a JSON path is an array of keys — ["a", "b"] — ` +
+        `not a JSONPath string. Prisma splits them the same way, and refuses ` +
+        `the other form on each database.`
+      : `On ${dialect.name} a JSON path is a JSONPath string — "$.a.b" — not ` +
+        `an array of keys. Prisma splits them the same way, and refuses the ` +
+        `other form on each database.`,
+  );
+}
+
 function compileFieldFilter(
   schema: ModelSchema,
   field: FieldSchema,
@@ -704,6 +915,13 @@ function compileFieldFilter(
 
   const filter = value as Record<string, unknown>;
   const keys = Object.keys(filter).sort();
+
+  // A `path` turns the whole operand into a JSON filter, whose operators are a
+  // different set from the scalar ones and whose left-hand side is an
+  // extraction rather than a column.
+  if (filter.path !== undefined) {
+    return compileJsonFilter(schema, field, column, filter, context, locate);
+  }
 
   // Prisma-only, and only meaningful next to a string operator. Read here so it
   // does not get treated as an operator in its own right.

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -765,6 +765,54 @@ function compileJsonFilter(
       );
     }
 
+    const operand = filter[key];
+
+    // **The sentinels have to be refused here, and only here.**
+    //
+    // `compileFieldFilter` refuses a bare sentinel above this branch, and
+    // refuses `AnyNull` under a non-`equals`/`not` operator in the scalar key
+    // loop below it. A `path` filter sits between the two and reaches neither,
+    // so before this check a sentinel inside a JSON filter went straight to the
+    // binder: Postgres compared against the literal text `Prisma.DbNull` and
+    // SQLite bound the sentinel object. Zero rows, no error — the failure class
+    // #259 and #266 exist to close, arrived at from the one direction nothing
+    // was watching.
+    //
+    // Refused rather than mapped. The scalar path *can* answer these because it
+    // compiles them against the column, where SQL NULL and the JSON value
+    // `null` are distinguishable. An extracted value has already lost that
+    // distinction — `#>>` yields NULL both for an absent key and for a JSON
+    // null — so answering here would mean picking one meaning and being
+    // silently wrong about the other.
+    const sentinel = jsonNullKind(operand);
+    if (sentinel) {
+      throw new InvalidArgumentError(
+        `where.${field.name}.${key}`,
+        schema.name,
+        context.operation,
+        `${sentinelName(sentinel)} is not a filter on an extracted JSON ` +
+          `value: the extraction yields NULL for an absent key and for a JSON ` +
+          `null alike, so the distinction the sentinel exists to make is ` +
+          `already gone. Filter the column itself — ` +
+          `{ ${field.name}: { equals: ${sentinelName(sentinel)} } } — or test ` +
+          `the path against the value you mean.`,
+      );
+    }
+
+    // The same shape one level down: `{ path: …, equals: { not: DbNull } }`.
+    if (carriesAnyNull(operand)) {
+      throw new InvalidArgumentError(
+        `where.${field.name}.${key}`,
+        schema.name,
+        context.operation,
+        `Prisma.AnyNull cannot be reached through a JSON path, for the same ` +
+          `reason the other two cannot: the extracted value does not ` +
+          `distinguish an absent key from a JSON null.`,
+      );
+    }
+
+    assertJsonOperand(key, operand, schema, field, context);
+
     parts.push(
       jsonComparison(key, column, path, field, dialect, (args) =>
         locate(args)?.[key],
@@ -775,6 +823,74 @@ function compileJsonFilter(
   return parts.length === 1
     ? parts[0]
     : group(parts, " and ");
+}
+
+/**
+ * What each JSON filter will accept as its operand.
+ *
+ * Two defects, both of them the shape the scalar path is already careful about
+ * and both silent:
+ *
+ *   - **The string filters had no non-string guard.** Their scalar siblings
+ *     refuse one, with a comment explaining that `String(null)` makes the
+ *     pattern `%null%` — "a query that runs and returns the wrong rows".
+ *     `string_contains: null` compiled to `like NULL`, which matches nothing
+ *     and raises nothing; `string_contains: 5` compiled to `%5%`. Prisma raises
+ *     for both.
+ *
+ *   - **`equals` / `not` accepted a non-scalar.** On Postgres the comparison
+ *     binds `String(raw)` because `#>>` yields text, so `equals: { b: 1 }` bound
+ *     the string `"[object Object]"` and matched nothing.
+ *
+ * The second is a **refusal rather than an implementation**, deliberately.
+ * Prisma does accept an object or an array there, and answering it properly
+ * means the `#>` + `::jsonb` form `array_contains` already uses — which is
+ * Postgres-only, so implementing it would give SQLite either a second wrong
+ * answer or a silent divergence. Refusing names the limitation on both
+ * dialects, which is what this file does everywhere else it cannot answer.
+ * `array_contains` is exempt because containment is precisely the operator that
+ * takes a document.
+ */
+function assertJsonOperand(
+  key: string,
+  operand: unknown,
+  schema: ModelSchema,
+  field: FieldSchema,
+  context: WhereContext,
+): void {
+  const stringly =
+    key === "string_contains" ||
+    key === "string_starts_with" ||
+    key === "string_ends_with";
+
+  if (stringly && typeof operand !== "string") {
+    throw new InvalidArgumentError(
+      `where.${field.name}.${key}`,
+      schema.name,
+      context.operation,
+      `Expected a string, received ${
+        operand === null ? "null" : typeof operand
+      }. Prisma raises here too — without this the pattern becomes ` +
+        `'%${String(operand)}%', which runs and returns the wrong rows.`,
+    );
+  }
+
+  if (key === "array_contains" || stringly) return;
+
+  // `equals`, `not`, and the four numeric comparisons all compare an extracted
+  // scalar against one bound value.
+  if (operand !== null && typeof operand === "object") {
+    throw new UnsupportedQueryError(
+      `where.${field.name}.${key}`,
+      schema.name,
+      context.operation,
+      `'${key}' on a JSON path compares the extracted value as a scalar, so ` +
+        `an object or array operand cannot be expressed — it would bind as ` +
+        `'${String(operand)}' and match nothing. Prisma accepts one here; ` +
+        `gemi does not yet. Use array_contains for containment, or narrow the ` +
+        `path until it names a scalar.`,
+    );
+  }
 }
 
 /** The comparison for one JSON filter key. */
@@ -853,6 +969,30 @@ function assertPathShape(
   const { dialect } = context;
   const wanted = dialect.jsonPathSyntax === "array" ? "array" : "jsonpath";
   const got = Array.isArray(path) ? "array" : typeof path === "string" ? "jsonpath" : "other";
+
+  // **The empty path is refused on both dialects, and it is not the same
+  // mistake as a wrong shape.** `[]` on Postgres extracts the whole document —
+  // `[].every` is vacuously true, so it used to pass this check — and `""` on
+  // SQLite raises inside `json_extract` at execution time. Neither is a path,
+  // and a caller who wrote one meant to write something. Refused with its own
+  // sentence rather than the grammar message below, which would tell them to
+  // use the form they already used.
+  const empty =
+    (Array.isArray(path) && path.length === 0) || path === "";
+  if (empty) {
+    throw new UnsupportedQueryError(
+      `${field.name}.path`,
+      schema.name,
+      context.operation,
+      `A JSON path cannot be empty. ${
+        dialect.jsonPathSyntax === "array"
+          ? `On ${dialect.name} an empty array selects the whole document, ` +
+            `which is a filter on the column rather than on a path — write ` +
+            `{ ${field.name}: { equals: … } } if that is what you meant.`
+          : `On ${dialect.name} an empty string raises inside json_extract.`
+      }`,
+    );
+  }
 
   if (got === wanted) {
     if (wanted !== "array") return;

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -232,9 +232,15 @@ export interface SqlDialect {
    * Postgres's `#>` accepts a `text[]`, SQLite's `json_extract` a string — so
    * nothing has to be bent to keep it out of the SQL text.
    *
-   * `asText` picks the extraction that yields SQL text rather than JSON, which
-   * is what the string filters compare against; the JSON form is what `equals`
-   * and `array_contains` need.
+   * `asText` picks the extraction that yields SQL text rather than JSON. Every
+   * comparison in `jsonComparison` passes `true` — the string filters compare
+   * against text, and `equals` / `not` / the numeric operators compare an
+   * extracted *scalar*, which is what the text form gives them. The JSON form
+   * has exactly one caller, `jsonArrayContains`, because containment is the one
+   * operator whose right-hand side is a document.
+   *
+   * SQLite ignores the flag: `json_extract` already yields a SQL value rather
+   * than a JSON document for a scalar at the path.
    */
   jsonExtract(column: string, path: Binder, asText: boolean): Fragment;
 

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -195,6 +195,53 @@ export interface SqlDialect {
   ): Fragment;
 
   /**
+   * How this dialect spells a JSON path, and which filters it can apply to one.
+   *
+   * The **path grammar itself differs**, which is unusual enough to be worth
+   * stating rather than hiding: Prisma takes `path: ["a", "b"]` on Postgres and
+   * `path: "$.a.b"` on SQLite, and refuses the other form on each. That is not
+   * a gemi choice — it is the shape the generated client accepts, measured on
+   * both — so reproducing it is what "Prisma-compatible" means here.
+   *
+   * `jsonFilters` is the set of scalar filters the dialect can apply to an
+   * extracted value. Prisma refuses `array_contains` and the numeric
+   * comparisons on SQLite with *"Unknown argument"*, so refusing them here is
+   * matching it rather than falling short of it.
+   */
+  readonly jsonPathSyntax: "array" | "jsonpath";
+  readonly jsonFilters: ReadonlySet<string>;
+
+  /**
+   * Whether an extracted value compares as **text**.
+   *
+   * Postgres's `#>>` yields `text`, so `equals: 3` has to bind `"3"` — comparing
+   * text to an integer parameter is a type error there. SQLite's `json_extract`
+   * yields a native value, so the same filter has to bind `3`: bind `"3"` and
+   * SQLite compares an INTEGER to a TEXT, which is silently *false* rather than
+   * an error. One filter, two encodings, and the wrong one is a returned-no-rows
+   * bug on one dialect and a raised error on the other.
+   */
+  readonly jsonComparesAsText: boolean;
+
+  /**
+   * The extracted value, as a fragment whose path is **bound**.
+   *
+   * A JSON path is the one place a caller's *value* decides part of an
+   * expression's meaning, which makes it the obvious place to interpolate by
+   * accident and break invariant 2. Both dialects can take it as a parameter —
+   * Postgres's `#>` accepts a `text[]`, SQLite's `json_extract` a string — so
+   * nothing has to be bent to keep it out of the SQL text.
+   *
+   * `asText` picks the extraction that yields SQL text rather than JSON, which
+   * is what the string filters compare against; the JSON form is what `equals`
+   * and `array_contains` need.
+   */
+  jsonExtract(column: string, path: Binder, asText: boolean): Fragment;
+
+  /** `<extracted> @> <value>` — Postgres only; see `jsonFilters`. */
+  jsonArrayContains(column: string, path: Binder, value: Binder): Fragment;
+
+  /**
    * `limit`/`offset`. Both are values and therefore parameters — this is the
    * single most tempting place in the compiler to inline a number.
    */

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -148,6 +148,79 @@ export class PostgresDialect implements SqlDialect {
     );
   }
 
+  /** `path: ["a", "b"]`, where SQLite takes `"$.a.b"`. Prisma's own split. */
+  readonly jsonPathSyntax = "array" as const;
+
+  /** Everything, which is what `jsonb` can express and Prisma exposes here. */
+  readonly jsonFilters: ReadonlySet<string> = new Set([
+    "equals",
+    "not",
+    "string_contains",
+    "string_starts_with",
+    "string_ends_with",
+    "array_contains",
+    "lt",
+    "lte",
+    "gt",
+    "gte",
+  ]);
+
+  /** `#>>` yields `text`, so a comparison binds the value's text form. */
+  readonly jsonComparesAsText = true;
+
+  /**
+   * `"col" #> $1` for the JSON value, `#>>` for its text.
+   *
+   * Both take the path as a **`text[]` parameter**, which is the whole reason
+   * this is expressible without bending invariant 2 — the one place a caller's
+   * value decides part of an expression's meaning, and it still never reaches
+   * the SQL text. The array is serialized the same way `inList` serializes
+   * one, for the same driver reason.
+   */
+  jsonExtract(column: string, path: Binder, asText: boolean): Fragment {
+    return concat(
+      sql(`${column} ${asText ? "#>>" : "#>"} `),
+      param((args, context) => arrayLiteral(path(args, context) as unknown[])),
+    );
+  }
+
+  /**
+   * `("col" #> $1) @> $2` — containment, which is what Prisma's
+   * `array_contains` compiles to and why it accepts both a scalar and a list:
+   * `@>` asks whether the left document contains the right one, and a bare
+   * value is a one-element containment test.
+   */
+  jsonArrayContains(column: string, path: Binder, value: Binder): Fragment {
+    return concat(
+      sql("("),
+      this.jsonExtract(column, path, false),
+      sql(") @> "),
+      // **Raw, not `JSON.stringify`d**, and the cast is what makes that safe.
+      // Bun already encodes a parameter bound against `jsonb` as JSON, so
+      // stringifying first sends the *string* `"[\"a\"]"` rather than the
+      // array — containment then asks whether a JSON array contains a JSON
+      // string spelling of itself, which is `false`. No error, no rows.
+      // Measured through the driver:
+      //
+      //   raw scalar "a"          -> true
+      //   raw array  ["a"]        -> true
+      //   JSON.stringify(["a"])   -> false      <- what this used to send
+      //   raw number 3            -> cannot cast type integer to jsonb
+      //
+      // The last line is why the cast is explicit and the value is normalised:
+      // a number has to become JSON text for the driver to type it as `jsonb`
+      // at all.
+      param((args, context) => {
+        const raw = value(args, context);
+        if (raw === null || raw === undefined) return null;
+        return typeof raw === "string" || typeof raw === "object"
+          ? raw
+          : JSON.stringify(raw);
+      }),
+      sql("::jsonb"),
+    );
+  }
+
   like(lhs: string, insensitive: boolean, pattern: Binder): Fragment {
     return concat(
       sql(`${lhs} ${insensitive ? "ilike" : "like"} `),

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -140,6 +140,62 @@ export class SqliteDialect implements SqlDialect {
     );
   }
 
+  /**
+   * `path: "$.a.b"` — a JSONPath *string*, where Postgres takes an array.
+   *
+   * Prisma's own split, measured on both: the generated client refuses
+   * `["a","b"]` here with *"Expected String, provided (String)"* and refuses
+   * `"$.a.b"` on Postgres with *"Expected String[], provided String"*. So the
+   * argument a caller writes is dialect-specific before it reaches this ORM,
+   * and reproducing that is what compatibility means.
+   */
+  readonly jsonPathSyntax = "jsonpath" as const;
+
+  /**
+   * What Prisma will apply to an extracted value here — and the absences are
+   * the point. `array_contains` and the numeric comparisons are refused by the
+   * generated client on SQLite with *"Unknown argument"*, so accepting them
+   * would put gemi ahead of Prisma on a dialect where a differential test has
+   * no oracle to check it against.
+   */
+  readonly jsonFilters: ReadonlySet<string> = new Set([
+    "equals",
+    "not",
+    "string_contains",
+    "string_starts_with",
+    "string_ends_with",
+  ]);
+
+  /**
+   * `json_extract` returns a *native* value — an INTEGER for a JSON number —
+   * so `equals: 3` binds `3`. Binding `"3"` compares INTEGER to TEXT, which
+   * SQLite answers `false` rather than refusing: no rows, no error, and the
+   * differential harness catching it against Prisma is the only reason it did
+   * not ship that way.
+   */
+  readonly jsonComparesAsText = false;
+
+  /**
+   * `json_extract("col", ?)`, with the path bound.
+   *
+   * SQLite has no separate text-returning extraction: `json_extract` already
+   * yields a SQL value rather than a JSON document for a scalar at the path, so
+   * `asText` changes nothing. That is why the string filters can compare
+   * against it directly.
+   */
+  jsonExtract(column: string, path: Binder, _asText: boolean): Fragment {
+    return concat(sql(`json_extract(${column}, `), param(path), sql(")"));
+  }
+
+  jsonArrayContains(): Fragment {
+    // Unreachable: `jsonFilters` does not list it, so `where.ts` refuses first
+    // with a message naming the dialect. Throwing here rather than returning
+    // something plausible keeps the two from disagreeing silently.
+    throw new Error(
+      "SQLite cannot express array_contains; `jsonFilters` is the guard.",
+    );
+  }
+
   like(lhs: string, _insensitive: boolean, pattern: Binder): Fragment {
     // `_insensitive` is unreachable — the compiler checks
     // `supportsInsensitiveMode` and raises a contextful error first.

--- a/packages/gemi/orm/soft-deletes.ts
+++ b/packages/gemi/orm/soft-deletes.ts
@@ -14,8 +14,12 @@ import type { ModelPolicy } from "./policy";
  * Usage — `deletedAt` must be a nullable `DateTime` on the model:
  *
  *     export class User extends UserModel {
- *       static $policies = [softDeletes<User>()]
+ *       static $policies = [softDeletes<typeof User>()]
  *     }
+ *
+ * `typeof User` rather than `User`: the class carries `$schema`, which is what
+ * constrains `field` to real columns (#262). The instance spelling still
+ * compiles and simply checks nothing.
  *
  *     await User.findMany({})        // deleted rows are not there
  *     await User.delete({ where })   // sets deletedAt, does not remove the row
@@ -23,7 +27,7 @@ import type { ModelPolicy } from "./policy";
  * Composing it with a policy of your own is now just a longer list, in the order
  * they should apply:
  *
- *     static $policies = [softDeletes<User>(), new TenantPolicy()]
+ *     static $policies = [softDeletes<typeof User>(), new TenantPolicy()]
  *
  * That ordering is the author's, and within a class it is the array's. Across
  * classes `policiesFor` still walks base to derived, so a `$policies` on a
@@ -35,15 +39,60 @@ import type { ModelPolicy } from "./policy";
  * reason.
  */
 
-export interface SoftDeleteOptions<M> {
+/**
+ * The column names a model *class* declares, read off its generated `$schema`.
+ *
+ * This is the part of #262 that made it worth doing. The old constraint was
+ * `keyof M & string` against an **instance** type, which is not a column check:
+ * `softDeletes<User>({ field: "save" })` compiled clean and then raised
+ * `UnknownFieldError` at runtime, because `save` is a method. Reading
+ * `$schema.fields` instead asks the schema what the columns are, so the check
+ * and the runtime error now disagree about nothing.
+ *
+ * It works because the generator emits `satisfies ModelSchema` rather than a
+ * `: ModelSchema` annotation — see `bin/orm/emit.ts`. An annotation would widen
+ * `fields` to `Record<string, FieldSchema>` and `keyof` it back to `string`.
+ *
+ * **Falls back to `string` rather than to `never`.** A caller can pass anything
+ * that behaves like a model — the structural fakes in `soft-deletes.test.ts` do
+ * — and those carry no literal schema. Degrading to unchecked keeps them
+ * working; degrading to `never` would reject every `field` they pass.
+ */
+type SchemaFields<M> = M extends { $schema: { fields: infer F } }
+  ? Extract<keyof F, string> extends never
+    ? string
+    : Extract<keyof F, string>
+  : string;
+
+/**
+ * The row a model class describes, so one type parameter can carry both.
+ *
+ * `softDeletes` hands its parameter to `ModelPolicy`, which uses it as the
+ * **row** type — `redact` is called with a `Partial` of it. The schema, though,
+ * hangs off the *class*. Taking the class and recovering the row through
+ * `prototype` is what lets one spelling supply both, and it is the mechanism
+ * #243 found and recorded rather than a new invention.
+ *
+ * An instance type has no `prototype`, so `softDeletes<User>()` still resolves
+ * to `User` and keeps compiling — it simply gets no field checking, because an
+ * instance type is not where the column names live.
+ */
+type RowOf<M> = M extends { prototype: infer Row } ? Row : M;
+
+export interface SoftDeleteOptions<F extends string = string> {
   /**
    * The timestamp column. Defaults to `deletedAt`, which the template uses.
    *
-   * Constrained to the model's own keys, so a typo or a model that has no such
-   * column is a compile error instead of a `no such column` from the database on
-   * the first read.
+   * Constrained to the model's **schema fields** when the model is reachable —
+   * `softDeletes<typeof User>()`, `softDelete(User)`, `softDeleteMany(User)` —
+   * so a typo, or a column the model does not have, is a compile error instead
+   * of an `UnknownFieldError` on the first read.
+   *
+   * Passing no model leaves it `string`, and therefore unchecked. That is the
+   * one spelling that cannot be constrained: there is nothing to constrain it
+   * against.
    */
-  field?: keyof M & string;
+  field?: F;
 }
 
 /**
@@ -56,8 +105,8 @@ export interface SoftDeleteOptions<M> {
  * written at the include site.
  */
 export function softDeletes<M = any>(
-  options: SoftDeleteOptions<M> = {},
-): ModelPolicy<any, any, M> {
+  options: SoftDeleteOptions<SchemaFields<M>> = {},
+): ModelPolicy<any, any, RowOf<M>> {
   const field = options.field ?? "deletedAt";
 
   return {
@@ -98,6 +147,35 @@ type SoftDeletable<T, Op extends string> = {
 } & { $schema?: { name: string } };
 
 /**
+ * Why this does not return the generated `delete`'s own signature — #263.
+ *
+ * `static delete = softDelete(User)` is the recipe the docs used to teach, and
+ * it does not type-check. The obvious repair is to have this return the model's
+ * own `delete` type so the override is assignable to what it overrides. That
+ * cannot work, and the reason is the language rather than the typing:
+ *
+ *     static delete = softDelete(User)
+ *     //     ^ the type of this member would be read off `User`...
+ *     //                       ^ ...whose `delete` is the member being defined
+ *
+ * TypeScript answers `TS7022: 'delete' implicitly has type 'any' because it
+ * does not have a type annotation and is referenced directly or indirectly in
+ * its own initializer.` Annotating it does not help either: the annotation has
+ * to name `typeof UserModel.delete`, and `softDelete(User)` is then checked
+ * against a generic signature it still cannot satisfy.
+ *
+ * Passing the *base* instead of the subclass would break the cycle and break
+ * the feature: `softDelete` delegates to `model.update`, policies are resolved
+ * per registered class, and `UserModel` carries none — so the soft-delete scope
+ * would not apply and `delete` would hide rows it never filtered.
+ *
+ * So the recipe changed instead of the types, and `delete` stays a hard delete.
+ * `docs/orm.md` says so in the words a reader needs, and
+ * `soft-delete.test-d.ts` holds the documented snippet verbatim so it cannot
+ * drift back.
+ */
+
+/**
  * The write half: rewrites a `delete` into an `update` that sets the timestamp.
  *
  * Kept separate from `softDeletes()` and applied at the call site rather than
@@ -108,10 +186,13 @@ type SoftDeletable<T, Op extends string> = {
  * a much larger claim than scoping a `where`.
  *
  *     export class User extends UserModel {
- *       static $policies = [softDeletes<User>()]
- *       static delete = softDelete(User)
- *       static deleteMany = softDeleteMany(User)
+ *       static $policies = [softDeletes<typeof User>()]
+ *       static expire = softDelete(User)
+ *       static expireMany = softDeleteMany(User)
  *     }
+ *
+ * **The name is not `delete`, and cannot be** — see the note below on #263.
+ * `User.delete()` stays a hard delete.
  *
  * Both return the row(s) the way the real operations do, and both are still
  * subject to the model's policies, because they go through `update` /
@@ -119,9 +200,9 @@ type SoftDeletable<T, Op extends string> = {
  * `delete({ where })` naming an already-deleted row finds nothing, exactly as
  * a hard delete of a missing row would.
  */
-export function softDelete<T, M = any>(
-  model: SoftDeletable<T, "update">,
-  options: SoftDeleteOptions<M> = {},
+export function softDelete<T, M>(
+  model: SoftDeletable<T, "update"> & M,
+  options: SoftDeleteOptions<SchemaFields<M>> = {},
 ): (args: any) => Promise<T> {
   const field = options.field ?? "deletedAt";
 
@@ -134,9 +215,9 @@ export function softDelete<T, M = any>(
   };
 }
 
-export function softDeleteMany<T, M = any>(
-  model: SoftDeletable<T, "updateMany">,
-  options: SoftDeleteOptions<M> = {},
+export function softDeleteMany<T, M>(
+  model: SoftDeletable<T, "updateMany"> & M,
+  options: SoftDeleteOptions<SchemaFields<M>> = {},
 ): (args: any) => Promise<T> {
   const field = options.field ?? "deletedAt";
 

--- a/packages/gemi/orm/soft-deletes.ts
+++ b/packages/gemi/orm/soft-deletes.ts
@@ -22,7 +22,11 @@ import type { ModelPolicy } from "./policy";
  * compiles and simply checks nothing.
  *
  *     await User.findMany({})        // deleted rows are not there
- *     await User.delete({ where })   // sets deletedAt, does not remove the row
+ *     await User.expire({ where })   // sets deletedAt, does not remove the row
+ *
+ * **`User.delete()` is still a hard delete**, and cannot be made otherwise —
+ * see the note on #263 above `softDelete` below. The policy scopes reads; it is
+ * the wrapper that rewrites a write, and the wrapper cannot be named `delete`.
  *
  * Composing it with a policy of your own is now just a longer list, in the order
  * they should apply:
@@ -58,7 +62,7 @@ import type { ModelPolicy } from "./policy";
  * — and those carry no literal schema. Degrading to unchecked keeps them
  * working; degrading to `never` would reject every `field` they pass.
  */
-type SchemaFields<M> = M extends { $schema: { fields: infer F } }
+export type SchemaFields<M> = M extends { $schema: { fields: infer F } }
   ? Extract<keyof F, string> extends never
     ? string
     : Extract<keyof F, string>
@@ -79,7 +83,19 @@ type SchemaFields<M> = M extends { $schema: { fields: infer F } }
  */
 type RowOf<M> = M extends { prototype: infer Row } ? Row : M;
 
-export interface SoftDeleteOptions<F extends string = string> {
+/**
+ * **The parameter is still the model type, not the field union.**
+ *
+ * `SoftDeleteOptions` is exported, so an application can annotate with it —
+ * `const opts: SoftDeleteOptions<User> = …`. Constraining the parameter to
+ * `extends string` and taking the union directly read more honestly from inside
+ * this file and broke every such annotation from outside it, with *"Type 'User'
+ * does not satisfy the constraint 'string'"*. Keeping the model type and
+ * resolving the union here costs nothing and keeps those compiling: a row type
+ * has no `$schema`, so it degrades to `string` exactly as it did before, and
+ * `SoftDeleteOptions<typeof User>` is the spelling that gains the check.
+ */
+export interface SoftDeleteOptions<M = any> {
   /**
    * The timestamp column. Defaults to `deletedAt`, which the template uses.
    *
@@ -92,7 +108,7 @@ export interface SoftDeleteOptions<F extends string = string> {
    * one spelling that cannot be constrained: there is nothing to constrain it
    * against.
    */
-  field?: F;
+  field?: SchemaFields<M>;
 }
 
 /**
@@ -105,7 +121,7 @@ export interface SoftDeleteOptions<F extends string = string> {
  * written at the include site.
  */
 export function softDeletes<M = any>(
-  options: SoftDeleteOptions<SchemaFields<M>> = {},
+  options: SoftDeleteOptions<M> = {},
 ): ModelPolicy<any, any, RowOf<M>> {
   const field = options.field ?? "deletedAt";
 
@@ -147,6 +163,30 @@ type SoftDeletable<T, Op extends string> = {
 } & { $schema?: { name: string } };
 
 /**
+ * The write half: rewrites a `delete` into an `update` that sets the timestamp.
+ *
+ * Kept separate from `softDeletes()` and applied at the call site rather than
+ * folded into the policy, because a policy rewrites *arguments* and this
+ * changes the *operation* — and `$exec` dispatches on the operation before a
+ * policy is consulted. Widening `ModelPolicy` to let a policy swap the
+ * operation would make every `$exec` call's meaning depend on a hook, which is
+ * a much larger claim than scoping a `where`.
+ *
+ *     export class User extends UserModel {
+ *       static $policies = [softDeletes<typeof User>()]
+ *       static expire = softDelete(User)
+ *       static expireMany = softDeleteMany(User)
+ *     }
+ *
+ * **The name is not `delete`, and cannot be** — the reason is below.
+ * `User.delete()` stays a hard delete.
+ *
+ * Both return the row(s) the way the real operations do, and both are still
+ * subject to the model's policies, because they go through `update` /
+ * `updateMany` — which means the soft-delete scope applies and a
+ * `expire({ where })` naming an already-deleted row finds nothing, exactly as
+ * a hard delete of a missing row would.
+ *
  * Why this does not return the generated `delete`'s own signature — #263.
  *
  * `static delete = softDelete(User)` is the recipe the docs used to teach, and
@@ -173,36 +213,11 @@ type SoftDeletable<T, Op extends string> = {
  * `docs/orm.md` says so in the words a reader needs, and
  * `soft-delete.test-d.ts` holds the documented snippet verbatim so it cannot
  * drift back.
+ 
  */
-
-/**
- * The write half: rewrites a `delete` into an `update` that sets the timestamp.
- *
- * Kept separate from `softDeletes()` and applied at the call site rather than
- * folded into the policy, because a policy rewrites *arguments* and this
- * changes the *operation* — and `$exec` dispatches on the operation before a
- * policy is consulted. Widening `ModelPolicy` to let a policy swap the
- * operation would make every `$exec` call's meaning depend on a hook, which is
- * a much larger claim than scoping a `where`.
- *
- *     export class User extends UserModel {
- *       static $policies = [softDeletes<typeof User>()]
- *       static expire = softDelete(User)
- *       static expireMany = softDeleteMany(User)
- *     }
- *
- * **The name is not `delete`, and cannot be** — see the note below on #263.
- * `User.delete()` stays a hard delete.
- *
- * Both return the row(s) the way the real operations do, and both are still
- * subject to the model's policies, because they go through `update` /
- * `updateMany` — which means the soft-delete scope applies and a
- * `delete({ where })` naming an already-deleted row finds nothing, exactly as
- * a hard delete of a missing row would.
- */
-export function softDelete<T, M>(
+export function softDelete<T, M = any>(
   model: SoftDeletable<T, "update"> & M,
-  options: SoftDeleteOptions<SchemaFields<M>> = {},
+  options: SoftDeleteOptions<M> = {},
 ): (args: any) => Promise<T> {
   const field = options.field ?? "deletedAt";
 
@@ -215,9 +230,9 @@ export function softDelete<T, M>(
   };
 }
 
-export function softDeleteMany<T, M>(
+export function softDeleteMany<T, M = any>(
   model: SoftDeletable<T, "updateMany"> & M,
-  options: SoftDeleteOptions<SchemaFields<M>> = {},
+  options: SoftDeleteOptions<M> = {},
 ): (args: any) => Promise<T> {
   const field = options.field ?? "deletedAt";
 

--- a/plans/orm/README.md
+++ b/plans/orm/README.md
@@ -11,15 +11,33 @@ nested reads**. Performance is the top priority throughout.
 
 ## Stack position
 
-This work is a **third level in an open PR stack**. Branch from
-`feat/database-layer` and target it, not `main` and not the release branch:
+**There is no stack. The ORM has landed.** `feat/orm` is an ancestor of
+`origin/next`, which carries `0.51.0-rc.0` and proposes to `main` as PR #273.
+Branch from `next`.
 
 ```
 main
- └── refactor/laravel-container-architecture   PR #30, OPEN — container/providers
-      └── feat/database-layer                  PR #33, OPEN — DatabaseManager, DB facade
-           └── feat/orm                        PR #45, OPEN — iterations 1-9 and after
+ └── next                    0.51.0-rc.0, PR #273 — contains the ORM
 ```
+
+The stack this section described is history, and reading it as instructions is
+the mistake it now exists to prevent:
+
+```
+main
+ └── refactor/laravel-container-architecture   PR #30, CLOSED — shipped in rc.2
+      └── feat/database-layer                  PR #33, CLOSED — shipped in rc.2
+           └── feat/orm                        PR #45, CLOSED — landed on next
+```
+
+#30 and #33 were closed as already-shipped: their content reached
+`release/v0.50.0-rc.2` on 2026-07-28 and their PRs were simply never closed, so
+for three days two open PRs described history. #45 is closed because the work
+went into `next` directly rather than into a base with nothing above it.
+
+**This section has now gone stale three times** — the original diagram, the
+correction below it, and this. Each rewrite has been to replace a *status* with
+a *date*, because a status rots silently and this document has no way to notice.
 
 ### How the stack landed
 
@@ -535,8 +553,8 @@ makes the *SQLite* suites fail for an unrelated reason afterwards.
 
 ## Picking up an iteration
 
-0. Confirm you are on a branch descended from `feat/database-layer` (see
-   [Stack position](#stack-position)), not from `main` or a release branch.
+0. Confirm you are on a branch descended from `next` (see
+   [Stack position](#stack-position)), not from `main`.
 1. Read this file, then the iteration's doc.
 2. Read the "Read first" list in that doc before writing anything.
 3. Respect the six invariants. If one is in the way, raise it — do not work around it.
@@ -555,9 +573,22 @@ makes the *SQLite* suites fail for an unrelated reason afterwards.
   of it — `app()` above all — handle two shapes forever, and hanging the handle
   off the Application shares it across concurrent requests, which is data
   corruption rather than a style question.
-- **MySQL / MariaDB.** Deferred. `DatabaseManager` already infers all four
-  dialects, and the strategy seam keeps the door open, but only SQLite and
-  Postgres are built and tested. Confirm this is acceptable.
+- ~~**MySQL / MariaDB.**~~ **Settled for 0.51.0: refused, not supported** (#269).
+  `DatabaseManager` still infers all four dialects and the strategy seam still
+  keeps the door open, but only SQLite and Postgres have compilers, and the
+  other two raise `UnsupportedDialectError` — which is careful to say the
+  *connection* is fine and the ORM is what does not speak that dialect.
+  `ReturningUnsupportedError` is the same gap seen from the write path.
+
+  This closes #71 (*"support it, or refuse it explicitly"*) by refusing, and
+  `docs/orm.md`'s **Dialects** section and errors table already say so. What
+  made it a decision rather than a build: the constraint is the differential
+  harness, not the compiler. Every correctness claim here is *the same query
+  through Prisma and through gemi against one database, compared on rows and
+  table contents* — so MySQL needs a MySQL Prisma client, a service container in
+  CI, and an answer to `RETURNING`, which MySQL does not have and which the
+  write path's row counts come from deliberately. That is a second answer to how
+  writes report what they did, not a dialect file.
 - ~~**Implicit many-to-many.**~~ **Covered.** Iteration 3 built the dedicated
   fixture this asked for —
   `templates/saas-starter/app/models/relations.many-to-many.test.ts` — a
@@ -568,18 +599,22 @@ makes the *SQLite* suites fail for an unrelated reason afterwards.
   Still true, and worth keeping in view: the template's own schema has no m-n, so
   the differential harness cannot reach one and this fixture asserts against
   Prisma's documented shape rather than a second generated client.
-- ~~**Coexistence.**~~ **Built.** `OrmAuthenticationAdapter` ships alongside the
-  Prisma one — both satisfy `IAuthenticationAdapter`, so an application selects
-  one and nothing else in `auth/` knows which. All twenty-two methods translated
-  with no changes to the ORM, which is the first evidence the query surface is
-  *sufficient* rather than merely tested: they were written against a real
-  application's needs rather than against the compiler's known capabilities.
-  `packages/gemi/auth/adapters/prisma.ts` and the template's
-  `app/database/prisma.ts` are untouched.
+- ~~**Coexistence.**~~ ~~**Built.**~~ **Overtaken — the seam is gone** (`922c45d`,
+  closing #270). All twenty-two methods translated with no changes to the ORM,
+  which was the first evidence the query surface is *sufficient* rather than
+  merely tested. Then the adapter interface itself was retired: there is one
+  `auth/UserProvider.ts`, `AuthManager` constructs it, and `app/config/auth.ts`
+  says nothing about persistence at all.
 
-  **Still open, and a decision rather than work:** the template's
-  `app/config/auth.ts` is not pointed at it. That is a behaviour change to a
-  working application and wants its own call.
-- **Where this stack merges.** PRs #30 and #33 are both open. If they land before
-  the ORM is ready, rebase onto whatever they merge into rather than carrying a
-  three-deep stack longer than necessary.
+  So the decision this entry was holding open — *should the template point at
+  the ORM adapter?* — was not answered either way. It stopped being a question:
+  there is no adapter to select and no `userProvider` line in the template. An
+  application that must change a query subclasses `UserProvider` and passes it
+  as `AuthManager`'s second constructor argument.
+- ~~**Where this stack merges.**~~ **Settled: it merged to `next`.** PRs #30 and
+  #33 were closed as already-shipped — their content had been on
+  `release/v0.50.0-rc.2` since 2026-07-28 — and `feat/orm` is now an ancestor of
+  `origin/next`, which carries `0.51.0-rc.0` and proposes to `main` as PR #273.
+  PR #45 is closed. **This section has gone stale three times; it is now a
+  statement about history rather than a plan, which is the only form that
+  cannot.** See #268 for the branch hygiene that outlived it.

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -885,6 +885,41 @@ const SQLITE_ONLY: [string, string, unknown][] = [
     "findMany",
     { where: { email: { contains: "ADA", mode: "insensitive" } } },
   ],
+
+  // --- JSON path filters, SQLite spelling (#70) -------------------------
+  //
+  // The path is a **JSONPath string** here and an array of keys on Postgres.
+  // That is Prisma's own split — its client refuses the other form on each
+  // database — so these cannot be one shared list, and the pair of lists is
+  // itself the assertion.
+  ["json path equals", "findMany", {
+    where: { metadata: { path: "$.plan", equals: "pro" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path not", "findMany", {
+    where: { metadata: { path: "$.plan", not: "pro" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path string_contains", "findMany", {
+    where: { metadata: { path: "$.plan", string_contains: "r" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path string_starts_with", "findMany", {
+    where: { metadata: { path: "$.plan", string_starts_with: "p" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path string_ends_with", "findMany", {
+    where: { metadata: { path: "$.plan", string_ends_with: "o" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path into a nested object", "findMany", {
+    where: { metadata: { path: "$.limits.seats", equals: 3 } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path that matches nothing", "findMany", {
+    where: { metadata: { path: "$.nope", equals: "x" } },
+    orderBy: { id: "asc" },
+  }],
 ];
 
 /**
@@ -1009,6 +1044,60 @@ const PER_PARENT_NESTED: [string, string, unknown][] = [
 ];
 
 const POSTGRES_ONLY: [string, string, unknown][] = [
+  // --- JSON path filters, Postgres spelling (#70) -----------------------
+  //
+  // The same seven as the SQLite list, spelled with an array path, plus the
+  // three Prisma only offers here. `array_contains` and the numeric
+  // comparisons are refused on SQLite by the generated client itself, so
+  // implementing them there would put gemi ahead of an oracle that cannot
+  // check it.
+  ["json path equals", "findMany", {
+    where: { metadata: { path: ["plan"], equals: "pro" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path not", "findMany", {
+    where: { metadata: { path: ["plan"], not: "pro" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path string_contains", "findMany", {
+    where: { metadata: { path: ["plan"], string_contains: "r" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path string_starts_with", "findMany", {
+    where: { metadata: { path: ["plan"], string_starts_with: "p" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path string_ends_with", "findMany", {
+    where: { metadata: { path: ["plan"], string_ends_with: "o" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path into a nested object", "findMany", {
+    where: { metadata: { path: ["limits", "seats"], equals: 3 } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path that matches nothing", "findMany", {
+    where: { metadata: { path: ["nope"], equals: "x" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json array_contains a scalar", "findMany", {
+    where: { metadata: { path: ["tags"], array_contains: "a" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json array_contains a list", "findMany", {
+    where: { metadata: { path: ["tags"], array_contains: ["a"] } },
+    orderBy: { id: "asc" },
+  }],
+  // A number inside a document, compared as a number. Both extractions yield
+  // text, so without a cast "10" would sort before "9".
+  ["json path gt on a number", "findMany", {
+    where: { metadata: { path: ["limits", "seats"], gt: 2 } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path lte on a number", "findMany", {
+    where: { metadata: { path: ["limits", "seats"], lte: 3 } },
+    orderBy: { id: "asc" },
+  }],
+
   [
     "mode insensitive matches case-blind on postgres",
     "findMany",

--- a/templates/saas-starter/app/models/generated/schema.ts
+++ b/templates/saas-starter/app/models/generated/schema.ts
@@ -10,7 +10,7 @@ import type { ModelSchema } from "gemi/orm";
 // rather than with a TypeError inside the compiler.
 export const ARTIFACT_VERSION = 1;
 
-export const Account: ModelSchema = {
+export const Account = {
   "name": "Account",
   "table": "Account",
   "fields": {
@@ -144,9 +144,9 @@ export const Account: ModelSchema = {
       "nullable": true
     }
   }
-};
+} satisfies ModelSchema;
 
-export const Ledger: ModelSchema = {
+export const Ledger = {
   "name": "Ledger",
   "table": "Ledger",
   "fields": {
@@ -191,9 +191,9 @@ export const Ledger: ModelSchema = {
       "nullable": false
     }
   }
-};
+} satisfies ModelSchema;
 
-export const LedgerEntry: ModelSchema = {
+export const LedgerEntry = {
   "name": "LedgerEntry",
   "table": "LedgerEntry",
   "fields": {
@@ -262,9 +262,9 @@ export const LedgerEntry: ModelSchema = {
       "nullable": false
     }
   }
-};
+} satisfies ModelSchema;
 
-export const MagicLinkToken: ModelSchema = {
+export const MagicLinkToken = {
   "name": "MagicLinkToken",
   "table": "MagicLinkToken",
   "fields": {
@@ -329,9 +329,9 @@ export const MagicLinkToken: ModelSchema = {
     ]
   ],
   "relations": {}
-};
+} satisfies ModelSchema;
 
-export const Membership: ModelSchema = {
+export const Membership = {
   "name": "Membership",
   "table": "Membership",
   "fields": {
@@ -381,9 +381,9 @@ export const Membership: ModelSchema = {
   ],
   "uniques": [],
   "relations": {}
-};
+} satisfies ModelSchema;
 
-export const Organization: ModelSchema = {
+export const Organization = {
   "name": "Organization",
   "table": "Organization",
   "fields": {
@@ -484,9 +484,9 @@ export const Organization: ModelSchema = {
       "nullable": false
     }
   }
-};
+} satisfies ModelSchema;
 
-export const OrganizationInvitation: ModelSchema = {
+export const OrganizationInvitation = {
   "name": "OrganizationInvitation",
   "table": "OrganizationInvitation",
   "fields": {
@@ -583,9 +583,9 @@ export const OrganizationInvitation: ModelSchema = {
       "nullable": false
     }
   }
-};
+} satisfies ModelSchema;
 
-export const PasswordResetToken: ModelSchema = {
+export const PasswordResetToken = {
   "name": "PasswordResetToken",
   "table": "PasswordResetToken",
   "fields": {
@@ -651,9 +651,9 @@ export const PasswordResetToken: ModelSchema = {
       "nullable": false
     }
   }
-};
+} satisfies ModelSchema;
 
-export const Post: ModelSchema = {
+export const Post = {
   "name": "Post",
   "table": "Post",
   "fields": {
@@ -697,9 +697,9 @@ export const Post: ModelSchema = {
       }
     }
   }
-};
+} satisfies ModelSchema;
 
-export const Session: ModelSchema = {
+export const Session = {
   "name": "Session",
   "table": "Session",
   "fields": {
@@ -805,9 +805,9 @@ export const Session: ModelSchema = {
       "nullable": true
     }
   }
-};
+} satisfies ModelSchema;
 
-export const SocialAccount: ModelSchema = {
+export const SocialAccount = {
   "name": "SocialAccount",
   "table": "SocialAccount",
   "fields": {
@@ -930,9 +930,9 @@ export const SocialAccount: ModelSchema = {
       "nullable": false
     }
   }
-};
+} satisfies ModelSchema;
 
-export const Tag: ModelSchema = {
+export const Tag = {
   "name": "Tag",
   "table": "Tag",
   "fields": {
@@ -980,9 +980,9 @@ export const Tag: ModelSchema = {
       }
     }
   }
-};
+} satisfies ModelSchema;
 
-export const User: ModelSchema = {
+export const User = {
   "name": "User",
   "table": "User",
   "fields": {
@@ -1186,4 +1186,4 @@ export const User: ModelSchema = {
       "nullable": false
     }
   }
-};
+} satisfies ModelSchema;

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -16,6 +16,7 @@ import {
   register,
   softDeletes,
   ScopeEscapeError,
+  UnknownFieldError,
   UnregisteredPolicyClassError,
   type ModelPolicy,
 } from "gemi/orm";
@@ -1427,6 +1428,53 @@ function softDeleteSuite(label: string, url?: string) {
         where: { id: bobId },
       });
       expect(await SoftUser.findMany({})).toHaveLength(1);
+    });
+
+    /**
+     * What a `field` naming something that is not a column actually does — the
+     * consequence the docs described for two releases as a `no such column`
+     * from the database.
+     *
+     * It is not, and never was. The compiler refuses an unknown name in a
+     * `where` or a `data` before a statement is built, so the query never
+     * reaches a dialect and no dialect ever gets to say `no such column`.
+     * `UnknownFieldError` names the model and lists every column it does have.
+     *
+     * #262 made this unreachable from most spellings — `field` is constrained
+     * to `$schema.fields` wherever a model is named, and
+     * `soft-delete.test-d.ts` pins exactly which. This is the backstop for the
+     * one spelling that cannot be checked statically, `softDeletes({ field })`,
+     * which names no model. Asserted rather than described, because the prose
+     * got it wrong twice.
+     */
+    describe("a field that is not a column", () => {
+      test("the read half refuses, naming the model and its columns", async () => {
+        (SoftUser as any).$policies = [softDeletes({ field: "nope" })];
+
+        const error = await SoftUser.findMany({}).catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(UnknownFieldError);
+        expect((error as UnknownFieldError).field).toBe("nope");
+        expect((error as UnknownFieldError).model).toBe("User");
+        expect((error as Error).message).toContain("deletedAt");
+      });
+
+      test("the write half refuses the same way", async () => {
+        (SoftUser as any).$policies = [softDeletes()];
+
+        // Cast on purpose: since #262 this argument is a *compile* error, which
+        // is the improvement. The runtime guard still has to hold for callers
+        // reaching it from untyped code, so the check is bypassed rather than
+        // the case dropped.
+        const options = { field: "nope" } as any;
+        const error = await softDelete(SoftUser, options)({
+          where: { id: bobId },
+        }).catch((e: unknown) => e);
+
+        expect(error).toBeInstanceOf(UnknownFieldError);
+        expect((error as UnknownFieldError).field).toBe("nope");
+        expect((error as UnknownFieldError).model).toBe("User");
+      });
     });
 
     // Composed through the prototype chain, which is the documented route and

--- a/templates/saas-starter/app/models/soft-delete.test-d.ts
+++ b/templates/saas-starter/app/models/soft-delete.test-d.ts
@@ -1,65 +1,106 @@
-import { test, describe } from "vitest";
+import { describe, test } from "vitest";
 
 import { softDelete, softDeleteMany, softDeletes } from "gemi/orm";
 
 import { UserModel } from "./generated";
 
 /**
- * Where the `field` option is checked, and where it is not.
+ * Where the `field` option is checked, and what the documented recipe is.
  *
- * `docs/orm.md` claimed it flatly — "`field` is constrained to the model's own
- * keys, so pointing it at a column that does not exist is a compile error
- * rather than a `no such column` on the first read" — and that is true of one of
- * the three functions it appears to describe.
+ * This file used to pin the *absence* of a guarantee. `SoftDeleteOptions<M>`
+ * constrained `field` to `keyof M & string` with `M` defaulting to `any`, so
+ * only `softDeletes<User>()` checked anything — and what it checked were the
+ * keys of an **instance**, which is not a column list: `field: "save"` compiled
+ * clean and then raised `UnknownFieldError` at runtime. Three cases here were
+ * written without `@ts-expect-error` on purpose, so that tightening the
+ * inference would break the file and force this note to be rewritten.
  *
- * `SoftDeleteOptions<M>` constrains `field` to `keyof M & string`, and `M`
- * defaults to `any`. `softDeletes<User>()` supplies it, so the constraint bites.
- * `softDelete(User)` and `softDeleteMany(User)` take the model as a *value*;
- * `M` stays `any`, `keyof any & string` is `string`, and any typo is accepted —
- * arriving as `no such column` on the first read, which is the failure the
- * sentence promised was impossible.
+ * It did. Both halves of #262 are closed:
  *
- * Defaulting `M = T` does not fix it. The row type is only recoverable from the
- * model's `update` signature, which is generic, so `T` infers too loosely to
- * constrain anything — tried, and it changed nothing. Recording that here so the
- * next person does not spend the same half hour on it.
+ *   - **Columns, not keys.** The generator emits `satisfies ModelSchema` rather
+ *     than a `: ModelSchema` annotation (`bin/orm/emit.ts`), which keeps the
+ *     literal field names instead of widening them to `string`. `field` is now
+ *     constrained to `$schema.fields` — the same list `UnknownFieldError`
+ *     prints — so `"save"` is rejected at compile time.
+ *   - **All four spellings.** The constraint is reachable from the model
+ *     *value* for `softDelete` / `softDeleteMany`, and from the model *class*
+ *     for `softDeletes<typeof User>()`. `ModelPolicy` still needs the row type,
+ *     which is recovered from the class through `prototype` — the mechanism
+ *     #243 recorded and left unused.
  *
- * So this pins the boundary rather than asserting a guarantee that does not
- * hold. The unchecked calls are written without `@ts-expect-error` on purpose:
- * if the inference is ever tightened, they become errors, this file stops
- * type-checking, and the note above needs revisiting — which is the outcome
- * worth having.
+ * The one spelling that stays unchecked is `softDeletes({ field })` with no
+ * type argument, and it is unchecked because there is nothing to check against.
  */
-type User = { id: number; email: string | null; deletedAt: Date | null };
+type LegacyRow = { id: number; email: string | null; deletedAt: Date | null };
 
-describe("softDeletes checks `field` when the model type is given", () => {
-  test("a real column is accepted", () => {
-    softDeletes<User>({ field: "deletedAt" });
-  });
+describe("the documented recipe compiles", () => {
+  /**
+   * #263, verbatim from `docs/orm.md`. It is a **non-overriding name**, and
+   * that is the finding rather than a workaround: `static delete =
+   * softDelete(User)` cannot be made to type-check, because the member's type
+   * would be read off the class whose member it is (`TS7022`). `soft-deletes.ts`
+   * carries the full reasoning.
+   *
+   * Held here so the snippet in the docs is one that has been compiled.
+   */
+  test("a soft-deleting model", () => {
+    class User extends UserModel {
+      static $policies = [softDeletes<typeof User>()];
+      static expire = softDelete(User);
+      static expireMany = softDeleteMany(User);
+    }
 
-  test("a column the model does not have is a compile error", () => {
-    // @ts-expect-error `nope` is not a key of User
-    softDeletes<User>({ field: "nope" });
+    void User;
   });
 
   /**
-   * Without the type parameter there is nothing to check against: `M` is `any`,
-   * so `keyof M & string` is `string`. Pinned because the documented sentence
-   * reads as though it applied here too.
+   * The spelling the docs taught before #262. It still compiles — an instance
+   * type has no `prototype`, so `RowOf` resolves to it unchanged — and it
+   * simply gets no field checking. Pinned so the migration is known to be
+   * additive rather than breaking.
    */
-  test("without the type parameter it is unchecked", () => {
-    softDeletes({ field: "nope" });
+  test("the pre-#262 instance-type spelling still compiles", () => {
+    class User extends UserModel {
+      static $policies = [softDeletes<LegacyRow>()];
+    }
+
+    void User;
   });
 });
 
-describe("softDelete and softDeleteMany do not check it", () => {
-  test("the model arrives as a value, so `field` is unconstrained", () => {
+describe("`field` is checked against the schema's columns", () => {
+  test("a real column is accepted, on every spelling", () => {
+    softDeletes<typeof UserModel>({ field: "deletedAt" });
+    softDelete(UserModel, { field: "deletedAt" });
+    softDeleteMany(UserModel, { field: "deletedAt" });
+  });
+
+  test("a column the model does not have is a compile error", () => {
+    // @ts-expect-error `nope` is not a field on User
+    softDeletes<typeof UserModel>({ field: "nope" });
+    // @ts-expect-error `nope` is not a field on User
     softDelete(UserModel, { field: "nope" });
+    // @ts-expect-error `nope` is not a field on User
     softDeleteMany(UserModel, { field: "nope" });
   });
 
-  test("the correct spelling compiles, which is all that is asserted", () => {
-    softDelete(UserModel, { field: "deletedAt" });
-    softDeleteMany(UserModel, { field: "deletedAt" });
+  /**
+   * The case that decides this was worth doing rather than being a typo check.
+   * `save` is a real key of the *instance* and not a column, so the old
+   * `keyof M` constraint accepted it and the database answered at runtime.
+   */
+  test("a method name is not a column", () => {
+    // @ts-expect-error `save` is a method, not a field
+    softDeletes<typeof UserModel>({ field: "save" });
+  });
+
+  /**
+   * Unchecked, and the one spelling that cannot be otherwise: no model is named,
+   * so `SchemaFields` falls back to `string`. Without `@ts-expect-error` on
+   * purpose — if a way is found to constrain this too, this line becomes an
+   * error and the note above needs revisiting. Same tripwire, one level up.
+   */
+  test("without a model there is nothing to check against", () => {
+    softDeletes({ field: "nope" });
   });
 });


### PR DESCRIPTION
Closes #262, closes #263, closes #267, closes #269.

The `orm`-labelled issues that were work rather than decisions, for the release
being cut from `next`. Three commits, verified on both dialects.

## What was actually open

The two tracker issues turned out to describe a world that had moved. #265 and
#268 route the reader through landing `feat/orm` as a three-deep PR stack onto
`rc.2` or `main` — but `feat/orm` is already an ancestor of `origin/next`, PRs
#30/#33/#45 are all closed, and `next` carries `0.51.0-rc.0` with #273 open to
`main`. So the "stack plumbing" that both issues call the blocker is done, and
what was left was four pieces of real work.

## `cc22399` — JSON path filters (#267, and the second half of #70)

`1fae1ea` was complete, green, and never merged: #70 named two findings, the
first landed, the issue was closed on it, and the second sat on a branch. Rebased
rather than replayed — `compile/where.ts` moved underneath it:

- The `path` branch is placed **after** the `AnyNull`/sentinel refusal from
  `b6aa637`, so `Prisma.DbNull` is still refused by name rather than read as an
  operator map that happens to carry a `path`.
- `where.ts` binds through `fieldParam` now, which adds the `::text::jsonb` cast
  a Json *column* needs (#209). A path comparison binds an extracted scalar, not
  a column, so it uses `param` directly.
- The dialect members landed beside #97's composite-`in` work, which had claimed
  the same insertion point in all three files.

`docs/llms-full.txt` is regenerated — `docs-scope.test.ts` postdates the original
commit and caught the omission.

## `5f959ff` — soft deletes (#262, #263)

One commit because they retype the same two functions.

**#262** had two defects and the second is the one that mattered. The constraint
reached one of four spellings, and where it applied it was `keyof` an *instance*
type — so `field: "save"` compiled clean and raised `UnknownFieldError` at
runtime. A check that disagrees with the runtime error about what a field is
catches typos and nothing else.

The fix starts in the generator, which is why #243 could not get here:

```diff
-export const User: ModelSchema = { … };
+export const User = { … } satisfies ModelSchema;
```

The annotation was widening `fields` to `Record<string, FieldSchema>`, leaving no
column names in the type system to constrain against. The emitted value is
byte-identical and the regeneration test passes unchanged.

**#263** — `static delete = softDelete(User)` cannot be made to type-check. The
repair that keeps the name is circular: the member's type would be read off the
class the member is being defined on (`TS7022`). Annotating does not break the
cycle, and passing the generated base breaks the feature, since policies resolve
per registered class and the base carries none. So the recipe changed to
`static expire`, and the consequence is now stated rather than implied:
**`User.delete()` on a soft-deleting model is still a hard delete.**

## `2b087ec` — decisions and stale prose (#269, plus #268/#270 sections)

#269 settled as **refused**: nothing was half-built, and the constraint is the
differential harness rather than the compiler — MySQL has no `RETURNING`, which
is where the write path's row counts come from deliberately.

Two plan sections retired. `Stack position` would have sent a reader to branch
under a stack that no longer exists; the `Coexistence` entry held open a question
that `922c45d` dissolved by retiring `IAuthenticationAdapter` entirely (#270).

Also carries the runtime pin from `719bb4c`, the commit stranded on
`fix/orm-soft-delete-field-constraint`. Its write-half case is now a *compile*
error, so it bypasses the check with a cast rather than being dropped — the
backstop still has to hold for callers arriving from untyped code.

## Verification

| | |
| --- | --- |
| `packages/gemi` | 100 files / 2082 tests, CI's exclusion set; `tsc` clean |
| template, sqlite | 654 tests + 36 type tests |
| template, postgres | 928 tests, real server via `app/models/postgres.sh` |

The 5 files failing outside CI's exclusion set are #163's `app/` copies,
untouched here.

## Not in this PR

- **#271** — multi-field relations in a nested write. Still refused, deliberately;
  the issue says no urgency and the work is N foreign-key columns across five
  operands plus a partial-failure mode the current refusal makes impossible.
- **#268's branch deletion** — 117 of 120 ORM branches now hold zero unique
  non-merge commits against `next`, re-measured. The three that did are all
  resolved by this PR, so all 120 are deletable; the list is on the issue rather
  than run from here.
- **`corpus.ts` is not extended for `path`.** It says it is the thing to extend
  when a new argument is implemented, and the invariant suites walk it against
  `userWithProfile`, which has no Json column — so covering it means adding one
  to a shared fixture and re-baselining every suite that reads all columns. Too
  broad for a release. The correctness direction still holds by construction:
  filter names are entries in the plan key, so two JSON shapes compiling to
  different SQL cannot share one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Breaking changes

**`SqlDialect` gains five required members** — `jsonPathSyntax`, `jsonFilters`,
`jsonComparesAsText`, `jsonExtract`, `jsonArrayContains`. The interface is
exported, so any out-of-tree implementor of it stops compiling until they are
added. Only the two in-tree dialects exist today, so this is a release-note line
rather than a migration.

Nothing else in the public surface changes. `SoftDeleteOptions` and
`softDelete` / `softDeleteMany` keep their existing type parameters — an earlier
revision narrowed both and that was reverted in `453c4ad`, so
`SoftDeleteOptions<User>` and `softDelete<Row>(model)` compile as before.
