### PR TITLE
Register models from the modules, and let the kernel's importer exit

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,72 @@
+# Upgrading from 0.50 to 0.51
+
+Two changes need a hand. There is no codemod for either — `bunx gemi migrate` is
+the 0.42→0.43 tool and does not touch any of this.
+
+## Declare your model modules on the Kernel
+
+**Do this even if nothing else in your app changes.** Until you do, a policy on
+a model subclass is skipped inside every nested `include`.
+
+A relation read resolves its target through the ORM registry *by name*. The
+generated `index.ts` registers each base under its model's name, so unless your
+own subclass replaces it there, `User.findMany({ include: { memberships: true } })`
+runs the generated `MembershipModel` — which carries none of the policies you
+wrote on `Membership`. Scoped at the root, unscoped inside the include, with
+nothing to notice it. A model you only ever read *through* an include never
+raises, because the query-time guard compares the class being run against the
+registered one and they are the same class.
+
+Put your model classes in a barrel and list it:
+
+```ts
+// app/models/index.ts
+export { User } from "./User"
+export { Membership } from "./Membership"
+```
+
+```ts
+// app/kernel/Kernel.ts
+import * as generated from "../models/generated"
+import * as models from "../models"
+
+export default class extends Kernel {
+  models = [generated, models]
+}
+```
+
+`boot()` registers every class those modules export under the name its schema
+carries — later modules winning, so each subclass takes the name its generated
+base was holding — and then refuses to start if any policied class lost its name
+to something else. The `register("User", User)` lines become unnecessary; they
+still work, and are still what you write for a class in a module the Kernel is
+not handed.
+
+In development, a Kernel with an empty `models` and a populated registry now
+warns at boot, so an app that skips this hears about it once per start rather
+than never.
+
+See [docs/orm.md](./docs/orm.md#your-model-class) for the full rules, including
+what happens with a typed view that carries its own policies.
+
+## `@prisma/client` is gone
+
+0.51 removed the type-only `@prisma/client` import from the generated model
+bases, so an app installs `prisma` alone. Delete the `generator client` block
+from every `.prisma` file, `bun remove @prisma/client`, and re-run
+`bunx prisma generate`.
+
+Your queries do not change. Two things start failing to compile that used to
+type-check and throw at runtime — `cursor` and `distinct`, which gemi refuses by
+design — and `_sum` / `_avg` are now restricted to numeric columns. If you
+passed `Prisma.DbNull`, `Prisma.JsonNull` or `Prisma.AnyNull`, import them from
+`gemi/orm` instead.
+
+The full detail, including the `Prisma.*` type mapping, is under
+**Setup** in [docs/orm.md](./docs/orm.md#setup).
+
+---
+
 # Upgrading from 0.42 to 0.43
 
 0.43 replaces the 16 hand-written `*ServiceContainer` singletons and the

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -100,16 +100,34 @@ managing sessions, and handling verification / reset / magic-link tokens. It run
 
 It resolves models from the ORM registry **by name, at call time**, so the framework never
 imports your generated classes. Anything that registers them before the first request is
-enough; the starter template does it from `app/preload.ts`:
+enough; the starter template lists them on its Kernel and also pulls them in from
+`app/preload.ts`:
 
 ```typescript
-// app/preload.ts — pulls in generated/index.ts (registering every model) and
-// then re-registers "User" against your subclass.
-import "@/app/models/User";
+// app/kernel/Kernel.ts — boot() registers everything these export.
+import * as generated from "../models/generated";
+import * as models from "../models";
+
+export default class extends Kernel {
+  models = [generated, models];
+}
+```
+
+```typescript
+// app/preload.ts — the same modules, before the server starts.
+import "@/app/models";
 ```
 
 Without that, the first sign-in raises `ModelNotRegisteredError`, which names the missing
 model and lists what is registered.
+
+> **The ORM comes with the provider, not optionally alongside it.** There is no adapter seam
+> any more: every `UserProvider` method resolves its model through the registry, so an app
+> with no other ORM adoption still has to run the generator, commit
+> `app/models/generated/` and register it at boot before authentication works *at all*. On a
+> large schema that is a real artifact — a 79-model schema generates around 750 KB across
+> three files. Budget for it when you plan the port; the error that tells you otherwise
+> arrives at runtime, after the code is already written.
 
 > **Note:** every query runs inside `Model.asSystem`, so [policies](./orm.md) are suspended.
 > Authentication happens before there is an authenticated user, so a policy scoping by

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2811,6 +2811,39 @@ structurally rather than by identity.
 
 </details>
 
+<details>
+<summary>Migrating model by model, with a Prisma client still in the app</summary>
+
+Nothing requires the switch to happen all at once. A `PrismaClient` and the gemi ORM coexist
+fine — but they are **two connection pools against the same database**, and by default nobody
+chooses their sizes.
+
+`DatabaseConfig.url` defaults to `DATABASE_URL`, which is normally the same URL the Prisma client
+already has. So the moment you register your first gemi model, the process holds Prisma's pool and
+gemi's Bun `SQL` pool at once, and their two defaults were each picked as though they were the only
+one. Against a managed Postgres with a connection cap — or a PgBouncer with a fixed pool — the
+symptom is connection exhaustion under a load that used to be fine, and it names neither library.
+
+Decide the split before you start rather than after the first incident:
+
+```typescript
+export default defineDatabaseConfig({
+  url: process.env.DATABASE_URL,
+
+  // Passed straight through to Bun's `SQL` client.
+  options: { max: 5 },   // gemi's share of the budget
+});
+```
+
+and lower Prisma's `connection_limit` by the same amount, so the two together stay inside the
+budget one of them used to have. Rebalance as models move across; when the last one has, drop the
+Prisma client and give gemi the whole budget.
+
+Pointing gemi at a *different* `url` is the other honest answer — a separate pool with its own cap,
+at the cost of two things to configure per environment.
+
+</details>
+
 Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 - `schema.ts` — runtime metadata: tables, columns, types, defaults, relations.
@@ -2859,45 +2892,79 @@ refused, by the row above rather than by a rule about lists.
 
 ### Your model class
 
-The generated base is not the class you write code on. Subclass it, and **re-register it**:
+The generated base is not the class you write code on. Subclass it, put the subclass in a barrel,
+and list that barrel on your Kernel:
 
 ```ts
 // app/models/User.ts
-import { register } from "gemi/orm"
 import { UserModel } from "./generated"
 
 export class User extends UserModel {}
-
-register("User", User)
 ```
 
-That `register` line is not bookkeeping. A relation read resolves its target through the registry
-by name, so whatever is registered under `"User"` is the class that runs inside every nested
-`include`. If that is the generated base while your policy lives on your subclass, the policy
-applies to root queries and is skipped inside includes — scoped one way, unscoped the other, with
-nothing to notice it. `Model.$exec` raises `UnregisteredPolicyClassError` when a class carrying
-policies is queried while a *different* class owns its name — but that guard is narrower than it
-sounds, and the gap runs the wrong way. **A model you only ever read through an `include` never
-trips it:** the include resolves the name to the unpolicied generated base, nothing diverges from
-nothing, and the rows come back unscoped with no error. That is the shape a membership or pivot
-model usually has, and it is exactly the kind that carries a tenant scope. Write the line next to
-every subclass regardless — the guard is a backstop for the cases it can see, not a substitute.
+```ts
+// app/models/index.ts
+export { User } from "./User"
+```
 
-For the case it cannot see, there is an audit you can run once instead of trusting thirteen
-subclasses:
+```ts
+// app/kernel/Kernel.ts
+import { Kernel } from "gemi/kernel"
+import * as generated from "../models/generated"
+import * as models from "../models"
+
+export default class extends Kernel {
+  models = [generated, models]
+}
+```
+
+`boot()` registers every model class those modules export under the name its schema carries, later
+modules winning — so each subclass takes the name its generated base was holding — and then checks
+that no policied class lost its name to something else.
+
+**Why the framework does this rather than you.** A relation read resolves its target through the
+registry by name, so whatever is registered under `"User"` is the class that runs inside every
+nested `include`. If that is the generated base while your policy lives on your subclass, the
+policy applies to root queries and is skipped inside includes — scoped one way, unscoped the other.
+The registration used to be a `register("User", User)` line next to each subclass, and forgetting
+it is invisible: `Model.$exec` raises `UnregisteredPolicyClassError` when a class carrying policies
+is *queried* while a different class owns its name, but that guard is narrower than it sounds and
+the gap runs the wrong way. **A model you only ever read through an `include` never trips it** — the
+include resolves the name to the unpolicied base, nothing diverges from nothing, and the rows come
+back unscoped with no error. That is the shape a membership or pivot model usually has, and exactly
+the kind that carries a tenant scope.
+
+Deriving the registration from the module removes the mistake instead of reporting it. The name is
+not a string you retype; it is `$schema.name`, which the generator wrote and your subclass inherits.
+
+`register` still exists and still works, for a class you want registered from a module you are not
+handing to the Kernel. And you can call the same thing directly — `registerModels(generated,
+models)` from `gemi/orm` — in a script or a test that boots no Kernel.
+
+Two classes in **one** module claiming the same model raise `AmbiguousModelRegistrationError`,
+unless one extends the other. A generated base and the subclass over it are not ambiguous (the
+subclass wins), nor are a class and a typed view over it (the class wins, and the view inherits its
+policies either way). Two siblings both written for the same model are, and `register` is how you
+say which.
+
+#### What this still cannot see
+
+Modules you hand it. A policied class in a file that no barrel re-exports is invisible to the
+Kernel exactly as it was to a forgotten `register` line — which is the reason for the barrel: one
+file to add a model to, and a missing line in it is a thing you can notice.
+
+`assertPoliciesRegistered` is the same audit without the registration, for running over modules the
+Kernel does not own:
 
 ```ts
 import { assertPoliciesRegistered } from "gemi/orm"
 import * as generated from "@/app/models/generated"
-import * as models from "@/app/models/User"
+import * as models from "@/app/models"
 
 assertPoliciesRegistered(generated, models)
 ```
 
-Same rule, triggered differently: it reads the classes out of the module namespace, so a policied
-class that nothing queries is still visible. In a test it closes the hole for CI at no runtime cost;
-at boot it turns a deploy of the mistake into a failure to start rather than a quiet cross-tenant
-read. It can only see modules you hand it, so it does not replace the `register` line either.
+In a test it closes the hole for CI at no runtime cost.
 
 ## Querying
 
@@ -3654,6 +3721,34 @@ migration whose transactions are legitimately long.
 The warning is development-only and never fires in production, whatever the config says. It is a
 diagnostic, not a limit: nothing cancels a long transaction.
 
+### Unit-testing code that opens one
+
+`Model.transaction` resolves its connection ambiently, out of the `AsyncLocalStorage` scope — which
+is exactly what lets `audit(user)` above join the transaction without being handed anything. The
+same property means there is no client to inject: a unit test of a function that crosses a
+transaction has to either boot a Kernel or replace the model module.
+
+Replacing the module is usually what you want, because the point of the test is the branching
+around the write rather than the SQL:
+
+```ts
+import { vi } from "vitest"
+
+vi.mock("@/app/models", () => ({
+  User: { create: vi.fn(), findFirst: vi.fn() },
+  transaction: (cb: () => unknown) => cb(),   // run the callback, open nothing
+}))
+```
+
+`transaction: (cb) => cb()` is the whole trick: the callback runs inline, the assertions are about
+what it called, and no connection is involved. `vi.spyOn` on the model statics does the same job
+when you want the real module for everything else.
+
+What this does not cover is the behaviour that only a real transaction has — the rollback, the
+savepoint, the Postgres abort described above. Those need a database, and they belong in an
+integration test rather than in a mock. Keep the seam for the control flow and test the transaction
+itself against Postgres.
+
 ## Policies
 
 A model carries a **list** of policies. Every member of a policy is optional; a model with none
@@ -3905,6 +4000,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
 | `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |
+| `AmbiguousModelRegistrationError` | `registerModels` found two unrelated classes in one module claiming the same model, and refused to pick (see [Setup](#your-model-class)). |
 | `RelationDepthExceededError` | An include tree past `MAX_RELATION_DEPTH`. |
 | `ParameterLimitError` | A statement exceeding the dialect's parameter ceiling. |
 | `MissingRequiredValueError` | A write leaving a required column with no value and no default. |
@@ -4129,11 +4225,13 @@ Two things are worth knowing:
   There is a **third** sentinel, and it belongs only in a filter:
 
   ```ts
-  await User.findMany({ where: { metadata: { equals: Prisma.AnyNull } } })  // both kinds at once
-  await User.findMany({ where: { metadata: { not: Prisma.AnyNull } } })     // neither kind
+  import { AnyNull } from "gemi/orm"
+
+  await User.findMany({ where: { metadata: { equals: AnyNull } } })  // both kinds at once
+  await User.findMany({ where: { metadata: { not: AnyNull } } })     // neither kind
   ```
 
-  `Prisma.AnyNull` asks for *either* empty state, which is usually what you want when you do not
+  `AnyNull` asks for *either* empty state, which is usually what you want when you do not
   care how the row got that way — it compiles to `is null or = 'null'`, one predicate rather than
   an `OR` you assemble yourself. It is a question about rows rather than a value, so writing it
   raises `InvalidArgumentError`, and so does using it under any operator other than `equals` and
@@ -4538,16 +4636,34 @@ managing sessions, and handling verification / reset / magic-link tokens. It run
 
 It resolves models from the ORM registry **by name, at call time**, so the framework never
 imports your generated classes. Anything that registers them before the first request is
-enough; the starter template does it from `app/preload.ts`:
+enough; the starter template lists them on its Kernel and also pulls them in from
+`app/preload.ts`:
 
 ```typescript
-// app/preload.ts — pulls in generated/index.ts (registering every model) and
-// then re-registers "User" against your subclass.
-import "@/app/models/User";
+// app/kernel/Kernel.ts — boot() registers everything these export.
+import * as generated from "../models/generated";
+import * as models from "../models";
+
+export default class extends Kernel {
+  models = [generated, models];
+}
+```
+
+```typescript
+// app/preload.ts — the same modules, before the server starts.
+import "@/app/models";
 ```
 
 Without that, the first sign-in raises `ModelNotRegisteredError`, which names the missing
 model and lists what is registered.
+
+> **The ORM comes with the provider, not optionally alongside it.** There is no adapter seam
+> any more: every `UserProvider` method resolves its model through the registry, so an app
+> with no other ORM adoption still has to run the generator, commit
+> `app/models/generated/` and register it at boot before authentication works *at all*. On a
+> large schema that is a real artifact — a 79-model schema generates around 750 KB across
+> three files. Budget for it when you plan the port; the error that tells you otherwise
+> arrives at runtime, after the code is already written.
 
 > **Note:** every query runs inside `Model.asSystem`, so [policies](./orm.md) are suspended.
 > Authentication happens before there is an authenticated user, so a policy scoping by
@@ -5008,7 +5124,6 @@ Requests without a valid `access_token` are rejected with an `AuthenticationErro
 (401 for API routes, a redirect to `/auth/sign-in` for views). See
 [Middleware](./middleware.md) for the full DSL (`-auth` to cancel, router vs per-route, etc.)
 and [Authorization](./authorization.md) for role enforcement.
-
 ---
 
 ## Authorization

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2922,6 +2922,11 @@ export default class extends Kernel {
 modules winning — so each subclass takes the name its generated base was holding — and then checks
 that no policied class lost its name to something else.
 
+**Upgrading an app that already has models?** `models` defaults to `[]`, so until you write that
+line your app behaves exactly as it did before — which is the arrangement the rest of this section
+is about. A Kernel with an empty `models` and a populated registry warns at boot in development.
+[UPGRADE.md](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md) has the short version.
+
 **Why the framework does this rather than you.** A relation read resolves its target through the
 registry by name, so whatever is registered under `"User"` is the class that runs inside every
 nested `include`. If that is the generated base while your policy lives on your subclass, the
@@ -2942,10 +2947,33 @@ handing to the Kernel. And you can call the same thing directly — `registerMod
 models)` from `gemi/orm` — in a script or a test that boots no Kernel.
 
 Two classes in **one** module claiming the same model raise `AmbiguousModelRegistrationError`,
-unless one extends the other. A generated base and the subclass over it are not ambiguous (the
-subclass wins), nor are a class and a typed view over it (the class wins, and the view inherits its
-policies either way). Two siblings both written for the same model are, and `register` is how you
-say which.
+unless one extends the other. A generated base and the subclass over it are not ambiguous — the
+subclass wins. Nor are a class and a typed view over it, *as long as the view adds no policies of
+its own*: the class wins and the view inherits its policies, so which one the registry holds changes
+nothing. Two siblings both written for the same model are ambiguous, and `register` is how you say
+which.
+
+Across **different** modules there is no election at all — the later one simply wins. What catches a
+bad outcome there is the audit that runs at the end, so a conflict between two policied classes is
+still refused; two unpolicied ones resolve by import order, which changes no query's scope.
+
+**A view that carries its own policies is refused rather than chosen between.** The registry holds
+one class per name, so registering `AdminUser` would apply its narrowing to every nested read of
+`User`, and leaving `User` registered would skip `AdminUser`'s policies entirely — both silent. Keep
+such a class out of the modules you hand to `Kernel.models` and query it directly where you want the
+narrowing:
+
+```ts
+// app/models/views/AdminUser.ts — not exported from app/models/index.ts
+export class AdminUser extends User {
+  static $policies: UserPolicy[] = [{ scope: () => ({ archived: false }) }]
+}
+
+const rows = await AdminUser.findMany({ … })   // narrowed, at the call site
+```
+
+If it is not a view but the model itself, move the policies onto the class the name resolves to and
+every subclass inherits them everywhere.
 
 #### What this still cannot see
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -78,6 +78,39 @@ structurally rather than by identity.
 
 </details>
 
+<details>
+<summary>Migrating model by model, with a Prisma client still in the app</summary>
+
+Nothing requires the switch to happen all at once. A `PrismaClient` and the gemi ORM coexist
+fine — but they are **two connection pools against the same database**, and by default nobody
+chooses their sizes.
+
+`DatabaseConfig.url` defaults to `DATABASE_URL`, which is normally the same URL the Prisma client
+already has. So the moment you register your first gemi model, the process holds Prisma's pool and
+gemi's Bun `SQL` pool at once, and their two defaults were each picked as though they were the only
+one. Against a managed Postgres with a connection cap — or a PgBouncer with a fixed pool — the
+symptom is connection exhaustion under a load that used to be fine, and it names neither library.
+
+Decide the split before you start rather than after the first incident:
+
+```typescript
+export default defineDatabaseConfig({
+  url: process.env.DATABASE_URL,
+
+  // Passed straight through to Bun's `SQL` client.
+  options: { max: 5 },   // gemi's share of the budget
+});
+```
+
+and lower Prisma's `connection_limit` by the same amount, so the two together stay inside the
+budget one of them used to have. Rebalance as models move across; when the last one has, drop the
+Prisma client and give gemi the whole budget.
+
+Pointing gemi at a *different* `url` is the other honest answer — a separate pool with its own cap,
+at the cost of two things to configure per environment.
+
+</details>
+
 Then `bunx prisma generate`. You get three files under `app/models/generated/`:
 
 - `schema.ts` — runtime metadata: tables, columns, types, defaults, relations.
@@ -126,45 +159,79 @@ refused, by the row above rather than by a rule about lists.
 
 ### Your model class
 
-The generated base is not the class you write code on. Subclass it, and **re-register it**:
+The generated base is not the class you write code on. Subclass it, put the subclass in a barrel,
+and list that barrel on your Kernel:
 
 ```ts
 // app/models/User.ts
-import { register } from "gemi/orm"
 import { UserModel } from "./generated"
 
 export class User extends UserModel {}
-
-register("User", User)
 ```
 
-That `register` line is not bookkeeping. A relation read resolves its target through the registry
-by name, so whatever is registered under `"User"` is the class that runs inside every nested
-`include`. If that is the generated base while your policy lives on your subclass, the policy
-applies to root queries and is skipped inside includes — scoped one way, unscoped the other, with
-nothing to notice it. `Model.$exec` raises `UnregisteredPolicyClassError` when a class carrying
-policies is queried while a *different* class owns its name — but that guard is narrower than it
-sounds, and the gap runs the wrong way. **A model you only ever read through an `include` never
-trips it:** the include resolves the name to the unpolicied generated base, nothing diverges from
-nothing, and the rows come back unscoped with no error. That is the shape a membership or pivot
-model usually has, and it is exactly the kind that carries a tenant scope. Write the line next to
-every subclass regardless — the guard is a backstop for the cases it can see, not a substitute.
+```ts
+// app/models/index.ts
+export { User } from "./User"
+```
 
-For the case it cannot see, there is an audit you can run once instead of trusting thirteen
-subclasses:
+```ts
+// app/kernel/Kernel.ts
+import { Kernel } from "gemi/kernel"
+import * as generated from "../models/generated"
+import * as models from "../models"
+
+export default class extends Kernel {
+  models = [generated, models]
+}
+```
+
+`boot()` registers every model class those modules export under the name its schema carries, later
+modules winning — so each subclass takes the name its generated base was holding — and then checks
+that no policied class lost its name to something else.
+
+**Why the framework does this rather than you.** A relation read resolves its target through the
+registry by name, so whatever is registered under `"User"` is the class that runs inside every
+nested `include`. If that is the generated base while your policy lives on your subclass, the
+policy applies to root queries and is skipped inside includes — scoped one way, unscoped the other.
+The registration used to be a `register("User", User)` line next to each subclass, and forgetting
+it is invisible: `Model.$exec` raises `UnregisteredPolicyClassError` when a class carrying policies
+is *queried* while a different class owns its name, but that guard is narrower than it sounds and
+the gap runs the wrong way. **A model you only ever read through an `include` never trips it** — the
+include resolves the name to the unpolicied base, nothing diverges from nothing, and the rows come
+back unscoped with no error. That is the shape a membership or pivot model usually has, and exactly
+the kind that carries a tenant scope.
+
+Deriving the registration from the module removes the mistake instead of reporting it. The name is
+not a string you retype; it is `$schema.name`, which the generator wrote and your subclass inherits.
+
+`register` still exists and still works, for a class you want registered from a module you are not
+handing to the Kernel. And you can call the same thing directly — `registerModels(generated,
+models)` from `gemi/orm` — in a script or a test that boots no Kernel.
+
+Two classes in **one** module claiming the same model raise `AmbiguousModelRegistrationError`,
+unless one extends the other. A generated base and the subclass over it are not ambiguous (the
+subclass wins), nor are a class and a typed view over it (the class wins, and the view inherits its
+policies either way). Two siblings both written for the same model are, and `register` is how you
+say which.
+
+#### What this still cannot see
+
+Modules you hand it. A policied class in a file that no barrel re-exports is invisible to the
+Kernel exactly as it was to a forgotten `register` line — which is the reason for the barrel: one
+file to add a model to, and a missing line in it is a thing you can notice.
+
+`assertPoliciesRegistered` is the same audit without the registration, for running over modules the
+Kernel does not own:
 
 ```ts
 import { assertPoliciesRegistered } from "gemi/orm"
 import * as generated from "@/app/models/generated"
-import * as models from "@/app/models/User"
+import * as models from "@/app/models"
 
 assertPoliciesRegistered(generated, models)
 ```
 
-Same rule, triggered differently: it reads the classes out of the module namespace, so a policied
-class that nothing queries is still visible. In a test it closes the hole for CI at no runtime cost;
-at boot it turns a deploy of the mistake into a failure to start rather than a quiet cross-tenant
-read. It can only see modules you hand it, so it does not replace the `register` line either.
+In a test it closes the hole for CI at no runtime cost.
 
 ## Querying
 
@@ -921,6 +988,34 @@ migration whose transactions are legitimately long.
 The warning is development-only and never fires in production, whatever the config says. It is a
 diagnostic, not a limit: nothing cancels a long transaction.
 
+### Unit-testing code that opens one
+
+`Model.transaction` resolves its connection ambiently, out of the `AsyncLocalStorage` scope — which
+is exactly what lets `audit(user)` above join the transaction without being handed anything. The
+same property means there is no client to inject: a unit test of a function that crosses a
+transaction has to either boot a Kernel or replace the model module.
+
+Replacing the module is usually what you want, because the point of the test is the branching
+around the write rather than the SQL:
+
+```ts
+import { vi } from "vitest"
+
+vi.mock("@/app/models", () => ({
+  User: { create: vi.fn(), findFirst: vi.fn() },
+  transaction: (cb: () => unknown) => cb(),   // run the callback, open nothing
+}))
+```
+
+`transaction: (cb) => cb()` is the whole trick: the callback runs inline, the assertions are about
+what it called, and no connection is involved. `vi.spyOn` on the model statics does the same job
+when you want the real module for everything else.
+
+What this does not cover is the behaviour that only a real transaction has — the rollback, the
+savepoint, the Postgres abort described above. Those need a database, and they belong in an
+integration test rather than in a mock. Keep the seam for the control flow and test the transaction
+itself against Postgres.
+
 ## Policies
 
 A model carries a **list** of policies. Every member of a policy is optional; a model with none
@@ -1172,6 +1267,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
 | `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |
+| `AmbiguousModelRegistrationError` | `registerModels` found two unrelated classes in one module claiming the same model, and refused to pick (see [Setup](#your-model-class)). |
 | `RelationDepthExceededError` | An include tree past `MAX_RELATION_DEPTH`. |
 | `ParameterLimitError` | A statement exceeding the dialect's parameter ceiling. |
 | `MissingRequiredValueError` | A write leaving a required column with no value and no default. |
@@ -1396,11 +1492,13 @@ Two things are worth knowing:
   There is a **third** sentinel, and it belongs only in a filter:
 
   ```ts
-  await User.findMany({ where: { metadata: { equals: Prisma.AnyNull } } })  // both kinds at once
-  await User.findMany({ where: { metadata: { not: Prisma.AnyNull } } })     // neither kind
+  import { AnyNull } from "gemi/orm"
+
+  await User.findMany({ where: { metadata: { equals: AnyNull } } })  // both kinds at once
+  await User.findMany({ where: { metadata: { not: AnyNull } } })     // neither kind
   ```
 
-  `Prisma.AnyNull` asks for *either* empty state, which is usually what you want when you do not
+  `AnyNull` asks for *either* empty state, which is usually what you want when you do not
   care how the row got that way — it compiles to `is null or = 'null'`, one predicate rather than
   an `OR` you assemble yourself. It is a question about rows rather than a value, so writing it
   raises `InvalidArgumentError`, and so does using it under any operator other than `equals` and

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -189,6 +189,11 @@ export default class extends Kernel {
 modules winning — so each subclass takes the name its generated base was holding — and then checks
 that no policied class lost its name to something else.
 
+**Upgrading an app that already has models?** `models` defaults to `[]`, so until you write that
+line your app behaves exactly as it did before — which is the arrangement the rest of this section
+is about. A Kernel with an empty `models` and a populated registry warns at boot in development.
+[UPGRADE.md](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md) has the short version.
+
 **Why the framework does this rather than you.** A relation read resolves its target through the
 registry by name, so whatever is registered under `"User"` is the class that runs inside every
 nested `include`. If that is the generated base while your policy lives on your subclass, the
@@ -209,10 +214,33 @@ handing to the Kernel. And you can call the same thing directly — `registerMod
 models)` from `gemi/orm` — in a script or a test that boots no Kernel.
 
 Two classes in **one** module claiming the same model raise `AmbiguousModelRegistrationError`,
-unless one extends the other. A generated base and the subclass over it are not ambiguous (the
-subclass wins), nor are a class and a typed view over it (the class wins, and the view inherits its
-policies either way). Two siblings both written for the same model are, and `register` is how you
-say which.
+unless one extends the other. A generated base and the subclass over it are not ambiguous — the
+subclass wins. Nor are a class and a typed view over it, *as long as the view adds no policies of
+its own*: the class wins and the view inherits its policies, so which one the registry holds changes
+nothing. Two siblings both written for the same model are ambiguous, and `register` is how you say
+which.
+
+Across **different** modules there is no election at all — the later one simply wins. What catches a
+bad outcome there is the audit that runs at the end, so a conflict between two policied classes is
+still refused; two unpolicied ones resolve by import order, which changes no query's scope.
+
+**A view that carries its own policies is refused rather than chosen between.** The registry holds
+one class per name, so registering `AdminUser` would apply its narrowing to every nested read of
+`User`, and leaving `User` registered would skip `AdminUser`'s policies entirely — both silent. Keep
+such a class out of the modules you hand to `Kernel.models` and query it directly where you want the
+narrowing:
+
+```ts
+// app/models/views/AdminUser.ts — not exported from app/models/index.ts
+export class AdminUser extends User {
+  static $policies: UserPolicy[] = [{ scope: () => ({ archived: false }) }]
+}
+
+const rows = await AdminUser.findMany({ … })   // narrowed, at the call site
+```
+
+If it is not a view but the model itself, move the policies onto the class the name resolves to and
+every subclass inherits them everywhere.
 
 #### What this still cannot see
 

--- a/packages/gemi/kernel/Kernel.test.ts
+++ b/packages/gemi/kernel/Kernel.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { Application } from "../foundation/Application";
 import { Kernel } from "./Kernel";
@@ -66,6 +66,70 @@ describe("boot registers the declared model modules", () => {
     new Kernel().boot();
 
     expect(registry.registeredNames()).toEqual([]);
+  });
+});
+
+/**
+ * The warning that keeps the fix from defaulting to off.
+ *
+ * `models` is `[]` on the base class, so an application upgrading from 0.48 is
+ * in exactly #316's state until somebody edits their Kernel — and the only
+ * place that says to is the Setup section of a page an existing app has already
+ * read. A populated registry with an empty `models` is the signature of that
+ * app precisely: the generated `index.ts` was imported, its bases own every
+ * name, and any policy on a subclass is being skipped inside includes right
+ * now.
+ */
+describe("an app that has models and has not declared them", () => {
+  const warn = () => vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.NODE_ENV;
+  });
+
+  test("is warned, with the fix in the message", () => {
+    const spy = warn();
+    registry.register("User", UserModel);
+
+    new Kernel().boot();
+
+    expect(spy).toHaveBeenCalledOnce();
+    const message = spy.mock.calls[0]![0] as string;
+    expect(message).toContain("Kernel.models is empty");
+    expect(message).toContain("models = [generated, models]");
+  });
+
+  /** A Kernel with no ORM at all has nothing to be wrong about. */
+  test("an empty registry says nothing", () => {
+    const spy = warn();
+
+    new Kernel().boot();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("declaring the modules says nothing", () => {
+    const spy = warn();
+
+    new KernelWith([{ UserModel }]).boot();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A diagnostic for the author's terminal, not a line in a production log. The
+   * app in this state is running today; the warning is how it learns there is
+   * something to change, and production is not where that conversation happens.
+   */
+  test("production is silent", () => {
+    const spy = warn();
+    process.env.NODE_ENV = "production";
+    registry.register("User", UserModel);
+
+    new Kernel().boot();
+
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/gemi/kernel/Kernel.test.ts
+++ b/packages/gemi/kernel/Kernel.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { Application } from "../foundation/Application";
+import { Kernel } from "./Kernel";
+import { UnregisteredPolicyClassError } from "../orm/errors";
+import { user } from "../orm/fixtures";
+import type { ModelPolicy } from "../orm/policy";
+import * as registry from "../orm/registry";
+
+/**
+ * `Kernel.models`, which is the difference between the registration audit
+ * existing and the registration audit running.
+ *
+ * The hole it closes is #316's first item: an application subclass carrying a
+ * policy that nothing registered leaves the generated base owning the name, so
+ * every nested `include` of that model resolves to the base and comes back
+ * unscoped — with no error at the root either, because `$exec`'s divergence
+ * guard begins `registered !== this` and the base it is running on *is* the
+ * registered one. The machinery to catch that was exported and off.
+ *
+ * These boot a bare `Kernel` rather than a template one: what is under test is
+ * that the field is read and acted on before anything else happens, and a real
+ * app's models would only make that harder to see.
+ */
+
+const scope: ModelPolicy = { scope: () => ({ organizationId: 7 }) };
+const other: ModelPolicy = { scope: () => ({ organizationId: 9 }) };
+
+class UserModel {
+  static $schema = user;
+}
+
+class KernelWith extends Kernel {
+  constructor(models: Array<Record<string, unknown>>) {
+    super();
+    this.models = models;
+  }
+}
+
+afterEach(() => {
+  registry.clearRegistry();
+});
+
+describe("boot registers the declared model modules", () => {
+  test("a generated base is registered under its schema's name", () => {
+    new KernelWith([{ UserModel }]).boot();
+
+    expect(registry.get("User")).toBe(UserModel);
+  });
+
+  /**
+   * The whole point. No `register` call anywhere, and the policied subclass
+   * still owns the name — so a nested read of this model runs the policy.
+   */
+  test("an application subclass takes the name with no register call", () => {
+    class User extends UserModel {
+      static $policies = [scope];
+    }
+
+    new KernelWith([{ UserModel }, { User }]).boot();
+
+    expect(registry.get("User")).toBe(User);
+  });
+
+  test("declaring no models leaves the registry alone", () => {
+    new Kernel().boot();
+
+    expect(registry.registeredNames()).toEqual([]);
+  });
+});
+
+describe("boot refuses a divergence it cannot resolve", () => {
+  /**
+   * Two classes written for the same model in different modules, neither
+   * extending the other. One wins the name and the other's policies would
+   * simply never run, which is the leak arrived at through the mechanism meant
+   * to prevent it.
+   */
+  test("two unrelated policied classes fail the boot", () => {
+    class Ours extends UserModel {
+      static $policies = [scope];
+    }
+    class Theirs extends UserModel {
+      static $policies = [other];
+    }
+
+    expect(() => new KernelWith([{ Ours }, { Theirs }]).boot()).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+
+  /**
+   * Before the container, on purpose. A registration that would leak should
+   * stop where nothing has been constructed and no request can be in flight —
+   * not halfway through provider registration, with this kernel's
+   * `Application` already installed as the process-wide current instance for
+   * whatever runs next to find.
+   */
+  test("it throws before the application is installed", () => {
+    class Ours extends UserModel {
+      static $policies = [scope];
+    }
+    class Theirs extends UserModel {
+      static $policies = [other];
+    }
+
+    const kernel = new KernelWith([{ Ours }, { Theirs }]);
+
+    expect(() => kernel.boot()).toThrow();
+    expect(Application.getInstance()).not.toBe(kernel.app);
+  });
+});

--- a/packages/gemi/kernel/Kernel.ts
+++ b/packages/gemi/kernel/Kernel.ts
@@ -2,6 +2,7 @@ import { Application } from "../foundation/Application";
 import type { ServiceProviderConstructor } from "../foundation/Application";
 import type { ServiceToken } from "../container/Container";
 import type { ConfigItems } from "../support/Repository";
+import { registerModels } from "../orm/registration";
 import { Scheduler } from "../services/cron/Scheduler";
 import { BroadcastManager } from "../services/pubsub/BroadcastManager";
 import { QueueManager } from "../services/queue/QueueManager";
@@ -29,6 +30,36 @@ export class Kernel {
    */
   protected providers: ServiceProviderConstructor[] = [];
 
+  /**
+   * The modules holding the app's model classes — normally
+   * `[generated, models]`, the generated namespace and the barrel of subclasses
+   * written over it. Every model class they export is registered under the name
+   * its schema carries, later modules winning, and the whole set is audited
+   * before anything else boots.
+   *
+   * ### Why this is a Kernel field and not a line in a file somewhere
+   *
+   * Registration used to be `register("User", User)` next to each subclass, and
+   * the failure mode of forgetting it is an authorization hole that nothing
+   * reports: a relation read resolves its target by name, so an unregistered
+   * policied subclass leaves the generated base owning the name and every
+   * nested `include` of that model comes back unscoped. No error at the root
+   * either, because `$exec`'s divergence guard begins `registered !== this` and
+   * the base it is running on *is* the registered one. A model only ever read
+   * through an include — a membership, a pivot, the kind that carries a tenant
+   * scope — never trips anything.
+   *
+   * Listing the modules here says it once, in the same place the app already
+   * declares its config slices and providers, and turns the mistake into a
+   * failure to boot rather than a quiet cross-tenant read.
+   *
+   * It sees the modules it is given, so a model class in a file that no barrel
+   * re-exports is still invisible. That is the residual, and it is a smaller
+   * one: a barrel is a place to notice an omission, and thirteen `register`
+   * lines scattered across thirteen files is not.
+   */
+  protected models: Array<Record<string, unknown>> = [];
+
   readonly app = new Application();
 
   /**
@@ -38,6 +69,11 @@ export class Kernel {
    * Phase two is `waitForBoot()`.
    */
   boot() {
+    // Before the container, deliberately. This throws on a model whose policies
+    // would be skipped, and the useful moment for that is the one where nothing
+    // has been constructed and no request can be in flight.
+    if (this.models.length > 0) registerModels(...this.models);
+
     this.app.config.merge(this.config);
     Application.setInstance(this.app);
     this.app.registerMany([...frameworkProviders, ...this.providers]);

--- a/packages/gemi/kernel/Kernel.ts
+++ b/packages/gemi/kernel/Kernel.ts
@@ -3,6 +3,7 @@ import type { ServiceProviderConstructor } from "../foundation/Application";
 import type { ServiceToken } from "../container/Container";
 import type { ConfigItems } from "../support/Repository";
 import { registerModels } from "../orm/registration";
+import { registeredNames } from "../orm/registry";
 import { Scheduler } from "../services/cron/Scheduler";
 import { BroadcastManager } from "../services/pubsub/BroadcastManager";
 import { QueueManager } from "../services/queue/QueueManager";
@@ -73,6 +74,7 @@ export class Kernel {
     // would be skipped, and the useful moment for that is the one where nothing
     // has been constructed and no request can be in flight.
     if (this.models.length > 0) registerModels(...this.models);
+    else warnIfModelsAreRegisteredButUndeclared();
 
     this.app.config.merge(this.config);
     Application.setInstance(this.app);
@@ -134,4 +136,52 @@ export class Kernel {
 
     kernelContext.disable();
   }
+}
+
+/**
+ * Says something to an application that has models and has not declared them.
+ *
+ * Without this the fix for #316 defaults to off. `models` is `[]`, `boot()`
+ * no-ops, and an app upgrading from 0.48 is in exactly the state the issue
+ * describes until somebody edits their Kernel by hand — while the only place
+ * that says to is the **Setup** section of `docs/orm.md`, which an existing app
+ * read once and will not read again. #316 was filed by an app mid-migration
+ * with a 79-model schema, which is precisely the reader who never sees it.
+ *
+ * The condition is what makes this worth printing. A populated registry with an
+ * empty `models` means the generated `index.ts` was imported and its bases are
+ * what every nested read resolves to — so if any policy lives on a subclass, it
+ * is being skipped inside includes right now. A Kernel with no ORM at all has
+ * an empty registry and hears nothing.
+ *
+ * Development only, and a warning rather than a throw: an app in this state is
+ * running today, and turning a working deploy into a failure to start over an
+ * arrangement that *might* be fine is not a patch-level thing to do. The
+ * failure it points at is silent, so the fix for it has to be noisy somewhere,
+ * and the terminal an author is already looking at is the cheapest somewhere
+ * there is.
+ */
+function warnIfModelsAreRegisteredButUndeclared(): void {
+  if (process.env.NODE_ENV === "production") return;
+
+  const registered = registeredNames();
+  if (registered.length === 0) return;
+
+  console.warn(
+    `[gemi] ${registered.length} model${registered.length === 1 ? " is" : "s are"} ` +
+      `registered, but Kernel.models is empty.\n` +
+      `        Nested relation reads resolve a model by name, so a policy on a ` +
+      `subclass that does not own its\n` +
+      `        name is skipped inside every include — scoped at the root, ` +
+      `unscoped in an include, with nothing\n` +
+      `        to notice it. Declaring the modules registers each class under ` +
+      `its own name and audits the set:\n\n` +
+      `            import * as generated from "../models/generated"\n` +
+      `            import * as models from "../models"\n\n` +
+      `            export default class extends Kernel {\n` +
+      `              models = [generated, models]\n` +
+      `            }\n\n` +
+      `        See docs/orm.md#your-model-class. Development only; this never ` +
+      `prints in production.`,
+  );
 }

