### PR TITLE
Check the files, and let the generator say which classes it wrote

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,19 @@ jobs:
         run: bun run typecheck
         working-directory: packages/gemi
 
+      # The generator's *output*, compiled against the runtime it is generated
+      # for. The step above covers `bin/orm` — the code that writes the artifact
+      # — and not the artifact, and the two can disagree: #319 shipped a
+      # `static $generated = true` that widened to `boolean` against a base
+      # declaring `?: true`, so every emitted class was a TS2417 and every check
+      # here was green. It was found by an app regenerating a 79-model schema.
+      #
+      # After `prisma generate` above, so it reads the artifact this run
+      # produced rather than the one that happens to be committed.
+      - name: Typecheck the generated artifact
+        run: bunx tsc --noEmit -p tsconfig.generated.json
+        working-directory: packages/gemi
+
       # Everything except a named red set, rather than a path filter.
       #
       # This step used to run `vitest run orm database`, chosen so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,27 @@ jobs:
         env:
           TZ: UTC
 
+      # `gemi check models`, against the one real project in this repository.
+      #
+      # The command's unit tests hand it module objects; nothing in them
+      # exercises the parts that only exist outside a test — resolving the app's
+      # `gemi/orm` rather than the copy bundled into `dist/bin/gemi.js`, reading
+      # `Kernel.models` off a constructed Kernel, and importing thirteen real
+      # model files. Each of those is a way for the command to be wrong while
+      # every unit test passes, and the failure it would hide is a check that
+      # reports nothing because it is looking at an empty registry.
+      #
+      # `--ignore bench` because `app/models/bench/` is a benchmark harness that
+      # runs on import — which the command found by running it, and rewriting its
+      # report, the first time it was pointed at this directory. That is the
+      # hazard the flag exists for, so exercising the flag here is not
+      # incidental.
+      - name: Check the template's model registrations
+        run: bunx gemi check models --ignore bench
+        working-directory: templates/saas-starter
+        env:
+          TZ: UTC
+
       # `.test-d.ts` files do not match vitest's default `include`, so the step
       # above collects none of them: 15 type assertions in `wrap.test-d.ts` and
       # `aggregate.test-d.ts` ran nowhere, locally or here. They are the only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,13 +163,16 @@ jobs:
 
       # `gemi check models`, against the one real project in this repository.
       #
-      # The command's unit tests hand it module objects; nothing in them
-      # exercises the parts that only exist outside a test — resolving the app's
-      # `gemi/orm` rather than the copy bundled into `dist/bin/gemi.js`, reading
-      # `Kernel.models` off a constructed Kernel, and importing thirteen real
-      # model files. Each of those is a way for the command to be wrong while
-      # every unit test passes, and the failure it would hide is a check that
-      # reports nothing because it is looking at an empty registry.
+      # `check-models.test.ts` covers the command over a fixture project, so
+      # what is left for this step is the one thing a fixture cannot do:
+      # resolve the app's *installed* `gemi/orm` — the same instance the model
+      # files register into — rather than the copy bundled into
+      # `dist/bin/gemi.js`. Get that wrong and the command reads an empty
+      # registry, finds nothing to report, and exits 0.
+      #
+      # Which is why the count is asserted rather than the exit code. A green
+      # run and a run that checked nothing print the same *shape* of line, and
+      # differ only in the number in it.
       #
       # `--ignore bench` because `app/models/bench/` is a benchmark harness that
       # runs on import — which the command found by running it, and rewriting its
@@ -177,7 +180,10 @@ jobs:
       # hazard the flag exists for, so exercising the flag here is not
       # incidental.
       - name: Check the template's model registrations
