### PR TITLE
Export AuthManager, fix gemi migrate, and cut 0.51.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ export default function SignIn() {
 
 ### Type-safe network layer
 
-Consuming api endpoints using `useGet` hook.
+Consuming api endpoints using the `useQuery` hook.
 
 ``` tsx
-import { useGet } from 'gemi/client'
+import { useQuery } from 'gemi/client'
 
 export default function OrderDetail() {
-  const { data: orders } = useGet('/orders/:orderId')
+  const { data: orders } = useQuery('/orders/:orderId')
 
   return (
     <div>...</div>

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -81,10 +81,19 @@ export default defineRouteConfig({
 and `route.view.rootRouter` have no defaults. Everything else can be omitted
 entirely.
 
-### One property was renamed
+### One property was retired
 
-`AuthenticationServiceProvider.adapter` is now `auth.userProvider`. The codemod
-renames it for you and says so in the summary.
+`AuthenticationServiceProvider.adapter` briefly became `auth.userProvider`, and
+then the seam it selected between was removed altogether: auth persistence is
+now the ORM-backed `UserProvider`, and `AuthConfig` has no field for it.
+
+The codemod comments the member out and leaves a TODO carrying the replacement —
+subclass `UserProvider` from `gemi/kernel`, override the methods the adapter
+implemented, and install it by rebinding `AuthManager` (from `gemi/services`) in
+a ServiceProvider, which takes the provider as its second constructor argument.
+The same TODO is written over a `userProvider` field left in an
+`app/config/auth.ts` by an earlier migration. See
+[docs/authentication.md](docs/authentication.md) for the worked example.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     },
     "packages/gemi": {
       "name": "gemi",
-      "version": "0.51.0-rc.1",
+      "version": "0.51.0-rc.2",
       "bin": {
         "gemi": "./dist/bin/gemi.js",
       },

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -189,9 +189,11 @@ argument:
 ```typescript
 // app/providers/AppServiceProvider.ts
 import { AuthManager } from "gemi/services";
-import { ServiceProvider } from "gemi/services";
+import { ServiceProvider } from "gemi/support";
 
-export class AppServiceProvider extends ServiceProvider {
+import { OrgProvisioningUserProvider } from "@/app/auth/OrgProvisioningUserProvider";
+
+export default class AppServiceProvider extends ServiceProvider {
   register() {
     this.app.singleton(
       AuthManager,
@@ -204,6 +206,10 @@ export class AppServiceProvider extends ServiceProvider {
   }
 }
 ```
+
+The provider has to be listed in your `Kernel`'s `providers` array to run — see
+[Project Structure](./project-structure.md#service-providers). App providers register *after*
+the framework's, so this binding replaces the default `AuthManager` rather than racing it.
 
 > **Note:** gemi runs `createUser` and then fires `onSignUp` *separately*. Provisioning
 > inside the `onSignUp` callback is therefore **not** atomic with user creation — a failure

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,7 +61,7 @@ It launches `dist/server/server.mjs` in a fresh Bun process with `NODE_ENV=produ
 
 ## `gemi migrate`
 
-Upgrades an app from the 0.42 service-provider layout to the 0.43 config + container layout.
+Upgrades an app from the 0.42 service-provider layout to the config + container layout introduced in 0.43, and flags the APIs retired since.
 
 ```bash
 gemi migrate --dry-run   # print the plan, write nothing
@@ -72,7 +72,9 @@ It reads `app/kernel/providers/`, turns each recognised provider into an `app/co
 
 Anything it cannot translate is left on disk and reported rather than guessed at — unrecognised providers are carried into the new `providers` array with a TODO, and `.use()` call sites are renamed but not rewritten. Run `--dry-run` first, and see [UPGRADE.md](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md) for the full list of what it does and does not handle.
 
-> This command only makes sense once, when moving from 0.42 to 0.43. It is a no-op on an app that has no `app/kernel/providers/` directory.
+It also annotates APIs retired after 0.43 rather than rewriting them, which is the half that applies to an app already on the config + container layout. Imports of the retired authentication adapters (`IAuthenticationAdapter`, `PrismaAuthenticationAdapter`, `OrmAuthenticationAdapter`) and the `userProvider` field in `app/config/auth.ts` get a TODO naming their replacement — subclass `UserProvider` and rebind `AuthManager` — because the substitute is an app-specific class no codemod can write. Retired fields are marked in place, never deleted: the value is an expression your app wrote, and removing it can strand an import or an instantiation you still need. See [Authentication](./authentication.md#changing-a-query).
+
+> The provider-to-config half only runs when `app/kernel/providers/` exists. Without it that step is skipped and your `Kernel.ts` is left alone — so re-running the command on an already-migrated app is safe, and the retired-API pass above is all it does.
 
 ## `gemi ide:generate-api-manifest`
 

--- a/docs/file-storage.md
+++ b/docs/file-storage.md
@@ -214,16 +214,16 @@ bun add @azure/storage-blob
 ```
 
 ```typescript
-// app/kernel/providers/FileStorageServiceProvider.ts
-import { FileStorageServiceProvider, AzureBlobDriver } from "gemi/services";
+// app/config/filesystem.ts
+import { defineFilesystemConfig, AzureBlobDriver } from "gemi/services";
 
-export default class extends FileStorageServiceProvider {
-  driver = new AzureBlobDriver({
+export default defineFilesystemConfig({
+  driver: new AzureBlobDriver({
     // defaults to process.env.AZURE_STORAGE_CONNECTION_STRING
     connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING,
     container: process.env.BUCKET_NAME,
-  });
-}
+  }),
+});
 ```
 
 The SDK is loaded lazily on first use, so importing `gemi/services` costs nothing when the driver is unused. Using it without the package installed throws an error telling you to install it.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -951,7 +951,7 @@ It launches `dist/server/server.mjs` in a fresh Bun process with `NODE_ENV=produ
 
 ## `gemi migrate`
 
-Upgrades an app from the 0.42 service-provider layout to the 0.43 config + container layout.
+Upgrades an app from the 0.42 service-provider layout to the config + container layout introduced in 0.43, and flags the APIs retired since.
 
 ```bash
 gemi migrate --dry-run   # print the plan, write nothing
@@ -962,7 +962,9 @@ It reads `app/kernel/providers/`, turns each recognised provider into an `app/co
 
 Anything it cannot translate is left on disk and reported rather than guessed at — unrecognised providers are carried into the new `providers` array with a TODO, and `.use()` call sites are renamed but not rewritten. Run `--dry-run` first, and see [UPGRADE.md](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md) for the full list of what it does and does not handle.
 
-> This command only makes sense once, when moving from 0.42 to 0.43. It is a no-op on an app that has no `app/kernel/providers/` directory.
+It also annotates APIs retired after 0.43 rather than rewriting them, which is the half that applies to an app already on the config + container layout. Imports of the retired authentication adapters (`IAuthenticationAdapter`, `PrismaAuthenticationAdapter`, `OrmAuthenticationAdapter`) and the `userProvider` field in `app/config/auth.ts` get a TODO naming their replacement — subclass `UserProvider` and rebind `AuthManager` — because the substitute is an app-specific class no codemod can write. Retired fields are marked in place, never deleted: the value is an expression your app wrote, and removing it can strand an import or an instantiation you still need. See [Authentication](./authentication.md#changing-a-query).
+
+> The provider-to-config half only runs when `app/kernel/providers/` exists. Without it that step is skipped and your `Kernel.ts` is left alone — so re-running the command on an already-migrated app is safe, and the retired-API pass above is all it does.
 
 ## `gemi ide:generate-api-manifest`
 
@@ -4590,9 +4592,11 @@ argument:
 ```typescript
 // app/providers/AppServiceProvider.ts
 import { AuthManager } from "gemi/services";
-import { ServiceProvider } from "gemi/services";
+import { ServiceProvider } from "gemi/support";
 
-export class AppServiceProvider extends ServiceProvider {
+import { OrgProvisioningUserProvider } from "@/app/auth/OrgProvisioningUserProvider";
+
+export default class AppServiceProvider extends ServiceProvider {
   register() {
     this.app.singleton(
       AuthManager,
@@ -4605,6 +4609,10 @@ export class AppServiceProvider extends ServiceProvider {
   }
 }
 ```
+
+The provider has to be listed in your `Kernel`'s `providers` array to run — see
+[Project Structure](./project-structure.md#service-providers). App providers register *after*
+the framework's, so this binding replaces the default `AuthManager` rather than racing it.
 
 > **Note:** gemi runs `createUser` and then fires `onSignUp` *separately*. Provisioning
 > inside the `onSignUp` callback is therefore **not** atomic with user creation — a failure

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Getting Started](https://nstfkc.github.io/gemi/getting-started.md): install, scaffold with create-gemi-app, dev/build/start, a first route + view.
 - [Project Structure & the Kernel](https://nstfkc.github.io/gemi/project-structure.md): the app/ layout, the Kernel, the container, app/config/*.ts, service providers, and app bootstrap.
 - [Configuration](https://nstfkc.github.io/gemi/configuration.md): gemi.config.ts (BUILD config, distinct from app/config/), .env handling, HTML compression, app/preload.ts, Vite config.
-- [CLI](https://nstfkc.github.io/gemi/cli.md): gemi dev/build/start, gemi migrate (0.42 -> 0.43 codemod), plus codegen and inspection commands.
+- [CLI](https://nstfkc.github.io/gemi/cli.md): gemi dev/build/start, gemi migrate (the 0.42 -> config/container codemod, and the retired-API TODOs), plus codegen and inspection commands.
 
 ## HTTP layer
 

--- a/packages/gemi/bin/gemi.ts
+++ b/packages/gemi/bin/gemi.ts
@@ -176,15 +176,16 @@ program.command("start").action(async () => {
 program
   .command("migrate")
   .description(
-    "Migrate an app from the 0.42 service-provider layout to 0.43 config + container",
+    "Migrate an app from the 0.42 service-provider layout to the config + " +
+      "container layout, flagging APIs retired since",
   )
   .option("--dry-run", "Print the plan without writing anything")
   .action(async (options: { dryRun?: boolean }) => {
     const rootDir = path.resolve(process.cwd());
     console.log(
       options.dryRun
-        ? `Planning migration of ${rootDir} (0.42 -> 0.43)...`
-        : `Migrating ${rootDir} (0.42 -> 0.43)...`,
+        ? `Planning migration of ${rootDir}...`
+        : `Migrating ${rootDir}...`,
     );
     await runMigrate({ rootDir, dryRun: options.dryRun });
   });

--- a/packages/gemi/bin/migrate/index.ts
+++ b/packages/gemi/bin/migrate/index.ts
@@ -20,6 +20,7 @@ import {
   FACADE_RENAMES,
   MODULE_MOVES,
   PROVIDER_MIGRATIONS,
+  RETIRED_CONFIG_FIELDS,
   SECTION_ORDER,
   SERVICE_RENAMES,
   TODO,
@@ -70,7 +71,25 @@ export async function runMigrate(options: MigrateOptions) {
   // referencing them, just through the new `providers` array.
   const carriedProviders: string[] = [];
 
-  if (existsSync(providersDir)) {
+  /**
+   * Whether the app is still on the 0.42 layout, and so whether steps 2 and 3
+   * have anything to do.
+   *
+   * Both used to run unconditionally, which made this command destructive on an
+   * app that had already migrated. `buildKernel` writes the `config` member from
+   * the slices it just generated, so it treats a Kernel's existing `config` as
+   * an unrecognised leftover and carries it over commented out — and `config` is
+   * part of the current Kernel shape, not a 0.42 relic. On an already-migrated
+   * app that silently unwires every config slice: the file still compiles, the
+   * app still boots, and nothing an app declares in `app/config` is merged.
+   *
+   * The directory's presence is the right signal rather than the slice count,
+   * because a providers directory whose every file is unrecognised is still a
+   * 0.42 app that wants its Kernel rewritten.
+   */
+  const onOldLayout = existsSync(providersDir);
+
+  if (onOldLayout) {
     for (const entry of readdirSync(providersDir).sort()) {
       if (!/\.tsx?$/.test(entry)) continue;
       const file = path.join(providersDir, entry);
@@ -119,42 +138,48 @@ export async function runMigrate(options: MigrateOptions) {
     }
   }
 
-  // 2. Kernel.
+  // 2. Kernel — only when there was a provider layout to move off, per
+  //    `onOldLayout`. Nothing is reported when the whole step is skipped: the
+  //    no-providers-directory note above already says why, and repeating it per
+  //    skipped step buries the retired-API findings under its own bookkeeping.
   const kernelFile = path.join(appDir, "kernel", "Kernel.ts");
-  if (existsSync(kernelFile)) {
-    changes.push({
-      file: kernelFile,
-      contents: buildKernel(
-        kernelFile,
-        [...slices.keys()],
-        carriedProviders,
-        rootDir,
-        notes,
-      ),
-    });
-  } else {
-    notes.push({
-      file: "app/kernel/Kernel.ts",
-      message: "not found — the Kernel rewrite was skipped",
-    });
+  if (onOldLayout) {
+    if (existsSync(kernelFile)) {
+      changes.push({
+        file: kernelFile,
+        contents: buildKernel(
+          kernelFile,
+          [...slices.keys()],
+          carriedProviders,
+          rootDir,
+          notes,
+        ),
+      });
+    } else {
+      notes.push({
+        file: "app/kernel/Kernel.ts",
+        message: "not found — the Kernel rewrite was skipped",
+      });
+    }
   }
 
   // 3. The app's own provider, which is where anything that used to live in a
   //    provider's `boot()` now belongs.
   const appProviderFile = path.join(appDir, "providers", "AppServiceProvider.ts");
-  if (!existsSync(appProviderFile)) {
+  if (onOldLayout && !existsSync(appProviderFile)) {
     changes.push({ file: appProviderFile, contents: APP_SERVICE_PROVIDER });
   }
 
   // 4. Provider files whose contents now live in app/config are superseded.
   for (const file of migratedFiles) changes.push({ file, contents: null });
 
-  // 5. Renames across the rest of the app.
+  // 5. Renames across the rest of the app, plus retired fields in app/config.
   const touched = new Set(changes.map((change) => change.file));
   for (const file of walk(appDir)) {
     if (touched.has(file)) continue;
     const source = readFileSync(file, "utf8");
-    const rewritten = rewriteReferences(source, rel(rootDir, file), notes);
+    let rewritten = rewriteReferences(source, rel(rootDir, file), notes);
+    rewritten = annotateRetiredFields(rewritten, file, appDir, rel(rootDir, file), notes);
     if (rewritten !== source) changes.push({ file, contents: rewritten });
   }
 
@@ -424,14 +449,28 @@ function renderMembers(
     if (member.blankBefore) lines.push("");
     if (member.leading.trim()) lines.push(reindent(member.leading, width, shift));
 
-    if (member.kind === "unsupported") {
+    // Two ways a member fails to become a config field: the parser could not
+    // classify it, or the field it would have become no longer exists. Both
+    // render the same — TODO, then the original commented out — and differ only
+    // in the sentence, so they share the branch.
+    const removal = member.name
+      ? migration.memberRemovals?.[member.name]
+      : undefined;
+
+    if (member.kind === "unsupported" || removal) {
+      const reason = removal ?? member.reason!;
       notes.push({
         file: label,
-        message: `\`${member.name ?? member.text.split(/\s/)[0]}\` — ${member.reason}; left commented out in the config file`,
+        message: removal
+          ? `\`${member.name}\` — ${removal}`
+          : `\`${member.name ?? member.text.split(/\s/)[0]}\` — ${reason}; left commented out in the config file`,
       });
+      // The parser's reasons are clause fragments; a removal's is prose that
+      // already punctuates itself.
+      const sentence = /[.!?]$/.test(reason) ? reason : `${reason}.`;
       lines.push(
         reindent(
-          `${TODO} ${member.reason}. The 0.42 source is kept below.`,
+          `${TODO} ${sentence} The 0.42 source is kept below.`,
           width,
           shift,
         ),
@@ -620,6 +659,54 @@ export default class AppServiceProvider extends ServiceProvider {
 // ---------------------------------------------------------------------------
 // Reference renames across the rest of app/
 // ---------------------------------------------------------------------------
+
+/**
+ * Marks retired fields in `app/config/*.ts` with a TODO, in place.
+ *
+ * Annotates rather than deletes, which is the whole design. A field's value is
+ * an expression the app wrote — `new OrgProvisioningAuthAdapter(prisma)` — and
+ * removing the property can strand an import, an instantiation with side
+ * effects, or the only reference to a class the app still wants. The type error
+ * is already a perfectly good forcing function; what it lacks is a sentence
+ * saying where the replacement lives, and that is what this adds.
+ *
+ * Matched by line rather than by parsing the object, because the target is a
+ * top-level key in a `define*Config({ … })` call and a nested `userProvider`
+ * inside some unrelated option would be a false positive the author can see and
+ * ignore — where a rewrite of the wrong node would not be.
+ */
+function annotateRetiredFields(
+  source: string,
+  file: string,
+  appDir: string,
+  label: string,
+  notes: Note[],
+): string {
+  const configDir = path.join(appDir, "config");
+  if (path.dirname(file) !== configDir) return source;
+
+  const slice = path.basename(file).replace(/\.tsx?$/, "");
+  const retired = RETIRED_CONFIG_FIELDS[slice];
+  if (!retired) return source;
+
+  let out = source;
+
+  for (const [field, message] of Object.entries(retired)) {
+    const property = new RegExp(`^([ \\t]*)${field}\\s*:`, "m");
+    const match = property.exec(out);
+    if (!match) continue;
+    // Idempotent: a second run must not stack TODOs on the same field.
+    if (out.slice(0, match.index).trimEnd().endsWith(message)) continue;
+
+    out =
+      out.slice(0, match.index) +
+      `${match[1]}${TODO} ${message}\n` +
+      out.slice(match.index);
+    notes.push({ file: label, message: `\`${field}\` — ${message}` });
+  }
+
+  return out;
+}
 
 function rewriteReferences(
   source: string,

--- a/packages/gemi/bin/migrate/index.ts
+++ b/packages/gemi/bin/migrate/index.ts
@@ -122,10 +122,32 @@ export async function runMigrate(options: MigrateOptions) {
       { rootDir, appDir, aliasPrefix },
       notes,
     );
-    changes.push({
-      file: path.join(appDir, "config", `${configKey}.ts`),
-      contents: emitted.contents,
-    });
+    // Same refusal the extracted files get below, for the same reason and one
+    // step earlier. A half-migrated app — a providers directory *and* a
+    // hand-written `app/config/<slice>.ts` — used to have that config silently
+    // replaced by the provider-derived one, under an `update` line and a
+    // "Nothing needs manual attention" summary. The two files are both the
+    // app's, neither is derivable from the other, and merging them is a
+    // judgement call this command should not make on its own.
+    const configFile = path.join(appDir, "config", `${configKey}.ts`);
+    if (existsSync(configFile)) {
+      notes.push({
+        file: rel(rootDir, configFile),
+        message:
+          `already exists — left untouched. The ${inputs.length === 1 ? "provider" : "providers"} it would ` +
+          `have been generated from ${inputs.length === 1 ? "is" : "are"} left in place too, so nothing is ` +
+          `lost; fold them together by hand and delete the provider.`,
+      });
+      // The provider files stay on disk: deleting them would strand the only
+      // copy of the settings this file was not allowed to receive.
+      for (const input of inputs) {
+        const index = migratedFiles.indexOf(input.file);
+        if (index !== -1) migratedFiles.splice(index, 1);
+      }
+      continue;
+    }
+
+    changes.push({ file: configFile, contents: emitted.contents });
     for (const extracted of emitted.extractedFiles) {
       if (existsSync(extracted.file)) {
         notes.push({
@@ -179,7 +201,7 @@ export async function runMigrate(options: MigrateOptions) {
     if (touched.has(file)) continue;
     const source = readFileSync(file, "utf8");
     let rewritten = rewriteReferences(source, rel(rootDir, file), notes);
-    rewritten = annotateRetiredFields(rewritten, file, appDir, rel(rootDir, file), notes);
+    rewritten = annotateRetiredFields(rewritten, file, rootDir, notes);
     if (rewritten !== source) changes.push({ file, contents: rewritten });
   }
 
@@ -672,40 +694,65 @@ export default class AppServiceProvider extends ServiceProvider {
  *
  * Matched by line rather than by parsing the object, because the target is a
  * top-level key in a `define*Config({ … })` call and a nested `userProvider`
- * inside some unrelated option would be a false positive the author can see and
+ * inside some unrelated option is a false positive the author can see and
  * ignore — where a rewrite of the wrong node would not be.
+ *
+ * *Every* match is annotated, not just the first. Marking one and stopping
+ * traded the tolerable false positive for an intolerable false negative: a
+ * nested key of the same name occurring earlier in the file would absorb the
+ * annotation and leave the real retired field unmarked, which is the one
+ * outcome this pass exists to prevent. Each match carries its own idempotency
+ * check, so annotating all of them stays safe across re-runs.
+ *
+ * Line-by-line rather than by advancing a `/g` regex over a string that grows
+ * as annotations are inserted. That version worked but was a trap: its
+ * termination depended on the `g` flag, so dropping the flag turned a wrong
+ * answer into an infinite loop — a test suite that hangs instead of failing.
+ * Iterating lines cannot outlive the array.
  */
 function annotateRetiredFields(
   source: string,
   file: string,
-  appDir: string,
-  label: string,
+  rootDir: string,
   notes: Note[],
 ): string {
-  const configDir = path.join(appDir, "config");
+  const configDir = path.join(rootDir, "app", "config");
   if (path.dirname(file) !== configDir) return source;
 
   const slice = path.basename(file).replace(/\.tsx?$/, "");
   const retired = RETIRED_CONFIG_FIELDS[slice];
   if (!retired) return source;
 
-  let out = source;
+  const entries = Object.entries(retired);
+  const out: string[] = [];
+  const marked = new Set<string>();
 
-  for (const [field, message] of Object.entries(retired)) {
-    const property = new RegExp(`^([ \\t]*)${field}\\s*:`, "m");
-    const match = property.exec(out);
-    if (!match) continue;
-    // Idempotent: a second run must not stack TODOs on the same field.
-    if (out.slice(0, match.index).trimEnd().endsWith(message)) continue;
+  for (const line of source.split("\n")) {
+    for (const [field, message] of entries) {
+      const match = new RegExp(`^([ \\t]*)${field}\\s*:`).exec(line);
+      if (!match) continue;
 
-    out =
-      out.slice(0, match.index) +
-      `${match[1]}${TODO} ${message}\n` +
-      out.slice(match.index);
-    notes.push({ file: label, message: `\`${field}\` — ${message}` });
+      // Idempotent: a second run must not stack TODOs on the same field. The
+      // annotation is a single line, so the one just emitted is the only place
+      // a previous run's could be.
+      const previous = out[out.length - 1] ?? "";
+      if (!previous.includes(message)) {
+        out.push(`${match[1]}${TODO} ${message}`);
+        marked.add(field);
+      }
+      break;
+    }
+    out.push(line);
   }
 
-  return out;
+  for (const field of marked) {
+    notes.push({
+      file: rel(rootDir, file),
+      message: `\`${field}\` — ${retired[field]}`,
+    });
+  }
+
+  return out.join("\n");
 }
 
 function rewriteReferences(
@@ -911,6 +958,33 @@ function rel(rootDir: string, file: string) {
   return path.relative(rootDir, file).split(path.sep).join("/");
 }
 
+/** The `` `member` — `` a note prepends to say which member it is about. */
+const QUALIFIER = /^`[^`]+` — /;
+
+/**
+ * Collapses notes that say the same thing about one file.
+ *
+ * An exact-string check is not enough, because a single retired API reaches the
+ * report through two tables: `DELETED_EXPORTS` fires on the import and
+ * `memberRemovals` on the member, and both carry `ADAPTER_RETIRED` — one bare,
+ * one prefixed with the member's name. That printed a ~330-character paragraph
+ * twice under the same filename, and the report is this command's entire output
+ * surface.
+ *
+ * The qualified form wins: "`adapter` — …" says which member to look at, and the
+ * bare one is the same sentence with that information removed.
+ */
+function dedupeBySentence(messages: string[]): string[] {
+  const bySentence = new Map<string, string>();
+  for (const message of messages) {
+    const sentence = message.replace(QUALIFIER, "");
+    if (!bySentence.has(sentence) || QUALIFIER.test(message)) {
+      bySentence.set(sentence, message);
+    }
+  }
+  return [...bySentence.values()];
+}
+
 function report(notes: Note[], dryRun: boolean) {
   console.log("");
   if (!notes.length) {
@@ -925,8 +999,11 @@ function report(notes: Note[], dryRun: boolean) {
   const grouped = new Map<string, string[]>();
   for (const note of notes) {
     const list = grouped.get(note.file) ?? [];
-    if (!list.includes(note.message)) list.push(note.message);
+    list.push(note.message);
     grouped.set(note.file, list);
+  }
+  for (const [file, messages] of grouped) {
+    grouped.set(file, dedupeBySentence(messages));
   }
 
   console.log(dryRun ? "Would report:" : "Summary:");

--- a/packages/gemi/bin/migrate/migrate.test.ts
+++ b/packages/gemi/bin/migrate/migrate.test.ts
@@ -1,0 +1,142 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { runMigrate } from "./index";
+
+/**
+ * What `gemi migrate` does to an app that has **already** migrated.
+ *
+ * The command advertises itself as a no-op without an `app/kernel/providers/`
+ * directory, and it was not one. Steps 2 and 3 ran unconditionally, so on a
+ * current app it rewrote `Kernel.ts` from the slices it had just generated —
+ * of which there were none — and carried the Kernel's existing `config` member
+ * over commented out, on the grounds that `buildKernel` writes that member
+ * itself and anything already there is an unrecognised leftover.
+ *
+ * `config` is part of the current Kernel shape (`kernel/Kernel.ts`), so that is
+ * not a leftover, it is the app's configuration. Commenting it out leaves a file
+ * that compiles and an app that boots with **every config slice silently
+ * unmerged** — no error, no crash, just defaults everywhere. The failure mode
+ * has no symptom at the point of the change.
+ *
+ * That is worth a test rather than a fix on its own because of who runs this
+ * command. An app still on 0.42 gets the rewrite it asked for; an app on the
+ * current layout runs it to find out what *else* changed — which is exactly the
+ * case that was destructive, and exactly the case no fixture covered.
+ */
+const KERNEL_43 = `import { Kernel as BaseKernel } from "gemi/kernel";
+import authConfig from "../config/auth";
+
+export default class Kernel extends BaseKernel {
+  config = { auth: authConfig };
+}
+`;
+
+const CONFIG_43 = `import { defineAuthConfig } from "gemi/services";
+import { OrgProvisioningAuthAdapter } from "@/app/kernel/adapters/OrgProvisioningAuthAdapter";
+
+export default defineAuthConfig({
+  verifyEmail: false,
+  userProvider: new OrgProvisioningAuthAdapter(prisma),
+});
+`;
+
+const PROVIDER_42 = `import { AuthenticationServiceProvider } from "gemi/services";
+import { PrismaAuthenticationAdapter } from "gemi/kernel";
+
+export default class AuthServiceProvider extends AuthenticationServiceProvider {
+  adapter = new PrismaAuthenticationAdapter(prisma);
+  verifyEmail = false;
+}
+`;
+
+let root: string;
+
+/** `runMigrate` reports through `console.log`; the assertions read the tree. */
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "gemi-migrate-"));
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(root, { recursive: true, force: true });
+});
+
+function write(relative: string, contents: string) {
+  const file = join(root, relative);
+  mkdirSync(join(file, ".."), { recursive: true });
+  writeFileSync(file, contents);
+}
+
+const read = (relative: string) => readFileSync(join(root, relative), "utf8");
+const exists = (relative: string) => {
+  try {
+    readFileSync(join(root, relative));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe("an app already on the config + container layout", () => {
+  beforeEach(async () => {
+    write("app/kernel/Kernel.ts", KERNEL_43);
+    write("app/config/auth.ts", CONFIG_43);
+    await runMigrate({ rootDir: root });
+  });
+
+  test("its Kernel is left exactly as it was", () => {
+    // Byte-identical, not merely "still has a config member": the bug commented
+    // the member out rather than dropping it, so a substring check for `config`
+    // passes on the broken output.
+    expect(read("app/kernel/Kernel.ts")).toBe(KERNEL_43);
+  });
+
+  test("no AppServiceProvider is invented for it", () => {
+    expect(exists("app/providers/AppServiceProvider.ts")).toBe(false);
+  });
+
+  test("the retired config field is marked where it is", () => {
+    const config = read("app/config/auth.ts");
+    expect(config).toContain("TODO(gemi-migrate)");
+    // Marked, not removed — the value is an expression the app wrote.
+    expect(config).toContain("userProvider: new OrgProvisioningAuthAdapter(prisma)");
+    expect(config).toContain("UserProvider");
+  });
+
+  test("a second run does not stack a second TODO", async () => {
+    await runMigrate({ rootDir: root });
+    const occurrences = read("app/config/auth.ts").match(/TODO\(gemi-migrate\)/g);
+    expect(occurrences).toHaveLength(1);
+  });
+});
+
+describe("an app still on the 0.42 provider layout", () => {
+  beforeEach(async () => {
+    write("app/kernel/Kernel.ts", `import { Kernel } from "gemi/kernel";
+export default class extends Kernel {}
+`);
+    write("app/kernel/providers/AuthenticationServiceProvider.ts", PROVIDER_42);
+    await runMigrate({ rootDir: root });
+  });
+
+  test("still gets the provider-to-config rewrite", () => {
+    const kernel = read("app/kernel/Kernel.ts");
+    expect(kernel).toContain("config = {");
+    expect(kernel).toContain("auth,");
+    expect(exists("app/providers/AppServiceProvider.ts")).toBe(true);
+    expect(exists("app/kernel/providers/AuthenticationServiceProvider.ts")).toBe(false);
+  });
+
+  test("the retired adapter member is commented out rather than renamed", () => {
+    const config = read("app/config/auth.ts");
+    // It used to become `userProvider`, a field `AuthConfig` no longer has —
+    // a migration whose output does not type-check.
+    expect(config).not.toMatch(/^\s*userProvider:/m);
+    expect(config).toContain("// adapter = new PrismaAuthenticationAdapter(prisma);");
+    expect(config).toContain("verifyEmail: false");
+  });
+});

--- a/packages/gemi/bin/migrate/migrate.test.ts
+++ b/packages/gemi/bin/migrate/migrate.test.ts
@@ -53,11 +53,19 @@ export default class AuthServiceProvider extends AuthenticationServiceProvider {
 `;
 
 let root: string;
+let logged: string[];
 
-/** `runMigrate` reports through `console.log`; the assertions read the tree. */
+/**
+ * `runMigrate` reports through `console.log`. Most assertions read the tree
+ * instead, but the summary is this command's entire output surface, so it is
+ * captured rather than discarded.
+ */
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "gemi-migrate-"));
-  vi.spyOn(console, "log").mockImplementation(() => {});
+  logged = [];
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logged.push(args.join(" "));
+  });
 });
 
 afterEach(() => {
@@ -114,6 +122,65 @@ describe("an app already on the config + container layout", () => {
   });
 });
 
+describe("a config file whose retired field is not the first match", () => {
+  test("the real top-level field is annotated, not just the first name-alike", async () => {
+    // The nested key is the false positive the line-matching approach accepts.
+    // Annotating only the first match turned that into a false *negative*: the
+    // nested one absorbed the TODO and the real retired field went unmarked,
+    // which is the single outcome this pass exists to prevent.
+    write(
+      "app/config/auth.ts",
+      `import { defineAuthConfig } from "gemi/services";
+
+export default defineAuthConfig({
+  social: {
+    userProvider: "unrelated",
+  },
+  userProvider: new OrgAdapter(prisma),
+});
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    const lines = read("app/config/auth.ts").split("\n");
+    const real = lines.findIndex((line) => line.startsWith("  userProvider:"));
+    expect(real).toBeGreaterThan(-1);
+    expect(lines[real - 1]).toContain("TODO(gemi-migrate)");
+  });
+});
+
+describe("a half-migrated app: providers AND a hand-written config", () => {
+  const HANDWRITTEN = `import { defineAuthConfig } from "gemi/services";
+
+export default defineAuthConfig({
+  handcrafted: true,
+  redirectPath: "/somewhere-important",
+});
+`;
+
+  beforeEach(async () => {
+    write("app/kernel/Kernel.ts", `import { Kernel } from "gemi/kernel";
+export default class extends Kernel {}
+`);
+    write("app/kernel/providers/AuthenticationServiceProvider.ts", PROVIDER_42);
+    write("app/config/auth.ts", HANDWRITTEN);
+    await runMigrate({ rootDir: root });
+  });
+
+  test("the hand-written config survives untouched", () => {
+    // It used to be replaced wholesale by the provider-derived file, under an
+    // `update` line and a "Nothing needs manual attention" summary. Both files
+    // are the app's, and neither is derivable from the other.
+    expect(read("app/config/auth.ts")).toBe(HANDWRITTEN);
+  });
+
+  test("the provider it would have come from is left on disk", () => {
+    // Deleting it would strand the only copy of the settings the config file
+    // was not allowed to receive.
+    expect(exists("app/kernel/providers/AuthenticationServiceProvider.ts")).toBe(true);
+  });
+});
+
 describe("an app still on the 0.42 provider layout", () => {
   beforeEach(async () => {
     write("app/kernel/Kernel.ts", `import { Kernel } from "gemi/kernel";
@@ -129,6 +196,20 @@ export default class extends Kernel {}
     expect(kernel).toContain("auth,");
     expect(exists("app/providers/AppServiceProvider.ts")).toBe(true);
     expect(exists("app/kernel/providers/AuthenticationServiceProvider.ts")).toBe(false);
+  });
+
+  test("the retired-adapter sentence is reported once, not once per table", () => {
+    // The same sentence reaches the report twice for this file — once from
+    // `DELETED_EXPORTS` on the import, once from `memberRemovals` on the
+    // member — and they differ only by the `` `adapter` — `` qualifier, so an
+    // exact-string dedup did not see them. A ~330-character paragraph printed
+    // twice under one filename is most of the report.
+    const summary = logged.join("\n");
+    const occurrences = summary.match(/The authentication adapter seam was removed/g);
+    expect(occurrences).toHaveLength(1);
+
+    // And the surviving copy is the one that says which member to look at.
+    expect(summary).toContain("`adapter` — The authentication adapter seam was removed");
   });
 
   test("the retired adapter member is commented out rather than renamed", () => {

--- a/packages/gemi/bin/migrate/tables.ts
+++ b/packages/gemi/bin/migrate/tables.ts
@@ -1,6 +1,24 @@
-// The 0.42 -> 0.43 rename tables the codemod drives off. Keeping them as data
-// (rather than scattered string literals) means `UPGRADE.md` and the codemod
-// cannot drift apart.
+// The rename tables the codemod drives off — the 0.42 -> 0.43 provider/config
+// move, plus the APIs retired since. Keeping them as data (rather than scattered
+// string literals) means `UPGRADE.md` and the codemod cannot drift apart.
+
+/**
+ * What the retired authentication-adapter seam leaves an app to do. One sentence
+ * reused by every name that seam exported, because they all have the same
+ * replacement: there is one `UserProvider`, it is a class rather than an
+ * interface, and an app that needs different queries subclasses it.
+ *
+ * A codemod cannot write that subclass — an adapter's method bodies are the
+ * app's own queries, against whatever client it was using — so this stops at
+ * naming the destination. That is still the difference between a compile error
+ * with no target and one that says where to go.
+ */
+const ADAPTER_RETIRED =
+  "The authentication adapter seam was removed; auth persistence is now the " +
+  "ORM-backed `UserProvider`. Subclass `UserProvider` from `gemi/kernel`, " +
+  "override the methods the adapter implemented, and install it by rebinding " +
+  "`AuthManager` (from `gemi/services`) in a ServiceProvider — it takes the " +
+  "provider as its second constructor argument. See docs/authentication.md.";
 
 export interface ProviderMigration {
   /** Base class the app's provider extended in 0.42. */
@@ -14,6 +32,13 @@ export interface ProviderMigration {
   defineModule: string;
   /** Provider members renamed on the way to config. */
   memberRenames?: Record<string, string>;
+  /**
+   * Provider members with no config field to land in, mapped to the sentence
+   * the TODO should carry. Rendered commented-out, like a member the parser
+   * could not classify — the app's source is preserved either way, and the
+   * difference is only whether we can say *why*.
+   */
+  memberRemovals?: Record<string, string>;
 }
 
 export const PROVIDER_MIGRATIONS: ProviderMigration[] = [
@@ -22,7 +47,15 @@ export const PROVIDER_MIGRATIONS: ProviderMigration[] = [
     configKey: "auth",
     defineFn: "defineAuthConfig",
     defineModule: "gemi/services",
-    memberRenames: { adapter: "userProvider" },
+    // `adapter` used to become the `userProvider` config field. That field is
+    // gone too — the seam it selected between no longer exists — so renaming it
+    // would emit a key `AuthConfig` does not have, turning a migration into a
+    // type error in the file the codemod just wrote. It is dropped with the
+    // instruction instead.
+    memberRemovals: {
+      adapter: ADAPTER_RETIRED,
+      userProvider: ADAPTER_RETIRED,
+    },
   },
   {
     provider: "EmailServiceProvider",
@@ -137,6 +170,22 @@ export const SERVICE_RENAMES: Record<string, string> = {
   KernelIdServiceContainer: "KernelId",
 };
 
+/**
+ * Config fields retired *after* 0.43, keyed by slice — the `app/config/<slice>.ts`
+ * basename — then by field.
+ *
+ * Distinct from `memberRenames`/`memberRemovals`, which only reach an app still
+ * carrying 0.42 provider classes. An app that migrated to 0.43 when it was
+ * current has no providers directory left, so the provider-to-config step finds
+ * nothing and every table above sits idle — while its config files keep naming
+ * fields that have since gone. That app is the one most likely to run this
+ * command, and until this table existed it was the one the command did least
+ * for.
+ */
+export const RETIRED_CONFIG_FIELDS: Record<string, Record<string, string>> = {
+  auth: { userProvider: ADAPTER_RETIRED },
+};
+
 /** Exports that are simply gone, with the sentence the TODO should carry. */
 export const DELETED_EXPORTS: Record<string, string> = {
   Singleton:
@@ -152,6 +201,10 @@ export const DELETED_EXPORTS: Record<string, string> = {
   KernelIdServiceProvider:
     "`KernelIdServiceProvider` is internal to the framework now and has no " +
     "app-facing config slice.",
+  IAuthenticationAdapter: ADAPTER_RETIRED,
+  PrismaAuthenticationAdapter: ADAPTER_RETIRED,
+  OrmAuthenticationAdapter: ADAPTER_RETIRED,
+  ormAuthenticationAdapter: ADAPTER_RETIRED,
 };
 
 /** Exports that moved module without changing name. */

--- a/packages/gemi/docs-imports.test.ts
+++ b/packages/gemi/docs-imports.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
 
@@ -55,8 +55,16 @@ const EXPORTS: Record<string, string> = JSON.parse(
  * docs were wrong. A static read covers every form these index files use —
  * re-exports, type re-exports, and the one `export * as registry`.
  */
-function exportsOf(entry: string): Set<string> {
-  const source = readFileSync(join(ROOT, EXPORTS[entry]), "utf8");
+function exportsOf(entry: string): Set<string> | undefined {
+  const target = join(ROOT, EXPORTS[entry]);
+  // `./runtime` is a legacy entry in the `exports` map whose source does not
+  // exist — `scripts/build-publish.ts` documents it as preserved only to avoid
+  // changing the published surface. Reading it unguarded turns the first
+  // snippet that imports `gemi/runtime` into a stack trace instead of an
+  // assertion, so a missing target is reported by the caller as unresolvable.
+  if (!existsSync(target)) return undefined;
+
+  const source = readFileSync(target, "utf8");
   const names = new Set<string>();
 
   // `export { a, b as c }` / `export type { A }`, in one- and multi-line form.
@@ -86,10 +94,19 @@ function exportsOf(entry: string): Set<string> {
 /**
  * `llms-full.txt` is the pages concatenated, so it carries every snippet a
  * second time. Checking it too is what keeps a fix to one copy from passing.
+ *
+ * The repository README is checked alongside them — it is the first gemi code
+ * most people read, and its snippets are ordinary current-version code. The
+ * root `UPGRADE.md` is deliberately excluded: it shows *pre*-0.43 source on
+ * purpose (`import { Singleton } from "gemi/services"`), so checking it needs a
+ * before/after fence convention that does not exist yet.
  */
-const PAGES = readdirSync(DOCS).filter(
-  (file) => file.endsWith(".md") || file === "llms-full.txt",
-);
+const PAGES: { label: string; path: string }[] = [
+  ...readdirSync(DOCS)
+    .filter((file) => file.endsWith(".md") || file === "llms-full.txt")
+    .map((file) => ({ label: file, path: join(DOCS, file) })),
+  { label: "README.md", path: join(ROOT, "../../README.md") },
+];
 
 /** `gemi/orm` -> `./orm`, the key `exports` is written with. */
 const subpathOf = (module: string) => `.${module.slice("gemi".length)}`;
@@ -100,8 +117,8 @@ interface DocImport {
   name: string;
 }
 
-const imports: DocImport[] = PAGES.flatMap((page) => {
-  const text = readFileSync(join(DOCS, page), "utf8");
+const imports: DocImport[] = PAGES.flatMap(({ label, path }) => {
+  const text = readFileSync(path, "utf8");
   const found: DocImport[] = [];
 
   for (const statement of text.matchAll(
@@ -109,7 +126,7 @@ const imports: DocImport[] = PAGES.flatMap((page) => {
   )) {
     for (const clause of statement[1].split(",")) {
       const name = clause.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0];
-      if (name) found.push({ page, module: statement[2], name: name.trim() });
+      if (name) found.push({ page: label, module: statement[2], name: name.trim() });
     }
   }
 
@@ -117,9 +134,36 @@ const imports: DocImport[] = PAGES.flatMap((page) => {
 });
 
 describe("documented gemi imports resolve", () => {
-  test("the docs import something", () => {
-    // A regex that silently stops matching would make every test below vacuous.
-    expect(imports.length).toBeGreaterThan(50);
+  /**
+   * The canary. Every assertion below is over `imports`, so a regex that
+   * quietly stopped matching most statements would leave them all vacuously
+   * true — and a floor low enough to be safe is also low enough to miss that.
+   *
+   * Both halves are pinned: the count, near the ~500 the docs currently
+   * produce, and the *set* of entrypoints seen. The set is the stronger of the
+   * two — losing `gemi/orm` entirely still leaves hundreds of imports, so only
+   * naming the modules catches a page dropping out of the sweep.
+   */
+  test("the sweep still sees the whole documentation surface", () => {
+    expect(imports.length).toBeGreaterThan(400);
+
+    const modules = [...new Set(imports.map((entry) => entry.module))].sort();
+    expect(modules).toEqual([
+      "gemi/app",
+      "gemi/broadcasting",
+      "gemi/client",
+      "gemi/config",
+      "gemi/email",
+      "gemi/facades",
+      "gemi/foundation",
+      "gemi/http",
+      "gemi/i18n",
+      "gemi/kernel",
+      "gemi/orm",
+      "gemi/server",
+      "gemi/services",
+      "gemi/support",
+    ]);
   });
 
   test("every subpath is in the package's exports map", () => {
@@ -135,7 +179,7 @@ describe("documented gemi imports resolve", () => {
 
   test("every named import exists on the entrypoint it comes from", () => {
     // `./dist/…` entrypoints are build output, absent until `bun run build`.
-    const readable = new Map<string, Set<string>>();
+    const readable = new Map<string, Set<string> | undefined>();
     const missing: string[] = [];
 
     for (const entry of imports) {
@@ -144,7 +188,15 @@ describe("documented gemi imports resolve", () => {
       if (!target || target.includes("/dist/")) continue;
 
       if (!readable.has(subpath)) readable.set(subpath, exportsOf(subpath));
-      if (!readable.get(subpath)!.has(entry.name)) {
+      const names = readable.get(subpath);
+
+      if (names === undefined) {
+        missing.push(
+          `${entry.page}: ${entry.module} maps to ${target}, which does not exist`,
+        );
+        continue;
+      }
+      if (!names.has(entry.name)) {
         missing.push(`${entry.page}: ${entry.name} from ${entry.module}`);
       }
     }

--- a/packages/gemi/docs-imports.test.ts
+++ b/packages/gemi/docs-imports.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Every `import … from "gemi/…"` in the documentation, checked against what the
+ * entrypoint actually exports.
+ *
+ * `docs/authentication.md` documented the only supported way to install a custom
+ * `UserProvider`:
+ *
+ * ```typescript
+ * import { AuthManager } from "gemi/services";
+ * import { ServiceProvider } from "gemi/services";
+ * ```
+ *
+ * Neither line resolved. `AuthManager` was never exported — the `// Auth`
+ * section of `services/index.ts` stopped at `AuthServiceProvider`, while every
+ * other manager in the file (`MailManager`, `QueueManager`, `RedisManager`, …)
+ * was exported beside its provider. `ServiceProvider` had moved to
+ * `gemi/support` — a move the codemod's own `MODULE_MOVES` table already knew
+ * about, and the docs had not followed.
+ *
+ * The cost was not a broken snippet. `AuthConfig` has no provider field, so
+ * rebinding `AuthManager` is the *whole* of the seam; with the export missing,
+ * an application had a documented path, a container that would have accepted the
+ * binding, and no way to name the token. That reads as a missing framework
+ * capability rather than a missing line, and it survived two release candidates
+ * being migrated against.
+ *
+ * What makes it worth a test rather than a fix is that nothing else could see
+ * it. `tsc` does not type-check fenced code, and the docs are prose the compiler
+ * never reads — so the one artifact stating the intended design was also the one
+ * artifact with no check on it. This closes that: the entrypoints are parsed
+ * statically, so a snippet naming an export that does not exist fails here.
+ */
+const ROOT = join(import.meta.dirname);
+const DOCS = join(ROOT, "../../docs");
+
+/**
+ * `exports` maps subpath to file, so the docs specifier resolves the same way a
+ * consumer's would — including the entrypoints that point at `dist/`, which are
+ * skipped below rather than guessed at.
+ */
+const EXPORTS: Record<string, string> = JSON.parse(
+  readFileSync(join(ROOT, "package.json"), "utf8"),
+).exports;
+
+/**
+ * Named exports of an entrypoint, read from its source rather than imported.
+ *
+ * Importing would be more faithful and is not an option: `gemi/client` and
+ * `gemi/runtime` pull in React DOM against a browser environment this suite does
+ * not run in, and an entrypoint that throws on import would fail as though the
+ * docs were wrong. A static read covers every form these index files use —
+ * re-exports, type re-exports, and the one `export * as registry`.
+ */
+function exportsOf(entry: string): Set<string> {
+  const source = readFileSync(join(ROOT, EXPORTS[entry]), "utf8");
+  const names = new Set<string>();
+
+  // `export { a, b as c }` / `export type { A }`, in one- and multi-line form.
+  for (const block of source.matchAll(/export\s+(?:type\s+)?\{([^}]*)\}/g)) {
+    for (const clause of block[1].split(",")) {
+      const name = clause.trim().split(/\s+as\s+/).pop()?.trim();
+      // `export type { A }` and `export { type A }` both reach here.
+      if (name) names.add(name.replace(/^type\s+/, ""));
+    }
+  }
+
+  // `export * as registry from "./registry"` — the namespace is the name.
+  for (const star of source.matchAll(/export\s+\*\s+as\s+([\w$]+)\s+from/g)) {
+    names.add(star[1]);
+  }
+
+  // Declarations exported in place.
+  for (const decl of source.matchAll(
+    /export\s+(?:declare\s+)?(?:abstract\s+)?(?:class|function|const|let|var|type|interface|enum)\s+([\w$]+)/g,
+  )) {
+    names.add(decl[1]);
+  }
+
+  return names;
+}
+
+/**
+ * `llms-full.txt` is the pages concatenated, so it carries every snippet a
+ * second time. Checking it too is what keeps a fix to one copy from passing.
+ */
+const PAGES = readdirSync(DOCS).filter(
+  (file) => file.endsWith(".md") || file === "llms-full.txt",
+);
+
+/** `gemi/orm` -> `./orm`, the key `exports` is written with. */
+const subpathOf = (module: string) => `.${module.slice("gemi".length)}`;
+
+interface DocImport {
+  page: string;
+  module: string;
+  name: string;
+}
+
+const imports: DocImport[] = PAGES.flatMap((page) => {
+  const text = readFileSync(join(DOCS, page), "utf8");
+  const found: DocImport[] = [];
+
+  for (const statement of text.matchAll(
+    /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*["'](gemi\/[\w/-]+)["']/g,
+  )) {
+    for (const clause of statement[1].split(",")) {
+      const name = clause.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0];
+      if (name) found.push({ page, module: statement[2], name: name.trim() });
+    }
+  }
+
+  return found;
+});
+
+describe("documented gemi imports resolve", () => {
+  test("the docs import something", () => {
+    // A regex that silently stops matching would make every test below vacuous.
+    expect(imports.length).toBeGreaterThan(50);
+  });
+
+  test("every subpath is in the package's exports map", () => {
+    const unknown = [
+      ...new Set(
+        imports
+          .filter((entry) => !(subpathOf(entry.module) in EXPORTS))
+          .map((entry) => `${entry.module} (${entry.page})`),
+      ),
+    ];
+    expect(unknown).toEqual([]);
+  });
+
+  test("every named import exists on the entrypoint it comes from", () => {
+    // `./dist/…` entrypoints are build output, absent until `bun run build`.
+    const readable = new Map<string, Set<string>>();
+    const missing: string[] = [];
+
+    for (const entry of imports) {
+      const subpath = subpathOf(entry.module);
+      const target = EXPORTS[subpath];
+      if (!target || target.includes("/dist/")) continue;
+
+      if (!readable.has(subpath)) readable.set(subpath, exportsOf(subpath));
+      if (!readable.get(subpath)!.has(entry.name)) {
+        missing.push(`${entry.page}: ${entry.name} from ${entry.module}`);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemi",
-  "version": "0.51.0-rc.1",
+  "version": "0.51.0-rc.2",
   "private": false,
   "license": "MIT",
   "author": "Enes Tufekci <enes@gemijs.dev>",

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -82,6 +82,12 @@ export { Sharp } from "./image-optimization/drivers/SharpDriver";
 
 // Auth
 export { AuthServiceProvider } from "../auth/AuthServiceProvider";
+// Exported for the same reason every other manager here is: an application that
+// needs a different `UserProvider` rebinds this token in its own service
+// provider, passing the subclass as the second constructor argument. That is
+// the only supported way to install one — `AuthConfig` has no field for it —
+// and `docs/authentication.md` documents it against this entrypoint.
+export { AuthManager } from "../auth/AuthManager";
 export { GoogleOAuthProvider } from "../auth/oauth/GoogleOAuthProvider";
 export { XOAuthProvider } from "../auth/oauth/XOAuthProvider";
 export { OAuthProvider } from "../auth/oauth/OAuthProvider";


### PR DESCRIPTION
Found while checking a 0.51.0-rc.1 migration report against the source. Each fix was mutation-checked by reverting it and confirming a test fails.

## The documented auth seam did not exist

`docs/authentication.md` has described the only supported way to install a custom `UserProvider` since 922c45d — subclass it, rebind `AuthManager` in a service provider — and neither import in that recipe resolved.

`AuthManager` was never exported. The `// Auth` section of `services/index.ts` stopped at `AuthServiceProvider`, while every other manager in the file sits beside its provider. `ServiceProvider` had moved to `gemi/support` — a move the codemod's own `MODULE_MOVES` table already knew about.

`AuthConfig` has no provider field, so rebinding `AuthManager` is the *whole* of the seam. An app had a documented path, a container that would have accepted the binding, and no way to name the token — which reads as a missing capability rather than a missing line. It shipped in both 0.51 release candidates.

## `gemi migrate` was destructive on an already-migrated app

The command advertises itself as a no-op without `app/kernel/providers/`, and was not one. Steps 2 and 3 ran unconditionally, so on a current app it rewrote `Kernel.ts` and carried the existing `config` member over commented out — `buildKernel` writes that member itself, so anything already there looked like a leftover.

`config` is part of the current Kernel shape. Commenting it out leaves a file that compiles and an app that boots with every config slice silently unmerged. No error, no crash, just defaults everywhere.

Also fixed: `memberRenames: { adapter: "userProvider" }` rewrote the 0.42 member into a key `AuthConfig` no longer has, so the codemod's own output did not type-check. And a new `RETIRED_CONFIG_FIELDS` pass annotates `userProvider` in `app/config/auth.ts` — the case that applies to apps which migrated when 0.43 was current, and the one the command previously did least for.

## Tests

- `docs-imports.test.ts` — checks every `gemi/*` import in `docs/` against what the entrypoint actually exports. `tsc` does not read fenced code, so the one artifact stating the intended design had no check on it. It immediately found a second live bug in `docs/file-storage.md`.
- `migrate.test.ts` — the codemod had no tests. The Kernel bug is the kind tests catch and review does not: the broken output still parses.

## Release

Bumps to `0.51.0-rc.2`. Verified `bun run build:publish` stages cleanly, and the published `dist/services/index.d.ts` carries the new export.

Full suite green on this base: 2203 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKmoiiGwuXwUS7fQQN7M9Q