--- a/packages/gemi/kernel/exit.test.ts
+++ b/packages/gemi/kernel/exit.test.ts
@@ -40,6 +40,13 @@ describe("a script that imports the kernel", () => {
       { encoding: "utf8", timeout: 10_000 },
     );
 
+    // Checked first because it is the outcome that looks like the others. A
+    // `bun` that is not on PATH gives `status: null` and `signal: null` and
+    // sets `error` — so without this the assertions below pass, and the
+    // environment problem surfaces as `expected undefined to contain "loaded"`,
+    // which names neither the cause nor the fix.
+    expect(result.error, "could not spawn bun").toBeUndefined();
+
     // `signal` is what a timeout kill shows up as, and it is the failure this
     // test is for — distinguished from an ordinary non-zero exit, which would
     // mean the import itself broke and is a different bug.

--- a/packages/gemi/kernel/exit.test.ts
+++ b/packages/gemi/kernel/exit.test.ts
@@ -1,0 +1,50 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Importing the kernel must let the process exit.
+ *
+ * #316's third item: `await import("gemi/kernel")` resolved in ~110ms and then
+ * hung forever — no open sockets, no timers, an empty kqueue, and
+ * `getActiveResourcesInfo()` returning `[]`. Every one-off script that touched
+ * the kernel needed an explicit `process.exit()` or it held CI open until the
+ * job timed out.
+ *
+ * The cause was one module-scope import. `react-dom/server.browser` on React
+ * 19.2.3 keeps a Bun process alive on its own — importing nothing else and
+ * rendering nothing is enough — and `ViewRouteDispatcher` had it at the top,
+ * which puts it in the graph of anything reaching `RouteServiceProvider`. It is
+ * loaded on first render now; see the note there.
+ *
+ * **Asserted by running it rather than by reading the import list.** A static
+ * check that `react-dom/server.browser` is absent would pass while the same
+ * hang came back through a different module, and would fail on a lazy import
+ * that is perfectly fine. The property anybody cares about is that the process
+ * ends, so that is what is measured — in a subprocess, because a test runner
+ * cannot observe its own exit.
+ */
+describe("a script that imports the kernel", () => {
+  const entry = join(import.meta.dirname, "index.ts");
+
+  /**
+   * The bound is `spawnSync`'s, not vitest's: a synchronous spawn blocks the
+   * runner's loop, so its own `testTimeout` cannot fire and this is what
+   * decides how long a regression takes to report. The happy path is ~200ms, so
+   * ten seconds is margin rather than a guess.
+   */
+  test("exits on its own", { timeout: 15_000 }, () => {
+    const result = spawnSync(
+      "bun",
+      ["-e", `await import(${JSON.stringify(entry)}); console.log("loaded")`],
+      { encoding: "utf8", timeout: 10_000 },
+    );
+
+    // `signal` is what a timeout kill shows up as, and it is the failure this
+    // test is for — distinguished from an ordinary non-zero exit, which would
+    // mean the import itself broke and is a different bug.
+    expect(result.signal, result.stderr).toBeNull();
+    expect(result.stdout).toContain("loaded");
+    expect(result.status).toBe(0);
+  });
+});

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -363,18 +363,41 @@ export class ScopeEscapeError extends Error {
 export class UnregisteredPolicyClassError extends Error {
   constructor(
     public readonly model: string,
+    /**
+     * Under `carries: "narrowing"` this is the *ancestor* — the class the model
+     * belongs to — rather than whatever the registry currently holds. The two
+     * classes are on one prototype chain there, and which of them is registered
+     * is the thing in question, so naming them by their relationship is what
+     * makes the message readable.
+     */
     public readonly registered: string,
+    /** Under `carries: "narrowing"`, the descendant: the view that narrows. */
     public readonly queried: string,
     /**
-     * Which side carries the policies that would be skipped. The two directions
-     * need different advice: one is a missing registration, the other is a
-     * query through the wrong class.
+     * Which side carries the policies that would be skipped, and therefore what
+     * the author should do about it. Three, because they need three different
+     * answers: a missing registration, a query through the wrong class, and a
+     * view that should not be competing for the name at all.
      */
-    public readonly carries: "queried" | "registered" = "queried",
+    public readonly carries: "queried" | "registered" | "narrowing" = "queried",
   ) {
     super(
-      carries === "queried"
-        ? `${queried} carries policies but the registry resolves '${model}' to ` +
+      carries === "narrowing"
+        ? `${queried} extends ${registered}, which owns the model '${model}', ` +
+            `and carries policies of its own on top of it. A class that ` +
+            `narrows an existing model is a view, and the registry holds one ` +
+            `class per name — so registering ${queried} would apply its ` +
+            `narrowing to every nested read of ${model}, and leaving ` +
+            `${registered} registered would skip ${queried}'s policies ` +
+            `entirely. Neither is a thing to choose for you.\n\n` +
+            `Keep the view out of the modules you hand to Kernel.models, and ` +
+            `query it directly where you want it:\n\n` +
+            `    ${queried}.findMany(…)   // narrowed, at the call site\n\n` +
+            `If it is not a view but the model itself, move the policies onto ` +
+            `${registered} — the class the model's name resolves to — and ` +
+            `${queried} inherits them everywhere.\n`
+        : carries === "queried"
+          ? `${queried} carries policies but the registry resolves '${model}' to ` +
             `${registered}. Nested relation reads go through the registry, so ` +
             `they would run on ${registered} and skip every policy on ` +
             `${queried} — scoped at the root, unscoped inside an include. ` +
@@ -382,7 +405,7 @@ export class UnregisteredPolicyClassError extends Error {
             `    import { register } from "gemi/orm"\n` +
             `    export class ${queried} extends ${registered} { … }\n` +
             `    register("${model}", ${queried})\n`
-        : `This query goes through ${queried}, but the registry resolves ` +
+          : `This query goes through ${queried}, but the registry resolves ` +
             `'${model}' to ${registered}, which carries policies ${queried} ` +
             `does not. Nested relation reads would be scoped and this query is ` +
             `not — the same policy applying to some queries and not others. ` +
@@ -410,6 +433,15 @@ export class UnregisteredPolicyClassError extends Error {
  * Refused rather than guessed at, because both guesses are silent. Picking
  * either would scope every `include` of the model by one class's policies while
  * the other's code keeps reading as though its own applied.
+ *
+ * **"In one module" is the exact scope, and the asymmetry is deliberate.**
+ * Election happens per module, so two unrelated claims split across *different*
+ * modules never meet inside one — the later import simply wins. What catches
+ * that is the audit at the end of `registerModels` rather than this error, and
+ * only when the two diverge in policies. Two unrelated *unpolicied* claims on
+ * one name resolve by import order and nothing reports it, which is tolerable
+ * for the same reason it is invisible: with no policies on either, the choice
+ * changes no query's scope.
  */
 export class AmbiguousModelRegistrationError extends Error {
   constructor(

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -397,6 +397,41 @@ export class UnregisteredPolicyClassError extends Error {
 }
 
 /**
+ * Thrown when `registerModels` finds two unrelated classes in one module both
+ * claiming the same model name.
+ *
+ * Deriving registration from a module namespace works because the candidates
+ * are normally a chain — a generated base, the application's subclass, perhaps
+ * a typed view over it — and a chain has a least element to elect. Two classes
+ * that extend the same base without extending each other do not: both were
+ * written for this model, and only the author knows which one nested reads
+ * should run.
+ *
+ * Refused rather than guessed at, because both guesses are silent. Picking
+ * either would scope every `include` of the model by one class's policies while
+ * the other's code keeps reading as though its own applied.
+ */
+export class AmbiguousModelRegistrationError extends Error {
+  constructor(
+    public readonly model: string,
+    public readonly candidates: readonly string[],
+  ) {
+    const named = candidates.map((candidate) => `'${candidate}'`).join(", ");
+    super(
+      `Two classes in one module claim the model '${model}' — ${named} — and ` +
+        `neither extends the other, so there is no way to tell which one ` +
+        `nested relation reads should run.\n\n` +
+        `Say which, and registerModels will leave it alone:\n\n` +
+        `    import { register } from "gemi/orm"\n` +
+        `    register("${model}", ${candidates[0]})\n\n` +
+        `A class that is only a typed view over the same rows belongs in a ` +
+        `module you do not hand to registerModels.`,
+    );
+    this.name = "AmbiguousModelRegistrationError";
+  }
+}
+
+/**
  * Thrown when a statement would bind more parameters than the driver's wire
  * protocol can carry.
  *

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -74,6 +74,7 @@ export {
 } from "./json-null";
 
 export {
+  AmbiguousModelRegistrationError,
   DecodeError,
   MalformedRelationError,
   MissingModelSchemaError,
@@ -139,7 +140,7 @@ export {
   type SqlFragment,
 } from "./sql";
 
-export { assertPoliciesRegistered } from "./registration";
+export { assertPoliciesRegistered, registerModels } from "./registration";
 
 export {
   softDelete,

--- a/packages/gemi/orm/registration.test.ts
+++ b/packages/gemi/orm/registration.test.ts
@@ -425,4 +425,169 @@ describe("registerModels", () => {
   test("no modules at all is a no-op rather than an error", () => {
     expect(() => registerModels()).not.toThrow();
   });
+
+  /**
+   * A refusal must not leave behind the thing it refused.
+   *
+   * The registry is process-wide and outlives the throw, so registering as we
+   * went meant `registerModels({Ours}, {Theirs})` threw *and* left `"User"`
+   * resolving to `Theirs` — the leaking mapping the audit had just rejected. A
+   * server whose boot dies never notices; a dev server that catches and keeps
+   * serving runs the rest of the process on it.
+   */
+  test("a refused call leaves the registry as it found it", () => {
+    class Established extends UserBase {
+      static $policies = [scope];
+    }
+    class Ours extends UserBase {
+      static $policies = [scope];
+    }
+    class Theirs extends UserBase {
+      static $policies = [other];
+    }
+
+    register("User", Established);
+
+    expect(() => registerModels({ Ours }, { Theirs })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+    expect(registry.get("User")).toBe(Established);
+  });
+
+  test("a successful call commits", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+
+    registerModels({ UserBase }, { User });
+
+    expect(registry.get("User")).toBe(User);
+  });
+});
+
+/**
+ * A typed view that carries policies of its own.
+ *
+ * `elect` reasons about this shape explicitly — it prefers the least-derived
+ * application class so a view's narrowing does not silently reach every nested
+ * read — and then the audit has to finish the thought, because electing the
+ * base is only half an answer. The registry holds one class per name: register
+ * the view and its narrowing applies to every include of the model; leave the
+ * base registered and the view's policies never run inside one. Both are
+ * silent, so neither is chosen.
+ */
+describe("a view that narrows a model it does not own", () => {
+  const narrow: ModelPolicy = { scope: () => ({ archived: false }) };
+
+  test("is refused when it shares a module with the class it extends", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class AdminUser extends User {
+      static $policies = [narrow];
+    }
+
+    expect(() => registerModels({ UserBase, User, AdminUser })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+
+  /**
+   * The spelling that used to pass. Election is per module, so a view in a
+   * *later* module met no competition and simply won the name — and the
+   * ancestor skip then read `User` as a base its subclass had replaced and
+   * waved it through. Every nested read of the model quietly acquired the
+   * view's narrowing.
+   */
+  test("is refused when it arrives in a later module", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class AdminUser extends User {
+      static $policies = [narrow];
+    }
+
+    expect(() => registerModels({ UserBase }, { User }, { AdminUser })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+
+  test("the message names the view and does not ask for a register line", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class AdminUser extends User {
+      static $policies = [narrow];
+    }
+
+    try {
+      registerModels({ UserBase, User, AdminUser });
+      expect.unreachable("expected a throw");
+    } catch (error) {
+      expect((error as UnregisteredPolicyClassError).carries).toBe("narrowing");
+
+      const message = (error as Error).message;
+      expect(message).toContain("AdminUser");
+      expect(message).toContain("Kernel.models");
+      // The old advice produced exactly the every-include narrowing the
+      // election had just refused to produce.
+      expect(message).not.toContain('register("User", AdminUser)');
+    }
+  });
+
+  /**
+   * The line between this and #316's leak. Both are a policied descendant of
+   * the registered class; what separates them is whether the registered class
+   * is the generated base — in which case the subclass is not a view, it is the
+   * model, and giving it the name is the fix.
+   */
+  test("a policied subclass of a generated base still gets the register advice", () => {
+    class Membership extends UserBase {
+      static $policies = [scope];
+    }
+
+    register("User", UserBase);
+
+    try {
+      assertPoliciesRegistered({ Membership });
+      expect.unreachable("expected a throw");
+    } catch (error) {
+      expect((error as UnregisteredPolicyClassError).carries).toBe("queried");
+      expect((error as Error).message).toContain('register("User", Membership)');
+    }
+  });
+
+  test("a view that adds no policies of its own is still fine", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class AdminUser extends User {}
+
+    expect(() =>
+      registerModels({ UserBase, User, AdminUser }),
+    ).not.toThrow();
+    expect(registry.get("User")).toBe(User);
+  });
+});
+
+/**
+ * `elect` turns on `Object.hasOwn(candidate, "$schema")`, and the reader's
+ * question at that line is what happens when it is wrong. A subclass that
+ * redeclares `$schema` reads as a base, every candidate looks generated, and
+ * the least derived wins — the base takes the name over the policied subclass.
+ *
+ * That is #316's arrangement, so what matters is that it does not pass
+ * quietly.
+ */
+describe("when the generated-base test guesses wrong", () => {
+  test("a subclass that redeclares $schema fails loudly rather than leaking", () => {
+    class User extends UserBase {
+      static $schema = user;
+      static $policies = [scope];
+    }
+
+    expect(() => registerModels({ UserBase, User })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
 });

--- a/packages/gemi/orm/registration.test.ts
+++ b/packages/gemi/orm/registration.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, test } from "vitest";
 
-import { UnregisteredPolicyClassError } from "./errors";
+import {
+  AmbiguousModelRegistrationError,
+  UnregisteredPolicyClassError,
+} from "./errors";
 import { user } from "./fixtures";
-import type { ModelPolicy } from "./policy";
-import { assertPoliciesRegistered } from "./registration";
+import { policiesFor, type ModelPolicy } from "./policy";
+import { assertPoliciesRegistered, registerModels } from "./registration";
+import * as registry from "./registry";
 import { clearRegistry, register } from "./registry";
 
 /**
@@ -143,19 +147,60 @@ describe("what it must not reject", () => {
 
 describe("the other direction", () => {
   /**
-   * Registered carries policies, the exported class does not. Querying the
-   * exported one would be unscoped where every include is scoped — the same
-   * policy applying to some queries and not others.
+   * The generated base, exported from the generated namespace, after the
+   * application's subclass took the name. This is the arrangement the audit is
+   * *for*, and it used to be the arrangement the audit rejected: the check ran
+   * on any divergence, `UserBase` diverges from a policied `User`, and so the
+   * documented `assertPoliciesRegistered(generated, models)` threw the moment
+   * an application wrote its first policy. It passed only while every subclass
+   * stayed unpolicied — which is to say, only while there was nothing to
+   * protect.
+   *
+   * Being reachable through a base is not the mistake. Querying through one is,
+   * and that is a fact about a call site rather than about a module's exports,
+   * so `Model.$exec` keeps that direction; see the test below it.
    */
-  test("an exported base is refused when a policied class owns the name", () => {
+  test("a base its own subclass replaced is not a divergence", () => {
     class User extends UserBase {
       static $policies = [scope];
     }
 
     register("User", User);
 
+    expect(() => assertPoliciesRegistered({ UserBase }, { User })).not.toThrow();
+  });
+
+  /**
+   * The same shape one step further out: a hand-written intermediate the
+   * application subclassed again. Still an ancestor, still not a divergence.
+   */
+  test("an ancestor two levels up is not a divergence either", () => {
+    class Base extends UserBase {}
+    class User extends Base {
+      static $policies = [scope];
+    }
+
+    register("User", User);
+
+    expect(() => assertPoliciesRegistered({ UserBase, Base })).not.toThrow();
+  });
+
+  /**
+   * What that skip must not swallow. Two classes extending the same base are
+   * not in each other's prototype chains, so an unpolicied sibling of the
+   * registered class is still a class whose queries would be unscoped where
+   * every include is scoped.
+   */
+  test("an unpolicied sibling of the registered class is still refused", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class Sibling extends UserBase {}
+
+    register("User", User);
+
     try {
-      assertPoliciesRegistered({ UserBase });
+      assertPoliciesRegistered({ Sibling });
       expect.unreachable("expected a throw");
     } catch (error) {
       expect((error as UnregisteredPolicyClassError).carries).toBe(
@@ -198,5 +243,186 @@ describe("more than one module", () => {
 
   test("no modules at all is a no-op rather than an error", () => {
     expect(() => assertPoliciesRegistered()).not.toThrow();
+  });
+});
+
+/**
+ * Registration derived from the module rather than repeated by the author.
+ *
+ * The audit above reports a forgotten `register` line. This removes the line,
+ * which is a better answer to the same problem: the name is not a string
+ * anybody retypes, it is `$schema.name`, and a subclass inherits it.
+ */
+describe("registerModels", () => {
+  test("an application subclass replaces the base it extends", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+
+    registerModels({ UserBase }, { User });
+
+    expect(registry.get("User")).toBe(User);
+  });
+
+  /**
+   * The whole point, as the leak: a policied subclass with no `register` call
+   * next to it, which is what left the generated base owning the name and every
+   * nested `include` unscoped.
+   */
+  test("the forgotten register line is no longer forgettable", () => {
+    class Membership extends UserBase {
+      static $policies = [scope];
+    }
+
+    registerModels({ UserBase }, { Membership });
+
+    expect(policiesFor(registry.get("User"))).toEqual([scope]);
+  });
+
+  /**
+   * The barrel that re-exports its own generated namespace, which is the file
+   * an author is most likely to write and the one where electing the base would
+   * be the leak itself. The generated class declares `$schema`; the subclass
+   * inherits it, and that is what tells them apart.
+   */
+  test("a base and its subclass in one module elects the subclass", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+
+    registerModels({ UserBase, User });
+
+    expect(registry.get("User")).toBe(User);
+  });
+
+  test("a base, its subclass and a typed view in one module elects the subclass", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class AdminUser extends User {}
+
+    registerModels({ UserBase, User, AdminUser });
+
+    expect(registry.get("User")).toBe(User);
+  });
+
+  test("a generated base alone still registers", () => {
+    registerModels({ UserBase });
+
+    expect(registry.get("User")).toBe(UserBase);
+  });
+
+  test("later modules win over earlier ones", () => {
+    class User extends UserBase {}
+    class Override extends User {}
+
+    registerModels({ UserBase }, { User }, { Override });
+
+    expect(registry.get("User")).toBe(Override);
+  });
+
+  /**
+   * A typed view exported alongside the class it narrows. Registering the view
+   * would apply its own policies to every nested read of the model, so the
+   * least-derived candidate is the one that owns the name — and it is the one
+   * whose policies the view inherits anyway.
+   */
+  test("a typed view in the same module does not take the name", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class AdminUser extends User {}
+
+    registerModels({ UserBase }, { User, AdminUser });
+
+    expect(registry.get("User")).toBe(User);
+  });
+
+  test("two unrelated claims on one name are refused rather than guessed", () => {
+    class Ours extends UserBase {
+      static $policies = [scope];
+    }
+    class Theirs extends UserBase {
+      static $policies = [other];
+    }
+
+    expect(() => registerModels({ Ours, Theirs })).toThrow(
+      AmbiguousModelRegistrationError,
+    );
+  });
+
+  test("the ambiguity names both classes and the way out", () => {
+    class Ours extends UserBase {
+      static $policies = [scope];
+    }
+    class Theirs extends UserBase {
+      static $policies = [other];
+    }
+
+    try {
+      registerModels({ Ours, Theirs });
+      expect.unreachable("expected a throw");
+    } catch (error) {
+      const message = (error as Error).message;
+      expect(message).toContain("Ours");
+      expect(message).toContain("Theirs");
+      expect(message).toContain('register("User"');
+    }
+  });
+
+  /**
+   * One class under two keys is one claim. `export { User }` beside a default
+   * export is the shape, and treating it as two candidates would make an
+   * ordinary barrel ambiguous.
+   */
+  test("the same class exported twice is not a conflict", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+
+    expect(() =>
+      registerModels({ User, default: User, Aliased: User }),
+    ).not.toThrow();
+    expect(registry.get("User")).toBe(User);
+  });
+
+  test("non-model exports are ignored", () => {
+    class User extends UserBase {}
+
+    expect(() =>
+      registerModels({
+        User,
+        DEFAULT_PAGE_SIZE: 20,
+        helper: () => "not a model",
+        nothing: undefined,
+        nullish: null,
+      }),
+    ).not.toThrow();
+    expect(registry.get("User")).toBe(User);
+  });
+
+  /**
+   * It audits what it registered, which matters because election is per-module:
+   * two unrelated claims in *different* modules are not a conflict any single
+   * election sees, and the later one simply wins. The earlier class is then a
+   * policied class that does not own its name — the leak, arrived at through
+   * the mechanism that exists to prevent it — so the audit at the end has to
+   * catch what the elections let past.
+   */
+  test("unrelated claims split across modules are still refused", () => {
+    class Ours extends UserBase {
+      static $policies = [scope];
+    }
+    class Theirs extends UserBase {
+      static $policies = [other];
+    }
+
+    expect(() => registerModels({ Ours }, { Theirs })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+
+  test("no modules at all is a no-op rather than an error", () => {
+    expect(() => registerModels()).not.toThrow();
   });
 });

--- a/packages/gemi/orm/registration.ts
+++ b/packages/gemi/orm/registration.ts
@@ -77,45 +77,84 @@ export function assertPoliciesRegistered(
       // `ModelNotRegisteredError`. Not this function's business.
       if (registered === undefined || registered === model) continue;
 
-      // The exported class is an *ancestor* of the registered one — which is
-      // what a generated base is, and why this has to be skipped rather than
-      // reported.
-      //
-      // `generated/index.ts` exports `UserModel` and the application subclasses
-      // it. So the moment a policy lands on `User`, the documented call
-      //
-      //     assertPoliciesRegistered(generated, models)
-      //
-      // walked the generated namespace, found `UserModel` diverging from the
-      // registered `User`, and threw — on the correct arrangement, in exactly
-      // the case the audit exists to protect. The recipe in the docs was
-      // unusable by anything it could have helped, and passed only while every
-      // subclass stayed unpolicied.
-      //
-      // Being *reachable* through a base is not the bug. Querying through one
-      // is, and that is a property of a call site rather than of a module's
-      // export list, so `Model.$exec` keeps it: a real
-      // `UserModel.findMany()` still raises with `carries: "registered"`. What
-      // this audit can see is which class owns a name, and a base its own
-      // subclass replaced has not lost anything.
-      //
-      // Siblings are untouched by this. Two classes extending the same base
-      // where only one is registered are not in each other's prototype chains,
-      // so they still diverge and are still refused.
-      if (descendsFrom(registered, model)) continue;
-
       const ours = policiesFor(model);
       const theirs = policiesFor(registered);
       const diverges =
         ours.length !== theirs.length ||
         ours.some((policy, index) => policy !== theirs[index]);
 
+      // The two classes are on one prototype chain — a base and something
+      // extending it — which is the arrangement almost every application has,
+      // and the one this audit used to get wrong in both directions.
+      //
+      // `policiesFor` accumulates upwards, so a descendant's chain always
+      // contains its ancestor's. What separates the two shapes is therefore
+      // whether the **ancestor** carries anything of its own.
+      if (descendsFrom(registered, model) || descendsFrom(model, registered)) {
+        const ancestor = descendsFrom(model, registered) ? registered : model;
+        const descendant = ancestor === registered ? model : registered;
+
+        if (policiesFor(ancestor).length === 0) {
+          // The ancestor contributes nothing, so the descendant is the first
+          // class to carry a policy: it is not a view over the model, it *is*
+          // the model. A generated base is the usual ancestor here, and a
+          // hand-written intermediate behaves the same way.
+          //
+          // Registered already? Then this is the correct arrangement, and it
+          // has to be skipped rather than reported — it used not to be, and
+          // that is why the documented
+          //
+          //     assertPoliciesRegistered(generated, models)
+          //
+          // threw the moment an application wrote its first policy: it walked
+          // the generated namespace, found `UserModel` diverging from the
+          // registered `User`, and refused the thing it exists to protect.
+          // Being reachable through a base is not the bug; querying through one
+          // is, and that is a property of a call site rather than of a module's
+          // export list, so `Model.$exec` keeps that direction.
+          if (registered === descendant) continue;
+
+          // Neither class carries anything, so which one owns the name changes
+          // no query's scope. An unregistered plain subclass is not a mistake.
+          if (!diverges) continue;
+
+          // Not registered, and it has policies: #316 itself. The policied
+          // class is not the one the name resolves to, so every nested read
+          // runs the ancestor and skips it.
+          throw new UnregisteredPolicyClassError(
+            name,
+            nameOf(registered),
+            nameOf(model),
+            ours.length > 0 ? "queried" : "registered",
+          );
+        }
+
+        // The ancestor carries policies of its own, so it is a registered model
+        // in good standing and the descendant is narrowing it. The registry
+        // holds one class per name: registering the view applies its narrowing
+        // to every nested read, and leaving the ancestor registered skips the
+        // view's policies entirely. Both are silent, so neither is chosen.
+        if (diverges) {
+          throw new UnregisteredPolicyClassError(
+            name,
+            nameOf(ancestor),
+            nameOf(descendant),
+            "narrowing",
+          );
+        }
+
+        // Same chain, same policies — a plain typed view. Nothing to report.
+        continue;
+      }
+
       if (!diverges) continue;
 
+      // Unrelated classes claiming one name. Whichever is registered, the
+      // other's policies are simply not in effect.
       throw new UnregisteredPolicyClassError(
         name,
-        (registered as { name?: string }).name ?? String(registered),
-        (model as { name?: string }).name ?? String(model),
+        nameOf(registered),
+        nameOf(model),
         ours.length > 0 ? "queried" : "registered",
       );
     }
@@ -163,6 +202,17 @@ export function assertPoliciesRegistered(
 export function registerModels(
   ...modules: Array<Record<string, unknown>>
 ): void {
+  // Elected into a local map first, and only committed once the audit passes.
+  //
+  // The registry is process-wide and outlives the throw. Registering as we went
+  // meant a refused call left the arrangement it had just refused installed —
+  // `registerModels({Ours}, {Theirs})` threw, and `"User"` resolved to `Theirs`
+  // afterwards, which is the leaking mapping the audit exists to reject. A
+  // server whose boot dies never notices; a dev server that catches and keeps
+  // serving, or a test harness that continues past the error, serves the rest
+  // of the process from it.
+  const staged = new Map<string, ModelClass>();
+
   for (const module of modules) {
     const candidates = new Map<string, ModelClass[]>();
 
@@ -178,12 +228,31 @@ export function registerModels(
       else existing.push(model);
     }
 
+    // Later modules win, which is what lets an application's classes replace
+    // the generated bases they extend.
     for (const [name, classes] of candidates) {
-      registry.register(name, elect(name, classes));
+      staged.set(name, elect(name, classes));
     }
   }
 
-  assertPoliciesRegistered(...modules);
+  // What the registry said before, so a failed audit can put it back. `register`
+  // has no inverse, so a name that was previously *absent* cannot be made
+  // absent again — it is left pointing at what this call elected. That is the
+  // one residue, and it is the harmless direction: the alternative to a wrong
+  // registration under a name nothing claimed is `ModelNotRegisteredError`, and
+  // the class elected here is the one this module set would have used anyway.
+  const previous = [...staged.keys()]
+    .filter((name) => registry.has(name))
+    .map((name) => [name, registry.get<unknown>(name)] as const);
+
+  for (const [name, model] of staged) registry.register(name, model);
+
+  try {
+    assertPoliciesRegistered(...modules);
+  } catch (error) {
+    for (const [name, model] of previous) registry.register(name, model);
+    throw error;
+  }
 }
 
 /**
@@ -249,7 +318,18 @@ function elect(name: string, classes: ModelClass[]): ModelClass {
  * it, so owning the property is the difference. Nothing has to be added to the
  * generated output for this to hold — it is already how `models.ts` is written,
  * and `Model.$exec` already reads `$schema` off the prototype chain for exactly
- * that reason.
+ * that reason. `registration.test.ts` in the template asserts the contract
+ * against real generator output, because this is the one place a generator
+ * change could quietly invalidate an assumption made here.
+ *
+ * **When it is wrong, it is wrong safely.** A subclass that redeclares
+ * `static $schema` — pointing at a modified schema object, or by copy-paste —
+ * reads as a base here. Every candidate then looks generated, `elect` falls
+ * through to the whole set, and the least derived wins: the base takes the name
+ * over the policied subclass. That is the arrangement #316 is about, so it does
+ * not pass quietly — `assertPoliciesRegistered` runs immediately after and
+ * refuses it, naming both classes. Loud and wrong beats silent and wrong, and
+ * the reader's question at `Object.hasOwn` is exactly this one.
  */
 function isGeneratedBase(candidate: ModelClass): boolean {
   return Object.hasOwn(candidate, "$schema");

--- a/packages/gemi/orm/registration.ts
+++ b/packages/gemi/orm/registration.ts
@@ -1,7 +1,13 @@
-import { UnregisteredPolicyClassError } from "./errors";
+import {
+  AmbiguousModelRegistrationError,
+  UnregisteredPolicyClassError,
+} from "./errors";
 import { policiesFor } from "./policy";
 import * as registry from "./registry";
 import type { ModelSchema } from "./schema";
+
+/** A model class, as much of one as anything below `Model.ts` can name. */
+type ModelClass = object & { $schema: ModelSchema };
 
 /**
  * Checks that every policied model class an application defines is the one the
@@ -44,11 +50,13 @@ import type { ModelSchema } from "./schema";
  * Reading a class out of a module namespace is what makes the unqueried case
  * visible — the class exists and is exported whether or not anything queries it.
  *
- * Call it at boot, or from a test. A test is enough to close the hole for CI and
- * costs nothing at runtime; booting with it turns a deploy of the mistake into a
- * failure to start rather than a quiet cross-tenant read. Neither is a
- * *substitute* for writing `register` next to the subclass, and this function
- * cannot become one: it can only see modules it is handed.
+ * `registerModels` runs this after registering, and `Kernel.models` runs
+ * `registerModels` at boot, so an application that declares its model modules
+ * gets it without asking. This is the same check for modules the Kernel does
+ * not own — a test over a package's models, a script that boots nothing.
+ *
+ * It can only see modules it is handed, which is the residual either way: a
+ * policied class in a file no barrel re-exports is invisible to it.
  */
 export function assertPoliciesRegistered(
   ...modules: Array<Record<string, unknown>>
@@ -69,6 +77,33 @@ export function assertPoliciesRegistered(
       // `ModelNotRegisteredError`. Not this function's business.
       if (registered === undefined || registered === model) continue;
 
+      // The exported class is an *ancestor* of the registered one — which is
+      // what a generated base is, and why this has to be skipped rather than
+      // reported.
+      //
+      // `generated/index.ts` exports `UserModel` and the application subclasses
+      // it. So the moment a policy lands on `User`, the documented call
+      //
+      //     assertPoliciesRegistered(generated, models)
+      //
+      // walked the generated namespace, found `UserModel` diverging from the
+      // registered `User`, and threw — on the correct arrangement, in exactly
+      // the case the audit exists to protect. The recipe in the docs was
+      // unusable by anything it could have helped, and passed only while every
+      // subclass stayed unpolicied.
+      //
+      // Being *reachable* through a base is not the bug. Querying through one
+      // is, and that is a property of a call site rather than of a module's
+      // export list, so `Model.$exec` keeps it: a real
+      // `UserModel.findMany()` still raises with `carries: "registered"`. What
+      // this audit can see is which class owns a name, and a base its own
+      // subclass replaced has not lost anything.
+      //
+      // Siblings are untouched by this. Two classes extending the same base
+      // where only one is registered are not in each other's prototype chains,
+      // so they still diverge and are still refused.
+      if (descendsFrom(registered, model)) continue;
+
       const ours = policiesFor(model);
       const theirs = policiesFor(registered);
       const diverges =
@@ -88,6 +123,159 @@ export function assertPoliciesRegistered(
 }
 
 /**
+ * Registers every model class the given modules export, under the name each
+ * one's schema carries, and then audits the result.
+ *
+ * ### The line this exists to delete
+ *
+ * `register("User", User)` next to every subclass is a correct instruction and
+ * a bad mechanism, because forgetting it is invisible. A relation read resolves
+ * its target by name, so an unregistered policied subclass leaves the generated
+ * base owning the name and every nested `include` of that model comes back
+ * unscoped — no error, no warning, and an authorization hole in the direction
+ * nobody checks. `assertPoliciesRegistered` turns that into a loud failure, but
+ * only for someone who remembered to run it.
+ *
+ * Deriving the registration from the module removes the mistake instead of
+ * reporting it. The name is not a string an author repeats; it is
+ * `$schema.name`, which the generator wrote and the subclass inherits:
+ *
+ *     import * as generated from "./generated"
+ *     import * as models from "./models"
+ *
+ *     registerModels(generated, models)
+ *
+ * Later modules win, so the application's classes replace the generated bases
+ * they extend. `register` still exists and still works — this is what an
+ * application calls once instead of writing it thirteen times.
+ *
+ * ### What it still cannot see
+ *
+ * Modules it is handed. A policied class in a file nothing imports is invisible
+ * to this exactly as it is to `assertPoliciesRegistered`, and closing *that*
+ * would take the framework enumerating the filesystem at boot. Handing it a
+ * barrel is the whole discipline: one file to add a model to, and the audit
+ * covers everything in it.
+ *
+ * `Kernel.models` is that call, wired at boot, so an application declares its
+ * model modules the way it already declares config slices and providers.
+ */
+export function registerModels(
+  ...modules: Array<Record<string, unknown>>
+): void {
+  for (const module of modules) {
+    const candidates = new Map<string, ModelClass[]>();
+
+    // Deduped by identity first: `export { User }` alongside a default export
+    // is the same class under two keys, not two classes competing for a name.
+    for (const exported of new Set(Object.values(module))) {
+      const model = asModelClass(exported);
+      if (model === null) continue;
+
+      const name = model.$schema.name;
+      const existing = candidates.get(name);
+      if (existing === undefined) candidates.set(name, [model]);
+      else existing.push(model);
+    }
+
+    for (const [name, classes] of candidates) {
+      registry.register(name, elect(name, classes));
+    }
+  }
+
+  assertPoliciesRegistered(...modules);
+}
+
+/**
+ * Which of several classes claiming one name in one module gets it.
+ *
+ * Two shapes put more than one candidate in a namespace, and they want opposite
+ * answers, so neither "most derived" nor "least derived" is the rule on its
+ * own:
+ *
+ *     export * from "./generated"      // UserModel, and
+ *     export class User extends UserModel { static $policies = [...] }
+ *
+ * wants the subclass — electing the base here *is* the leak, in the one file an
+ * author most plausibly writes it in. While
+ *
+ *     export class User extends UserModel { static $policies = [...] }
+ *     export class AdminUser extends User {}
+ *
+ * wants `User`. `AdminUser` is a typed view over the same rows; it inherits the
+ * policies either way, so registering it changes nothing when it adds none and
+ * silently applies its own narrowing to every nested read when it does.
+ *
+ * What separates them is which class the *generator* wrote. It emits
+ * `static $schema = schema.User` on the base, and a subclass inherits that
+ * property rather than declaring one — so an own `$schema` is the mark of a
+ * generated base, and it is a fact about the classes rather than about the
+ * order somebody exported them in. Application classes are preferred over
+ * bases; among application classes the least derived wins, for the reason
+ * `AdminUser` gives.
+ *
+ * When that leaves no single answer the candidates are unrelated classes with a
+ * genuine claim each, and there is nothing left to infer. That case is refused
+ * rather than guessed at: `register` says which, in the application's own
+ * words.
+ */
+function elect(name: string, classes: ModelClass[]): ModelClass {
+  if (classes.length === 1) return classes[0]!;
+
+  const written = classes.filter((candidate) => !isGeneratedBase(candidate));
+  const eligible = written.length > 0 ? written : classes;
+
+  if (eligible.length === 1) return eligible[0]!;
+
+  const roots = eligible.filter((candidate) =>
+    eligible.every(
+      (other) => other === candidate || descendsFrom(other, candidate),
+    ),
+  );
+
+  if (roots.length === 1) return roots[0]!;
+
+  throw new AmbiguousModelRegistrationError(
+    name,
+    eligible.map((candidate) => nameOf(candidate)),
+  );
+}
+
+/**
+ * Whether the generator wrote this class, rather than an application extending
+ * one it wrote.
+ *
+ * `$schema` is declared on the emitted base and inherited by everything below
+ * it, so owning the property is the difference. Nothing has to be added to the
+ * generated output for this to hold — it is already how `models.ts` is written,
+ * and `Model.$exec` already reads `$schema` off the prototype chain for exactly
+ * that reason.
+ */
+function isGeneratedBase(candidate: ModelClass): boolean {
+  return Object.hasOwn(candidate, "$schema");
+}
+
+/**
+ * Whether `derived` has `base` in its static prototype chain — the `extends`
+ * relation between two classes, walked on the constructor side because that is
+ * where `$schema` and `$policies` live.
+ */
+function descendsFrom(derived: unknown, base: unknown): boolean {
+  let current = Object.getPrototypeOf(derived);
+
+  while (current !== null && current !== Function.prototype) {
+    if (current === base) return true;
+    current = Object.getPrototypeOf(current);
+  }
+
+  return false;
+}
+
+function nameOf(value: unknown): string {
+  return (value as { name?: string })?.name ?? String(value);
+}
+
+/**
  * A model class, structurally.
  *
  * Structural rather than `instanceof Model` on purpose: this module sits below
@@ -100,13 +288,11 @@ export function assertPoliciesRegistered(
  * constants, helpers and re-exported values do not — so everything that is not
  * a model class is skipped rather than treated as an error.
  */
-function asModelClass(
-  value: unknown,
-): (object & { $schema: ModelSchema }) | null {
+function asModelClass(value: unknown): ModelClass | null {
   if (typeof value !== "function") return null;
 
   const schema = (value as { $schema?: ModelSchema }).$schema;
   if (schema === undefined || typeof schema.name !== "string") return null;
 
-  return value as unknown as object & { $schema: ModelSchema };
+  return value as unknown as ModelClass;
 }

--- a/packages/gemi/services/router/ViewRouteDispatcher.ts
+++ b/packages/gemi/services/router/ViewRouteDispatcher.ts
@@ -63,6 +63,12 @@ import { createRoutePayloadStream } from "./routePayloadStream";
  *
  * Wrapped rather than awaited at each call site so the three of them read
  * unchanged.
+ *
+ * The slot is cleared on failure so a rejection is not what gets memoised. A
+ * missing `react-dom` is fatal either way — this is about the diagnostic, not
+ * about recovery: caching the rejected promise would make every later render
+ * report whatever the loader threw the first time, with no stack from the call
+ * that actually failed.
  */
 let serverRenderer:
   | Promise<{ renderToReadableStream: (...args: any[]) => Promise<any> }>
@@ -70,7 +76,10 @@ let serverRenderer:
 
 const renderToReadableStream = async (...args: any[]): Promise<any> => {
   // @ts-ignore
-  serverRenderer ??= import("react-dom/server.browser");
+  serverRenderer ??= import("react-dom/server.browser").catch((error) => {
+    serverRenderer = undefined;
+    throw error;
+  });
   return (await serverRenderer).renderToReadableStream(...args);
 };
 

--- a/packages/gemi/services/router/ViewRouteDispatcher.ts
+++ b/packages/gemi/services/router/ViewRouteDispatcher.ts
@@ -15,8 +15,6 @@ import { viewRouteConfigDefaults, type ViewRouteConfig } from "./config";
 import { resolvePartialRender } from "./planPartialRender";
 import { matchViewRoute } from "./matchViewRoute";
 import { PARTIAL_RENDER_HEADER, type PartialRenderInfo } from "../../utils/partialRender";
-// @ts-ignore
-import { renderToReadableStream } from "react-dom/server.browser";
 import { createElement, Fragment } from "react";
 
 import { createFileResponse, type FileOutput, type ViewRoutes } from "../../http/ViewRouter";
@@ -37,6 +35,44 @@ import { createServerQueryFetcher } from "./serverQueryFetcher";
 import { injectQueryPayloads, isBotUserAgent } from "./streamQueryInjection";
 import { createShellContentObserver, createShellContentReporter } from "./shellContentReport";
 import { createRoutePayloadStream } from "./routePayloadStream";
+
+/**
+ * React's server renderer, loaded on the first render rather than on import.
+ *
+ * **Importing `react-dom/server.browser` keeps the process alive forever.** On
+ * React 19.2.3 under Bun, that one import — nothing else, no render, no server
+ * — is enough that the process never exits: `getActiveResourcesInfo()` comes
+ * back empty, there are no timers, no sockets and an empty kqueue, and it hangs
+ * anyway. `react-dom/server.node` does not do it. Reduced from #316's third
+ * item, which reports the same hang from `await import("gemi/kernel")` and
+ * predates the 0.51 line.
+ *
+ * That import sat at module scope here, and this module is reachable from
+ * `gemi/kernel` through `RouteServiceProvider` — so *any* script that touched
+ * the kernel inherited the hang and needed an explicit `process.exit()`. A
+ * one-off migration, a seeder, a cron entry point, a CI check: all of them
+ * loaded the SSR renderer to get a `Kernel` they were going to use for
+ * something else entirely.
+ *
+ * Deferring it costs one already-resolved dynamic import on the first document
+ * render and nothing after — `react-dom` is external in the framework build, so
+ * this stays a runtime resolve out of the app's own `node_modules` exactly as
+ * the static import was. A server renders, so it pays this once at first
+ * request; a script that never renders no longer pays it at all, which is the
+ * whole point.
+ *
+ * Wrapped rather than awaited at each call site so the three of them read
+ * unchanged.
+ */
+let serverRenderer:
+  | Promise<{ renderToReadableStream: (...args: any[]) => Promise<any> }>
+  | undefined;
+
+const renderToReadableStream = async (...args: any[]): Promise<any> => {
+  // @ts-ignore
+  serverRenderer ??= import("react-dom/server.browser");
+  return (await serverRenderer).renderToReadableStream(...args);
+};
 
 /**
  * How long a document response may keep streaming before pending segments are

--- a/templates/saas-starter/app/kernel/Kernel.ts
+++ b/templates/saas-starter/app/kernel/Kernel.ts
@@ -12,9 +12,19 @@ import route from "../config/route";
 import schedule from "../config/schedule";
 import translation from "../config/translation";
 
+import * as generated from "../models/generated";
+import * as models from "../models";
+
 import AppServiceProvider from "../providers/AppServiceProvider";
 
 export default class extends Kernel {
+  // The generated bases, then the classes written over them — later wins, so
+  // each subclass takes the name its base was holding. `boot()` registers them
+  // and then checks that no policied class lost its name to something else,
+  // which is the mistake that would otherwise show up as an `include` quietly
+  // returning rows nobody was allowed to see.
+  models = [generated, models];
+
   config = {
     auth,
     database,

--- a/templates/saas-starter/app/models/User.ts
+++ b/templates/saas-starter/app/models/User.ts
@@ -29,17 +29,19 @@ import { UserModel } from "./generated";
 // literal and the parameters are implicitly `any`.
 export class User extends UserModel {}
 
-// Re-registers the name against *this* class, replacing the generated base that
+// Registers the name against *this* class, replacing the generated base that
 // `generated/index.ts` registered.
 //
-// This is not optional bookkeeping. A relation read resolves its target through
-// the registry by name, so whatever is registered under "User" is the class that
-// runs for every nested `include` — and if that is the generated base while your
-// policy lives here, the policy applies to root queries and is skipped inside
-// includes. Scoped one way, unscoped the other, with nothing to notice it.
+// `app/kernel/Kernel.ts` already does this for everything `app/models/index.ts`
+// exports, so the line is no longer what makes the app correct — which is the
+// point of listing the modules there. It is kept because this module is also
+// imported on its own, by tests and by `app/preload.ts`, and in those the
+// registry is whatever the imports made it.
 //
-// `Model.$exec` raises `UnregisteredPolicyClassError` if a class carrying
-// policies is not the registered one, so forgetting this line fails loudly
-// rather than leaking — but the line belongs next to every subclass regardless,
-// because the same reasoning will apply to observers and hooks.
+// What it is protecting against, either way: a relation read resolves its target
+// through the registry by name, so whatever is registered under "User" is the
+// class that runs inside every nested `include`. If that is the generated base
+// while a policy lives here, the policy applies to root queries and is skipped
+// inside includes — scoped one way, unscoped the other, with nothing to notice
+// it.
 register("User", User);

--- a/templates/saas-starter/app/models/index.ts
+++ b/templates/saas-starter/app/models/index.ts
@@ -1,0 +1,14 @@
+// The application's own model classes, in one place.
+//
+// `app/kernel/Kernel.ts` lists this module in `models`, and `Kernel.boot()`
+// registers everything it exports under the name each class's schema carries —
+// so a subclass added here owns its name without anybody writing a `register`
+// line for it, and a policy on it applies inside nested `include`s as well as at
+// the root.
+//
+// That is the whole reason this file exists rather than each model registering
+// itself. Forgetting to register a policied subclass does not fail: the
+// generated base keeps the name, every nested read of the model comes back
+// unscoped, and nothing raises. Adding a model to this barrel is a step you can
+// notice missing; a `register` call scattered across thirteen files is not.
+export { User } from "./User";

--- a/templates/saas-starter/app/models/registration.test.ts
+++ b/templates/saas-starter/app/models/registration.test.ts
@@ -3,12 +3,13 @@ import {
   assertPoliciesRegistered,
   policiesFor,
   register,
+  registerModels,
   registry,
 } from "gemi/orm";
 import { afterEach, describe, expect, test } from "vitest";
 
 import * as generated from "./generated";
-import * as models from "./User";
+import * as models from "./index";
 
 /**
  * The registration audit, against the template's **real** generated classes.
@@ -38,6 +39,77 @@ describe("the template's own models", () => {
   test("User.ts has replaced the generated base in the registry", () => {
     expect(models.User).not.toBe(generated.UserModel);
     expect(Object.getPrototypeOf(models.User)).toBe(generated.UserModel);
+  });
+
+  /**
+   * **The contract `elect` is built on, checked against the generator rather
+   * than against a stand-in.**
+   *
+   * `registerModels` decides which of several candidates owns a name by asking
+   * whether a class declares `$schema` itself or inherits it: an own property
+   * means the generator emitted it, and an inherited one means an application
+   * wrote it. Every unit test of that rule uses a hand-written
+   * `class UserBase { static $schema = user }`, which is exactly the thing that
+   * cannot tell you whether real generator output still looks like this.
+   *
+   * If `models.ts` ever moved `$schema` — onto the prototype, into a getter, up
+   * into `Model` — `elect` would read every candidate as a base and hand the
+   * name to the generated class over the application's subclass. That fails
+   * loudly rather than leaking, because the audit refuses it a moment later,
+   * but "loudly" is a worse day than this assertion.
+   */
+  test("the generator declares $schema and subclasses inherit it", () => {
+    expect(Object.hasOwn(generated.UserModel, "$schema")).toBe(true);
+    expect(Object.hasOwn(models.User, "$schema")).toBe(false);
+  });
+});
+
+/**
+ * `registerModels` — the mechanism `Kernel.models` runs — against the real
+ * generated namespace and the real barrel.
+ *
+ * The audit above checks a registry somebody else populated. This checks the
+ * thing that populates it, on thirteen generated classes and the application
+ * subclass written over one of them, which is the arrangement every gemi app
+ * has and the one the unit tests can only approximate.
+ */
+describe("registering the template's models the way the Kernel does", () => {
+  const before = new Map(
+    registry.registeredNames().map((name) => [name, registry.get(name)]),
+  );
+
+  afterEach(() => {
+    for (const [name, model] of before) register(name, model);
+  });
+
+  test("every generated model ends up registered under its own name", () => {
+    registerModels(generated, models);
+
+    for (const name of before.keys()) {
+      expect(registry.has(name), name).toBe(true);
+    }
+  });
+
+  /**
+   * The point of the whole mechanism: `User.ts` needs no `register` line for
+   * its class to own the name, because the name comes from `$schema` and the
+   * subclass inherits it.
+   */
+  test("the application subclass takes the name from its generated base", () => {
+    register("User", generated.UserModel);
+
+    registerModels(generated, models);
+
+    expect(registry.get("User")).toBe(models.User);
+  });
+
+  /**
+   * The barrel is what the Kernel is handed, so a model missing from it is
+   * a model the Kernel cannot see. Asserted here so `index.ts` is load-bearing
+   * in a test rather than only in the template's Kernel.
+   */
+  test("the barrel is what carries the application's classes", () => {
+    expect(Object.values(models)).toContain(models.User);
   });
 });
 

--- a/templates/saas-starter/app/preload.ts
+++ b/templates/saas-starter/app/preload.ts
@@ -7,14 +7,18 @@
 // relations resolve their targets and how `UserProvider` — the framework's
 // authentication persistence — finds `User`, `Session` and the token models.
 //
-// Importing `User` rather than `generated` on purpose: it pulls in
-// `generated/index.ts` (registering all of them) and *then* re-registers "User"
-// against the app's own subclass, so a policy added there applies inside nested
-// includes too. Importing only `generated` would leave the base registered and
-// silently skip it.
+// Importing the app's own barrel rather than `generated` on purpose: it pulls in
+// `generated/index.ts` (registering all of them) and *then* the subclasses
+// written over those bases, so a policy on one applies inside nested includes
+// too. Importing only `generated` would leave the bases registered and silently
+// skip them.
+//
+// `Kernel.boot()` registers the same modules through `models`, and does it
+// whether or not this file exists. This runs earlier — before the server, and
+// before anything a preload plugin might do — which is why it is still here.
 //
 // This import is load-bearing — sign-in raises `ModelNotRegisteredError` without
 // it — so unlike the rest of this file it is not safe to delete.
-import "@/app/models/User";
+import "@/app/models";
 
 console.log("[app/preload.ts] preloaded before server start");


### PR DESCRIPTION
Closes #316 items 1 and 3, and documents 4–6. Item 2 is answered below rather than coded.

## 1. An unregistered subclass silently serves unpolicied rows — fixed

The gate. Two things were wrong, and the second is why the first had no working mitigation.

**The hole.** `register("User", User)` is a correct instruction and a bad mechanism: forgetting it is invisible. A relation read resolves its target by name, so an unregistered policied subclass leaves the generated base owning the name and every nested `include` comes back unscoped. `$exec`'s guard begins `registered !== this`, so a model only ever read through an include never trips it.

**`registerModels(...modules)` derives the registration from the module** instead of asking an author to repeat the name. The name is `$schema.name` — the generator wrote it, the subclass inherits it. `Kernel.models` is that call at boot:

```ts
// app/kernel/Kernel.ts
import * as generated from "../models/generated"
import * as models from "../models"

export default class extends Kernel {
  models = [generated, models]
}
```

Later modules win, so each subclass takes the name its base was holding, and the audit runs over the whole set before the container is touched. For a 79-model schema that is one line and one barrel, not 79 `register` calls.

Election is per module, and the two shapes that put more than one candidate in a namespace want **opposite** answers:

| the module | wants | why |
|---|---|---|
| `export * from "./generated"` + `class User extends UserModel` | the subclass | electing the base *is* the leak |
| `class User` + `class AdminUser extends User {}` | `User` | the view inherits the policies either way, and would apply its own narrowing to every nested read |

An own `$schema` separates them — the generator declares it on the base, a subclass inherits — so application classes beat bases, and among application classes the least derived wins. Two unrelated claims raise `AmbiguousModelRegistrationError` rather than getting picked between.

**`register` still works** and is still what you write for a class in a module the Kernel doesn't own. The template keeps its line in `User.ts` because that module is also imported alone, by tests and by `preload.ts`.

### The second defect: the recommended audit threw on the correct arrangement

`docs/orm.md` told you to run `assertPoliciesRegistered(generated, models)`. That call walked the generated namespace, found `UserModel` diverging from the policied `User` that had replaced it, and threw — so **the only documented mitigation for the hole above failed the moment an app wrote its first policy**, and passed only while there was nothing to protect. On a 79-model schema you'd have hit this on the first policy.

Reachability through a base is not the bug; *querying* through one is, and that's a property of a call site rather than of a module's export list. `$exec` keeps that direction (`UserModel.findMany()` still raises with `carries: "registered"`); the audit stops reporting ancestors. Siblings — two classes extending the same base, only one registered — still diverge and are still refused.

### Residual, stated plainly

It sees the modules it's handed. A policied class in a file no barrel re-exports is still invisible, and closing *that* needs the framework enumerating the filesystem at boot. The barrel is the discipline: one file to add a model to, where a missing line is a thing you can notice.

Not taken: emitting bases unregistered (every app then needs explicit registration for models it never subclassed, and a one-call helper puts you straight back where you started), and refusing at relation resolution (unimplementable — nothing at runtime can see a class that was never registered and never queried).

## 3. `await import("gemi/kernel")` never let the process exit — fixed

Reduced to one module-scope import. On React 19.2.3 under Bun:

```
import 'react-dom/server.browser'   → hangs, getActiveResourcesInfo() === []
import 'react-dom/server.node'      → exits
import 'satori'; import 'sharp'     → exits
```

`ViewRouteDispatcher` had `react-dom/server.browser` at the top, and that module is in the graph of everything reaching `RouteServiceProvider` — so the hang propagated to `gemi/kernel` and every script that touched it. Chain: `kernel → RouteServiceProvider → ViewRouteDispatcher → react-dom/server.browser`.

Loaded on the first render now, wrapped so the three call sites read unchanged. `react-dom` is external in the framework build, so it stays a runtime resolve out of the app's `node_modules` exactly as the static import was. A server pays it once at first request; a script that never renders no longer pays it at all.

Tested by running a script and watching it end (`kernel/exit.test.ts`) rather than by asserting the import list — a static check would pass while the same hang came back through a different module, and would fail on a lazy import that is fine. Verified it fails when the static import is restored.

`satori` and `sharp` are still eager. Neither hangs, and making them lazy would move a missing-peer-dependency failure from boot to first OG request. Happy to do it as a follow-up if you want the cold start.

## 2. Runtime evidence — what exists today

Not just static. The ORM has a real-database suite that runs on every CI push:

- **21 model suites in the template, 14 of them database-backed**, on the real generated artifact for the template's 13-model schema — the same generator output path your 79 models take.
- **Two CI jobs**: `sqlite` runs the dialect-agnostic half; `postgres` brings up a `postgres:16` service container, repoints `schema.prisma`, `db push`es, regenerates, and runs the Postgres-labelled suites against it. 133 tests in the template suite are Postgres-gated and skip locally without `TEST_POSTGRES_URL`.
- **Three of those suites are differential**: they execute the same query through gemi and through a real generated Prisma client against the same Postgres and compare results, which is what pins the combinator-typed output to Prisma's actual semantics rather than to our reading of them.

What that does *not* cover is your auth port specifically — provisioning rollback, the three sign-up paths, a concurrent-provision race against the driver's unique violation. Those are app-shaped and I'd want your run. The generic paths underneath them (nested writes rolling back the parent row, `UniqueConstraintError` identification, savepoint semantics) are covered against real Postgres.

## 4, 5, 6 — docs

- **4.** `docs/authentication.md` now says the ORM comes *with* `UserProvider` rather than optionally alongside it: no adapter seam, every method resolves through the registry, so an app with zero other ORM adoption still generates, commits and registers the models before auth works at all — ~750 KB across three files on a 79-model schema. Stated where you plan the port, not where you hit it at runtime.
- **5.** `docs/orm.md` documents the unit-test seam for code crossing `Model.transaction`: `transaction: (cb) => cb()` in a module mock, or `vi.spyOn` on the model statics — and says explicitly that rollback, savepoints and the Postgres abort need a database and belong in an integration test.
- **6.** A migration section prompts the pool-size decision: `DatabaseConfig.url` defaults to `DATABASE_URL`, so registering your first gemi model opens a second pool against the same database with two defaults each picked as though it were the only one. Shows splitting the budget via `options: { max }` and lowering Prisma's `connection_limit` by the same amount.

Also fixed in passing: the Json filter examples still wrote `Prisma.AnyNull` while the surrounding examples had moved to the bare `gemi/orm` spelling.

## Verification

```
packages/gemi     110 files, 2540 passed, 1 skipped
template           20 files, 655 passed, 133 skipped (Postgres-gated)
tsc --noEmit      clean (packages/gemi)
test:types        61 passed, no type errors
oxlint            clean on changed files (1 pre-existing warning)
```

Postgres jobs run in CI. The `exit.test.ts` regression check was confirmed to fail with the static import restored and pass with it lazy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e9XQt5uXmT2B2KFN5dnBz
