### PR TITLE
Scalar lists on Postgres, and the second schema that gives them an oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,10 @@ jobs:
       # parameter, which reads as a connection failure rather than a bad URL.
       TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/gemi_test
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/gemi_test
+      # The scalar-list schema's own database — see the two steps that create
+      # and push it. A second database rather than a second set of tables,
+      # because `prisma db push` reconciles a whole database to one schema.
+      TEST_POSTGRES_LISTS_URL: postgres://postgres:postgres@localhost:5432/gemi_lists
       TZ: UTC
 
     steps:
@@ -244,6 +248,32 @@ jobs:
       - name: Create the schema
         run: bunx prisma db push --skip-generate
         working-directory: templates/saas-starter
+
+      # `prisma/postgres-only.prisma` — the scalar lists (#300), which cannot
+      # live in the schema above because a `String[]` is a *validation error* on
+      # SQLite, and that schema has its provider flipped between dialects. So
+      # they get their own schema, their own client and their own database.
+      #
+      # A separate database because `prisma db push` reconciles a whole database
+      # to one schema: pushed at `gemi_test`, it would drop every table the main
+      # schema owns and the rest of this job would fail with missing relations.
+      #
+      # Skipping this step does not fail anything — `scalar-list.test.ts` gates
+      # on `TEST_POSTGRES_LISTS_URL` — so it would read as a pass. That is
+      # exactly the silence `postgres-suite-selection.test.ts` exists to catch,
+      # and the suite prints a loud warning when it does not run.
+      - name: Create the scalar-list database
+        run: >-
+          PGPASSWORD=postgres psql -h localhost -U postgres -d gemi_test
+          -c 'CREATE DATABASE gemi_lists'
+
+      - name: Generate and push the scalar-list schema
+        run: |
+          bunx prisma generate --schema prisma/postgres-only.prisma
+          bunx prisma db push --schema prisma/postgres-only.prisma --skip-generate
+        working-directory: templates/saas-starter
+        env:
+          LISTS_DATABASE_URL: postgres://postgres:postgres@localhost:5432/gemi_lists
 
       # `-t postgres` selects the dialect-labelled suites, and it is required
       # rather than tidy. `@prisma/client` speaks one provider at a time, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,10 +262,14 @@ jobs:
       # on `TEST_POSTGRES_LISTS_URL` — so it would read as a pass. That is
       # exactly the silence `postgres-suite-selection.test.ts` exists to catch,
       # and the suite prints a loud warning when it does not run.
+      # `|| true` for the same reason `app/models/postgres.sh` has one: a
+      # re-created database is an error rather than a no-op, so a rerun against
+      # a persisted service container would fail a step that is not the point of
+      # the job. A fresh container makes it succeed the first time either way.
       - name: Create the scalar-list database
         run: >-
           PGPASSWORD=postgres psql -h localhost -U postgres -d gemi_test
-          -c 'CREATE DATABASE gemi_lists'
+          -c 'CREATE DATABASE gemi_lists' || true
 
       - name: Generate and push the scalar-list schema
         run: |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3113,6 +3113,7 @@ merely unsupported:
 
 An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
 document, which is a filter on the column rather than on a path.
+
 ### Scalar lists (Postgres only)
 
 ```ts

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2789,12 +2789,11 @@ Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 ### Columns the generator refuses
 
-Two kinds of column stop generation with an `UnsupportedSchemaError` naming the model and field,
+One kind of column stops generation with an `UnsupportedSchemaError` naming the model and field,
 rather than being skipped:
 
 | Column | Why |
 | --- | --- |
-| A scalar list — `tags String[]` | Postgres-only, and needs array decoding this ORM does not have. |
 | `Decimal` | Prisma types it as `Prisma.Decimal`; SQLite stores a REAL and the driver returns a JS number, so the value would be a float pretending to be an arbitrary-precision decimal. |
 
 **Refused rather than omitted, and the whole generation fails rather than the one field.** Skipping
@@ -2806,7 +2805,25 @@ visible at the moment you introduce it.
 A `Unsupported(...)` column is different and is *not* refused: Prisma's own client omits those from
 its result types, so omitting them is what keeps the shapes identical.
 
-Scalar lists are tracked in [#300](https://github.com/nstfkc/gemi/issues/300).
+```
+UnsupportedSchemaError: User.price is a Decimal, which the gemi ORM does not support yet:
+Prisma types a Decimal field as `Prisma.Decimal`, but SQLite stores it as a REAL and the
+driver returns a JS number — so the value would be a float pretending to be an
+arbitrary-precision decimal, losing exactly the precision the type exists to keep.
+Keep using the Prisma client for this model, or change the field's type.
+```
+
+A scalar type the generator cannot map at all — a future Prisma addition — raises the same error.
+Both are *generator* errors rather than runtime ones, so neither is in the
+[errors table](#errors) below, which is about queries. If you see one, the fix is in
+`schema.prisma`.
+
+**A scalar list used to be in this table and no longer is.** `tags String[]` is implemented on
+Postgres — see [Scalar lists](#scalar-lists-postgres-only). The refusal did not disappear so much as
+move: this artifact is dialect-agnostic on purpose, because `DATABASE_URL` can name a different
+database than `prisma generate` saw, so refusing here refused the column for Postgres too. SQLite
+now declines it at query time instead, with a message naming the dialect. `Decimal[]` is still
+refused, by the row above rather than by a rule about lists.
 
 ### Your model class
 
@@ -3096,6 +3113,59 @@ merely unsupported:
 
 An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
 document, which is a filter on the column rather than on a path.
+### Scalar lists (Postgres only)
+
+```ts
+// model Post { tags String[] }
+await Post.findMany({ where: { tags: { has: "urgent" } } })
+await Post.findMany({ where: { tags: { hasEvery: ["urgent", "draft"] } } })
+await Post.update({ where: { id }, data: { tags: { push: "urgent" } } })
+```
+
+**Postgres only, and that is Prisma's line rather than this ORM's.** SQLite has no array type, and
+`prisma generate` refuses the column outright there — *"Field `tags` in model `Post` can't be a
+list. The current connector does not support lists of primitive types."* So there is no SQLite
+behaviour to match.
+
+The filters, which are a **different set from the scalar operators** on a different kind of column:
+
+| | |
+| --- | --- |
+| `has` | the list contains this element |
+| `hasEvery` | the list contains all of these |
+| `hasSome` | the list and this one share an element |
+| `isEmpty` | `true` or `false` |
+| `equals` | the whole list, in order |
+
+`contains`, `startsWith`, `in` and the comparisons are **not** among them: `contains` on a `String`
+asks about a substring, and on a `String[]` there is no such question — the one Prisma spells is
+`has`. Writing one gets an error naming both sets.
+
+One asymmetry worth knowing before it surprises you, because it is Prisma's and gemi reproduces it:
+
+```ts
+await Post.findMany({ where: { tags: ["a", "b"] } })      // ✗ refused
+await Post.findMany({ where: { tags: { equals: ["a", "b"] } } })  // ✓
+await Post.update({ where: { id }, data: { tags: ["a", "b"] } })  // ✓ a bare array is a value
+```
+
+A bare array is a **value** but not a **filter**. Prisma rejects the first line with *"Expected
+StringNullableListFilter"*, so gemi does too rather than guessing that `equals` was meant.
+
+Writes take `set` and `push`; `push` accepts one element or a list. `increment` and its siblings
+apply to a number, not to a list of them, and are refused by name.
+
+**An omitted list is written as the empty list, not refused.** A `String[]` with no `@default` is
+still not "missing" on `create` — Prisma writes `[]`, and so does gemi. That was measured against a
+generated client rather than read off the input type, which says only that the field is optional.
+
+Every element type Prisma allows is supported — `String`, `Int`, `Float`, `Boolean`, `BigInt`,
+`DateTime`, `Bytes`, `Json` and enums. `Decimal[]` is refused, because `Decimal` itself is (see
+below); a list of a scalar no dialect can round-trip is not more supportable for being a list.
+
+An enum list is worth one note: the driver hands those back as an unparsed Postgres array literal
+rather than as an array, so gemi parses them. You will not see the difference — that is the point —
+but it is why a list column costs a decode where a `String` does not.
 
 ### What a refusal tells you
 
@@ -4099,10 +4169,6 @@ if (!ormSupports(DB.dialect)) throw new Error("this deployment needs Postgres")
 
 Stated so you can plan around them rather than discover them:
 
-- **No scalar lists.** `tags String[]` is refused at *generation* time, so this one stops your build
-  rather than a query — see [Columns the generator refuses](#columns-the-generator-refuses). Prisma
-  itself refuses them on SQLite, so half the supported matrix could never have had them.
-  Pending rather than declined ([#300](https://github.com/nstfkc/gemi/issues/300)).
 - **No identity map and no unit of work.** Two queries for the same row give you two objects. Half
   an identity map is worse than none.
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
@@ -4122,6 +4188,13 @@ Stated so you can plan around them rather than discover them:
 - **No `cursor`, also deliberate.** It is only correct under a *total* ordering, which Prisma does
   not enforce — under a non-unique `orderBy` it skips or repeats rows at the page boundary. Use
   `take` with a `where` on the last row's sort key, or compose the keyset comparison with `sql`.
+- **No `Decimal`, on either dialect.** Refused at `prisma generate` rather than at query time — see
+  [Columns the generator refuses](#columns-the-generator-refuses). SQLite stores it as a REAL and
+  hands back a JS number, so the value would be a float typed as `Prisma.Decimal`. `Decimal[]` is
+  refused for the same reason.
+- **Scalar lists are Postgres-only**, which is not a gemi limit but Prisma's: SQLite rejects the
+  column at schema validation. They are otherwise fully supported — see
+  [Scalar lists](#scalar-lists-postgres-only).
 
 Both of the last two throw `UnsupportedByDesignError`, which says *"and this is a decision rather
 than a gap"* rather than *"yet"* — so a refusal you can plan around reads differently from one that

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -58,12 +58,11 @@ Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 ### Columns the generator refuses
 
-Two kinds of column stop generation with an `UnsupportedSchemaError` naming the model and field,
+One kind of column stops generation with an `UnsupportedSchemaError` naming the model and field,
 rather than being skipped:
 
 | Column | Why |
 | --- | --- |
-| A scalar list — `tags String[]` | Postgres-only, and needs array decoding this ORM does not have. |
 | `Decimal` | Prisma types it as `Prisma.Decimal`; SQLite stores a REAL and the driver returns a JS number, so the value would be a float pretending to be an arbitrary-precision decimal. |
 
 **Refused rather than omitted, and the whole generation fails rather than the one field.** Skipping
@@ -75,7 +74,25 @@ visible at the moment you introduce it.
 A `Unsupported(...)` column is different and is *not* refused: Prisma's own client omits those from
 its result types, so omitting them is what keeps the shapes identical.
 
-Scalar lists are tracked in [#300](https://github.com/nstfkc/gemi/issues/300).
+```
+UnsupportedSchemaError: User.price is a Decimal, which the gemi ORM does not support yet:
+Prisma types a Decimal field as `Prisma.Decimal`, but SQLite stores it as a REAL and the
+driver returns a JS number — so the value would be a float pretending to be an
+arbitrary-precision decimal, losing exactly the precision the type exists to keep.
+Keep using the Prisma client for this model, or change the field's type.
+```
+
+A scalar type the generator cannot map at all — a future Prisma addition — raises the same error.
+Both are *generator* errors rather than runtime ones, so neither is in the
+[errors table](#errors) below, which is about queries. If you see one, the fix is in
+`schema.prisma`.
+
+**A scalar list used to be in this table and no longer is.** `tags String[]` is implemented on
+Postgres — see [Scalar lists](#scalar-lists-postgres-only). The refusal did not disappear so much as
+move: this artifact is dialect-agnostic on purpose, because `DATABASE_URL` can name a different
+database than `prisma generate` saw, so refusing here refused the column for Postgres too. SQLite
+now declines it at query time instead, with a message naming the dialect. `Decimal[]` is still
+refused, by the row above rather than by a rule about lists.
 
 ### Your model class
 
@@ -365,6 +382,59 @@ merely unsupported:
 
 An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
 document, which is a filter on the column rather than on a path.
+### Scalar lists (Postgres only)
+
+```ts
+// model Post { tags String[] }
+await Post.findMany({ where: { tags: { has: "urgent" } } })
+await Post.findMany({ where: { tags: { hasEvery: ["urgent", "draft"] } } })
+await Post.update({ where: { id }, data: { tags: { push: "urgent" } } })
+```
+
+**Postgres only, and that is Prisma's line rather than this ORM's.** SQLite has no array type, and
+`prisma generate` refuses the column outright there — *"Field `tags` in model `Post` can't be a
+list. The current connector does not support lists of primitive types."* So there is no SQLite
+behaviour to match.
+
+The filters, which are a **different set from the scalar operators** on a different kind of column:
+
+| | |
+| --- | --- |
+| `has` | the list contains this element |
+| `hasEvery` | the list contains all of these |
+| `hasSome` | the list and this one share an element |
+| `isEmpty` | `true` or `false` |
+| `equals` | the whole list, in order |
+
+`contains`, `startsWith`, `in` and the comparisons are **not** among them: `contains` on a `String`
+asks about a substring, and on a `String[]` there is no such question — the one Prisma spells is
+`has`. Writing one gets an error naming both sets.
+
+One asymmetry worth knowing before it surprises you, because it is Prisma's and gemi reproduces it:
+
+```ts
+await Post.findMany({ where: { tags: ["a", "b"] } })      // ✗ refused
+await Post.findMany({ where: { tags: { equals: ["a", "b"] } } })  // ✓
+await Post.update({ where: { id }, data: { tags: ["a", "b"] } })  // ✓ a bare array is a value
+```
+
+A bare array is a **value** but not a **filter**. Prisma rejects the first line with *"Expected
+StringNullableListFilter"*, so gemi does too rather than guessing that `equals` was meant.
+
+Writes take `set` and `push`; `push` accepts one element or a list. `increment` and its siblings
+apply to a number, not to a list of them, and are refused by name.
+
+**An omitted list is written as the empty list, not refused.** A `String[]` with no `@default` is
+still not "missing" on `create` — Prisma writes `[]`, and so does gemi. That was measured against a
+generated client rather than read off the input type, which says only that the field is optional.
+
+Every element type Prisma allows is supported — `String`, `Int`, `Float`, `Boolean`, `BigInt`,
+`DateTime`, `Bytes`, `Json` and enums. `Decimal[]` is refused, because `Decimal` itself is (see
+below); a list of a scalar no dialect can round-trip is not more supportable for being a list.
+
+An enum list is worth one note: the driver hands those back as an unparsed Postgres array literal
+rather than as an array, so gemi parses them. You will not see the difference — that is the point —
+but it is why a list column costs a decode where a `String` does not.
 
 ### What a refusal tells you
 
@@ -1368,10 +1438,6 @@ if (!ormSupports(DB.dialect)) throw new Error("this deployment needs Postgres")
 
 Stated so you can plan around them rather than discover them:
 
-- **No scalar lists.** `tags String[]` is refused at *generation* time, so this one stops your build
-  rather than a query — see [Columns the generator refuses](#columns-the-generator-refuses). Prisma
-  itself refuses them on SQLite, so half the supported matrix could never have had them.
-  Pending rather than declined ([#300](https://github.com/nstfkc/gemi/issues/300)).
 - **No identity map and no unit of work.** Two queries for the same row give you two objects. Half
   an identity map is worse than none.
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
@@ -1391,6 +1457,13 @@ Stated so you can plan around them rather than discover them:
 - **No `cursor`, also deliberate.** It is only correct under a *total* ordering, which Prisma does
   not enforce — under a non-unique `orderBy` it skips or repeats rows at the page boundary. Use
   `take` with a `where` on the last row's sort key, or compose the keyset comparison with `sql`.
+- **No `Decimal`, on either dialect.** Refused at `prisma generate` rather than at query time — see
+  [Columns the generator refuses](#columns-the-generator-refuses). SQLite stores it as a REAL and
+  hands back a JS number, so the value would be a float typed as `Prisma.Decimal`. `Decimal[]` is
+  refused for the same reason.
+- **Scalar lists are Postgres-only**, which is not a gemi limit but Prisma's: SQLite rejects the
+  column at schema validation. They are otherwise fully supported — see
+  [Scalar lists](#scalar-lists-postgres-only).
 
 Both of the last two throw `UnsupportedByDesignError`, which says *"and this is a decision rather
 than a gap"* rather than *"yet"* — so a refusal you can plan around reads differently from one that

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -382,6 +382,7 @@ merely unsupported:
 
 An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
 document, which is a filter on the column rather than on a path.
+
 ### Scalar lists (Postgres only)
 
 ```ts