-        run: bunx gemi check models --ignore bench
+        run: |
+          output=$(bunx gemi check models --ignore bench)
+          echo "$output"
+          echo "$output" | grep -qE 'against [1-9][0-9]* registered models'
         working-directory: templates/saas-starter
         env:
           TZ: UTC

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -49,6 +49,38 @@ than never.
 See [docs/orm.md](./docs/orm.md#your-model-class) for the full rules, including
 what happens with a typed view that carries its own policies.
 
+### And then run the check once
+
+`Kernel.models` can only audit the modules it is handed, so the mistake it
+removes has a smaller version one level up: a policied class in a file the
+barrel does not re-export. Nothing raises for that either.
+
+```sh
+bunx gemi check models
+```
+
+It walks `app/models`, imports every file, and reports any policied class the
+declared modules do not register — with the `export` line that fixes it. Exit
+code `1` on a finding, so it is worth a step in CI. It imports what it walks,
+which matters if a file under `app/models` does work on import; `--ignore` takes
+a comma-separated list, and the command prints what it skipped.
+
+## Regenerate, so registration stops guessing
+
+Nothing breaks if you skip this, and it is one command:
+
+```sh
+bunx prisma generate
+```
+
+The generator now marks each base it emits with `static $generated = true`, and
+`Kernel.models` reads that mark to decide which of several classes claiming one
+name is the generated one and which is yours. Artifacts generated before 0.51
+carry no mark, so registration falls back to the older signal — whether a class
+declares `$schema` itself — which a subclass that redeclares `static $schema`
+defeats, handing the name to the base. That case fails loudly rather than
+silently: boot refuses it and names both classes. Regenerating removes it.
+
 ## `@prisma/client` is gone
 
 0.51 removed the type-only `@prisma/client` import from the generated model

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,11 +94,11 @@ This command walks `app/models`, imports every file, and asks the same question 
 ```
 
 - `--dir <path>` — walk somewhere other than `app/models`.
-- `--ignore <paths>` — comma-separated paths under `--dir` to skip. What was skipped is printed.
+- `--ignore <paths>` — paths under `--dir` to skip. Comma-separated, and repeatable. What was skipped is printed.
 
 > **Gotcha:** finding a class means evaluating the module that declares it, so every file walked is imported and a file that *does* something on import does it here. Tests, type tests, benchmarks, `.d.ts` files and directories with their own `package.json` are skipped already; `--ignore` is for the rest.
 
-A typed view carrying its own policies is deliberately *not* reported — that class is supposed to be absent from the declared modules. See [ORM → Your model class](./orm.md#your-model-class).
+It reports one thing: a class carrying policies the registered class does not. A typed view carrying its own narrowing, and an unpolicied class written against a model's schema, are both deliberately *not* reported — each is supposed to be absent from the declared modules, and exporting either would turn a working boot into `AmbiguousModelRegistrationError`. See [ORM → Your model class](./orm.md#your-model-class).
 
 ## `gemi ide:generate-api-manifest`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,6 +95,15 @@ This command walks `app/models`, imports every file, and asks the same question 
 
 - `--dir <path>` — walk somewhere other than `app/models`.
 - `--ignore <paths>` — paths under `--dir` to skip. Comma-separated, and repeatable. What was skipped is printed.
+- `--models <paths>` — register from these modules instead of reading `Kernel.models`. Comma-separated, and repeatable.
+
+> **When you need `--models`:** the command reads the module list off your Kernel, which means importing it — and a Kernel's import graph does not have to survive a bare runtime import. `?raw` imports, virtual modules and asset imports are all ordinary in a gemi app, and a bundler resolves them where `await import()` does not. If loading the Kernel fails, the command says which file and exits `1` rather than passing green; naming the modules yourself is the way through:
+>
+> ```bash
+> gemi check models --models app/models/generated,app/models
+> ```
+>
+> This is not the tool guessing your model layout from a filename convention — that would let the check pass on an app whose Kernel declares nothing, which is the very state it exists to find. It's you stating the list, the same act as writing `models = [...]`, and the report prints how many models it registered so a wrong list is visible.
 
 > **Gotcha:** finding a class means evaluating the module that declares it, so every file walked is imported and a file that *does* something on import does it here. Tests, type tests, benchmarks, `.d.ts` files and directories with their own `package.json` are skipped already; `--ignore` is for the rest.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ bun run build
 bun run start
 ```
 
-> **Note:** Apart from `gemi migrate --dry-run`, the commands take no flags or options — each is a bare subcommand. gemi discovers your project from the current working directory (it expects `app/` and, for tooling commands, `app/kernel/Kernel.ts`).
+> **Note:** Apart from `gemi migrate --dry-run` and `gemi check models`, the commands take no flags or options — each is a bare subcommand. gemi discovers your project from the current working directory (it expects `app/` and, for tooling commands, `app/kernel/Kernel.ts`).
 
 ## `gemi dev`
 
@@ -75,6 +75,30 @@ Anything it cannot translate is left on disk and reported rather than guessed at
 It also annotates APIs retired after 0.43 rather than rewriting them, which is the half that applies to an app already on the config + container layout. Imports of the retired authentication adapters (`IAuthenticationAdapter`, `PrismaAuthenticationAdapter`, `OrmAuthenticationAdapter`) and the `userProvider` field in `app/config/auth.ts` get a TODO naming their replacement — subclass `UserProvider` and rebind `AuthManager` — because the substitute is an app-specific class no codemod can write. Retired fields are marked in place, never deleted: the value is an expression your app wrote, and removing it can strand an import or an instantiation you still need. See [Authentication](./authentication.md#changing-a-query).
 
 > The provider-to-config half only runs when `app/kernel/providers/` exists. Without it that step is skipped and your `Kernel.ts` is left alone — so re-running the command on an already-migrated app is safe, and the retired-API pass above is all it does.
+
+## `gemi check models`
+
+Reports model classes carrying policies that the modules your Kernel declares do not register.
+
+```bash
+gemi check models
+gemi check models --dir app/models --ignore bench,vendor
+```
+
+`Kernel.models` registers every model class in the modules it is handed and refuses a set where a policied class would lose its name. It can only see the modules it is given, so the mistake moves one level up: a policied `Membership` in `app/models/Membership.ts` that `app/models/index.ts` forgets to re-export leaves the generated base owning the name, and every nested `include` of that model comes back unscoped with nothing raised.
+
+This command walks `app/models`, imports every file, and asks the same question of the classes the directory holds. Findings are printed under their file with the export that fixes them, and the command exits `1` — so it belongs in CI:
+
+```yaml
+- run: bunx gemi check models
+```
+
+- `--dir <path>` — walk somewhere other than `app/models`.
+- `--ignore <paths>` — comma-separated paths under `--dir` to skip. What was skipped is printed.
+
+> **Gotcha:** finding a class means evaluating the module that declares it, so every file walked is imported and a file that *does* something on import does it here. Tests, type tests, benchmarks, `.d.ts` files and directories with their own `package.json` are skipped already; `--ignore` is for the rest.
+
+A typed view carrying its own policies is deliberately *not* reported — that class is supposed to be absent from the declared modules. See [ORM → Your model class](./orm.md#your-model-class).
 
 ## `gemi ide:generate-api-manifest`
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -984,11 +984,11 @@ This command walks `app/models`, imports every file, and asks the same question 
 ```
 
 - `--dir <path>` — walk somewhere other than `app/models`.
-- `--ignore <paths>` — comma-separated paths under `--dir` to skip. What was skipped is printed.
+- `--ignore <paths>` — paths under `--dir` to skip. Comma-separated, and repeatable. What was skipped is printed.
 
 > **Gotcha:** finding a class means evaluating the module that declares it, so every file walked is imported and a file that *does* something on import does it here. Tests, type tests, benchmarks, `.d.ts` files and directories with their own `package.json` are skipped already; `--ignore` is for the rest.
 
-A typed view carrying its own policies is deliberately *not* reported — that class is supposed to be absent from the declared modules. See [ORM → Your model class](./orm.md#your-model-class).
+It reports one thing: a class carrying policies the registered class does not. A typed view carrying its own narrowing, and an unpolicied class written against a model's schema, are both deliberately *not* reported — each is supposed to be absent from the declared modules, and exporting either would turn a working boot into `AmbiguousModelRegistrationError`. See [ORM → Your model class](./orm.md#your-model-class).
 
 ## `gemi ide:generate-api-manifest`
 
@@ -3022,8 +3022,8 @@ so it belongs in CI:
 Three things worth knowing before you wire it up.
 
 **It imports your model files.** There is no way to find a class without evaluating the module that
-declares it. A file that *does* something when imported does it here — `--ignore <paths>` skips a
-comma-separated list under `app/models`, and the command prints what it skipped. Tests, type tests,
+declares it. A file that *does* something when imported does it here — `--ignore <paths>` skips
+paths under `app/models`, comma-separated and repeatable, and the command prints what it skipped. Tests, type tests,
 benchmarks, `.d.ts` files and any directory with its own `package.json` are skipped already.
 
 **It does not credit a `register` call your file made on the way in.** A class that owns its name
@@ -3031,9 +3031,12 @@ only because loading its module said so loses it the day nothing imports the mod
 failure being checked for. The registry is put back to what `Kernel.models` made it before each file
 is audited.
 
-**It does not report a typed view carrying its own policies.** That class is *supposed* to be absent
-from the declared modules — see above — and a checker that demanded you export it would be telling
-you to undo what the framework told you to do.
+**It reports one thing: a class carrying policies the registered class does not.** A typed view
+carrying its own narrowing is *supposed* to be absent from the declared modules — see above — and so
+is an unpolicied class written against a model's schema, which
+`AmbiguousModelRegistrationError` likewise tells you to keep out. A checker that demanded you export
+either would be telling you to undo what the framework told you to do, and would turn a working boot
+into that error.
 
 Run it against another directory with `--dir`, and prefer it over a boot-time scan: enumerating the
 filesystem at start-up would couple the framework to your bundler and make every production process

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -985,6 +985,15 @@ This command walks `app/models`, imports every file, and asks the same question 
 
 - `--dir <path>` — walk somewhere other than `app/models`.
 - `--ignore <paths>` — paths under `--dir` to skip. Comma-separated, and repeatable. What was skipped is printed.
+- `--models <paths>` — register from these modules instead of reading `Kernel.models`. Comma-separated, and repeatable.
+
+> **When you need `--models`:** the command reads the module list off your Kernel, which means importing it — and a Kernel's import graph does not have to survive a bare runtime import. `?raw` imports, virtual modules and asset imports are all ordinary in a gemi app, and a bundler resolves them where `await import()` does not. If loading the Kernel fails, the command says which file and exits `1` rather than passing green; naming the modules yourself is the way through:
+>
+> ```bash
+> gemi check models --models app/models/generated,app/models
+> ```
+>
+> This is not the tool guessing your model layout from a filename convention — that would let the check pass on an app whose Kernel declares nothing, which is the very state it exists to find. It's you stating the list, the same act as writing `models = [...]`, and the report prints how many models it registered so a wrong list is visible.
 
 > **Gotcha:** finding a class means evaluating the module that declares it, so every file walked is imported and a file that *does* something on import does it here. Tests, type tests, benchmarks, `.d.ts` files and directories with their own `package.json` are skipped already; `--ignore` is for the rest.
 
@@ -3038,9 +3047,17 @@ is an unpolicied class written against a model's schema, which
 either would be telling you to undo what the framework told you to do, and would turn a working boot
 into that error.
 
-Run it against another directory with `--dir`, and prefer it over a boot-time scan: enumerating the
-filesystem at start-up would couple the framework to your bundler and make every production process
-pay, on every start, for a mistake that can only be made while editing.
+Run it against another directory with `--dir`. And if it cannot load your Kernel — the module list
+lives there, so it has to import it, and a Kernel's import graph does not have to survive a bare
+runtime import (`?raw` imports, virtual modules, asset imports) — name the modules yourself instead:
+
+```bash
+gemi check models --models app/models/generated,app/models
+```
+
+Prefer all of this over a boot-time scan: enumerating the filesystem at start-up would couple the
+framework to your bundler and make every production process pay, on every start, for a mistake that
+can only be made while editing.
 
 `assertPoliciesRegistered` is the same audit without the registration, for running over modules the
 Kernel does not own — a test over a package's models, a script that boots nothing:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -896,13 +896,13 @@ Run a command directly with Bun:
 
 ```bash
 bun run gemi <command>
-## or, since the templates wire them into scripts:
+# or, since the templates wire them into scripts:
 bun dev
 bun run build
 bun run start
 ```
 
-> **Note:** Apart from `gemi migrate --dry-run`, the commands take no flags or options — each is a bare subcommand. gemi discovers your project from the current working directory (it expects `app/` and, for tooling commands, `app/kernel/Kernel.ts`).
+> **Note:** Apart from `gemi migrate --dry-run` and `gemi check models`, the commands take no flags or options — each is a bare subcommand. gemi discovers your project from the current working directory (it expects `app/` and, for tooling commands, `app/kernel/Kernel.ts`).
 
 ## `gemi dev`
 
@@ -966,6 +966,30 @@ It also annotates APIs retired after 0.43 rather than rewriting them, which is t
 
 > The provider-to-config half only runs when `app/kernel/providers/` exists. Without it that step is skipped and your `Kernel.ts` is left alone — so re-running the command on an already-migrated app is safe, and the retired-API pass above is all it does.
 
+## `gemi check models`
+
+Reports model classes carrying policies that the modules your Kernel declares do not register.
+
+```bash
+gemi check models
+gemi check models --dir app/models --ignore bench,vendor
+```
+
+`Kernel.models` registers every model class in the modules it is handed and refuses a set where a policied class would lose its name. It can only see the modules it is given, so the mistake moves one level up: a policied `Membership` in `app/models/Membership.ts` that `app/models/index.ts` forgets to re-export leaves the generated base owning the name, and every nested `include` of that model comes back unscoped with nothing raised.
+
+This command walks `app/models`, imports every file, and asks the same question of the classes the directory holds. Findings are printed under their file with the export that fixes them, and the command exits `1` — so it belongs in CI:
+
+```yaml
+- run: bunx gemi check models
+```
+
+- `--dir <path>` — walk somewhere other than `app/models`.
+- `--ignore <paths>` — comma-separated paths under `--dir` to skip. What was skipped is printed.
+
+> **Gotcha:** finding a class means evaluating the module that declares it, so every file walked is imported and a file that *does* something on import does it here. Tests, type tests, benchmarks, `.d.ts` files and directories with their own `package.json` are skipped already; `--ignore` is for the rest.
+
+A typed view carrying its own policies is deliberately *not* reported — that class is supposed to be absent from the declared modules. See [ORM → Your model class](./orm.md#your-model-class).
+
 ## `gemi ide:generate-api-manifest`
 
 Generates the API route manifest used for editor integration (jump-to-definition from a route path to its controller method).
@@ -1001,8 +1025,6 @@ Like `app:component-tree`, it loads the app from the kernel and prints the resol
 - [Getting Started](./getting-started.md) — installing gemi and running your first commands.
 - [Configuration](./configuration.md) — `.env`, `preload.ts`, and `gemi.config.ts` that these commands consume.
 - [Project Structure & the Kernel](./project-structure.md) — `server.ts`, the kernel, and how the app boots.
-
-
 ---
 
 ## Routing
@@ -2981,8 +3003,44 @@ Modules you hand it. A policied class in a file that no barrel re-exports is inv
 Kernel exactly as it was to a forgotten `register` line — which is the reason for the barrel: one
 file to add a model to, and a missing line in it is a thing you can notice.
 
+`gemi check models` is what notices it for you:
+
+```
+$ gemi check models
+Checked 10 model files against 13 registered models. Every policied class owns its name.
+```
+
+It walks `app/models`, imports every file, and asks the same question `Kernel.models` asks — of the
+classes the directory holds rather than of the modules the Kernel was handed. A policied class no
+declared module registers is reported with the export that would fix it, and the command exits `1`,
+so it belongs in CI:
+
+```yaml
+- run: bunx gemi check models
+```
+
+Three things worth knowing before you wire it up.
+
+**It imports your model files.** There is no way to find a class without evaluating the module that
+declares it. A file that *does* something when imported does it here — `--ignore <paths>` skips a
+comma-separated list under `app/models`, and the command prints what it skipped. Tests, type tests,
+benchmarks, `.d.ts` files and any directory with its own `package.json` are skipped already.
+
+**It does not credit a `register` call your file made on the way in.** A class that owns its name
+only because loading its module said so loses it the day nothing imports the module, which is the
+failure being checked for. The registry is put back to what `Kernel.models` made it before each file
+is audited.
+
+**It does not report a typed view carrying its own policies.** That class is *supposed* to be absent
+from the declared modules — see above — and a checker that demanded you export it would be telling
+you to undo what the framework told you to do.
+
+Run it against another directory with `--dir`, and prefer it over a boot-time scan: enumerating the
+filesystem at start-up would couple the framework to your bundler and make every production process
+pay, on every start, for a mistake that can only be made while editing.
+
 `assertPoliciesRegistered` is the same audit without the registration, for running over modules the
-Kernel does not own:
+Kernel does not own — a test over a package's models, a script that boots nothing:
 
 ```ts
 import { assertPoliciesRegistered } from "gemi/orm"
@@ -2992,7 +3050,8 @@ import * as models from "@/app/models"
 assertPoliciesRegistered(generated, models)
 ```
 
-In a test it closes the hole for CI at no runtime cost.
+`auditModelRegistrations` is the same rule again, returning the errors instead of throwing the first
+— which is what `gemi check models` uses to sort a leak from a view.
 
 ## Querying
 
@@ -3892,7 +3951,8 @@ Two limits, both deliberate:
 
 - **`asSystem` suspends all of it**, for the whole async subtree, not just the model you named.
 - **A policy only applies if its class is the registered one.** See [Setup](#your-model-class) —
-  this is the gap the guarantee genuinely has, and `assertPoliciesRegistered` is the backstop.
+  this is the gap the guarantee genuinely has. `Kernel.models` closes it for the modules you
+  declare, and `gemi check models` closes it for the files you forgot to declare.
 
 ### `ctx.user` denies by default
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -248,8 +248,44 @@ Modules you hand it. A policied class in a file that no barrel re-exports is inv
 Kernel exactly as it was to a forgotten `register` line — which is the reason for the barrel: one
 file to add a model to, and a missing line in it is a thing you can notice.
 
+`gemi check models` is what notices it for you:
+
+```
+$ gemi check models
+Checked 10 model files against 13 registered models. Every policied class owns its name.
+```
+
+It walks `app/models`, imports every file, and asks the same question `Kernel.models` asks — of the
+classes the directory holds rather than of the modules the Kernel was handed. A policied class no
+declared module registers is reported with the export that would fix it, and the command exits `1`,
+so it belongs in CI:
+
+```yaml
+- run: bunx gemi check models
+```
+
+Three things worth knowing before you wire it up.
+
+**It imports your model files.** There is no way to find a class without evaluating the module that
+declares it. A file that *does* something when imported does it here — `--ignore <paths>` skips a
+comma-separated list under `app/models`, and the command prints what it skipped. Tests, type tests,
+benchmarks, `.d.ts` files and any directory with its own `package.json` are skipped already.
+
+**It does not credit a `register` call your file made on the way in.** A class that owns its name
+only because loading its module said so loses it the day nothing imports the module, which is the
+failure being checked for. The registry is put back to what `Kernel.models` made it before each file
+is audited.
+
+**It does not report a typed view carrying its own policies.** That class is *supposed* to be absent
+from the declared modules — see above — and a checker that demanded you export it would be telling
+you to undo what the framework told you to do.
+
+Run it against another directory with `--dir`, and prefer it over a boot-time scan: enumerating the
+filesystem at start-up would couple the framework to your bundler and make every production process
+pay, on every start, for a mistake that can only be made while editing.
+
 `assertPoliciesRegistered` is the same audit without the registration, for running over modules the
-Kernel does not own:
+Kernel does not own — a test over a package's models, a script that boots nothing:
 
 ```ts
 import { assertPoliciesRegistered } from "gemi/orm"
@@ -259,7 +295,8 @@ import * as models from "@/app/models"
 assertPoliciesRegistered(generated, models)
 ```
 
-In a test it closes the hole for CI at no runtime cost.
+`auditModelRegistrations` is the same rule again, returning the errors instead of throwing the first
+— which is what `gemi check models` uses to sort a leak from a view.
 
 ## Querying
 
@@ -1159,7 +1196,8 @@ Two limits, both deliberate:
 
 - **`asSystem` suspends all of it**, for the whole async subtree, not just the model you named.
 - **A policy only applies if its class is the registered one.** See [Setup](#your-model-class) —
-  this is the gap the guarantee genuinely has, and `assertPoliciesRegistered` is the backstop.
+  this is the gap the guarantee genuinely has. `Kernel.models` closes it for the modules you
+  declare, and `gemi check models` closes it for the files you forgot to declare.
 
 ### `ctx.user` denies by default
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -267,8 +267,8 @@ so it belongs in CI:
 Three things worth knowing before you wire it up.
 
 **It imports your model files.** There is no way to find a class without evaluating the module that
-declares it. A file that *does* something when imported does it here — `--ignore <paths>` skips a
-comma-separated list under `app/models`, and the command prints what it skipped. Tests, type tests,
+declares it. A file that *does* something when imported does it here — `--ignore <paths>` skips
+paths under `app/models`, comma-separated and repeatable, and the command prints what it skipped. Tests, type tests,
 benchmarks, `.d.ts` files and any directory with its own `package.json` are skipped already.
 
 **It does not credit a `register` call your file made on the way in.** A class that owns its name
@@ -276,9 +276,12 @@ only because loading its module said so loses it the day nothing imports the mod
 failure being checked for. The registry is put back to what `Kernel.models` made it before each file
 is audited.
 
-**It does not report a typed view carrying its own policies.** That class is *supposed* to be absent
-from the declared modules — see above — and a checker that demanded you export it would be telling
-you to undo what the framework told you to do.
+**It reports one thing: a class carrying policies the registered class does not.** A typed view
+carrying its own narrowing is *supposed* to be absent from the declared modules — see above — and so
+is an unpolicied class written against a model's schema, which
+`AmbiguousModelRegistrationError` likewise tells you to keep out. A checker that demanded you export
+either would be telling you to undo what the framework told you to do, and would turn a working boot
+into that error.
 
 Run it against another directory with `--dir`, and prefer it over a boot-time scan: enumerating the
 filesystem at start-up would couple the framework to your bundler and make every production process

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -283,9 +283,17 @@ is an unpolicied class written against a model's schema, which
 either would be telling you to undo what the framework told you to do, and would turn a working boot
 into that error.
 
-Run it against another directory with `--dir`, and prefer it over a boot-time scan: enumerating the
-filesystem at start-up would couple the framework to your bundler and make every production process
-pay, on every start, for a mistake that can only be made while editing.
+Run it against another directory with `--dir`. And if it cannot load your Kernel — the module list
+lives there, so it has to import it, and a Kernel's import graph does not have to survive a bare
+runtime import (`?raw` imports, virtual modules, asset imports) — name the modules yourself instead:
+
+```bash
+gemi check models --models app/models/generated,app/models
+```
+
+Prefer all of this over a boot-time scan: enumerating the filesystem at start-up would couple the
+framework to your bundler and make every production process pay, on every start, for a mistake that
+can only be made while editing.
 
 `assertPoliciesRegistered` is the same audit without the registration, for running over modules the
 Kernel does not own — a test over a package's models, a script that boots nothing:

--- a/packages/gemi/bin/check-models.test.ts
+++ b/packages/gemi/bin/check-models.test.ts
@@ -7,7 +7,9 @@ import * as orm from "../orm/index";
 import { user } from "../orm/fixtures";
 import type { ModelPolicy } from "../orm/policy";
 import {
+  CheckModelsError,
   auditModules,
+  checkModels,
   modelFiles,
   printReport,
   snapshotRegistry,
@@ -38,8 +40,8 @@ class UserBase {
 
 /** A module record, as `import * as ns` produces one. */
 const module = (exports: Record<string, unknown>) => ({
-  path: "/app/models/x.ts",
   label: "app/models/x.ts",
+  specifier: "./x",
   module: exports,
 });
 
@@ -233,6 +235,36 @@ describe("what counts as a finding", () => {
     expect(auditModules(orm, [module({ Typed })], snapshotRegistry(orm))).toEqual([]);
   });
 
+  /**
+   * **The other answer that must not be reported**, and the one that is easy to
+   * miss because it does not look like a subclass at all.
+   *
+   * `asModelClass` asks for a `$schema` with a name and nothing more, so a class
+   * written against a model's schema without extending its base — a reporting
+   * projection, a read-side view — is a candidate for that name while sitting
+   * outside its prototype chain. Unpolicied, it comes back as
+   * `carries: "registered"`.
+   *
+   * Reporting it would contradict the rule above *and* print the wrong fix:
+   * exporting it from the barrel puts two unrelated classes claiming one model
+   * in the modules the Kernel is handed, which is `AmbiguousModelRegistrationError`
+   * and a boot that stops. Keeping it out is what that error asks for.
+   */
+  test("an unpolicied class claiming a policied model's name is not a finding", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class UserSnapshot {
+      static $schema = user;
+    }
+
+    orm.registerModels({ UserBase }, { User });
+
+    expect(
+      auditModules(orm, [module({ UserSnapshot })], snapshotRegistry(orm)),
+    ).toEqual([]);
+  });
+
   test("non-model exports are ignored", () => {
     orm.registerModels({ UserBase });
 
@@ -254,8 +286,16 @@ describe("what counts as a finding", () => {
     orm.registerModels({ UserBase });
 
     const findings = auditModules(orm, [
-      { path: "/a.ts", label: "app/models/Membership.ts", module: { Membership } },
-      { path: "/b.ts", label: "app/models/Invoice.ts", module: { Invoice } },
+      {
+        label: "app/models/Membership.ts",
+        specifier: "./Membership",
+        module: { Membership },
+      },
+      {
+        label: "app/models/Invoice.ts",
+        specifier: "./Invoice",
+        module: { Invoice },
+      },
     ], snapshotRegistry(orm));
 
     expect(findings.map((finding) => finding.file)).toEqual([
@@ -312,6 +352,176 @@ describe("a register call that ran while the file was importing", () => {
   });
 });
 
+/**
+ * `checkModels` itself, over a project on disk.
+ *
+ * Everything above enters below the entry point, with module objects handed
+ * straight to the rule. That leaves the parts that only exist outside a test
+ * uncovered — loading the Kernel and reading `models` off it, walking and
+ * importing real files, and the ordering that decides which registry each file
+ * is judged against — and those are precisely where this command's failure mode
+ * lives. A regression in any of them prints *Every policied class owns its
+ * name*, exits 0, and CI stays green: a checker that reports nothing looks
+ * exactly like a project with nothing to report.
+ *
+ * So the assertion that matters is the red path, on the real function.
+ *
+ * The fixture imports nothing from `gemi` — a class needs a `$schema` with a
+ * name and a `$policies` array to be everything the audit reads, and the Kernel
+ * only has to be a default-exported constructor with a `models` field. That is
+ * what lets it live in a temp directory with no `node_modules` above it, and
+ * why `orm` is injected: resolving `gemi/orm` from the project is right for the
+ * command and impossible for a fixture.
+ */
+describe("the command, over a project on disk", () => {
+  const roots: string[] = [];
+
+  const write = (root: string, path: string, source: string) => {
+    mkdirSync(join(root, path, ".."), { recursive: true });
+    writeFileSync(join(root, path), source);
+  };
+
+  /**
+   * One generated base, one policied subclass the barrel exports, and one
+   * policied subclass in a subdirectory that it does not — which is #318's
+   * case A, in the layout that makes the printed fix worth getting right.
+   */
+  const project = (): string => {
+    const root = mkdtempSync(join(tmpdir(), "gemi-check-project-"));
+    roots.push(root);
+
+    write(
+      root,
+      "app/models/generated/index.ts",
+      `export class WidgetModel {
+         static $schema = { name: "Widget" };
+         static $generated = true;
+       }
+       export class GadgetModel {
+         static $schema = { name: "Gadget" };
+         static $generated = true;
+       }`,
+    );
+
+    write(
+      root,
+      "app/models/Widget.ts",
+      `import { WidgetModel } from "./generated";
+       export class Widget extends WidgetModel {
+         static $policies = [{ scope: () => ({ organizationId: 7 }) }];
+       }`,
+    );
+
+    // The one nobody exported.
+    write(
+      root,
+      "app/models/billing/Gadget.ts",
+      `import { GadgetModel } from "./../generated";
+       export class Gadget extends GadgetModel {
+         static $policies = [{ scope: () => ({ organizationId: 7 }) }];
+       }`,
+    );
+
+    write(root, "app/models/index.ts", `export { Widget } from "./Widget";`);
+
+    write(
+      root,
+      "app/kernel/Kernel.ts",
+      `import * as generated from "../models/generated";
+       import * as models from "../models";
+       export default class {
+         models = [generated, models];
+       }`,
+    );
+
+    return root;
+  };
+
+  afterAll(() => {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  });
+
+  test("reports the policied class the barrel forgot, and only that one", async () => {
+    const report = await checkModels({ rootDir: project(), orm });
+
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0]!.file).toBe("app/models/billing/Gadget.ts");
+    expect(report.findings[0]!.className).toBe("Gadget");
+    // Spelled for a barrel at `app/models/index.ts`, which is the only place it
+    // is any use.
+    expect(report.findings[0]!.specifier).toBe("./billing/Gadget");
+  });
+
+  /**
+   * And the green path, on the same project — because a checker that reports
+   * everything is as useless as one that reports nothing, and `Widget` is the
+   * class that is arranged correctly.
+   */
+  test("says nothing about the class the barrel does export", async () => {
+    const report = await checkModels({ rootDir: project(), orm });
+
+    expect(report.files).toContain("app/models/Widget.ts");
+    expect(report.findings.map((finding) => finding.className)).not.toContain(
+      "Widget",
+    );
+    // The registry it judged against is the declared one, not an empty one —
+    // the failure that would make every other assertion here vacuous.
+    expect(report.registered).toBe(2);
+  });
+
+  test("--ignore keeps a directory out, and the report says so", async () => {
+    const report = await checkModels({
+      rootDir: project(),
+      ignore: ["billing"],
+      orm,
+    });
+
+    expect(report.findings).toEqual([]);
+    expect(report.ignored).toEqual(["billing"]);
+    expect(report.files.join()).not.toContain("billing");
+  });
+
+  /**
+   * The state an app upgrading from 0.48 is in. There is no declared
+   * arrangement to compare files against, so the command says that rather than
+   * comparing them against an empty registry and reporting every model.
+   */
+  test("an empty Kernel.models is refused, with the fix", async () => {
+    const root = project();
+    write(root, "app/kernel/Kernel.ts", `export default class {};`);
+
+    await expect(checkModels({ rootDir: root, orm })).rejects.toThrow(
+      /Kernel\.models` is empty/,
+    );
+  });
+
+  test("a project with no Kernel is refused by name", async () => {
+    const root = mkdtempSync(join(tmpdir(), "gemi-check-empty-"));
+    roots.push(root);
+    mkdirSync(join(root, "app/models"), { recursive: true });
+
+    await expect(checkModels({ rootDir: root, orm })).rejects.toThrow(
+      CheckModelsError,
+    );
+  });
+
+  /**
+   * With no `orm` injected there is nothing to resolve from a temp directory,
+   * which is the one branch a fixture cannot exercise from the inside. Its
+   * failure side is worth pinning anyway: run outside a project, the command
+   * should say so rather than throw a resolver's stack.
+   */
+  test("outside a gemi project it says so", async () => {
+    const root = mkdtempSync(join(tmpdir(), "gemi-check-bare-"));
+    roots.push(root);
+    mkdirSync(join(root, "app/models"), { recursive: true });
+
+    await expect(checkModels({ rootDir: root })).rejects.toThrow(
+      /Could not resolve `gemi\/orm`/,
+    );
+  });
+});
+
 describe("the printed report", () => {
   const lines = (report: Parameters<typeof printReport>[0]) => {
     const out: string[] = [];
@@ -340,6 +550,7 @@ describe("the printed report", () => {
       findings: [
         {
           file: "app/models/Membership.ts",
+          specifier: "./Membership",
           className: "Membership",
           message: "Membership carries\npolicies",
         },
@@ -358,15 +569,22 @@ describe("the printed report", () => {
    * correct fix and the wrong one to lead with here: the class was found by
    * walking a directory, so what went missing is the export, and a hand-written
    * `register` line puts the app back on the mechanism 0.51 replaced.
+   *
+   * **Spelled from the models directory, not from the project root and not from
+   * the basename.** A model in a subdirectory is the case the walker is built
+   * for, and `./ScopedMembership` pasted into `app/models/index.ts` resolves to
+   * nothing — an author who follows the advice trades a silent leak for a
+   * module-not-found.
    */
-  test("names the export that was missing, spelled for the file it was in", () => {
+  test("names the export that was missing, spelled for a barrel to import", () => {
     const { text } = lines({
-      files: ["app/models/ScopedMembership.ts"],
+      files: ["app/models/billing/ScopedMembership.ts"],
       registered: 13,
       ignored: [],
       findings: [
         {
-          file: "app/models/ScopedMembership.ts",
+          file: "app/models/billing/ScopedMembership.ts",
+          specifier: "./billing/ScopedMembership",
           className: "Membership",
           message: "…",
         },
@@ -374,7 +592,7 @@ describe("the printed report", () => {
     });
 
     expect(text).toContain(
-      'export { Membership } from "./ScopedMembership"',
+      'export { Membership } from "./billing/ScopedMembership"',
     );
   });
 
@@ -396,7 +614,9 @@ describe("the printed report", () => {
         files: ["a.ts"],
         registered: 1,
         ignored: [],
-        findings: [{ file: "a.ts", className: "A", message: "x" }],
+        findings: [
+          { file: "a.ts", specifier: "./a", className: "A", message: "x" },
+        ],
       }).text,
     ).toContain("1 model class is not registered");
 
@@ -406,8 +626,8 @@ describe("the printed report", () => {
         registered: 1,
         ignored: [],
         findings: [
-          { file: "a.ts", className: "A", message: "x" },
-          { file: "b.ts", className: "B", message: "y" },
+          { file: "a.ts", specifier: "./a", className: "A", message: "x" },
+          { file: "b.ts", specifier: "./b", className: "B", message: "y" },
         ],
       }).text,
     ).toContain("2 model classes are not registered");

--- a/packages/gemi/bin/check-models.test.ts
+++ b/packages/gemi/bin/check-models.test.ts
@@ -495,6 +495,73 @@ describe("the command, over a project on disk", () => {
     );
   });
 
+  /**
+   * `--models`, and the reason it exists: reading the list off the Kernel means
+   * importing the Kernel, and a gemi app's import graph does not have to be
+   * resolvable by a bare `await import()`. The app that reported #316 and #318
+   * transitively reaches a `.md?raw` import from its Kernel, so the command
+   * could not run on the project it was written for.
+   *
+   * The fixture reproduces that shape with an import nothing can resolve.
+   */
+  test("names the model modules directly, for a Kernel that will not import", async () => {
+    const root = project();
+    write(
+      root,
+      "app/kernel/Kernel.ts",
+      `import doc from "./guide.md?raw";
+       import * as generated from "../models/generated";
+       import * as models from "../models";
+       export default class {
+         models = [generated, models];
+         doc = doc;
+       }`,
+    );
+
+    // The Kernel path fails, loudly, naming the file rather than passing green.
+    await expect(checkModels({ rootDir: root, orm })).rejects.toThrow(
+      /Could not load app\/kernel\/Kernel\.ts/,
+    );
+
+    // And the flag gets the same answer without going near it.
+    const report = await checkModels({
+      rootDir: root,
+      models: ["app/models/generated", "app/models"],
+      orm,
+    });
+
+    expect(report.registered).toBe(2);
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0]!.className).toBe("Gadget");
+  });
+
+  test("--models is checked in the order given, so a later module wins", async () => {
+    const report = await checkModels({
+      rootDir: project(),
+      models: ["app/models/generated", "app/models"],
+      orm,
+    });
+
+    // The barrel's subclass took the name from the base it extends, which is
+    // what "later wins" means and what makes `Widget` not a finding.
+    expect(
+      (orm.registry.get("Widget") as { name: string }).name,
+    ).toBe("Widget");
+    expect(report.findings.map((finding) => finding.className)).toEqual([
+      "Gadget",
+    ]);
+  });
+
+  test("a path --models names that cannot be imported says which", async () => {
+    await expect(
+      checkModels({
+        rootDir: project(),
+        models: ["app/models/nope"],
+        orm,
+      }),
+    ).rejects.toThrow(/--models named app\/models\/nope/);
+  });
+
   test("a project with no Kernel is refused by name", async () => {
     const root = mkdtempSync(join(tmpdir(), "gemi-check-empty-"));
     roots.push(root);

--- a/packages/gemi/bin/check-models.test.ts
+++ b/packages/gemi/bin/check-models.test.ts
@@ -1,0 +1,415 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, describe, expect, test } from "vitest";
+
+import * as orm from "../orm/index";
+import { user } from "../orm/fixtures";
+import type { ModelPolicy } from "../orm/policy";
+import {
+  auditModules,
+  modelFiles,
+  printReport,
+  snapshotRegistry,
+} from "./check-models";
+
+/**
+ * `gemi check models` — the file-walking half of #318.
+ *
+ * The rule it applies is `auditModelRegistrations`, tested against every shape
+ * in `orm/registration.test.ts`. What is this file's own is everything around
+ * it: which files are offered to the rule, which of its answers are findings,
+ * and whether a `register` call that ran while a file was being imported is
+ * allowed to answer for that file.
+ *
+ * The last one is the point of the whole command. A class that owns its name
+ * only because loading its module said so is a class whose registration
+ * disappears the day nothing imports the module — which is exactly the failure
+ * being checked for, so crediting it would make the check agree with the bug.
+ */
+
+const scope: ModelPolicy = { scope: () => ({ organizationId: 7 }) };
+const narrow: ModelPolicy = { scope: () => ({ archived: false }) };
+
+class UserBase {
+  static $schema = user;
+  static $generated = true;
+}
+
+/** A module record, as `import * as ns` produces one. */
+const module = (exports: Record<string, unknown>) => ({
+  path: "/app/models/x.ts",
+  label: "app/models/x.ts",
+  module: exports,
+});
+
+afterEach(() => {
+  orm.registry.clearRegistry();
+});
+
+describe("which files are offered to the rule", () => {
+  const roots: string[] = [];
+
+  const tree = (files: string[]): string => {
+    const root = mkdtempSync(join(tmpdir(), "gemi-check-models-"));
+    roots.push(root);
+    for (const file of files) {
+      const path = join(root, file);
+      mkdirSync(join(path, ".."), { recursive: true });
+      writeFileSync(path, "");
+    }
+    return root;
+  };
+
+  afterAll(() => {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  });
+
+  test("walks nested directories, because apps group models into folders", () => {
+    const root = tree(["index.ts", "billing/Invoice.ts", "billing/Plan.ts"]);
+
+    expect(modelFiles(root).map((path) => path.slice(root.length + 1))).toEqual([
+      "billing/Invoice.ts",
+      "billing/Plan.ts",
+      "index.ts",
+    ]);
+  });
+
+  /**
+   * Tests and benchmarks are the files certain not to be a model module and
+   * most likely to be expensive to import — the template's own `app/models` has
+   * thirty of them, several of which load a Prisma client.
+   */
+  test("skips tests, type tests and benchmarks", () => {
+    const root = tree([
+      "User.ts",
+      "User.test.ts",
+      "select.test-d.ts",
+      "reads.bench.ts",
+      "notes.spec.ts",
+    ]);
+
+    expect(modelFiles(root).map((path) => path.slice(root.length + 1))).toEqual([
+      "User.ts",
+    ]);
+  });
+
+  test("skips node_modules and dot-directories", () => {
+    const root = tree([
+      "User.ts",
+      "node_modules/pkg/index.ts",
+      ".cache/thing.ts",
+    ]);
+
+    expect(modelFiles(root).map((path) => path.slice(root.length + 1))).toEqual([
+      "User.ts",
+    ]);
+  });
+
+  /**
+   * `generated/` is walked like anything else. Its classes are registered by
+   * the declared modules, so they produce no findings — and skipping a
+   * directory by name would be one more guess about generator output, which is
+   * the habit #318's other half removes.
+   */
+  test("does not special-case the generated directory", () => {
+    const root = tree(["index.ts", "generated/models.ts"]);
+
+    expect(modelFiles(root).map((path) => path.slice(root.length + 1))).toEqual([
+      "generated/models.ts",
+      "index.ts",
+    ]);
+  });
+
+  test("ignores files that are not TypeScript", () => {
+    const root = tree(["User.ts", "schema.prisma", "notes.md", "dev.db"]);
+
+    expect(modelFiles(root).map((path) => path.slice(root.length + 1))).toEqual([
+      "User.ts",
+    ]);
+  });
+
+  /** `.d.ts` ends in `.ts` and has no runtime module behind it. */
+  test("skips declaration files", () => {
+    const root = tree(["User.ts", "client/index.d.ts"]);
+
+    expect(modelFiles(root).map((path) => path.slice(root.length + 1))).toEqual([
+      "User.ts",
+    ]);
+  });
+
+  /**
+   * A directory with a `package.json` is a package that happens to live here —
+   * a vendored client, a generated SDK — and importing its entry point runs
+   * somebody else's module graph. The template has two under `app/models`, both
+   * gitignored Prisma clients.
+   */
+  test("skips a vendored package", () => {
+    const root = tree([
+      "User.ts",
+      "prisma-client/package.json",
+      "prisma-client/index.ts",
+    ]);
+
+    expect(modelFiles(root).map((path) => path.slice(root.length + 1))).toEqual([
+      "User.ts",
+    ]);
+  });
+
+  test("--ignore skips a path and everything under it", () => {
+    const root = tree(["User.ts", "bench/run.ts", "bench/harness.ts"]);
+
+    expect(
+      modelFiles(root, ["bench"]).map((path) => path.slice(root.length + 1)),
+    ).toEqual(["User.ts"]);
+  });
+
+  test("--ignore can name a single file", () => {
+    const root = tree(["User.ts", "bench/run.ts", "bench/harness.ts"]);
+
+    expect(
+      modelFiles(root, ["bench/run.ts"]).map((path) =>
+        path.slice(root.length + 1),
+      ),
+    ).toEqual(["User.ts", "bench/harness.ts"].sort());
+  });
+});
+
+describe("what counts as a finding", () => {
+  /**
+   * #318's case A, in full: the class is written, the policy is written, and
+   * the barrel does not re-export it — so the Kernel registers the generated
+   * base and every nested read of the model comes back unscoped.
+   */
+  test("a policied class the declared modules never saw", () => {
+    class Membership extends UserBase {
+      static $policies = [scope];
+    }
+
+    orm.registerModels({ UserBase });
+
+    const findings = auditModules(orm, [module({ Membership })], snapshotRegistry(orm));
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.file).toBe("app/models/x.ts");
+    expect(findings[0]!.message).toContain("Membership");
+  });
+
+  test("a class the declared modules do register is not a finding", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+
+    orm.registerModels({ UserBase }, { User });
+
+    expect(auditModules(orm, [module({ User })], snapshotRegistry(orm))).toEqual([]);
+  });
+
+  /**
+   * **The view that must not be reported.** `registerModels` refuses a policied
+   * view *because* registering it would apply its narrowing to every nested
+   * read, and the error tells the author to keep it out of `Kernel.models` and
+   * query it directly. Being absent from the declared modules is what following
+   * that advice looks like.
+   */
+  test("a policied view kept out of the declared modules is not a finding", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+    class AdminUser extends User {
+      static $policies = [narrow];
+    }
+
+    orm.registerModels({ UserBase }, { User });
+
+    expect(auditModules(orm, [module({ AdminUser })], snapshotRegistry(orm))).toEqual([]);
+  });
+
+  test("an unpolicied class the barrel does not export is not a finding", () => {
+    class Typed extends UserBase {}
+
+    orm.registerModels({ UserBase });
+
+    expect(auditModules(orm, [module({ Typed })], snapshotRegistry(orm))).toEqual([]);
+  });
+
+  test("non-model exports are ignored", () => {
+    orm.registerModels({ UserBase });
+
+    expect(
+      auditModules(orm, [
+        module({ PAGE_SIZE: 20, helper: () => null, nothing: undefined }),
+      ], snapshotRegistry(orm)),
+    ).toEqual([]);
+  });
+
+  test("every file is reported, not just the first", () => {
+    class Membership extends UserBase {
+      static $policies = [scope];
+    }
+    class Invoice extends UserBase {
+      static $policies = [narrow];
+    }
+
+    orm.registerModels({ UserBase });
+
+    const findings = auditModules(orm, [
+      { path: "/a.ts", label: "app/models/Membership.ts", module: { Membership } },
+      { path: "/b.ts", label: "app/models/Invoice.ts", module: { Invoice } },
+    ], snapshotRegistry(orm));
+
+    expect(findings.map((finding) => finding.file)).toEqual([
+      "app/models/Membership.ts",
+      "app/models/Invoice.ts",
+    ]);
+  });
+});
+
+/**
+ * The reason the check restores the registry between files.
+ *
+ * Importing a module runs it, and a model file written the pre-0.51 way ends in
+ * `register("User", User)`. That call makes the class own its name for the rest
+ * of the process — including for the audit that is about to ask whether it owns
+ * its name. The answer would be yes, for every file, and the check would report
+ * nothing on an app where nothing imports any of them.
+ */
+describe("a register call that ran while the file was importing", () => {
+  test("does not answer for the file that made it", () => {
+    class Membership extends UserBase {
+      static $policies = [scope];
+    }
+
+    orm.registerModels({ UserBase });
+
+    // The command's own ordering: the baseline is taken while the registry is
+    // still what the declared modules made it, and every file is imported
+    // after.
+    const baseline = snapshotRegistry(orm);
+
+    // What `await import("./Membership")` does, on a model file written the
+    // pre-0.51 way.
+    orm.register("User", Membership);
+
+    expect(
+      auditModules(orm, [module({ Membership })], baseline),
+    ).toHaveLength(1);
+  });
+
+  /** And the registry is left as the declared modules made it. */
+  test("and is undone before the command returns", () => {
+    class Membership extends UserBase {
+      static $policies = [scope];
+    }
+
+    orm.registerModels({ UserBase });
+    const baseline = snapshotRegistry(orm);
+    orm.register("User", Membership);
+
+    auditModules(orm, [module({ Membership })], baseline);
+
+    expect(orm.registry.get("User")).toBe(UserBase);
+  });
+});
+
+describe("the printed report", () => {
+  const lines = (report: Parameters<typeof printReport>[0]) => {
+    const out: string[] = [];
+    const code = printReport(report, (line: string) => out.push(line));
+    return { code, text: out.join("\n") };
+  };
+
+  test("a clean run says what it covered and exits zero", () => {
+    const { code, text } = lines({
+      files: ["app/models/index.ts", "app/models/User.ts"],
+      registered: 13,
+      ignored: [],
+      findings: [],
+    });
+
+    expect(code).toBe(0);
+    expect(text).toContain("2 model files");
+    expect(text).toContain("13 registered models");
+  });
+
+  test("a finding is printed under its file and exits non-zero", () => {
+    const { code, text } = lines({
+      files: ["app/models/Membership.ts"],
+      registered: 13,
+      ignored: [],
+      findings: [
+        {
+          file: "app/models/Membership.ts",
+          className: "Membership",
+          message: "Membership carries\npolicies",
+        },
+      ],
+    });
+
+    expect(code).toBe(1);
+    expect(text).toContain("app/models/Membership.ts");
+    // Indented under the filename, and the indent survives a multi-line message.
+    expect(text).toContain("    Membership carries\n    policies");
+    expect(text).toContain("Kernel.models");
+  });
+
+  /**
+   * The error's own advice is `register("Membership", Membership)`, which is a
+   * correct fix and the wrong one to lead with here: the class was found by
+   * walking a directory, so what went missing is the export, and a hand-written
+   * `register` line puts the app back on the mechanism 0.51 replaced.
+   */
+  test("names the export that was missing, spelled for the file it was in", () => {
+    const { text } = lines({
+      files: ["app/models/ScopedMembership.ts"],
+      registered: 13,
+      ignored: [],
+      findings: [
+        {
+          file: "app/models/ScopedMembership.ts",
+          className: "Membership",
+          message: "…",
+        },
+      ],
+    });
+
+    expect(text).toContain(
+      'export { Membership } from "./ScopedMembership"',
+    );
+  });
+
+  /** A run that covered less than the directory has to say so. */
+  test("says what it was told to skip", () => {
+    const { text } = lines({
+      files: ["app/models/User.ts"],
+      registered: 13,
+      ignored: ["bench", "vendor"],
+      findings: [],
+    });
+
+    expect(text).toContain("Ignoring bench, vendor.");
+  });
+
+  test("counts read as English in both directions", () => {
+    expect(
+      lines({
+        files: ["a.ts"],
+        registered: 1,
+        ignored: [],
+        findings: [{ file: "a.ts", className: "A", message: "x" }],
+      }).text,
+    ).toContain("1 model class is not registered");
+
+    expect(
+      lines({
+        files: ["a.ts"],
+        registered: 1,
+        ignored: [],
+        findings: [
+          { file: "a.ts", className: "A", message: "x" },
+          { file: "b.ts", className: "B", message: "y" },
+        ],
+      }).text,
+    ).toContain("2 model classes are not registered");
+  });
+});

--- a/packages/gemi/bin/check-models.ts
+++ b/packages/gemi/bin/check-models.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { basename, join, relative, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 
 import type { UnregisteredPolicyClassError } from "../orm/errors";
 
@@ -46,14 +46,17 @@ import type { UnregisteredPolicyClassError } from "../orm/errors";
  * so is reported like any other. The fix printed for it — declare the module —
  * is the one that survives a tree-shake.
  *
- * **It does not report a policied view.** `AdminUser extends User` carrying its
- * own narrowing is refused by `registerModels` precisely so that its scope does
- * not silently reach every nested read of `User`, and the error for that case
- * tells the author to keep it out of `Kernel.models` and query it directly. A
- * checker that then demanded it be exported from the barrel would be telling
- * them to undo it. `carries === "narrowing"` is the discriminator.
+ * **It reports one of the audit's three answers.** `carries === "queried"` — a
+ * class carrying policies the registered one does not — and neither of the
+ * others, because both are arrangements the framework itself asked for:
+ * `narrowing` is a policied view, which `registerModels` refuses so that its
+ * scope does not silently reach every nested read, and whose error says to keep
+ * it out of `Kernel.models`; `registered` is an unpolicied class claiming a
+ * policied model's name, which `AmbiguousModelRegistrationError` likewise says
+ * to keep out. A checker that demanded either be exported from the barrel would
+ * be telling an author to undo what an error told them to do.
  *
- * **It does not report an unpolicied class.** One missing from the declared
+ * **So it does not report an unpolicied class.** One missing from the declared
  * modules is a real if smaller problem — its statics and row methods do not run
  * inside a nested read — but it is indistinguishable from a typed view somebody
  * meant to keep local, and a check whose findings are half false positives is a
@@ -88,8 +91,18 @@ export interface CheckReport {
 }
 
 export interface Finding {
-  /** Path relative to the project root, for the printed report. */
+  /** Path relative to the project root, for the printed report's heading. */
   file: string;
+  /**
+   * The module specifier a barrel in the model directory's root would import
+   * this file by — `./billing/Invoice`.
+   *
+   * Separate from `file` because they differ the moment a model lives in a
+   * subdirectory, and the printed fix is an `export … from` line: `file` is
+   * relative to the *project* root, and pasting a specifier derived from its
+   * basename into `app/models/index.ts` gives a module that does not resolve.
+   */
+  specifier: string;
   /** The class whose policies are not in effect inside an `include`. */
   className: string;
   message: string;
@@ -117,6 +130,7 @@ export interface OrmSurface {
     register: (name: string, model: unknown) => void;
     get: <T = unknown>(name: string) => T;
     registeredNames: () => string[];
+    clearRegistry: () => void;
   };
 }
 
@@ -188,15 +202,19 @@ export type RegistrySnapshot = ReadonlyArray<readonly [string, unknown]>;
 /**
  * The registry as the declared modules left it.
  *
- * Taken *before* a single model file is imported, and that ordering is the
- * whole of it: importing a file runs it, and a model file written the pre-0.51
- * way ends in `register("User", User)`. A snapshot taken afterwards would
- * already contain the answer the check is supposed to be testing.
+ * **What makes this the declared arrangement is `registerModels`, not the
+ * moment this is called.** The obvious reading — "taken before any model file
+ * is imported" — is false: loading the Kernel to read `models` off it imports
+ * `../models/generated` and `../models` on the way, so by the time this runs
+ * the generated `index.ts` has already run its `register` calls and every file
+ * the barrel reaches has run its top-level side effects, legacy
+ * `register("User", User)` lines included.
  *
- * `register` has no inverse, so a name the baseline does not hold cannot be
- * restored to absent. In an app that has one it is a model the generated
- * modules never emitted, which is a different thing entirely; and this is a
- * process that is about to exit.
+ * What restores the property is that `registerModels(...declared)` runs after
+ * all of that and re-asserts the election over whatever the imports left. So
+ * this snapshot is the arrangement the app boots with regardless of what ran
+ * during the loading — and the files walked *after* it are the ones whose
+ * import-time `register` calls the audit must not credit.
  */
 export function snapshotRegistry(orm: OrmSurface): RegistrySnapshot {
   return orm.registry
@@ -213,10 +231,18 @@ export function snapshotRegistry(orm: OrmSurface): RegistrySnapshot {
  */
 export function auditModules(
   orm: OrmSurface,
-  files: Array<{ path: string; label: string; module: Record<string, unknown> }>,
+  files: Array<{
+    label: string;
+    specifier: string;
+    module: Record<string, unknown>;
+  }>,
   baseline: RegistrySnapshot,
 ): Finding[] {
+  // Cleared rather than overwritten, so a name the baseline does not hold —
+  // registered by some file's own import — goes away instead of surviving into
+  // the next file's audit.
   const restore = () => {
+    orm.registry.clearRegistry();
     for (const [name, model] of baseline) orm.registry.register(name, model);
   };
 
@@ -226,13 +252,28 @@ export function auditModules(
     restore();
 
     for (const problem of orm.auditModelRegistrations(file.module)) {
-      // The arrangement `registerModels` refuses on purpose, and the arrangement
-      // its error tells the author to keep out of the declared modules. Being
-      // absent from them is what it is *supposed* to look like.
-      if (problem.carries === "narrowing") continue;
+      // Only `queried` — "this class carries policies the registered one does
+      // not" — is this command's business. The other two are shapes it would be
+      // wrong to report:
+      //
+      //   `narrowing` is a policied view, which `registerModels` refuses
+      //   *because* registering it would apply its scope to every nested read,
+      //   and whose error tells the author to keep it out of the declared
+      //   modules. Being absent from them is what following that advice looks
+      //   like.
+      //
+      //   `registered` is the mirror image: an *unpolicied* class claiming a
+      //   name the registered class carries policies for. That contradicts this
+      //   command's own rule about unpolicied classes, and its message is
+      //   written for a call site — "query the registered one instead" — under
+      //   which the export line printed below would land two unrelated classes
+      //   in one namespace and turn a working boot into
+      //   `AmbiguousModelRegistrationError`.
+      if (problem.carries !== "queried") continue;
 
       findings.push({
         file: file.label,
+        specifier: file.specifier,
         className: problem.queried,
         message: problem.message,
       });
@@ -293,6 +334,13 @@ export async function checkModels(options: {
   rootDir: string;
   modelsDir?: string;
   ignore?: string[];
+  /**
+   * The ORM to check against, for a test holding a fixture project rather than
+   * an installation. The command never passes it: resolving `gemi/orm` from the
+   * project is the point, and a fixture written into a temp directory has no
+   * `node_modules` above it to resolve through.
+   */
+  orm?: OrmSurface;
 }): Promise<CheckReport> {
   const rootDir = resolve(options.rootDir);
   const modelsDir = resolve(rootDir, options.modelsDir ?? "app/models");
@@ -300,7 +348,9 @@ export async function checkModels(options: {
 
   let orm: OrmSurface;
   try {
-    orm = (await import(Bun.resolveSync("gemi/orm", rootDir))) as OrmSurface;
+    orm =
+      options.orm ??
+      ((await import(Bun.resolveSync("gemi/orm", rootDir))) as OrmSurface);
   } catch {
     throw new CheckModelsError(
       `Could not resolve \`gemi/orm\` from ${rootDir}. Run this from the root ` +
@@ -350,22 +400,32 @@ export async function checkModels(options: {
     );
   }
 
-  // Before the first import, for the reason `snapshotRegistry` gives.
+  // After `registerModels`, which is what makes it the declared arrangement —
+  // see `snapshotRegistry`.
   const baseline = snapshotRegistry(orm);
 
   const paths = modelFiles(modelsDir, ignore);
   const files: Array<{
-    path: string;
     label: string;
+    specifier: string;
     module: Record<string, unknown>;
   }> = [];
 
   for (const path of paths) {
     const label = relative(rootDir, path);
+    // What a barrel at the model directory's root would import this file by,
+    // which is what the printed fix is a line of. Relative to `modelsDir`, not
+    // to `rootDir`, and not the basename: `app/models/billing/Invoice.ts` is
+    // `./billing/Invoice` there and `./Invoice` nowhere.
+    const specifier = `./${relative(modelsDir, path)
+      .split("\\")
+      .join("/")
+      .replace(/\.tsx?$/, "")}`;
+
     try {
       files.push({
-        path,
         label,
+        specifier,
         module: (await import(path)) as Record<string, unknown>,
       });
     } catch (error) {
@@ -417,7 +477,7 @@ export function printReport(report: CheckReport, log = console.log): number {
           `Or export it from a module \`Kernel.models\` declares, which is ` +
             `what makes\n` +
             `the registration survive without a \`register\` line:\n\n` +
-            `    export { ${finding.className} } from "./${basename(finding.file).replace(/\.tsx?$/, "")}"\n`,
+            `    export { ${finding.className} } from "${finding.specifier}"\n`,
         ),
     );
   }

--- a/packages/gemi/bin/check-models.ts
+++ b/packages/gemi/bin/check-models.ts
@@ -289,12 +289,56 @@ export function auditModules(
 export class CheckModelsError extends Error {}
 
 /**
+ * The modules named by `--models`, imported in the order given.
+ *
+ * **Why an app would want this instead of the Kernel.** Reading the list off
+ * `Kernel.models` means importing the Kernel, and that drags in the whole
+ * Kernel import graph — config slices, providers, and whatever they reach. A
+ * gemi app's does not have to be resolvable by a bare runtime import: `?raw`
+ * imports, virtual modules and asset imports are ordinary, and a bundler
+ * resolves them where `await import()` does not. The app that reported #316 and
+ * #318 is exactly that app; its Kernel transitively reaches a `.md?raw` import
+ * and the command cannot load it.
+ *
+ * It fails loudly there rather than passing green, which is the right failure —
+ * but a command that cannot run on the project that asked for it is not much
+ * use, and the whole check needs is the *model* modules.
+ *
+ * This is not the filename convention `declaredModules` rejects. That guess
+ * would let the check pass on an app whose Kernel declares nothing, because the
+ * tool would have supplied the list the app failed to. A flag is the author
+ * stating it, which is the same act as writing `models = [...]` — and if they
+ * state the wrong list, they see it in the count the report prints.
+ */
+async function namedModules(
+  rootDir: string,
+  paths: string[],
+): Promise<Array<Record<string, unknown>>> {
+  const modules: Array<Record<string, unknown>> = [];
+
+  for (const path of paths) {
+    const resolved = resolve(rootDir, path);
+    try {
+      modules.push((await import(resolved)) as Record<string, unknown>);
+    } catch (error) {
+      throw new CheckModelsError(
+        `--models named ${path}, which could not be imported:\n    ` +
+          `${(error as Error).message}`,
+      );
+    }
+  }
+
+  return modules;
+}
+
+/**
  * Loads the project's Kernel and returns the model modules it declares.
  *
- * The Kernel is where the modules are named, so it is where the check has to
- * read them from — inferring the list from a filename convention would let the
- * check pass on an app whose Kernel declares nothing, which is the state #316
- * describes.
+ * The Kernel is where the modules are named, so it is where the check reads
+ * them from by default — inferring the list from a filename convention would
+ * let the check pass on an app whose Kernel declares nothing, which is the
+ * state #316 describes. `--models` is the way to say it directly; see
+ * `namedModules`.
  *
  * `models` is `protected`, which is a statement about application code rather
  * than about the framework's own tooling; the cast is that distinction.
@@ -335,6 +379,12 @@ export async function checkModels(options: {
   modelsDir?: string;
   ignore?: string[];
   /**
+   * Module paths to register from, instead of reading `Kernel.models`. Empty or
+   * absent means load the Kernel, which is the default and the better answer
+   * when it works — see `namedModules`.
+   */
+  models?: string[];
+  /**
    * The ORM to check against, for a test holding a fixture project rather than
    * an installation. The command never passes it: resolving `gemi/orm` from the
    * project is the point, and a fixture written into a temp directory has no
@@ -371,7 +421,12 @@ export async function checkModels(options: {
     throw new CheckModelsError(`No model directory at ${modelsDir}.`);
   }
 
-  const declared = await declaredModules(rootDir);
+  const named = options.models ?? [];
+  const declared =
+    named.length > 0
+      ? await namedModules(rootDir, named)
+      : await declaredModules(rootDir);
+
   if (declared.length === 0) {
     throw new CheckModelsError(
       "`Kernel.models` is empty, so nothing is registered from a module and " +
@@ -382,6 +437,8 @@ export async function checkModels(options: {
         "    export default class extends Kernel {\n" +
         "      models = [generated, models];\n" +
         "    }\n\n" +
+        "Or name them directly, for a Kernel this command cannot import:\n\n" +
+        "    gemi check models --models app/models/generated,app/models\n\n" +
         "See UPGRADE.md and docs/orm.md#your-model-class.",
     );
   }

--- a/packages/gemi/bin/check-models.ts
+++ b/packages/gemi/bin/check-models.ts
@@ -1,0 +1,440 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, join, relative, resolve } from "node:path";
+
+import type { UnregisteredPolicyClassError } from "../orm/errors";
+
+/**
+ * `gemi check models` — the last silent version of #316, closed where the cost
+ * of closing it is nobody's request.
+ *
+ * ### What is left after `Kernel.models`
+ *
+ * `registerModels` registers every model class in the modules it is handed and
+ * audits the result, so a policied subclass no longer needs a `register` line
+ * beside it. The mistake it removed has a smaller cousin one level up (#318):
+ * instead of forgetting `register("Membership", Membership)`, you forget
+ *
+ *     export { Membership } from "./Membership"
+ *
+ * in `app/models/index.ts`. The class is written, its policy is written, and the
+ * Kernel is never handed the module it lives in — so the generated base keeps
+ * the name, every nested `include` of that model comes back unscoped, and
+ * nothing raises. The audit cannot report a class it was never given, and
+ * `Model.$exec`'s guard needs a root query that a model read only through
+ * includes never gets.
+ *
+ * ### Why a command rather than a boot step
+ *
+ * The only way to find a class nobody imported is to enumerate the filesystem,
+ * and doing that at boot buys a real cost: bundler coupling, a dev/prod
+ * divergence, and a directory walk plus an import of every model file that every
+ * production process pays for on every start, for a mistake that can only be
+ * made while editing.
+ *
+ * A check somebody runs pays none of it. This is the same rule
+ * `registerModels` applies — `auditModelRegistrations`, unchanged — with the
+ * class list coming from `app/models/**` instead of from the Kernel. It runs in
+ * CI, it costs production nothing, and it needs no cooperation from a bundler.
+ *
+ * ### What it deliberately does not do
+ *
+ * **It does not credit an import-time `register` call.** A file that registers
+ * itself is correct only for as long as something imports it, and "something
+ * imports it" is the property that just went missing. So the registry is put
+ * back to what the Kernel's declared modules made it before each file is
+ * audited, and a class that owns its name only because loading its module said
+ * so is reported like any other. The fix printed for it — declare the module —
+ * is the one that survives a tree-shake.
+ *
+ * **It does not report a policied view.** `AdminUser extends User` carrying its
+ * own narrowing is refused by `registerModels` precisely so that its scope does
+ * not silently reach every nested read of `User`, and the error for that case
+ * tells the author to keep it out of `Kernel.models` and query it directly. A
+ * checker that then demanded it be exported from the barrel would be telling
+ * them to undo it. `carries === "narrowing"` is the discriminator.
+ *
+ * **It does not report an unpolicied class.** One missing from the declared
+ * modules is a real if smaller problem — its statics and row methods do not run
+ * inside a nested read — but it is indistinguishable from a typed view somebody
+ * meant to keep local, and a check whose findings are half false positives is a
+ * check people learn to skip.
+ *
+ * ### It runs your model files
+ *
+ * There is no way to find a class without evaluating the module that declares
+ * it, so every file this walks is imported, and a file that *does something*
+ * when imported does it here. That is not hypothetical: the first run of this
+ * command against the template imported `app/models/bench/run.ts`, which is a
+ * benchmark, and it duly ran the benchmark and rewrote its report.
+ *
+ * The exclusions above keep tests and vendored packages out. `--ignore` is for
+ * the rest, and what it skipped is printed, so a narrowed run does not read
+ * like a complete one.
+ */
+
+/** The problems one run found, plus enough to say what was covered. */
+export interface CheckReport {
+  /** Model files that were walked and imported. */
+  files: string[];
+  /** Model classes the declared modules registered. */
+  registered: number;
+  /**
+   * `--ignore` patterns this run honoured. Printed, so a run that covered less
+   * than the directory says so rather than reading as though it covered
+   * everything.
+   */
+  ignored: string[];
+  findings: Finding[];
+}
+
+export interface Finding {
+  /** Path relative to the project root, for the printed report. */
+  file: string;
+  /** The class whose policies are not in effect inside an `include`. */
+  className: string;
+  message: string;
+}
+
+/**
+ * The ORM's own surface, as this file uses it.
+ *
+ * Injected rather than imported, and the reason is a hazard rather than a
+ * preference. This command is bundled into `dist/bin/gemi.js`, so a static
+ * `import { auditModelRegistrations } from "../orm/registration"` would bundle a
+ * *second* copy of the registry — while the app's model files resolve
+ * `gemi/orm` from the app's own `node_modules` and populate the first. The check
+ * would then read an empty registry and report every model in the project.
+ *
+ * So the ORM is resolved from the project being checked, at runtime, and the
+ * static import above is type-only.
+ */
+export interface OrmSurface {
+  auditModelRegistrations: (
+    ...modules: Array<Record<string, unknown>>
+  ) => UnregisteredPolicyClassError[];
+  registerModels: (...modules: Array<Record<string, unknown>>) => void;
+  registry: {
+    register: (name: string, model: unknown) => void;
+    get: <T = unknown>(name: string) => T;
+    registeredNames: () => string[];
+  };
+}
+
+/**
+ * Files that could hold a model class.
+ *
+ * Everything under the directory, because apps do group models into folders,
+ * minus what cannot be one. The check has to *import* each of these, so the
+ * exclusions are about what is certainly not model source rather than about
+ * what is probably not:
+ *
+ *   - **Declaration files.** `.d.ts` has no runtime module behind it.
+ *   - **Tests, type tests and benchmarks**, by the suffix a runner already
+ *     recognises.
+ *   - **Dot-directories and `node_modules`.**
+ *   - **Any directory holding a `package.json`.** That is a package that
+ *     happens to live here — a vendored client, a generated SDK — not this
+ *     app's source, and importing its entry point runs somebody else's module
+ *     graph. The template has two.
+ *
+ * `generated/` is deliberately *not* skipped. It is one of the declared
+ * modules, so its classes are registered and produce no findings — and skipping
+ * a directory because of its name would be one more inference about generator
+ * output, which is the thing #318's other half is about.
+ *
+ * `ignore` is the escape hatch for the rest: a path prefix, relative to `dir`,
+ * for a directory of model-adjacent code that runs something on import. Nothing
+ * is ignored by default, and the command prints what was.
+ */
+export function modelFiles(dir: string, ignore: string[] = []): string[] {
+  const out: string[] = [];
+
+  const ignored = (path: string) => {
+    const rel = relative(dir, path).split("\\").join("/");
+    return ignore.some(
+      (pattern) => rel === pattern || rel.startsWith(`${pattern}/`),
+    );
+  };
+
+  const walk = (current: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true }).sort(
+      (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
+    )) {
+      const path = join(current, entry.name);
+      if (ignored(path)) continue;
+
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+        if (existsSync(join(path, "package.json"))) continue;
+        walk(path);
+        continue;
+      }
+
+      if (!entry.name.endsWith(".ts") && !entry.name.endsWith(".tsx")) continue;
+      if (entry.name.endsWith(".d.ts")) continue;
+      if (/\.(test|test-d|spec|bench)\.tsx?$/.test(entry.name)) continue;
+
+      out.push(path);
+    }
+  };
+
+  walk(dir);
+  return out;
+}
+
+/** What the registry held at a moment, enough to put it back. */
+export type RegistrySnapshot = ReadonlyArray<readonly [string, unknown]>;
+
+/**
+ * The registry as the declared modules left it.
+ *
+ * Taken *before* a single model file is imported, and that ordering is the
+ * whole of it: importing a file runs it, and a model file written the pre-0.51
+ * way ends in `register("User", User)`. A snapshot taken afterwards would
+ * already contain the answer the check is supposed to be testing.
+ *
+ * `register` has no inverse, so a name the baseline does not hold cannot be
+ * restored to absent. In an app that has one it is a model the generated
+ * modules never emitted, which is a different thing entirely; and this is a
+ * process that is about to exit.
+ */
+export function snapshotRegistry(orm: OrmSurface): RegistrySnapshot {
+  return orm.registry
+    .registeredNames()
+    .map((name) => [name, orm.registry.get(name)] as const);
+}
+
+/**
+ * The audit itself: what the Kernel declares, against what the directory holds.
+ *
+ * `baseline` is the registry the application actually boots with. Each file's
+ * module is audited against it in isolation — restored first, so a `register`
+ * call that ran while some file was importing cannot answer for any of them.
+ */
+export function auditModules(
+  orm: OrmSurface,
+  files: Array<{ path: string; label: string; module: Record<string, unknown> }>,
+  baseline: RegistrySnapshot,
+): Finding[] {
+  const restore = () => {
+    for (const [name, model] of baseline) orm.registry.register(name, model);
+  };
+
+  const findings: Finding[] = [];
+
+  for (const file of files) {
+    restore();
+
+    for (const problem of orm.auditModelRegistrations(file.module)) {
+      // The arrangement `registerModels` refuses on purpose, and the arrangement
+      // its error tells the author to keep out of the declared modules. Being
+      // absent from them is what it is *supposed* to look like.
+      if (problem.carries === "narrowing") continue;
+
+      findings.push({
+        file: file.label,
+        className: problem.queried,
+        message: problem.message,
+      });
+    }
+  }
+
+  restore();
+
+  return findings;
+}
+
+/** A condition that makes the check meaningless, phrased for the terminal. */
+export class CheckModelsError extends Error {}
+
+/**
+ * Loads the project's Kernel and returns the model modules it declares.
+ *
+ * The Kernel is where the modules are named, so it is where the check has to
+ * read them from — inferring the list from a filename convention would let the
+ * check pass on an app whose Kernel declares nothing, which is the state #316
+ * describes.
+ *
+ * `models` is `protected`, which is a statement about application code rather
+ * than about the framework's own tooling; the cast is that distinction.
+ */
+async function declaredModules(
+  rootDir: string,
+): Promise<Array<Record<string, unknown>>> {
+  const path = resolve(rootDir, "app/kernel/Kernel.ts");
+
+  let Kernel: new () => { models?: Array<Record<string, unknown>> };
+  try {
+    ({ default: Kernel } = (await import(path)) as {
+      default: new () => { models?: Array<Record<string, unknown>> };
+    });
+  } catch (error) {
+    throw new CheckModelsError(
+      `Could not load ${relative(rootDir, path)}:\n    ` +
+        `${(error as Error).message}`,
+    );
+  }
+
+  // Constructed, not booted. `boot()` installs the Application as the
+  // process-wide instance and registers every provider, none of which this needs
+  // — and one of which might well open a connection.
+  return new Kernel().models ?? [];
+}
+
+/**
+ * Runs the check against a project directory.
+ *
+ * Throws `CheckModelsError` for the conditions that make the check meaningless
+ * rather than failing — a missing Kernel, an empty `models`, a model file that
+ * cannot be imported — because each is a different sentence to print and none of
+ * them is a finding about a model class.
+ */
+export async function checkModels(options: {
+  rootDir: string;
+  modelsDir?: string;
+  ignore?: string[];
+}): Promise<CheckReport> {
+  const rootDir = resolve(options.rootDir);
+  const modelsDir = resolve(rootDir, options.modelsDir ?? "app/models");
+  const ignore = options.ignore ?? [];
+
+  let orm: OrmSurface;
+  try {
+    orm = (await import(Bun.resolveSync("gemi/orm", rootDir))) as OrmSurface;
+  } catch {
+    throw new CheckModelsError(
+      `Could not resolve \`gemi/orm\` from ${rootDir}. Run this from the root ` +
+        `of a gemi project.`,
+    );
+  }
+
+  if (typeof orm.auditModelRegistrations !== "function") {
+    throw new CheckModelsError(
+      "The gemi installed in this project is older than `gemi check models`. " +
+        "Upgrade it to 0.51 or newer.",
+    );
+  }
+
+  try {
+    statSync(modelsDir);
+  } catch {
+    throw new CheckModelsError(`No model directory at ${modelsDir}.`);
+  }
+
+  const declared = await declaredModules(rootDir);
+  if (declared.length === 0) {
+    throw new CheckModelsError(
+      "`Kernel.models` is empty, so nothing is registered from a module and " +
+        "there is no arrangement to check against.\n" +
+        "Declare the model modules in `app/kernel/Kernel.ts`:\n\n" +
+        '    import * as generated from "../models/generated";\n' +
+        '    import * as models from "../models";\n\n' +
+        "    export default class extends Kernel {\n" +
+        "      models = [generated, models];\n" +
+        "    }\n\n" +
+        "See UPGRADE.md and docs/orm.md#your-model-class.",
+    );
+  }
+
+  // Registers, and audits what it registered — so a problem in the declared set
+  // is reported by the framework's own error rather than restated here. It is
+  // also the problem this app has *first*: the check below compares files
+  // against an arrangement that, in this case, would not boot.
+  try {
+    orm.registerModels(...declared);
+  } catch (error) {
+    throw new CheckModelsError(
+      `The modules \`Kernel.models\` declares do not register cleanly, so ` +
+        `this app would refuse to boot before reaching anything below:\n\n` +
+        `${(error as Error).message}`,
+    );
+  }
+
+  // Before the first import, for the reason `snapshotRegistry` gives.
+  const baseline = snapshotRegistry(orm);
+
+  const paths = modelFiles(modelsDir, ignore);
+  const files: Array<{
+    path: string;
+    label: string;
+    module: Record<string, unknown>;
+  }> = [];
+
+  for (const path of paths) {
+    const label = relative(rootDir, path);
+    try {
+      files.push({
+        path,
+        label,
+        module: (await import(path)) as Record<string, unknown>,
+      });
+    } catch (error) {
+      // A file that will not import is a file the check did not cover, and a
+      // check that quietly covers less than it claims is worse than one that
+      // stops.
+      throw new CheckModelsError(
+        `${label} could not be imported, so it could not be checked:\n` +
+          `    ${(error as Error).message}`,
+      );
+    }
+  }
+
+  return {
+    files: files.map((file) => file.label),
+    registered: baseline.length,
+    ignored: ignore,
+    findings: auditModules(orm, files, baseline),
+  };
+}
+
+/** The report as the command prints it. Returns the process exit code. */
+export function printReport(report: CheckReport, log = console.log): number {
+  // Printed either way. A run that skipped part of the directory and said
+  // nothing about it reads exactly like one that covered all of it.
+  if (report.ignored.length > 0) {
+    log(`Ignoring ${report.ignored.join(", ")}.`);
+  }
+
+  if (report.findings.length === 0) {
+    log(
+      `Checked ${report.files.length} model file${report.files.length === 1 ? "" : "s"} ` +
+        `against ${report.registered} registered model${report.registered === 1 ? "" : "s"}. ` +
+        `Every policied class owns its name.`,
+    );
+    return 0;
+  }
+
+  for (const finding of report.findings) {
+    // The error's own message, and then the fix for *this* command's version of
+    // the problem. Its advice — write a `register` line — is a correct fix and
+    // the direct one where it is thrown, at a query or over a module somebody
+    // handed the audit. Here the class was found by walking a directory, so the
+    // thing that went missing is the export, and re-registering by hand puts the
+    // app back on the mechanism 0.51 replaced.
+    log(
+      `\n${finding.file}\n${indent(finding.message)}\n` +
+        indent(
+          `Or export it from a module \`Kernel.models\` declares, which is ` +
+            `what makes\n` +
+            `the registration survive without a \`register\` line:\n\n` +
+            `    export { ${finding.className} } from "./${basename(finding.file).replace(/\.tsx?$/, "")}"\n`,
+        ),
+    );
+  }
+
+  log(
+    `\n${report.findings.length} model class${report.findings.length === 1 ? "" : "es"} ` +
+      `${report.findings.length === 1 ? "is" : "are"} not registered by the modules ` +
+      `\`Kernel.models\` declares. Every nested read of ${report.findings.length === 1 ? "it" : "them"} ` +
+      `runs the class that is, so the policies above are not in effect inside an \`include\`.`,
+  );
+
+  return 1;
+}
+
+function indent(message: string): string {
+  return message
+    .split("\n")
+    .map((line) => (line.length > 0 ? `    ${line}` : line))
+    .join("\n");
+}

--- a/packages/gemi/bin/gemi.ts
+++ b/packages/gemi/bin/gemi.ts
@@ -9,6 +9,7 @@ import { build } from "vite";
 import gemiVite from "../vite";
 
 import { program } from "commander";
+import { CheckModelsError, checkModels, printReport } from "./check-models";
 import { ApiManifestGenerator } from "./ide/generateApiManifest";
 
 // `bun --preload` args for the app's optional `app/preload.ts`. Preloaded (after
@@ -188,6 +189,51 @@ program
         : `Migrating ${rootDir}...`,
     );
     await runMigrate({ rootDir, dryRun: options.dryRun });
+  });
+
+// A command group rather than a `check:models` colon name, which is the shape
+// the other namespaced commands use. Those namespaces are *areas* — `app:`,
+// `ide:` — and this one is a verb, so it reads with the bare verbs at the top
+// level (`gemi dev`, `gemi build`) and leaves room for `gemi check <other>`.
+const check = program
+  .command("check")
+  .description("Checks that can be run in CI, on a project that is not running");
+
+check
+  .command("models")
+  .description(
+    "Report policied model classes that the modules `Kernel.models` declares " +
+      "do not register — the leak `Kernel.models` cannot see, because it can " +
+      "only audit the modules it is handed. Imports every file it walks, so a " +
+      "model file that does work when imported does it here; use --ignore",
+  )
+  .option(
+    "--dir <path>",
+    "Model directory to walk, relative to the project root",
+    "app/models",
+  )
+  .option(
+    "--ignore <paths>",
+    "Comma-separated paths under --dir to skip, for model-adjacent code that " +
+      "runs something when imported",
+    (value: string) => value.split(",").map((entry) => entry.trim()).filter(Boolean),
+    [] as string[],
+  )
+  .action(async (options: { dir: string; ignore: string[] }) => {
+    try {
+      const report = await checkModels({
+        rootDir: path.resolve(process.cwd()),
+        modelsDir: options.dir,
+        ignore: options.ignore,
+      });
+      process.exit(printReport(report));
+    } catch (error) {
+      // A `CheckModelsError` is a sentence written for this moment; anything
+      // else is a bug and keeps its stack.
+      if (!(error instanceof CheckModelsError)) throw error;
+      console.error(error.message);
+      process.exit(1);
+    }
   });
 
 program.command("ide:generate-api-manifest").action(async () => {

--- a/packages/gemi/bin/gemi.ts
+++ b/packages/gemi/bin/gemi.ts
@@ -213,6 +213,17 @@ check
     "app/models",
   )
   .option(
+    "--models <paths>",
+    "Module paths to register from, instead of reading `Kernel.models` — for " +
+      "a Kernel whose import graph needs build-time transforms this command " +
+      "cannot apply. Comma-separated, and repeatable",
+    (value: string, previous: string[]) => [
+      ...previous,
+      ...value.split(",").map((entry) => entry.trim()).filter(Boolean),
+    ],
+    [] as string[],
+  )
+  .option(
     "--ignore <paths>",
     "Paths under --dir to skip, for model-adjacent code that runs something " +
       "when imported. Comma-separated, and repeatable",
@@ -225,22 +236,25 @@ check
     ],
     [] as string[],
   )
-  .action(async (options: { dir: string; ignore: string[] }) => {
-    try {
-      const report = await checkModels({
-        rootDir: path.resolve(process.cwd()),
-        modelsDir: options.dir,
-        ignore: options.ignore,
-      });
-      process.exit(printReport(report));
-    } catch (error) {
-      // A `CheckModelsError` is a sentence written for this moment; anything
-      // else is a bug and keeps its stack.
-      if (!(error instanceof CheckModelsError)) throw error;
-      console.error(error.message);
-      process.exit(1);
-    }
-  });
+  .action(
+    async (options: { dir: string; ignore: string[]; models: string[] }) => {
+      try {
+        const report = await checkModels({
+          rootDir: path.resolve(process.cwd()),
+          modelsDir: options.dir,
+          ignore: options.ignore,
+          models: options.models,
+        });
+        process.exit(printReport(report));
+      } catch (error) {
+        // A `CheckModelsError` is a sentence written for this moment; anything
+        // else is a bug and keeps its stack.
+        if (!(error instanceof CheckModelsError)) throw error;
+        console.error(error.message);
+        process.exit(1);
+      }
+    },
+  );
 
 program.command("ide:generate-api-manifest").action(async () => {
   const parser = new ApiManifestGenerator();

--- a/packages/gemi/bin/gemi.ts
+++ b/packages/gemi/bin/gemi.ts
@@ -214,9 +214,15 @@ check
   )
   .option(
     "--ignore <paths>",
-    "Comma-separated paths under --dir to skip, for model-adjacent code that " +
-      "runs something when imported",
-    (value: string) => value.split(",").map((entry) => entry.trim()).filter(Boolean),
+    "Paths under --dir to skip, for model-adjacent code that runs something " +
+      "when imported. Comma-separated, and repeatable",
+    // Accumulating, because a coercion that drops `previous` makes
+    // `--ignore a --ignore b` keep only `b` — silently, and while reading like
+    // it took both.
+    (value: string, previous: string[]) => [
+      ...previous,
+      ...value.split(",").map((entry) => entry.trim()).filter(Boolean),
+    ],
     [] as string[],
   )
   .action(async (options: { dir: string; ignore: string[] }) => {

--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -754,10 +754,33 @@ describe("emitArtifacts()", () => {
   test("marks each emitted base as generated", () => {
     const models = files["models.ts"];
 
-    expect(models).toContain("static $generated = true;");
-    expect([...models.matchAll(/^\s*static \$generated = true;$/gm)]).toHaveLength(
-      2,
-    );
+    expect(models).toContain("static readonly $generated = true;");
+    expect(
+      [...models.matchAll(/^\s*static readonly \$generated = true;$/gm)],
+    ).toHaveLength(2);
+  });
+
+  /**
+   * **`readonly`, and the artifact does not typecheck without it.**
+   *
+   * `Model` declares `declare static $generated?: true`, deliberately the
+   * literal rather than `boolean` so that a hand-written `= false` is the type
+   * error `isGeneratedBase` reads it as. A mutable `static $generated = true`
+   * widens to `boolean`, which is not assignable to `true`, so every class in
+   * the emitted file becomes
+   *
+   *     TS2417: Class static side 'typeof AccountModel' incorrectly extends
+   *     base class static side 'typeof Model'.
+   *
+   * It shipped that way in #319 and was found by an app regenerating a 79-model
+   * schema — 79 errors, and 15 in this repository's own template, with every
+   * check in CI green. `tsconfig.generated.json` is the gate that now compiles
+   * the artifact against the runtime it is generated for; this is the assertion
+   * that says *why* the keyword is there, next to the line, so it is not
+   * tidied away as noise.
+   */
+  test("the mark does not widen, because the base declares the literal", () => {
+    expect(files["models.ts"]).not.toMatch(/^\s*static \$generated = true;$/m);
   });
 
   // Generated files hold data and thin delegating methods only. Anything smart

--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -732,6 +732,34 @@ describe("emitArtifacts()", () => {
     expect(files["index.ts"]).toContain('register("Post", PostModel);');
   });
 
+  /**
+   * **The generator says which classes it wrote, rather than leaving it to be
+   * inferred (#318).**
+   *
+   * `registerModels` has to prefer an application's subclass over the base it
+   * extends when both are in one namespace, because electing the base is #316's
+   * leak. It used to decide that by asking whether a class declared `$schema`
+   * itself — true of the emitted base, false of a subclass — which is an
+   * inference about how this file happens to be written, and one a subclass
+   * redeclaring `static $schema` defeated.
+   *
+   * So this line is a contract between two files, and it is asserted at both
+   * ends: `isGeneratedBase` reads it, `registration.test.ts` in the template
+   * checks that real generator output still carries it.
+   *
+   * One class per model carries it, because the mark has to be *own* rather than
+   * inherited to say anything — a subclass inherits `true` and must still read
+   * as an application class.
+   */
+  test("marks each emitted base as generated", () => {
+    const models = files["models.ts"];
+
+    expect(models).toContain("static $generated = true;");
+    expect([...models.matchAll(/^\s*static \$generated = true;$/gm)]).toHaveLength(
+      2,
+    );
+  });
+
   // Generated files hold data and thin delegating methods only. Anything smart
   // in there cannot be hotfixed without a codegen release.
   test("keeps the operations one-line delegations to the choke point", () => {

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -1075,6 +1075,13 @@ ${imports.map((name) => `  ${name},`).join("\n")}
 export class ${schema.name}Model extends Model {
   static $schema = schema.${schema.name};
 
+  // Says this class came out of the generator, so \`registerModels\` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // \`isGeneratedBase\`.
+  static $generated = true;
+
   // Narrowed from \`Model\`'s \`PolicyEntry[]\` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
   // against columns that do not exist.

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -1080,7 +1080,13 @@ export class ${schema.name}Model extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // \`isGeneratedBase\`.
-  static $generated = true;
+  //
+  // \`readonly\` so the initialiser keeps the literal type. \`Model\` declares this
+  // \`?: true\`, and a mutable \`= true\` widens to \`boolean\` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. \`tsconfig.generated.json\`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from \`Model\`'s \`PolicyEntry[]\` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -143,6 +143,13 @@ export abstract class Model {
    * `Model.$generated` of `undefined` would answer that question `true` for
    * every class, in every app, including the ones with no mark to read.
    * `registration.test.ts` pins it.
+   *
+   * **`?: true` and not `?: boolean`**, which is what makes a hand-written
+   * `static $generated = false` the type error `isGeneratedBase` reads it as.
+   * The cost is that the generator has to emit a non-widening initialiser —
+   * `static readonly $generated = true`, since a mutable one widens to
+   * `boolean` and every emitted class becomes a TS2417. That happened;
+   * `tsconfig.generated.json` is the check that catches it now.
    */
   declare static $generated?: true;
 

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -126,6 +126,27 @@ export abstract class Model {
   static $schema: ModelSchema;
 
   /**
+   * Set to `true` by the generator on each base it emits, and by nothing else.
+   *
+   * `registerModels` has to tell a generated base from an application class
+   * written over it, because when both are in one namespace the subclass is the
+   * one that must own the name — electing the base *is* #316's leak. It used to
+   * answer that by asking whether a class declared `$schema` itself, which is an
+   * inference about how the generator happens to be written rather than a
+   * statement by the generator, and a subclass that redeclared `static $schema`
+   * read as a base because of it. This is the generator saying so.
+   *
+   * **`declare`, and it has to stay `declare`.** The property must not exist on
+   * `Model` at runtime: `isGeneratedBase` reads `"$generated" in candidate` to
+   * decide whether the artifacts in front of it carry the mark at all, and falls
+   * back to the old inference for artifacts generated before this existed. A
+   * `Model.$generated` of `undefined` would answer that question `true` for
+   * every class, in every app, including the ones with no mark to read.
+   * `registration.test.ts` pins it.
+   */
+  declare static $generated?: true;
+
+  /**
    * The model's own policies, in the order they should apply.
    *
    * A list rather than the single `$policy` this replaced, because composition

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -140,7 +140,11 @@ export {
   type SqlFragment,
 } from "./sql";
 
-export { assertPoliciesRegistered, registerModels } from "./registration";
+export {
+  assertPoliciesRegistered,
+  auditModelRegistrations,
+  registerModels,
+} from "./registration";
 
 export {
   softDelete,

--- a/packages/gemi/orm/registration.test.ts
+++ b/packages/gemi/orm/registration.test.ts
@@ -5,6 +5,7 @@ import {
   UnregisteredPolicyClassError,
 } from "./errors";
 import { user } from "./fixtures";
+import { Model } from "./Model";
 import { policiesFor, type ModelPolicy } from "./policy";
 import { assertPoliciesRegistered, registerModels } from "./registration";
 import * as registry from "./registry";
@@ -571,16 +572,82 @@ describe("a view that narrows a model it does not own", () => {
 });
 
 /**
- * `elect` turns on `Object.hasOwn(candidate, "$schema")`, and the reader's
- * question at that line is what happens when it is wrong. A subclass that
- * redeclares `$schema` reads as a base, every candidate looks generated, and
- * the least derived wins — the base takes the name over the policied subclass.
+ * Which class the generator wrote — stated by the generator, and inferred only
+ * where there is no statement to read (#318).
  *
- * That is #316's arrangement, so what matters is that it does not pass
- * quietly.
+ * `elect` has to prefer an application's subclass over the base it extends,
+ * because electing the base is #316's leak in the one file an author is most
+ * likely to write it in. It used to answer "which is the base" with
+ * `Object.hasOwn(candidate, "$schema")` — true of the emitted class, false of a
+ * subclass. That is an inference about how the generator happens to be written,
+ * and it reads a subclass that redeclares `static $schema` as a base.
+ *
+ * `UserBase` above deliberately carries no mark, so every test in this file
+ * other than these exercises the fallback — which is what an app whose
+ * `app/models/generated` predates 0.51 will be running on.
  */
-describe("when the generated-base test guesses wrong", () => {
-  test("a subclass that redeclares $schema fails loudly rather than leaking", () => {
+describe("the generator's mark on its own output", () => {
+  class MarkedBase {
+    static $schema = user;
+    static $generated = true;
+  }
+
+  /**
+   * The #318 case, with the mark: the subclass redeclares `$schema`, is
+   * therefore indistinguishable from a base by the old inference, and still
+   * takes the name — because the mark is *owned* by one class per model and a
+   * subclass only inherits it.
+   */
+  test("a subclass that redeclares $schema still takes the name", () => {
+    class User extends MarkedBase {
+      static $schema = user;
+      static $policies = [scope];
+    }
+
+    expect(() => registerModels({ MarkedBase, User })).not.toThrow();
+    expect(registry.get("User")).toBe(User);
+  });
+
+  test("an ordinary subclass of a marked base takes the name too", () => {
+    class User extends MarkedBase {
+      static $policies = [scope];
+    }
+
+    registerModels({ MarkedBase, User });
+
+    expect(registry.get("User")).toBe(User);
+  });
+
+  /**
+   * The mark does not disturb the shape it was not added for: a policied view
+   * over a marked model is still refused rather than silently registered.
+   */
+  test("a marked base does not make a narrowing view acceptable", () => {
+    class User extends MarkedBase {
+      static $policies = [scope];
+    }
+    class AdminUser extends User {
+      static $policies = [other];
+    }
+
+    expect(() => registerModels({ MarkedBase, User, AdminUser })).toThrow(
+      UnregisteredPolicyClassError,
+    );
+  });
+
+  /**
+   * **Unmarked artifacts keep the old behaviour, including the old sharp
+   * edge.** The fallback is chosen by `"$generated" in candidate`, which walks
+   * the prototype chain — so it separates apps, not classes. An app on
+   * pre-0.51 generated files gets the inference for everything, and the
+   * redeclaring subclass still loses its name there.
+   *
+   * That is not silent, which is why the fallback is acceptable at all:
+   * `assertPoliciesRegistered` runs immediately after `elect`, sees a policied
+   * class that did not get its name, and refuses. Regenerating is the fix, and
+   * the error names both classes.
+   */
+  test("an unmarked base still fails loudly rather than leaking", () => {
     class User extends UserBase {
       static $schema = user;
       static $policies = [scope];
@@ -589,5 +656,27 @@ describe("when the generated-base test guesses wrong", () => {
     expect(() => registerModels({ UserBase, User })).toThrow(
       UnregisteredPolicyClassError,
     );
+  });
+
+  /**
+   * **`Model.$generated` must not exist at runtime**, and this is what says so.
+   *
+   * It is declared on `Model` for a type and a place to document it, with
+   * `declare` so nothing is emitted. Drop that keyword and the property exists,
+   * valued `undefined`, on every model class in every application — which makes
+   * `"$generated" in candidate` true everywhere, retires the fallback for apps
+   * that have nothing else to read, and hands every name back to the generated
+   * base.
+   */
+  test("Model carries no mark of its own", () => {
+    expect("$generated" in Model).toBe(false);
+  });
+
+  test("the generated base owns the mark and its subclass does not", () => {
+    class User extends MarkedBase {}
+
+    expect(Object.hasOwn(MarkedBase, "$generated")).toBe(true);
+    expect(Object.hasOwn(User, "$generated")).toBe(false);
+    expect("$generated" in User).toBe(true);
   });
 });

--- a/packages/gemi/orm/registration.ts
+++ b/packages/gemi/orm/registration.ts
@@ -57,10 +57,47 @@ type ModelClass = object & { $schema: ModelSchema };
  *
  * It can only see modules it is handed, which is the residual either way: a
  * policied class in a file no barrel re-exports is invisible to it.
+ * `gemi check models` closes that by handing it the files instead of the
+ * barrel — see `auditModelRegistrations`, which is the same rule without the
+ * throw.
  */
 export function assertPoliciesRegistered(
   ...modules: Array<Record<string, unknown>>
 ): void {
+  const [first] = auditModelRegistrations(...modules);
+  if (first !== undefined) throw first;
+}
+
+/**
+ * Every problem `assertPoliciesRegistered` would report, as values rather than
+ * as a throw — in the order it would have reported them, so the first element is
+ * exactly what that function throws.
+ *
+ * ### Why the rule needed a second caller
+ *
+ * A throw is the right shape at boot: the first policied class that does not own
+ * its name is a reason not to start, and the rest of the list is noise nobody
+ * reads before fixing the first one.
+ *
+ * It is the wrong shape for a checker. `gemi check models` walks
+ * `app/models/**` and audits each file, so it wants *all* of them, and it wants
+ * to sort them — a policied class the Kernel never sees is a leak to report,
+ * while a policied view deliberately kept out of the declared modules is the
+ * arrangement the error for that case actually recommends, and reporting it
+ * would be telling an author to undo what the framework told them to do.
+ * `UnregisteredPolicyClassError.carries` is what separates the two, and it can
+ * only be read off an error somebody is holding.
+ *
+ * Errors rather than a plain finding type, because the message is the useful
+ * part and it is already written once, in the error. Constructing them is not
+ * free — a stack per finding — and it is a check somebody runs, not a request
+ * path.
+ */
+export function auditModelRegistrations(
+  ...modules: Array<Record<string, unknown>>
+): UnregisteredPolicyClassError[] {
+  const problems: UnregisteredPolicyClassError[] = [];
+
   for (const module of modules) {
     for (const exported of Object.values(module)) {
       const model = asModelClass(exported);
@@ -121,12 +158,15 @@ export function assertPoliciesRegistered(
           // Not registered, and it has policies: #316 itself. The policied
           // class is not the one the name resolves to, so every nested read
           // runs the ancestor and skips it.
-          throw new UnregisteredPolicyClassError(
-            name,
-            nameOf(registered),
-            nameOf(model),
-            ours.length > 0 ? "queried" : "registered",
+          problems.push(
+            new UnregisteredPolicyClassError(
+              name,
+              nameOf(registered),
+              nameOf(model),
+              ours.length > 0 ? "queried" : "registered",
+            ),
           );
+          continue;
         }
 
         // The ancestor carries policies of its own, so it is a registered model
@@ -135,11 +175,13 @@ export function assertPoliciesRegistered(
         // to every nested read, and leaving the ancestor registered skips the
         // view's policies entirely. Both are silent, so neither is chosen.
         if (diverges) {
-          throw new UnregisteredPolicyClassError(
-            name,
-            nameOf(ancestor),
-            nameOf(descendant),
-            "narrowing",
+          problems.push(
+            new UnregisteredPolicyClassError(
+              name,
+              nameOf(ancestor),
+              nameOf(descendant),
+              "narrowing",
+            ),
           );
         }
 
@@ -151,14 +193,18 @@ export function assertPoliciesRegistered(
 
       // Unrelated classes claiming one name. Whichever is registered, the
       // other's policies are simply not in effect.
-      throw new UnregisteredPolicyClassError(
-        name,
-        nameOf(registered),
-        nameOf(model),
-        ours.length > 0 ? "queried" : "registered",
+      problems.push(
+        new UnregisteredPolicyClassError(
+          name,
+          nameOf(registered),
+          nameOf(model),
+          ours.length > 0 ? "queried" : "registered",
+        ),
       );
     }
   }
+
+  return problems;
 }
 
 /**
@@ -314,24 +360,42 @@ function elect(name: string, classes: ModelClass[]): ModelClass {
  * Whether the generator wrote this class, rather than an application extending
  * one it wrote.
  *
- * `$schema` is declared on the emitted base and inherited by everything below
- * it, so owning the property is the difference. Nothing has to be added to the
- * generated output for this to hold — it is already how `models.ts` is written,
- * and `Model.$exec` already reads `$schema` off the prototype chain for exactly
- * that reason. `registration.test.ts` in the template asserts the contract
- * against real generator output, because this is the one place a generator
- * change could quietly invalidate an assumption made here.
+ * The generator marks its own output — `static $generated = true` on each
+ * emitted base, and on nothing else — so for artifacts that carry the mark this
+ * is a fact the generator stated rather than a property of how it happens to be
+ * written. A subclass *inherits* the mark and does not own it, which is what
+ * makes own-vs-inherited the whole test.
  *
- * **When it is wrong, it is wrong safely.** A subclass that redeclares
- * `static $schema` — pointing at a modified schema object, or by copy-paste —
- * reads as a base here. Every candidate then looks generated, `elect` falls
- * through to the whole set, and the least derived wins: the base takes the name
- * over the policied subclass. That is the arrangement #316 is about, so it does
- * not pass quietly — `assertPoliciesRegistered` runs immediately after and
- * refuses it, naming both classes. Loud and wrong beats silent and wrong, and
- * the reader's question at `Object.hasOwn` is exactly this one.
+ * ### The fallback, and why it is second
+ *
+ * `$schema` is also declared on the emitted base and inherited below it, so
+ * owning *that* used to answer the same question, and it answered it wrongly for
+ * one shape (#318): a subclass that redeclares `static $schema` — pointing at a
+ * modified schema object, or by copy-paste — read as a base, every candidate
+ * looked generated, and the least derived won. That did not pass quietly, since
+ * `assertPoliciesRegistered` runs immediately after `elect` and refuses a
+ * policied class that lost its name. But loud-and-wrong is still wrong, and the
+ * silent half — a subclass with statics and row methods but no policies, whose
+ * methods then never run inside a nested read — had nothing to refuse.
+ *
+ * The inference survives as the fallback for artifacts generated *before* the
+ * mark existed, where it is the only signal there is. `"$generated" in candidate`
+ * is what separates the two worlds: it walks the prototype chain, so it is true
+ * for a marked base and for everything under it, and false for every class in an
+ * app whose `app/models/generated` predates 0.51. Asking `Object.hasOwn` first
+ * and falling back on `false` would send a subclass of a *marked* base back into
+ * the inference — which is exactly the case the mark was added to fix.
+ *
+ * `registration.test.ts` in the template asserts the contract against real
+ * generator output, because this is the one place a generator change could
+ * quietly invalidate an assumption made here.
  */
 function isGeneratedBase(candidate: ModelClass): boolean {
+  // Owning the mark, not merely having it: `Model` declares the property
+  // `declare static $generated?: true`, so `true` is the only value the type
+  // admits and presence is the whole question.
+  if ("$generated" in candidate) return Object.hasOwn(candidate, "$generated");
+
   return Object.hasOwn(candidate, "$schema");
 }
 

--- a/packages/gemi/orm/registration.ts
+++ b/packages/gemi/orm/registration.ts
@@ -391,10 +391,16 @@ function elect(name: string, classes: ModelClass[]): ModelClass {
  * quietly invalidate an assumption made here.
  */
 function isGeneratedBase(candidate: ModelClass): boolean {
-  // Owning the mark, not merely having it: `Model` declares the property
-  // `declare static $generated?: true`, so `true` is the only value the type
-  // admits and presence is the whole question.
-  if ("$generated" in candidate) return Object.hasOwn(candidate, "$generated");
+  // Owning the mark, not merely having it — and owning it set to `true`. The
+  // declared type is `?: true`, so TypeScript already refuses `false`; reading
+  // the value anyway is what makes `static $generated = false` mean the thing
+  // it plainly says in an app with no typechecking between it and here.
+  if ("$generated" in candidate) {
+    return (
+      Object.hasOwn(candidate, "$generated") &&
+      (candidate as { $generated?: unknown }).$generated === true
+    );
+  }
 
   return Object.hasOwn(candidate, "$schema");
 }

--- a/packages/gemi/tsconfig.generated.json
+++ b/packages/gemi/tsconfig.generated.json
@@ -1,0 +1,40 @@
+{
+  // The generator's output, typechecked against the runtime it is generated
+  // for — the gate that would have caught #319's `static $generated = true`.
+  //
+  // That line widened to `boolean` against a `Model` declaring `?: true`, so
+  // every emitted class became a TS2417 the moment an app regenerated: 15 in
+  // this repository's template, 79 in the app that reported it. Neither check
+  // that runs could see it. `tsconfig.json` next door covers `bin/orm` — the
+  // code that *writes* the artifact — and not the artifact; the template's own
+  // `tsc --noEmit` does cover it, and reports 277 pre-existing errors in the
+  // template's app code alongside it, so 15 new ones are indistinguishable from
+  // the noise already there.
+  //
+  // **On this side of the repository rather than the template's**, because the
+  // options have to be ones something is already green under. gemi's own source
+  // is green under these and is not under the template's, and the artifact
+  // imports `gemi/orm` — so checking it from the template drags every gemi
+  // source file in under options it was never checked against, and the noise
+  // problem comes back one level down.
+  //
+  // `generated-lists` is the Postgres-only scalar-list schema's output. It is
+  // gitignored and generated on demand, so this matches nothing for it in a
+  // fresh clone and checks it in the job that creates it.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "emitDeclarationOnly": false,
+    // The artifact imports `gemi/orm` by package name, the way an application's
+    // does. Nothing resolves that from inside the package itself, so it is
+    // pointed at the source the template's `node_modules/gemi` symlink reaches.
+    "paths": {
+      "gemi/orm": ["./orm/index.ts"]
+    }
+  },
+  "include": [
+    "orm",
+    "../../templates/saas-starter/app/models/generated/**/*.ts",
+    "../../templates/saas-starter/app/models/generated-lists/**/*.ts"
+  ]
+}

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -114,6 +114,13 @@ export abstract class AccountScopedPolicy extends ScopedPolicy<
 export class AccountModel extends Model {
   static $schema = schema.Account;
 
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
+
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
   // against columns that do not exist.
@@ -292,6 +299,13 @@ export abstract class LedgerScopedPolicy extends ScopedPolicy<
 
 export class LedgerModel extends Model {
   static $schema = schema.Ledger;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -476,6 +490,13 @@ export abstract class LedgerEntryScopedPolicy extends ScopedPolicy<
 export class LedgerEntryModel extends Model {
   static $schema = schema.LedgerEntry;
 
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
+
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
   // against columns that do not exist.
@@ -657,6 +678,13 @@ export abstract class MagicLinkTokenScopedPolicy extends ScopedPolicy<
 export class MagicLinkTokenModel extends Model {
   static $schema = schema.MagicLinkToken;
 
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
+
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
   // against columns that do not exist.
@@ -835,6 +863,13 @@ export abstract class MembershipScopedPolicy extends ScopedPolicy<
 
 export class MembershipModel extends Model {
   static $schema = schema.Membership;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -1023,6 +1058,13 @@ export abstract class OrganizationScopedPolicy extends ScopedPolicy<
 export class OrganizationModel extends Model {
   static $schema = schema.Organization;
 
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
+
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
   // against columns that do not exist.
@@ -1210,6 +1252,13 @@ export abstract class OrganizationInvitationScopedPolicy extends ScopedPolicy<
 export class OrganizationInvitationModel extends Model {
   static $schema = schema.OrganizationInvitation;
 
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
+
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
   // against columns that do not exist.
@@ -1391,6 +1440,13 @@ export abstract class PasswordResetTokenScopedPolicy extends ScopedPolicy<
 export class PasswordResetTokenModel extends Model {
   static $schema = schema.PasswordResetToken;
 
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
+
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
   // against columns that do not exist.
@@ -1567,6 +1623,13 @@ export abstract class PostScopedPolicy extends ScopedPolicy<
 
 export class PostModel extends Model {
   static $schema = schema.Post;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -1758,6 +1821,13 @@ export abstract class SessionScopedPolicy extends ScopedPolicy<
 
 export class SessionModel extends Model {
   static $schema = schema.Session;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -1954,6 +2024,13 @@ export abstract class SocialAccountScopedPolicy extends ScopedPolicy<
 export class SocialAccountModel extends Model {
   static $schema = schema.SocialAccount;
 
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
+
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
   // against columns that do not exist.
@@ -2130,6 +2207,13 @@ export abstract class TagScopedPolicy extends ScopedPolicy<
 
 export class TagModel extends Model {
   static $schema = schema.Tag;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -2337,6 +2421,13 @@ export abstract class UserScopedPolicy extends ScopedPolicy<
 
 export class UserModel extends Model {
   static $schema = schema.User;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  static $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -119,7 +119,13 @@ export class AccountModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -305,7 +311,13 @@ export class LedgerModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -495,7 +507,13 @@ export class LedgerEntryModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -683,7 +701,13 @@ export class MagicLinkTokenModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -869,7 +893,13 @@ export class MembershipModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -1063,7 +1093,13 @@ export class OrganizationModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -1257,7 +1293,13 @@ export class OrganizationInvitationModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -1445,7 +1487,13 @@ export class PasswordResetTokenModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -1629,7 +1677,13 @@ export class PostModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -1827,7 +1881,13 @@ export class SessionModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -2029,7 +2089,13 @@ export class SocialAccountModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -2213,7 +2279,13 @@ export class TagModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled
@@ -2427,7 +2499,13 @@ export class UserModel extends Model {
   // It reads own-vs-inherited, and a subclass inherits this rather than
   // declaring it — so the mark is on exactly one class per model. See
   // `isGeneratedBase`.
-  static $generated = true;
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
 
   // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
   // written for another model is a type error here rather than a scope compiled

--- a/templates/saas-starter/app/models/registration.test.ts
+++ b/templates/saas-starter/app/models/registration.test.ts
@@ -46,17 +46,28 @@ describe("the template's own models", () => {
    * than against a stand-in.**
    *
    * `registerModels` decides which of several candidates owns a name by asking
-   * whether a class declares `$schema` itself or inherits it: an own property
-   * means the generator emitted it, and an inherited one means an application
-   * wrote it. Every unit test of that rule uses a hand-written
-   * `class UserBase { static $schema = user }`, which is exactly the thing that
-   * cannot tell you whether real generator output still looks like this.
+   * which one the generator wrote, and the generator answers by marking its own
+   * output: `static $generated = true` on each emitted base, owned there and
+   * merely inherited below it. Every unit test of that rule uses a hand-written
+   * stand-in, which is exactly the thing that cannot tell you whether real
+   * generator output still carries the mark.
    *
-   * If `models.ts` ever moved `$schema` — onto the prototype, into a getter, up
-   * into `Model` — `elect` would read every candidate as a base and hand the
-   * name to the generated class over the application's subclass. That fails
-   * loudly rather than leaking, because the audit refuses it a moment later,
-   * but "loudly" is a worse day than this assertion.
+   * If `emit.ts` ever dropped the line, `isGeneratedBase` would fall back to the
+   * `$schema` inference it replaced (#318) — silently, since the fallback exists
+   * for artifacts generated before the mark did and cannot tell those from a
+   * regression. So this is the assertion that would fail instead.
+   */
+  test("the generator marks the classes it wrote", () => {
+    expect(Object.hasOwn(generated.UserModel, "$generated")).toBe(true);
+    expect(Object.hasOwn(models.User, "$generated")).toBe(false);
+    // Inherited, so the fallback is not what the app is running on.
+    expect("$generated" in models.User).toBe(true);
+  });
+
+  /**
+   * The signal the mark replaced, still asserted: it remains the fallback for
+   * artifacts generated before 0.51, and `Model.$exec` reads `$schema` off the
+   * prototype chain for its own reasons.
    */
   test("the generator declares $schema and subclasses inherit it", () => {
     expect(Object.hasOwn(generated.UserModel, "$schema")).toBe(true);


### PR DESCRIPTION
Closes #318. **Stacked on #317** — the base branch is `fix/316-registration-and-kernel-exit`, because both items are edits to code that PR introduced. Retarget to `main` once #317 lands.

Neither item blocks 0.51, and the issue says so. Both are the last silent cases left in model registration.

---

## A. A policied class no barrel re-exports

`Kernel.models` audits the modules it is handed, so #316's mistake survives one level up: instead of forgetting `register("Membership", Membership)`, you forget

```ts
export { Membership } from "./Membership"
```

The generated base keeps the name, every nested `include` of that model comes back unscoped, and nothing raises — the audit cannot report a class it was never given, and `$exec`'s guard needs a root query an include-only model never gets.

**`gemi check models`** closes it where the issue suggested: at check time, not boot time.

```
$ gemi check models
Checked 7 model files against 13 registered models. Every policied class owns its name.
```

It walks `app/models`, imports each file, and applies the rule `registerModels` already applies — only the source of the class list changes. Exit `1` on a finding, printed under its file with the export that fixes it. A step in the sqlite CI job runs it against the template.

`assertPoliciesRegistered` is now a two-line wrapper over a new **`auditModelRegistrations`**, which returns the errors rather than throwing the first. The checker needs all of them, and needs `carries` to sort a leak from a view.

### Three decisions worth your attention

**It does not credit a `register` call a file made while being imported.** A class that owns its name only because something loaded its module loses it the day nothing does — which is the failure being checked for, so crediting it would make the check agree with the bug. The registry is restored to what the declared modules made it before each file is audited, and the baseline is taken *before* the first import for the same reason.

**It does not report unpolicied classes.** One missing from the declared modules is a real if smaller problem, but it is indistinguishable from a typed view somebody meant to keep local.

**It does not report a policied view.** `registerModels` refuses one precisely so its narrowing does not reach every nested read, and that error tells the author to keep it out of `Kernel.models`. A checker demanding they export it would be telling them to undo it.

### It imports what it walks

Unavoidable — you cannot find a class without evaluating the module that declares it. Not hypothetical either: the first build, pointed at the template, imported `app/models/bench/run.ts`, ran the benchmark, and rewrote `plans/orm/benchmarks.json`. Tests, type tests, benchmarks, `.d.ts` and directories with their own `package.json` are skipped; `--ignore` takes the rest and the command prints what it skipped, so a narrowed run does not read like a complete one.

---

## B. `isGeneratedBase` was an inference

`Object.hasOwn(candidate, "$schema")` reads "the generator wrote this", and a subclass that redeclares `static $schema` defeats it. The generator now marks its own output:

```ts
export class UserModel extends Model {
  static $schema = schema.User;
  static $generated = true;
}
```

Own-vs-inherited is the whole test, since a subclass inherits the mark and does not own it. `"$generated" in candidate` selects between two worlds rather than two classes: an app whose `app/models/generated` predates 0.51 keeps the old inference — including its sharp edge, which is loud rather than silent, and which regenerating removes. Asking `Object.hasOwn` first and falling back on `false` would have sent a subclass of a *marked* base back into the inference, which is the case the mark exists to fix.

`Model` declares the property with `declare` so nothing is emitted, and a test pins `"\$generated" in Model === false`: drop that keyword and the property exists valued `undefined` on every model class in every app, which answers the world-selecting question `true` everywhere and retires the fallback for exactly the apps that have nothing else to read.

The template's `registration.test.ts` asserts the mark against real generator output, which is what would fail if `emit.ts` ever dropped the line — the fallback cannot tell a regression from an old artifact.

---

## Verification

- `packages/gemi`: 111 files, 2581 passed, 1 skipped. `tsc --noEmit` clean. `oxlint orm --deny-warnings` at zero.
- Template: 18 files, 657 passed, 133 skipped (Postgres-gated). `test:types` 61 passed, no type errors.
- `prisma generate` re-run for both schemas; the zero-diff test passes.
- End-to-end: `bunx gemi check models --ignore bench` exits 0 on the template, and exits 1 naming the file when a policied `Membership` subclass is dropped into `app/models` without a barrel export.

## Docs

`docs/cli.md` gains the command. `docs/orm.md`'s *What this still cannot see* is rewritten around it, including the three decisions above. `UPGRADE.md` gains a "run the check once" step and a "regenerate, so registration stops guessing" section. `docs/llms-full.txt` resynced for both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e9XQt5uXmT2B2KFN5dnBz
