### PR TITLE
Read app/jobs and app/cron, and give CronJob a gate that holds

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,7 +1,9 @@
 # Upgrading from 0.50 to 0.51
 
-Two changes need a hand. There is no codemod for either — `bunx gemi migrate` is
-the 0.42→0.43 tool and does not touch any of this.
+Three changes need a hand, and the third is a look rather than an edit — it only
+becomes work if you were using an unlisted job as an off switch. There is no
+codemod for any of them — `bunx gemi migrate` is the 0.42→0.43 tool and does not
+touch any of this.
 
 ## Declare your model modules on the Kernel
 
@@ -96,6 +98,37 @@ passed `Prisma.DbNull`, `Prisma.JsonNull` or `Prisma.AnyNull`, import them from
 
 The full detail, including the `Prisma.*` type mapping, is under
 **Setup** in [docs/orm.md](./docs/orm.md#setup).
+
+## Check `app/cron` and `app/jobs` before you drop the explicit list
+
+0.51 discovers jobs from the filesystem. Every `Job` subclass under `app/jobs` is
+registered and every `CronJob` under `app/cron` is scheduled — unless the config
+slice declares `jobs` itself, which still wins and still reads no directory.
+
+**Nothing to do if your `app/config/queue.ts` and `app/config/schedule.ts`
+already declare `jobs`.** That includes `jobs: []`, which every app scaffolded
+before 0.51 has in `app/config/queue.ts`: an empty array is an application saying
+it has no jobs, it is honoured as such, and nothing starts running under you.
+Delete the key when you want the directory read instead.
+
+Two things to look at before you do:
+
+- **A job you switched off by unlisting it.** Deleting a class from the array and
+  leaving the file in place used to disable it. Discovery finds the file, so it
+  starts running on the next boot. Delete the file, or keep the explicit list.
+- **Anything in those directories that is not a declaration.** Finding the
+  classes means importing the files — a class does not exist until its module has
+  run — so a helper sitting in `app/cron` that opens a connection or seeds a
+  cache at the top level now does that at boot, on every start. Move it out, or
+  keep the explicit list and skip the walk.
+
+The walk itself skips `.d.ts` files, tests and benchmarks by their filename
+suffix, dot-directories, `node_modules`, and anything under a directory with its
+own `package.json`. Nothing else is guessed at, so a file it cannot import fails
+the boot naming itself rather than being quietly left out.
+
+Both directories are covered in [docs/cron.md](./docs/cron.md) and
+[docs/jobs-and-queues.md](./docs/jobs-and-queues.md).
 
 ---
 

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -203,6 +203,12 @@ export class SubscriptionAudit extends CronJob {
 
 Both are scheduled. Neither is mentioned anywhere else.
 
+### Two jobs, one name
+
+`name` is the scheduler's key, so only one job can hold it. If two claim the same one, the first is scheduled and the second is refused with both class names on stderr — a directory walk makes this easy to write by accident, since `billing/DailyReport.ts` and `analytics/DailyReport.ts` never have to appear side by side the way two entries in a list would.
+
+Both still appear in `scheduler.jobs`, which reports what the scheduler was handed rather than what it accepted, so a test walking the schedule sees the clash instead of a tidied-up set.
+
 ### What the walk costs
 
 A class does not exist until its module has run, so there is no way to read a directory of classes without importing it. **Every `.ts`/`.tsx` file under `app/cron` is imported at boot** — in development and in production, on every start — and a file that *does something* when it is imported does that thing at boot. A module that opens a connection, seeds a cache, or registers a listener at the top level is doing it before the first request, from a directory nobody thought of as an entry point.

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,6 +1,6 @@
 # Cron
 
-Cron jobs run code on a recurring schedule — nightly reports, hourly cleanups, periodic audits — without any incoming request. You define each one as a class extending `CronJob` (from `gemi/services`) and list it in `app/config/schedule.ts`. gemi schedules them in-process using `Bun.cron`.
+Cron jobs run code on a recurring schedule — nightly reports, hourly cleanups, periodic audits — without any incoming request. You define each one as a class extending `CronJob` (from `gemi/services`) in a file under `app/cron/`, and gemi schedules it in-process using `Bun.cron`. Nothing else is needed — the directory is read at boot.
 
 ## Defining a cron job
 
@@ -22,15 +22,7 @@ export class DailyDigest extends CronJob {
 }
 ```
 
-```typescript
-// app/config/schedule.ts
-import { defineScheduleConfig } from "gemi/services";
-import { DailyDigest } from "@/app/cron/DailyDigest";
-
-export default defineScheduleConfig({
-  jobs: [DailyDigest],
-});
-```
+That file is the whole registration — there is no list to add it to. **Registering jobs**, below, covers how the directory is read and how to take registration over yourself.
 
 Fields and hooks on `CronJob`:
 
@@ -38,11 +30,12 @@ Fields and hooks on `CronJob`:
 | --- | --- | --- |
 | `name` | `string` | Unique job name. Required — a job without a name is skipped with an error. Also used as the registry key so a hot reload updates the job in place instead of stacking duplicates. |
 | `cron` | `CronExpression` | The schedule. Required — a job without an expression is skipped. |
+| `shouldRun()` | `() => boolean \| Promise<boolean>` | Optional gate, evaluated once per tick before anything else. Returns `true` by default; returning `false` skips the whole tick — `onTick()`, `callback()` and `onComplete()` alike. See **Skipping a tick**, below. |
 | `callback()` | `() => void \| Promise<void>` | The work to run on each tick. |
-| `onTick()` | `() => void \| Promise<void>` | Optional hook run alongside each tick. |
-| `onComplete()` | `() => void \| Promise<void>` | Optional hook run when the tick's work completes. |
+| `onTick()` | `() => void \| Promise<void>` | Optional hook run immediately before `callback()` — sequentially, not alongside it. |
+| `onComplete()` | `() => void \| Promise<void>` | Optional hook run after `callback()` finishes, whether it returned or threw. |
 
-Each tick re-enters the application context, so a job body resolves services exactly like a request handler does — `prisma`, `Email`, the `Storage`/`Log`/`Lang` facades, `Job.dispatch`, or anything you resolve yourself with `app(SomeService)`. Scheduling happens in `ScheduleServiceProvider.boot()`, which runs after every provider has registered, so any binding the container holds is available by the time a job first ticks. Errors thrown in `callback`, `onTick`, or `onComplete` are caught and logged rather than crashing the scheduler.
+Each tick re-enters the application context, so a job body resolves services exactly like a request handler does — `prisma`, `Email`, the `Storage`/`Log`/`Lang` facades, `Job.dispatch`, or anything you resolve yourself with `app(SomeService)`. Scheduling happens in `ScheduleServiceProvider.boot()`, which runs after every provider has registered, so any binding the container holds is available by the time a job first ticks. Errors thrown in `shouldRun`, `onTick`, `callback`, or `onComplete` are caught and logged rather than crashing the scheduler — with one difference: a `shouldRun` that throws also skips the tick, while the other three log and carry on to the next hook.
 
 ## Schedule expressions — `CronJob.exp(...)`
 
@@ -89,9 +82,96 @@ cron = CronJob.exp("@hourly");
 
 > **Note:** Only the nicknames above and standard 5-field expressions are valid — they are handled by `Bun.cron`. Extended shortcuts you may see in older gemi apps (e.g. `@at_9:00`, `@every_5_minutes`, `@on_monday`, `@between_9_17`) came from gemi's previous custom cron engine and are **not** understood by the current `Bun.cron`-based scheduler. Translate them to standard expressions — for example `@at_9:00` becomes `"0 9 * * *"` (09:00 UTC), and `@every_5_minutes` becomes `"*/5 * * * *"`.
 
-## Registering jobs — `app/config/schedule.ts`
+## Skipping a tick — `shouldRun()`
 
-List every cron job class in the `schedule` config slice. The framework's `ScheduleServiceProvider` reads that slice, binds a `Scheduler` into the container, and schedules the jobs when the kernel boots.
+`shouldRun()` decides whether a tick happens at all. It is evaluated once per tick, before anything else, and returning `false` skips `onTick()`, `callback()` and `onComplete()` alike. The default returns `true`, so a job that says nothing about it behaves exactly as it always did.
+
+```typescript
+// app/cron/StorageAlert.ts
+import { CronJob } from "gemi/services";
+
+export class StorageAlert extends CronJob {
+  name = "StorageAlert";
+  cron = CronJob.exp("0 9 * * *");
+
+  shouldRun() {
+    return process.env.NODE_ENV === "production";
+  }
+
+  async callback() {
+    // ...check remaining capacity and page whoever is on call...
+  }
+}
+```
+
+The reason this is a member rather than a line at the top of `callback` is that `onTick` and `onComplete` are called *outside* `callback`, so a guard written inside `callback` only stops the work. A job that reports outward — mails a digest, opens a Sentry issue, pings a channel — usually announces itself in `onTick` and `onComplete`, and those would still fire from a laptop. `shouldRun()` is the one place that covers a whole tick.
+
+**It gates work, not registration.** A job whose gate returns `false` is still scheduled, still holds its `Bun.cron` handle, and still appears in `scheduler.jobs`. "Is it scheduled" and "will it do anything" are different questions, and the second is answered fresh on every tick — which is also why this is a method. A field would be read once, when the scheduler constructs the job at boot, and would freeze whatever it saw then.
+
+**A gate that throws skips the tick**, and the error is logged. A gate that failed has said nothing about whether the job may run, and the two wrong answers are not the same size: a skipped tick of recurring work comes back on the next tick, an email sent from the wrong machine does not come back at all.
+
+**Nothing calls `super` for you.** Writing the gate once on a base class that several jobs share is the ordinary case, and a subclass that overrides `shouldRun()` for a reason of its own silently drops whatever the base was gating on. Narrow rather than redefine:
+
+```typescript
+// app/support/AlertingCronJob.ts
+import { CronJob } from "gemi/services";
+
+export abstract class AlertingCronJob extends CronJob {
+  shouldRun(): boolean | Promise<boolean> {
+    return process.env.NODE_ENV === "production";
+  }
+}
+```
+
+> **Keep a shared base out of `app/cron`.** `abstract` is a TypeScript idea and is gone by the time the scheduler runs, so a base class sitting in the discovered directory is a class extending `CronJob` like any other: it is found, constructed, and — having no `name` — rejected on every boot with `Cron job must have a name`. It also lands in `scheduler.jobs`, which breaks the very assertion **Asking what is scheduled**, below, suggests writing. Any directory outside the walk will do — the template ships no particular home for this, and `app/support/` is just what these snippets picked.
+
+Annotate the return type on a shared base rather than letting it be inferred. A base that returns a plain `boolean` narrows the signature its subclasses inherit, and a subclass that needs to `await super.shouldRun()` has to be `async` — which TypeScript then rejects against the narrowed base. Writing the type `CronJob` declares keeps both spellings open.
+
+```typescript
+// app/cron/WeeklyRevenue.ts
+import { AlertingCronJob } from "@/app/support/AlertingCronJob";
+import { CronJob } from "gemi/services";
+
+export class WeeklyRevenue extends AlertingCronJob {
+  name = "WeeklyRevenue";
+  cron = CronJob.exp("0 8 * * 1");
+
+  async shouldRun() {
+    return (await super.shouldRun()) && (await this.hasSubscribers());
+  }
+
+  async hasSubscribers() {
+    // ...
+    return true;
+  }
+
+  async callback() {
+    // ...build and send the report...
+  }
+}
+```
+
+Note what the subclass keeps: `callback`, the name the rest of this page teaches. Holding only the gate is all the base class is for. Without `shouldRun()`, the only base class that could gate a job was one that shadowed `callback` itself:
+
+```typescript
+// the shape this replaces — don't write it
+export abstract class GatedCronJob extends CronJob {
+  abstract run(): Promise<void>;
+
+  async callback() {
+    if (process.env.NODE_ENV !== "production") return;
+    await this.run();
+  }
+}
+```
+
+That works, and it costs the app the framework's own vocabulary: a job under it reads `async run()` while every page of this documentation reads `async callback()`. The next person to follow the docs writes a `callback`, the base class overrides it, and the job silently does nothing — no error, no output, nothing to notice. It also never reached `onTick` and `onComplete`, which the scheduler calls outside `callback`.
+
+## Registering jobs — `app/cron/`
+
+Cron jobs are discovered. Every class under `app/cron` that extends `CronJob` is scheduled when the kernel boots, so writing the file is all it takes — there is no list to keep in step with it.
+
+That is deliberate, and it is about the failure that happens when the two disagree. A cron job that is written and never listed fires never, and unlike a dropped request there is nothing downstream waiting to notice: the report simply stops arriving, for as long as it takes somebody to ask why they stopped seeing it.
 
 ```typescript
 // app/cron/ProductCreationReport.ts
@@ -121,6 +201,24 @@ export class SubscriptionAudit extends CronJob {
 }
 ```
 
+Both are scheduled. Neither is mentioned anywhere else.
+
+### What the walk costs
+
+A class does not exist until its module has run, so there is no way to read a directory of classes without importing it. **Every `.ts`/`.tsx` file under `app/cron` is imported at boot** — in development and in production, on every start — and a file that *does something* when it is imported does that thing at boot. A module that opens a connection, seeds a cache, or registers a listener at the top level is doing it before the first request, from a directory nobody thought of as an entry point.
+
+So `app/cron` wants to hold cron declarations rather than merely contain some. Keep a helper that runs work on import somewhere else, or list the jobs explicitly (below) and skip the walk entirely. A file that cannot be imported at all — one reaching a `?raw` or `.css` specifier through its imports, say — fails the boot naming itself, rather than being quietly left out of the schedule.
+
+The walk takes every class that extends `CronJob`, and `abstract` does not survive to runtime — so a shared base class belongs outside this directory too. See **Skipping a tick**, above, where that is the pattern most likely to tempt you into writing one.
+
+The walk skips what certainly is not a declaration: `.d.ts` files, tests, type tests and benchmarks by their filename suffix, dot-directories, `node_modules`, and anything under a directory carrying its own `package.json`. Nothing else is guessed at.
+
+A new file is picked up on the next server reload — under `gemi dev`, creating a file does not by itself trigger one, so save any other file (or restart) if a job you just wrote has not appeared.
+
+### Listing them explicitly — `app/config/schedule.ts`
+
+Declaring `jobs` in the `schedule` config slice turns discovery off and uses your list verbatim. Reach for it when the jobs live somewhere the walk cannot reach, when you want a deliberate subset, or when the deploy ships only the build output and there is no `app/cron` on disk to read.
+
 ```typescript
 // app/config/schedule.ts
 import { defineScheduleConfig } from "gemi/services";
@@ -132,7 +230,9 @@ export default defineScheduleConfig({
 });
 ```
 
-`defineScheduleConfig` is an identity helper — it exists only to type the object. The slice's only field is `jobs`, an array of `CronJob` subclasses.
+`defineScheduleConfig` is an identity helper — it exists only to type the object.
+
+**A present `jobs` wins, and `jobs: []` is present.** An empty array means an application with nothing scheduled and is honoured as such; it does not mean "go and find some". Leaving the key out — or leaving the slice out entirely — is what asks for discovery.
 
 The file is wired into the kernel by name:
 
@@ -146,13 +246,14 @@ export default class extends Kernel {
 }
 ```
 
-| Config key | Field | Type | Default |
-| --- | --- | --- | --- |
-| `schedule` | `jobs` | `(new () => CronJob)[]` | `[]` |
+| Config key | Field | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `schedule` | `jobs` | `(new () => CronJob)[]` | *discovered* | The scheduled job classes. Omit to discover them from `jobsDir`. |
+| `schedule` | `jobsDir` | `string` | `"app/cron"` | Where to discover them. Relative to the project root, or absolute. |
 
 See [Project Structure](./project-structure.md) for the full kernel layout.
 
-> **Coming from Laravel:** the vocabulary is the same — a `ServiceProvider` registers bindings into the `Container`, config lives in `app/config`, and facades are static proxies to container-resolved services. One thing is deliberately different: gemi has no `Schedule::command(...)` macro called from a provider's `boot()`. Recurring work is declared as `CronJob` classes in the `schedule` slice, and per-subsystem hooks (`filterRecipients`, `onLogCreated`, `detectLocale`, ...) are **config callbacks** in `app/config/*.ts` rather than things you register from `boot()`. `boot()` is for wiring you cannot express as data.
+> **Coming from Laravel:** the vocabulary is the same — a `ServiceProvider` registers bindings into the `Container`, config lives in `app/config`, and facades are static proxies to container-resolved services. One thing is deliberately different: gemi has no `Schedule::command(...)` macro called from a provider's `boot()`. Recurring work is declared as `CronJob` classes under `app/cron`, and per-subsystem hooks (`filterRecipients`, `onLogCreated`, `detectLocale`, ...) are **config callbacks** in `app/config/*.ts` rather than things you register from `boot()`. `boot()` is for wiring you cannot express as data.
 
 ### Resolving the scheduler
 
@@ -163,6 +264,28 @@ import { app } from "gemi/foundation";
 import { Scheduler } from "gemi/services";
 
 app(Scheduler); // typed Scheduler, no cast
+```
+
+### Asking what is scheduled
+
+`scheduler.jobs` is the set the scheduler took — discovered or declared, whichever the slice asked for. Reach for it in a test that wants to assert something about the whole schedule (that every report has an owner, that no two share an expression), which used to be written by importing the `jobs` array from the config module:
+
+```typescript
+import { app } from "gemi/foundation";
+import { Scheduler } from "gemi/services";
+
+for (const Job of app(Scheduler).jobs) {
+  const job = new Job();
+  expect(job.name).toBeTruthy();
+}
+```
+
+`discoverCronJobs()` answers the same question without an application around it — it walks `app/cron` (or a directory you name) and returns the classes it finds. `discoverJobs()` is its counterpart for the queue. Both import every file they walk, so calling one runs the app's cron modules the same way boot does.
+
+```typescript
+import { discoverCronJobs } from "gemi/services";
+
+const jobs = await discoverCronJobs(); // every CronJob subclass under app/cron
 ```
 
 > **Note:** Cron jobs run **in-process** in the server. Every running server instance registers and fires its own schedule, so if you run multiple replicas, a job scheduled `@daily` fires once per replica per day. For work that must run exactly once across a fleet, add your own coordination (e.g. an advisory lock) inside `callback`.

--- a/docs/jobs-and-queues.md
+++ b/docs/jobs-and-queues.md
@@ -28,6 +28,8 @@ export class ProcessVideoJob extends Job {
 ```
 
 > **Note:** The static `name` is **required** — jobs are enqueued and dispatched to workers by this name, and dispatching a job whose `name` is still the default (`"unset"`) throws. Give every job a unique static `name`.
+>
+> Omitting it does not fall back harmlessly to the class name, and under discovery it fails in production only. `gemi build` minifies the server entry, and the app code reachable from it — a controller, and every job class it imports to dispatch — is bundled and minified with it. That renames the class binding, and a class's implicit `.name` *is* that binding, so `TestJob` becomes something like `D` in the bundle. Discovery reads `app/jobs/TestJob.ts` from source at runtime, where it is still `TestJob`, and the two halves stop agreeing. A declared `static name` is a string literal, which survives minification intact. Discovery warns at boot about any job that leaves it out.
 
 ### Lifecycle hooks
 
@@ -74,6 +76,14 @@ ProcessVideoJob.dispatch({ videoId: video.id });
 Jobs are discovered. Every class under `app/jobs` that extends `Job` is registered when the kernel boots, so writing the file is all it takes — there is no list to keep in step with it.
 
 That is deliberate, and it is about the failure that happens when the two disagree. The queue looks a dispatched job up by name; a name it has never heard of is dropped with a line on stderr and nothing else. `Job.dispatch` has already returned by then — it returns as soon as the job is queued, not when it runs — so the dispatch simply does not happen, whatever was supposed to follow it does not either, and the only trace is in the server log.
+
+### Two jobs, one class name
+
+The queue's key is the **class name**, and that is also what a dispatch carries — so two `Job` subclasses called `SendEmail` cannot both be registered. The first is, the second is refused with a line on stderr, and `Job.dispatch` on either resolves to the first.
+
+Worth spelling out because the failure it replaces was the worst one in this subsystem: the registry used to keep whichever came last, silently, so `SendEmail.dispatch(...)` written against `app/jobs/auth/SendEmail.ts` would run the body of `app/jobs/billing/SendEmail.ts`. Nothing was dropped and nothing errored — the wrong work happened and reported success. A hand-written list forced an import alias the moment two names clashed; a directory walk does not, so `auth/SendEmail.ts` beside `billing/SendEmail.ts` is an entirely ordinary thing to write. Rename one.
+
+Both still appear in `registeredJobs`, which reports what the manager was handed rather than what the registry accepted, so a test walking it sees the clash.
 
 ### What the walk costs
 

--- a/docs/jobs-and-queues.md
+++ b/docs/jobs-and-queues.md
@@ -2,7 +2,7 @@
 
 Jobs move slow or non-essential work off the request path. Instead of making a user wait while you call an external API, generate an image, or send a batch of emails, you dispatch a **Job** — it runs in the background through gemi's in-process queue, and the request returns immediately.
 
-You define jobs as classes extending `Job` (from `gemi/services`), list them in `app/config/queue.ts`, and fire them with `Job.dispatch(...)`.
+You define jobs as classes extending `Job` (from `gemi/services`) in files under `app/jobs/`, and fire them with `Job.dispatch(...)`. The directory is read at boot, so there is no list to keep alongside it.
 
 ## Defining a job
 
@@ -69,9 +69,25 @@ ProcessVideoJob.dispatch({ videoId: video.id });
 
 `dispatch` enqueues the job and returns `void` (fire-and-forget) — it does not wait for the job to finish, and the payload is serialized as JSON, so pass plain, serializable data (not class instances or functions). See [Controllers](./controllers.md) for dispatching from request handlers.
 
-## Registering jobs — `app/config/queue.ts`
+## Registering jobs — `app/jobs/`
 
-Every job class must be listed in the `queue` config slice so the queue knows how to construct it by name. You also set the worker `concurrency` here.
+Jobs are discovered. Every class under `app/jobs` that extends `Job` is registered when the kernel boots, so writing the file is all it takes — there is no list to keep in step with it.
+
+That is deliberate, and it is about the failure that happens when the two disagree. The queue looks a dispatched job up by name; a name it has never heard of is dropped with a line on stderr and nothing else. `Job.dispatch` has already returned by then — it returns as soon as the job is queued, not when it runs — so the dispatch simply does not happen, whatever was supposed to follow it does not either, and the only trace is in the server log.
+
+### What the walk costs
+
+A class does not exist until its module has run, so there is no way to read a directory of classes without importing it. **Every `.ts`/`.tsx` file under `app/jobs` is imported at boot** — in development and in production, on every start — and a file that *does something* when it is imported does that thing at boot. A module that opens a connection, seeds a cache, or registers a listener at the top level is doing it before the first request, from a directory nobody thought of as an entry point.
+
+So `app/jobs` wants to hold job declarations rather than merely contain some. Keep a helper that runs work on import somewhere else, or list the jobs explicitly (below) and skip the walk entirely. A file that cannot be imported at all — one reaching a `?raw` or `.css` specifier through its imports, say — fails the boot naming itself, rather than being quietly left out of the registry.
+
+The walk skips what certainly is not a declaration: `.d.ts` files, tests, type tests and benchmarks by their filename suffix, dot-directories, `node_modules`, and anything under a directory carrying its own `package.json`. Nothing else is guessed at.
+
+A new file is picked up on the next server reload — under `gemi dev`, creating a file does not by itself trigger one, so save any other file (or restart) if a job you just wrote has not appeared.
+
+### Configuring the queue — `app/config/queue.ts`
+
+The `queue` slice is where `concurrency` lives, and where you can take over registration yourself. Declaring `jobs` turns discovery off and uses your list verbatim — reach for it when the jobs live somewhere the walk cannot reach, when you want a deliberate subset, or when the deploy ships only the build output and there is no `app/jobs` on disk to read.
 
 ```typescript
 // app/config/queue.ts
@@ -80,15 +96,18 @@ import { ProcessVideoJob } from "@/app/jobs/ProcessVideoJob";
 
 export default defineQueueConfig({
   concurrency: 20, // max jobs running at once (default 1)
-  jobs: [ProcessVideoJob],
+  jobs: [ProcessVideoJob], // omit to discover them from app/jobs
 });
 ```
 
 `defineQueueConfig` is an identity helper — it exists only to type the object.
 
+**A present `jobs` wins, and `jobs: []` is present.** An empty array means an application with no jobs and is honoured as such; it does not mean "go and find some". Leaving the key out — or leaving the slice out entirely — is what asks for discovery.
+
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `jobs` | `(new () => Job)[]` | `[]` | All dispatchable job classes. A job not listed here cannot be dispatched. |
+| `jobs` | `(new () => Job)[]` | *discovered* | All dispatchable job classes. Omit to discover them from `jobsDir`. A job that reaches neither is dispatched into nothing. |
+| `jobsDir` | `string` | `"app/jobs"` | Where to discover them. Relative to the project root, or absolute. |
 | `concurrency` | `number` | `1` | Maximum number of jobs processed simultaneously. |
 
 The slice is wired into the kernel by name:
@@ -103,7 +122,7 @@ export default class extends Kernel {
 }
 ```
 
-Behind the scenes the framework's `QueueServiceProvider` reads that slice in its `register()` and binds a `QueueManager` singleton into the container under the token `"queue"`. You never construct or reference the provider yourself — providers register bindings, config configures them.
+Behind the scenes the framework's `QueueServiceProvider` reads that slice in its `register()` and binds a `QueueManager` singleton into the container under the token `"queue"`, then fills in the discovered jobs in its `boot()`. You never construct or reference the provider yourself — providers register bindings, config configures them.
 
 ### Resolving the queue
 
@@ -114,6 +133,25 @@ import { app } from "gemi/foundation";
 import { QueueManager } from "gemi/services";
 
 app(QueueManager); // typed QueueManager, no cast
+```
+
+`registeredJobs` is the set it ended up with, discovered or declared. That is what a test asserts against now — an app that used to import the `jobs` array from its config module to check something about every job it dispatches asks the manager instead:
+
+```typescript
+import { app } from "gemi/foundation";
+import { QueueManager } from "gemi/services";
+
+for (const Registered of app(QueueManager).registeredJobs) {
+  expect(new Registered().maxAttempts).toBeGreaterThan(0);
+}
+```
+
+`discoverJobs()` answers the same question without an application around it — it walks `app/jobs` (or a directory you name) and returns the classes it finds. Every file it walks is imported, as above:
+
+```typescript
+import { discoverJobs } from "gemi/services";
+
+const jobs = await discoverJobs(); // every Job subclass under app/jobs
 ```
 
 See [Project Structure](./project-structure.md) for the full kernel layout.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -268,7 +268,8 @@ app/
     requests/            # HttpRequest subclasses used for validation
   views/                 # React views (.tsx), layouts, and the RootLayout
   email/                 # email templates (jsx-email)
-  cron/                  # CronJob classes
+  cron/                  # CronJob classes — scheduled by being here
+  jobs/                  # Job classes — registered by being here
   i18n/                  # translation dictionaries
   database/
     prisma.ts            # the Prisma client instance
@@ -316,6 +317,12 @@ If present, `app/preload.ts` runs once, before the server starts, for both `gemi
 - **`email/`** — email templates built with `jsx-email`, extending `Email` from `gemi/email`.
 - **`i18n/`** — translation dictionaries created with `Dictionary.create` from `gemi/i18n`, exported as a single default object.
 - **`database/prisma.ts`** — your Prisma client instance, imported wherever you query the database.
+
+### `cron/` and `jobs/` — the two discovered directories
+
+These two directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, and every class under `app/jobs` extending `Job` is registered at boot, with nothing anywhere naming them — writing the file is the registration. The `schedule` and `queue` slices can still declare `jobs` explicitly, which turns the walk off and uses the declared list verbatim; `jobs: []` is a declaration too, and means an app with none.
+
+Discovery imports every `.ts`/`.tsx` file it walks, because a class does not exist until its module has run — so a file in either directory that does work when imported does that work at boot. Keep them to declarations. See [Cron](./cron.md) and [Jobs & Queues](./jobs-and-queues.md) for the walk's skip rules and the reasons for reading a directory at all.
 
 ## The Kernel
 
@@ -547,7 +554,7 @@ The hooks are ordinary config values, so a service reads them the same way it re
 | `log` | `onLogCreated`, `onLogFileClosed` |
 | `translation` | `detectLocale`, `onLocaleChange` |
 | `route.api` | `onRequestStart`, `onRequestEnd`, `onRequestFail` |
-| `route.view` | `onRequestStart`, `onRequestEnd`, `onRequestFail` |
+| `route.view` | `onRequestStart`, `onRequestEnd`, `onRequestFail`, `onStreamComplete` |
 
 Request lifecycle hooks are the usual place for tracing and error reporting:
 
@@ -644,6 +651,49 @@ The boot is split in two because `new App({ kernel })` is a synchronous construc
 2. **`kernel.waitForBoot()` — asynchronous.** Runs every provider's `boot()` in registration order. Idempotent.
 
 `new App({ kernel })` performs phase one for you; `Server.start()` awaits phase two before binding the port. If you drive `App` yourself, `await app.waitForBoot()` before serving.
+
+### Instrumenting streamed responses
+
+View responses stream: the handler returns at time-to-shell while query payloads keep streaming for as long as the slowest query takes. A span that ends when the handler returns (or in a `finally` around `app.fetch`) therefore records ~milliseconds for a request whose body stayed open for a second — the duration of the shell, not the response.
+
+The `route.view` slice's `onStreamComplete(req, summary)` hook fires when the response body actually closes — after the last streamed chunk, or when the stream deadline aborts rendering. The `summary` reports:
+
+- **`shellAt`** — ms from request start to the response's first byte.
+- **`settledAt`** — ms to the last chunk, when the body closed.
+- **`aborted`** — whether the stream deadline cut rendering short.
+- **`queries`** — per-query `path`, `variantKey`, `startedAt`, `settledAt`, `status`, and `source` (`"prefetch"` or `"render"`).
+
+Non-streamed responses (`.json` navigation payloads, `"no-stream"` routes, bot requests) report `shellAt === settledAt`. The hook also fires when a shell render crashes (or the deadline aborts it before the shell resolved) — the fallback error document's body still closes, so the span still ends.
+
+> **Scope:** `onStreamComplete` fires for document and `.json` navigation bodies — the responses that stream. Responses without a query lifecycle (OG images, `FILE` routes, redirects and error responses produced by `RequestBreakerError`) do not fire it, so a span opened unconditionally in instrumentation needs a fallback end (e.g. also ending it in `onRequestEnd` / `onRequestFail` when no stream ever started).
+
+Start the span where you already do, and end it here instead:
+
+```typescript
+// app/config/route.ts
+import { defineRouteConfig } from "gemi/services";
+import type { StreamSummary } from "gemi/services";
+import type { HttpRequest } from "gemi/http";
+
+export default defineRouteConfig({
+  api: { rootRouter: RootApiRouter },
+  view: {
+    rootRouter: RootViewRouter,
+    root: createRoot(RootLayout),
+
+    onStreamComplete(req: HttpRequest, summary: StreamSummary) {
+      // e.g. end the Sentry span opened for this request:
+      // span.setAttribute("gemi.shell_ms", summary.shellAt);
+      // span.setAttribute("gemi.aborted", summary.aborted);
+      // span.end(); // now measures the full streamed response
+    },
+  },
+});
+```
+
+Query failures during the streamed render are routed through `onRequestFail(req, error)` exactly once per rejected query, with a `QueryError` carrying the query's path, variant, and status — so error tracking wired to `onRequestFail` keeps seeing server-side failures that React quietly hands over to client rendering. (`Query.instant` rethrows into the handler; that rejection is still reported only once.) An api handler that fails with a `RequestBreakerError` (or an error `Response`) yields a `QueryError` with that response's status; a raw `throw` inside the handler yields a status-500 `QueryError` with the original error on `cause`.
+
+> **Gotcha:** a raw `throw` inside an api handler also fires the **api** slice's `onRequestFail` — the query runs the api handler in-process, and the api router reports its own failures. If both slices report to the same error tracker, dedupe there (the view hook's error is the `QueryError` wrapper, the api hook's is the original error on its `cause`).
 
 ## App bootstrap
 
@@ -6482,7 +6532,7 @@ You can also set default `attachments` on the class if every send should carry t
 
 Jobs move slow or non-essential work off the request path. Instead of making a user wait while you call an external API, generate an image, or send a batch of emails, you dispatch a **Job** — it runs in the background through gemi's in-process queue, and the request returns immediately.
 
-You define jobs as classes extending `Job` (from `gemi/services`), list them in `app/config/queue.ts`, and fire them with `Job.dispatch(...)`.
+You define jobs as classes extending `Job` (from `gemi/services`) in files under `app/jobs/`, and fire them with `Job.dispatch(...)`. The directory is read at boot, so there is no list to keep alongside it.
 
 ## Defining a job
 
@@ -6549,9 +6599,25 @@ ProcessVideoJob.dispatch({ videoId: video.id });
 
 `dispatch` enqueues the job and returns `void` (fire-and-forget) — it does not wait for the job to finish, and the payload is serialized as JSON, so pass plain, serializable data (not class instances or functions). See [Controllers](./controllers.md) for dispatching from request handlers.
 
-## Registering jobs — `app/config/queue.ts`
+## Registering jobs — `app/jobs/`
 
-Every job class must be listed in the `queue` config slice so the queue knows how to construct it by name. You also set the worker `concurrency` here.
+Jobs are discovered. Every class under `app/jobs` that extends `Job` is registered when the kernel boots, so writing the file is all it takes — there is no list to keep in step with it.
+
+That is deliberate, and it is about the failure that happens when the two disagree. The queue looks a dispatched job up by name; a name it has never heard of is dropped with a line on stderr and nothing else. `Job.dispatch` has already returned by then — it returns as soon as the job is queued, not when it runs — so the dispatch simply does not happen, whatever was supposed to follow it does not either, and the only trace is in the server log.
+
+### What the walk costs
+
+A class does not exist until its module has run, so there is no way to read a directory of classes without importing it. **Every `.ts`/`.tsx` file under `app/jobs` is imported at boot** — in development and in production, on every start — and a file that *does something* when it is imported does that thing at boot. A module that opens a connection, seeds a cache, or registers a listener at the top level is doing it before the first request, from a directory nobody thought of as an entry point.
+
+So `app/jobs` wants to hold job declarations rather than merely contain some. Keep a helper that runs work on import somewhere else, or list the jobs explicitly (below) and skip the walk entirely. A file that cannot be imported at all — one reaching a `?raw` or `.css` specifier through its imports, say — fails the boot naming itself, rather than being quietly left out of the registry.
+
+The walk skips what certainly is not a declaration: `.d.ts` files, tests, type tests and benchmarks by their filename suffix, dot-directories, `node_modules`, and anything under a directory carrying its own `package.json`. Nothing else is guessed at.
+
+A new file is picked up on the next server reload — under `gemi dev`, creating a file does not by itself trigger one, so save any other file (or restart) if a job you just wrote has not appeared.
+
+### Configuring the queue — `app/config/queue.ts`
+
+The `queue` slice is where `concurrency` lives, and where you can take over registration yourself. Declaring `jobs` turns discovery off and uses your list verbatim — reach for it when the jobs live somewhere the walk cannot reach, when you want a deliberate subset, or when the deploy ships only the build output and there is no `app/jobs` on disk to read.
 
 ```typescript
 // app/config/queue.ts
@@ -6560,15 +6626,18 @@ import { ProcessVideoJob } from "@/app/jobs/ProcessVideoJob";
 
 export default defineQueueConfig({
   concurrency: 20, // max jobs running at once (default 1)
-  jobs: [ProcessVideoJob],
+  jobs: [ProcessVideoJob], // omit to discover them from app/jobs
 });
 ```
 
 `defineQueueConfig` is an identity helper — it exists only to type the object.
 
+**A present `jobs` wins, and `jobs: []` is present.** An empty array means an application with no jobs and is honoured as such; it does not mean "go and find some". Leaving the key out — or leaving the slice out entirely — is what asks for discovery.
+
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `jobs` | `(new () => Job)[]` | `[]` | All dispatchable job classes. A job not listed here cannot be dispatched. |
+| `jobs` | `(new () => Job)[]` | *discovered* | All dispatchable job classes. Omit to discover them from `jobsDir`. A job that reaches neither is dispatched into nothing. |
+| `jobsDir` | `string` | `"app/jobs"` | Where to discover them. Relative to the project root, or absolute. |
 | `concurrency` | `number` | `1` | Maximum number of jobs processed simultaneously. |
 
 The slice is wired into the kernel by name:
@@ -6583,7 +6652,7 @@ export default class extends Kernel {
 }
 ```
 
-Behind the scenes the framework's `QueueServiceProvider` reads that slice in its `register()` and binds a `QueueManager` singleton into the container under the token `"queue"`. You never construct or reference the provider yourself — providers register bindings, config configures them.
+Behind the scenes the framework's `QueueServiceProvider` reads that slice in its `register()` and binds a `QueueManager` singleton into the container under the token `"queue"`, then fills in the discovered jobs in its `boot()`. You never construct or reference the provider yourself — providers register bindings, config configures them.
 
 ### Resolving the queue
 
@@ -6594,6 +6663,25 @@ import { app } from "gemi/foundation";
 import { QueueManager } from "gemi/services";
 
 app(QueueManager); // typed QueueManager, no cast
+```
+
+`registeredJobs` is the set it ended up with, discovered or declared. That is what a test asserts against now — an app that used to import the `jobs` array from its config module to check something about every job it dispatches asks the manager instead:
+
+```typescript
+import { app } from "gemi/foundation";
+import { QueueManager } from "gemi/services";
+
+for (const Registered of app(QueueManager).registeredJobs) {
+  expect(new Registered().maxAttempts).toBeGreaterThan(0);
+}
+```
+
+`discoverJobs()` answers the same question without an application around it — it walks `app/jobs` (or a directory you name) and returns the classes it finds. Every file it walks is imported, as above:
+
+```typescript
+import { discoverJobs } from "gemi/services";
+
+const jobs = await discoverJobs(); // every Job subclass under app/jobs
 ```
 
 See [Project Structure](./project-structure.md) for the full kernel layout.
@@ -6624,7 +6712,7 @@ For work that must happen on a **schedule** (nightly reports, hourly cleanups) r
 
 ## Cron
 
-Cron jobs run code on a recurring schedule — nightly reports, hourly cleanups, periodic audits — without any incoming request. You define each one as a class extending `CronJob` (from `gemi/services`) and list it in `app/config/schedule.ts`. gemi schedules them in-process using `Bun.cron`.
+Cron jobs run code on a recurring schedule — nightly reports, hourly cleanups, periodic audits — without any incoming request. You define each one as a class extending `CronJob` (from `gemi/services`) in a file under `app/cron/`, and gemi schedules it in-process using `Bun.cron`. Nothing else is needed — the directory is read at boot.
 
 ## Defining a cron job
 
@@ -6646,15 +6734,7 @@ export class DailyDigest extends CronJob {
 }
 ```
 
-```typescript
-// app/config/schedule.ts
-import { defineScheduleConfig } from "gemi/services";
-import { DailyDigest } from "@/app/cron/DailyDigest";
-
-export default defineScheduleConfig({
-  jobs: [DailyDigest],
-});
-```
+That file is the whole registration — there is no list to add it to. **Registering jobs**, below, covers how the directory is read and how to take registration over yourself.
 
 Fields and hooks on `CronJob`:
 
@@ -6662,11 +6742,12 @@ Fields and hooks on `CronJob`:
 | --- | --- | --- |
 | `name` | `string` | Unique job name. Required — a job without a name is skipped with an error. Also used as the registry key so a hot reload updates the job in place instead of stacking duplicates. |
 | `cron` | `CronExpression` | The schedule. Required — a job without an expression is skipped. |
+| `shouldRun()` | `() => boolean \| Promise<boolean>` | Optional gate, evaluated once per tick before anything else. Returns `true` by default; returning `false` skips the whole tick — `onTick()`, `callback()` and `onComplete()` alike. See **Skipping a tick**, below. |
 | `callback()` | `() => void \| Promise<void>` | The work to run on each tick. |
-| `onTick()` | `() => void \| Promise<void>` | Optional hook run alongside each tick. |
-| `onComplete()` | `() => void \| Promise<void>` | Optional hook run when the tick's work completes. |
+| `onTick()` | `() => void \| Promise<void>` | Optional hook run immediately before `callback()` — sequentially, not alongside it. |
+| `onComplete()` | `() => void \| Promise<void>` | Optional hook run after `callback()` finishes, whether it returned or threw. |
 
-Each tick re-enters the application context, so a job body resolves services exactly like a request handler does — `prisma`, `Email`, the `Storage`/`Log`/`Lang` facades, `Job.dispatch`, or anything you resolve yourself with `app(SomeService)`. Scheduling happens in `ScheduleServiceProvider.boot()`, which runs after every provider has registered, so any binding the container holds is available by the time a job first ticks. Errors thrown in `callback`, `onTick`, or `onComplete` are caught and logged rather than crashing the scheduler.
+Each tick re-enters the application context, so a job body resolves services exactly like a request handler does — `prisma`, `Email`, the `Storage`/`Log`/`Lang` facades, `Job.dispatch`, or anything you resolve yourself with `app(SomeService)`. Scheduling happens in `ScheduleServiceProvider.boot()`, which runs after every provider has registered, so any binding the container holds is available by the time a job first ticks. Errors thrown in `shouldRun`, `onTick`, `callback`, or `onComplete` are caught and logged rather than crashing the scheduler — with one difference: a `shouldRun` that throws also skips the tick, while the other three log and carry on to the next hook.
 
 ## Schedule expressions — `CronJob.exp(...)`
 
@@ -6713,9 +6794,96 @@ cron = CronJob.exp("@hourly");
 
 > **Note:** Only the nicknames above and standard 5-field expressions are valid — they are handled by `Bun.cron`. Extended shortcuts you may see in older gemi apps (e.g. `@at_9:00`, `@every_5_minutes`, `@on_monday`, `@between_9_17`) came from gemi's previous custom cron engine and are **not** understood by the current `Bun.cron`-based scheduler. Translate them to standard expressions — for example `@at_9:00` becomes `"0 9 * * *"` (09:00 UTC), and `@every_5_minutes` becomes `"*/5 * * * *"`.
 
-## Registering jobs — `app/config/schedule.ts`
+## Skipping a tick — `shouldRun()`
 
-List every cron job class in the `schedule` config slice. The framework's `ScheduleServiceProvider` reads that slice, binds a `Scheduler` into the container, and schedules the jobs when the kernel boots.
+`shouldRun()` decides whether a tick happens at all. It is evaluated once per tick, before anything else, and returning `false` skips `onTick()`, `callback()` and `onComplete()` alike. The default returns `true`, so a job that says nothing about it behaves exactly as it always did.
+
+```typescript
+// app/cron/StorageAlert.ts
+import { CronJob } from "gemi/services";
+
+export class StorageAlert extends CronJob {
+  name = "StorageAlert";
+  cron = CronJob.exp("0 9 * * *");
+
+  shouldRun() {
+    return process.env.NODE_ENV === "production";
+  }
+
+  async callback() {
+    // ...check remaining capacity and page whoever is on call...
+  }
+}
+```
+
+The reason this is a member rather than a line at the top of `callback` is that `onTick` and `onComplete` are called *outside* `callback`, so a guard written inside `callback` only stops the work. A job that reports outward — mails a digest, opens a Sentry issue, pings a channel — usually announces itself in `onTick` and `onComplete`, and those would still fire from a laptop. `shouldRun()` is the one place that covers a whole tick.
+
+**It gates work, not registration.** A job whose gate returns `false` is still scheduled, still holds its `Bun.cron` handle, and still appears in `scheduler.jobs`. "Is it scheduled" and "will it do anything" are different questions, and the second is answered fresh on every tick — which is also why this is a method. A field would be read once, when the scheduler constructs the job at boot, and would freeze whatever it saw then.
+
+**A gate that throws skips the tick**, and the error is logged. A gate that failed has said nothing about whether the job may run, and the two wrong answers are not the same size: a skipped tick of recurring work comes back on the next tick, an email sent from the wrong machine does not come back at all.
+
+**Nothing calls `super` for you.** Writing the gate once on a base class that several jobs share is the ordinary case, and a subclass that overrides `shouldRun()` for a reason of its own silently drops whatever the base was gating on. Narrow rather than redefine:
+
+```typescript
+// app/support/AlertingCronJob.ts
+import { CronJob } from "gemi/services";
+
+export abstract class AlertingCronJob extends CronJob {
+  shouldRun(): boolean | Promise<boolean> {
+    return process.env.NODE_ENV === "production";
+  }
+}
+```
+
+> **Keep a shared base out of `app/cron`.** `abstract` is a TypeScript idea and is gone by the time the scheduler runs, so a base class sitting in the discovered directory is a class extending `CronJob` like any other: it is found, constructed, and — having no `name` — rejected on every boot with `Cron job must have a name`. It also lands in `scheduler.jobs`, which breaks the very assertion **Asking what is scheduled**, below, suggests writing. Any directory outside the walk will do — the template ships no particular home for this, and `app/support/` is just what these snippets picked.
+
+Annotate the return type on a shared base rather than letting it be inferred. A base that returns a plain `boolean` narrows the signature its subclasses inherit, and a subclass that needs to `await super.shouldRun()` has to be `async` — which TypeScript then rejects against the narrowed base. Writing the type `CronJob` declares keeps both spellings open.
+
+```typescript
+// app/cron/WeeklyRevenue.ts
+import { AlertingCronJob } from "@/app/support/AlertingCronJob";
+import { CronJob } from "gemi/services";
+
+export class WeeklyRevenue extends AlertingCronJob {
+  name = "WeeklyRevenue";
+  cron = CronJob.exp("0 8 * * 1");
+
+  async shouldRun() {
+    return (await super.shouldRun()) && (await this.hasSubscribers());
+  }
+
+  async hasSubscribers() {
+    // ...
+    return true;
+  }
+
+  async callback() {
+    // ...build and send the report...
+  }
+}
+```
+
+Note what the subclass keeps: `callback`, the name the rest of this page teaches. Holding only the gate is all the base class is for. Without `shouldRun()`, the only base class that could gate a job was one that shadowed `callback` itself:
+
+```typescript
+// the shape this replaces — don't write it
+export abstract class GatedCronJob extends CronJob {
+  abstract run(): Promise<void>;
+
+  async callback() {
+    if (process.env.NODE_ENV !== "production") return;
+    await this.run();
+  }
+}
+```
+
+That works, and it costs the app the framework's own vocabulary: a job under it reads `async run()` while every page of this documentation reads `async callback()`. The next person to follow the docs writes a `callback`, the base class overrides it, and the job silently does nothing — no error, no output, nothing to notice. It also never reached `onTick` and `onComplete`, which the scheduler calls outside `callback`.
+
+## Registering jobs — `app/cron/`
+
+Cron jobs are discovered. Every class under `app/cron` that extends `CronJob` is scheduled when the kernel boots, so writing the file is all it takes — there is no list to keep in step with it.
+
+That is deliberate, and it is about the failure that happens when the two disagree. A cron job that is written and never listed fires never, and unlike a dropped request there is nothing downstream waiting to notice: the report simply stops arriving, for as long as it takes somebody to ask why they stopped seeing it.
 
 ```typescript
 // app/cron/ProductCreationReport.ts
@@ -6745,6 +6913,24 @@ export class SubscriptionAudit extends CronJob {
 }
 ```
 
+Both are scheduled. Neither is mentioned anywhere else.
+
+### What the walk costs
+
+A class does not exist until its module has run, so there is no way to read a directory of classes without importing it. **Every `.ts`/`.tsx` file under `app/cron` is imported at boot** — in development and in production, on every start — and a file that *does something* when it is imported does that thing at boot. A module that opens a connection, seeds a cache, or registers a listener at the top level is doing it before the first request, from a directory nobody thought of as an entry point.
+
+So `app/cron` wants to hold cron declarations rather than merely contain some. Keep a helper that runs work on import somewhere else, or list the jobs explicitly (below) and skip the walk entirely. A file that cannot be imported at all — one reaching a `?raw` or `.css` specifier through its imports, say — fails the boot naming itself, rather than being quietly left out of the schedule.
+
+The walk takes every class that extends `CronJob`, and `abstract` does not survive to runtime — so a shared base class belongs outside this directory too. See **Skipping a tick**, above, where that is the pattern most likely to tempt you into writing one.
+
+The walk skips what certainly is not a declaration: `.d.ts` files, tests, type tests and benchmarks by their filename suffix, dot-directories, `node_modules`, and anything under a directory carrying its own `package.json`. Nothing else is guessed at.
+
+A new file is picked up on the next server reload — under `gemi dev`, creating a file does not by itself trigger one, so save any other file (or restart) if a job you just wrote has not appeared.
+
+### Listing them explicitly — `app/config/schedule.ts`
+
+Declaring `jobs` in the `schedule` config slice turns discovery off and uses your list verbatim. Reach for it when the jobs live somewhere the walk cannot reach, when you want a deliberate subset, or when the deploy ships only the build output and there is no `app/cron` on disk to read.
+
 ```typescript
 // app/config/schedule.ts
 import { defineScheduleConfig } from "gemi/services";
@@ -6756,7 +6942,9 @@ export default defineScheduleConfig({
 });
 ```
 
-`defineScheduleConfig` is an identity helper — it exists only to type the object. The slice's only field is `jobs`, an array of `CronJob` subclasses.
+`defineScheduleConfig` is an identity helper — it exists only to type the object.
+
+**A present `jobs` wins, and `jobs: []` is present.** An empty array means an application with nothing scheduled and is honoured as such; it does not mean "go and find some". Leaving the key out — or leaving the slice out entirely — is what asks for discovery.
 
 The file is wired into the kernel by name:
 
@@ -6770,13 +6958,14 @@ export default class extends Kernel {
 }
 ```
 
-| Config key | Field | Type | Default |
-| --- | --- | --- | --- |
-| `schedule` | `jobs` | `(new () => CronJob)[]` | `[]` |
+| Config key | Field | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `schedule` | `jobs` | `(new () => CronJob)[]` | *discovered* | The scheduled job classes. Omit to discover them from `jobsDir`. |
+| `schedule` | `jobsDir` | `string` | `"app/cron"` | Where to discover them. Relative to the project root, or absolute. |
 
 See [Project Structure](./project-structure.md) for the full kernel layout.
 
-> **Coming from Laravel:** the vocabulary is the same — a `ServiceProvider` registers bindings into the `Container`, config lives in `app/config`, and facades are static proxies to container-resolved services. One thing is deliberately different: gemi has no `Schedule::command(...)` macro called from a provider's `boot()`. Recurring work is declared as `CronJob` classes in the `schedule` slice, and per-subsystem hooks (`filterRecipients`, `onLogCreated`, `detectLocale`, ...) are **config callbacks** in `app/config/*.ts` rather than things you register from `boot()`. `boot()` is for wiring you cannot express as data.
+> **Coming from Laravel:** the vocabulary is the same — a `ServiceProvider` registers bindings into the `Container`, config lives in `app/config`, and facades are static proxies to container-resolved services. One thing is deliberately different: gemi has no `Schedule::command(...)` macro called from a provider's `boot()`. Recurring work is declared as `CronJob` classes under `app/cron`, and per-subsystem hooks (`filterRecipients`, `onLogCreated`, `detectLocale`, ...) are **config callbacks** in `app/config/*.ts` rather than things you register from `boot()`. `boot()` is for wiring you cannot express as data.
 
 ### Resolving the scheduler
 
@@ -6787,6 +6976,28 @@ import { app } from "gemi/foundation";
 import { Scheduler } from "gemi/services";
 
 app(Scheduler); // typed Scheduler, no cast
+```
+
+### Asking what is scheduled
+
+`scheduler.jobs` is the set the scheduler took — discovered or declared, whichever the slice asked for. Reach for it in a test that wants to assert something about the whole schedule (that every report has an owner, that no two share an expression), which used to be written by importing the `jobs` array from the config module:
+
+```typescript
+import { app } from "gemi/foundation";
+import { Scheduler } from "gemi/services";
+
+for (const Job of app(Scheduler).jobs) {
+  const job = new Job();
+  expect(job.name).toBeTruthy();
+}
+```
+
+`discoverCronJobs()` answers the same question without an application around it — it walks `app/cron` (or a directory you name) and returns the classes it finds. `discoverJobs()` is its counterpart for the queue. Both import every file they walk, so calling one runs the app's cron modules the same way boot does.
+
+```typescript
+import { discoverCronJobs } from "gemi/services";
+
+const jobs = await discoverCronJobs(); // every CronJob subclass under app/cron
 ```
 
 > **Note:** Cron jobs run **in-process** in the server. Every running server instance registers and fires its own schedule, so if you run multiple replicas, a job scheduled `@daily` fires once per replica per day. For work that must run exactly once across a fleet, add your own coordination (e.g. an advisory lock) inside `callback`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6558,6 +6558,8 @@ export class ProcessVideoJob extends Job {
 ```
 
 > **Note:** The static `name` is **required** — jobs are enqueued and dispatched to workers by this name, and dispatching a job whose `name` is still the default (`"unset"`) throws. Give every job a unique static `name`.
+>
+> Omitting it does not fall back harmlessly to the class name, and under discovery it fails in production only. `gemi build` minifies the server entry, and the app code reachable from it — a controller, and every job class it imports to dispatch — is bundled and minified with it. That renames the class binding, and a class's implicit `.name` *is* that binding, so `TestJob` becomes something like `D` in the bundle. Discovery reads `app/jobs/TestJob.ts` from source at runtime, where it is still `TestJob`, and the two halves stop agreeing. A declared `static name` is a string literal, which survives minification intact. Discovery warns at boot about any job that leaves it out.
 
 ### Lifecycle hooks
 
@@ -6604,6 +6606,14 @@ ProcessVideoJob.dispatch({ videoId: video.id });
 Jobs are discovered. Every class under `app/jobs` that extends `Job` is registered when the kernel boots, so writing the file is all it takes — there is no list to keep in step with it.
 
 That is deliberate, and it is about the failure that happens when the two disagree. The queue looks a dispatched job up by name; a name it has never heard of is dropped with a line on stderr and nothing else. `Job.dispatch` has already returned by then — it returns as soon as the job is queued, not when it runs — so the dispatch simply does not happen, whatever was supposed to follow it does not either, and the only trace is in the server log.
+
+### Two jobs, one class name
+
+The queue's key is the **class name**, and that is also what a dispatch carries — so two `Job` subclasses called `SendEmail` cannot both be registered. The first is, the second is refused with a line on stderr, and `Job.dispatch` on either resolves to the first.
+
+Worth spelling out because the failure it replaces was the worst one in this subsystem: the registry used to keep whichever came last, silently, so `SendEmail.dispatch(...)` written against `app/jobs/auth/SendEmail.ts` would run the body of `app/jobs/billing/SendEmail.ts`. Nothing was dropped and nothing errored — the wrong work happened and reported success. A hand-written list forced an import alias the moment two names clashed; a directory walk does not, so `auth/SendEmail.ts` beside `billing/SendEmail.ts` is an entirely ordinary thing to write. Rename one.
+
+Both still appear in `registeredJobs`, which reports what the manager was handed rather than what the registry accepted, so a test walking it sees the clash.
 
 ### What the walk costs
 
@@ -6914,6 +6924,12 @@ export class SubscriptionAudit extends CronJob {
 ```
 
 Both are scheduled. Neither is mentioned anywhere else.
+
+### Two jobs, one name
+
+`name` is the scheduler's key, so only one job can hold it. If two claim the same one, the first is scheduled and the second is refused with both class names on stderr — a directory walk makes this easy to write by accident, since `billing/DailyReport.ts` and `analytics/DailyReport.ts` never have to appear side by side the way two entries in a list would.
+
+Both still appear in `scheduler.jobs`, which reports what the scheduler was handed rather than what it accepted, so a test walking the schedule sees the clash instead of a tidied-up set.
 
 ### What the walk costs
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -34,7 +34,8 @@ app/
     requests/            # HttpRequest subclasses used for validation
   views/                 # React views (.tsx), layouts, and the RootLayout
   email/                 # email templates (jsx-email)
-  cron/                  # CronJob classes
+  cron/                  # CronJob classes — scheduled by being here
+  jobs/                  # Job classes — registered by being here
   i18n/                  # translation dictionaries
   database/
     prisma.ts            # the Prisma client instance
@@ -82,6 +83,12 @@ If present, `app/preload.ts` runs once, before the server starts, for both `gemi
 - **`email/`** — email templates built with `jsx-email`, extending `Email` from `gemi/email`.
 - **`i18n/`** — translation dictionaries created with `Dictionary.create` from `gemi/i18n`, exported as a single default object.
 - **`database/prisma.ts`** — your Prisma client instance, imported wherever you query the database.
+
+### `cron/` and `jobs/` — the two discovered directories
+
+These two directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, and every class under `app/jobs` extending `Job` is registered at boot, with nothing anywhere naming them — writing the file is the registration. The `schedule` and `queue` slices can still declare `jobs` explicitly, which turns the walk off and uses the declared list verbatim; `jobs: []` is a declaration too, and means an app with none.
+
+Discovery imports every `.ts`/`.tsx` file it walks, because a class does not exist until its module has run — so a file in either directory that does work when imported does that work at boot. Keep them to declarations. See [Cron](./cron.md) and [Jobs & Queues](./jobs-and-queues.md) for the walk's skip rules and the reasons for reading a directory at all.
 
 ## The Kernel
 

--- a/packages/gemi/bin/check-models.ts
+++ b/packages/gemi/bin/check-models.ts
@@ -1,6 +1,7 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { statSync } from "node:fs";
+import { relative, resolve } from "node:path";
 
+import { sourceFiles } from "../support/discover";
 import type { UnregisteredPolicyClassError } from "../orm/errors";
 
 /**
@@ -70,9 +71,9 @@ import type { UnregisteredPolicyClassError } from "../orm/errors";
  * command against the template imported `app/models/bench/run.ts`, which is a
  * benchmark, and it duly ran the benchmark and rewrote its report.
  *
- * The exclusions above keep tests and vendored packages out. `--ignore` is for
- * the rest, and what it skipped is printed, so a narrowed run does not read
- * like a complete one.
+ * The exclusions `sourceFiles` applies keep tests and vendored packages out.
+ * `--ignore` is for the rest, and what it skipped is printed, so a narrowed run
+ * does not read like a complete one.
  */
 
 /** The problems one run found, plus enough to say what was covered. */
@@ -137,63 +138,27 @@ export interface OrmSurface {
 /**
  * Files that could hold a model class.
  *
- * Everything under the directory, because apps do group models into folders,
- * minus what cannot be one. The check has to *import* each of these, so the
- * exclusions are about what is certainly not model source rather than about
- * what is probably not:
+ * The walk itself is `sourceFiles`, which this command shared with job and cron
+ * discovery when #322 asked for one mechanism rather than three. Its skip rules
+ * are written down there, and they are these ones: the question "which files
+ * under this directory might declare a class, given that answering means
+ * importing every one of them" has the same answer for models, jobs and crons.
  *
- *   - **Declaration files.** `.d.ts` has no runtime module behind it.
- *   - **Tests, type tests and benchmarks**, by the suffix a runner already
- *     recognises.
- *   - **Dot-directories and `node_modules`.**
- *   - **Any directory holding a `package.json`.** That is a package that
- *     happens to live here — a vendored client, a generated SDK — not this
- *     app's source, and importing its entry point runs somebody else's module
- *     graph. The template has two.
+ * What stays here is what is true of models in particular. `generated/` is
+ * deliberately *not* skipped — it is one of the declared modules, so its classes
+ * are registered and produce no findings, and skipping a directory because of
+ * its name would be one more inference about generator output, which is the
+ * thing #318's other half is about. And `ignore` is the escape hatch the
+ * `--ignore` flag fills, for model-adjacent code that runs something on import;
+ * the command prints what it honoured, so a narrowed run does not read like a
+ * complete one.
  *
- * `generated/` is deliberately *not* skipped. It is one of the declared
- * modules, so its classes are registered and produce no findings — and skipping
- * a directory because of its name would be one more inference about generator
- * output, which is the thing #318's other half is about.
- *
- * `ignore` is the escape hatch for the rest: a path prefix, relative to `dir`,
- * for a directory of model-adjacent code that runs something on import. Nothing
- * is ignored by default, and the command prints what was.
+ * A missing directory yields an empty list rather than throwing, which changes
+ * nothing for this command: `checkModels` stats the model directory first and
+ * says so in a sentence worth printing.
  */
 export function modelFiles(dir: string, ignore: string[] = []): string[] {
-  const out: string[] = [];
-
-  const ignored = (path: string) => {
-    const rel = relative(dir, path).split("\\").join("/");
-    return ignore.some(
-      (pattern) => rel === pattern || rel.startsWith(`${pattern}/`),
-    );
-  };
-
-  const walk = (current: string) => {
-    for (const entry of readdirSync(current, { withFileTypes: true }).sort(
-      (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
-    )) {
-      const path = join(current, entry.name);
-      if (ignored(path)) continue;
-
-      if (entry.isDirectory()) {
-        if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
-        if (existsSync(join(path, "package.json"))) continue;
-        walk(path);
-        continue;
-      }
-
-      if (!entry.name.endsWith(".ts") && !entry.name.endsWith(".tsx")) continue;
-      if (entry.name.endsWith(".d.ts")) continue;
-      if (/\.(test|test-d|spec|bench)\.tsx?$/.test(entry.name)) continue;
-
-      out.push(path);
-    }
-  };
-
-  walk(dir);
-  return out;
+  return sourceFiles(dir, ignore);
 }
 
 /** What the registry held at a moment, enough to put it back. */

--- a/packages/gemi/server/httpProd.ts
+++ b/packages/gemi/server/httpProd.ts
@@ -8,9 +8,13 @@ import type { App } from "../app";
 import { Instrumentation } from "./types";
 import { printStartupBanner } from "./banner";
 import { RESERVED_ROUTE_PREFIX } from "../services/router/ViewRouteDispatcher";
+import { projectRoot } from "../support/discover";
 
-const projectDir = process.env.GEMI_PROJECT_DIR ?? "";
-const rootDir = join(process.cwd(), projectDir);
+// The rule this file used to spell out itself. It moved to `projectRoot`
+// because discovery needs the same answer during `waitForBoot()`, which is
+// before `ROOT_DIR` below exists — and two spellings of "where is the project"
+// is how a job gets looked for in one directory and served from another.
+const rootDir = projectRoot();
 
 const appDir = join(rootDir, "app");
 const distDir = join(rootDir, "dist");

--- a/packages/gemi/services/cron/CronJob.ts
+++ b/packages/gemi/services/cron/CronJob.ts
@@ -16,6 +16,64 @@ export class CronJob {
   name: string;
   cron: CronExpression;
 
+  /**
+   * Decides whether this tick happens at all. Evaluated once per tick, before
+   * anything else; returning `false` skips `onTick`, `callback` and
+   * `onComplete` alike.
+   *
+   * ### Why this is a member and not a line the job writes for itself
+   *
+   * A job that reports outward — mails a digest, opens a Sentry issue, pings a
+   * channel — must not fire from a laptop, and the guard for that has to cover
+   * the whole tick. There was nowhere to write it. gemi calls `onTick` and
+   * `onComplete` *outside* `callback`, so a guard placed in a lifecycle hook
+   * only stops the hook it lives in: an early `return` at the top of `callback`
+   * leaves the job still announcing that it started and still announcing that
+   * it finished, which for an outward-reporting job is most of the damage.
+   *
+   * The only construct that covered every hook was an abstract base class that
+   * shadowed `callback` with the guard and renamed the real body to `run()` —
+   * and that costs the app the framework's own vocabulary. A job then reads
+   * `async run()` while every page of the documentation reads `async
+   * callback()`, so the next person to follow the docs writes a `callback` the
+   * base class never calls: no error, no output, a job that silently does
+   * nothing. Forgetting *this* member fails the other way round — the job runs,
+   * which is what it did before anyone asked for a gate.
+   *
+   * ### What it gates
+   *
+   * Work, not registration. A job whose gate returns `false` is still
+   * scheduled, still holds its `Bun.cron` handle, and still appears in
+   * `app(Scheduler).jobs` — "is it scheduled" and "will it do anything" are
+   * different questions and the second one is answered per tick. That is also
+   * why this is a method: a field would be read once, when the scheduler
+   * constructs the job at boot, and would freeze whatever it saw then.
+   *
+   * A gate that throws is logged and treated as `false`. Cron work recurs, so
+   * a skipped tick is recovered by the next one, while an email sent from the
+   * wrong machine is not recovered at all.
+   *
+   * ### Composing with a base class
+   *
+   * Nothing here calls `super` for you. A subclass that overrides `shouldRun`
+   * for its own reason silently replaces whatever its base was gating on, so
+   * narrow rather than redefine:
+   *
+   * ```typescript
+   * async shouldRun() {
+   *   return (await super.shouldRun()) && this.hasSubscribers();
+   * }
+   * ```
+   *
+   * A shared base should annotate its return type as written here rather than
+   * let it be inferred: a base returning a plain `boolean` narrows the
+   * signature its subclasses inherit, and the `await super` above then does not
+   * typecheck against it.
+   */
+  shouldRun(): Promise<boolean> | boolean {
+    return true;
+  }
+
   callback(): Promise<void> | void {}
   onTick(): Promise<void> | void {}
   onComplete(): Promise<void> | void {}

--- a/packages/gemi/services/cron/ScheduleServiceProvider.ts
+++ b/packages/gemi/services/cron/ScheduleServiceProvider.ts
@@ -1,6 +1,7 @@
 import { kernelContext } from "../../kernel/context";
 import { ServiceProvider } from "../../support/ServiceProvider";
 import { withDefaults } from "../../support/withDefaults";
+import { discoverCronJobs } from "../discovery";
 import { scheduleConfigDefaults, type ScheduleConfig } from "./config";
 import { Scheduler } from "./Scheduler";
 
@@ -19,13 +20,38 @@ export class ScheduleServiceProvider extends ServiceProvider {
   }
 
   /**
+   * Resolves the schedule, then starts it.
+   *
    * Cron jobs are scheduled in phase two, not in `register()`: a job body is
    * free to resolve any service, and by the time `boot()` runs every provider
    * has registered. Each tick re-enters the application context so the job sees
    * the same container a request handler would.
+   *
+   * ### Why the raw slice and not the scheduler's config
+   *
+   * The decision here is whether the app said anything, and by the time the
+   * scheduler holds a config it can no longer tell: `withDefaults` treats an
+   * absent key and an `undefined` one alike and substitutes the default `[]`,
+   * which is the same value an app writes when it means "nothing scheduled, and
+   * I mean it". Reading the slice before defaults are applied is the only place
+   * that difference still exists.
+   *
+   * So: `jobs` present, including `jobs: []`, is used verbatim and no directory
+   * is read. Absent or `undefined` — which includes an app with no `schedule`
+   * slice at all — the classes under `jobsDir` are, which is the case #323 is
+   * about: a cron job that is written and never listed fires never, and nothing
+   * downstream is waiting to notice.
    */
-  boot() {
+  async boot() {
+    const scheduler = this.app.make(Scheduler);
+    const slice = this.app.config.get<ScheduleConfig>("schedule", {});
+
+    if (slice.jobs === undefined) {
+      const { jobsDir } = withDefaults(scheduleConfigDefaults(), slice);
+      scheduler.useJobs(await discoverCronJobs(jobsDir));
+    }
+
     const app = this.app;
-    this.app.make(Scheduler).start((cb) => kernelContext.run(app, cb));
+    scheduler.start((cb) => kernelContext.run(app, cb));
   }
 }

--- a/packages/gemi/services/cron/Scheduler.test.ts
+++ b/packages/gemi/services/cron/Scheduler.test.ts
@@ -1,0 +1,463 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { CronJob } from "./CronJob";
+import { Scheduler, runTick } from "./Scheduler";
+
+/**
+ * The tick, driven by hand.
+ *
+ * `shouldRun` exists because there was no place in a job that covered a whole
+ * tick, so the assertions here are almost all about the *other two* hooks: a
+ * gate that only stopped `callback` would be sugar for an early `return`, and
+ * the job it was written for — one that mails or pages on `onTick` and
+ * `onComplete` — would still report from a laptop. Every test below therefore
+ * records all three and asserts on the list, not on whether the work ran.
+ *
+ * Time is the awkward part. The tightest schedule `Bun.cron` accepts is once a
+ * minute, which no test can sit through, so the tick is fired directly. Two
+ * ways in are used deliberately: `runTick` for the gate's own semantics, and a
+ * stubbed `Bun.cron` for the questions that are really about the scheduler —
+ * that the callback it registered is gated at all, that the gate runs inside
+ * the runner, and that it is asked again rather than remembered.
+ */
+
+/** A job that records which hooks ran, in order. */
+function recorder(calls: string[]) {
+  return class Recorded extends CronJob {
+    name = "Recorded";
+    cron = "@daily";
+    onTick() {
+      calls.push("onTick");
+    }
+    callback() {
+      calls.push("callback");
+    }
+    onComplete() {
+      calls.push("onComplete");
+    }
+  };
+}
+
+/**
+ * Starts a scheduler over `jobs` with `Bun.cron` stubbed, and hands back a way
+ * to fire each registered tick on demand. What is given up is Bun's clock,
+ * which is not under test; what is kept is every line the scheduler puts
+ * between the clock and the job, which is.
+ */
+function scheduled(
+  jobs: Array<new () => CronJob>,
+  run?: <T>(cb: () => T | Promise<T>) => Promise<T> | T,
+) {
+  const ticks: Array<() => unknown> = [];
+  // Handles that remember being stopped, because "which schedule is still
+  // running" is a question one of the tests below is entirely about.
+  const handles: Array<{ stopped: boolean }> = [];
+  vi.spyOn(Bun, "cron").mockImplementation(((
+    _expression: string,
+    callback: () => unknown,
+  ) => {
+    ticks.push(callback);
+    const handle = {
+      stopped: false,
+      stop() {
+        handle.stopped = true;
+      },
+    };
+    handles.push(handle);
+    return handle;
+  }) as unknown as typeof Bun.cron);
+
+  const scheduler = new Scheduler({ jobs, jobsDir: "app/cron" });
+  scheduler.start(run);
+
+  return {
+    scheduler,
+    handles,
+    registered: ticks.length,
+    tick: async (index = 0) => {
+      await ticks[index]!();
+    },
+  };
+}
+
+afterEach(() => {
+  // The stub's handles are inert, but the name-keyed registry survives the file
+  // and a stale entry would be `stop()`ed by the next scheduler that reuses the
+  // name — after `Bun.cron` has been restored, on an object that is not a
+  // handle.
+  globalThis.__gemiCronJobs?.clear();
+  vi.restoreAllMocks();
+});
+
+describe("the default", () => {
+  test("a job that says nothing runs, hooks and all", async () => {
+    const calls: string[] = [];
+
+    await runTick(new (recorder(calls))());
+
+    expect(calls).toEqual(["onTick", "callback", "onComplete"]);
+  });
+
+  test("`shouldRun` is on the base class, so every job has one", () => {
+    class DailyDigest extends CronJob {
+      name = "DailyDigest";
+      cron = "@daily";
+    }
+
+    expect(new DailyDigest().shouldRun()).toBe(true);
+  });
+});
+
+describe("a gate that says no", () => {
+  test("skips onTick, callback and onComplete alike", async () => {
+    const calls: string[] = [];
+    class Gated extends recorder(calls) {
+      shouldRun() {
+        return false;
+      }
+    }
+
+    await runTick(new Gated());
+
+    // Not just `callback`: an outward-reporting job announces itself in
+    // `onTick` and `onComplete`, which is most of what the gate is for.
+    expect(calls).toEqual([]);
+  });
+
+  test("still leaves the job scheduled and readable", async () => {
+    const calls: string[] = [];
+    class Gated extends recorder(calls) {
+      shouldRun() {
+        return false;
+      }
+    }
+
+    const { scheduler, registered, tick } = scheduled([Gated]);
+    await tick();
+
+    // Gating work is not the same as unscheduling: "is it scheduled" and "will
+    // it do anything" are different questions, and a schedule that hid its own
+    // gated jobs would make `scheduler.jobs` lie to the test that walks it.
+    expect(registered).toBe(1);
+    expect(scheduler.jobs).toEqual([Gated]);
+    expect(globalThis.__gemiCronJobs?.has("Recorded")).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  test("an async gate is awaited before anything runs", async () => {
+    const calls: string[] = [];
+    class Gated extends recorder(calls) {
+      async shouldRun() {
+        await Promise.resolve();
+        return false;
+      }
+    }
+
+    await runTick(new Gated());
+
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("when the gate is asked", () => {
+  test("every tick, not once when the schedule was registered", async () => {
+    const calls: string[] = [];
+    let allowed = false;
+    class Gated extends recorder(calls) {
+      shouldRun() {
+        return allowed;
+      }
+    }
+
+    const { tick } = scheduled([Gated]);
+
+    // The scheduler constructs the job once, inside `start()`. A gate read at
+    // that moment — a field rather than a method — would freeze whatever it saw
+    // at boot, which is the one thing an environment gate must not do.
+    await tick();
+    expect(calls).toEqual([]);
+
+    allowed = true;
+    await tick();
+    expect(calls).toEqual(["onTick", "callback", "onComplete"]);
+
+    allowed = false;
+    await tick();
+    expect(calls).toEqual(["onTick", "callback", "onComplete"]);
+  });
+
+  test("inside the runner, where it can resolve services like the job body can", async () => {
+    const calls: string[] = [];
+    let inside = false;
+    class Gated extends recorder(calls) {
+      shouldRun() {
+        calls.push(inside ? "gate inside" : "gate outside");
+        return true;
+      }
+    }
+
+    const { tick } = scheduled([Gated], async (cb) => {
+      inside = true;
+      try {
+        return await cb();
+      } finally {
+        inside = false;
+      }
+    });
+    await tick();
+
+    // A gate evaluated in the `Bun.cron` arrow instead of inside the runner
+    // would have no application context — and under the fail-closed rule below,
+    // a gate that throws for want of one means the job never runs anywhere.
+    expect(calls[0]).toBe("gate inside");
+  });
+});
+
+describe("a gate that throws", () => {
+  test("skips the tick rather than running it", async () => {
+    const calls: string[] = [];
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    class Gated extends recorder(calls) {
+      shouldRun(): boolean {
+        throw new Error("config unavailable");
+      }
+    }
+
+    await runTick(new Gated());
+
+    // Fail closed: a gate that threw has said nothing about whether the job may
+    // run, and the two wrong answers are not the same size. A skipped tick of
+    // recurring work comes back on the next tick; an email sent from the wrong
+    // machine does not come back at all.
+    expect(calls).toEqual([]);
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0]?.[0]).toContain("shouldRun");
+    expect(error.mock.calls[0]?.[0]).toContain("Recorded");
+  });
+
+  test("and a rejected promise counts as a throw", async () => {
+    const calls: string[] = [];
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    class Gated extends recorder(calls) {
+      async shouldRun(): Promise<boolean> {
+        throw new Error("config unavailable");
+      }
+    }
+
+    await runTick(new Gated());
+
+    expect(calls).toEqual([]);
+  });
+
+  test("without taking the scheduler down with it", async () => {
+    const calls: string[] = [];
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    class Gated extends recorder(calls) {
+      shouldRun(): boolean {
+        throw new Error("config unavailable");
+      }
+    }
+
+    const { tick } = scheduled([Gated]);
+
+    await expect(tick()).resolves.toBeUndefined();
+  });
+});
+
+describe("a gate inherited from a base class", () => {
+  test("covers a subclass that does not override it", async () => {
+    const calls: string[] = [];
+    let production = false;
+
+    // The shape the issue describes: several jobs report outward, so the gate
+    // is written once on a base they share. Before `shouldRun`, that base had
+    // to shadow `callback` and rename the real body to `run()`.
+    abstract class ReportingCron extends CronJob {
+      shouldRun() {
+        return production;
+      }
+    }
+    class WeeklyRevenue extends ReportingCron {
+      name = "WeeklyRevenue";
+      cron = "@weekly";
+      onTick() {
+        calls.push("onTick");
+      }
+      callback() {
+        calls.push("callback");
+      }
+      onComplete() {
+        calls.push("onComplete");
+      }
+    }
+
+    await runTick(new WeeklyRevenue());
+    expect(calls).toEqual([]);
+
+    production = true;
+    await runTick(new WeeklyRevenue());
+    // And the subclass kept `callback` — the name the documentation teaches,
+    // rather than a `run()` only its own base class knows to call.
+    expect(calls).toEqual(["onTick", "callback", "onComplete"]);
+  });
+
+  test("narrows rather than disappears when a subclass calls super", async () => {
+    const calls: string[] = [];
+    abstract class ReportingCron extends CronJob {
+      // Annotated, not inferred. A base that returns a plain `boolean` narrows
+      // the signature its subclasses inherit, and the `super` composition below
+      // has to be `async` to await it — which TypeScript then rejects as
+      // incompatible with the base. Writing the type `CronJob` declares keeps
+      // both spellings open.
+      shouldRun(): Promise<boolean> | boolean {
+        return false;
+      }
+    }
+    class WeeklyRevenue extends ReportingCron {
+      name = "WeeklyRevenue";
+      cron = "@weekly";
+      subscribers = true;
+      async shouldRun() {
+        return (await super.shouldRun()) && this.subscribers;
+      }
+      callback() {
+        calls.push("callback");
+      }
+    }
+
+    await runTick(new WeeklyRevenue());
+
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("what the gate did not change", () => {
+  test("onComplete still runs when callback throws", async () => {
+    const calls: string[] = [];
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    class Failing extends recorder(calls) {
+      callback(): void {
+        calls.push("callback");
+        throw new Error("nope");
+      }
+    }
+
+    await runTick(new Failing());
+
+    // It is a `finally`, not a success handler — true before `shouldRun` and
+    // still true after, which is why a gated tick has to skip it explicitly
+    // rather than rely on the work not happening.
+    expect(calls).toEqual(["onTick", "callback", "onComplete"]);
+  });
+
+  test("a job with no name or no expression is still refused, unasked", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const asked: string[] = [];
+
+    class Nameless extends CronJob {
+      cron = "@daily";
+      shouldRun() {
+        asked.push("Nameless");
+        return true;
+      }
+    }
+    class Scheduleless extends CronJob {
+      name = "Scheduleless";
+      shouldRun() {
+        asked.push("Scheduleless");
+        return true;
+      }
+    }
+
+    const { registered } = scheduled([Nameless, Scheduleless]);
+
+    expect(registered).toBe(0);
+    expect(asked).toEqual([]);
+    expect(error).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * What discovery did to a name.
+ *
+ * Under an explicit `jobs` array both of these were at least visible: two
+ * classes claiming one name sat on adjacent lines of a config file, and a base
+ * class was one nobody had listed. Reading a directory takes that away — the
+ * set is assembled from whatever is on disk — so the scheduler is now the only
+ * thing in a position to notice, and both of these used to pass through it
+ * without a word that helped.
+ */
+describe("what a directory can hand the scheduler", () => {
+  test("two jobs claiming one name: the first keeps it, the second is refused", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    class BillingDailyReport extends CronJob {
+      name = "DailyReport";
+      cron = "@daily";
+    }
+    class AnalyticsDailyReport extends CronJob {
+      name = "DailyReport";
+      cron = "@daily";
+    }
+
+    const { registered, handles, scheduler } = scheduled([
+      BillingDailyReport,
+      AnalyticsDailyReport,
+    ]);
+
+    // One schedule, and it is the first job's — still running. Before this, the
+    // second registration reached `registry.get(name).stop()` and killed the
+    // first one's handle on its way past, so the surviving schedule was the
+    // *last* class the walk happened to return.
+    expect(registered).toBe(1);
+    expect(handles[0]!.stopped).toBe(false);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain(
+      'Two cron jobs claim the name "DailyReport"',
+    );
+
+    // `jobs` still lists both, deliberately: it reports what the scheduler was
+    // handed, and a test walking it should see the collision rather than have
+    // it tidied away.
+    expect(scheduler.jobs).toHaveLength(2);
+  });
+
+  test("re-registering the same name across a reload still replaces in place", () => {
+    class DailyDigest extends CronJob {
+      name = "DailyDigest";
+      cron = "@daily";
+    }
+
+    const first = scheduled([DailyDigest]);
+    expect(first.handles[0]!.stopped).toBe(false);
+
+    // A second `start()`, which is what a `bun --hot` reload amounts to. The
+    // name-claimed check is per-pass, so it must not mistake this for the
+    // collision above — the previous handle is stopped and replaced.
+    const second = scheduled([DailyDigest]);
+
+    expect(first.handles[0]!.stopped).toBe(true);
+    expect(second.registered).toBe(1);
+  });
+
+  test("a nameless class is refused by a message that names it and says why", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // `abstract` is erased before any of this runs, so a shared base sitting in
+    // the walked directory arrives here indistinguishable from a job. Nothing
+    // in the framework can tell them apart; the message is the whole remedy,
+    // and `JSON.stringify` of a nameless job prints `{}`.
+    abstract class AlertingCronJob extends CronJob {
+      shouldRun() {
+        return process.env.NODE_ENV === "production";
+      }
+    }
+
+    const { registered } = scheduled([AlertingCronJob as new () => CronJob]);
+
+    expect(registered).toBe(0);
+    const message = vi.mocked(error).mock.calls[0]![0] as string;
+    expect(message).toContain("AlertingCronJob");
+    expect(message).toContain("base class");
+  });
+});

--- a/packages/gemi/services/cron/Scheduler.test.ts
+++ b/packages/gemi/services/cron/Scheduler.test.ts
@@ -440,6 +440,18 @@ describe("what a directory can hand the scheduler", () => {
     expect(second.registered).toBe(1);
   });
 
+  test("`jobs` is a copy, so walking it cannot edit what the scheduler runs from", () => {
+    class DailyDigest extends CronJob {
+      name = "DailyDigest";
+      cron = "@daily";
+    }
+
+    const { scheduler } = scheduled([DailyDigest]);
+    (scheduler.jobs as Array<new () => CronJob>).length = 0;
+
+    expect(scheduler.jobs).toHaveLength(1);
+  });
+
   test("a nameless class is refused by a message that names it and says why", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/packages/gemi/services/cron/Scheduler.ts
+++ b/packages/gemi/services/cron/Scheduler.ts
@@ -97,10 +97,14 @@ export class Scheduler {
    * what the scheduler took.
    *
    * It lists what `start()` iterates, not what `Bun.cron` accepted. A job with
-   * no name or no expression is logged and skipped, and still appears here.
+   * no name, no expression, or a name another job already claimed is logged and
+   * skipped, and still appears here — a test walking this should see the
+   * problem rather than have it tidied away.
+   *
+   * A copy, so that walk cannot edit the set the scheduler is running from.
    */
   get jobs(): ReadonlyArray<new () => CronJob> {
-    return this.resolved;
+    return [...this.resolved];
   }
 
   /**

--- a/packages/gemi/services/cron/Scheduler.ts
+++ b/packages/gemi/services/cron/Scheduler.ts
@@ -1,3 +1,4 @@
+import type { CronJob } from "./CronJob";
 import type { ScheduleConfig } from "./config";
 
 // The handle the in-process `Bun.cron(schedule, callback)` overload returns
@@ -18,12 +19,104 @@ declare global {
   var __gemiCronJobs: Map<string, BunCronHandle> | undefined;
 }
 
+/**
+ * One tick of one job: the gate, then the three hooks in order.
+ *
+ * Named and exported rather than left inline in `start()` because otherwise the
+ * only way to reach it is to wait — the tightest schedule `Bun.cron` accepts is
+ * once a minute, which is not a thing a test can honestly sit through. What a
+ * caller gives up by calling this directly is Bun's clock; what it keeps is
+ * everything the scheduler puts between the clock and the job, which is the
+ * part that has behaviour.
+ *
+ * The three hooks each catch and log, so one throwing does not stop the next —
+ * `onComplete` in particular runs whether `callback` returned or threw, closer
+ * to a `finally` than to a success handler.
+ */
+export async function runTick(job: CronJob): Promise<void> {
+  try {
+    // Plain truthiness, not `!== false`. The sloppy gate an app writes is
+    // `if (!isProduction) return false;`, which returns `undefined` on the path
+    // that was meant to run — and between the two readings of that, the one
+    // that skips a recurring tick is recoverable and the one that mails a
+    // customer from a developer's laptop is not. The declared return type makes
+    // that method a compile error anyway, so the type system catches it while
+    // it is still being written and the runtime stays on the safe side.
+    if (!(await job.shouldRun.call(job))) {
+      return;
+    }
+  } catch (error) {
+    // Fail closed, for the same reason. A gate that throws has told us nothing
+    // about whether the job may run, and the framework already refuses to
+    // schedule a job whose name or expression it cannot read rather than run
+    // something half-declared. The throw is logged, so this is loud; the missed
+    // tick comes back on the next one.
+    console.error(
+      `Error evaluating shouldRun for cron job ${job.name}:`,
+      error,
+    );
+    return;
+  }
+
+  try {
+    await job.onTick.call(job);
+  } catch (error) {
+    console.error(`Error executing cron job ${job.name}:`, error);
+  }
+  try {
+    await job.callback.call(job);
+  } catch (error) {
+    console.error(`Error in cron job ${job.name}:`, error);
+  }
+  try {
+    await job.onComplete.call(job);
+  } catch (error) {
+    console.error(`Error completing cron job ${job.name}:`, error);
+  }
+}
+
 export class Scheduler {
   static token = "scheduler";
 
   private handles: BunCronHandle[] = [];
+  private resolved: Array<new () => CronJob>;
 
-  constructor(private config: Required<ScheduleConfig>) {}
+  constructor(config: Required<ScheduleConfig>) {
+    this.resolved = config.jobs;
+  }
+
+  /**
+   * The jobs this scheduler will run, or ran — declared in the config slice or
+   * discovered under `app/cron`, whichever the slice asked for.
+   *
+   * #323 turned an application's schedule from an array it could import into a
+   * directory it cannot, and an app that had a test walking that array —
+   * asserting every report has an owner, that no two share an expression — was
+   * about to lose it. This is where that test goes instead, and it is the
+   * better question anyway: the config slice says what was asked for, this says
+   * what the scheduler took.
+   *
+   * It lists what `start()` iterates, not what `Bun.cron` accepted. A job with
+   * no name or no expression is logged and skipped, and still appears here.
+   */
+  get jobs(): ReadonlyArray<new () => CronJob> {
+    return this.resolved;
+  }
+
+  /**
+   * Replaces the job set, for the provider to hand over what it found under
+   * `app/cron` before it calls `start()`.
+   *
+   * The scheduler is constructed in `register()`, where reading a directory and
+   * importing what is in it is not allowed to happen — that phase is
+   * synchronous and resolves nothing. So it is built from whatever the slice
+   * declared and corrected in `boot()`, one line before it starts. Calling this
+   * after `start()` changes what `jobs` reports and nothing else; the schedules
+   * are already registered.
+   */
+  useJobs(jobs: Array<new () => CronJob>) {
+    this.resolved = jobs;
+  }
 
   /**
    * Schedules every configured job. Called from `ScheduleServiceProvider.boot()`
@@ -32,46 +125,66 @@ export class Scheduler {
    * the old `kernel.waitForBoot()` handshake.
    */
   start(run: ScheduleRunner = (cb) => cb()) {
-    if (this.config.jobs.length === 0) {
+    if (this.resolved.length === 0) {
       return;
     }
 
     const registry = (globalThis.__gemiCronJobs ??= new Map());
 
-    for (const Job of this.config.jobs) {
+    // Names claimed during *this* pass, which is a different question from what
+    // `registry` holds. `registry` spans hot reloads and is supposed to already
+    // contain the previous reload's handle under the same name; this starts
+    // empty every time and is how a name claimed twice in one schedule is told
+    // apart from the same job coming back after an edit.
+    const claimed = new Map<string, string>();
+
+    for (const Job of this.resolved) {
       const job = new Job();
       if (!job.name) {
-        console.error(`Cron job must have a name. Job: ${JSON.stringify(job)}`);
+        // Named by its class, because under discovery nobody wrote this job
+        // down anywhere and `JSON.stringify(job)` on a nameless one prints
+        // `{}`. The overwhelmingly common cause is the second sentence: a
+        // shared base class sitting in the walked directory. `abstract` is
+        // erased before this code runs, so there is nothing here that could
+        // tell a base class from a job — only the message can.
+        console.error(
+          `Cron job must have a name — ${Job.name || "an anonymous class"} ` +
+            `has none, so it is not scheduled. If this is a base class that ` +
+            `other jobs extend, move it out of the discovered directory: ` +
+            `\`abstract\` does not survive to runtime, so a class under ` +
+            `app/cron is indistinguishable from a job.`,
+        );
         continue;
       }
       if (!job.cron) {
         console.error(`Cron job must have an expression. Job: ${job.name}`);
         continue;
       }
+      const taken = claimed.get(job.name);
+      if (taken !== undefined) {
+        // Refusing the second one, rather than letting it through to the
+        // `registry.get(...).stop()` below — which is what used to happen, and
+        // it stopped the *first* job's schedule while leaving both classes in
+        // `jobs`. That is the failure #323 exists to remove wearing a disguise:
+        // a report that silently stops arriving, and a test walking `jobs` that
+        // sees two healthy entries and passes.
+        console.error(
+          `Two cron jobs claim the name "${job.name}" — ${taken} is ` +
+            `scheduled and ${Job.name || "an anonymous class"} is not. A name ` +
+            `is the scheduler's key, so only one job can hold it. Rename one.`,
+        );
+        continue;
+      }
+      claimed.set(job.name, Job.name || "an anonymous class");
 
       // Update in place: stop any schedule previously registered under this name
       // before re-registering, so a hot reload replaces rather than duplicates.
       registry.get(job.name)?.stop();
 
-      const handle = Bun.cron(job.cron, () =>
-        run(async () => {
-          try {
-            await job.onTick.call(job);
-          } catch (error) {
-            console.error(`Error executing cron job ${job.name}:`, error);
-          }
-          try {
-            await job.callback.call(job);
-          } catch (error) {
-            console.error(`Error in cron job ${job.name}:`, error);
-          }
-          try {
-            await job.onComplete.call(job);
-          } catch (error) {
-            console.error(`Error completing cron job ${job.name}:`, error);
-          }
-        }),
-      );
+      // Inside `run`, gate included: a `shouldRun` that resolves a service to
+      // decide is the ordinary case, and evaluating it out here would leave it
+      // without the application context every other line of the tick has.
+      const handle = Bun.cron(job.cron, () => run(() => runTick(job)));
 
       registry.set(job.name, handle);
       this.handles.push(handle);

--- a/packages/gemi/services/cron/config.ts
+++ b/packages/gemi/services/cron/config.ts
@@ -2,7 +2,49 @@ import type { CronJob } from "./CronJob";
 
 // Config key: `schedule`. Consumed by `ScheduleServiceProvider`.
 export interface ScheduleConfig {
+  /**
+   * The `CronJob` subclasses this application runs on a schedule, or nothing.
+   *
+   * ### Why "or nothing" is the point
+   *
+   * A cron job that is written and not listed here never fires, and unlike a
+   * dropped dispatch there is no caller left waiting to notice: nothing is
+   * downstream of a tick that did not happen. The report is simply not sent,
+   * for as long as it takes somebody to ask why they stopped seeing it. That is
+   * the whole failure — the file exists, the expression is right, and the class
+   * was never in the module graph.
+   *
+   * Leaving this out spells the schedule once: the jobs are the classes under
+   * `jobsDir`.
+   *
+   * ### The rule, exactly
+   *
+   * **Declared wins, and `[]` is declared.** A `jobs` that is present is used
+   * verbatim and no directory is read — the escape hatch for an app whose jobs
+   * live somewhere this cannot walk, for one that runs a deliberate subset, and
+   * for a deploy that ships no source. An empty array means an app with nothing
+   * scheduled and says so; it does not mean "find some".
+   *
+   * **Absent or `undefined` discovers.** `undefined` counts as absent for the
+   * same reason `withDefaults` treats it that way everywhere else: a key spread
+   * in from an optional value is an omission, not an instruction.
+   *
+   * Either way the set the scheduler ended up with is readable afterwards, as
+   * `app(Scheduler).jobs` — an app that used to import this array to assert
+   * something about its own schedule asks the scheduler instead.
+   */
   jobs?: Array<new () => CronJob>;
+
+  /**
+   * Where to look when `jobs` was not declared. Relative to the project root,
+   * or absolute.
+   *
+   * Every `.ts`/`.tsx` file underneath it is imported at boot and every exported
+   * class extending `CronJob` is scheduled, so this wants to be a directory of
+   * cron declarations rather than a directory that merely contains some. Moving
+   * the jobs is what this field is for; pointing it at `app/` is not.
+   */
+  jobsDir?: string;
 }
 
 export function defineScheduleConfig(config: ScheduleConfig): ScheduleConfig {
@@ -12,5 +54,6 @@ export function defineScheduleConfig(config: ScheduleConfig): ScheduleConfig {
 export function scheduleConfigDefaults(): Required<ScheduleConfig> {
   return {
     jobs: [],
+    jobsDir: "app/cron",
   };
 }

--- a/packages/gemi/services/discovery.test.ts
+++ b/packages/gemi/services/discovery.test.ts
@@ -1,0 +1,405 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, resolve } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+import { Application } from "../foundation/Application";
+import { Repository } from "../support/Repository";
+import type { ConfigItems } from "../support/Repository";
+import { Scheduler } from "./cron/Scheduler";
+import { ScheduleServiceProvider } from "./cron/ScheduleServiceProvider";
+import { CronJob } from "./cron/CronJob";
+import { discoverCronJobs, discoverJobs } from "./discovery";
+import { Job } from "./queue/Job";
+import { QueueManager } from "./queue/QueueManager";
+import { QueueServiceProvider } from "./queue/QueueServiceProvider";
+
+/**
+ * Discovery from the outside: an application directory on disk, booted, asked
+ * what it ended up with.
+ *
+ * The failures being guarded are both silent ones. A job class that never
+ * reaches the `QueueManager`'s registry means a dispatch dropped after the
+ * caller has already moved on, and a `CronJob` that never reaches the
+ * `Scheduler` means a report
+ * nobody is waiting for and nobody misses. Neither shows up as an error, so the
+ * assertion has to be on the set itself — which is the same reason both managers
+ * grew a readable view of what they took.
+ *
+ * The fixtures are real files in a temp directory, because that is the thing
+ * under test: the skip rules are only true of a filesystem, and the config's
+ * override rule turns on a distinction (absent versus `[]`) that only exists
+ * before defaults are applied. They import their base class by absolute path
+ * rather than from `gemi/services`, since a temp directory has no
+ * `node_modules` above it to resolve that through — the path resolves to the
+ * very module this file imports `Job` and `CronJob` from, so the identity
+ * `discoverClasses` walks the prototype chain for holds.
+ */
+
+const JOB = JSON.stringify(resolve(import.meta.dirname, "queue/Job.ts"));
+const CRON_JOB = JSON.stringify(
+  resolve(import.meta.dirname, "cron/CronJob.ts"),
+);
+
+const roots: string[] = [];
+const applications: Application[] = [];
+
+/** An application tree in a temp directory. Keys are paths, values are source. */
+function project(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "gemi-discovery-"));
+  roots.push(root);
+  for (const [path, source] of Object.entries(files)) {
+    mkdirSync(join(root, path, ".."), { recursive: true });
+    writeFileSync(join(root, path), source);
+  }
+  return root;
+}
+
+/** A `Job` subclass whose `run` is observable through the class it returns. */
+const job = (name: string) => `import { Job } from ${JOB};
+export class ${name} extends Job {
+  run() { return ${JSON.stringify(name)}; }
+}`;
+
+const cron = (
+  name: string,
+  expression = "@daily",
+) => `import { CronJob } from ${CRON_JOB};
+export class ${name} extends CronJob {
+  name = ${JSON.stringify(name)};
+  cron = ${JSON.stringify(expression)};
+}`;
+
+/**
+ * Boots an application holding nothing but the provider under test, the way
+ * `RateLimitMiddleware.test.ts` does — a real container, so the register/boot
+ * split the override rule depends on is the real one.
+ */
+async function boot(
+  config: ConfigItems,
+  Provider: typeof QueueServiceProvider | typeof ScheduleServiceProvider,
+) {
+  const application = new Application(new Repository(config));
+  applications.push(application);
+  application.register(Provider);
+  await application.boot();
+  return application;
+}
+
+const names = (classes: ReadonlyArray<{ name: string }>) =>
+  classes.map((value) => value.name);
+
+/**
+ * Runs `fn` with the project root pointed at a fixture, so the *default*
+ * directory — the relative `app/jobs` and `app/cron` every real app uses — has
+ * something to find.
+ *
+ * Every other test here names an absolute `jobsDir`, which is convenient and
+ * skips `resolveDir`'s relative branch entirely: an absolute path is returned
+ * untouched, so the join against the project root is never exercised and a
+ * change that dropped it would leave the suite green while sending every
+ * deployment that sets `GEMI_PROJECT_DIR` to walk the wrong directory. The
+ * variable is the lever because `projectRoot()` is `cwd` joined with it, which
+ * also means it has to be handed a *relative* path — `join` does not restart on
+ * an absolute segment. Setting it beats `process.chdir()`, which is not
+ * available in every pool vitest can run this file in.
+ */
+async function withProjectRoot(root: string, fn: () => Promise<void>) {
+  const previous = process.env.GEMI_PROJECT_DIR;
+  process.env.GEMI_PROJECT_DIR = relative(process.cwd(), root);
+  try {
+    await fn();
+  } finally {
+    if (previous === undefined) delete process.env.GEMI_PROJECT_DIR;
+    else process.env.GEMI_PROJECT_DIR = previous;
+  }
+}
+
+afterEach(() => {
+  // Every `Bun.cron` handle a booted Scheduler registered, including the
+  // cross-reload registry it keys by name — a schedule left running would keep
+  // ticking into the next test file.
+  for (const application of applications.splice(0)) {
+    if (application.resolved(Scheduler)) application.make(Scheduler).stop();
+  }
+  for (const [name, handle] of globalThis.__gemiCronJobs ?? []) {
+    handle.stop();
+    globalThis.__gemiCronJobs?.delete(name);
+  }
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+describe("asking an application what it has", () => {
+  test("finds every Job subclass under the directory, nested included", async () => {
+    const root = project({
+      "app/jobs/SendWelcomeEmail.ts": job("SendWelcomeEmail"),
+      "app/jobs/billing/ChargeCard.ts": job("ChargeCard"),
+    });
+
+    // Capitals sort before lowercase, so the file beats the directory beside it.
+    expect(names(await discoverJobs(join(root, "app/jobs")))).toEqual([
+      "SendWelcomeEmail",
+      "ChargeCard",
+    ]);
+  });
+
+  test("finds every CronJob subclass, and never the base class itself", async () => {
+    const root = project({
+      "app/cron/DailyDigest.ts": cron("DailyDigest"),
+      // The shape an app reaches for when several jobs share something: a base
+      // beside them, re-exported. Scheduling it would run a job nobody wrote.
+      "app/cron/base.ts": `export { CronJob } from ${CRON_JOB};`,
+    });
+
+    expect(names(await discoverCronJobs(join(root, "app/cron")))).toEqual([
+      "DailyDigest",
+    ]);
+  });
+
+  test("a directory that does not exist is an empty list, not a throw", async () => {
+    const root = project({ "app/config/queue.ts": "" });
+
+    expect(await discoverJobs(join(root, "app/jobs"))).toEqual([]);
+    expect(await discoverCronJobs(join(root, "app/cron"))).toEqual([]);
+  });
+});
+
+describe("the queue registry", () => {
+  test("is filled from app/jobs when the slice leaves `jobs` out", async () => {
+    const root = project({
+      "app/jobs/SendWelcomeEmail.ts": job("SendWelcomeEmail"),
+      "app/jobs/billing/ChargeCard.ts": job("ChargeCard"),
+    });
+
+    const application = await boot(
+      { queue: { jobsDir: join(root, "app/jobs") } },
+      QueueServiceProvider,
+    );
+    const queue = application.make(QueueManager);
+
+    expect(names(queue.registeredJobs)).toEqual([
+      "SendWelcomeEmail",
+      "ChargeCard",
+    ]);
+    // Keyed by name, which is what a dispatch carries and what `next()` looks
+    // up before deciding to drop it.
+    expect(queue.dispatchJob("ChargeCard", "[]")).toBe("ChargeCard");
+  });
+
+  test("a slice with no `queue` key at all discovers too, from the default app/jobs", async () => {
+    const root = project({
+      "app/jobs/SendWelcomeEmail.ts": job("SendWelcomeEmail"),
+    });
+
+    // The whole path a scaffolded app takes: no slice, no `jobsDir`, so the
+    // default relative `app/jobs` is resolved against the project root. An app
+    // that never wrote a config file is the ordinary case, not an opt-out —
+    // and asserting the class comes back is what tells "it looked" apart from
+    // "it refused", which an empty expectation cannot.
+    await withProjectRoot(root, async () => {
+      const application = await boot({}, QueueServiceProvider);
+
+      expect(names(application.make(QueueManager).registeredJobs)).toEqual([
+        "SendWelcomeEmail",
+      ]);
+    });
+  });
+
+  test("an explicit list wins and the directory is never read", async () => {
+    const root = project({
+      "app/jobs/SendWelcomeEmail.ts": job("SendWelcomeEmail"),
+      "app/jobs/ChargeCard.ts": job("ChargeCard"),
+    });
+
+    class ReticulateSplines extends Job {}
+
+    const application = await boot(
+      { queue: { jobs: [ReticulateSplines], jobsDir: join(root, "app/jobs") } },
+      QueueServiceProvider,
+    );
+
+    expect(names(application.make(QueueManager).registeredJobs)).toEqual([
+      "ReticulateSplines",
+    ]);
+  });
+
+  test("`jobs: []` means an app with no jobs, not an app that wants them found", async () => {
+    const root = project({
+      "app/jobs/SendWelcomeEmail.ts": job("SendWelcomeEmail"),
+    });
+
+    const application = await boot(
+      { queue: { jobs: [], jobsDir: join(root, "app/jobs") } },
+      QueueServiceProvider,
+    );
+
+    expect(application.make(QueueManager).registeredJobs).toEqual([]);
+  });
+
+  /**
+   * `withDefaults` treats an explicit `undefined` as an omission everywhere
+   * else, and a `jobs` key spread in from an optional value is exactly that.
+   * Reading the slice before defaults are applied is the only place the
+   * difference is still visible.
+   */
+  test("`jobs: undefined` counts as absent and discovers", async () => {
+    const root = project({
+      "app/jobs/SendWelcomeEmail.ts": job("SendWelcomeEmail"),
+    });
+
+    const application = await boot(
+      { queue: { jobs: undefined, jobsDir: join(root, "app/jobs") } },
+      QueueServiceProvider,
+    );
+
+    expect(names(application.make(QueueManager).registeredJobs)).toEqual([
+      "SendWelcomeEmail",
+    ]);
+  });
+
+  test("a missing app/jobs leaves the registry empty rather than failing to boot", async () => {
+    const root = project({ "app/config/queue.ts": "" });
+
+    const application = await boot(
+      { queue: { jobsDir: join(root, "app/jobs") } },
+      QueueServiceProvider,
+    );
+
+    expect(application.make(QueueManager).registeredJobs).toEqual([]);
+  });
+});
+
+describe("the schedule", () => {
+  test("is filled from app/cron when the slice leaves `jobs` out", async () => {
+    const root = project({
+      "app/cron/DailyDigest.ts": cron("DailyDigest"),
+      "app/cron/reports/WeeklyRevenue.ts": cron("WeeklyRevenue", "@weekly"),
+    });
+
+    const application = await boot(
+      { schedule: { jobsDir: join(root, "app/cron") } },
+      ScheduleServiceProvider,
+    );
+
+    expect(names(application.make(Scheduler).jobs)).toEqual([
+      "DailyDigest",
+      "WeeklyRevenue",
+    ]);
+  });
+
+  /**
+   * The requirement from #323 itself: an application exported `jobs` from its
+   * config module so a test could walk the same list the scheduler runs. Under
+   * discovery there is no array to import, so the resolved set has to be
+   * readable from the scheduler — and it has to be the set that was actually
+   * scheduled, not the one the config asked for.
+   */
+  test("what was resolved is readable afterwards, and is what got scheduled", async () => {
+    const root = project({ "app/cron/DailyDigest.ts": cron("DailyDigest") });
+
+    const application = await boot(
+      { schedule: { jobsDir: join(root, "app/cron") } },
+      ScheduleServiceProvider,
+    );
+
+    expect(names(application.make(Scheduler).jobs)).toEqual(["DailyDigest"]);
+    expect(globalThis.__gemiCronJobs?.has("DailyDigest")).toBe(true);
+  });
+
+  test("an application with no `schedule` slice at all discovers, from the default app/cron", async () => {
+    const root = project({ "app/cron/DailyDigest.ts": cron("DailyDigest") });
+
+    await withProjectRoot(root, async () => {
+      const application = await boot({}, ScheduleServiceProvider);
+
+      expect(names(application.make(Scheduler).jobs)).toEqual(["DailyDigest"]);
+    });
+  });
+
+  test("an explicit list wins and the directory is never read", async () => {
+    const root = project({ "app/cron/DailyDigest.ts": cron("DailyDigest") });
+
+    class NightlyBackup extends CronJob {
+      name = "NightlyBackup";
+      cron = "@daily";
+    }
+
+    const application = await boot(
+      {
+        schedule: {
+          jobs: [NightlyBackup],
+          jobsDir: join(root, "app/cron"),
+        },
+      },
+      ScheduleServiceProvider,
+    );
+
+    expect(names(application.make(Scheduler).jobs)).toEqual(["NightlyBackup"]);
+    expect(globalThis.__gemiCronJobs?.has("DailyDigest")).toBe(false);
+  });
+
+  test("`jobs: []` means nothing scheduled, not everything found", async () => {
+    const root = project({ "app/cron/DailyDigest.ts": cron("DailyDigest") });
+
+    const application = await boot(
+      { schedule: { jobs: [], jobsDir: join(root, "app/cron") } },
+      ScheduleServiceProvider,
+    );
+
+    expect(application.make(Scheduler).jobs).toEqual([]);
+  });
+
+  test("a missing app/cron leaves the schedule empty rather than failing to boot", async () => {
+    const root = project({ "app/config/schedule.ts": "" });
+
+    const application = await boot(
+      { schedule: { jobsDir: join(root, "app/cron") } },
+      ScheduleServiceProvider,
+    );
+
+    expect(application.make(Scheduler).jobs).toEqual([]);
+  });
+});
+
+/**
+ * A missing directory reads two ways and only one of them is worth saying out
+ * loud. "This app has no cron jobs" is an ordinary answer that would otherwise
+ * be repeated on every boot forever; "this deploy shipped without the app's
+ * source" is the silence these issues exist to remove, wearing the same face.
+ */
+describe("when the source is not there at all", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  test("says so when neither the directory nor the tree above it exists", async () => {
+    const root = project({ "package.json": "{}" });
+
+    await discoverCronJobs(join(root, "app/cron"));
+
+    expect(console.warn).toHaveBeenCalledOnce();
+    expect(vi.mocked(console.warn).mock.calls[0]?.[0]).toContain(
+      join(root, "app/cron"),
+    );
+  });
+
+  test("stays quiet when the app is simply there and has none", async () => {
+    const root = project({ "app/config/schedule.ts": "" });
+
+    await discoverCronJobs(join(root, "app/cron"));
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gemi/services/discovery.test.ts
+++ b/packages/gemi/services/discovery.test.ts
@@ -403,3 +403,66 @@ describe("when the source is not there at all", () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * The one hazard discovery adds rather than removes.
+ *
+ * A production build minifies the server entry, and the app code reachable from
+ * it — a controller, and the job classes it imports to dispatch — is bundled
+ * and minified with it. That renames the class binding, and a class's implicit
+ * `.name` *is* that binding: verified against `Bun.build({minify:true})`, a
+ * `TestJob` in the bundle reports `"D"`. Discovery imports the same file from
+ * source at runtime, where it is still `"TestJob"`, so the queue's key and the
+ * dispatch's key stop agreeing — in production and nowhere else.
+ *
+ * Before discovery an app could get away without `static name`, because the
+ * explicit `jobs` array was bundled too and both halves were wrong identically.
+ * So the warning is on the discovery path only, where the hazard is new.
+ */
+describe("a job whose name will not survive a production build", () => {
+  test("is warned about, by name, with the line that fixes it", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const root = project({
+      "app/jobs/SendWelcomeEmail.ts": job("SendWelcomeEmail"),
+    });
+
+    await discoverJobs(join(root, "app/jobs"));
+
+    const message = vi.mocked(warn).mock.calls.at(-1)![0] as string;
+    expect(message).toContain("SendWelcomeEmail");
+    expect(message).toContain('static name = "SendWelcomeEmail"');
+  });
+
+  test("a job that declares `static name` is left alone", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const root = project({
+      "app/jobs/SendWelcomeEmail.ts": `import { Job } from ${JOB};
+export class SendWelcomeEmail extends Job {
+  static name = "SendWelcomeEmail";
+  run() { return "SendWelcomeEmail"; }
+}`,
+    });
+
+    await discoverJobs(join(root, "app/jobs"));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test("the two are told apart exactly, not guessed at", () => {
+    class Implicit extends Job {}
+    class Explicit extends Job {
+      static name = "Explicit";
+    }
+
+    // A `static name = "..."` class field defines a writable own property; the
+    // implicit class name is non-writable. Both report the same string, so the
+    // descriptor is the only thing that separates them.
+    expect(Implicit.name).toBe("Implicit");
+    expect(Object.getOwnPropertyDescriptor(Implicit, "name")?.writable).toBe(
+      false,
+    );
+    expect(Object.getOwnPropertyDescriptor(Explicit, "name")?.writable).toBe(
+      true,
+    );
+  });
+});

--- a/packages/gemi/services/discovery.ts
+++ b/packages/gemi/services/discovery.ts
@@ -82,7 +82,47 @@ export async function discoverJobs(
 ): Promise<Array<new () => Job>> {
   const resolved = resolveDir(dir);
   warnIfSourceIsMissing(resolved, "queue jobs", "queue");
-  return await discoverClasses(resolved, Job);
+  const jobs = await discoverClasses(resolved, Job);
+  warnIfNameWillNotSurviveTheBuild(jobs);
+  return jobs;
+}
+
+/**
+ * Says something about a discovered job that never declared `static name`.
+ *
+ * This is the one hazard discovery introduces rather than removes, and it is
+ * production-only. `gemi build` minifies the server entry, and app code
+ * reachable from it — a controller, and every job class that controller
+ * imports to dispatch — is bundled and minified with it. Minification renames
+ * the class binding, and a class's implicit `.name` is that binding: a
+ * `TestJob` in the bundle reports `"D"`. Discovery, meanwhile, imports
+ * `app/jobs/TestJob.ts` from source at runtime, where it is still `"TestJob"`.
+ * The queue is keyed by that name, so the two halves stop agreeing and the
+ * dispatch is dropped — in production, and only there.
+ *
+ * A declared `static name = "TestJob"` is a string literal, which survives
+ * minification intact, and the two halves agree again. `docs/jobs-and-queues.md`
+ * has always called it required; before discovery an app could get away without
+ * it, because the explicit `jobs` array was bundled too and both sides were
+ * wrong in the same way.
+ *
+ * The check is exact rather than a guess: a `static name = "..."` class field
+ * defines a *writable* own property, while the implicit class name is
+ * non-writable. Cron is unaffected — `CronJob.name` is an instance field
+ * holding a string literal, not the class binding.
+ */
+function warnIfNameWillNotSurviveTheBuild(jobs: Array<new () => Job>) {
+  for (const job of jobs) {
+    if (Object.getOwnPropertyDescriptor(job, "name")?.writable) continue;
+
+    console.warn(
+      `Queued job ${job.name} does not declare \`static name\`, so it is ` +
+        `registered under its class name. A production build minifies the ` +
+        `class that dispatches it and renames it, while discovery reads this ` +
+        `file from source and does not — so the dispatch would be dropped in ` +
+        `production and nowhere else. Add: static name = "${job.name}";`,
+    );
+  }
 }
 
 /**

--- a/packages/gemi/services/discovery.ts
+++ b/packages/gemi/services/discovery.ts
@@ -1,0 +1,106 @@
+import { existsSync } from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
+
+import { discoverClasses, projectRoot } from "../support/discover";
+import { CronJob } from "./cron/CronJob";
+import { scheduleConfigDefaults } from "./cron/config";
+import { Job } from "./queue/Job";
+import { queueConfigDefaults } from "./queue/config";
+
+/**
+ * Reading an application's jobs off the filesystem, for the two subsystems that
+ * were asking every app to write its job list twice.
+ *
+ * Both functions here are the same call to `discoverClasses` with a different
+ * base class, which is deliberate: one walk, one set of skip rules, one answer
+ * to "what does this app have". They are exported from `gemi/services` rather
+ * than kept private to the providers because the list stopped being something
+ * an app could import — a test that used to walk the exported `jobs` array
+ * needs somewhere to ask the same question, and so does a script.
+ *
+ * What the providers add on top of these is the decision of *whether* to ask,
+ * which is the config's to make and not this file's.
+ */
+
+/**
+ * A directory the app named, resolved the way the app meant it.
+ *
+ * Relative paths hang off the project root rather than `process.cwd()` at the
+ * moment of the call, because a config slice saying `app/jobs` means the app's
+ * `app/jobs` and not whatever directory somebody happened to launch a script
+ * from. Absolute paths are taken as given, which is what makes these callable
+ * from a test that has no project around it.
+ */
+function resolveDir(dir: string): string {
+  return isAbsolute(dir) ? dir : join(projectRoot(), dir);
+}
+
+/**
+ * Says something when the directory is missing *and so is the tree it lives in*.
+ *
+ * A missing directory has two readings and they want opposite responses. An app
+ * that has never written a cron job has no `app/cron`, and warning about that on
+ * every boot for the rest of its life is noise — the answer "you have no cron
+ * jobs" is correct and uninteresting. But a deploy that ships `dist/` and
+ * `node_modules/` without the source has no `app/cron` *and no `app/`*, and
+ * there discovery quietly returns nothing while the app very much does have
+ * jobs: the exact silence #322 and #323 exist to remove, reintroduced one layer
+ * down and in production only.
+ *
+ * The parent directory is what tells them apart. If neither the directory nor
+ * the one above it is there, the tree this was pointed into is not there
+ * either, and that is worth a sentence.
+ */
+function warnIfSourceIsMissing(
+  resolved: string,
+  subject: string,
+  slice: string,
+) {
+  if (existsSync(resolved) || existsSync(dirname(resolved))) return;
+
+  console.warn(
+    `No ${subject} were discovered: neither ${resolved} nor the directory ` +
+      `above it exists, so this process cannot see the application's source. ` +
+      `If this is a deploy that ships only the build output, list the classes ` +
+      `explicitly in app/config/${slice}.ts so they travel with it.`,
+  );
+}
+
+/**
+ * The `Job` subclasses under `dir`, defaulting to the config slice's `app/jobs`.
+ *
+ * This is what a `queue` config slice with no `jobs` key resolves to. Call it
+ * directly to ask the question a test used to answer by importing the array:
+ * every job this application would register, in the order it would register
+ * them.
+ *
+ * Every file underneath is imported, so calling this runs the app's job modules
+ * — the cost `discoverClasses` documents at length, paid once per call.
+ */
+export async function discoverJobs(
+  dir: string = queueConfigDefaults().jobsDir,
+): Promise<Array<new () => Job>> {
+  const resolved = resolveDir(dir);
+  warnIfSourceIsMissing(resolved, "queue jobs", "queue");
+  return await discoverClasses(resolved, Job);
+}
+
+/**
+ * The `CronJob` subclasses under `dir`, defaulting to the config slice's
+ * `app/cron`.
+ *
+ * This is what a `schedule` config slice with no `jobs` key resolves to. Call it
+ * directly to ask the question a test used to answer by importing the array —
+ * though after boot `app(Scheduler).jobs` is the better one, because it is what
+ * the scheduler actually took rather than what this would find if asked again.
+ *
+ * Every file underneath is imported, so calling this runs the app's cron
+ * modules — the cost `discoverClasses` documents at length, paid once per call.
+ */
+export async function discoverCronJobs(
+  dir: string = scheduleConfigDefaults().jobsDir,
+): Promise<Array<new () => CronJob>> {
+  const resolved = resolveDir(dir);
+  warnIfSourceIsMissing(resolved, "cron jobs", "schedule");
+  return await discoverClasses(resolved, CronJob);
+}

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -105,6 +105,11 @@ export { ScheduleServiceProvider } from "./cron/ScheduleServiceProvider";
 export { Scheduler } from "./cron/Scheduler";
 export { CronJob } from "./cron/CronJob";
 
+// Discovery. What a `jobs`-less `queue` or `schedule` slice resolves to, and
+// the only way left to ask an application what it has: the config array a test
+// used to import may not exist any more.
+export { discoverJobs, discoverCronJobs } from "./discovery";
+
 // Redis
 export { RedisServiceProvider } from "./redis/RedisServiceProvider";
 export { RedisManager } from "./redis/RedisManager";

--- a/packages/gemi/services/queue/QueueManager.test.ts
+++ b/packages/gemi/services/queue/QueueManager.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { Job } from "./Job";
+import { QueueManager } from "./QueueManager";
+
+/**
+ * What happens to a dispatch the registry cannot resolve.
+ *
+ * This is the exact failure #322 is about, seen from the far end: the job class
+ * exists, the dispatch happened, and the name it carried matches nothing the
+ * manager holds. Discovery is what makes that state ordinary rather than
+ * exotic — an app no longer writes the registry by hand, so "nothing is
+ * registered" is now reachable by shipping a build without its source, and the
+ * queue has to survive it.
+ *
+ * `next()` runs to completion synchronously on this path — nothing before the
+ * unknown name is awaited — so `push()` is enough to drive it, and a
+ * non-terminating one takes the test process down with it rather than timing
+ * out politely.
+ */
+
+class SendWelcomeEmail extends Job {
+  run() {
+    return "sent";
+  }
+}
+
+class ChargeCard extends Job {
+  run() {
+    return "charged";
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("a dispatch nothing is registered under", () => {
+  test("is dropped, said out loud, and does not wedge the queue", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const queue = new QueueManager({ jobs: [] });
+
+    queue.push(SendWelcomeEmail, "[]");
+
+    // Drained, not left at the head. It used to stay: the delete lived inside
+    // the branch that resolved the name, so the queue never emptied, the
+    // `size === 0` return was never reached, and `next()` recursed on the same
+    // entry until the stack gave out — a stack overflow in place of the
+    // dropped job the docs describe.
+    expect(queue.queue.size).toBe(0);
+    expect(queue.isRunning).toBe(false);
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain(
+      'nothing is registered under the name "SendWelcomeEmail"',
+    );
+  });
+
+  test("does not stop the jobs behind it in the queue from running", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const queue = new QueueManager({ jobs: [ChargeCard], concurrency: 5 });
+    const ran = vi.spyOn(ChargeCard.prototype, "run");
+
+    queue.push(SendWelcomeEmail, "[]");
+    queue.push(ChargeCard, "[]");
+
+    expect(ran).toHaveBeenCalledTimes(1);
+    expect(queue.queue.size).toBe(0);
+  });
+});
+
+describe("a dispatch that resolves", () => {
+  test("runs, and leaves the queue empty", () => {
+    const queue = new QueueManager({ jobs: [ChargeCard] });
+    const ran = vi.spyOn(ChargeCard.prototype, "run");
+
+    queue.push(ChargeCard, "[]");
+
+    expect(ran).toHaveBeenCalledTimes(1);
+    expect(queue.queue.size).toBe(0);
+  });
+});

--- a/packages/gemi/services/queue/QueueManager.test.ts
+++ b/packages/gemi/services/queue/QueueManager.test.ts
@@ -67,6 +67,63 @@ describe("a dispatch nothing is registered under", () => {
   });
 });
 
+/**
+ * Two classes with one name.
+ *
+ * A directory walk is what makes this ordinary: `auth/SendEmail.ts` beside
+ * `billing/SendEmail.ts` is a natural thing to write, and nothing forces the
+ * import alias that a hand-written list would have demanded. The failure is
+ * also the worst one here — not a dropped dispatch but the wrong body running
+ * under the right name, reporting success.
+ */
+describe("two jobs claiming one class name", () => {
+  /** Same class name, different bodies — what two directories would produce. */
+  const sendEmail = (from: string) =>
+    ({
+      SendEmail: class SendEmail extends Job {
+        run() {
+          return from;
+        }
+      },
+    }).SendEmail;
+
+  test("the first keeps the name, the second is refused out loud", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const auth = sendEmail("auth");
+    const billing = sendEmail("billing");
+
+    const queue = new QueueManager({ jobs: [auth, billing] });
+
+    // The registry resolves to the first. It used to resolve to the last —
+    // `Object.fromEntries` keeps the final occurrence of a repeated key — so
+    // dispatching the auth class ran billing's body and said nothing.
+    expect(queue.dispatchJob("SendEmail", "[]")).toBe("auth");
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain(
+      'Two queued jobs are named "SendEmail"',
+    );
+  });
+
+  test("both still appear in `registeredJobs`, so a test can see the clash", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const queue = new QueueManager({
+      jobs: [sendEmail("auth"), sendEmail("billing")],
+    });
+
+    expect(queue.registeredJobs).toHaveLength(2);
+  });
+});
+
+describe("the readable view", () => {
+  test("is a copy, so walking it cannot edit what the queue runs from", () => {
+    const queue = new QueueManager({ jobs: [ChargeCard] });
+
+    (queue.registeredJobs as Array<new () => Job>).length = 0;
+
+    expect(queue.registeredJobs).toHaveLength(1);
+  });
+});
+
 describe("a dispatch that resolves", () => {
   test("runs, and leaves the queue empty", () => {
     const queue = new QueueManager({ jobs: [ChargeCard] });

--- a/packages/gemi/services/queue/QueueManager.ts
+++ b/packages/gemi/services/queue/QueueManager.ts
@@ -74,9 +74,41 @@ export class QueueManager {
 
   constructor(config: QueueConfig = {}) {
     this.config = withDefaults(queueConfigDefaults(), config);
-    this.jobs = Object.fromEntries(
-      this.config.jobs.map((job) => [job.name, job]),
-    );
+    this.useJobs(this.config.jobs);
+  }
+
+  /**
+   * Replaces the registered set, for the provider to hand over what it found
+   * under `app/jobs`.
+   *
+   * This exists because the two phases disagree about when the answer is
+   * knowable. The manager is constructed in `register()`, which is synchronous
+   * and must resolve nothing; reading a directory and importing what is in it is
+   * neither. So the manager is built from whatever the config slice declared —
+   * nothing, when the app left `jobs` out — and the discovered set arrives in
+   * `boot()`.
+   *
+   * The consequence worth knowing: anything that constructs an application and
+   * skips phase two sees an empty registry, and every dispatch against an empty
+   * registry is dropped — loudly on stderr, but after `Job.dispatch` has already
+   * returned, so no caller finds out. An app that lists its jobs explicitly is
+   * unaffected, because that list is already in place by the end of `register()`.
+   */
+  useJobs(jobs: Array<new () => Job>) {
+    this.config.jobs = jobs;
+    this.jobs = Object.fromEntries(jobs.map((job) => [job.name, job]));
+  }
+
+  /**
+   * What the manager ended up with, discovered or declared.
+   *
+   * The registry is keyed by name, and a name is exactly what a dispatch
+   * carries, so "is this job registered?" is a question with a silent wrong
+   * answer — `next()` skips an unknown name and the work disappears. This is
+   * where a test asks it out loud.
+   */
+  get registeredJobs(): ReadonlyArray<new () => Job> {
+    return this.config.jobs;
   }
 
   dispatchJob(jobName: string, args: string) {
@@ -96,15 +128,36 @@ export class QueueManager {
       return this.next();
     }
 
-    const jobDefinition = this.queue.values().next().value as JobDefinition;
+    const jobDefinition = this.queue.values().next().value as
+      | JobDefinition
+      | undefined;
 
-    if (this.jobs[jobDefinition?.class]) {
-      const { value } = this.queue.values().next();
-      if (value) {
-        this.queue.delete(value);
+    if (jobDefinition) {
+      // Taken off the queue before anything decides what to do with it. The
+      // delete used to live inside the `if` below, so a name the registry could
+      // not resolve left the head in place, the `size === 0` check below was
+      // never reached, and `next()` recursed on the same entry until the stack
+      // gave out. An unregistered dispatch is meant to be a dropped job, not a
+      // crash — and discovery makes an empty registry newly reachable (a deploy
+      // that ships no source finds nothing to register), so the difference
+      // stopped being theoretical.
+      this.queue.delete(jobDefinition);
+
+      if (this.jobs[jobDefinition.class]) {
+        this.run(jobDefinition);
+      } else {
+        // The one place this is observable. A dispatch carries a name, the
+        // registry is keyed by name, and a name nobody registered matches
+        // nothing — which is exactly the silence #322 is about, except here it
+        // has already happened and the work is gone. Saying so is all that is
+        // left to do about it.
+        console.error(
+          `Dropped a queued job: nothing is registered under the name ` +
+            `"${jobDefinition.class}". If the class exists, it was not ` +
+            `discovered — check that it is under the queue slice's jobsDir ` +
+            `(app/jobs by default), or list it in app/config/queue.ts.`,
+        );
       }
-
-      this.run(jobDefinition);
     }
 
     if (this.queue.size === 0) {

--- a/packages/gemi/services/queue/QueueManager.ts
+++ b/packages/gemi/services/queue/QueueManager.ts
@@ -96,19 +96,54 @@ export class QueueManager {
    */
   useJobs(jobs: Array<new () => Job>) {
     this.config.jobs = jobs;
-    this.jobs = Object.fromEntries(jobs.map((job) => [job.name, job]));
+
+    // Built one at a time rather than by `Object.fromEntries`, which resolves a
+    // repeated key by keeping the last and saying nothing.
+    //
+    // Two classes with one name is the worst failure in this subsystem, and it
+    // is worse than the dropped dispatch the rest of this file is about: the
+    // registry is keyed by class name, a dispatch carries a class name, so
+    // `SendEmail.dispatch(...)` on the one under `app/jobs/auth` would run the
+    // body of the one under `app/jobs/billing`. Nothing is dropped and nothing
+    // errors — the wrong work happens and reports success.
+    //
+    // Discovery is what makes it ordinary. A hand-written list forces an import
+    // alias in one visible file the moment two names clash; a directory walk
+    // does not, and `auth/SendEmail.ts` beside `billing/SendEmail.ts` is a
+    // perfectly natural thing to write. So the first claim wins and the second
+    // is refused out loud — the same rule `Scheduler.start` applies to a cron
+    // name, and the reverse of the silent last-wins this replaces.
+    this.jobs = {};
+    for (const job of jobs) {
+      const taken = this.jobs[job.name];
+      if (taken) {
+        console.error(
+          `Two queued jobs are named "${job.name}" — the first is registered ` +
+            `and this one is not, so dispatching either would have run one of ` +
+            `them. A class name is the queue's key, so only one job can hold ` +
+            `it. Rename one.`,
+        );
+        continue;
+      }
+      this.jobs[job.name] = job;
+    }
   }
 
   /**
-   * What the manager ended up with, discovered or declared.
+   * What the manager was handed, discovered or declared.
    *
    * The registry is keyed by name, and a name is exactly what a dispatch
    * carries, so "is this job registered?" is a question with a silent wrong
-   * answer — `next()` skips an unknown name and the work disappears. This is
-   * where a test asks it out loud.
+   * answer — `next()` drops an unknown name long after the caller moved on.
+   * This is where a test asks it out loud.
+   *
+   * It reports what came in, not what the registry accepted, so a name claimed
+   * twice appears twice here — deliberately, the same way `Scheduler.jobs`
+   * does. A test walking this should see the collision rather than have it
+   * tidied away. A copy, so that walk cannot edit the registry underneath it.
    */
   get registeredJobs(): ReadonlyArray<new () => Job> {
-    return this.config.jobs;
+    return [...this.config.jobs];
   }
 
   dispatchJob(jobName: string, args: string) {

--- a/packages/gemi/services/queue/QueueServiceProvider.ts
+++ b/packages/gemi/services/queue/QueueServiceProvider.ts
@@ -1,5 +1,7 @@
 import { ServiceProvider } from "../../support/ServiceProvider";
-import type { QueueConfig } from "./config";
+import { discoverJobs } from "../discovery";
+import { withDefaults } from "../../support/withDefaults";
+import { queueConfigDefaults, type QueueConfig } from "./config";
 import { QueueManager } from "./QueueManager";
 
 export class QueueServiceProvider extends ServiceProvider {
@@ -8,5 +10,36 @@ export class QueueServiceProvider extends ServiceProvider {
       QueueManager,
       () => new QueueManager(this.app.config.get<QueueConfig>("queue", {})),
     );
+  }
+
+  /**
+   * Fills in the job registry when the app did not declare one.
+   *
+   * ### Why the raw slice and not the manager's config
+   *
+   * The decision here is whether the app said anything, and by the time the
+   * manager holds a config it can no longer tell: `withDefaults` treats an
+   * absent key and an `undefined` one alike and substitutes the default `[]`,
+   * which is the same value an app writes when it means "no jobs, and I mean
+   * it". Reading the slice before defaults are applied is the only place the
+   * difference still exists.
+   *
+   * So: `jobs` present, including `jobs: []`, is used verbatim and no directory
+   * is read. Absent or `undefined`, the classes under `jobsDir` are.
+   *
+   * ### Why phase two
+   *
+   * Discovery imports every file it walks, which is asynchronous, and
+   * `register()` is not. It also has to happen before the first dispatch rather
+   * than before the first tick — there is no equivalent of the scheduler's
+   * `start()` to hang it off, so the registry has to be complete by the end of
+   * boot.
+   */
+  async boot() {
+    const slice = this.app.config.get<QueueConfig>("queue", {});
+    if (slice.jobs !== undefined) return;
+
+    const { jobsDir } = withDefaults(queueConfigDefaults(), slice);
+    this.app.make(QueueManager).useJobs(await discoverJobs(jobsDir));
   }
 }

--- a/packages/gemi/services/queue/config.ts
+++ b/packages/gemi/services/queue/config.ts
@@ -2,7 +2,46 @@ import type { Job } from "./Job";
 
 // Config key: `queue`. Derived from `QueueServiceProvider`.
 export interface QueueConfig {
+  /**
+   * The `Job` subclasses this application dispatches, or nothing.
+   *
+   * ### Why "or nothing" is the point
+   *
+   * A dispatch that names a job the `QueueManager` has never heard of does not
+   * fail — `next()` looks the name up in this list, and what is not there is
+   * dropped with a line on stderr and nothing else. `Job.dispatch` has already
+   * returned by then, so nothing upstream can be told. The list is therefore a
+   * second spelling of `app/jobs`, kept in step by hand, and the cost of the
+   * two disagreeing is paid by whatever was supposed to happen after the
+   * dispatch.
+   *
+   * Leaving this out spells it once: the jobs are the classes under `jobsDir`.
+   *
+   * ### The rule, exactly
+   *
+   * **Declared wins, and `[]` is declared.** A `jobs` that is present is used
+   * verbatim and no directory is read — that is the escape hatch for an app
+   * whose jobs live somewhere this cannot walk, for one that deliberately
+   * registers a subset, and for a deploy that ships no source. An empty array
+   * means an app with no jobs and says so; it does not mean "find some".
+   *
+   * **Absent or `undefined` discovers.** `undefined` counts as absent for the
+   * same reason `withDefaults` treats it that way everywhere else: a key spread
+   * in from an optional value is an omission, not an instruction.
+   */
   jobs?: Array<new () => Job>;
+
+  /**
+   * Where to look when `jobs` was not declared. Relative to the project root,
+   * or absolute.
+   *
+   * Every `.ts`/`.tsx` file underneath it is imported at boot and every exported
+   * class extending `Job` is registered, so this wants to be a directory of job
+   * declarations rather than a directory that merely contains some. Moving the
+   * jobs is what this field is for; pointing it at `app/` is not.
+   */
+  jobsDir?: string;
+
   concurrency?: number;
 }
 
@@ -13,6 +52,7 @@ export function defineQueueConfig(config: QueueConfig): QueueConfig {
 export function queueConfigDefaults(): Required<QueueConfig> {
   return {
     jobs: [],
+    jobsDir: "app/jobs",
     concurrency: 1,
   };
 }

--- a/packages/gemi/support/discover.test.ts
+++ b/packages/gemi/support/discover.test.ts
@@ -1,0 +1,380 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, describe, expect, test } from "vitest";
+
+import {
+  DiscoveryError,
+  discoverClasses,
+  projectRoot,
+  sourceFiles,
+} from "./discover";
+
+/**
+ * The walk #322 and #323 both stand on.
+ *
+ * Two halves, and they fail in opposite directions. The walker decides which
+ * files are imported at all, so its mistakes are silent: a rule that skips one
+ * file too many produces a job that is never registered and never complained
+ * about, which is the failure discovery was built to remove. `discoverClasses`
+ * decides what counts as a class worth returning, and its mistakes are loud —
+ * scheduling an abstract base, or a helper function that happens to be
+ * exported.
+ *
+ * So both halves are asserted against a real directory rather than a mock: the
+ * skip rules are only true of a filesystem, and a fixture that imports nothing
+ * from `gemi` is what lets these projects live in a temp directory with no
+ * `node_modules` above them. That is also why `discoverClasses` takes its base
+ * class as an argument — the fixtures below declare their own and hand it back.
+ */
+
+const roots: string[] = [];
+
+const write = (root: string, path: string, source: string) => {
+  mkdirSync(join(root, path, ".."), { recursive: true });
+  writeFileSync(join(root, path), source);
+};
+
+/** A directory of empty files, for the questions that are only about paths. */
+const tree = (files: string[]): string => {
+  const root = mkdtempSync(join(tmpdir(), "gemi-discover-"));
+  roots.push(root);
+  for (const file of files) write(root, file, "");
+  return root;
+};
+
+/** A directory of real modules, for the questions that are about what is in them. */
+const project = (files: Record<string, string>): string => {
+  const root = mkdtempSync(join(tmpdir(), "gemi-discover-project-"));
+  roots.push(root);
+  for (const [path, source] of Object.entries(files)) write(root, path, source);
+  return root;
+};
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+/** The base every fixture below extends, written into the fixture itself. */
+const BASE = `export class Base {
+  run() {}
+}`;
+
+/** Reads the fixture's own base class back out, so identity holds. */
+const baseOf = async (root: string) =>
+  (
+    (await import(join(root, "base.ts"))) as {
+      Base: abstract new () => unknown;
+    }
+  ).Base;
+
+const names = (classes: Array<{ name: string }>) =>
+  classes.map((value) => value.name);
+
+describe("which files the walk offers", () => {
+  const relative = (root: string, paths: string[]) =>
+    paths.map((path) => path.slice(root.length + 1));
+
+  test("walks nested directories, because apps group classes into folders", () => {
+    const root = tree(["index.ts", "billing/Invoice.ts", "billing/Plan.ts"]);
+
+    expect(relative(root, sourceFiles(root))).toEqual([
+      "billing/Invoice.ts",
+      "billing/Plan.ts",
+      "index.ts",
+    ]);
+  });
+
+  /**
+   * The files certain not to declare a job and most likely to be expensive to
+   * import. A test file next to the job it tests is the ordinary layout, and
+   * importing it at boot would run the suite inside the server.
+   */
+  test("skips tests, type tests and benchmarks", () => {
+    const root = tree([
+      "SendEmail.ts",
+      "SendEmail.test.ts",
+      "dispatch.test-d.ts",
+      "throughput.bench.ts",
+      "retries.spec.ts",
+    ]);
+
+    expect(relative(root, sourceFiles(root))).toEqual(["SendEmail.ts"]);
+  });
+
+  test("skips node_modules and dot-directories", () => {
+    const root = tree([
+      "SendEmail.ts",
+      "node_modules/pkg/index.ts",
+      ".cache/thing.ts",
+    ]);
+
+    expect(relative(root, sourceFiles(root))).toEqual(["SendEmail.ts"]);
+  });
+
+  /** `.d.ts` ends in `.ts` and has no runtime module behind it. */
+  test("skips declaration files", () => {
+    const root = tree(["SendEmail.ts", "client/index.d.ts"]);
+
+    expect(relative(root, sourceFiles(root))).toEqual(["SendEmail.ts"]);
+  });
+
+  test("ignores files that are not TypeScript", () => {
+    const root = tree(["SendEmail.ts", "queue.json", "notes.md", "dev.db"]);
+
+    expect(relative(root, sourceFiles(root))).toEqual(["SendEmail.ts"]);
+  });
+
+  /**
+   * A directory with a `package.json` is a package that happens to live here —
+   * a vendored client, a generated SDK — and importing its entry point runs
+   * somebody else's module graph.
+   */
+  test("skips a vendored package", () => {
+    const root = tree([
+      "SendEmail.ts",
+      "prisma-client/package.json",
+      "prisma-client/index.ts",
+    ]);
+
+    expect(relative(root, sourceFiles(root))).toEqual(["SendEmail.ts"]);
+  });
+
+  test("`ignore` skips a path and everything under it", () => {
+    const root = tree(["SendEmail.ts", "bench/run.ts", "bench/harness.ts"]);
+
+    expect(relative(root, sourceFiles(root, ["bench"]))).toEqual([
+      "SendEmail.ts",
+    ]);
+  });
+
+  test("`ignore` can name a single file", () => {
+    const root = tree(["SendEmail.ts", "bench/run.ts", "bench/harness.ts"]);
+
+    expect(relative(root, sourceFiles(root, ["bench/run.ts"]))).toEqual([
+      "SendEmail.ts",
+      "bench/harness.ts",
+    ]);
+  });
+
+  /**
+   * `readdirSync` returns the filesystem's order, not a sorted one, so the sort
+   * inside the walk is what makes two runs over one tree agree — and the caller
+   * is a scheduler importing in that order. Sorting per directory rather than
+   * sorting the finished list is what puts `a/b.ts` before `a.ts`.
+   */
+  test("is ordered the same on every run, directories before their siblings", () => {
+    const root = tree(["a.ts", "a/b.ts", "b.ts"]);
+
+    expect(relative(root, sourceFiles(root))).toEqual([
+      "a/b.ts",
+      "a.ts",
+      "b.ts",
+    ]);
+    expect(sourceFiles(root)).toEqual(sourceFiles(root));
+  });
+
+  /**
+   * An app that has not written its first job yet is an ordinary state, and
+   * throwing at it would make discovery something an app has to opt out of by
+   * creating an empty directory.
+   */
+  test("a directory that is not there is an empty list, not a throw", () => {
+    const root = tree(["SendEmail.ts"]);
+
+    expect(sourceFiles(join(root, "nowhere"))).toEqual([]);
+  });
+});
+
+describe("which classes come back", () => {
+  /**
+   * The order is the walk's, which is per-directory and by codepoint — so
+   * `SendEmail.ts` comes before the `billing/` beside it, and a run that
+   * reordered itself between two boots would show up here.
+   */
+  test("a subclass in each file, in the walk's order", async () => {
+    const root = project({
+      "base.ts": BASE,
+      "SendEmail.ts": `import { Base } from "./base";
+        export class SendEmail extends Base {}`,
+      "billing/Invoice.ts": `import { Base } from "../base";
+        export class Invoice extends Base {}`,
+    });
+
+    const found = await discoverClasses(root, await baseOf(root));
+
+    expect(names(found)).toEqual(["SendEmail", "Invoice"]);
+  });
+
+  /**
+   * The shape an app reaches for the moment several jobs share a gate: a base
+   * of its own, in the same directory, exported like everything else. A
+   * framework that scheduled it would be running a job nobody wrote.
+   */
+  test("the base itself is never one of them, even where it is exported beside them", async () => {
+    const root = project({
+      "base.ts": BASE,
+      "Reporting.ts": `import { Base } from "./base";
+        export abstract class Reporting extends Base {}`,
+      "Weekly.ts": `import { Reporting } from "./Reporting";
+        export class Weekly extends Reporting {}`,
+    });
+
+    const found = await discoverClasses(root, await baseOf(root));
+
+    expect(names(found)).toEqual(["Reporting", "Weekly"]);
+  });
+
+  test("a subclass two levels down the chain still matches", async () => {
+    const root = project({
+      "base.ts": BASE,
+      "chain.ts": `import { Base } from "./base";
+        class Middle extends Base {}
+        class Inner extends Middle {}
+        export class Leaf extends Inner {}`,
+    });
+
+    const found = await discoverClasses(root, await baseOf(root));
+
+    expect(names(found)).toEqual(["Leaf"]);
+  });
+
+  /**
+   * A directory holds more than its classes — a helper, a schedule constant, a
+   * type. `typeof value === "function"` is true of the helper too, so the
+   * prototype chain is what has to answer, not the typeof.
+   */
+  test("an export that is not a subclass is not one of them", async () => {
+    const root = project({
+      "base.ts": BASE,
+      "SendEmail.ts": `import { Base } from "./base";
+        export class SendEmail extends Base {}
+        export class Formatter {}
+        export function helper() {}
+        export const EVERY_MINUTE = "* * * * *";
+        export default { name: "not a class" };`,
+    });
+
+    const found = await discoverClasses(root, await baseOf(root));
+
+    expect(names(found)).toEqual(["SendEmail"]);
+  });
+
+  /**
+   * A barrel beside the classes it re-exports is the ordinary layout, and it
+   * makes every one of them reachable twice. Registering a cron twice is two
+   * `Bun.cron` handles on one schedule.
+   */
+  test("a class re-exported by a barrel comes back once", async () => {
+    const root = project({
+      "base.ts": BASE,
+      "SendEmail.ts": `import { Base } from "./base";
+        export class SendEmail extends Base {}`,
+      "index.ts": `export { SendEmail } from "./SendEmail";`,
+    });
+
+    const found = await discoverClasses(root, await baseOf(root));
+
+    expect(names(found)).toEqual(["SendEmail"]);
+    expect(found).toHaveLength(1);
+  });
+
+  /**
+   * `export default class` is how a file holding exactly one class often reads,
+   * and a module namespace names it `default` like anything else — so the rule
+   * is about the prototype chain, not about the export being named.
+   */
+  test("a default export counts", async () => {
+    const root = project({
+      "base.ts": BASE,
+      "SendEmail.ts": `import { Base } from "./base";
+        export default class SendEmail extends Base {}`,
+    });
+
+    const found = await discoverClasses(root, await baseOf(root));
+
+    expect(names(found)).toEqual(["SendEmail"]);
+  });
+
+  test("`ignore` keeps a directory out of the walk and out of the answer", async () => {
+    const root = project({
+      "base.ts": BASE,
+      "SendEmail.ts": `import { Base } from "./base";
+        export class SendEmail extends Base {}`,
+      "bench/Throughput.ts": `import { Base } from "../base";
+        export class Throughput extends Base {}`,
+    });
+
+    const found = await discoverClasses(root, await baseOf(root), ["bench"]);
+
+    expect(names(found)).toEqual(["SendEmail"]);
+  });
+
+  test("a directory that is not there discovers nothing", async () => {
+    const root = project({ "base.ts": BASE });
+
+    expect(
+      await discoverClasses(join(root, "nowhere"), await baseOf(root)),
+    ).toEqual([]);
+  });
+
+  /**
+   * The red path, and the one worth spelling out. A file that will not import
+   * is a class the caller was going to be told about and now is not, so it
+   * stops the walk — but the throw a failed dynamic import produces names the
+   * specifier that would not resolve, several frames deep, and nothing about
+   * the walk that asked for it. Naming the file, and the way out, is the whole
+   * difference between a boot failure somebody can act on and a stack trace.
+   */
+  test("a file that will not import names itself, and the way out", async () => {
+    const root = project({
+      "base.ts": BASE,
+      "Broken.ts": `throw new Error("a template this needs is not a module");`,
+    });
+
+    const failure = await discoverClasses(root, await baseOf(root)).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(DiscoveryError);
+    const error = failure as DiscoveryError;
+    expect(error.message).toContain(join(root, "Broken.ts"));
+    expect(error.message).toContain("a template this needs is not a module");
+    expect(error.message).toContain("List the classes explicitly");
+    // The original is kept, because the message above summarises a stack that
+    // is the only thing naming the specifier that actually failed.
+    expect(error.cause).toBeInstanceOf(Error);
+  });
+});
+
+/**
+ * The rule every relative `jobsDir` is resolved by.
+ *
+ * It has no caller inside this file's other tests and none inside the
+ * discovery tests either — those all name an absolute directory, because a
+ * fixture in `tmpdir()` has no other way to be found. So the one line that
+ * turns `"app/cron"` into a path is the one line nothing was exercising, and
+ * deleting it left the whole suite green while pointing every deployment that
+ * sets `GEMI_PROJECT_DIR` at the wrong directory — where it would find no jobs
+ * and say nothing, which is the failure this feature exists to remove.
+ */
+describe("where a relative directory is resolved from", () => {
+  const previous = process.env.GEMI_PROJECT_DIR;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.GEMI_PROJECT_DIR;
+    else process.env.GEMI_PROJECT_DIR = previous;
+  });
+
+  test("the working directory, when nothing says otherwise", () => {
+    delete process.env.GEMI_PROJECT_DIR;
+
+    expect(projectRoot()).toBe(process.cwd());
+  });
+
+  test("the subdirectory `GEMI_PROJECT_DIR` names, the way httpProd reads it", () => {
+    process.env.GEMI_PROJECT_DIR = "packages/app";
+
+    expect(projectRoot()).toBe(join(process.cwd(), "packages/app"));
+  });
+});

--- a/packages/gemi/support/discover.ts
+++ b/packages/gemi/support/discover.ts
@@ -1,0 +1,236 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+
+/**
+ * Finding the classes an application declared and never imported — the walk
+ * #322 and #323 both end at.
+ *
+ * ### Why it has to run the files
+ *
+ * A job that is written and not listed does not fail; it disappears.
+ * `QueueManager.next` looks a dispatched name up in the map its config built and
+ * skips what is not there, so the dispatch is simply lost. A cron drifts worse:
+ * nothing is waiting on a tick, so a job that never fires reports nothing to
+ * anyone. What both come down to is that `app/config/queue.ts` naming every
+ * `Job` subclass is the *only* thing putting those classes in the module graph —
+ * the list and the directory are two spellings of one set, kept in step by hand.
+ *
+ * The way out of that is to read the directory, and there is no static read that
+ * will do: the class does not exist until its module has run. So **every file
+ * walked here is imported**, and a file that *does something* when imported does
+ * it here — at boot, in production, on every start. `gemi check models` makes
+ * the same trade for the same reason and pays it once per CI run; a caller of
+ * this pays it once per process.
+ *
+ * ### What that asks of a caller
+ *
+ * **Point it at a directory of class declarations, not at `app/`.** The skip
+ * rules on `sourceFiles` drop what certainly is not one — tests, benchmarks,
+ * `.d.ts`, vendored packages — and nothing else. Widening the guesses is how a
+ * discovery pass ends up quietly covering less than the directory holds, which
+ * is the same silence in a new place.
+ *
+ * **Let a broken file stop the boot.** `discoverClasses` rethrows an import
+ * failure naming the file rather than dropping it and carrying on, for the same
+ * reason: four classes found out of five looks exactly like five out of five.
+ *
+ * **Leave a way out.** Discovery is what should happen when an app said
+ * nothing. An app that lists its classes explicitly must not reach this file at
+ * all — that is the escape hatch for a directory holding something this cannot
+ * import, and it is the sentence an error from here should point at.
+ *
+ * ### One more thing worth knowing
+ *
+ * This imports by absolute path, while the application imports the same files
+ * through the `@/app/*` alias. Bun keys its module registry by the *resolved*
+ * path, so those two specifiers land on one module: a job already reached from
+ * a controller is not evaluated a second time here, and the class object is the
+ * same one. `gemi build` leaves that true in production — `packages: "external"`
+ * keeps the app's own code out of `dist/server/server.mjs` and resolves it from
+ * source at runtime, exactly as `gemi dev` does.
+ *
+ * Nothing here depends on that holding, and deliberately: `QueueManager` and the
+ * `Scheduler`'s cross-reload registry are both keyed by name rather than by
+ * class identity, so a build that did inline the app's modules would produce a
+ * duplicate class object and still register the right job. Worth knowing before
+ * writing a registry keyed the other way.
+ */
+
+/**
+ * The files under `dir` that could declare a class.
+ *
+ * Everything underneath it, because apps do group classes into folders, minus
+ * what cannot be one. Each of these is going to be *imported*, so the exclusions
+ * are about what is certainly not source rather than about what is probably not:
+ *
+ *   - **Declaration files.** `.d.ts` has no runtime module behind it.
+ *   - **Tests, type tests and benchmarks**, by the suffix a runner already
+ *     recognises.
+ *   - **Dot-directories and `node_modules`.**
+ *   - **Any directory holding a `package.json`.** That is a package that happens
+ *     to live here — a vendored client, a generated SDK — not this app's source,
+ *     and importing its entry point runs somebody else's module graph. The
+ *     template has two under `app/models`.
+ *
+ * `ignore` is the escape hatch for the rest: a path prefix, relative to `dir`,
+ * naming a file or a directory of adjacent code that runs something on import.
+ * Nothing is ignored by default.
+ *
+ * The order is the same on every run over the same tree, which matters because
+ * the caller is going to import in it: entries are sorted per directory before
+ * recursing, and `readdirSync` order is the filesystem's rather than
+ * alphabetical — a tree written `A.ts` then `B.ts` reads back `B.ts` first on
+ * the machines this was tested on. Sorting per directory rather than sorting the
+ * finished list is deliberate: for a tree holding both `a.ts` and `a/b.ts`, this
+ * emits `a/b.ts` first, because the directory sorts before the file.
+ *
+ * A directory that does not exist yields an empty list rather than throwing.
+ * "The app has no jobs yet" is an ordinary state and not this function's to
+ * complain about — but it is indistinguishable from "the app's source did not
+ * ship", so a caller that boots on the answer owes the reader a word about which
+ * one it got.
+ */
+export function sourceFiles(dir: string, ignore: string[] = []): string[] {
+  const out: string[] = [];
+
+  const ignored = (path: string) => {
+    const rel = relative(dir, path).split("\\").join("/");
+    return ignore.some(
+      (pattern) => rel === pattern || rel.startsWith(`${pattern}/`),
+    );
+  };
+
+  const walk = (current: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true }).sort(
+      (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
+    )) {
+      const path = join(current, entry.name);
+      if (ignored(path)) continue;
+
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith(".") || entry.name === "node_modules")
+          continue;
+        if (existsSync(join(path, "package.json"))) continue;
+        walk(path);
+        continue;
+      }
+
+      if (!entry.name.endsWith(".ts") && !entry.name.endsWith(".tsx")) continue;
+      if (entry.name.endsWith(".d.ts")) continue;
+      if (/\.(test|test-d|spec|bench)\.tsx?$/.test(entry.name)) continue;
+
+      out.push(path);
+    }
+  };
+
+  if (!existsSync(dir)) return out;
+
+  walk(dir);
+  return out;
+}
+
+/**
+ * A class, as much of one as this file can name. `abstract` so that a base an
+ * app never instantiates directly is a legal argument.
+ */
+type ClassLike = abstract new (...args: never[]) => unknown;
+
+/**
+ * A file that would not import, reported with the file that would not import.
+ *
+ * Separate from a bare rethrow because the stack of a failed dynamic import
+ * names the module that failed to *resolve*, several frames deep, and says
+ * nothing about the walk that asked for it — so the reader learns that some
+ * `?raw` specifier is unresolvable without learning that discovery is what
+ * imported it, or that listing the classes explicitly is how they get their boot
+ * back.
+ */
+export class DiscoveryError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "DiscoveryError";
+  }
+}
+
+/**
+ * Every exported class under `dir` whose prototype chain reaches `base`.
+ *
+ * `base` is a parameter rather than an import so that this file names no
+ * service and stays cheap to depend on — `bin/check-models.ts` uses the walker
+ * above and is bundled into `dist/bin/gemi.js`, which is not somewhere gemi's
+ * service layer should end up. It is also what lets a test hand in a base class
+ * of its own instead of standing up a project that can resolve `gemi/services`.
+ *
+ * `base` itself is never returned. A directory whose files import their base
+ * from a sibling — the shape an app reaches for when several jobs share a gate —
+ * re-exports it as often as not, and a framework that scheduled the abstract
+ * base along with its subclasses would be running a job nobody wrote.
+ *
+ * A class is returned once no matter how many exports name it. A barrel in the
+ * directory re-exporting everything beside it is the ordinary case, and it makes
+ * every class reachable twice.
+ *
+ * The order is the walk's, and within a file the module namespace's, which the
+ * language sorts by name. So the answer is the same on every run — worth having
+ * where the caller is a scheduler and the alternative is a boot order that
+ * depends on the filesystem.
+ *
+ * @throws DiscoveryError if a walked file cannot be imported. Not a skip: a file
+ * that will not load is a class the caller was going to be told about and now is
+ * not, which is the failure discovery exists to remove.
+ */
+export async function discoverClasses<T extends ClassLike>(
+  dir: string,
+  base: T,
+  ignore: string[] = [],
+): Promise<T[]> {
+  const found = new Set<T>();
+
+  for (const path of sourceFiles(dir, ignore)) {
+    let module: Record<string, unknown>;
+
+    try {
+      module = (await import(path)) as Record<string, unknown>;
+    } catch (error) {
+      throw new DiscoveryError(
+        `${path} could not be imported, so the classes in it could not be ` +
+          `discovered:\n    ${(error as Error).message}\n` +
+          `List the classes explicitly in the config slice for this directory ` +
+          `to skip the walk.`,
+        { cause: error },
+      );
+    }
+
+    for (const value of Object.values(module)) {
+      if (typeof value !== "function" || value === base) continue;
+      if (!Object.prototype.isPrototypeOf.call(base, value)) continue;
+      found.add(value as unknown as T);
+    }
+  }
+
+  return [...found];
+}
+
+/**
+ * The directory an app's `app/` sits in, as the running process can know it.
+ *
+ * `ROOT_DIR` is the obvious answer and is not available: `Server.start` awaits
+ * `waitForBoot()` — every provider's `register` and `boot` — and only then
+ * imports the http layer that sets it. Anything resolving paths during boot is
+ * earlier than the variable it would want.
+ *
+ * What it can use is the same rule `httpProd` computes `ROOT_DIR` with a moment
+ * later, which is why that file now calls this instead of repeating it. `gemi
+ * dev` and `gemi start` both spawn the server with no `cwd`, so the process
+ * inherits the CLI's, and the CLI takes `process.cwd()` for the project root
+ * itself — `bun/preload.ts` reads `gemi.config` from it on the same assumption.
+ *
+ * `httpDev` computes a bare `process.cwd()`, so it and `httpProd` already
+ * disagree whenever `GEMI_PROJECT_DIR` is set. Nothing in this repo sets it and
+ * `gemi start` ignores it when locating the built entry point, so the two rules
+ * are the same rule for every configuration that runs today; the divergence is
+ * older than this function and wants its own fix.
+ */
+export function projectRoot(): string {
+  return join(process.cwd(), process.env.GEMI_PROJECT_DIR ?? "");
+}

--- a/packages/gemi/support/index.ts
+++ b/packages/gemi/support/index.ts
@@ -2,3 +2,9 @@ export { ServiceProvider } from "./ServiceProvider";
 export { Repository, type ConfigItems } from "./Repository";
 export { createConfigRepository, loadConfigFrom } from "./loadConfig";
 export { withDefaults } from "./withDefaults";
+export {
+  DiscoveryError,
+  discoverClasses,
+  projectRoot,
+  sourceFiles,
+} from "./discover";

--- a/templates/saas-starter/app/config/queue.ts
+++ b/templates/saas-starter/app/config/queue.ts
@@ -1,6 +1,20 @@
 import { defineQueueConfig } from "gemi/services";
 
+/**
+ * The queue.
+ *
+ * `jobs` is left out on purpose, and leaving it out is what asks gemi to read
+ * `app/jobs`: every `Job` subclass under there is registered at boot, so a job
+ * is dispatchable by existing. `app/jobs/TestJob.ts` is registered by this file
+ * saying nothing about it.
+ *
+ * Declare `jobs` to take that over — a present `jobs` is used verbatim and no
+ * directory is read, and `jobs: []` counts as present. Do not write `jobs: []`
+ * meaning "none yet"; it means "no jobs, and I mean it", and every dispatch
+ * against an empty registry is then dropped.
+ *
+ * Either way, what the queue ended up with is `app(QueueManager).registeredJobs`.
+ */
 export default defineQueueConfig({
-  // Register your `Job` subclasses here.
-  jobs: [],
+  concurrency: 1, // max jobs running at once
 });

--- a/templates/saas-starter/app/config/schedule.ts
+++ b/templates/saas-starter/app/config/schedule.ts
@@ -1,7 +1,18 @@
 import { defineScheduleConfig } from "gemi/services";
 
-import { TestCron } from "@/app/cron/TestCron";
-
-export default defineScheduleConfig({
-  jobs: [TestCron],
-});
+/**
+ * The schedule.
+ *
+ * `jobs` is left out on purpose, and leaving it out is what asks gemi to read
+ * `app/cron`: every `CronJob` subclass under there is scheduled at boot, so a
+ * job is registered by existing. `app/cron/TestCron.ts` is scheduled by this
+ * file saying nothing about it.
+ *
+ * Declare `jobs` to take that over — a present `jobs` is used verbatim and no
+ * directory is read, and `jobs: []` counts as present. Do not write `jobs: []`
+ * meaning "none yet"; it means "nothing scheduled, and I mean it", and the
+ * directory stops being read.
+ *
+ * Either way, what the scheduler ended up with is `app(Scheduler).jobs`.
+ */
+export default defineScheduleConfig({});

--- a/templates/saas-starter/app/cron/TestCron.ts
+++ b/templates/saas-starter/app/cron/TestCron.ts
@@ -2,6 +2,17 @@ import { CronJob } from "gemi/services";
 
 import { User } from "@/app/models/User";
 
+/**
+ * A `CronJob` subclass, scheduled by being here.
+ *
+ * Nothing lists this file. Every class under `app/cron` that extends `CronJob`
+ * is scheduled when the kernel boots, which is what keeps a cron job from being
+ * written and then never firing: there is no second list to forget.
+ *
+ * `shouldRun()` decides whether a tick happens at all — override it to keep a
+ * job that reports outward from firing off a developer machine. It is left at
+ * its default here so this one runs everywhere.
+ */
 export class TestCron extends CronJob {
   name = "TestCron";
   cron = CronJob.exp("@daily");

--- a/templates/saas-starter/app/jobs/TestJob.ts
+++ b/templates/saas-starter/app/jobs/TestJob.ts
@@ -10,8 +10,17 @@ import { Job } from "gemi/services";
  *
  * Dispatch it from anywhere with `TestJob.dispatch({ message: "hello" })` — the
  * call is typed against `run`.
+ *
+ * `static name` is not decoration. The queue is keyed by it, and a production
+ * build minifies the code that dispatches — renaming the class, and with it the
+ * implicit `.name` the queue would otherwise use. Discovery reads this file
+ * from source, where the name is untouched, so without the literal below the
+ * two halves disagree in production and the dispatch is dropped there and
+ * nowhere else.
  */
 export class TestJob extends Job {
+  static name = "TestJob";
+
   async run(input: { message: string }) {
     console.log("TestJob executed:", input.message);
   }

--- a/templates/saas-starter/app/jobs/TestJob.ts
+++ b/templates/saas-starter/app/jobs/TestJob.ts
@@ -1,0 +1,22 @@
+import { Job } from "gemi/services";
+
+/**
+ * A `Job` subclass, registered by being here.
+ *
+ * Nothing lists this file. Every class under `app/jobs` that extends `Job` is
+ * discovered when the kernel boots, which is what keeps a dispatch from being
+ * dropped: the queue resolves a job by name, and a name it was never told about
+ * is dropped with a line on stderr, long after `dispatch` returned.
+ *
+ * Dispatch it from anywhere with `TestJob.dispatch({ message: "hello" })` — the
+ * call is typed against `run`.
+ */
+export class TestJob extends Job {
+  async run(input: { message: string }) {
+    console.log("TestJob executed:", input.message);
+  }
+
+  onFail(error: Error) {
+    console.error("TestJob failed:", error);
+  }
+}


### PR DESCRIPTION
Closes #322, #323 and #324. The first two are one mechanism, which is what #322 asked for, so they share a walk.

## What changed

**Discovery.** `app/jobs` and `app/cron` are read at boot. A `Job` or `CronJob` subclass is registered by existing, and there is no second list to keep in step.

The override rule is **declared wins, and `[]` is declared**. A `jobs` that is present is used verbatim and no directory is read; leaving the key out — or leaving the slice out entirely — is what asks for discovery. `jobsDir` moves the directory without giving up the walk.

That distinction is load-bearing and easy to lose: `withDefaults` deliberately treats `undefined` as absent, so both providers read the raw slice before defaults are applied. The template previously shipped `jobs: []` in `app/config/queue.ts`; left alone, that would have silently disabled discovery in every scaffolded app. Both template config files now omit the key and say why.

**The resolved set stayed readable.** #323 flagged that an app exports `jobs` from its config module so a test can walk what the scheduler runs. `app(Scheduler).jobs` and `app(QueueManager).registeredJobs` are where that test goes now, plus `discoverCronJobs()` / `discoverJobs()` for asking without an application around.

**The gate.** `CronJob.shouldRun()` is evaluated once per tick, before anything else, and `false` skips `onTick`, `callback` and `onComplete` together — which is the whole point, since a guard inside `callback` leaves an outward-reporting job still announcing that it started and finished. A gate that **throws skips the tick** and logs: cron work recurs, so a missed tick is recovered by the next one, and an email sent from the wrong machine is not.

## Two failures found while reviewing this, fixed here

Both were reachable before this branch, and both are the kind of silence these issues are about:

- **Two cron jobs claiming one name collapsed silently.** The second registration hit `registry.get(name).stop()` and killed the *first* job's handle on its way past, while `jobs` still listed both — so a report stopped arriving and a test walking the schedule saw two healthy entries. The first now keeps the name; the second is refused with a message naming both classes.
- **`QueueManager.next()` recursed forever on an unresolvable name.** The head was only deleted on the branch that resolved it, so an unknown name left `queue.size` unchanged and `next()` re-entered on the same entry until the stack gave out. It is now dropped and logged. Four passages in this branch had asserted the benign reading; they were wrong and are corrected.

## Decisions worth disagreeing with

**A shared base class must live outside the walked directory.** `abstract` is erased before the scheduler runs, so a base extending `CronJob` in `app/cron` is found, constructed, and rejected for having no `name` — on every boot, and it lands in `scheduler.jobs`. This is exactly the shape #324 makes people write, so it matters.

I considered having discovery drop any class that is another discovered class's prototype. I did not, because a *concrete* job that is also extended would then stop being scheduled with nothing said — a new silent failure, which is the thing being removed. Instead the docs put the base outside `app/cron` and explain why, and the scheduler's rejection now names the class and says what it probably is. Open to the other call if you'd rather the pattern work in place.

**Discovery evaluates every file it walks.** There is no way to find a class nobody imported without running its module, so a file that does work on import does it at boot. Tests, type tests, benchmarks, `.d.ts` and directories with their own `package.json` are skipped; nothing else is guessed at. Documented on both pages.

**`GEMI_PROJECT_DIR`, not `ROOT_DIR`.** Provider `boot()` runs inside `waitForBoot()`, which finishes before `httpProd`/`httpDev` set `ROOT_DIR`, so discovery computes the root the way `httpProd` does. `httpProd` now delegates to the same function.

## Verification

`bun --bun vitest run` in `packages/gemi`: 115 files, 2652 passed, 1 skipped. Template: 20 files, 660 passed. `bun run typecheck` clean; `oxlint` 0 errors (79 warnings, all pre-existing and in untouched files). Test files were typechecked separately, since `packages/gemi/tsconfig.json` excludes `**/*.test.ts`.

I mutation-checked the three assertions this stands on rather than trusting green: reverting the duplicate-name refusal, the unconditional queue delete, and the `projectRoot()` join each fails a test (the second reproduces the stack overflow). The last one mattered — two tests booted `{}` and asserted `[]`, which passed whether discovery ran or refused, and `resolveDir`'s relative branch had no coverage at all. Both now assert against a fixture reached through the default relative path.

`docs/llms-full.txt` was verified line-for-line against the `cron.md` and `jobs-and-queues.md` regions, not assumed.

## Known, not fixed

`worker = true` jobs are broken independently of this: `QueueManager.createWorker()` imports `app/bootstrap.ts`, which was deleted in a4df8fc, and nothing emits `dist/server/bootstrap.mjs`. `runInWorker` also sets no `onerror`, so the promise never settles. Out of scope here, but if that path is ever revived, note that discovered jobs resolve in `boot()` and a worker that skips phase two would not see them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e9XQt5uXmT2B2KFN5dnBz