--- a/packages/gemi/bin/orm-generator.ts
+++ b/packages/gemi/bin/orm-generator.ts
@@ -116,12 +116,21 @@ generatorHandler({
     // A module specifier, not a path: it is written into an `import` in the
     // generated file, so it is resolved relative to `output` by whatever
     // resolves that file — the same rule as any other import.
+    // Checked for emptiness as well as for type. A Prisma generator block
+    // cannot express `undefined`, so `client = ""` is how the option gets
+    // written by someone clearing it — and it would emit
+    // `import type { Prisma } from ""`, which fails at the *importing* file
+    // rather than here, naming a generated artifact nobody edited.
     const client = options.generator.config?.client;
-    if (client !== undefined && typeof client !== "string") {
+    if (
+      client !== undefined &&
+      (typeof client !== "string" || client.trim() === "")
+    ) {
       throw new Error(
         "The gemi ORM generator's `client` option is the module specifier its " +
           "generated models type-import `Prisma` from, so it must be a single " +
-          'string — `client = "./client"`.',
+          'non-empty string — `client = "./client"`. Remove the line entirely ' +
+          "to get the default, `@prisma/client`.",
       );
     }
 

--- a/packages/gemi/bin/orm-generator.ts
+++ b/packages/gemi/bin/orm-generator.ts
@@ -102,9 +102,32 @@ generatorHandler({
     warnOnPrismaVersion(options);
     warnOnDatasource(options);
 
+    // Where the emitted `models.ts` type-imports `Prisma` from. Absent for
+    // every ordinary app, and then it is `@prisma/client`; supplied by a schema
+    // whose `generator client` writes somewhere else, where that name resolves
+    // to a different schema's types or to nothing at all.
+    //
+    //   generator gemi {
+    //     provider = "gemi-orm-generator"
+    //     output   = "../app/models/generated-lists"
+    //     client   = "./client"
+    //   }
+    //
+    // A module specifier, not a path: it is written into an `import` in the
+    // generated file, so it is resolved relative to `output` by whatever
+    // resolves that file — the same rule as any other import.
+    const client = options.generator.config?.client;
+    if (client !== undefined && typeof client !== "string") {
+      throw new Error(
+        "The gemi ORM generator's `client` option is the module specifier its " +
+          "generated models type-import `Prisma` from, so it must be a single " +
+          'string — `client = "./client"`.',
+      );
+    }
+
     // Prisma hands the DMMF over directly, so nothing here parses
     // `schema.prisma`.
-    const files = emitArtifacts(options.dmmf.datamodel.models);
+    const files = emitArtifacts(options.dmmf.datamodel.models, { client });
 
     await mkdir(output, { recursive: true });
     for (const [name, content] of Object.entries(files)) {

--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -163,7 +163,6 @@ describe("buildModelSchemas()", () => {
   // A Decimal generates cleanly and then returns the driver's raw JS number
   // typed as `Prisma.Decimal` — a wrong answer rather than an error, which is
   // the same class as the Date -> NULL binding this iteration is built around.
-  // The generator refuses it for the same reason it refuses a scalar list.
   test("refuses a Decimal field, which no dialect can round-trip yet", () => {
     expect(() =>
       buildModelSchemas([
@@ -195,13 +194,57 @@ describe("buildModelSchemas()", () => {
     ).toThrow(UnsupportedSchemaError);
   });
 
-  // Skipping it would silently change the result shape versus Prisma.
-  test("refuses a scalar list", () => {
+  // #300. This used to assert the opposite — "refuses a scalar list" — and the
+  // refusal was correct for as long as no dialect could decode an array. What
+  // moved is where the refusal lives, not whether there is one: the artifact is
+  // dialect-agnostic, so a column that is legal on Postgres and a validation
+  // error on SQLite cannot be adjudicated here. SQLite says no at compile time
+  // instead, naming itself; see `SqliteDialect.listFilters`.
+  test("describes a scalar list rather than refusing it", () => {
+    const [only] = buildModelSchemas([
+      model({ fields: [field({ name: "tags", type: "String", isList: true })] }),
+    ]);
+    expect(only.fields.tags).toMatchObject({ type: "String", isList: true });
+  });
+
+  // The flag is absent, not `false`, on everything else — which is what keeps a
+  // schema with no list generating the artifact it generated before #300, byte
+  // for byte, and is why `SCHEMA_ARTIFACT_VERSION` did not have to move.
+  test("omits isList on a scalar field", () => {
+    const [only] = buildModelSchemas([
+      model({ fields: [field({ name: "email", type: "String" })] }),
+    ]);
+    expect("isList" in only.fields.email).toBe(false);
+  });
+
+  // A list of a scalar no dialect can round-trip is not more supportable for
+  // being a list, and the error a reader gets should be the *Decimal* one —
+  // with the precision reasoning — rather than a generic list refusal.
+  test("refuses a Decimal list as a Decimal", () => {
     expect(() =>
       buildModelSchemas([
-        model({ fields: [field({ name: "tags", type: "String", isList: true })] }),
+        model({
+          fields: [field({ name: "prices", type: "Decimal", isList: true })],
+        }),
       ]),
-    ).toThrow(/scalar list/);
+    ).toThrow(/User\.prices is a Decimal/);
+  });
+
+  // An enum list keeps both facts: the element travels as a string, and the
+  // column holds many of them.
+  test("describes an enum list", () => {
+    const [only] = buildModelSchemas([
+      model({
+        fields: [
+          field({ kind: "enum", name: "roles", type: "Role", isList: true }),
+        ],
+      }),
+    ]);
+    expect(only.fields.roles).toMatchObject({
+      type: "String",
+      enum: "Role",
+      isList: true,
+    });
   });
 
   // Prisma's own client omits `Unsupported(...)` columns from its result types,

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -39,10 +39,26 @@ const SCALAR_TYPES: Record<string, ScalarType> = {
 };
 
 // Scalars the artifact can describe but no dialect can round-trip yet, mapped
-// to the reason. Refusing at generation time is the same call the `isList`
-// check below makes, and for the same reason: the alternative is a model that
-// generates cleanly and then returns a value that silently disagrees with the
-// type Prisma gave it. That is the failure mode this iteration is built around.
+// to the reason. Refusing at generation time rather than emitting the column:
+// the alternative is a model that generates cleanly and then returns a value
+// that silently disagrees with the type Prisma gave it. That is the failure
+// mode this iteration is built around.
+//
+// **A scalar list used to be refused here too, and is not any more** (#300).
+// The refusal was right for as long as no dialect could decode an array, and
+// its comment pointed at "iteration 2", which shipped without doing it. What
+// changed the answer is not that lists became decodable — it is *where* the
+// refusal belongs. A list is legal on Postgres and a validation error on
+// SQLite, but this artifact is generated once and is dialect-agnostic by
+// design: `DATABASE_URL` can name a different database than `prisma generate`
+// saw. So refusing here would refuse a column the running dialect can serve
+// perfectly well, and the honest place to say no is the dialect, at compile
+// time, naming which one — the shape `UnsupportedDialectError` already has.
+// `SqliteDialect.listFilters` is that refusal.
+//
+// `Decimal[]` is still refused, and by this table rather than by a list rule:
+// a list of a scalar no dialect can round-trip is not more supportable for
+// being a list.
 const UNSUPPORTED_SCALARS: Partial<Record<ScalarType, string>> = {
   Decimal:
     "Prisma types a Decimal field as `Prisma.Decimal`, but SQLite stores it " +
@@ -145,6 +161,18 @@ function fieldSchema(model: string, field: DMMF.Field): FieldSchema {
   // Prisma enums travel as strings on the wire, so `type` stays `"String"` and
   // the enum's identity is recorded separately for a later iteration.
   if (field.kind === "enum") schema.enum = field.type;
+
+  // A scalar list — `tags String[]`. `type` above is already the *element*
+  // type, which is the whole reason this is a flag: the generator says what the
+  // column holds and how many of them, and the dialect decides what that is in
+  // SQL. Set rather than always-emitted so a schema with no list generates the
+  // artifact it generated before this existed, byte for byte.
+  //
+  // Deliberately after the `scalarType` call above rather than before it, so a
+  // `Decimal[]` is refused as a **Decimal** — with the precision reasoning in
+  // `UNSUPPORTED_SCALARS`, which is the part a reader needs — rather than being
+  // admitted as a list of something no dialect can round-trip one of.
+  if (field.isList) schema.isList = true;
 
   const def = defaultSpec(field);
   if (def) schema.default = def;
@@ -253,14 +281,6 @@ export function buildModelSchema(
       // Prisma's own client omits `Unsupported(...)` columns from its result
       // types, so omitting them keeps our result shape identical to Prisma's.
       continue;
-    }
-    // A list of scalars is Postgres-only and needs array decoding; iteration 2
-    // handles it. Skipping silently would change the result shape, so refuse.
-    if (field.isList) {
-      throw new UnsupportedSchemaError(
-        `${model.name}.${field.name} is a scalar list, which the gemi ORM ` +
-          `does not support yet.`,
-      );
     }
     fields[field.name] = fieldSchema(model.name, field);
   }
@@ -663,10 +683,30 @@ function batchOperation(
 `;
 }
 
-export function emitModelsFile(schemas: ModelSchema[]): string {
+/**
+ * Where `models.ts` type-imports `Prisma` from.
+ *
+ * `@prisma/client` for every ordinary app, and the default is what keeps the
+ * emitted file byte-identical to what it was before this parameter existed.
+ *
+ * It is a parameter at all because a schema can generate its client somewhere
+ * else — `generator client { output = … }` — and then `@prisma/client` is not
+ * where its types live. That is not a hypothetical: it is how a repository
+ * covers a column one dialect has and the other cannot, which is exactly the
+ * position `String[]` is in (#300). One `schema.prisma` cannot carry a scalar
+ * list, because Prisma refuses the declaration outright on SQLite, so the
+ * second schema needs a second client and the artifacts generated from it have
+ * to import that one.
+ */
+const DEFAULT_CLIENT = "@prisma/client";
+
+export function emitModelsFile(
+  schemas: ModelSchema[],
+  client: string = DEFAULT_CLIENT,
+): string {
   const parts = [
     HEADER,
-    `\nimport type { Prisma } from "@prisma/client";\n`,
+    `\nimport type { Prisma } from ${JSON.stringify(client)};\n`,
     `import {
   Model,
   ScopedPolicy,
@@ -740,13 +780,19 @@ export * as schema from "./schema";
 `;
 }
 
+export interface EmitOptions {
+  /** See {@link emitModelsFile}. Defaults to `@prisma/client`. */
+  client?: string;
+}
+
 export function emitArtifacts(
   models: readonly DMMF.Model[],
+  options: EmitOptions = {},
 ): Record<GeneratedFile, string> {
   const schemas = buildModelSchemas(models);
   return {
     "schema.ts": emitSchemaFile(schemas),
-    "models.ts": emitModelsFile(schemas),
+    "models.ts": emitModelsFile(schemas, options.client),
     "index.ts": emitIndexFile(schemas),
   };
 }

--- a/packages/gemi/orm/compile/lateral.ts
+++ b/packages/gemi/orm/compile/lateral.ts
@@ -578,7 +578,13 @@ function jsonObject(
     // exact. Found by the all-scalars-through-a-relation fixture, which exists
     // because the template's schema has no BigInt behind a relation and the
     // differential matrix therefore cannot reach this.
-    const expression = field.type === "BigInt" ? `${column}::text` : column;
+    //
+    // `::text[]` for a `BigInt[]`, and the measurement is the same one: a
+    // `bigint[]` rendered into JSON is an array of JSON numbers, and
+    // 9007199254740993 came back as ...992 element-wise. The array form of the
+    // same trap, and it needs the array form of the same cast.
+    const expression =
+      field.type === "BigInt" ? `${column}::text${field.isList ? "[]" : ""}` : column;
     return `'${field.name}', ${expression}`;
   });
 
@@ -653,8 +659,35 @@ function buildDecoder(
 /**
  * How one field's JSON form becomes its JavaScript form, or `undefined` when JSON
  * already carries it faithfully (`Int`, `String`, `Boolean`, `Float`, `Json`).
+ *
+ * A **scalar list** is the element's own converter mapped over a JSON array,
+ * which is exactly right and is worth saying because the alternative is
+ * tempting: `PostgresDialect.decode` is *not* reusable here. Its whole job is
+ * normalising the containers Bun's driver produces — an `Int32Array`, an
+ * unparsed `{a,b}` literal — and none of them exist on this path. `json_agg`
+ * hands over a JSON array whatever the element type, including for the enum
+ * lists the driver refuses to parse. Two decoding sites, two container
+ * problems, one shared per-element rule.
  */
 function jsonConverter(
+  field: FieldSchema,
+): ((value: unknown) => unknown) | undefined {
+  if (field.isList) {
+    const element = elementConverter(field);
+    if (!element) return undefined;
+    return (value) => {
+      if (value === null || value === undefined) return null;
+      if (!Array.isArray(value)) return value;
+      return value.map((item) =>
+        item === null || item === undefined ? null : element(item),
+      );
+    };
+  }
+
+  return elementConverter(field);
+}
+
+function elementConverter(
   field: FieldSchema,
 ): ((value: unknown) => unknown) | undefined {
   switch (field.type) {

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -1587,6 +1587,18 @@ function assertKeyable(
   relation: RelationSchema,
   key: FieldSchema,
 ): void {
+  // A scalar list is refused for the identical reason, and the element type is
+  // a red herring: a `String[]` decodes to a fresh *array* per row, so `keyOf`
+  // compares two references that are never equal — as unusable a key as a
+  // `Json`, even though `String` is the most keyable scalar there is.
+  if (key.isList) {
+    throw new MalformedRelationError(
+      schema.name,
+      relation.name,
+      `it joins on '${key.name}', a ${key.type} list — which decodes to a new ` +
+        `array per row and so cannot be compared between the two sides.`,
+    );
+  }
   if (key.type !== "Json") return;
   throw new MalformedRelationError(
     schema.name,

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -665,6 +665,256 @@ function assertCompositeInOperand(
   return fields;
 }
 
+/**
+ * The filters Prisma applies to a **scalar list** — `tags String[]`.
+ *
+ * A different set on a different left-hand side, which is why it is a branch
+ * rather than four more entries in `OPERATORS`: `contains` on a `String` asks
+ * about a substring, and on a `String[]` there is no such question — the one
+ * Prisma spells is `has`. Sharing the table would have made every scalar
+ * operator compile against an array column and answer something.
+ */
+const LIST_FILTERS = new Set([
+  "equals",
+  "has",
+  "hasEvery",
+  "hasSome",
+  "isEmpty",
+]);
+
+/**
+ * `where: { tags: { has: "urgent" } }`.
+ *
+ * **The dialect answers first**, before any operand is looked at, because on
+ * SQLite the answer is "not this column, on this database, ever" rather than
+ * "not this filter". That refusal used to live in the generator (#300) and
+ * could not stay there: the generated artifact is dialect-agnostic on purpose,
+ * so refusing a scalar list at generation refused it for Postgres too — and
+ * refused the *whole artifact*, since one `String[]` anywhere threw before any
+ * model was emitted.
+ */
+function compileListFilter(
+  schema: ModelSchema,
+  field: FieldSchema,
+  column: string,
+  value: unknown,
+  context: WhereContext,
+  locate: (args: any) => any,
+): Fragment {
+  const { dialect } = context;
+  assertListDialect(schema, field, `where.${field.name}`, context.operation, dialect);
+
+  // **A bare array is not shorthand for `equals` here**, and that is the one
+  // place a list deliberately reads differently from a scalar — where
+  // `{ email: "a@b" }` means `equals`, `{ tags: ["a"] }` means nothing.
+  //
+  // Not a judgement call: Prisma refuses it, measured against a generated 6.19
+  // client — *"Argument `strings`: Invalid value provided. Expected
+  // StringNullableListFilter, provided (String)."* Accepting it would make gemi
+  // a silent superset of Prisma on the one dialect where a differential test
+  // could otherwise check every other answer, which is the trade this project
+  // has declined every time it has come up.
+  //
+  // The asymmetry that surprises: the same bare array *is* accepted as a
+  // **write** value — `data: { tags: ["a"] }` is valid Prisma and valid here.
+  // Filter and value are different positions and Prisma treats them
+  // differently; so does this.
+  if (Array.isArray(value)) {
+    throw new InvalidArgumentError(
+      `where.${field.name}`,
+      schema.name,
+      context.operation,
+      `'${field.name}' is a scalar list, and a bare array is not a filter on ` +
+        `one — Prisma rejects it here too. Say which comparison you mean: ` +
+        `{ ${field.name}: { equals: [...] } } for the whole list, or ` +
+        `{ ${field.name}: { hasEvery: [...] } } for "contains all of these". ` +
+        `A bare array *is* accepted as a value in \`data\`.`,
+    );
+  }
+
+  if (!isFilterObject(value)) {
+    throw new InvalidArgumentError(
+      `where.${field.name}`,
+      schema.name,
+      context.operation,
+      `'${field.name}' is a scalar list. Expected an object holding ` +
+        `${[...LIST_FILTERS].sort().join(", ")}; received ` +
+        `${value === null ? "null" : typeof value}.`,
+    );
+  }
+
+  const filter = value as Record<string, unknown>;
+  const parts: Fragment[] = [];
+
+  // Sorted, for the reason `compileWhere` sorts: the plan cache canonicalises
+  // key order, so two objects differing only in it must compile alike.
+  for (const key of Object.keys(filter).sort()) {
+    const operand = filter[key];
+    if (operand === undefined) continue;
+
+    if (!LIST_FILTERS.has(key)) {
+      throw new InvalidArgumentError(
+        `where.${field.name}.${key}`,
+        schema.name,
+        context.operation,
+        `'${field.name}' is a scalar list, and a list filter takes ` +
+          `${[...LIST_FILTERS].sort().join(", ")}. The scalar operators — ` +
+          `${[...OPERATORS].sort().join(", ")} — apply to a single value and ` +
+          `Prisma does not offer them here.`,
+      );
+    }
+
+    const at = (args: any) => locate(args)?.[key];
+    parts.push(listComparison(schema, field, column, key, operand, context, at));
+  }
+
+  // An empty filter object constrains nothing, which is what the scalar path
+  // does with `{}` too.
+  if (parts.length === 0) return sql("true");
+  if (parts.length === 1) return parts[0];
+  return group(parts, " and ");
+}
+
+/** One list filter key. */
+function listComparison(
+  schema: ModelSchema,
+  field: FieldSchema,
+  column: string,
+  key: string,
+  operand: unknown,
+  context: WhereContext,
+  locate: (args: any) => any,
+): Fragment {
+  const { dialect } = context;
+
+  if (key === "equals") {
+    return listEquals(schema, field, column, operand, context, locate);
+  }
+
+  if (key === "isEmpty") {
+    if (typeof operand !== "boolean") {
+      throw new InvalidArgumentError(
+        `where.${field.name}.isEmpty`,
+        schema.name,
+        context.operation,
+        `Expected true or false, received ${operand === null ? "null" : typeof operand}.`,
+      );
+    }
+    return dialect.listIsEmpty(column, operand);
+  }
+
+  if (key === "has") {
+    // One **element**, so it binds as one — through the element's own field, so
+    // a `Json[]` gets #209's `::text::jsonb` on the placeholder and the
+    // serialisation that has to travel with it. Binding it as a list instead
+    // would produce an array literal on the left of `= any(...)`, and binding
+    // it with no cast answers *false* on a `Json[]` rather than raising.
+    const element = elementOf(field);
+    return dialect.listHas(
+      column,
+      fieldParam(element, dialect, encoded(element, dialect, locate)),
+    );
+  }
+
+  // `hasEvery` / `hasSome` — both take a list, and both have a defined answer
+  // for an empty one: `@> '{}'` is true of every row and `&& '{}'` of none,
+  // which is what Prisma means by "contains all of nothing" and "shares one
+  // element with nothing".
+  if (!Array.isArray(operand)) {
+    throw new InvalidArgumentError(
+      `where.${field.name}.${key}`,
+      schema.name,
+      context.operation,
+      `Expected an array, received ${operand === null ? "null" : typeof operand}.`,
+    );
+  }
+
+  const values = fieldParam(field, dialect, encoded(field, dialect, locate));
+  return key === "hasEvery"
+    ? dialect.listHasEvery(column, values)
+    : dialect.listHasSome(column, values);
+}
+
+/** `"tags" = $1` — whole-list equality, which is order-sensitive in SQL. */
+function listEquals(
+  schema: ModelSchema,
+  field: FieldSchema,
+  column: string,
+  operand: unknown,
+  context: WhereContext,
+  locate: (args: any) => any,
+): Fragment {
+  const { dialect } = context;
+
+  // A list column cannot be null in Prisma — `String[]?` is refused at schema
+  // validation — but `equals: null` is still in the generated filter type, and
+  // a column written by something other than Prisma can hold NULL. Same
+  // reading as everywhere else: `= NULL` matches nothing, `is null` is meant.
+  if (operand === null) return sql(`${column} is null`);
+
+  if (!Array.isArray(operand)) {
+    throw new InvalidArgumentError(
+      `where.${field.name}.equals`,
+      schema.name,
+      context.operation,
+      `'${field.name}' is a scalar list, so it compares against an array. ` +
+        `Received ${typeof operand}. For "is this element present", use ` +
+        `{ ${field.name}: { has: … } }.`,
+    );
+  }
+
+  return concat(
+    sql(`${column} = `),
+    fieldParam(field, dialect, encoded(field, dialect, locate)),
+  );
+}
+
+/**
+ * The same field, seen as **one element of itself**.
+ *
+ * `type` already carries the element type — that is the whole reason `isList`
+ * is a flag beside it rather than a `ScalarType` constructor — so dropping the
+ * flag is the entire conversion, and `encode`, `decode` and `castParameter` all
+ * read it as the scalar they were written for.
+ */
+function elementOf(field: FieldSchema): FieldSchema {
+  return { ...field, isList: false };
+}
+
+/**
+ * Refuses a scalar list on a dialect that has no array type, naming it.
+ *
+ * Shared by the read and write paths, and it says more than "unsupported"
+ * because the reader's likeliest next question is whether they did something
+ * wrong. They did not: Prisma refuses the *column* on SQLite, so a schema that
+ * declares one was generated against Postgres and this process is pointed at a
+ * database that could not hold it either.
+ */
+export function assertListDialect(
+  schema: ModelSchema,
+  field: FieldSchema,
+  argument: string,
+  operation: string,
+  dialect: SqlDialect,
+): void {
+  if (dialect.listFilters.size > 0) return;
+
+  throw new UnsupportedQueryError(
+    argument,
+    schema.name,
+    operation,
+    `'${field.name}' is a scalar list, and ${dialect.name} has no array type ` +
+      `to hold one. Prisma refuses the column itself on ${dialect.name} — ` +
+      `"the current connector does not support lists of primitive types" — so ` +
+      `this is a difference between the databases rather than a gap in the ` +
+      `ORM. The generated artifact is dialect-agnostic, which is why this ` +
+      `surfaces here rather than at \`prisma generate\`: the schema was ` +
+      `generated against Postgres and DATABASE_URL names a ${dialect.name} ` +
+      `database, which has no '${field.column}' column either. It works on ` +
+      `postgres.`,
+  );
+}
+
 /** The filters Prisma applies to a value extracted from a JSON path. */
 const JSON_FILTERS = new Set([
   "equals",
@@ -1045,6 +1295,16 @@ function compileFieldFilter(
         `its own — Prisma rejects it here too. Write it as an explicit ` +
         `comparison: { ${field.name}: { equals: ${sentinelName(sentinel)} } }.`,
     );
+  }
+
+  // A scalar list takes a different operator set on a different left-hand side,
+  // so the whole operand belongs to that branch — the same shape the `path`
+  // check below has for a JSON document. Placed *above* the bare-value
+  // shorthand because on a list the bare form is an **array**, which
+  // `isFilterObject` reports as a value and would send to the scalar `equals`
+  // with no dialect check and no operand validation.
+  if (field.isList) {
+    return compileListFilter(schema, field, column, value, context, locate);
   }
 
   // A bare value is shorthand for `equals`. A `Date` is a value, not a filter

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -377,7 +377,14 @@ function createManyColumns(
     // exists because a single `VALUES` list cannot ask for a database default
     // per row. A list needs no default asked for: `{}` is a value, so the rows
     // that omitted it get one written rather than needing the statement split.
-    if (field.isList) continue;
+    //
+    // `suppliesEmptyList` rather than `field.isList`, which is the whole of the
+    // distinction: this stands in for a list that has **nothing else** to fall
+    // back on. A list with a *database-side* default still cannot be expressed
+    // per row, so it falls through to the refusal below rather than silently
+    // acquiring `{}` — and one with a client-side default never reaches here,
+    // because `hasClientSideValue` answered above.
+    if (suppliesEmptyList(field)) continue;
 
     // A database-side default that only some rows override. `NULL` would
     // *overwrite* the default rather than request it, and SQLite has no
@@ -410,12 +417,35 @@ function createManyColumns(
   return rows.map((row, index) =>
     union.map((field) => {
       if (!supplied[index].has(field.name)) {
+        // **`suppliesEmptyList`, not `field.isList`**, and the difference is a
+        // row that comes out wrong rather than a statement that fails.
+        //
+        // `@default([])` and `@default(["seed"])` are *client-side* defaults —
+        // `kind: "value"`, which `isClientSideDefault` admits — so `create`
+        // binds the declared value through `defaultBinder`. Asking `isList`
+        // here put `{}` ahead of that, so one `createMany` row omitting a
+        // defaulted list wrote the empty array where `create` wrote the
+        // default, and where Prisma writes the default — so `create` and
+        // `createMany` disagreed about one schema, silently, in the row.
+        //
+        // Invisible to the differential until the fixture changed: the template
+        // declared `@default([])`, where the correct value and the wrong one are
+        // the same array. It now declares a non-empty default, and the
+        // `createMany` case supplies it on one row and omits it on the other.
         return {
           field,
-          value: field.isList
+          value: suppliesEmptyList(field)
             ? emptyList(field, dialect)
             : defaultBinder(field, dialect),
         };
+      }
+
+      if (field.isList) {
+        // Compile-time, like `insertColumns` and `assignment` — this was the
+        // one write path that let a bad operand reach the binder. `["set"]`
+        // because an insert takes no `push`, and a refusal naming `push` on the
+        // operation where it is never legal is a puzzle rather than a next step.
+        assertListOperand(schema, field, (row as any)?.[field.name], op, ["set"]);
       }
 
       // Per row, because two rows of one `createMany` may legitimately spell
@@ -1065,6 +1095,14 @@ function insertColumns(
     // describe the *input type* — where the field is optional — and say nothing
     // about what is written when it is absent.
     if (field.isList) {
+      // Asked *here* as well as on the supplied path above, because this branch
+      // invents a value the caller never wrote — and an unasked dialect is how
+      // `create({ data: { id: 1 } })` on SQLite compiled a statement binding
+      // raw JS arrays for the driver to reject with a type error, where naming
+      // the column would have said "sqlite has no array type … It works on
+      // postgres". The check belongs to the *column*, not to the caller
+      // mentioning it.
+      assertListDialect(schema, field, `data.${field.name}`, op, dialect);
       columns.push({ field, value: emptyList(field, dialect) });
       continue;
     }

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -31,7 +31,7 @@ import { planRelations, strategiesOf } from "./plan-relations";
 import { type CountPlan, planRelationCounts } from "./relation-count";
 import { resolveSelection, withKeyFields } from "./select";
 import { matchUniqueKey } from "./unique";
-import { compileWhere } from "./where";
+import { assertListDialect, compileWhere } from "./where";
 
 /**
  * The write surface: `create`, `createMany`, `update`, `updateMany`, `delete`,
@@ -361,7 +361,9 @@ function createManyColumns(
   const union: FieldSchema[] = [];
   for (const field of Object.values(schema.fields)) {
     const inSome = supplied.some((keys) => keys.has(field.name));
-    if (inSome || hasClientSideValue(field)) union.push(field);
+    if (inSome || hasClientSideValue(field) || suppliesEmptyList(field)) {
+      union.push(field);
+    }
   }
 
   for (const field of union) {
@@ -370,6 +372,12 @@ function createManyColumns(
 
     if (hasClientSideValue(field)) continue;
     if (field.nullable) continue;
+    // The empty list stands in for an absent one — see `insertColumns`. It also
+    // resolves the "some rows set it and others do not" refusal below, which
+    // exists because a single `VALUES` list cannot ask for a database default
+    // per row. A list needs no default asked for: `{}` is a value, so the rows
+    // that omitted it get one written rather than needing the statement split.
+    if (field.isList) continue;
 
     // A database-side default that only some rows override. `NULL` would
     // *overwrite* the default rather than request it, and SQLite has no
@@ -393,15 +401,37 @@ function createManyColumns(
     );
   }
 
-  return rows.map((_row, index) =>
-    union.map((field) => ({
-      field,
-      value: supplied[index].has(field.name)
-        ? valueBinder(schema, op, field, dialect, (callArgs) =>
-            listOf(callArgs?.data)[index]?.[field.name],
-          )
-        : defaultBinder(field, dialect),
-    })),
+  for (const field of union) {
+    if (field.isList) {
+      assertListDialect(schema, field, `data.${field.name}`, op, dialect);
+    }
+  }
+
+  return rows.map((row, index) =>
+    union.map((field) => {
+      if (!supplied[index].has(field.name)) {
+        return {
+          field,
+          value: field.isList
+            ? emptyList(field, dialect)
+            : defaultBinder(field, dialect),
+        };
+      }
+
+      // Per row, because two rows of one `createMany` may legitimately spell
+      // the same list differently — `["a"]` and `{ set: ["a"] }`. The plan key
+      // records the whole `data` array's shape, so the two are already
+      // different entries and this stays a compile-time decision.
+      const setForm = isListSetOperand(field, (row as any)?.[field.name]);
+
+      return {
+        field,
+        value: valueBinder(schema, op, field, dialect, (callArgs) => {
+          const value = listOf(callArgs?.data)[index]?.[field.name];
+          return setForm ? value?.set : value;
+        }),
+      };
+    }),
   );
 }
 
@@ -989,11 +1019,25 @@ function insertColumns(
     }
 
     if (supplied.has(field.name)) {
+      if (field.isList) {
+        assertListDialect(schema, field, `data.${field.name}`, op, dialect);
+        assertListOperand(schema, field, (data as any)?.[field.name], op, ["set"]);
+      }
+
+      // `{ tags: { set: [...] } }` is what Prisma documents for a list, and it
+      // is accepted in `create` as well as in `update` — where a bare array is
+      // also accepted, and means the same thing. Unwrapped at *compile* time
+      // rather than in the binder because the two spellings are two argument
+      // shapes and so already two plan-cache entries; deciding it here keeps
+      // the binder a pure function of the value it is handed.
+      const setForm = isListSetOperand(field, (data as any)?.[field.name]);
+
       columns.push({
         field,
-        value: valueBinder(schema, op, field, dialect, (args) =>
-          locateData(args)?.[field.name],
-        ),
+        value: valueBinder(schema, op, field, dialect, (args) => {
+          const value = locateData(args)?.[field.name];
+          return setForm ? value?.set : value;
+        }),
       });
       continue;
     }
@@ -1007,10 +1051,104 @@ function insertColumns(
     // its own default or as NULL.
     if (field.default || field.nullable) continue;
 
+    // **A scalar list is never missing**, whatever the schema says about
+    // required-ness. Measured against a generated 6.19 client: `create({ data:
+    // { id: 900 } })` on a model whose every list is `NOT NULL` with no
+    // `@default` succeeds, and every one of them reads back as `[]`. So Prisma
+    // treats "no value" as the empty list rather than as an omission, and a
+    // column with no database default gives it no choice — leaving the column
+    // out would violate the NOT NULL constraint.
+    //
+    // This was a `MissingRequiredValueError` until the differential harness ran:
+    // four `create` cases refused a call Prisma answers. It is exactly the kind
+    // of divergence no amount of reading the docs produces, because the docs
+    // describe the *input type* — where the field is optional — and say nothing
+    // about what is written when it is absent.
+    if (field.isList) {
+      columns.push({ field, value: emptyList(field, dialect) });
+      continue;
+    }
+
     throw new MissingRequiredValueError(schema.name, op, field.name);
   }
 
   return columns;
+}
+
+/**
+ * Refuses an operator map a scalar list does not take — `{ increment: 1 }` —
+ * at **compile** time.
+ *
+ * The value-shaped refusal in `valueBinder` would eventually catch it, and too
+ * late: `isOperatorObject` answers false for an operator a list does not have,
+ * so `{ counts: { increment: 1 } }` was read as a *value* and travelled all the
+ * way to the binder before anything objected. Compile is a pure function of the
+ * argument shape and this is a shape question, so it belongs here — the same
+ * call `assertCompositeInOperand` records making for the same reason.
+ *
+ * Note this is unambiguous even for a `Json[]`, where an object is a plausible
+ * element: the column's value is an *array*, so a bare object in this position
+ * is never data. `isOperatorObject` relies on the same fact.
+ */
+function assertListOperand(
+  schema: ModelSchema,
+  field: FieldSchema,
+  value: unknown,
+  op: Operation,
+  /**
+   * The operators legal in *this* position. An insert takes `set` only —
+   * Prisma's create input for a list is `T[] | { set: T[] }`, with no `push`,
+   * and there is nothing for a `push` to append to on a row that does not exist
+   * yet.
+   */
+  allowed: readonly string[],
+): void {
+  if (!field.isList) return;
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    value instanceof Date ||
+    ArrayBuffer.isView(value)
+  ) {
+    return;
+  }
+
+  const given = Object.keys(value as Record<string, unknown>).filter(
+    (key) => (value as Record<string, unknown>)[key] !== undefined,
+  );
+  if (given.length === 1 && allowed.includes(given[0])) return;
+
+  throw new UnsupportedQueryError(
+    `data.${field.name}`,
+    schema.name,
+    op,
+    `'${field.name}' is a scalar list, so it takes ${allowed.join(" or ")} — ` +
+      `or a bare array. Received ${
+        given.length === 0 ? "an empty object" : `{ ${given.join(", ")} }`
+      }. The arithmetic operators apply to a number, not to a list of them.`,
+  );
+}
+
+/**
+ * `{ set: [...] }` on a scalar list, which is the spelling Prisma documents and
+ * which an insert accepts as readily as an update.
+ *
+ * Unambiguous in a way the scalar `Json` case is not — see `isOperatorObject` —
+ * because a list column's data form is always an array, so an object here can
+ * only be the operator.
+ */
+function isListSetOperand(field: FieldSchema, value: unknown): boolean {
+  return (
+    field.isList === true &&
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date) &&
+    !ArrayBuffer.isView(value) &&
+    Object.keys(value).length === 1 &&
+    "set" in value
+  );
 }
 
 /** The scalar fields a `data` object actually sets, validated against the schema. */
@@ -1157,6 +1295,11 @@ function updateAssignments(
  * Prisma's update operators. `set` is the explicit spelling of a plain
  * assignment; the arithmetic four read the column and write it back, so they
  * are the one place a column name appears on the right of an `=`.
+ *
+ * `push` is the sixth and belongs to scalar lists only, so it lives beside them
+ * rather than here — see {@link listOperators}. Keeping it out of this table is
+ * what makes `{ tags: { increment: 1 } }` and `{ count: { push: 1 } }` both
+ * errors that name the field's kind, rather than one of them compiling.
  */
 const ARITHMETIC: Record<string, string> = {
   increment: "+",
@@ -1164,6 +1307,13 @@ const ARITHMETIC: Record<string, string> = {
   multiply: "*",
   divide: "/",
 };
+
+/** The update operators a scalar list takes: `set` and `push`, and nothing else. */
+const LIST_OPERATORS = ["set", "push"] as const;
+
+function listOperators(field: FieldSchema): readonly string[] {
+  return field.isList ? LIST_OPERATORS : ["set", ...Object.keys(ARITHMETIC)];
+}
 
 function assignment(
   schema: ModelSchema,
@@ -1179,6 +1329,11 @@ function assignment(
 ): Fragment {
   const value = (data as Record<string, unknown>)[field.name];
 
+  if (field.isList) {
+    assertListDialect(schema, field, `data.${field.name}`, op, dialect);
+    assertListOperand(schema, field, value, op, LIST_OPERATORS);
+  }
+
   if (isOperatorObject(value, field)) {
     const keys = Object.keys(value as Record<string, unknown>).filter(
       (key) => (value as Record<string, unknown>)[key] !== undefined,
@@ -1189,7 +1344,7 @@ function assignment(
         `data.${field.name}`,
         schema.name,
         op,
-        `Expected exactly one of ${["set", ...Object.keys(ARITHMETIC)].join(", ")}.`,
+        `Expected exactly one of ${listOperators(field).join(", ")}.`,
       );
     }
 
@@ -1200,6 +1355,32 @@ function assignment(
       return concat(
         sql(`${column} = `),
         fieldParam(field, dialect, valueBinder(schema, op, field, dialect, at)),
+      );
+    }
+
+    if (key === "push") {
+      // `array_cat(<column>, $1)` — the column on the right of an `=`, like the
+      // arithmetic four below, and for the same reason: the new value is a
+      // function of the old one.
+      //
+      // The operand is normalised to a list **at bind time**, because Prisma
+      // accepts both `push: "a"` and `push: ["a", "b"]` and the two are the
+      // same statement. That normalisation is also what lets the dialect use a
+      // single-signature function: `||` would read the two spellings as
+      // different operators — see `PostgresDialect.listPush`.
+      return concat(
+        sql(`${column} = `),
+        dialect.listPush(
+          source,
+          fieldParam(
+            field,
+            dialect,
+            valueBinder(schema, op, field, dialect, (args) => {
+              const supplied = at(args);
+              return Array.isArray(supplied) ? supplied : [supplied];
+            }),
+          ),
+        ),
       );
     }
 
@@ -1223,6 +1404,14 @@ function assignment(
  * Prisma resolves the ambiguity through its types; we resolve it by treating a
  * Json column's object as data, which is the reading that never loses the
  * caller's value.
+ *
+ * **A `Json[]` is not excluded**, and the exclusion above is why: the ambiguity
+ * it exists for cannot arise on a list. A `Json` column can legitimately hold
+ * the object `{ set: 1 }`; a `Json[]` column holds an *array*, so an object
+ * operand is never data there and reading it as an operator loses nothing.
+ * Without this the one spelling Prisma documents for writing a list —
+ * `{ tags: { set: [...] } }` — would have been stored as a single JSON object
+ * on exactly the element type where that is a plausible-looking value.
  */
 function isOperatorObject(value: unknown, field: FieldSchema): boolean {
   if (
@@ -1231,14 +1420,15 @@ function isOperatorObject(value: unknown, field: FieldSchema): boolean {
     Array.isArray(value) ||
     value instanceof Date ||
     ArrayBuffer.isView(value) ||
-    field.type === "Json"
+    (field.type === "Json" && !field.isList)
   ) {
     return false;
   }
 
+  const operators = listOperators(field);
   const keys = Object.keys(value as Record<string, unknown>);
   if (keys.length === 0) return false;
-  return keys.every((key) => key === "set" || key in ARITHMETIC);
+  return keys.every((key) => operators.includes(key));
 }
 
 /**
@@ -1280,8 +1470,52 @@ function valueBinder(
       );
     }
 
+    // A list operand is checked here rather than left to `encode`, for the
+    // reason this whole function exists: the dialect has the value and nothing
+    // else, so its refusal can only report an ORM bug. The schema and operation
+    // are closed over here, so this one says which field of which model.
+    if (field.isList && value !== null && value !== undefined) {
+      if (!Array.isArray(value)) {
+        throw new InvalidArgumentError(
+          `data.${field.name}`,
+          schema.name,
+          op,
+          `'${field.name}' is a scalar list, so it takes an array — or ` +
+            `{ set: [...] } / { push: … }. Received ${typeof value}.`,
+        );
+      }
+      if (value.some((element) => jsonNullKind(element) === "any")) {
+        throw new InvalidArgumentError(
+          `data.${field.name}`,
+          schema.name,
+          op,
+          `Prisma.AnyNull is a filter operand, not a value, and that does not ` +
+            `change for being inside a list.`,
+        );
+      }
+    }
+
     return dialect.encode(value, field);
   };
+}
+
+/**
+ * `{}` for a scalar list nobody supplied — what Prisma writes, measured rather
+ * than assumed. See the note in `insertColumns`.
+ */
+function emptyList(field: FieldSchema, dialect: SqlDialect): Binder {
+  return () => dialect.encode([], field);
+}
+
+/**
+ * Whether an absent value for this field means "write the empty list" — a
+ * scalar list with no database default of its own to fall back to.
+ *
+ * A list *with* a default stays out of the statement so the default fires,
+ * which is the same rule every other field follows and produces the same rows.
+ */
+function suppliesEmptyList(field: FieldSchema): boolean {
+  return field.isList === true && !field.default && !field.nullable;
 }
 
 function defaultBinder(field: FieldSchema, dialect: SqlDialect): Binder {

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -195,6 +195,68 @@ export interface SqlDialect {
   ): Fragment;
 
   /**
+   * The filters this dialect can apply to a **scalar list** — `tags String[]`.
+   *
+   * **Empty is the whole of SQLite's answer**, and it is a capability rather
+   * than a gap in this ORM: SQLite has no array type, and Prisma refuses the
+   * declaration there at validation time — *"Field `tags` in model `User` can't
+   * be a list. The current connector does not support lists of primitive
+   * types."* So a SQLite database cannot hold such a column to begin with.
+   *
+   * The refusal lives here rather than in the generator, which is where it used
+   * to live (#300). The generated artifact is dialect-agnostic on purpose —
+   * `DATABASE_URL` can name a different database than `prisma generate` saw —
+   * so a generator that refused a scalar list refused it for Postgres too, and
+   * one `String[]` anywhere meant no artifact for *any* model. Asking the
+   * dialect at compile time refuses exactly the combination that cannot work,
+   * and names it, which is the shape {@link UnsupportedDialectError} already
+   * has for the dialects with no compiler at all.
+   */
+  readonly listFilters: ReadonlySet<string>;
+
+  /**
+   * `<value> = any(<column>)` — is this element in the list?
+   *
+   * The mirror of {@link inList} rather than a variant of it, and the two are
+   * easy to confuse: there, one column is matched against a caller's list;
+   * here, one caller value is matched against a column that *is* a list.
+   *
+   * **These four take a `Fragment` where every other member here takes a
+   * `Binder`**, which is a deliberate exception. A list operand may need a cast
+   * on its placeholder — a single element of a `Json[]` needs #209's
+   * `::text::jsonb`, and the serialisation that must travel with it — so the
+   * parameter is built by `fieldParam` before it arrives and the dialect
+   * chooses only the operator. Handing over a `Binder` instead would oblige
+   * each dialect to restate `fieldParam`'s rule, and restating it slightly
+   * wrong is silent: `$1::jsonb = any(col)` answers *false* where
+   * `$1::text::jsonb = any(col)` answers true, with no error on either.
+   */
+  listHas(column: string, value: Fragment): Fragment;
+
+  /** `hasEvery` — every element of the operand is present in the column. */
+  listHasEvery(column: string, values: Fragment): Fragment;
+
+  /** `hasSome` — the column and the operand share at least one element. */
+  listHasSome(column: string, values: Fragment): Fragment;
+
+  /**
+   * `isEmpty: true`, or its negation when `empty` is false.
+   *
+   * The odd one out with no operand at all: the value being compared against is
+   * the empty list, which is the compiler's own constant rather than the
+   * caller's. It stays a bound parameter regardless — see `jsonNullComparison`,
+   * which declines the same exception for the same reason.
+   */
+  listIsEmpty(column: string, empty: boolean): Fragment;
+
+  /**
+   * The right-hand side of a `push`: the column's current value with the
+   * operand appended. An expression rather than a statement, because it is
+   * assigned by the write compiler like any other `set` value.
+   */
+  listPush(column: string, values: Fragment): Fragment;
+
+  /**
    * How this dialect spells a JSON path, and which filters it can apply to one.
    *
    * The **path grammar itself differs**, which is unusual enough to be worth

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -148,6 +148,101 @@ export class PostgresDialect implements SqlDialect {
     );
   }
 
+  /**
+   * Everything Prisma exposes on a scalar list, because `text[]` can express
+   * all of it (#300).
+   *
+   * `equals` is in the set even though it is compiled by the generic `equals`
+   * path rather than by a method here: the set is what the compiler consults to
+   * decide whether a list filter is *available at all*, and leaving it out
+   * would make `{ tags: ["a"] }` — the bare-array shorthand — refuse itself on
+   * the one dialect that can serve it.
+   */
+  readonly listFilters: ReadonlySet<string> = new Set([
+    "equals",
+    "has",
+    "hasEvery",
+    "hasSome",
+    "isEmpty",
+  ]);
+
+  /**
+   * `$1 = any("tags")` — the element on the left, which is the mirror of
+   * {@link inList} and worth not confusing with it. There, one column is
+   * matched against a caller's list; here, one caller value is matched against
+   * a column that *is* a list.
+   *
+   * No cast is added *here*, in this method or the three below. An untyped
+   * array literal resolves against the column's own element type in every one
+   * of these positions — measured through Bun 1.3.14 against Postgres 16 on
+   * `text[]`, `jsonb[]`, `bytea[]`, `timestamp(3)[]` and an `enum[]`. That is
+   * not merely convenient: an explicit cast would have to *name* the element
+   * type, and for an enum that name is the database's own enum type, which the
+   * generated artifact does not carry. Leaning on inference is what lets enum
+   * lists work without widening the artifact.
+   *
+   * **The operand is a `Fragment`, not a `Binder`**, and `Json` is why. A
+   * single element of a `Json[]` still needs #209's `::text::jsonb`, and it
+   * needs the serialisation that travels with it — so the parameter is built by
+   * `fieldParam` before it gets here, and this method only picks the operator.
+   * Measured, because every wrong form fails *silently*:
+   *
+   *   $1 = any(docs)                {"a":1}   ->  false
+   *   $1::jsonb = any(docs)         {"a":1}   ->  false
+   *   $1::text::jsonb = any(docs)   {"a":1}   ->  true
+   *
+   * No error on either of the first two. A dialect that built its own parameter
+   * here would have to restate `fieldParam`'s rule, and the version that
+   * restated it slightly wrong would return "no rows" rather than raising.
+   */
+  listHas(column: string, value: Fragment): Fragment {
+    return concat(value, sql(` = any(${column})`));
+  }
+
+  /** `"tags" @> $1` — containment: every element of the operand is present. */
+  listHasEvery(column: string, values: Fragment): Fragment {
+    return concat(sql(`${column} @> `), values);
+  }
+
+  /** `"tags" && $1` — overlap: at least one element is shared. */
+  listHasSome(column: string, values: Fragment): Fragment {
+    return concat(sql(`${column} && `), values);
+  }
+
+  /**
+   * `"tags" = $1` against the empty array, rather than `cardinality(…) = 0`.
+   *
+   * The two are equivalent on a non-null column — and a scalar list cannot be
+   * null, since Prisma refuses `String[]?` — including on the NULL case, where
+   * both yield NULL and so exclude the row.
+   *
+   * The comparison is the one that keeps the invariant `FALSE` is spelled
+   * `false` for: **no digit reaches the SQL text outside an identifier**. A
+   * literal `0` would be the first, for a constant the compiler already knows —
+   * which is exactly the exception `jsonNullComparison` declines to make.
+   */
+  listIsEmpty(column: string, empty: boolean): Fragment {
+    return concat(
+      sql(`${column} ${empty ? "=" : "<>"} `),
+      param(() => arrayLiteral([])),
+    );
+  }
+
+  /**
+   * `array_cat("tags", $1)` — the right-hand side of a `push`.
+   *
+   * **`array_cat` rather than `||`**, and the difference is not stylistic.
+   * `||` is overloaded `anyarray || anyarray` *and* `anyarray || anyelement`,
+   * so an untyped parameter beside it is genuinely ambiguous — and Prisma's
+   * `push` accepts both a single element and a list, which is precisely the
+   * pair that would resolve differently. `array_cat` has one signature, so the
+   * compiler can normalise `push` to an array once and the operator cannot be
+   * read the other way.
+   */
+  listPush(column: string, values: Fragment): Fragment {
+    return concat(sql(`array_cat(${column}, `), values, sql(")"));
+  }
+
   /** `path: ["a", "b"]`, where SQLite takes `"$.a.b"`. Prisma's own split. */
   readonly jsonPathSyntax = "array" as const;
 
@@ -302,22 +397,62 @@ export class PostgresDialect implements SqlDialect {
     return { kind: "unique", columns, constraint };
   }
 
-  // Every type binds natively here, including `Json`, so nothing in the body
-  // reads `field` any more — the signature is the interface's, the disuse is
-  // this dialect's. `Date`, `boolean`, `bigint` and arrays are Bun's to
-  // serialize, and so, it turns out, is JSON.
-  // `$1::text::jsonb` for a `Json` column, and nothing for anything else.
+  // `$1::text::jsonb` for a `Json` column, nothing for a scalar list, and
+  // nothing for anything else. A scalar `Date`, `boolean` or `bigint` binds
+  // natively and needs neither a cast nor an encoder — which is why `encode`
+  // below reads `field` for exactly two questions and passes everything else
+  // through.
   //
   // The value is serialised by `fieldParam`, not by `encode` below, so a
   // binding site that does not ask for the cast still binds raw and keeps the
   // loud failure rather than acquiring a silent mis-store. The comment on
   // `encode` has the measurements.
   castParameter(field: FieldSchema): string {
+    // A list is bound as an array literal and needs no cast in any position it
+    // can occupy — see `listHas` for the measurements. Checked *before* the
+    // `Json` branch rather than after, because a `Json[]` would otherwise take
+    // it and bind `$1::text::jsonb` against a `jsonb[]` column, which is a type
+    // error rather than a wrong answer. The order is the whole check.
+    if (field.isList) return "";
     return field.type === "Json" ? "::text::jsonb" : "";
   }
 
-  encode(value: unknown, _field: FieldSchema): unknown {
+  encode(value: unknown, field: FieldSchema): unknown {
     if (value === null || value === undefined) return null;
+
+    // A scalar list crosses as one Postgres array literal, which is the same
+    // trick `inList` and `compositeIn` already use for a bound array: still one
+    // parameter, still nothing in the SQL text.
+    //
+    // `Json` is the element type that needs work here rather than in
+    // `fieldParam`, and it is not the exception it looks like. `fieldParam`'s
+    // rule is that the cast and the serialisation travel together; a list emits
+    // *no* cast, because the array literal already carries the element's text
+    // form and Postgres casts each element to the column's element type. So
+    // serialising a `Json` element here is what makes the literal well-formed,
+    // not a second place doing `fieldParam`'s job.
+    if (field.isList) {
+      // Not an `InvalidArgumentError`: the compiler validates every list
+      // operand where the model and operation are in scope to name them, so a
+      // non-array arriving here reports an ORM bug rather than a caller's —
+      // the same call `fieldParam` makes about a stray `AnyNull`.
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `gemi ORM bug: a non-array reached the parameter binder for the ` +
+            `scalar list '${field.column}' (received ${typeof value}). Every ` +
+            `path that binds a list is supposed to have checked its operand.`,
+        );
+      }
+      return arrayLiteral(
+        field.type === "Json"
+          ? value.map((element) =>
+              element === null || element === undefined
+                ? null
+                : JSON.stringify(element),
+            )
+          : value,
+      );
+    }
     // **`Json` is handed over raw**, because Bun serializes it for a `jsonb`
     // parameter and doing it here first is the mirror of the decode bug beside
     // it: `JSON.stringify({a:1})` produces the *string* `{"a":1}`, and Bun then
@@ -401,12 +536,71 @@ export class PostgresDialect implements SqlDialect {
     // "false when the driver already returns exactly what Prisma would" — which
     // is now exactly true. Leaving it in cost a function call per Json value on
     // every read for nothing.
-    return field.type === "BigInt" || field.type === "Bytes";
+    //
+    // **Every list is decoded**, including a `String[]` whose elements the
+    // driver already hands back correctly. Three separate reasons, and the
+    // first alone settles it: the *container* is wrong for two element types
+    // regardless of the elements — `int[]` arrives as an `Int32Array`, and an
+    // `enum[]` arrives as an unparsed `{…}` literal — so a predicate that
+    // answered per element type would have to encode which container Bun picks
+    // for which Postgres type, which is a table nothing keeps in step. Second,
+    // `int[]`'s container differs *by protocol*: `Int32Array` when the
+    // statement binds a parameter, a plain `Array` when it does not. Third, the
+    // cost is one call per list value, not per element.
+    return field.isList === true || field.type === "BigInt" || field.type === "Bytes";
   }
 
   decode(value: unknown, field: FieldSchema): unknown {
     if (value === null || value === undefined) return null;
+    if (field.isList) return this.decodeList(value, field);
+    return this.decodeScalar(value, field);
+  }
 
+  /**
+   * One array column, element by element.
+   *
+   * **Three container shapes arrive here**, all measured through Bun 1.3.14
+   * against Postgres 16 rather than read off a driver's documentation:
+   *
+   *   text[] float8[] bool[] timestamp[] bytea[] jsonb[] bigint[]  -> Array
+   *   int[]                                                        -> Int32Array
+   *   enum[]  domain[]                                             -> "{a,b}"
+   *
+   * The third is the surprise and the reason this is not four lines: Bun has no
+   * decoder for an array whose element type it does not recognise, so it hands
+   * the **Postgres array output literal back as a string** — and every enum
+   * list is in that case. `real[]` is the same story as `int[]` with a
+   * `Float32Array`, which is why the typed-array branch is written against
+   * `ArrayBuffer.isView` rather than against `Int32Array` by name.
+   *
+   * `int[]`'s container also depends on the *protocol*: a statement that binds
+   * at least one parameter goes over the extended protocol and yields an
+   * `Int32Array`, one that binds none yields a plain `Array`. Same column, same
+   * row, two shapes — so this cannot be decided once and cached.
+   *
+   * Elements then go through {@link decodeScalar}, which is the same function
+   * the scalar path uses. That is what makes `BigInt[]` exact and `Bytes[]` a
+   * `Uint8Array[]` rather than a `Buffer[]` without restating either rule.
+   */
+  private decodeList(value: unknown, field: FieldSchema): unknown {
+    const elements = Array.isArray(value)
+      ? value
+      : typeof value === "string"
+        ? parseArrayLiteral(value, field)
+        : ArrayBuffer.isView(value)
+          ? Array.from(value as unknown as ArrayLike<unknown>)
+          : null;
+
+    if (elements === null) throw new DecodeError(field, value);
+
+    return elements.map((element) =>
+      element === null || element === undefined
+        ? null
+        : this.decodeScalar(element, field),
+    );
+  }
+
+  private decodeScalar(value: unknown, field: FieldSchema): unknown {
     switch (field.type) {
       case "BigInt":
         if (typeof value === "bigint") return value;
@@ -527,4 +721,85 @@ function arrayElement(value: unknown): string {
 
   const text = typeof value === "string" ? value : String(value);
   return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * `{a,"b,c",NULL}` -> `["a", "b,c", null]`: the same form, read back.
+ *
+ * **Only reached for an array type Bun has no decoder for**, which today means
+ * an `enum[]` or a `domain[]` — everything else arrives as a JS array and never
+ * comes near this. That is why it exists at all: an enum list is the one scalar
+ * list a Prisma schema is *likely* to declare, and it is precisely the one the
+ * driver hands back as text.
+ *
+ * Splitting on commas is wrong and looks right, which is the whole reason this
+ * is a state machine. Postgres quotes an element only when it has to, and then
+ * escapes `"` and `\` inside the quotes — so a label containing a comma, a
+ * brace, a quote or a backslash all survive the output format and none of them
+ * survive a `split(",")`. Verified against a live server with an enum declaring
+ * exactly those labels, plus one spelled `NULL`: unquoted `NULL` is the null
+ * element, and quoted `"NULL"` is the four-character string.
+ *
+ * A nested `{` is a multi-dimensional array, which Prisma's scalar lists cannot
+ * be. It is refused rather than flattened — flattening would return a row shape
+ * that disagrees with the type Prisma handed the caller, which is the failure
+ * this whole feature was refused for eight iterations to avoid.
+ */
+function parseArrayLiteral(text: string, field: FieldSchema): unknown[] {
+  if (!text.startsWith("{") || !text.endsWith("}")) {
+    throw new DecodeError(field, text);
+  }
+  if (text === "{}") return [];
+
+  const out: unknown[] = [];
+  let index = 1;
+  const end = text.length - 1;
+
+  while (index <= end) {
+    let raw = "";
+    let quoted = false;
+
+    if (text[index] === '"') {
+      quoted = true;
+      index++;
+      while (index < end && text[index] !== '"') {
+        // One level of backslash escaping, which is what the writer above emits
+        // and what `bytea`'s own `\x` prefix is doubled to survive.
+        raw += text[index] === "\\" ? text[++index] : text[index];
+        index++;
+      }
+      // The closing quote.
+      index++;
+    } else {
+      while (index < end && text[index] !== ",") {
+        if (text[index] === "{") throw new DecodeError(field, text);
+        raw += text[index];
+        index++;
+      }
+    }
+
+    // Unquoted `NULL` is the null element; quoted, it is the string.
+    out.push(!quoted && raw.toUpperCase() === "NULL" ? null : raw);
+
+    // Either a separator or the closing brace, and nothing else is well-formed.
+    if (index < end && text[index] !== ",") throw new DecodeError(field, text);
+    index++;
+  }
+
+  if (field.type !== "Json") return out;
+
+  // **The one place a JS string is not ambiguous**, which is worth saying next
+  // to `decodeScalar`'s `Json` case insisting that it usually is. There, a
+  // string could be raw JSON text the driver skipped *or* a JSON string value
+  // it parsed, and nothing distinguishes them. Here the element was read out of
+  // Postgres' own array output a moment ago, so it is raw text by construction
+  // and there is no second reading to guess between.
+  return out.map((element) => {
+    if (element === null) return null;
+    try {
+      return JSON.parse(element as string);
+    } catch {
+      throw new DecodeError(field, element);
+    }
+  });
 }

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -141,6 +141,46 @@ export class SqliteDialect implements SqlDialect {
   }
 
   /**
+   * **None**, because SQLite has no array type — and this is Prisma's answer
+   * before it is gemi's. The generated client never sees such a column here:
+   * `prisma generate` refuses the *schema* with *"Field `tags` in model `User`
+   * can't be a list. The current connector does not support lists of primitive
+   * types."*
+   *
+   * So the only way to reach a scalar list on this dialect is an artifact
+   * generated against a Postgres schema and a `DATABASE_URL` pointed at SQLite
+   * — a real configuration, since the artifact is deliberately dialect-agnostic
+   * (#300), and one where the underlying table has no such column either. An
+   * empty set is what turns that into a refusal naming the dialect, in place of
+   * `no such column: tags` from the driver.
+   */
+  readonly listFilters: ReadonlySet<string> = new Set();
+
+  // All five are unreachable: `listFilters` is empty, so `where.ts` and
+  // `write.ts` refuse first with a message naming the dialect. Throwing rather
+  // than emitting something plausible keeps the two from disagreeing silently —
+  // the same call `compositeIn` and `jsonArrayContains` above already make.
+  listHas(): Fragment {
+    throw new Error(unsupportedList("has"));
+  }
+
+  listHasEvery(): Fragment {
+    throw new Error(unsupportedList("hasEvery"));
+  }
+
+  listHasSome(): Fragment {
+    throw new Error(unsupportedList("hasSome"));
+  }
+
+  listIsEmpty(): Fragment {
+    throw new Error(unsupportedList("isEmpty"));
+  }
+
+  listPush(): Fragment {
+    throw new Error(unsupportedList("push"));
+  }
+
+  /**
    * `path: "$.a.b"` — a JSONPath *string*, where Postgres takes an array.
    *
    * Prisma's own split, measured on both: the generated client refuses
@@ -390,4 +430,11 @@ export class SqliteDialect implements SqlDialect {
         return value;
     }
   }
+}
+
+function unsupportedList(operator: string): string {
+  return (
+    `SQLite has no array type, so it cannot express '${operator}' on a scalar ` +
+    `list; \`listFilters\` is the guard.`
+  );
 }

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -311,8 +311,39 @@ export function canonicalShape(
   return `{${entries.join(",")}}`;
 }
 
-/** The operators whose operand is a list of values rather than a structure. */
-const LIST_KEYS = new Set(["in", "notIn"]);
+/**
+ * The operators whose operand is a list of values rather than a structure.
+ *
+ * `in` / `notIn` bind as one `= any($1)` on Postgres. So do a scalar list's
+ * `hasEvery`, `hasSome` and `push` (#300) — `col @> $1`, `col && $1` and
+ * `array_cat(col, $1)` are each one parameter however long the operand is, so
+ * recording it element-wise mints one entry per distinct length, every one of
+ * them holding SQL identical to its neighbours'. A `hasEvery` built from user
+ * input is exactly the churn `collapsedList` exists to prevent.
+ *
+ * **Three names, and the two obvious omissions are deliberate.**
+ *
+ * `equals` and `set` are *overloaded*, and `set` is the one that would have
+ * been a real bug rather than a missed optimisation: it is also a **relation**
+ * operator — `data: { tags: { set: [{ id: 1 }, { id: 2 }] } }` rewrites a join
+ * table, and that statement's text grows with the list. Collapsing it would
+ * hand a plan the wrong number of placeholders, which is precisely the failure
+ * the note above warns about for `OR`. Checked in `compile/nested-writes.ts`
+ * rather than assumed from the name.
+ *
+ * The three below carry no such second meaning: `grep` finds them only in the
+ * scalar-list filter set and the list write operators.
+ *
+ * **One case is still uncollapsed and needs a schema to fix.** A bare array as
+ * a *write* value — `data: { tags: ["a", "b"] }` — is keyed by the **field
+ * name**, so no fixed set can recognise it; telling it from `data: { AND: … }`
+ * needs to know that `tags` is a list on this model, and `canonicalShape` is
+ * deliberately schema-free. Left as churn rather than guessed at: the cost is
+ * bounded by the LRU and the SQL is identical either way, where a wrong
+ * collapse is a wrong statement. The filter side — which is where a
+ * user-sized list actually arrives — is covered.
+ */
+const LIST_KEYS = new Set(["in", "notIn", "hasEvery", "hasSome", "push"]);
 
 /**
  * The internal composite-`in` key — see `compile/where.ts`, which owns it.

--- a/packages/gemi/orm/postgres-suite-selection.test.ts
+++ b/packages/gemi/orm/postgres-suite-selection.test.ts
@@ -52,11 +52,22 @@ const filter = (() => {
   return match![1];
 })();
 
-/** Files that gate a suite behind `POSTGRES_URL`, and the suite names they use. */
+/**
+ * Files that gate a suite behind a Postgres URL, and the suite names they use.
+ *
+ * The pattern admits any `POSTGRES…_URL`, not just `POSTGRES_URL` itself. There
+ * is a second one now — `POSTGRES_LISTS_URL`, for the scalar-list schema that
+ * needs its own database (#300) — and a check written against the one name
+ * would have silently stopped covering the file that introduced it. That is the
+ * precise shape of the failure this test exists for: three suites were selected
+ * by neither job, and nothing said so.
+ */
 const gated = readdirSync(MODELS)
   .filter((file) => file.endsWith(".test.ts"))
   .map((file) => ({ file, source: readFileSync(join(MODELS, file), "utf8") }))
-  .filter(({ source }) => /POSTGRES_URL \? describe : describe\.skip/.test(source))
+  .filter(({ source }) =>
+    /POSTGRES(?:_[A-Z]+)*_URL \? describe : describe\.skip/.test(source),
+  )
   .map(({ file, source }) => ({
     file,
     suites: [...source.matchAll(/^RUN\(\s*"([^"]+)"/gm)].map((match) => match[1]),

--- a/packages/gemi/orm/scalar-list.test.ts
+++ b/packages/gemi/orm/scalar-list.test.ts
@@ -5,6 +5,7 @@ import { compileWrite } from "./compile/write";
 import { PostgresDialect } from "./dialect/postgres";
 import { SqliteDialect } from "./dialect/sqlite";
 import { DecodeError, UnsupportedQueryError } from "./errors";
+import { canonicalShape } from "./plan";
 import type { FieldSchema, ModelSchema } from "./schema";
 
 const postgres = new PostgresDialect();
@@ -63,6 +64,14 @@ const TAGGED: ModelSchema = {
     counts: field({ name: "counts", column: "counts", type: "Int" }),
     docs: field({ name: "docs", column: "docs", type: "Json" }),
     renamed: field({ name: "renamed", column: "renamed_column" }),
+    // A **non-empty** default on purpose: with `@default([])` a write that
+    // ignored the default and a write that honoured it produce the same array,
+    // so the bug below could not be seen.
+    defaulted: field({
+      name: "defaulted",
+      column: "defaulted",
+      default: { kind: "value", value: ["seed"] },
+    }),
   },
   primaryKey: ["id"],
   uniques: [["id"]],
@@ -327,6 +336,167 @@ describe("the SQL a list write compiles to", () => {
 });
 
 /**
+ * The plan key, which has to follow the SQL text rather than the argument.
+ *
+ * The suite above asserts a list operand's *length* does not reach the
+ * statement. That is only half the property: if the key still varies with it,
+ * every distinct length mints an LRU entry holding SQL identical to its
+ * neighbours' — which is the churn `collapsedList` was written for.
+ */
+describe("the plan key for a list operand", () => {
+  const key = (where: unknown) =>
+    canonicalShape({ where }, false, true);
+
+  test.each(["hasEvery", "hasSome"])(
+    "%s does not vary with the operand's length",
+    (operator) => {
+      expect(key({ tags: { [operator]: ["a"] } })).toBe(
+        key({ tags: { [operator]: ["a", "b", "c"] } }),
+      );
+    },
+  );
+
+  test("push does not vary with the operand's length", () => {
+    expect(canonicalShape({ data: { tags: { push: ["a"] } } }, false, true)).toBe(
+      canonicalShape({ data: { tags: { push: ["a", "b"] } } }, false, true),
+    );
+  });
+
+  /**
+   * An empty operand keeps its own key, as `in: []` does: it is a different
+   * predicate often enough that sharing would be the riskier default.
+   */
+  test("an empty operand keeps its own key", () => {
+    expect(key({ tags: { hasEvery: [] } })).not.toBe(
+      key({ tags: { hasEvery: ["a"] } }),
+    );
+  });
+
+  /** Different operators must not share an entry — their SQL differs. */
+  test("hasEvery and hasSome are different keys", () => {
+    expect(key({ tags: { hasEvery: ["a"] } })).not.toBe(
+      key({ tags: { hasSome: ["a"] } }),
+    );
+  });
+
+  /**
+   * **`set` is deliberately not collapsed**, and this is the test that says so
+   * rather than leaving the omission to look like an oversight.
+   *
+   * It is also a *relation* operator — `{ tags: { set: [{ id: 1 }] } }` rewrites
+   * a join table — and that statement's text grows with the list. Collapsing by
+   * the name alone would hand such a plan the wrong number of placeholders.
+   */
+  test("set keeps its length, because it is also a relation operator", () => {
+    expect(
+      canonicalShape({ data: { tags: { set: [{ id: 1 }] } } }, false, true),
+    ).not.toBe(
+      canonicalShape(
+        { data: { tags: { set: [{ id: 1 }, { id: 2 }] } } },
+        false,
+        true,
+      ),
+    );
+  });
+
+  /**
+   * SQLite refuses scalar lists outright, so the collapse must not fire there —
+   * the flag is what carries "this dialect binds a list as one parameter", and
+   * borrowing it for a dialect that cannot bind one at all would be a claim
+   * about the wrong thing.
+   */
+  test("nothing collapses when the dialect does not bind a list as one parameter", () => {
+    expect(canonicalShape({ where: { tags: { hasEvery: ["a"] } } }, false, false)).not.toBe(
+      canonicalShape({ where: { tags: { hasEvery: ["a", "b"] } } }, false, false),
+    );
+  });
+});
+
+/**
+ * What an insert *invents* for a list nobody supplied — the seam between
+ * `create` and `createMany`, and where all three write-path defects lived.
+ */
+describe("an absent list on an insert", () => {
+  const binds = (op: "create" | "createMany", args: unknown) => {
+    const compiled = compileWrite(TAGGED, op as never, args as never, postgres);
+    return compiled.bind(args as never, { now: new Date(0) } as never);
+  };
+
+  /**
+   * Prisma writes `[]` for a list with no default rather than refusing the
+   * call — measured against a generated client, since the input type says only
+   * that the field is optional.
+   */
+  test("create writes [] for a list with no default", () => {
+    expect(binds("create", { data: { id: 1 } })).toContain("{}");
+  });
+
+  /**
+   * The defect the review caught. `@default(["seed"])` is a *client-side*
+   * default, so `create` binds the declared value — and `createMany` bound `{}`
+   * over it, because it asked `isList` where it had to ask "does this list have
+   * anything else to fall back on".
+   */
+  test("create binds a list's declared default, not []", () => {
+    expect(binds("create", { data: { id: 1 } })).toContain('{"seed"}');
+  });
+
+  test("createMany binds the same default on a row that omits it", () => {
+    const values = binds("createMany", {
+      data: [{ id: 1 }, { id: 2, defaulted: ["explicit"] }],
+    });
+    expect(values).toContain('{"seed"}');
+    expect(values).toContain('{"explicit"}');
+  });
+
+  /** The two operations must not disagree about one schema. */
+  test("create and createMany agree on what an omitted list is worth", () => {
+    const one = binds("create", { data: { id: 1 } });
+    const many = binds("createMany", { data: [{ id: 1 }] });
+    expect(many.filter((value) => typeof value === "string")).toEqual(
+      one.filter((value) => typeof value === "string"),
+    );
+  });
+
+  /**
+   * A list with a *database-side* default still cannot be expressed per row, so
+   * it keeps the existing refusal rather than quietly acquiring `{}`.
+   */
+  test("a database-side default that only some rows set is still refused", () => {
+    const schema: ModelSchema = {
+      ...TAGGED,
+      fields: {
+        ...TAGGED.fields,
+        generated: field({
+          name: "generated",
+          column: "generated",
+          default: { kind: "dbgenerated" },
+        }),
+      },
+    };
+    expect(() =>
+      compileWrite(
+        schema,
+        "createMany" as never,
+        { data: [{ id: 1 }, { id: 2, generated: ["x"] }] } as never,
+        postgres,
+      ),
+    ).toThrow(/leave it to the database default/);
+  });
+
+  /**
+   * The dialect owes an answer for a column it cannot hold whether or not the
+   * caller mentioned it. Without the check on this branch, SQLite compiled a
+   * statement and left the driver to reject raw JS arrays with a type error.
+   */
+  test("SQLite refuses a list the caller never mentioned", () => {
+    expect(() =>
+      compileWrite(TAGGED, "create" as never, { data: { id: 1 } } as never, sqlite),
+    ).toThrow(/sqlite has no array type/);
+  });
+});
+
+/**
  * Refusals. Each one names the field's *kind*, because "unsupported" sends a
  * reader looking for a release note when the fix is in their own call.
  */
@@ -438,5 +608,34 @@ describe("refusals", () => {
       );
     expect(bad).toThrow(/scalar list, so it takes set —/);
     expect(bad).toThrow(/Received \{ push \}/);
+  });
+
+  /**
+   * `createMany` was the one write path with no compile-time operand check, so
+   * a bad operand reached the *binder* — and the binder's message offers
+   * `{ push: … }` as the remedy, on the one operation where `push` is never
+   * legal. A late refusal that also points the wrong way.
+   */
+  test("createMany refuses a bad operand at compile time, like create", () => {
+    const bad = () =>
+      compileWrite(
+        TAGGED,
+        "createMany" as never,
+        { data: [{ id: 1, tags: { push: ["a"] } }] } as never,
+        postgres,
+      );
+    expect(bad).toThrow(/scalar list, so it takes set —/);
+    expect(bad).not.toThrow(/\{ push: … \}/);
+  });
+
+  test("createMany refuses an arithmetic operator on a list too", () => {
+    expect(() =>
+      compileWrite(
+        TAGGED,
+        "createMany" as never,
+        { data: [{ id: 1, counts: { increment: 1 } }] } as never,
+        postgres,
+      ),
+    ).toThrow(/scalar list, so it takes set —/);
   });
 });

--- a/packages/gemi/orm/scalar-list.test.ts
+++ b/packages/gemi/orm/scalar-list.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, test } from "vitest";
+
+import { compileRead } from "./compile/read";
+import { compileWrite } from "./compile/write";
+import { PostgresDialect } from "./dialect/postgres";
+import { SqliteDialect } from "./dialect/sqlite";
+import { DecodeError, UnsupportedQueryError } from "./errors";
+import type { FieldSchema, ModelSchema } from "./schema";
+
+const postgres = new PostgresDialect();
+const sqlite = new SqliteDialect();
+
+/**
+ * Scalar lists, at the level the differential harness **cannot** reach (#300).
+ *
+ * `templates/saas-starter/app/models/scalar-list.test.ts` is the oracle: it runs
+ * every filter and every write through Prisma and through gemi against one
+ * Postgres and compares rows. It is the stronger test and it is where a
+ * behavioural question gets settled.
+ *
+ * Three things are structurally out of its reach, and they are what this file
+ * is for:
+ *
+ *  1. **The array-literal parser's escaping.** The parser only runs for an array
+ *     type Bun has no decoder for, which in practice means an `enum[]`. A Prisma
+ *     enum member is `[A-Za-z][A-Za-z0-9_]*`, and Postgres quotes an array
+ *     element only when it contains a delimiter, a quote or a backslash — so no
+ *     schema Prisma will accept can produce a quoted element there. The escaping
+ *     is real code on a real path and nothing Prisma can write exercises it.
+ *  2. **SQLite's refusal.** Prisma refuses the *column* on SQLite, so there is
+ *     no SQLite client to compare against — by construction, forever.
+ *  3. **The SQL text.** A differential says the answers agree; it cannot say
+ *     the statement is the one that keeps the plan cache honest.
+ */
+
+function field(overrides: Partial<FieldSchema>): FieldSchema {
+  return {
+    name: "tags",
+    column: "tags",
+    type: "String",
+    nullable: false,
+    isId: false,
+    isUpdatedAt: false,
+    isList: true,
+    ...overrides,
+  };
+}
+
+const TAGGED: ModelSchema = {
+  name: "Tagged",
+  table: "Tagged",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    tags: field({}),
+    counts: field({ name: "counts", column: "counts", type: "Int" }),
+    docs: field({ name: "docs", column: "docs", type: "Json" }),
+    renamed: field({ name: "renamed", column: "renamed_column" }),
+  },
+  primaryKey: ["id"],
+  uniques: [["id"]],
+  relations: {},
+};
+
+/** The value actually bound for a list operand, as Postgres array-literal text. */
+function bound(value: unknown, overrides: Partial<FieldSchema> = {}): unknown {
+  return postgres.encode(value, field(overrides));
+}
+
+describe("the Postgres array literal, written", () => {
+  test("quotes every element, whatever its type", () => {
+    expect(bound(["a", "b"])).toBe('{"a","b"}');
+    expect(bound([1, 2], { type: "Int" })).toBe('{"1","2"}');
+    expect(bound([true], { type: "Boolean" })).toBe('{"true"}');
+  });
+
+  test("the empty list is {}", () => {
+    expect(bound([])).toBe("{}");
+  });
+
+  /**
+   * The four characters that would otherwise end the element early, plus the
+   * one that cannot be quoted at all.
+   */
+  test("escapes the delimiters", () => {
+    expect(bound(['a"b'])).toBe('{"a\\"b"}');
+    expect(bound(["a\\b"])).toBe('{"a\\\\b"}');
+    expect(bound(["a,b"])).toBe('{"a,b"}');
+    expect(bound(["{a}"])).toBe('{"{a}"}');
+    expect(bound([""])).toBe('{""}');
+  });
+
+  test("a null element is unquoted NULL, which is not the string", () => {
+    expect(bound([null])).toBe("{NULL}");
+    expect(bound(["NULL"])).toBe('{"NULL"}');
+  });
+
+  /**
+   * `Json` elements are serialised here rather than by `fieldParam`, because a
+   * list emits no cast for `fieldParam` to travel with — see the note on
+   * `encode`. Without it `String({a:1})` is `[object Object]`.
+   */
+  test("serialises Json elements", () => {
+    expect(bound([{ a: 1 }], { type: "Json" })).toBe('{"{\\"a\\":1}"}');
+    expect(bound(["42"], { type: "Json" })).toBe('{"\\"42\\""}');
+    expect(bound([7], { type: "Json" })).toBe('{"7"}');
+  });
+
+  test("a bigint past 2^53 keeps every digit", () => {
+    expect(bound([9007199254740993n], { type: "BigInt" })).toBe(
+      '{"9007199254740993"}',
+    );
+  });
+
+  test("bytes take the doubled-backslash hex form", () => {
+    expect(bound([new Uint8Array([1, 2, 255])], { type: "Bytes" })).toBe(
+      '{"\\\\x0102ff"}',
+    );
+  });
+});
+
+/**
+ * The parser, which only an `enum[]` reaches through the driver — and which no
+ * Prisma-legal enum can push past the unquoted case. See the header.
+ */
+describe("the Postgres array literal, read back", () => {
+  const read = (text: string, overrides: Partial<FieldSchema> = {}) =>
+    postgres.decode(text, field(overrides));
+
+  test("splits unquoted elements", () => {
+    expect(read("{urgent,blocked}")).toEqual(["urgent", "blocked"]);
+  });
+
+  test("the empty literal is the empty list, not [\"\"]", () => {
+    expect(read("{}")).toEqual([]);
+  });
+
+  /**
+   * The case a `split(",")` gets wrong, and the reason this is a state machine.
+   */
+  test("a quoted element may contain the delimiter", () => {
+    expect(read('{a,"b,c",d}')).toEqual(["a", "b,c", "d"]);
+  });
+
+  test("unescapes quotes and backslashes", () => {
+    expect(read('{"a\\"b"}')).toEqual(['a"b']);
+    expect(read('{"a\\\\b"}')).toEqual(["a\\b"]);
+  });
+
+  test("a brace inside quotes is content, not nesting", () => {
+    expect(read('{"{a}"}')).toEqual(["{a}"]);
+  });
+
+  test("unquoted NULL is null; quoted NULL is the string", () => {
+    expect(read("{NULL}")).toEqual([null]);
+    expect(read('{"NULL"}')).toEqual(["NULL"]);
+  });
+
+  test("an empty quoted element is the empty string", () => {
+    expect(read('{"",a}')).toEqual(["", "a"]);
+  });
+
+  /**
+   * Prisma's scalar lists are one-dimensional. Flattening a nested literal would
+   * return a row shape that disagrees with the type Prisma handed the caller,
+   * which is the failure this feature was refused for eight iterations to avoid.
+   */
+  test("refuses a multi-dimensional literal rather than flattening it", () => {
+    expect(() => read("{{a,b},{c}}")).toThrow(DecodeError);
+  });
+
+  test("refuses text that is not a literal at all", () => {
+    expect(() => read("a,b")).toThrow(DecodeError);
+  });
+});
+
+describe("decoding the containers the driver actually returns", () => {
+  test("a plain array decodes element-wise", () => {
+    expect(postgres.decode(["1", "2"], field({ type: "BigInt" }))).toEqual([
+      1n,
+      2n,
+    ]);
+  });
+
+  /**
+   * `int[]` arrives as an `Int32Array` over the extended protocol and a plain
+   * `Array` over the simple one — the same statement, two containers, decided
+   * by whether it bound a parameter. Prisma returns `number[]` for both.
+   */
+  test("a typed array becomes a plain array", () => {
+    const decoded = postgres.decode(
+      new Int32Array([1, 2]),
+      field({ type: "Int" }),
+    );
+    expect(Array.isArray(decoded)).toBe(true);
+    expect(decoded).toEqual([1, 2]);
+  });
+
+  /**
+   * `Buffer` is a `Uint8Array` subclass, so a divergence here survives the
+   * generated type and any element-wise comparison — and `toString("hex")`
+   * reads `"0102ff"` from one and `"1,2,255"` from the other.
+   */
+  test("Buffer elements become Uint8Array, as Prisma returns", () => {
+    const decoded = postgres.decode(
+      [Buffer.from([1, 2, 255])],
+      field({ type: "Bytes" }),
+    ) as unknown[];
+    expect(decoded[0]).toBeInstanceOf(Uint8Array);
+    expect(Buffer.isBuffer(decoded[0])).toBe(false);
+  });
+
+  test("a null column stays null rather than becoming []", () => {
+    expect(postgres.decode(null, field({}))).toBeNull();
+  });
+
+  test("null elements survive", () => {
+    expect(postgres.decode(["a", null], field({}))).toEqual(["a", null]);
+  });
+
+  /** Every list is decoded — see the note on `needsDecode` for why. */
+  test("needsDecode is true for a list of any element type", () => {
+    expect(postgres.needsDecode(field({ type: "String" }))).toBe(true);
+    expect(postgres.needsDecode(field({ type: "Int" }))).toBe(true);
+  });
+});
+
+describe("the parameter cast", () => {
+  /**
+   * The ordering is the whole check: a `Json[]` binding `$1::text::jsonb`
+   * against a `jsonb[]` column is a type error, and `Json` is the branch it
+   * would otherwise take.
+   */
+  test("a list gets no cast, including a Json list", () => {
+    expect(postgres.castParameter(field({ type: "Json" }))).toBe("");
+    expect(postgres.castParameter(field({ type: "String" }))).toBe("");
+  });
+
+  test("a scalar Json still gets one", () => {
+    expect(postgres.castParameter(field({ type: "Json", isList: false }))).toBe(
+      "::text::jsonb",
+    );
+  });
+});
+
+describe("the SQL a list filter compiles to", () => {
+  const read = (where: unknown) =>
+    compileRead(TAGGED, "findMany" as never, { where } as never, postgres).text;
+
+  test("has puts the element on the left of = any", () => {
+    expect(read({ tags: { has: "a" } })).toContain(`$1 = any("tags")`);
+  });
+
+  test("hasEvery is containment and hasSome is overlap", () => {
+    expect(read({ tags: { hasEvery: ["a"] } })).toContain(`"tags" @> $1`);
+    expect(read({ tags: { hasSome: ["a"] } })).toContain(`"tags" && $1`);
+  });
+
+  test("equals is whole-list equality", () => {
+    expect(read({ tags: { equals: ["a"] } })).toContain(`"tags" = $1`);
+  });
+
+  test("isEmpty compares against a bound empty list, with no digit in the text", () => {
+    const empty = read({ tags: { isEmpty: true } });
+    expect(empty).toContain(`"tags" = $1`);
+    expect(empty.replace(/"[^"]*"|\$\d+/g, "")).not.toMatch(/\d/);
+    expect(read({ tags: { isEmpty: false } })).toContain(`"tags" <> $1`);
+  });
+
+  test("the column is the mapped name, not the field name", () => {
+    expect(read({ renamed: { has: "a" } })).toContain(`= any("renamed_column")`);
+  });
+
+  /**
+   * Invariant 2, at the point most likely to break it: the operand is a caller
+   * value and the list is the caller's too, so nothing about its *length* may
+   * reach the text.
+   */
+  test("two lists of different lengths compile to the same text", () => {
+    expect(read({ tags: { hasEvery: ["a"] } })).toBe(
+      read({ tags: { hasEvery: ["a", "b", "c"] } }),
+    );
+  });
+
+  test("has and equals compile differently, so they cannot share a plan", () => {
+    expect(read({ tags: { has: "a" } })).not.toBe(read({ tags: { equals: ["a"] } }));
+  });
+});
+
+describe("the SQL a list write compiles to", () => {
+  const write = (data: unknown) =>
+    compileWrite(
+      TAGGED,
+      "update" as never,
+      { where: { id: 1 }, data } as never,
+      postgres,
+    ).text;
+
+  test("set is a plain assignment", () => {
+    expect(write({ tags: { set: ["a"] } })).toContain(`"tags" = $`);
+  });
+
+  test("push reads the column back through array_cat", () => {
+    expect(write({ tags: { push: "a" } })).toContain(`"tags" = array_cat("tags", $`);
+  });
+
+  /**
+   * `push: "a"` and `push: ["a"]` are the same statement, which is what lets the
+   * dialect use a single-signature function — `||` would read the two spellings
+   * as different operators.
+   */
+  test("push of one and push of many compile alike", () => {
+    expect(write({ tags: { push: "a" } })).toBe(write({ tags: { push: ["a"] } }));
+  });
+
+  test("a bare array is a value, not an operator", () => {
+    expect(write({ tags: ["a"] })).toContain(`"tags" = $`);
+    expect(write({ tags: ["a"] })).not.toContain("array_cat");
+  });
+});
+
+/**
+ * Refusals. Each one names the field's *kind*, because "unsupported" sends a
+ * reader looking for a release note when the fix is in their own call.
+ */
+describe("refusals", () => {
+  const read = (where: unknown, dialect = postgres) =>
+    compileRead(TAGGED, "findMany" as never, { where } as never, dialect).text;
+
+  /**
+   * Prisma refuses this too — *"Expected StringNullableListFilter, provided
+   * (String)"* — and accepting it made gemi a silent superset on the one
+   * dialect where every other answer can be checked against Prisma.
+   */
+  test("a bare array is not a filter, and the message says what is", () => {
+    expect(() => read({ tags: ["a"] })).toThrow(/bare array is not a filter/);
+    expect(() => read({ tags: ["a"] })).toThrow(/equals/);
+  });
+
+  test("a scalar operator on a list names both operator sets", () => {
+    expect(() => read({ tags: { contains: "a" } })).toThrow(
+      /list filter takes.*equals, has, hasEvery, hasSome, isEmpty/s,
+    );
+    expect(() => read({ tags: { contains: "a" } })).toThrow(/scalar operators/);
+  });
+
+  test("hasEvery and hasSome refuse a non-array, naming the type received", () => {
+    expect(() => read({ tags: { hasEvery: "a" } })).toThrow(
+      /Expected an array, received string/,
+    );
+    expect(() => read({ tags: { hasSome: 1 } })).toThrow(
+      /Expected an array, received number/,
+    );
+  });
+
+  test("isEmpty refuses a non-boolean", () => {
+    expect(() => read({ tags: { isEmpty: "yes" } })).toThrow(
+      /Expected true or false/,
+    );
+  });
+
+  test("equals refuses a scalar and points at has", () => {
+    expect(() => read({ tags: { equals: "a" } })).toThrow(/has/);
+  });
+
+  /**
+   * The refusal that moved from the generator to here (#300). It has to say
+   * more than "unsupported": the reader's likeliest question is whether they
+   * did something wrong, and they did not.
+   */
+  test("SQLite refuses the column and explains that Prisma does too", () => {
+    expect(() => read({ tags: { has: "a" } }, sqlite)).toThrow(
+      UnsupportedQueryError,
+    );
+    expect(() => read({ tags: { has: "a" } }, sqlite)).toThrow(
+      /sqlite has no array type/,
+    );
+    expect(() => read({ tags: { has: "a" } }, sqlite)).toThrow(
+      /lists of primitive types/,
+    );
+    expect(() => read({ tags: { has: "a" } }, sqlite)).toThrow(/It works on postgres/);
+  });
+
+  test("SQLite refuses a list write too, not only a filter", () => {
+    expect(() =>
+      compileWrite(
+        TAGGED,
+        "update" as never,
+        { where: { id: 1 }, data: { tags: { set: ["a"] } } } as never,
+        sqlite,
+      ),
+    ).toThrow(/sqlite has no array type/);
+  });
+
+  test("SQLite's list fragments are unreachable but still refuse loudly", () => {
+    expect(() => sqlite.listHas()).toThrow(/listFilters` is the guard/);
+    expect(() => sqlite.listPush()).toThrow(/listFilters` is the guard/);
+  });
+
+  /**
+   * At **compile** time, which is the point. `isOperatorObject` answers false
+   * for an operator a list does not have, so this used to be read as a *value*
+   * and travelled to the binder before anything objected.
+   */
+  test("an arithmetic operator on a list names set and push", () => {
+    const bad = () =>
+      compileWrite(
+        TAGGED,
+        "update" as never,
+        { where: { id: 1 }, data: { counts: { increment: 1 } } } as never,
+        postgres,
+      );
+    expect(bad).toThrow(/scalar list, so it takes set or push/);
+    expect(bad).toThrow(/Received \{ increment \}/);
+  });
+
+  /**
+   * `push` is legal on `update` and not on `create`, which is Prisma's split:
+   * its create input for a list is `T[] | { set: T[] }`, and there is nothing
+   * for a `push` to append to on a row that does not exist yet. The error names
+   * the operators legal *in this position* rather than the operators a list has
+   * in general, which is the difference between a next step and a puzzle.
+   */
+  test("push is refused on create, naming only what create takes", () => {
+    const bad = () =>
+      compileWrite(
+        TAGGED,
+        "create" as never,
+        { data: { tags: { push: ["a"] } } } as never,
+        postgres,
+      );
+    expect(bad).toThrow(/scalar list, so it takes set —/);
+    expect(bad).toThrow(/Received \{ push \}/);
+  });
+});

--- a/packages/gemi/orm/schema.ts
+++ b/packages/gemi/orm/schema.ts
@@ -17,6 +17,16 @@
  * `assertSchemaArtifactVersion` compares the two at registration time so a stale
  * `app/models/generated` fails with "run prisma generate" rather than with a
  * `TypeError` five stack frames into the compiler.
+ *
+ * **`FieldSchema.isList` did not bump it**, and the reason is worth stating
+ * because the obvious reading says it should have. The hazard a bump guards
+ * against is a *new* artifact read by an *old* runtime, which would see a list
+ * column, not know the flag, and treat it as a scalar. That pairing cannot
+ * occur: the generator is `bin/orm` and the runtime is `orm/`, both shipped by
+ * the same `gemi` package and the same version — a runtime old enough to miss
+ * the flag came with a generator that refused to emit the column at all. The
+ * reverse pairing, an old artifact on a new runtime, is what `isList` being
+ * optional already covers.
  */
 export const SCHEMA_ARTIFACT_VERSION = 1;
 
@@ -59,6 +69,24 @@ export interface FieldSchema {
   nullable: boolean;
   isId: boolean;
   isUpdatedAt: boolean;
+  /**
+   * A Prisma **scalar list** — `tags String[]`. Postgres only; SQLite has no
+   * array type and Prisma refuses the declaration there outright.
+   *
+   * **A flag beside `type` rather than a `ScalarType` constructor**, and the
+   * choice reaches further than it looks. `type` keeps meaning the *element*
+   * type, so every `switch (field.type)` already written — `encode`, `decode`,
+   * `castParameter`, the lateral strategy's `jsonConverter`, `COMPOSITE_IN_TYPES`
+   * — keeps reading correctly and only has to ask this one extra question where
+   * a list genuinely differs. A `"String[]"` member of the union would have made
+   * every one of those switches silently non-exhaustive instead: no compile
+   * error, just a `default:` branch answering for a shape it had never seen.
+   *
+   * Absent rather than `false` on a non-list field, so an artifact generated
+   * before this existed is byte-identical to one generated after it — see the
+   * note on `SCHEMA_ARTIFACT_VERSION`, which is deliberately *not* bumped here.
+   */
+  isList?: boolean;
   /**
    * Set when the field is a Prisma enum. The enum's members are strings on the
    * wire, so `type` is `"String"` and this carries the name for later.

--- a/templates/saas-starter/.gitignore
+++ b/templates/saas-starter/.gitignore
@@ -12,3 +12,10 @@ node_modules/
 .gemi
 .env
 .debug
+
+# The artifacts of `prisma/postgres-only.prisma`, which only exist during a
+# Postgres run — see `app/models/postgres.sh`. Uncommitted on purpose, unlike
+# `app/models/generated/`: they carry a whole generated Prisma client, and the
+# models they describe cannot be generated at all on SQLite, so a committed copy
+# would be a directory that half the CI matrix could neither produce nor check.
+app/models/generated-lists/

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -219,12 +219,27 @@ export async function createDifferential(options: {
   const sqlitePath = join(workspace, "diff.db");
   const url = options.url ?? `file:${sqlitePath}`;
 
-  if (options.client && !options.url) {
-    throw new Error(
-      "createDifferential({ client }) is for a second Postgres schema, so it " +
-        "needs the `url` of the database that schema was pushed to. There is " +
-        "no SQLite path for it.",
-    );
+  // Both, not just `url`. Omitting `tables` was the worse of the two and the
+  // one that failed *quietly*: the default list below names the main schema's
+  // tables, so a second-schema harness without its own would issue a `TRUNCATE`
+  // for tables that do not exist in the database it is pointed at — clearing
+  // nothing it meant to clear, and reporting it as a truncation error rather
+  // than as the missing argument it is.
+  if (options.client) {
+    const missing = [
+      !options.url && "url",
+      !options.tables && "tables",
+    ].filter(Boolean);
+
+    if (missing.length > 0) {
+      throw new Error(
+        `createDifferential({ client }) is for a second Postgres schema, so it ` +
+          `needs ${missing.join(" and ")}: the \`url\` of the database that ` +
+          `schema was pushed to, and the \`tables\` to clear between cases — ` +
+          `the defaults name the main schema's, which are not in that ` +
+          `database. There is no SQLite path for it.`,
+      );
+    }
   }
 
   // SQLite gets a brand-new file with the committed migrations replayed into

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -155,6 +155,27 @@ function normalize(value: unknown, volatile?: Set<string>): unknown {
 }
 
 /**
+ * `User.findMany({"where":…})` — the label every assertion below is reported
+ * under, so a failure in a `test.each` says which case failed.
+ *
+ * `JSON.stringify` on its own is not enough and fails *loudly*: it throws
+ * `TypeError: JSON.stringify cannot serialize BigInt`. That turned four
+ * scalar-list cases into an error raised while building the message rather than
+ * a comparison — the harness failing to describe the test instead of running
+ * it, which reads at a glance like the case itself failing.
+ *
+ * Reachable before now only in principle: the template's one `BigInt` column is
+ * never an *argument*, and `BigInt[]` is the first thing that put one inside a
+ * `where` and a `data`.
+ */
+function describeCall(model: string, operation: string, args: unknown): string {
+  const text = JSON.stringify(args ?? {}, (_key, value) =>
+    typeof value === "bigint" ? `${value}n` : value,
+  );
+  return `${model}.${operation}(${text})`;
+}
+
+/**
  * What a generated value looks like, without what it is. Keeps the comparison
  * meaningful for `@default(cuid())` and `@default(now())` — a string of the
  * wrong length or with the wrong first character still fails.
@@ -173,10 +194,38 @@ export async function createDifferential(options: {
   /** Applied to both clients before any comparison runs. */
   seed: (prisma: PrismaClient) => Promise<void>;
   url?: string;
+  /**
+   * A Prisma client to compare against, instead of the one this module imports.
+   *
+   * **For a schema that is not `prisma/schema.prisma`**, which today means
+   * `prisma/postgres-only.prisma` and its scalar lists (#300). That schema has
+   * to be separate — a `String[]` is a validation error on SQLite, so it cannot
+   * share a file whose provider is flipped between dialects — and a separate
+   * schema generates a separate client, which `@prisma/client` does not name.
+   *
+   * Injecting it rather than importing a second client here is what keeps this
+   * module loadable during a SQLite run: the scalar-list client only exists
+   * after `prisma generate --schema prisma/postgres-only.prisma`, and eleven
+   * other suites import this file.
+   *
+   * Postgres only, and required to come with `url` and `tables` — there is no
+   * SQLite fallback for a schema SQLite cannot express.
+   */
+  client?: PrismaClient;
+  /** Tables to truncate between cases, children before parents. */
+  tables?: string[];
 }): Promise<Differential> {
   const workspace = mkdtempSync(join(tmpdir(), "gemi-orm-diff-"));
   const sqlitePath = join(workspace, "diff.db");
   const url = options.url ?? `file:${sqlitePath}`;
+
+  if (options.client && !options.url) {
+    throw new Error(
+      "createDifferential({ client }) is for a second Postgres schema, so it " +
+        "needs the `url` of the database that schema was pushed to. There is " +
+        "no SQLite path for it.",
+    );
+  }
 
   // SQLite gets a brand-new file with the committed migrations replayed into
   // it. Deliberately not `prisma db push --force-reset`: that command is
@@ -186,7 +235,11 @@ export async function createDifferential(options: {
     await applyMigrations(sqlitePath);
   }
 
-  const prisma = new PrismaClient({ datasources: { db: { url } } });
+  // An injected client is already constructed and already pointed at its own
+  // database; re-constructing it here would need its class, which is the thing
+  // this module deliberately does not import.
+  const prisma =
+    options.client ?? new PrismaClient({ datasources: { db: { url } } });
 
   // Postgres runs against whatever `TEST_POSTGRES_URL` names, so the harness
   // clears only the table it seeds and nothing else. The env var's contract is
@@ -195,7 +248,7 @@ export async function createDifferential(options: {
 
   // Children before parents: the schema's foreign keys are enforced on both
   // dialects, and a scratch database is only scratch for this suite.
-  const TABLES = [
+  const TABLES = options.tables ?? [
     "_PostToTag",
     "Post",
     "Tag",
@@ -337,7 +390,7 @@ export async function createDifferential(options: {
       const gemiModel = options.models[model];
       if (!gemiModel) throw new Error(`No gemi model registered for ${model}.`);
 
-      const label = `${model}.${operation}(${JSON.stringify(args ?? {})})`;
+      const label = describeCall(model, operation, args);
 
       const [fromPrisma, fromGemi] = await Promise.all([
         settle(() => prismaDelegate(prisma, model)[operation](args)),
@@ -373,7 +426,7 @@ export async function createDifferential(options: {
     async expectSameWrite(model, operation, args, comparison = {}) {
       const volatile = new Set(comparison.volatile ?? VOLATILE);
       const tables = comparison.tables ?? [model];
-      const label = `${model}.${operation}(${JSON.stringify(args ?? {})})`;
+      const label = describeCall(model, operation, args);
 
       // Sequential, not concurrent: a write run through both clients against
       // one database would have the second see the first one's effects. Each

--- a/templates/saas-starter/app/models/postgres.sh
+++ b/templates/saas-starter/app/models/postgres.sh
@@ -5,7 +5,7 @@
 #     app/models/postgres.sh                    # the whole suite
 #     app/models/postgres.sh app/models/lateral.test.ts
 #
-# The sequence below is four steps and **all four matter**, which is why this
+# The sequence below is five steps and **all five matter**, which is why this
 # file exists. Getting it wrong does not error: the suite runs, the Postgres
 # describes skip or fail, and the number at the bottom looks like a result.
 #
@@ -14,6 +14,8 @@
 #   3. db push                     — or the tables are not there
 #   4. prisma generate             — or the differential harness compares
 #                                    against a client built for the other dialect
+#   5. the same two for            — or the scalar-list suite has no models and
+#      postgres-only.prisma          skips, which reads exactly like passing
 #
 # I have got this wrong three times in one sitting, each time reading the
 # resulting 121 failures as a regression before recognising the shape. A script
@@ -27,6 +29,10 @@ cd "$(dirname "$0")/../.."
 CONTAINER="${GEMI_PG_CONTAINER:-gemi-orm-pg}"
 PORT="${GEMI_PG_PORT:-55432}"
 URL="postgres://gemi:gemi@localhost:${PORT}/gemi"
+# `prisma/postgres-only.prisma` gets a database of its own, not a second set of
+# tables in `gemi`. `prisma db push` reconciles a *whole database* to one
+# schema, so pushing it alongside would drop every table the main schema owns.
+LISTS_URL="postgres://gemi:gemi@localhost:${PORT}/gemi_lists"
 STARTED=""
 
 restore() {
@@ -58,6 +64,16 @@ echo "==> db push + generate"
 DATABASE_URL="$URL" npx prisma db push --skip-generate --accept-data-loss >/dev/null
 DATABASE_URL="$URL" npx prisma generate >/dev/null
 
+# The scalar-list schema (#300), in its own database and with its own client.
+# `createdb` is idempotent here only because the failure is swallowed: it exists
+# after the first run, and re-creating it would be an error rather than a no-op.
+echo "==> db push + generate (postgres-only.prisma)"
+docker exec "$CONTAINER" createdb -U gemi gemi_lists >/dev/null 2>&1 || true
+LISTS_DATABASE_URL="$LISTS_URL" npx prisma db push \
+  --schema prisma/postgres-only.prisma --skip-generate --accept-data-loss >/dev/null
+LISTS_DATABASE_URL="$LISTS_URL" npx prisma generate \
+  --schema prisma/postgres-only.prisma >/dev/null
+
 echo "==> vitest"
-TZ=UTC TEST_POSTGRES_URL="$URL" bun --bun vitest run --no-file-parallelism \
-  "${@:-app/models/}"
+TZ=UTC TEST_POSTGRES_URL="$URL" TEST_POSTGRES_LISTS_URL="$LISTS_URL" \
+  bun --bun vitest run --no-file-parallelism "${@:-app/models/}"

--- a/templates/saas-starter/app/models/scalar-list.test.ts
+++ b/templates/saas-starter/app/models/scalar-list.test.ts
@@ -306,7 +306,15 @@ RUN("scalar lists vs prisma — postgres", () => {
     );
   });
 
-  test("a list with @default([]) is left to the database", async () => {
+  /**
+   * A defaulted list is written with its **declared** value, not with `[]`.
+   *
+   * `@default([...])` is a client-side default — the value is in the DMMF — so
+   * gemi binds it rather than leaving the column out. The distinction only
+   * became testable when the fixture's default stopped being `[]`, where the
+   * right answer and the wrong one are the same array.
+   */
+  test("an omitted list with a default is written with that default", async () => {
     await differential.expectSameWrite(
       "Tagged",
       "create",
@@ -347,6 +355,43 @@ RUN("scalar lists vs prisma — postgres", () => {
           { id: 15, strings: { set: ["q", "r"] } },
         ],
       },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  /**
+   * **The case that catches `createMany` disagreeing with `create`.**
+   *
+   * One row supplies `defaulted` and the other omits it, so the column enters
+   * the union with a row that has no value of its own — the exact seam where
+   * `createMany` picked the empty-list binder ahead of the default binder and
+   * wrote `{}` over `["seed"]`. `create` honoured the default the whole time,
+   * so the two operations disagreed about one schema, in the row rather than in
+   * an error.
+   *
+   * Two properties are needed for it to be visible at all, and the suite had
+   * neither: a **non-empty** default, and a `createMany` where one row supplies
+   * the defaulted column and another does not.
+   */
+  test("createMany honours a list default on the rows that omit it", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "createMany",
+      {
+        data: [
+          { id: 17, strings: ["p"] },
+          { id: 18, strings: ["q"], defaulted: ["explicit"] },
+        ],
+      },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("createMany with every list omitted on every row", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "createMany",
+      { data: [{ id: 19 }, { id: 21 }] },
       { tables: ["Tagged"] },
     );
   });

--- a/templates/saas-starter/app/models/scalar-list.test.ts
+++ b/templates/saas-starter/app/models/scalar-list.test.ts
@@ -1,0 +1,470 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { createDifferential, type Differential } from "./differential";
+import { POSTGRES_LISTS_URL } from "./scratch";
+
+/**
+ * Scalar lists — `tags String[]` — against Prisma, on a real Postgres (#300).
+ *
+ * **The schema is a second one, and that decision came before the compiler.**
+ * A scalar list is legal on Postgres and a validation error on SQLite, and
+ * `app/models/postgres.sh` covers both dialects by flipping the provider in one
+ * `schema.prisma`. So the column cannot live there: it would not merely go
+ * untested on SQLite, it would stop every SQLite suite from generating.
+ * `prisma/postgres-only.prisma` carries it instead, with its own client and its
+ * own database, which is what keeps the property the rest of this ORM's
+ * correctness rests on — the same query through both clients, compared on rows
+ * *and* on table contents.
+ *
+ * The cheaper options were considered and are weaker in a way worth recording:
+ * asserting against Prisma's documented shape checks gemi against a reading of
+ * the docs, and a hand-built table with raw SQL gives a real round trip with no
+ * oracle at all. Both would have missed the two defects this file actually
+ * found — see the `documents` cases, where a wrong cast answers *false* rather
+ * than raising, and the `bigints` case behind a relation.
+ *
+ * **Everything is imported dynamically.** `app/models/generated-lists/` is
+ * gitignored and only exists after `prisma generate --schema
+ * prisma/postgres-only.prisma`, so a static import would fail this file's
+ * *collection* during a SQLite run — which takes the whole file out of the
+ * totals rather than skipping it, the failure mode
+ * `template-import-graph.test.ts` documents at length.
+ */
+const RUN = POSTGRES_LISTS_URL ? describe : describe.skip;
+
+/**
+ * Both halves of the established idiom, because each buys something different.
+ *
+ * `RUN` is the `POSTGRES…_URL ? describe : describe.skip` shape that
+ * `packages/gemi/orm/postgres-suite-selection.test.ts` looks for — which is
+ * what makes it check that this suite's *name* contains `postgres`, since the
+ * CI job's `-t postgres` filter is what selects it. Without that, a file can be
+ * run by neither job and nothing says so; three files were in that position.
+ *
+ * The passing test below is the announcement. `describe.skip` is silent, and a
+ * silently skipped dialect reads as a passing one — so the absence is reported
+ * where a person scanning CI output will see it. The wording is deliberately
+ * the same as the four suites that already do this.
+ */
+if (!POSTGRES_LISTS_URL) {
+  describe("scalar lists vs prisma — postgres (skipped)", () => {
+    test("SKIPPED — set TEST_POSTGRES_LISTS_URL to cover scalar lists", () => {
+      console.warn(
+        "\n  ⚠  Scalar-list differential tests did NOT run.\n" +
+          "     They need the second schema: app/models/postgres.sh pushes " +
+          "prisma/postgres-only.prisma\n" +
+          "     to its own database and sets TEST_POSTGRES_LISTS_URL.\n",
+      );
+      expect(POSTGRES_LISTS_URL).toBeUndefined();
+    });
+  });
+}
+
+/**
+ * One row's worth of every element type Prisma allows in a list on Postgres.
+ *
+ * Chosen so a wrong answer is visible rather than plausible: a string holding
+ * every delimiter the Postgres array literal uses, a bigint past 2^53, a JSON
+ * value that is legitimately a *string*, and an empty list beside a populated
+ * one so `isEmpty` has something to be wrong about.
+ */
+const SEEDS = [
+  {
+    id: 1,
+    strings: ["alpha", 'has "quote", brace } and \\ backslash', ""],
+    ints: [1, 2, 3],
+    floats: [1.5, -2.25],
+    booleans: [true, false],
+    bigints: [9007199254740993n, 2n],
+    stamps: [new Date("2024-01-02T03:04:05.678Z")],
+    blobs: [new Uint8Array([1, 2, 255])],
+    documents: [{ a: 1 }, [1, 2], "42", 7, null],
+    labels: ["urgent" as const, "needs_review" as const],
+    renamed: ["mapped"],
+  },
+  {
+    id: 2,
+    strings: ["alpha", "beta"],
+    ints: [3],
+    floats: [],
+    booleans: [],
+    bigints: [],
+    stamps: [],
+    blobs: [],
+    documents: [],
+    labels: ["blocked" as const],
+    renamed: [],
+  },
+  {
+    id: 3,
+    strings: [],
+    ints: [],
+    floats: [],
+    booleans: [],
+    bigints: [],
+    stamps: [],
+    blobs: [],
+    documents: [],
+    labels: [],
+    renamed: [],
+  },
+];
+
+RUN("scalar lists vs prisma — postgres", () => {
+  let differential: Differential;
+  let models: Record<string, any>;
+
+  beforeAll(async () => {
+    // Non-literal specifiers: `tsc` cannot resolve them and so does not try,
+    // which is the point — these paths do not exist during a SQLite run.
+    const generated = "./generated-lists";
+    const clientModule = "./generated-lists/client";
+
+    const [{ TaggedModel, NoteModel }, { PrismaClient }] = await Promise.all([
+      import(/* @vite-ignore */ generated),
+      import(/* @vite-ignore */ clientModule),
+    ]);
+
+    models = { Tagged: TaggedModel, Note: NoteModel };
+
+    differential = await createDifferential({
+      models,
+      url: POSTGRES_LISTS_URL,
+      client: new PrismaClient({
+        datasources: { db: { url: POSTGRES_LISTS_URL } },
+      }),
+      // Children before parents.
+      tables: ["Note", "Tagged"],
+      seed: async (prisma: any) => {
+        for (const row of SEEDS) {
+          await prisma.tagged.create({ data: row });
+        }
+        await prisma.note.create({
+          data: {
+            taggedId: 1,
+            keywords: ["one", "two"],
+            counts: [4, 5],
+            amounts: [9007199254740993n],
+            when: [new Date("2024-03-04T05:06:07.008Z")],
+          },
+        });
+      },
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    await differential?.dispose();
+  });
+
+  // --- reading -------------------------------------------------------------
+
+  /**
+   * The decode path, per element type, in one comparison.
+   *
+   * This is the case the whole second schema exists for. `Int[]` arrives from
+   * the driver as an `Int32Array`, `BigInt[]` as an array of *strings*,
+   * `Bytes[]` as `Buffer`s, and an enum list as the **unparsed** literal
+   * `{urgent,needs_review}` — four different containers, none of them what
+   * Prisma returns, and `normalize` in the harness compares constructor names
+   * so a `Buffer` where Prisma gives a `Uint8Array` fails rather than passing.
+   */
+  test("every element type decodes to what Prisma returns", async () => {
+    await differential.expectSame("Tagged", "findMany", {
+      orderBy: { id: "asc" },
+    });
+  });
+
+  test("an empty list is [] rather than null", async () => {
+    await differential.expectSame("Tagged", "findUnique", { where: { id: 3 } });
+  });
+
+  test("a mapped column is read through its field name", async () => {
+    await differential.expectSame("Tagged", "findMany", {
+      select: { id: true, renamed: true },
+      orderBy: { id: "asc" },
+    });
+  });
+
+  // --- filtering -----------------------------------------------------------
+
+  const FILTERS: [string, unknown][] = [
+    ["has", { strings: { has: "alpha" } }],
+    ["has, absent", { strings: { has: "nope" } }],
+    ["has, on the delimiter string", { strings: { has: 'has "quote", brace } and \\ backslash' } }],
+    ["has, empty string", { strings: { has: "" } }],
+    ["hasEvery", { strings: { hasEvery: ["alpha", "beta"] } }],
+    ["hasEvery, empty", { strings: { hasEvery: [] } }],
+    ["hasSome", { strings: { hasSome: ["beta", "nope"] } }],
+    ["hasSome, empty", { strings: { hasSome: [] } }],
+    ["isEmpty true", { strings: { isEmpty: true } }],
+    ["isEmpty false", { strings: { isEmpty: false } }],
+    ["equals", { strings: { equals: ["alpha", "beta"] } }],
+    ["equals, order matters", { strings: { equals: ["beta", "alpha"] } }],
+    ["equals, empty", { strings: { equals: [] } }],
+    ["equals null", { strings: { equals: null } }],
+    ["has null", { strings: { has: null } }],
+    ["ints has", { ints: { has: 3 } }],
+    ["ints hasEvery", { ints: { hasEvery: [1, 2] } }],
+    ["floats has", { floats: { has: -2.25 } }],
+    ["booleans has", { booleans: { has: false } }],
+    ["bigints has", { bigints: { has: 9007199254740993n } }],
+    ["stamps has", { stamps: { has: new Date("2024-01-02T03:04:05.678Z") } }],
+    ["blobs has", { blobs: { has: new Uint8Array([1, 2, 255]) } }],
+    ["labels has", { labels: { has: "needs_review" } }],
+    ["labels hasSome", { labels: { hasSome: ["urgent", "blocked"] } }],
+    ["renamed has", { renamed: { has: "mapped" } }],
+    // The `Json[]` cases. `$1::jsonb = any(col)` answers *false* where
+    // `$1::text::jsonb` answers true — no error on the wrong one — so these are
+    // the cases a docs-shaped assertion could not have caught.
+    ["documents has an object", { documents: { has: { a: 1 } } }],
+    ["documents has an array", { documents: { has: [1, 2] } }],
+    ["documents has a JSON string", { documents: { has: "42" } }],
+    ["documents has a JSON number", { documents: { has: 7 } }],
+    ["documents hasSome", { documents: { hasSome: [{ a: 1 }, { z: 9 }] } }],
+    ["documents isEmpty", { documents: { isEmpty: true } }],
+    // Combinators over a list filter, so it composes like any other predicate.
+    ["AND of two list filters", { AND: [{ ints: { has: 3 } }, { strings: { has: "alpha" } }] }],
+    ["NOT of a list filter", { NOT: { strings: { has: "alpha" } } }],
+    ["OR of list filters", { OR: [{ ints: { has: 1 } }, { labels: { has: "blocked" } }] }],
+  ];
+
+  test.each(FILTERS)("filter: %s", async (_name, where) => {
+    await differential.expectSame("Tagged", "findMany", {
+      where,
+      orderBy: { id: "asc" },
+    });
+  });
+
+  test.each(FILTERS)("count: %s", async (_name, where) => {
+    await differential.expectSame("Tagged", "count", { where });
+  });
+
+  // --- relations -----------------------------------------------------------
+
+  /**
+   * A list one relation down, which is a **second decoding site**: under the
+   * lateral strategy the child arrives inside `json_agg`, where the driver's
+   * type mapping never runs. `BigInt[]` is the one that fails silently there —
+   * JSON has no integer type, so 9007199254740993 comes back as ...992 without
+   * a `::text[]` cast.
+   */
+  test("a list inside an include, both strategies", async () => {
+    for (const strategy of ["batched", "lateral"] as const) {
+      await differential.expectSame(
+        "Tagged",
+        "findMany",
+        { where: { id: 1 }, include: { notes: true } },
+        { relationStrategy: strategy } as never,
+      );
+    }
+  });
+
+  test("a list filter through a relation", async () => {
+    await differential.expectSame("Tagged", "findMany", {
+      where: { notes: { some: { keywords: { has: "one" } } } },
+      orderBy: { id: "asc" },
+    });
+  });
+
+  // --- writing -------------------------------------------------------------
+
+  test("create with a bare array", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "create",
+      { data: { id: 10, strings: ["x", "y"], ints: [1] } },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("create with { set }", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "create",
+      { data: { id: 11, strings: { set: ["x", "y"] } } },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  /**
+   * **The case that found the divergence.** Every list but `strings` is absent
+   * here, and every one of them is `NOT NULL` with no database default. gemi
+   * refused the call — *"missing a value for 'ints', which is required and has
+   * no default"* — and Prisma answered it, writing `[]` to all nine.
+   *
+   * No reading of Prisma's documentation produces this: the docs describe the
+   * *input type*, where a list field is optional, and say nothing about what
+   * gets written when it is omitted. Only running both clients against one
+   * database does.
+   */
+  test("an omitted list is written as [], not refused", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "create",
+      { data: { id: 12, strings: ["x"] } },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("a list with @default([]) is left to the database", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "create",
+      { data: { id: 16, strings: ["x"], defaulted: undefined } },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("create with every element type", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "create",
+      {
+        data: {
+          id: 13,
+          strings: ["a"],
+          ints: [1],
+          floats: [0.5],
+          booleans: [true],
+          bigints: [9007199254740993n],
+          stamps: [new Date("2020-06-07T08:09:10.011Z")],
+          blobs: [new Uint8Array([9, 8])],
+          documents: [{ b: 2 }, "text"],
+          labels: ["needs_review"],
+        },
+      },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("createMany mixing the bare and { set } spellings", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "createMany",
+      {
+        data: [
+          { id: 14, strings: ["p"] },
+          { id: 15, strings: { set: ["q", "r"] } },
+        ],
+      },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  const WRITES: [string, unknown][] = [
+    ["set", { strings: { set: ["only"] } }],
+    ["set empty", { strings: { set: [] } }],
+    ["bare array", { strings: ["bare"] }],
+    ["push one", { strings: { push: "appended" } }],
+    ["push many", { strings: { push: ["one", "two"] } }],
+    ["push onto an empty list", { floats: { push: 1.25 } }],
+    ["push a bigint", { bigints: { push: 9007199254740994n } }],
+    ["push an enum label", { labels: { push: "blocked" } }],
+    ["push a json value", { documents: { push: { c: 3 } } }],
+    ["push bytes", { blobs: { push: new Uint8Array([7]) } }],
+    ["set a mapped column", { renamed: { set: ["remapped"] } }],
+  ];
+
+  test.each(WRITES)("update: %s", async (_name, data) => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "update",
+      { where: { id: 1 }, data },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("updateMany pushes onto every matched row", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "updateMany",
+      { where: { strings: { has: "alpha" } }, data: { ints: { push: 99 } } },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("upsert creates and then updates the same list", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "upsert",
+      {
+        where: { id: 20 },
+        create: { id: 20, strings: ["created"] },
+        update: { strings: { push: "updated" } },
+      },
+      { tables: ["Tagged"] },
+    );
+    await differential.expectSameWrite(
+      "Tagged",
+      "upsert",
+      {
+        where: { id: 1 },
+        create: { id: 1, strings: ["created"] },
+        update: { strings: { push: "updated" } },
+      },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("deleteMany by a list filter", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "deleteMany",
+      { where: { strings: { isEmpty: true } } },
+      { tables: ["Tagged", "Note"] },
+    );
+  });
+
+  // --- refusals ------------------------------------------------------------
+
+  /**
+   * The operator sets are disjoint, and gemi says so rather than compiling
+   * something. Prisma refuses these too — its generated types have no
+   * `contains` on a `StringNullableListFilter` — so this is parity, not
+   * strictness.
+   */
+  test("a scalar operator on a list is refused, naming both sets", async () => {
+    await expect(
+      models.Tagged.findMany({ where: { strings: { contains: "a" } } }),
+    ).rejects.toThrow(/scalar list.*list filter takes/s);
+  });
+
+  /**
+   * Prisma refuses this — *"Expected StringNullableListFilter, provided
+   * (String)"* — so gemi does too. It accepted it at first, which is a silent
+   * *superset* of Prisma: the query ran, returned plausible rows, and only the
+   * comparison against Prisma's refusal caught it.
+   */
+  test("a bare array is not a filter, and the error says what is", async () => {
+    await expect(
+      models.Tagged.findMany({ where: { strings: ["alpha"] } }),
+    ).rejects.toThrow(/bare array is not a filter/);
+  });
+
+  test("a bare array IS a value in data", async () => {
+    await differential.expectSameWrite(
+      "Tagged",
+      "update",
+      { where: { id: 1 }, data: { strings: ["bare", "value"] } },
+      { tables: ["Tagged"] },
+    );
+  });
+
+  test("a list operator on a scalar is refused", async () => {
+    await expect(
+      models.Tagged.findMany({ where: { id: { has: 1 } } }),
+    ).rejects.toThrow(/has/);
+  });
+
+  test("hasEvery with a non-array is refused with the value's type", async () => {
+    await expect(
+      models.Tagged.findMany({ where: { strings: { hasEvery: "alpha" } } }),
+    ).rejects.toThrow(/Expected an array, received string/);
+  });
+
+  test("increment on a list is refused", async () => {
+    await expect(
+      models.Tagged.update({ where: { id: 1 }, data: { ints: { increment: 1 } } }),
+    ).rejects.toThrow();
+  });
+});

--- a/templates/saas-starter/app/models/scratch.ts
+++ b/templates/saas-starter/app/models/scratch.ts
@@ -42,6 +42,17 @@ import { join } from "node:path";
 export const POSTGRES_URL = process.env.TEST_POSTGRES_URL;
 
 /**
+ * The scratch database for `prisma/postgres-only.prisma` — the scalar-list
+ * schema (#300), which needs a database of its own because `prisma db push`
+ * reconciles a whole database to one schema and would drop the main tables.
+ *
+ * Separate from {@link POSTGRES_URL} rather than derived from it, so the one
+ * suite that needs it skips when only the main schema was pushed instead of
+ * connecting to a database with no tables in it and failing per case.
+ */
+export const POSTGRES_LISTS_URL = process.env.TEST_POSTGRES_LISTS_URL;
+
+/**
  * Replays the committed migrations into a fresh SQLite file, in name order —
  * which is Prisma's own ordering, since it prefixes every directory with a
  * timestamp. Statements are split on `;` at end of line, which is enough for

--- a/templates/saas-starter/prisma/postgres-only.prisma
+++ b/templates/saas-starter/prisma/postgres-only.prisma
@@ -1,0 +1,119 @@
+// The columns Postgres has and SQLite cannot have, in a schema of their own.
+//
+// **Why this is a second file rather than four more fields in `schema.prisma`.**
+// A scalar list is legal on Postgres and a *validation error* on SQLite —
+// `prisma generate` refuses the schema with "the current connector does not
+// support lists of primitive types" — and `app/models/postgres.sh` covers both
+// dialects by `sed`-flipping the provider in one file. So a `String[]` added
+// there does not merely go untested on SQLite: it stops the SQLite suites from
+// generating at all, and one such column means no artifacts for any model.
+//
+// That is the constraint #300 had to solve before any compiler work, because it
+// decides what "done" can be evidenced by. The three candidates were: assert
+// against Prisma's documented shape (cheap, and checks gemi against a reading of
+// the docs rather than against Prisma); a Postgres-only suite that builds its
+// own table with raw SQL (a real round trip, still no Prisma oracle); or this —
+// a second schema with its own client, which keeps the property every other
+// correctness claim in this ORM rests on: **the same query through Prisma and
+// through gemi, against one database, compared on rows and table contents.**
+//
+// The cost is honest and contained: this schema is never generated during a
+// SQLite run, so `app/models/generated-lists/` is gitignored and the suite that
+// reads it is gated on `TEST_POSTGRES_URL`. `app/models/postgres.sh` pushes and
+// generates it alongside the main one.
+//
+// It lives in its own database — `LISTS_DATABASE_URL`, `gemi_lists` — rather
+// than beside the main tables. `prisma db push` reconciles a whole database to
+// one schema, so pushing this one at `gemi` would drop every table the other
+// schema owns.
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
+  output          = "../app/models/generated-lists/client"
+}
+
+generator gemi {
+  provider = "gemi-orm-generator"
+  output   = "../app/models/generated-lists"
+  // Not `@prisma/client`: that name resolves to the *main* schema's client,
+  // which has never heard of these models. See the generator's `client` option.
+  client   = "./client"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("LISTS_DATABASE_URL")
+}
+
+/// An enum array is the one scalar list Bun's driver hands back **unparsed** —
+/// as the Postgres array literal `{urgent,blocked}` — so this is what makes the
+/// decoder's literal parser reachable end to end at all.
+///
+/// It cannot reach the *quoting* half of that parser, and that is a property of
+/// Prisma rather than an omission here: an enum member is a Prisma identifier,
+/// `[A-Za-z][A-Za-z0-9_]*`, and Postgres quotes an array element only when it
+/// contains a delimiter, a quote or a backslash. So no schema Prisma will accept
+/// can produce a quoted element in this position. The escaping cases are unit
+/// tested against the parser directly, in `packages/gemi/orm/dialect`, and that
+/// split is deliberate rather than a gap papered over.
+///
+/// `@@map` renames the *type*, which is the case that would break a design
+/// naming the element type in a cast. This one infers it from the column
+/// instead, and this line is what keeps that honest.
+enum Label {
+  urgent
+  blocked
+  needs_review
+
+  @@map("label_kind")
+}
+
+/// Every element type Prisma allows in a scalar list on Postgres, in one model,
+/// so the differential matrix reaches all of them rather than the two a
+/// realistic schema would have used.
+///
+/// `Decimal[]` is the one absence, and it is not a gap here: `Decimal` itself is
+/// refused at generation time — a SQLite REAL cannot carry it — and a list of a
+/// scalar no dialect can round-trip is not more supportable for being a list.
+model Tagged {
+  id Int @id @default(autoincrement())
+
+  strings   String[]
+  ints      Int[]
+  floats    Float[]
+  booleans  Boolean[]
+  bigints   BigInt[]
+  stamps    DateTime[]
+  blobs     Bytes[]
+  documents Json[]
+  labels    Label[]
+
+  /// A list with a database-side default, which is the ordinary way one is
+  /// declared and the case where the insert must *omit* the column rather than
+  /// bind an empty array.
+  defaulted String[] @default([])
+
+  /// `@map`, so the compiler is exercised on a list whose column name is not
+  /// its field name — the one thing a hand-written `has` filter would get right
+  /// by accident.
+  renamed String[] @map("renamed_column")
+
+  notes Note[]
+}
+
+/// A second model behind a relation, so the lateral strategy's decoder — which
+/// is a *separate* decoding site from the driver's, reached only when a list
+/// arrives inside `json_agg` — is covered too. That path is where `BigInt[]`
+/// silently loses its low bit without a `::text[]` cast.
+model Note {
+  id       Int      @id @default(autoincrement())
+  taggedId Int
+  tagged   Tagged   @relation(fields: [taggedId], references: [id], onDelete: Cascade)
+  keywords String[]
+  counts   Int[]
+  amounts  BigInt[]
+  when     DateTime[]
+
+  @@index([taggedId])
+}

--- a/templates/saas-starter/prisma/postgres-only.prisma
+++ b/templates/saas-starter/prisma/postgres-only.prisma
@@ -19,7 +19,10 @@
 //
 // The cost is honest and contained: this schema is never generated during a
 // SQLite run, so `app/models/generated-lists/` is gitignored and the suite that
-// reads it is gated on `TEST_POSTGRES_URL`. `app/models/postgres.sh` pushes and
+// reads it is gated on `TEST_POSTGRES_LISTS_URL` — a *second* variable, not the
+// main suite's, so the suite skips when only the main schema was pushed rather
+// than connecting to a database with no tables in it.
+// `app/models/postgres.sh` pushes and
 // generates it alongside the main one.
 //
 // It lives in its own database — `LISTS_DATABASE_URL`, `gemi_lists` — rather
@@ -89,10 +92,18 @@ model Tagged {
   documents Json[]
   labels    Label[]
 
-  /// A list with a database-side default, which is the ordinary way one is
-  /// declared and the case where the insert must *omit* the column rather than
-  /// bind an empty array.
-  defaulted String[] @default([])
+  /// A list with a default, and a **non-empty** one on purpose.
+  ///
+  /// `@default([])` is what this was, and it could not fail: the correct value
+  /// and the wrong one are both the empty array, so a write that ignored the
+  /// default and wrote `{}` compared equal to one that honoured it. A seeded
+  /// default is what makes the two distinguishable — and it caught `createMany`
+  /// overwriting the declared default where `create` honoured it.
+  ///
+  /// Note `@default([...])` is a *client-side* default, like `@default(cuid())`:
+  /// the value is in the DMMF, so gemi binds it rather than leaving the column
+  /// out for the database to fill.
+  defaulted String[] @default(["seed"])
 
   /// `@map`, so the compiler is exercised on a list whose column name is not
   /// its field name — the one thing a hand-written `has` filter would get right


### PR DESCRIPTION
Closes #300. Stacked on #299 — based on `feat/orm-release-issues` at `b5db21e`, whose docs commit this reconciles.

`tags String[]` could not be used with the ORM at all. The refusal was correct; what was missing is that nothing tracked it, nothing documented it, and the comment recording the deferral pointed at "iteration 2", which shipped seven iterations ago without doing it.

## The three decisions the issue asked for

**1. Build it.**

**2. The harness, decided before the compiler** — because it decides what "done" can be evidenced by. `templates/saas-starter` has one `schema.prisma` and `postgres.sh` covers both dialects by `sed`-flipping its provider. A scalar list is legal on Postgres and a *validation error* on SQLite, so a `String[]` added there does not merely go untested — it stops every SQLite suite from generating.

Of the issue's three options this takes the first: `prisma/postgres-only.prisma`, with its own client and its own database. That keeps the property every other correctness claim in this ORM rests on — the same query through Prisma and through gemi against one database, compared on rows *and* table contents. The cheaper options are weaker in a way worth naming: asserting against Prisma's documented shape checks gemi against a reading of the docs, and a hand-built table gives a real round trip with no oracle.

**3. Element types: everything Prisma allows on Postgres** — `String`, `Int`, `Float`, `Boolean`, `BigInt`, `DateTime`, `Bytes`, `Json` and enums. `Decimal[]` stays refused because `Decimal` is; a list of a scalar no dialect can round-trip is not more supportable for being a list.

## What the oracle caught

Three defects survived design and unit tests and died on contact with Prisma:

- **`create` refused calls Prisma answers.** A `String[]` with no `@default` is not "missing" — Prisma writes `[]`. No reading of the docs produces this: they describe the *input type*, where the field is optional, and say nothing about what is written when it is absent.
- **A bare array is a value but not a filter.** `{ tags: ["a"] }` compiled as `equals`; Prisma rejects it with *"Expected StringNullableListFilter"*. Accepting it made gemi a silent superset that returned plausible rows.
- **`$1::jsonb = any(col)` answers `false` where `$1::text::jsonb` answers `true`**, with no error on either. That is #209 one level in, and it is why the dialect's list methods take a `Fragment` rather than a `Binder` — `fieldParam` stays the single authority on cast-plus-serialisation, instead of each dialect restating a rule whose wrong version returns no rows.

## The refusal moved rather than disappeared

`emit.ts` was the wrong place for it and would have been even once arrays decoded: the artifact is dialect-agnostic on purpose, since `DATABASE_URL` can name a different database than `prisma generate` saw. Refusing there refused the column for Postgres too — and refused the *whole artifact*, since one `String[]` anywhere threw before any model was emitted. `SqliteDialect.listFilters` is empty now, and the compiler refuses from there naming the dialect and saying Prisma rejects the column on SQLite as well.

## Measured rather than reasoned about

Every operator resolves against an untyped array literal on `text[]`, `jsonb[]`, `bytea[]`, `timestamp(3)[]` and an `enum[]` — so no casts, no enum type name in the artifact, and `SCHEMA_ARTIFACT_VERSION` does not move.

The teeth were in decoding, where the driver returns three different containers:

```
text[] float8[] bool[] timestamp[] bytea[] jsonb[] bigint[]  -> Array
int[]                                                        -> Int32Array
enum[]  domain[]                                             -> "{a,b}"
```

`int[]`'s container depends on the *protocol*, so it cannot be decided once; an enum array arrives unparsed, which is why there is a literal parser at all. `BigInt[]` needed the array form of the `::text` cast the scalar case already documents — without it `9007199254740993` came back as `...992`, element-wise, through `json_agg`.

`isList` is a flag beside `type` rather than a `ScalarType` constructor, so `type` keeps meaning the *element* type and every existing `switch` over it stays exhaustive instead of quietly acquiring a shape it had never seen.

## Reconciling `b5db21e`

That commit documented this refusal as permanent — a **Columns the generator refuses** table listing scalar lists beside `Decimal`, and a *No scalar lists* entry under **Not in scope**. Implementing them makes both wrong, so both are fixed here rather than left to contradict the feature two sections away. The table keeps `Decimal`, loses the scalar-list row, and says the row *moved* rather than vanished. A section this branch had written independently is dropped and its one unique fact folded into `b5db21e`'s instead of duplicating it.

`453c4ad`'s changes to `compile/where.ts` and `dialect/index.ts` merged cleanly; the conflicts were `docs/orm.md` and its `llms-full.txt` embed, both by adjacency. `docs-links.test.ts` caught the one dangling anchor the reconciliation left behind.

## Verification

Both dialects, separately, as `postgres.sh` requires:

| | |
| --- | --- |
| `packages/gemi` | 61 files / 1674 ORM tests, `tsc` clean, `oxlint orm --deny-warnings` at 0 |
| template, sqlite | 652 tests + 36 type tests |
| template, postgres | 1027 tests on a real server (928 before — the +99 is the new suite) |
| template, CI's `-t postgres` | 783 tests, 0 failures |

Two things stated rather than left to be discovered. The six `app/`/`services/router/` failures in a full package run are #163 and predate this — confirmed identical at `2b087ec` in a scratch worktree rather than assumed. And `postgres.sh` unfiltered still fails the two SQLite-only differential suites, which is the documented one-dialect-at-a-time property, also identical at baseline; CI's filter excludes them.

**Known gap, stated rather than left to be found.** The differential cannot reach the literal parser's *escaping*: a Prisma enum member is `[A-Za-z][A-Za-z0-9_]*`, and Postgres quotes an array element only when it contains a delimiter, a quote or a backslash — so no schema Prisma accepts can produce a quoted element there. Those cases are unit tested against the parser directly in `orm/scalar-list.test.ts`, and the split is written down in both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKmoiiGwuXwUS7fQQN7M9Q