### PR TITLE
Support a second named connection, so a slow analytics pool cannot starve the hot path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Navigation](./navigation.md)** — `Link`, `useNavigate`, `useParams`, `useSearchParams`, and the `Redirect` component vs. facade.
 
 ### Data
-- **[ORM](./orm.md)** — the Prisma-typed, gemi-executed query layer: models, relations, ambient transactions, policies, soft deletes.
+- **[ORM](./orm.md)** — the Prisma-typed, gemi-executed query layer: models, relations, ambient transactions, named connections, policies, soft deletes.
 - **[Rows & Entities](./orm-rows-and-entities.md)** — plain objects by default, `track` + `save`, and `wrap`.
 
 ### Auth

--- a/docs/index.html
+++ b/docs/index.html
@@ -109,7 +109,7 @@
 
       <h2>Data</h2>
       <div class="grid">
-        <a class="card" href="orm.md"><span class="t">ORM</span><span class="d">Models, relations, ambient transactions, policies, soft deletes.</span></a>
+        <a class="card" href="orm.md"><span class="t">ORM</span><span class="d">Models, relations, ambient transactions, named connections, policies, soft deletes.</span></a>
         <a class="card" href="orm-rows-and-entities.md"><span class="t">Rows &amp; Entities</span><span class="d">POJOs by default, track + save, wrap.</span></a>
       </div>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2871,7 +2871,8 @@ budget one of them used to have. Rebalance as models move across; when the last 
 Prisma client and give gemi the whole budget.
 
 Pointing gemi at a *different* `url` is the other honest answer — a separate pool with its own cap,
-at the cost of two things to configure per environment.
+at the cost of two things to configure per environment. The same arithmetic applies to gemi's own
+second pool: see [Connections](#connections).
 
 </details>
 
@@ -3856,6 +3857,102 @@ savepoint, the Postgres abort described above. Those need a database, and they b
 integration test rather than in a mock. Keep the seam for the control flow and test the transaction
 itself against Postgres.
 
+## Connections
+
+One connection is the default and needs no configuration. A second one is for the case where two
+workloads share a database and want opposite settings from it — a hot path that must never block,
+and an analytics path whose queries legitimately run for seconds:
+
+| | hot path | analytics |
+| --- | --- | --- |
+| pool max | 12 | 3 |
+| statement timeout | 8s | 45s |
+
+A value that protects one of those is the wrong value for the other, which is the whole reason they
+cannot be one pool with one setting. Without a second connection, a dashboard aggregate can drain
+the pool and block sign-in.
+
+The top-level `url` and `options` describe the connection called `default`. Everything else goes
+under `connections`:
+
+```typescript
+// app/config/database.ts
+export default defineDatabaseConfig({
+  url: process.env.DATABASE_URL,
+  options: { max: 12 },
+
+  connections: {
+    analytics: {
+      url: process.env.DATABASE_URL,          // the same database, deliberately
+      options: { max: 3, idleTimeout: 60 },   // a pool of its own
+      slowTransactionThreshold: 60_000,       // and a threshold that suits it
+    },
+  },
+})
+```
+
+The same URL twice is normal and is not a mistake: what differs is the pool, not the database.
+`url` and `options` are never inherited from the top level — a connection that borrowed the
+default's URL by omitting one would be a second pool created by a typo — but
+`slowTransactionThreshold` is, since it is a diagnostic that applies to any pool.
+
+### Naming one, per query
+
+```ts
+const rows = await Subscription.on("analytics").findMany({ where })
+const raw = await DB.connection("analytics").query(sql`select …`)
+```
+
+**Which connection a model uses is a per-query property, not a per-model one.** The same
+`Subscription` is read on the hot path during sign-in and swept by the nightly audit, so a
+`connection` declared on the model class would force one of those two to be wrong. `on` returns the
+model class with the connection bound to it, so the whole typed surface is there and narrows exactly
+as it does on the class itself.
+
+The connection reaches everything that query fans out into — the nested reads of an `include`, the
+extra statements of a nested write, the relation reads a `_count` compiles — because it travels in
+the same ambient scope the transaction does. There is no argument to forget to pass on.
+
+An unknown name raises `UnknownConnectionError` and lists the ones that are configured. It never
+falls back to the default: `Subscription.on("analitycs")` running on the hot path is the exact
+incident the second pool was configured to prevent, and it would arrive weeks later with nothing
+pointing at the typo.
+
+### A transaction cannot span two connections
+
+This is the constraint to design around, and it is enforced rather than documented:
+
+```ts
+await Model.transaction(async () => {
+  await Invoice.create({ data })
+  await Subscription.on("analytics").findMany({})   // CrossConnectionTransactionError
+})
+```
+
+A transaction lives on one reserved connection of one pool. A statement on another pool cannot join
+it and cannot be rolled back with it, so the alternatives to raising are both worse: run it outside
+the transaction and it stays committed when the transaction rolls back; run it on the open handle
+and it goes to the wrong database, which is usually a table of the same shape and no error at all.
+
+Catching the error leaves the transaction usable, so the fix is local — move that query outside the
+transaction, or do the whole unit on one connection.
+
+Inside a transaction, a query that does **not** name a connection joins it, whichever connection it
+was opened on:
+
+```ts
+await DB.connection("analytics").transaction(async () => {
+  await Digest.create({ data })    // on "analytics", inside the transaction
+})
+```
+
+### What a second connection costs
+
+Every connection is a real pool, counted separately against whatever limit the server or the pooler
+enforces. Two pools of 12 is 24 connections, not 12 — so split the budget rather than adding to it,
+the same arithmetic as [running a Prisma client alongside gemi](#setup). `DB.close()` closes all of
+them.
+
 ## Policies
 
 A model carries a **list** of policies. Every member of a policy is optional; a model with none
@@ -4116,6 +4213,8 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `UnsupportedByDesignError` | A subclass of `UnsupportedQueryError` for the arguments under [Not in scope](#not-in-scope) — it says *decision*, where the parent says *not yet*. Catch this one to tell them apart. |
 | `InvalidArgumentError` | The other subclass: the argument exists and the *value* cannot mean anything — `take: "-2"`. Says what a good value looks like, rather than that the argument is unsupported. |
 | `UnsupportedDialectError` | A model operation on a dialect with no compiler — MySQL and MariaDB. See [Dialects](#dialects). |
+| `UnknownConnectionError` | A connection name that is not configured, listing the ones that are. Never a fall back to the default — see [Connections](#connections). |
+| `CrossConnectionTransactionError` | A statement naming one connection while a transaction is open on another. Both are named; the fix is to move that query outside the transaction. |
 | `ReturningUnsupportedError` | A write on a dialect without `RETURNING`, which is the same gap seen from the write path. |
 | `StaleSchemaArtifactError` | Generated files predate the running gemi. Re-run `prisma generate`. |
 | `MalformedRelationError` / `MissingModelSchemaError` / `UnregisteredRelationTargetError` | The generated artifact and the registry disagree — the same family as the two above, and the same fix. |
@@ -4454,6 +4553,7 @@ might lift next release.
   registry by name, so registering them at boot is what makes sign-in work.
 - **[Authorization](./authorization.md)** — route-level authorization, which policies complement
   rather than replace.
+
 ---
 
 ## Rows and entities

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3918,6 +3918,15 @@ falls back to the default: `Subscription.on("analitycs")` running on the hot pat
 incident the second pool was configured to prevent, and it would arrive weeks later with nothing
 pointing at the typo.
 
+`query`, `execute` and `transaction` on a handle *reject*, so a `.catch()` catches a wrong name or a
+refusal. The `sql` and `dialect` getters have nowhere to put a rejection and throw synchronously
+instead — and `DB.connection(name).sql` is Bun's raw template, so it runs on that connection's
+**pool** rather than on an open transaction, exactly as `DB.sql` always has. Use `query` and
+`execute` when the difference matters.
+
+A `save` writes back to the connection its row was read on, since a tracked row outlives the scope
+that produced it — see [Rows & entities](./orm-rows-and-entities.md).
+
 ### A transaction cannot span two connections
 
 This is the constraint to design around, and it is enforced rather than documented:
@@ -4553,7 +4562,6 @@ might lift next release.
   registry by name, so registering them at boot is what makes sign-in work.
 - **[Authorization](./authorization.md)** — route-level authorization, which policies complement
   rather than replace.
-
 ---
 
 ## Rows and entities
@@ -4660,11 +4668,36 @@ which row to update, and `save` says so rather than failing further down with a 
 instant the update happened rather than the one you fetched. Anything else the database rewrote
 comes back too.
 
+### It saves back to the connection the row came from
+
+If you read the row on a [named connection](./orm.md#connections), `save` writes it there:
+
+```ts
+const [row] = await User.on("analytics").findMany({}, { track: true })
+row.name = "changed"
+await User.save(row)                    // updates "analytics", with nothing said here
+```
+
+This is the one place a connection is not resolved from the surrounding scope, and it is why the
+connection is part of provenance alongside the model and the primary key. A tracked row is an
+ordinary object: it outlives the query that produced it, so by the time it is saved — three
+functions later, from code that never mentioned a connection — there is no scope left to read.
+Resolved the other way, `save` would compile a correct `update` and send it to the default
+connection, where the same id usually names a real and different row.
+
+Naming a *different* connection is a contradiction rather than an instruction and raises:
+`User.on("default").save(rowFromAnalytics)`. Copying a row between connections is a write in its
+own right — say it with `update`, where the `where` and the `data` are both visible.
+
+`wrap` carries the connection across too, so `User.wrap(row).save()` goes where `row` came from.
+
 ### Everything else still applies
 
 `save` compiles through the same path as any other write, so [policies](./orm.md#policies)
 scope it, `@updatedAt` stamps it, an open transaction contains it, and two saves touching the
-same columns share one cached plan.
+same columns share one cached plan. Inside a transaction on *another* connection it raises
+`CrossConnectionTransactionError` instead: that update cannot join the transaction, so it must not
+run at all.
 
 ## Level 3 — `wrap`, for behaviour
 
@@ -4738,8 +4771,6 @@ await Model.transaction(async () => {
 If this tier is ever pursued properly it gets its own plan and its own decision about whether
 the ORM is the product rather than one part of the framework. Until then, the levels above are
 what there is, and they are complete as described.
-
-
 ---
 
 ## Authentication

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,7 +28,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 
 ## Data
 
-- [ORM](https://nstfkc.github.io/gemi/orm.md): the Prisma-typed, gemi-executed query layer — the Prisma generator block, every operation, relations and the batched/lateral strategies, ambient transactions, policies that apply to nested reads, soft deletes.
+- [ORM](https://nstfkc.github.io/gemi/orm.md): the Prisma-typed, gemi-executed query layer — the Prisma generator block, every operation, relations and the batched/lateral strategies, ambient transactions, named connections, policies that apply to nested reads, soft deletes.
 - [Rows & Entities](https://nstfkc.github.io/gemi/orm-rows-and-entities.md): plain objects by default, opt-in provenance with track + save, and wrap for methods on a record.
 
 ## Auth

--- a/docs/orm-rows-and-entities.md
+++ b/docs/orm-rows-and-entities.md
@@ -102,11 +102,36 @@ which row to update, and `save` says so rather than failing further down with a 
 instant the update happened rather than the one you fetched. Anything else the database rewrote
 comes back too.
 
+### It saves back to the connection the row came from
+
+If you read the row on a [named connection](./orm.md#connections), `save` writes it there:
+
+```ts
+const [row] = await User.on("analytics").findMany({}, { track: true })
+row.name = "changed"
+await User.save(row)                    // updates "analytics", with nothing said here
+```
+
+This is the one place a connection is not resolved from the surrounding scope, and it is why the
+connection is part of provenance alongside the model and the primary key. A tracked row is an
+ordinary object: it outlives the query that produced it, so by the time it is saved — three
+functions later, from code that never mentioned a connection — there is no scope left to read.
+Resolved the other way, `save` would compile a correct `update` and send it to the default
+connection, where the same id usually names a real and different row.
+
+Naming a *different* connection is a contradiction rather than an instruction and raises:
+`User.on("default").save(rowFromAnalytics)`. Copying a row between connections is a write in its
+own right — say it with `update`, where the `where` and the `data` are both visible.
+
+`wrap` carries the connection across too, so `User.wrap(row).save()` goes where `row` came from.
+
 ### Everything else still applies
 
 `save` compiles through the same path as any other write, so [policies](./orm.md#policies)
 scope it, `@updatedAt` stamps it, an open transaction contains it, and two saves touching the
-same columns share one cached plan.
+same columns share one cached plan. Inside a transaction on *another* connection it raises
+`CrossConnectionTransactionError` instead: that update cannot join the transaction, so it must not
+run at all.
 
 ## Level 3 — `wrap`, for behaviour
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1154,6 +1154,15 @@ falls back to the default: `Subscription.on("analitycs")` running on the hot pat
 incident the second pool was configured to prevent, and it would arrive weeks later with nothing
 pointing at the typo.
 
+`query`, `execute` and `transaction` on a handle *reject*, so a `.catch()` catches a wrong name or a
+refusal. The `sql` and `dialect` getters have nowhere to put a rejection and throw synchronously
+instead — and `DB.connection(name).sql` is Bun's raw template, so it runs on that connection's
+**pool** rather than on an open transaction, exactly as `DB.sql` always has. Use `query` and
+`execute` when the difference matters.
+
+A `save` writes back to the connection its row was read on, since a tracked row outlives the scope
+that produced it — see [Rows & entities](./orm-rows-and-entities.md).
+
 ### A transaction cannot span two connections
 
 This is the constraint to design around, and it is enforced rather than documented:

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -107,7 +107,8 @@ budget one of them used to have. Rebalance as models move across; when the last 
 Prisma client and give gemi the whole budget.
 
 Pointing gemi at a *different* `url` is the other honest answer — a separate pool with its own cap,
-at the cost of two things to configure per environment.
+at the cost of two things to configure per environment. The same arithmetic applies to gemi's own
+second pool: see [Connections](#connections).
 
 </details>
 
@@ -1092,6 +1093,102 @@ savepoint, the Postgres abort described above. Those need a database, and they b
 integration test rather than in a mock. Keep the seam for the control flow and test the transaction
 itself against Postgres.
 
+## Connections
+
+One connection is the default and needs no configuration. A second one is for the case where two
+workloads share a database and want opposite settings from it — a hot path that must never block,
+and an analytics path whose queries legitimately run for seconds:
+
+| | hot path | analytics |
+| --- | --- | --- |
+| pool max | 12 | 3 |
+| statement timeout | 8s | 45s |
+
+A value that protects one of those is the wrong value for the other, which is the whole reason they
+cannot be one pool with one setting. Without a second connection, a dashboard aggregate can drain
+the pool and block sign-in.
+
+The top-level `url` and `options` describe the connection called `default`. Everything else goes
+under `connections`:
+
+```typescript
+// app/config/database.ts
+export default defineDatabaseConfig({
+  url: process.env.DATABASE_URL,
+  options: { max: 12 },
+
+  connections: {
+    analytics: {
+      url: process.env.DATABASE_URL,          // the same database, deliberately
+      options: { max: 3, idleTimeout: 60 },   // a pool of its own
+      slowTransactionThreshold: 60_000,       // and a threshold that suits it
+    },
+  },
+})
+```
+
+The same URL twice is normal and is not a mistake: what differs is the pool, not the database.
+`url` and `options` are never inherited from the top level — a connection that borrowed the
+default's URL by omitting one would be a second pool created by a typo — but
+`slowTransactionThreshold` is, since it is a diagnostic that applies to any pool.
+
+### Naming one, per query
+
+```ts
+const rows = await Subscription.on("analytics").findMany({ where })
+const raw = await DB.connection("analytics").query(sql`select …`)
+```
+
+**Which connection a model uses is a per-query property, not a per-model one.** The same
+`Subscription` is read on the hot path during sign-in and swept by the nightly audit, so a
+`connection` declared on the model class would force one of those two to be wrong. `on` returns the
+model class with the connection bound to it, so the whole typed surface is there and narrows exactly
+as it does on the class itself.
+
+The connection reaches everything that query fans out into — the nested reads of an `include`, the
+extra statements of a nested write, the relation reads a `_count` compiles — because it travels in
+the same ambient scope the transaction does. There is no argument to forget to pass on.
+
+An unknown name raises `UnknownConnectionError` and lists the ones that are configured. It never
+falls back to the default: `Subscription.on("analitycs")` running on the hot path is the exact
+incident the second pool was configured to prevent, and it would arrive weeks later with nothing
+pointing at the typo.
+
+### A transaction cannot span two connections
+
+This is the constraint to design around, and it is enforced rather than documented:
+
+```ts
+await Model.transaction(async () => {
+  await Invoice.create({ data })
+  await Subscription.on("analytics").findMany({})   // CrossConnectionTransactionError
+})
+```
+
+A transaction lives on one reserved connection of one pool. A statement on another pool cannot join
+it and cannot be rolled back with it, so the alternatives to raising are both worse: run it outside
+the transaction and it stays committed when the transaction rolls back; run it on the open handle
+and it goes to the wrong database, which is usually a table of the same shape and no error at all.
+
+Catching the error leaves the transaction usable, so the fix is local — move that query outside the
+transaction, or do the whole unit on one connection.
+
+Inside a transaction, a query that does **not** name a connection joins it, whichever connection it
+was opened on:
+
+```ts
+await DB.connection("analytics").transaction(async () => {
+  await Digest.create({ data })    // on "analytics", inside the transaction
+})
+```
+
+### What a second connection costs
+
+Every connection is a real pool, counted separately against whatever limit the server or the pooler
+enforces. Two pools of 12 is 24 connections, not 12 — so split the budget rather than adding to it,
+the same arithmetic as [running a Prisma client alongside gemi](#setup). `DB.close()` closes all of
+them.
+
 ## Policies
 
 A model carries a **list** of policies. Every member of a policy is optional; a model with none
@@ -1352,6 +1449,8 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `UnsupportedByDesignError` | A subclass of `UnsupportedQueryError` for the arguments under [Not in scope](#not-in-scope) — it says *decision*, where the parent says *not yet*. Catch this one to tell them apart. |
 | `InvalidArgumentError` | The other subclass: the argument exists and the *value* cannot mean anything — `take: "-2"`. Says what a good value looks like, rather than that the argument is unsupported. |
 | `UnsupportedDialectError` | A model operation on a dialect with no compiler — MySQL and MariaDB. See [Dialects](#dialects). |
+| `UnknownConnectionError` | A connection name that is not configured, listing the ones that are. Never a fall back to the default — see [Connections](#connections). |
+| `CrossConnectionTransactionError` | A statement naming one connection while a transaction is open on another. Both are named; the fix is to move that query outside the transaction. |
 | `ReturningUnsupportedError` | A write on a dialect without `RETURNING`, which is the same gap seen from the write path. |
 | `StaleSchemaArtifactError` | Generated files predate the running gemi. Re-run `prisma generate`. |
 | `MalformedRelationError` / `MissingModelSchemaError` / `UnregisteredRelationTargetError` | The generated artifact and the registry disagree — the same family as the two above, and the same fix. |

--- a/packages/gemi/database/Connection.ts
+++ b/packages/gemi/database/Connection.ts
@@ -1,0 +1,214 @@
+import { SQL } from "bun";
+import type { ConnectionConfig } from "./config";
+import { MissingDatabaseUrlError, inferDialect, type Dialect } from "./dialect";
+
+/**
+ * The name of the connection an application gets without asking for one: the
+ * `url` / `options` pair at the top level of `app/config/database.ts`.
+ *
+ * A constant rather than the string spelled at each site, because it is
+ * compared in five places across three layers — the manager resolving a name,
+ * the ORM deciding whether a query names a different pool than the open
+ * transaction, and the facade — and a typo in any one of them reads as "that
+ * connection is not configured" rather than as a typo.
+ */
+export const DEFAULT_CONNECTION = "default";
+
+/**
+ * What every layer above `database/` is allowed to know about a connection.
+ *
+ * `DatabaseManager` implements this itself and *is* the default connection —
+ * see the note on `DatabaseManager.connection`. So this interface is the one
+ * shape the ORM and the `DB` facade read, whether they are looking at the
+ * default pool or at a named one, and neither has to branch on which it got.
+ */
+export interface DatabaseConnection {
+  /** `"default"`, or the key this connection was declared under. */
+  readonly name: string;
+  readonly url: string;
+  readonly dialect: Dialect;
+  readonly sql: SQL;
+  readonly ready: Promise<void>;
+  readonly config: ConnectionConfig;
+}
+
+/** A connection named in the config that the manager has no pool for. */
+export class UnknownConnectionError extends Error {
+  constructor(name: string, known: readonly string[]) {
+    super(
+      `No database connection named "${name}". Configured: ` +
+        `${known.map((one) => `"${one}"`).join(", ")}. Declare it under ` +
+        `\`connections\` in app/config/database.ts.`,
+    );
+    this.name = "UnknownConnectionError";
+  }
+}
+
+/**
+ * A `connections` entry that would shadow the top-level `url`.
+ *
+ * Refused rather than merged, because the two spellings would be a silent
+ * either/or: whichever the manager happened to build last would win, and the
+ * losing half of the config would go on describing a pool nothing uses.
+ */
+export class ReservedConnectionNameError extends Error {
+  constructor(name: string) {
+    super(
+      `"${name}" is the name of the connection declared by the top-level ` +
+        `\`url\` and \`options\`, so it cannot also appear under ` +
+        `\`connections\`. Rename it, or move its settings up to the top level.`,
+    );
+    this.name = "ReservedConnectionNameError";
+  }
+}
+
+/**
+ * A statement that named one connection while a transaction was open on
+ * another.
+ *
+ * **The whole reason named connections refuse rather than route.** A
+ * transaction lives on one reserved connection of one pool; there is no
+ * mechanism by which a second pool's statement could join it, and no rollback
+ * that could take it back. So the alternatives to this error are both worse
+ * than an error:
+ *
+ * - Run it on the other pool anyway, *outside* the transaction. The caller
+ *   wrote `Model.transaction`, the block rolls back, and that one statement
+ *   stays committed. Half the work landed and nothing said so.
+ * - Run it on the open handle, ignoring the name. Then the statement went to
+ *   the wrong database, which the ORM cannot even detect afterwards — the
+ *   tables are usually the same shape.
+ *
+ * There is no third answer at this layer; two-phase commit is not what a second
+ * pool for analytics is asking for. So the failure is made loud and early, at
+ * the call that would have straddled the two, and the fix is always the same
+ * shape: move that query outside the transaction, or do the whole unit on one
+ * connection.
+ */
+export class CrossConnectionTransactionError extends Error {
+  constructor(
+    /** The connection the open transaction belongs to. */
+    public readonly open: string,
+    /** The connection the refused statement named. */
+    public readonly requested: string,
+  ) {
+    super(
+      `A transaction is open on the "${open}" connection, and this statement ` +
+        `names "${requested}". A transaction cannot span two connections: ` +
+        `the statement would run outside it and stay committed when the ` +
+        `transaction rolls back. Move this query outside the transaction, or ` +
+        `run the whole unit on one connection.`,
+    );
+    this.name = "CrossConnectionTransactionError";
+  }
+}
+
+/**
+ * One pool: a URL, its dialect, and Bun's client for it.
+ *
+ * Extracted from `DatabaseManager` when a second connection became
+ * configurable (#327). The manager kept the lifecycle — which names exist, how
+ * they are resolved, closing them all — and this kept everything that is true
+ * of a connection *one at a time*, so the two do not have to be written twice.
+ *
+ * Safe to build eagerly, like the manager it came from: Bun's client connects
+ * on the first query, not at construction. A named connection an application
+ * declares and never queries therefore costs an object.
+ */
+export class Connection implements DatabaseConnection {
+  public readonly sql: SQL;
+  public readonly dialect: Dialect;
+  public readonly url: string;
+
+  /**
+   * Resolves once the connection has been configured, or rejects if it could
+   * not be. Only SQLite has anything to do; elsewhere it is already resolved.
+   *
+   * Exposed so a caller that needs the guarantee can wait for it. Nothing has
+   * to: SQLite queues statements on one connection in the order they were
+   * issued, so the pragma below is ahead of anything a caller sends after the
+   * constructor returns. That ordering is asserted in `DatabaseManager.test.ts`
+   * rather than assumed, because it is the load-bearing half.
+   */
+  public readonly ready: Promise<void>;
+
+  constructor(
+    public readonly name: string,
+    public readonly config: ConnectionConfig = {},
+  ) {
+    const url = config.url;
+    if (!url) {
+      throw new MissingDatabaseUrlError(name);
+    }
+
+    this.url = url;
+    // An explicit `dialect` wins, for URLs whose protocol we can't read (a
+    // pooler on a custom scheme). Otherwise infer, which throws rather than
+    // guessing — see the note in dialect.ts.
+    this.dialect = config.dialect ?? inferDialect(url);
+    this.sql = config.options
+      ? new SQL(url, config.options as any)
+      : new SQL(url);
+    this.ready = this.configure();
+  }
+
+  /**
+   * `pragma foreign_keys = ON`, which SQLite leaves **off** by default — and so
+   * does Bun's driver, which reports `0` on a fresh connection.
+   *
+   * Without it SQLite enforces nothing at all. Not "cascades do not fire":
+   * nothing. An insert naming a parent that does not exist is accepted, a
+   * dangling reference survives the parent's deletion, and `ON DELETE RESTRICT`
+   * does not restrict — while the migrations declare all three. Postgres
+   * enforces them always, and Prisma turns the pragma on for every SQLite
+   * connection it opens, so leaving it off meant development and production
+   * disagreed about whether the schema's constraints were real.
+   *
+   * It is also why this is more than a dialect gap. The differential harness
+   * compares gemi against Prisma on one database per dialect; with the pragma
+   * off on one side, the two were being asked to agree while running under
+   * different integrity rules, so an entire class of divergence was invisible
+   * to the instrument rather than merely untested.
+   *
+   * **Per connection, not per database**, which is what makes this a live
+   * assumption rather than a one-line fix: Bun serves SQLite from a single
+   * connection today, so setting it once holds for every later statement. If
+   * that ever becomes a pool, one statement's worth of enforcement would move
+   * to whichever connection happened to serve it. `DatabaseManager.test.ts`
+   * pins both halves — the value, and that it is the same across concurrent
+   * queries — so the day it changes is a failing test rather than a silent
+   * regression.
+   *
+   * That per-connection wording is now literal in a second sense: a named
+   * SQLite connection is a *different* Bun client, so it needs the pragma of
+   * its own. Running it from this constructor is what makes that automatic —
+   * the alternative, doing it once for the default connection, was correct
+   * exactly while there was only one.
+   *
+   * Issued outside any transaction. SQLite documents the pragma as a no-op
+   * inside one, so a lazy "set it on first use" would be correct exactly until
+   * the first use happened to be a transaction.
+   */
+  private async configure(): Promise<void> {
+    if (this.dialect !== "sqlite") return;
+    await this.sql.unsafe("pragma foreign_keys = ON");
+  }
+
+  // Escape hatch matching Bun's own API, so `connection.query` reads like `sql`
+  // does in Bun's docs: connection.query`select * from users where id = ${id}`
+  get query(): SQL {
+    return this.sql;
+  }
+
+  async close(): Promise<void> {
+    // A close that races the constructor's `pragma` leaves that statement to
+    // settle against a client that is going away, and it settles as a rejection
+    // — `ERR_SQLITE_CONNECTION_CLOSED`, from a promise nobody is holding, which
+    // arrives as an unhandled rejection naming neither the close nor the
+    // pragma. The caller asked for this connection to go away, so that
+    // rejection is expected rather than something to surface. Marked handled
+    // here rather than suppressed globally, and only on the way out.
+    this.ready.catch(() => {});
+    await this.sql.close();
+  }
+}

--- a/packages/gemi/database/DatabaseManager.ts
+++ b/packages/gemi/database/DatabaseManager.ts
@@ -1,6 +1,13 @@
-import { SQL } from "bun";
-import type { DatabaseConfig } from "./config";
-import { MissingDatabaseUrlError, inferDialect, type Dialect } from "./dialect";
+import type { SQL } from "bun";
+import type { ConnectionConfig, DatabaseConfig } from "./config";
+import {
+  Connection,
+  DEFAULT_CONNECTION,
+  ReservedConnectionNameError,
+  UnknownConnectionError,
+  type DatabaseConnection,
+} from "./Connection";
+import type { Dialect } from "./dialect";
 
 // Wraps Bun's `SQL` client. Bun ships one client that speaks SQLite, Postgres,
 // MySQL and MariaDB, so gemi does not need a driver per database — it needs to
@@ -10,76 +17,143 @@ import { MissingDatabaseUrlError, inferDialect, type Dialect } from "./dialect";
 // the first query, not at construction. It is still bound as a lazy singleton,
 // so an app that never touches the database never resolves it and never has to
 // have DATABASE_URL set.
-export class DatabaseManager {
+//
+// Since #327 it holds *connections*, plural: the top-level `url` and `options`
+// build the one called `"default"`, and each key under `connections` builds
+// another. What it does not do is decide which one a query uses — that is the
+// ORM's ambient scope and the `DB` facade, because the choice is per query
+// rather than per application. See `connection` below.
+export class DatabaseManager implements DatabaseConnection {
   static token = "database";
 
-  public readonly sql: SQL;
-  public readonly dialect: Dialect;
-  public readonly url: string;
+  /**
+   * This object *is* the default connection, so it answers to the name.
+   *
+   * Not a formality: `connection("default")` returns `this` rather than the
+   * `Connection` in the map, which is what keeps every existing reader —
+   * `DB.sql`, `db.dialect`, and the test harnesses that wrap the manager in a
+   * Proxy to count statements — looking at the same object the ORM executes
+   * through. A second object for the default pool would have quietly bypassed
+   * all of them while every test still passed.
+   */
+  public readonly name = DEFAULT_CONNECTION;
 
   /**
-   * Resolves once the connection has been configured, or rejects if it could
-   * not be. Only SQLite has anything to do; elsewhere it is already resolved.
+   * Every pool this manager owns, keyed by name and including the default one.
    *
-   * Exposed so a caller that needs the guarantee can wait for it. Nothing has
-   * to: SQLite queues statements on one connection in the order they were
-   * issued, so the pragma below is ahead of anything a caller sends after the
-   * constructor returns. That ordering is asserted in `DatabaseManager.test.ts`
-   * rather than assumed, because it is the load-bearing half.
+   * Private because the map is the manager's bookkeeping — `connection()` is
+   * the way in, and it is the only path that knows the default is `this`.
+   */
+  private readonly pools = new Map<string, Connection>();
+
+  /**
+   * Resolves once **every** connection has been configured, or rejects if one
+   * could not be. Only SQLite has anything to do; elsewhere it is already
+   * resolved.
+   *
+   * All of them rather than the default alone, because the thing a caller waits
+   * on this for — SQLite's `pragma foreign_keys` — is per client, so a second
+   * SQLite connection has its own and a caller awaiting one manager-level
+   * promise means all of them.
    */
   public readonly ready: Promise<void>;
 
   constructor(public config: DatabaseConfig = {}) {
-    const url = config.url;
-    if (!url) {
-      throw new MissingDatabaseUrlError();
+    const { connections = {}, ...primary } = config;
+
+    // The default first, so a `MissingDatabaseUrlError` from a missing
+    // `DATABASE_URL` still comes out of construction the way it always has,
+    // rather than after a named connection has already opened a client.
+    this.pools.set(DEFAULT_CONNECTION, new Connection(DEFAULT_CONNECTION, primary));
+
+    // A connection that is built before the one whose config is wrong is still
+    // a live client with an open handle, and on the throwing path nothing else
+    // will ever hold it: the manager never becomes a value, so nobody can call
+    // `close`. Left alone, the pragma this constructor issues for a SQLite
+    // connection settles against a client being torn down and surfaces as an
+    // unhandled rejection with no configuration error anywhere near it.
+    try {
+      this.build(connections, primary.slowTransactionThreshold);
+    } catch (error) {
+      for (const pool of this.pools.values()) {
+        // The in-flight configuration first: it is what rejects when the client
+        // under it goes away, and this is the only place that can say the
+        // rejection was expected.
+        pool.ready.catch(() => {});
+        pool.close().catch(() => {});
+      }
+      throw error;
     }
 
-    this.url = url;
-    // An explicit `dialect` wins, for URLs whose protocol we can't read (a
-    // pooler on a custom scheme). Otherwise infer, which throws rather than
-    // guessing — see the note in dialect.ts.
-    this.dialect = config.dialect ?? inferDialect(url);
-    this.sql = config.options
-      ? new SQL(url, config.options as any)
-      : new SQL(url);
-    this.ready = this.configure();
+    // Built once here rather than derived per read, so that a connection whose
+    // configuration rejects produces one unhandled rejection at most instead of
+    // a fresh one per access.
+    this.ready = Promise.all(
+      [...this.pools.values()].map((pool) => pool.ready),
+    ).then(() => undefined);
+  }
+
+  private build(
+    connections: Record<string, ConnectionConfig>,
+    slowTransactionThreshold: number | false | undefined,
+  ): void {
+    for (const [name, connection] of Object.entries(connections)) {
+      if (name === DEFAULT_CONNECTION) throw new ReservedConnectionNameError(name);
+
+      this.pools.set(
+        name,
+        new Connection(name, {
+          // The threshold is the one setting a named connection is likely to
+          // want *unchanged*: it is a development diagnostic about holding a
+          // pooled connection, and that concern does not stop applying because
+          // the pool has a name. `url`, `options` and `dialect` are deliberately
+          // not inherited — a connection that borrowed the default's URL by
+          // omission would be a second pool onto the same database created by a
+          // typo in a key.
+          slowTransactionThreshold,
+          ...connection,
+        }),
+      );
+    }
   }
 
   /**
-   * `pragma foreign_keys = ON`, which SQLite leaves **off** by default — and so
-   * does Bun's driver, which reports `0` on a fresh connection.
+   * The connection called `name`, or the default one when called with nothing.
    *
-   * Without it SQLite enforces nothing at all. Not "cascades do not fire":
-   * nothing. An insert naming a parent that does not exist is accepted, a
-   * dangling reference survives the parent's deletion, and `ON DELETE RESTRICT`
-   * does not restrict — while the migrations declare all three. Postgres
-   * enforces them always, and Prisma turns the pragma on for every SQLite
-   * connection it opens, so leaving it off meant development and production
-   * disagreed about whether the schema's constraints were real.
-   *
-   * It is also why this is more than a dialect gap. The differential harness
-   * compares gemi against Prisma on one database per dialect; with the pragma
-   * off on one side, the two were being asked to agree while running under
-   * different integrity rules, so an entire class of divergence was invisible
-   * to the instrument rather than merely untested.
-   *
-   * **Per connection, not per database**, which is what makes this a live
-   * assumption rather than a one-line fix: Bun serves SQLite from a single
-   * connection today, so setting it once holds for every later statement. If
-   * that ever becomes a pool, one statement's worth of enforcement would move
-   * to whichever connection happened to serve it. `DatabaseManager.test.ts`
-   * pins both halves — the value, and that it is the same across concurrent
-   * queries — so the day it changes is a failing test rather than a silent
-   * regression.
-   *
-   * Issued outside any transaction. SQLite documents the pragma as a no-op
-   * inside one, so a lazy "set it on first use" would be correct exactly until
-   * the first use happened to be a transaction.
+   * Throws rather than falling back to the default for an unknown name, and
+   * that is the important half. A fallback would make `Model.on("analitycs")`
+   * run on the hot path — the exact pool the caller was trying to stay off —
+   * and the only symptom would be the incident it was meant to prevent,
+   * arriving weeks later with nothing pointing back at the typo.
    */
-  private async configure(): Promise<void> {
-    if (this.dialect !== "sqlite") return;
-    await this.sql.unsafe("pragma foreign_keys = ON");
+  connection(name: string = DEFAULT_CONNECTION): DatabaseConnection {
+    // `this`, not `pools.get(DEFAULT_CONNECTION)` — see `name` above.
+    if (name === DEFAULT_CONNECTION) return this;
+
+    const found = this.pools.get(name);
+    if (!found) throw new UnknownConnectionError(name, this.connectionNames);
+    return found;
+  }
+
+  /** Every configured name, default first. For error messages and diagnostics. */
+  get connectionNames(): string[] {
+    return [...this.pools.keys()];
+  }
+
+  /**
+   * The default connection's client. Unchanged in meaning: an application that
+   * never names a connection sees exactly what it saw before #327.
+   */
+  get sql(): SQL {
+    return this.default.sql;
+  }
+
+  get dialect(): Dialect {
+    return this.default.dialect;
+  }
+
+  get url(): string {
+    return this.default.url;
   }
 
   // Escape hatch matching Bun's own API, so `db.query` reads like `sql` does in
@@ -88,7 +162,16 @@ export class DatabaseManager {
     return this.sql;
   }
 
+  /** Closes every connection, not only the default one. */
   async close(): Promise<void> {
-    await this.sql.close();
+    // The aggregate promise needs the same treatment each connection's own
+    // `ready` gets in `Connection.close` — it is derived from them, so a
+    // rejection there arrives here as a second, separately unhandled one.
+    this.ready.catch(() => {});
+    await Promise.all([...this.pools.values()].map((pool) => pool.close()));
+  }
+
+  private get default(): Connection {
+    return this.pools.get(DEFAULT_CONNECTION)!;
   }
 }

--- a/packages/gemi/database/DatabaseManager.ts
+++ b/packages/gemi/database/DatabaseManager.ts
@@ -64,7 +64,10 @@ export class DatabaseManager implements DatabaseConnection {
     // The default first, so a `MissingDatabaseUrlError` from a missing
     // `DATABASE_URL` still comes out of construction the way it always has,
     // rather than after a named connection has already opened a client.
-    this.pools.set(DEFAULT_CONNECTION, new Connection(DEFAULT_CONNECTION, primary));
+    this.pools.set(
+      DEFAULT_CONNECTION,
+      new Connection(DEFAULT_CONNECTION, primary),
+    );
 
     // A connection that is built before the one whose config is wrong is still
     // a live client with an open handle, and on the throwing path nothing else
@@ -98,7 +101,8 @@ export class DatabaseManager implements DatabaseConnection {
     slowTransactionThreshold: number | false | undefined,
   ): void {
     for (const [name, connection] of Object.entries(connections)) {
-      if (name === DEFAULT_CONNECTION) throw new ReservedConnectionNameError(name);
+      if (name === DEFAULT_CONNECTION)
+        throw new ReservedConnectionNameError(name);
 
       this.pools.set(
         name,

--- a/packages/gemi/database/DatabaseServiceProvider.ts
+++ b/packages/gemi/database/DatabaseServiceProvider.ts
@@ -44,13 +44,27 @@ export class DatabaseServiceProvider extends ServiceProvider {
  */
 function warnIfOrmUnavailable(database: DatabaseManager): void {
   if (process.env.NODE_ENV !== "development") return;
-  if (ormSupports(database.dialect)) return;
 
-  console.warn(
-    `[gemi] DATABASE_URL points at ${database.dialect}, which the gemi ORM ` +
-      `does not implement — only sqlite and postgres are. The connection ` +
-      `works, so raw SQL through DB.query / DB.sql and transactions are fine, ` +
-      `but every model operation will raise UnsupportedDialectError.\n` +
-      `(development only)`,
-  );
+  // Every connection, not only the default one. A named connection is a whole
+  // pool an application will run model queries on — `Model.on("analytics")` —
+  // so it can be pointed at MySQL exactly as the default can, and warning about
+  // only one of them would make the check pass while the query that raises is
+  // on the other.
+  for (const name of database.connectionNames) {
+    const connection = database.connection(name);
+    if (ormSupports(connection.dialect)) continue;
+
+    const source =
+      name === database.name
+        ? "DATABASE_URL"
+        : `The "${name}" database connection`;
+
+    console.warn(
+      `[gemi] ${source} points at ${connection.dialect}, which the gemi ORM ` +
+        `does not implement — only sqlite and postgres are. The connection ` +
+        `works, so raw SQL through DB.query / DB.sql and transactions are ` +
+        `fine, but every model operation will raise ` +
+        `UnsupportedDialectError.\n(development only)`,
+    );
+  }
 }

--- a/packages/gemi/database/config.ts
+++ b/packages/gemi/database/config.ts
@@ -1,8 +1,14 @@
 import type { SQL } from "bun";
 import type { Dialect } from "./dialect";
 
-// Config key: `database`.
-export interface DatabaseConfig {
+// One connection: a URL, the dialect to compile for, and the pool behind it.
+//
+// Split out of `DatabaseConfig` when a second connection became configurable
+// (#327), so that a named connection is described by exactly the same fields
+// the default one is — rather than by a smaller, second-class shape that would
+// need widening the first time somebody's analytics pool needed a `dialect`
+// override or a threshold of its own.
+export interface ConnectionConfig {
   // Connection string. Defaults to the `DATABASE_URL` environment variable.
   // The dialect is inferred from it — `postgres://`, `mysql://`, `mariadb://`,
   // `sqlite://`, `file:`, or a SQLite path like `./dev.db` or `:memory:`.
@@ -32,7 +38,57 @@ export interface DatabaseConfig {
   // that is not a positive finite number falls back to the 2s default rather
   // than disabling, so the warning cannot be lost to a typo — say `false` when
   // you mean off.
+  //
+  // Per connection, and this is the field most likely to differ between two of
+  // them: a connection that exists *because* its queries are slow will warn on
+  // every transaction it opens if it inherits the hot path's threshold, and a
+  // warning that always fires is one nobody reads. A named connection that
+  // does not set it inherits the top-level value.
   slowTransactionThreshold?: number | false;
+}
+
+// Config key: `database`.
+//
+// The top-level `url` / `options` / `dialect` describe the connection called
+// `"default"` — the one every query uses unless it says otherwise. `connections`
+// declares the others.
+export interface DatabaseConfig extends ConnectionConfig {
+  // Additional connections, keyed by the name `DB.connection(name)` and
+  // `Model.on(name)` take.
+  //
+  // The case this exists for is two pools against **one** database with
+  // opposite workloads — a hot path that must never block, and an analytics
+  // path whose queries legitimately run for seconds:
+  //
+  //     export default defineDatabaseConfig({
+  //       url: process.env.DATABASE_URL,
+  //       options: { max: 12 },
+  //
+  //       connections: {
+  //         analytics: {
+  //           url: process.env.DATABASE_URL,
+  //           options: { max: 3, idleTimeout: 60, connectionTimeout: 45 },
+  //           slowTransactionThreshold: 60_000,
+  //         },
+  //       },
+  //     })
+  //
+  // A value that protects one of those is the wrong value for the other, which
+  // is the entire reason they cannot be one pool with one setting. The same URL
+  // twice is normal here and is not a mistake: what differs is the pool, not
+  // the database.
+  //
+  // Two consequences worth knowing before declaring one, both of them
+  // structural rather than incidental:
+  //
+  // - **A transaction cannot span two connections.** A statement that names one
+  //   while a transaction is open on another raises
+  //   `CrossConnectionTransactionError` rather than quietly running outside the
+  //   transaction.
+  // - **Every connection is a real pool**, counted separately against whatever
+  //   connection cap the server or the pooler enforces. Two pools of 12 is 24
+  //   connections, not 12.
+  connections?: Record<string, ConnectionConfig>;
 }
 
 export function defineDatabaseConfig(config: DatabaseConfig): DatabaseConfig {
@@ -45,6 +101,7 @@ export function databaseConfigDefaults(): DatabaseConfig {
     dialect: undefined,
     options: undefined,
     slowTransactionThreshold: SLOW_TRANSACTION_THRESHOLD,
+    connections: undefined,
   };
 }
 

--- a/packages/gemi/database/connections.test.ts
+++ b/packages/gemi/database/connections.test.ts
@@ -184,7 +184,9 @@ describe("named connections", () => {
     expect(db.connection("analytics").config.slowTransactionThreshold).toBe(
       SLOW_TRANSACTION_THRESHOLD,
     );
-    expect(db.connection("digest").config.slowTransactionThreshold).toBe(60_000);
+    expect(db.connection("digest").config.slowTransactionThreshold).toBe(
+      60_000,
+    );
 
     await db.close();
   });

--- a/packages/gemi/database/connections.test.ts
+++ b/packages/gemi/database/connections.test.ts
@@ -1,0 +1,255 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  CrossConnectionTransactionError,
+  DEFAULT_CONNECTION,
+  ReservedConnectionNameError,
+  UnknownConnectionError,
+} from "./Connection";
+import { SLOW_TRANSACTION_THRESHOLD } from "./config";
+import { DatabaseManager } from "./DatabaseManager";
+import { MissingDatabaseUrlError } from "./dialect";
+
+/**
+ * More than one connection out of one config (#327).
+ *
+ * The case is two pools against the same database with opposite workloads: a
+ * hot path that must never block, and an analytics path whose queries run for
+ * seconds. What makes it a feature rather than "call `new SQL` twice" is that
+ * every setting they disagree about — pool size, timeouts, the slow-transaction
+ * threshold — has to be declarable per connection, and that the ORM has to be
+ * able to *reach* the second one.
+ *
+ * These are the manager's half: which connections exist, which object answers
+ * to a name, and what happens to the ones that do not. The routing half —
+ * `Model.on`, and a transaction that cannot span two of them — is in
+ * `orm/context.test.ts` and the template's `connections.test.ts`.
+ *
+ * Real SQLite files rather than `:memory:`, because two in-memory databases are
+ * indistinguishable from one and the point here is that they are not the same.
+ */
+describe("named connections", () => {
+  const workspaces: string[] = [];
+
+  afterEach(() => {
+    for (const path of workspaces.splice(0)) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  function workspace(): string {
+    const path = mkdtempSync(join(tmpdir(), "gemi-connections-"));
+    workspaces.push(path);
+    return path;
+  }
+
+  /** A manager with a default connection and an `analytics` one beside it. */
+  function pair(analytics: Record<string, unknown> = {}) {
+    const dir = workspace();
+    return new DatabaseManager({
+      url: `sqlite://${join(dir, "hot.db")}`,
+      connections: {
+        analytics: {
+          url: `sqlite://${join(dir, "analytics.db")}`,
+          ...analytics,
+        },
+      },
+    });
+  }
+
+  /**
+   * The manager *is* the default connection, which is the property everything
+   * else that reads `manager.sql` depends on — including the test harnesses
+   * that wrap the manager in a Proxy to count statements. A second object for
+   * the default pool would have left them all watching an object nothing
+   * executes through.
+   */
+  test("the default connection is the manager itself", async () => {
+    const db = pair();
+
+    expect(db.name).toBe(DEFAULT_CONNECTION);
+    expect(db.connection()).toBe(db);
+    expect(db.connection(DEFAULT_CONNECTION)).toBe(db);
+    expect(db.connection().sql).toBe(db.sql);
+
+    await db.close();
+  });
+
+  test("a named connection is a different client, and a different database", async () => {
+    const db = pair();
+    const analytics = db.connection("analytics");
+
+    expect(analytics.name).toBe("analytics");
+    expect(analytics.sql).not.toBe(db.sql);
+    expect(analytics.url).not.toBe(db.url);
+    expect(analytics.dialect).toBe("sqlite");
+
+    // Not merely different objects: statements land in different files.
+    await db.sql.unsafe(`create table t (id integer primary key)`);
+    await db.sql.unsafe(`insert into t (id) values (1)`);
+
+    const here = (await db.sql.unsafe(`select count(*) as c from t`)) as any;
+    expect(here[0].c).toBe(1);
+    await expect(analytics.sql.unsafe(`select * from t`)).rejects.toThrow(
+      /no such table/i,
+    );
+
+    await db.close();
+  });
+
+  test("the names are listed, default first", async () => {
+    const db = pair();
+    expect(db.connectionNames).toEqual([DEFAULT_CONNECTION, "analytics"]);
+    await db.close();
+  });
+
+  /**
+   * Falling back to the default for an unknown name is the failure this exists
+   * to prevent, not a convenience: `Model.on("analitycs")` would run on the hot
+   * path — the exact pool the caller was staying off — and the only symptom
+   * would be the incident the second connection was configured to avoid.
+   */
+  test("an unknown name raises, and says which ones exist", async () => {
+    const db = pair();
+
+    expect(() => db.connection("analitycs")).toThrow(UnknownConnectionError);
+    expect(() => db.connection("analitycs")).toThrow(/"default", "analytics"/);
+
+    await db.close();
+  });
+
+  test("`default` cannot be declared a second time", () => {
+    expect(
+      () =>
+        new DatabaseManager({
+          url: "sqlite://:memory:",
+          connections: { default: { url: "sqlite://:memory:" } },
+        }),
+    ).toThrow(ReservedConnectionNameError);
+  });
+
+  /**
+   * The generic "set DATABASE_URL" message would send whoever reads it to check
+   * an environment variable that is set and is not what is missing.
+   */
+  test("a named connection with no url names itself", () => {
+    expect(
+      () =>
+        new DatabaseManager({
+          url: "sqlite://:memory:",
+          connections: { analytics: {} },
+        }),
+    ).toThrow(/"analytics" database connection has no `url`/);
+
+    expect(
+      () =>
+        new DatabaseManager({
+          url: "sqlite://:memory:",
+          connections: { analytics: {} },
+        }),
+    ).toThrow(MissingDatabaseUrlError);
+  });
+
+  /**
+   * The threshold is a development diagnostic about holding a pooled
+   * connection, and that concern does not stop applying because the pool has a
+   * name — so it is inherited. It is also the setting most likely to differ:
+   * a connection that exists *because* its queries are slow warns on every
+   * transaction if it keeps the hot path's 2s.
+   */
+  test("the slow-transaction threshold is inherited, and overridable", async () => {
+    const inherited = pair();
+    expect(
+      inherited.connection("analytics").config.slowTransactionThreshold,
+    ).toBeUndefined();
+    await inherited.close();
+
+    const dir = workspace();
+    const db = new DatabaseManager({
+      url: `sqlite://${join(dir, "hot.db")}`,
+      slowTransactionThreshold: SLOW_TRANSACTION_THRESHOLD,
+      connections: {
+        analytics: { url: `sqlite://${join(dir, "a.db")}` },
+        digest: {
+          url: `sqlite://${join(dir, "d.db")}`,
+          slowTransactionThreshold: 60_000,
+        },
+      },
+    });
+
+    expect(db.connection("analytics").config.slowTransactionThreshold).toBe(
+      SLOW_TRANSACTION_THRESHOLD,
+    );
+    expect(db.connection("digest").config.slowTransactionThreshold).toBe(60_000);
+
+    await db.close();
+  });
+
+  /**
+   * `url` and `options` are deliberately *not* inherited. A connection that
+   * borrowed the default's URL by omission would be a second pool onto the same
+   * database created by a typo in a key — which is exactly what this feature is
+   * for, so it must never happen by accident.
+   */
+  test("a named connection does not inherit the default's options", async () => {
+    const dir = workspace();
+    const db = new DatabaseManager({
+      url: `sqlite://${join(dir, "hot.db")}`,
+      options: { max: 12 },
+      connections: { analytics: { url: `sqlite://${join(dir, "a.db")}` } },
+    });
+
+    expect(db.connection("analytics").config.options).toBeUndefined();
+    await db.close();
+  });
+
+  /**
+   * The pragma is per *client*, and a named SQLite connection is another
+   * client. Setting it once for the default connection was correct exactly
+   * while there was only one — with the second one silently unenforced, an
+   * insert naming a parent that does not exist would be accepted on one
+   * connection and refused on the other.
+   */
+  test("every SQLite connection gets the foreign-key pragma", async () => {
+    const db = pair();
+    await db.ready;
+
+    for (const name of db.connectionNames) {
+      const rows = (await db
+        .connection(name)
+        .sql.unsafe(`pragma foreign_keys`)) as any;
+      expect(rows[0].foreign_keys, `${name} enforces foreign keys`).toBe(1);
+    }
+
+    await db.close();
+  });
+
+  test("close closes every connection, not only the default", async () => {
+    const db = pair();
+    const analytics = db.connection("analytics");
+
+    await db.close();
+
+    await expect(db.sql.unsafe(`select 1`)).rejects.toThrow();
+    await expect(analytics.sql.unsafe(`select 1`)).rejects.toThrow();
+  });
+
+  /**
+   * The error the whole design turns on, checked here for its message rather
+   * than its behaviour — the behaviour is in `orm/context.test.ts`. It has to
+   * name both connections: "a transaction is open" with no names is a message
+   * that sends someone looking through every query in the block.
+   */
+  test("the cross-connection error names both connections", () => {
+    const error = new CrossConnectionTransactionError("default", "analytics");
+
+    expect(error.message).toContain(`"default"`);
+    expect(error.message).toContain(`"analytics"`);
+    expect(error.open).toBe("default");
+    expect(error.requested).toBe("analytics");
+  });
+});

--- a/packages/gemi/database/dialect.ts
+++ b/packages/gemi/database/dialect.ts
@@ -17,10 +17,17 @@ export class UnknownDatabaseUrlError extends Error {
 }
 
 export class MissingDatabaseUrlError extends Error {
-  constructor() {
+  // The connection's name, when it is not the default one. A named connection
+  // has no environment variable behind it and no top-level `url` to fall back
+  // on, so the generic message would send whoever reads it to check
+  // `DATABASE_URL`, which is set and is not what is missing.
+  constructor(connection?: string) {
     super(
-      "No database URL configured. Set the DATABASE_URL environment variable, " +
-        "or set `url` in app/config/database.ts.",
+      connection === undefined || connection === "default"
+        ? "No database URL configured. Set the DATABASE_URL environment " +
+            "variable, or set `url` in app/config/database.ts."
+        : `The "${connection}" database connection has no \`url\`. Set one ` +
+            `under \`connections.${connection}\` in app/config/database.ts.`,
     );
     this.name = "MissingDatabaseUrlError";
   }

--- a/packages/gemi/database/index.ts
+++ b/packages/gemi/database/index.ts
@@ -1,8 +1,17 @@
 export { DatabaseManager } from "./DatabaseManager";
 export { DatabaseServiceProvider } from "./DatabaseServiceProvider";
 export {
+  Connection,
+  CrossConnectionTransactionError,
+  DEFAULT_CONNECTION,
+  ReservedConnectionNameError,
+  UnknownConnectionError,
+  type DatabaseConnection,
+} from "./Connection";
+export {
   defineDatabaseConfig,
   databaseConfigDefaults,
+  type ConnectionConfig,
   type DatabaseConfig,
 } from "./config";
 export {

--- a/packages/gemi/facades/DB.ts
+++ b/packages/gemi/facades/DB.ts
@@ -43,7 +43,22 @@ export class ConnectionQueries {
     return this.bound ?? currentConnectionName();
   }
 
-  /** The Bun `SQL` client. Tagged-template queries go through here. */
+  /**
+   * The Bun `SQL` client. Tagged-template queries go through here.
+   *
+   * **The pool, not the open transaction.** `DB.sql` has always been Bun's own
+   * template and has never joined the ambient transaction — on Postgres it runs
+   * on a pooled connection and survives a rollback — and a named handle does
+   * not change that, only which pool it is. `query` and `execute` are the ones
+   * that join; reach for them when the difference matters.
+   *
+   * **This getter throws where the methods reject**, and it cannot do
+   * otherwise: an accessor has nowhere to put a rejection. So
+   * `DB.connection("typo").sql` throws `UnknownConnectionError` synchronously,
+   * and reading it while a transaction is open on another connection throws
+   * `CrossConnectionTransactionError` the same way. `query`, `execute` and
+   * `transaction` are `async` precisely so a `.catch()` cannot miss those.
+   */
   get sql(): SQL {
     return this.connection().sql;
   }
@@ -52,6 +67,8 @@ export class ConnectionQueries {
    * Which database is in use, inferred from the connection URL. Read this when
    * generating SQL that differs across databases (upserts, `RETURNING`,
    * autoincrement, boolean and timestamp types).
+   *
+   * Throws rather than rejects, for the reason given on `sql` above.
    */
   get dialect(): Dialect {
     return this.connection().dialect;
@@ -190,15 +207,6 @@ export class ConnectionQueries {
   }
 }
 
-/**
- * The handles `DB.connection` has already built.
- *
- * A handle holds a name and nothing else — it resolves the manager per call —
- * so one per name is enough, and reusing them keeps `DB.connection("analytics")`
- * free to be written inline in a hot path.
- */
-const handles = new Map<string, ConnectionQueries>();
-
 /** The unqualified handle: whichever connection is ambient, per call. */
 const ambient = new ConnectionQueries();
 
@@ -236,10 +244,13 @@ export class DB extends Facade {
    * `CrossConnectionTransactionError` rather than running the statement outside
    * that transaction, where it would survive the rollback.
    */
+  // Built per call rather than memoised by name. A handle is one string and a
+  // few methods that resolve everything else per call, so caching it saves an
+  // allocation — and a `Map` keyed on the caller's string is a slow leak the
+  // moment a name reaches it from a request, since an unknown name is not
+  // rejected until the handle is *used*. Nothing is worth keeping here.
   static connection(name: string): ConnectionQueries {
-    let handle = handles.get(name);
-    if (handle === undefined) handles.set(name, (handle = new ConnectionQueries(name)));
-    return handle;
+    return new ConnectionQueries(name);
   }
 
   // The Bun `SQL` client. Tagged-template queries go through here.

--- a/packages/gemi/facades/DB.ts
+++ b/packages/gemi/facades/DB.ts
@@ -1,34 +1,60 @@
 import type { SQL } from "bun";
+import type { DatabaseConnection } from "../database/Connection";
 import { DatabaseManager } from "../database/DatabaseManager";
 import type { Dialect } from "../database/dialect";
-import { currentTransaction, withTransaction } from "../orm/context";
+import { app } from "../foundation/app";
+import {
+  assertConnectionUsable,
+  currentConnectionName,
+  currentTransaction,
+  runOnConnection,
+  withTransaction,
+} from "../orm/context";
 import { dialectFor } from "../orm/dialect";
 import { renderFragment, type SqlFragment } from "../orm/sql";
 import { Facade } from "./Facade";
 
-// Access to the app's database connection. Bun's `SQL` client is a tagged
-// template, so queries read the same here as they do in Bun's own docs:
-//
-//   const users = await DB.sql`select * from users where id = ${id}`
-//
-// Values interpolated into the template are bound as parameters, not
-// concatenated into the SQL string — `${id}` is a placeholder, so this is not a
-// SQL injection risk.
-export class DB extends Facade {
-  static getFacadeAccessor() {
-    return DatabaseManager;
+/**
+ * The raw-SQL surface, pointed at one connection.
+ *
+ * `DB` itself is one of these — the one that resolves the **ambient**
+ * connection per call — and `DB.connection(name)` returns one bound to a name.
+ * Written once rather than twice so the two cannot drift: a fragment run
+ * through a named connection has to reach the driver by exactly the path
+ * `DB.query` does, or the ambient transaction, the placeholder numbering and
+ * the string refusal would each be a thing that works on one of them.
+ *
+ * Every method resolves the manager, the connection and the dialect **per
+ * call** and captures none of them, which is the rule `Model.$exec` follows and
+ * what keeps the connection swappable in tests.
+ */
+export class ConnectionQueries {
+  /**
+   * `undefined` means *whichever connection is ambient*, which is the default
+   * one unless an enclosing transaction or `Model.on` named another. That is
+   * the mode `DB`'s own statics use, and it is why an unqualified `DB.query`
+   * inside `DB.connection("analytics").transaction(...)` joins that transaction
+   * instead of being refused by it.
+   */
+  constructor(private readonly bound?: string) {}
+
+  /** The name this handle will use for the call happening now. */
+  get name(): string {
+    return this.bound ?? currentConnectionName();
   }
 
-  // The Bun `SQL` client. Tagged-template queries go through here.
-  static get sql(): SQL {
-    return this.getFacadeRoot().sql;
+  /** The Bun `SQL` client. Tagged-template queries go through here. */
+  get sql(): SQL {
+    return this.connection().sql;
   }
 
-  // Which database is in use, inferred from the connection URL. Read this when
-  // generating SQL that differs across databases (upserts, `RETURNING`,
-  // autoincrement, boolean and timestamp types).
-  static get dialect(): Dialect {
-    return this.getFacadeRoot().dialect;
+  /**
+   * Which database is in use, inferred from the connection URL. Read this when
+   * generating SQL that differs across databases (upserts, `RETURNING`,
+   * autoincrement, boolean and timestamp types).
+   */
+  get dialect(): Dialect {
+    return this.connection().dialect;
   }
 
   // Runs a composed fragment and returns its rows.
@@ -57,7 +83,7 @@ export class DB extends Facade {
   // *rejects* instead of throwing synchronously. An API that does one sometimes
   // and the other otherwise is a footgun: `DB.query(...).catch(…)` would miss
   // exactly the errors this refuses to run.
-  static async query<T = any>(fragment: SqlFragment): Promise<T[]> {
+  async query<T = any>(fragment: SqlFragment): Promise<T[]> {
     return (await this.run(fragment, "query")) as T[];
   }
 
@@ -88,21 +114,9 @@ export class DB extends Facade {
   // because there the statement shape is ours to choose and an exact count that
   // depends on nothing undocumented is worth a key column per row. Here the
   // statement is the caller's, so there is nothing to add a `RETURNING` to.
-  static async execute(fragment: SqlFragment): Promise<number> {
+  async execute(fragment: SqlFragment): Promise<number> {
     const result = await this.run(fragment, "execute");
     return Number((result as { count?: unknown })?.count ?? 0);
-  }
-
-  private static run(fragment: SqlFragment, operation: string) {
-    const db = this.getFacadeRoot();
-    // Per call, never captured: the same rule `Model.$exec` follows, and what
-    // keeps the connection swappable in tests.
-    const { text, values } = renderFragment(
-      fragment,
-      dialectFor(db.dialect),
-      operation,
-    );
-    return (currentTransaction() ?? db.sql).unsafe(text, values);
   }
 
   // Runs the callback inside a transaction, committing when it resolves and
@@ -121,13 +135,145 @@ export class DB extends Facade {
   // The slow-transaction threshold comes from the same `database` config as it
   // does for the ORM, so a `DB.transaction` holding a connection too long warns
   // exactly as a `Model.transaction` would. Same reason as above: one system.
-  static transaction<T>(fn: (tx: SQL) => Promise<T>): Promise<T> {
-    const db = this.getFacadeRoot();
-    return withTransaction(db.sql, fn as (tx: SQL) => Promise<T>, {
-      slowTransactionThreshold: db.config.slowTransactionThreshold,
-    });
+  //
+  // On a named connection the whole callback runs with that connection ambient,
+  // so a `User.create` inside `DB.connection("analytics").transaction(...)`
+  // joins the transaction rather than opening a second one on the hot path.
+  //
+  // `async` so that a handle used inside a transaction on another connection
+  // *rejects* rather than throwing synchronously — the same reason `query`
+  // above is, and the same `.catch()` that would otherwise miss it.
+  async transaction<T>(fn: (tx: SQL) => Promise<T>): Promise<T> {
+    const name = this.name;
+    const connection = this.connection(name);
+
+    return withTransaction(
+      connection.sql,
+      (tx) => runOnConnection(name, () => fn(tx)),
+      {
+        slowTransactionThreshold: connection.config.slowTransactionThreshold,
+        connection: name,
+      },
+    );
   }
 
+  private run(fragment: SqlFragment, operation: string) {
+    const db = this.connection();
+    // Per call, never captured: the same rule `Model.$exec` follows, and what
+    // keeps the connection swappable in tests.
+    const { text, values } = renderFragment(
+      fragment,
+      dialectFor(db.dialect),
+      operation,
+    );
+    return (this.handle() ?? db.sql).unsafe(text, values);
+  }
+
+  /**
+   * The open transaction, but only when it belongs to this handle's connection.
+   *
+   * `assertConnectionUsable` has already refused the case where they differ, so
+   * reaching this with a mismatch is impossible — except for the unqualified
+   * handle, whose name *is* the transaction's. The comparison is kept anyway
+   * because it is what makes that reasoning local: nothing here has to know
+   * which caller checked what.
+   */
+  private handle() {
+    const tx = currentTransaction();
+    if (tx === undefined) return undefined;
+    return currentConnectionName() === this.name ? tx : undefined;
+  }
+
+  private connection(name = this.name): DatabaseConnection {
+    assertConnectionUsable(name);
+    return app(DatabaseManager).connection(name);
+  }
+}
+
+/**
+ * The handles `DB.connection` has already built.
+ *
+ * A handle holds a name and nothing else — it resolves the manager per call —
+ * so one per name is enough, and reusing them keeps `DB.connection("analytics")`
+ * free to be written inline in a hot path.
+ */
+const handles = new Map<string, ConnectionQueries>();
+
+/** The unqualified handle: whichever connection is ambient, per call. */
+const ambient = new ConnectionQueries();
+
+// Access to the app's database connections. Bun's `SQL` client is a tagged
+// template, so queries read the same here as they do in Bun's own docs:
+//
+//   const users = await DB.sql`select * from users where id = ${id}`
+//
+// Values interpolated into the template are bound as parameters, not
+// concatenated into the SQL string — `${id}` is a placeholder, so this is not a
+// SQL injection risk.
+//
+// Every static here works on the **ambient** connection: the default one,
+// unless an enclosing `DB.connection(name).transaction(...)` named another.
+// `DB.connection(name)` is the way to name one explicitly.
+export class DB extends Facade {
+  static getFacadeAccessor() {
+    return DatabaseManager;
+  }
+
+  /**
+   * The raw-SQL surface for a named connection.
+   *
+   *     const rows = await DB.connection("analytics").query(sql`…`)
+   *     await DB.connection("analytics").transaction(async () => { … })
+   *
+   * The names are the keys of `connections` in `app/config/database.ts`, plus
+   * `"default"` for the top-level `url`. An unknown one raises
+   * `UnknownConnectionError` when the handle is used, listing what is
+   * configured — never a silent fall back to the default, which would put the
+   * query on precisely the pool the caller was trying to stay off.
+   *
+   * A transaction cannot span two connections. Using a named handle while a
+   * transaction is open on another connection raises
+   * `CrossConnectionTransactionError` rather than running the statement outside
+   * that transaction, where it would survive the rollback.
+   */
+  static connection(name: string): ConnectionQueries {
+    let handle = handles.get(name);
+    if (handle === undefined) handles.set(name, (handle = new ConnectionQueries(name)));
+    return handle;
+  }
+
+  // The Bun `SQL` client. Tagged-template queries go through here.
+  static get sql(): SQL {
+    return ambient.sql;
+  }
+
+  // Which database is in use, inferred from the connection URL. Read this when
+  // generating SQL that differs across databases (upserts, `RETURNING`,
+  // autoincrement, boolean and timestamp types).
+  static get dialect(): Dialect {
+    return ambient.dialect;
+  }
+
+  // Runs a composed fragment and returns its rows, on the ambient transaction
+  // when there is one. See `ConnectionQueries.query`, which is the whole of it.
+  static query<T = any>(fragment: SqlFragment): Promise<T[]> {
+    return ambient.query<T>(fragment);
+  }
+
+  // The same, for a statement whose answer is *how many rows it touched* — the
+  // compare-and-swap primitive. See `ConnectionQueries.execute`.
+  static execute(fragment: SqlFragment): Promise<number> {
+    return ambient.execute(fragment);
+  }
+
+  // Runs the callback inside a transaction, committing when it resolves and
+  // rolling back if it throws. One transaction system with the ORM's, so a
+  // `User.create` inside this joins it. See `ConnectionQueries.transaction`.
+  static transaction<T>(fn: (tx: SQL) => Promise<T>): Promise<T> {
+    return ambient.transaction(fn);
+  }
+
+  /** Closes every configured connection, not only the default one. */
   static close(): Promise<void> {
     return this.getFacadeRoot().close();
   }

--- a/packages/gemi/facades/index.ts
+++ b/packages/gemi/facades/index.ts
@@ -11,4 +11,7 @@ export { Meta } from "./Meta";
 export { Cookie } from "./Cookie";
 export { Redis } from "./Redis";
 export { RateLimiter } from "./RateLimiter";
-export { DB } from "./DB";
+// `ConnectionQueries` is what `DB.connection(name)` hands back, so it has to be
+// nameable by an application that wants to keep one in a variable or annotate a
+// parameter with it.
+export { DB, ConnectionQueries } from "./DB";

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -4,7 +4,6 @@ import { DatabaseManager } from "../database/DatabaseManager";
 import { app } from "../foundation/app";
 import { type BindContext, createBindContext } from "./compile/fragment";
 import {
-  assertConnectionUsable,
   currentConnectionName,
   currentTransaction,
   isSystemScope,
@@ -325,6 +324,22 @@ export abstract class Model {
    *
    * Raises when handed an object with no provenance. See `untracked` for why
    * that is a loud failure rather than a fallback to writing everything.
+   *
+   * **It writes back to the connection the row was read on**, which is the one
+   * place a connection cannot be resolved from the ambient scope: a row read on
+   * `analytics` is an ordinary object that outlives the scope that produced it,
+   * and by the time it is saved — three functions later, from code that never
+   * named a connection — the scope is gone. So the connection is part of the
+   * row's provenance, exactly as the model and the primary key are, and for the
+   * same reason. Left to the ambient default, `save` compiled a correct
+   * `update` and sent it to the wrong database, where the same id usually names
+   * a real and different row.
+   *
+   * Naming a *different* connection explicitly — `User.on("default").save(row)`
+   * for a row read on `analytics` — is a contradiction rather than an
+   * instruction, and raises. Copying a row between connections is a write in
+   * its own right: say it with `update`, where the `where` and the `data` are
+   * both visible.
    */
   static async save<T extends object>(row: T): Promise<unknown> {
     const schema = this.$modelSchema();
@@ -339,6 +354,23 @@ export abstract class Model {
         "save",
         `This row came from ${record.model}, not ${schema.name}. Save it ` +
           `through the model it was read from.`,
+      );
+    }
+
+    if (
+      this.$connection !== undefined &&
+      this.$connection !== record.connection
+    ) {
+      throw new UnsupportedQueryError(
+        "save",
+        schema.name,
+        "save",
+        `This row was read on the "${record.connection}" connection and this ` +
+          `save names "${this.$connection}". A save writes the row back where ` +
+          `it came from, so the two cannot both be honoured. Drop the ` +
+          `\`on("${this.$connection}")\`, or write it as an explicit ` +
+          `${schema.name}.on("${this.$connection}").update({ where, data }) if ` +
+          `copying it across connections is what you meant.`,
       );
     }
 
@@ -365,10 +397,18 @@ export abstract class Model {
     const changed = changedFields(row, schema);
     if (Object.keys(changed).length === 0) return null;
 
-    const updated = await this.$exec("update", {
-      where: record.key,
-      data: changed,
-    });
+    // On the row's own connection, entered here rather than left to `$exec`:
+    // `$exec` resolves the *ambient* name, and the whole point is that the row
+    // outlived the scope that read it. Inside a transaction on another
+    // connection this raises `CrossConnectionTransactionError` from `$exec`,
+    // which is the correct answer — that update cannot join the transaction, so
+    // it must not run at all.
+    const updated = await runOnConnection(record.connection, () =>
+      this.$exec("update", {
+        where: record.key,
+        data: changed,
+      }),
+    );
 
     // Copy the *returned* row back over the caller's, not just the values sent.
     //
@@ -431,7 +471,21 @@ export abstract class Model {
     Object.assign(instance, row);
     // Tracked on the instance, not the argument — `save()` on the instance has
     // to diff against the values it was constructed from.
-    track(instance, schema);
+    //
+    // The connection is the argument's, when the argument has one. `wrap` runs
+    // *after* the query's scope has closed, so the ambient name here is
+    // whatever the caller happens to be in — usually the default — and a row
+    // read on `analytics` would be wrapped into an instance whose `save()`
+    // wrote to the hot path. Taken in order: an explicit `on`, then where the
+    // row actually came from, then the ambient connection for a row that was
+    // never tracked at all.
+    track(
+      instance,
+      schema,
+      this.$connection ??
+        provenanceOf(row)?.connection ??
+        currentConnectionName(),
+    );
 
     return instance;
   }
@@ -520,8 +574,8 @@ export abstract class Model {
     // `Subscription.on("analytics").transaction(...)` opens on that connection,
     // and a bare `Model.transaction` opens on whatever is ambient — which is
     // the default connection unless something outside has already named one.
+    // `withTransaction` refuses the mismatch; there is no second check here.
     const name = this.$connection ?? currentConnectionName();
-    assertConnectionUsable(name);
 
     return transact(app(DatabaseManager).connection(name), () =>
       runOnConnection(name, () => fn()),
@@ -545,16 +599,20 @@ export abstract class Model {
    * connection the open transaction cannot reach has to reject like every other
    * failure `$exec` produces, rather than being the one that throws before the
    * promise exists.
+   *
+   * The cross-connection refusal is `runOnConnection`'s, not repeated here:
+   * *entering* the connection is the only moment at which the scope still holds
+   * both the open transaction and the name it belongs to, so that is where the
+   * comparison has to live.
    */
   static async $exec(
     op: Operation,
     args: any = {},
     options?: ExecOptions,
   ): Promise<unknown> {
-    const name = this.$connection ?? currentConnectionName();
-    assertConnectionUsable(name);
-
-    return runOnConnection(name, () => this.$execute(op, args, options));
+    return runOnConnection(this.$connection ?? currentConnectionName(), () =>
+      this.$execute(op, args, options),
+    );
   }
 
   private static async $execute(
@@ -640,12 +698,23 @@ export abstract class Model {
     //
     // Cost on the common path: one `Map.get` and one reference compare, for a
     // model where nothing is registered under a different class.
+    //
+    // `inheritsPoliciesFrom` keeps that true for `Model.on(name)`, whose bound
+    // subclass is never the registered class and so failed the reference
+    // compare on *every* query — leaving each one to resolve the registered
+    // chain and walk it twice to reach the same conclusion. A direct subclass
+    // that declares no policies of its own has, by construction, the chain its
+    // parent has: there is nothing to compare.
     if (!system) {
       const registered = registry.has(schema.name)
         ? registry.get<unknown>(schema.name)
         : undefined;
 
-      if (registered !== undefined && registered !== this) {
+      if (
+        registered !== undefined &&
+        registered !== this &&
+        !inheritsPoliciesFrom(this, registered)
+      ) {
         const theirs = policiesFor(registered);
         const diverges =
           policies.length !== theirs.length ||
@@ -1111,6 +1180,31 @@ export abstract class Model {
   static $shape(plan: QueryPlan, rows: unknown[]): unknown {
     return plan.shape(rows);
   }
+}
+
+/**
+ * Whether `queried` can only have the policies `registered` has.
+ *
+ * True for a direct subclass that declares none of its own — which is what
+ * `Model.on(name)` builds, and also what `class AdminUser extends User {}` is.
+ * `policiesFor` walks the prototype chain and takes each level's own
+ * `$policies`; a level that declares none contributes nothing, so the walk from
+ * here and the walk from the parent visit the same levels in the same order and
+ * cannot disagree.
+ *
+ * Structural rather than a flag on the classes `on` mints, so the typed-view
+ * subclass the divergence guard already argues should be allowed gets the same
+ * short-circuit rather than paying for a second resolution of the chain.
+ *
+ * `$policy` — the removed name — is deliberately not checked: `policiesFor` has
+ * already walked this class by the time this is called, and it raises on that
+ * name at any level, so a class carrying it never reaches here.
+ */
+function inheritsPoliciesFrom(queried: unknown, registered: unknown): boolean {
+  return (
+    Object.getPrototypeOf(queried) === registered &&
+    !Object.hasOwn(queried as object, "$policies")
+  );
 }
 
 async function runSteps(

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -1,12 +1,16 @@
 import type { SQL, TransactionSQL } from "bun";
+import type { DatabaseConnection } from "../database/Connection";
 import { DatabaseManager } from "../database/DatabaseManager";
 import { app } from "../foundation/app";
 import { type BindContext, createBindContext } from "./compile/fragment";
 import {
+  assertConnectionUsable,
+  currentConnectionName,
   currentTransaction,
   isSystemScope,
   runAsSystem,
   runAsUser,
+  runOnConnection,
   withTransaction,
 } from "./context";
 import {
@@ -95,15 +99,38 @@ const ORTHROW = new Set([
  * quietly open a transaction that ignores the setting. `withTransaction` itself
  * takes the threshold as an argument on purpose; it knows nothing about the
  * container, and this is the seam where the two meet.
+ *
+ * The same argument now carries the connection's **name**: a pool cannot be
+ * asked which one it is, and `withTransaction` has to know in order to tell a
+ * nested transaction on the same connection (a savepoint) from one on another
+ * (a refusal). Taking the whole connection rather than the manager is what
+ * makes both come from the same object, so a named connection cannot end up
+ * with the default's threshold.
  */
 function transact<T>(
-  db: DatabaseManager,
+  connection: DatabaseConnection,
   fn: (tx: TransactionSQL) => Promise<T>,
 ): Promise<T> {
-  return withTransaction(db.sql, fn, {
-    slowTransactionThreshold: db.config.slowTransactionThreshold,
+  return withTransaction(connection.sql, fn, {
+    slowTransactionThreshold: connection.config.slowTransactionThreshold,
+    connection: connection.name,
   });
 }
+
+/**
+ * The classes `Model.on` has already built, keyed by the class it was called on
+ * and then by connection name.
+ *
+ * `User.on("analytics")` is a per-query call, so it can happen in a loop and in
+ * a hot path; minting a class each time would allocate one per query and defeat
+ * every identity comparison downstream — the policy-divergence guard's
+ * `registered !== this` among them, which would then run `policiesFor` against
+ * a class it had never seen before on every call.
+ *
+ * A `WeakMap` on the outside so a model class that goes out of scope takes its
+ * bound variants with it, which matters for tests that define models inline.
+ */
+const boundToConnection = new WeakMap<object, Map<string, typeof Model>>();
 
 export abstract class Model {
   /**
@@ -173,6 +200,75 @@ export abstract class Model {
    * typing, which a bare `$policies = [...]` does not get on its own.
    */
   static $policies?: readonly PolicyEntry[];
+
+  /**
+   * The connection this class's operations run on, set only by `on` below.
+   *
+   * `undefined` — which is what every model an application writes has — means
+   * *the ambient connection*, not *the default one*. The two differ inside
+   * `DB.connection("analytics").transaction(...)`, where an unqualified query
+   * has to join the open transaction rather than quietly reach for the hot
+   * path's pool.
+   */
+  static $connection?: string;
+
+  /**
+   * The same model, reading and writing on a named connection.
+   *
+   *     const rows = await Subscription.on("analytics").findMany({ where })
+   *
+   * **Per query, not per model**, which is the shape the problem actually has:
+   * the same `Subscription` is read on the hot path during sign-in and swept by
+   * the nightly audit. A `static $connection = "analytics"` on the class would
+   * force one of those two to be wrong, so the choice lives at the call site
+   * and every query that does not make it stays on the default connection.
+   *
+   * What it returns is the model class with the connection bound to it, so the
+   * whole typed surface — all fifteen operations, `transaction`, `save` — is
+   * there unchanged and narrows exactly as it does on the class itself. The
+   * connection reaches nested `include` reads and nested writes as well, which
+   * an argument on `findMany` could not have done: those recurse through the
+   * *target* model's `$exec` by way of the registry, so it is carried in the
+   * ambient scope rather than in anyone's parameter list.
+   *
+   * **A transaction cannot span connections.** Naming one inside a transaction
+   * open on another raises `CrossConnectionTransactionError` rather than
+   * running the statement outside the transaction, where it would survive the
+   * rollback. See that error for why refusing is the only honest answer.
+   *
+   * An unknown name raises `UnknownConnectionError` at the query, not here:
+   * `on` is a pure lookup and does not resolve the container, so a model bound
+   * in a module's top-level scope cannot force the database open at import
+   * time.
+   */
+  static on<T extends typeof Model>(this: T, connection: string): T {
+    let byName = boundToConnection.get(this);
+    if (byName === undefined) boundToConnection.set(this, (byName = new Map()));
+
+    const cached = byName.get(connection);
+    if (cached !== undefined) return cached as T;
+
+    // A subclass rather than a Proxy. Both would forward the operations, but a
+    // subclass *is* a class: `policiesFor` walks the prototype chain with
+    // `Object.hasOwn`, the generated statics are inherited by the language
+    // rather than by a trap, and `$exec`'s `this` needs no special handling to
+    // stay bound to it.
+    const bound = class extends (this as unknown as typeof Model) {
+      static $connection = connection;
+    };
+
+    // Otherwise the class expression takes its name from the binding above and
+    // every error that names the model says "bound". `UnregisteredPolicyClassError`
+    // reads `this.name` in particular, and it is exactly the kind of message
+    // that has to name the class the caller wrote.
+    Object.defineProperty(bound, "name", {
+      value: (this as { name: string }).name,
+      configurable: true,
+    });
+
+    byName.set(connection, bound);
+    return bound as unknown as T;
+  }
 
   /**
    * Runs `fn` with policies suspended, for code that has no user and knows it:
@@ -415,11 +511,53 @@ export abstract class Model {
    * bound, or `false` switches it off. In production it just holds the
    * connection. Keep network and filesystem I/O outside.
    */
-  static transaction<T>(fn: () => Promise<T>): Promise<T> {
-    return transact(app(DatabaseManager), () => fn());
+  // `async`, so that naming a connection this transaction cannot reach —
+  // `Subscription.on("analytics").transaction(...)` inside a transaction on the
+  // hot path — *rejects* rather than throwing synchronously. The same reasoning
+  // `DB.query` records: an API that does one sometimes and the other otherwise
+  // is a footgun, and a `.catch()` would miss exactly this error.
+  static async transaction<T>(fn: () => Promise<T>): Promise<T> {
+    // `Subscription.on("analytics").transaction(...)` opens on that connection,
+    // and a bare `Model.transaction` opens on whatever is ambient — which is
+    // the default connection unless something outside has already named one.
+    const name = this.$connection ?? currentConnectionName();
+    assertConnectionUsable(name);
+
+    return transact(app(DatabaseManager).connection(name), () =>
+      runOnConnection(name, () => fn()),
+    );
   }
 
+  /**
+   * The choke point's outer half: which connection this operation runs on.
+   *
+   * Split from the body below so that the name is resolved and entered
+   * **once**, around everything — the policy pass, the plan lookup, the nested
+   * writes and every relation read that recurses back through here. The
+   * alternative, resolving it inside, would have left each nested read to
+   * rediscover it, and the one that did not would have run against the default
+   * connection with no error to show for it.
+   *
+   * Recursive calls cost a comparison: the ambient name already matches, so
+   * `runOnConnection` calls straight through without entering a second scope.
+   *
+   * `async` for the reason `transaction` is: an operation refused for naming a
+   * connection the open transaction cannot reach has to reject like every other
+   * failure `$exec` produces, rather than being the one that throws before the
+   * promise exists.
+   */
   static async $exec(
+    op: Operation,
+    args: any = {},
+    options?: ExecOptions,
+  ): Promise<unknown> {
+    const name = this.$connection ?? currentConnectionName();
+    assertConnectionUsable(name);
+
+    return runOnConnection(name, () => this.$execute(op, args, options));
+  }
+
+  private static async $execute(
     op: Operation,
     args: any = {},
     options?: ExecOptions,
@@ -428,7 +566,13 @@ export abstract class Model {
 
     // Resolved per call, never captured at module scope: that is what keeps the
     // connection swappable in tests.
-    const db = app(DatabaseManager);
+    //
+    // Through `connection()` rather than off the manager directly, so that a
+    // query on a named connection reads *that* pool's client and dialect. The
+    // default connection is the manager itself, which is what keeps every
+    // existing wrapper of it — the harnesses that Proxy `sql` to count
+    // statements — looking at the object this executes through.
+    const db = app(DatabaseManager).connection(currentConnectionName());
     const dialect = dialectFor(db.dialect);
 
     // The ambient-transaction hook, and the entire integration. It is one line

--- a/packages/gemi/orm/context.test.ts
+++ b/packages/gemi/orm/context.test.ts
@@ -557,9 +557,13 @@ describe("the ambient connection", () => {
   test("a named transaction puts its connection in scope, and takes it out again", async () => {
     const pool = fakePool("analytics");
 
-    await withTransaction(pool, async () => {
-      expect(currentConnectionName()).toBe("analytics");
-    }, { connection: "analytics" });
+    await withTransaction(
+      pool,
+      async () => {
+        expect(currentConnectionName()).toBe("analytics");
+      },
+      { connection: "analytics" },
+    );
 
     expect(currentConnectionName()).toBe("default");
   });
@@ -574,19 +578,33 @@ describe("the ambient connection", () => {
   test("an unqualified statement inside one is not refused by it", async () => {
     const pool = fakePool("analytics");
 
-    await withTransaction(pool, async () => {
-      expect(() => assertConnectionUsable(currentConnectionName())).not.toThrow();
-    }, { connection: "analytics" });
+    await withTransaction(
+      pool,
+      async () => {
+        expect(() =>
+          assertConnectionUsable(currentConnectionName()),
+        ).not.toThrow();
+      },
+      { connection: "analytics" },
+    );
   });
 
   test("naming the same connection again is a savepoint, not a refusal", async () => {
     const pool = fakePool("analytics");
 
-    await withTransaction(pool, async () => {
-      await withTransaction(pool, async () => {
-        expect(transactionDepth()).toBe(1);
-      }, { connection: "analytics" });
-    }, { connection: "analytics" });
+    await withTransaction(
+      pool,
+      async () => {
+        await withTransaction(
+          pool,
+          async () => {
+            expect(transactionDepth()).toBe(1);
+          },
+          { connection: "analytics" },
+        );
+      },
+      { connection: "analytics" },
+    );
   });
 
   /**
@@ -599,22 +617,26 @@ describe("the ambient connection", () => {
     const hot = fakePool("default");
     const analytics = fakePool("analytics");
 
-    await withTransaction(hot, async () => {
-      // Synchronously, before `begin` — this function already throws that way
-      // for a closed pool, and the public doors (`Model.transaction`,
-      // `DB.connection(name).transaction`) are `async`, so what an application
-      // sees is a rejection either way.
-      expect(() =>
-        withTransaction(analytics, async () => "unreachable", {
-          connection: "analytics",
-        }),
-      ).toThrow(CrossConnectionTransactionError);
+    await withTransaction(
+      hot,
+      async () => {
+        // Synchronously, before `begin` — this function already throws that way
+        // for a closed pool, and the public doors (`Model.transaction`,
+        // `DB.connection(name).transaction`) are `async`, so what an application
+        // sees is a rejection either way.
+        expect(() =>
+          withTransaction(analytics, async () => "unreachable", {
+            connection: "analytics",
+          }),
+        ).toThrow(CrossConnectionTransactionError);
 
-      // Nothing was issued on either handle, which is the half that says it
-      // refused rather than ran and rolled back.
-      expect(analytics.log).toEqual([]);
-      expect(hot.log).toEqual([]);
-    }, { connection: "default" });
+        // Nothing was issued on either handle, which is the half that says it
+        // refused rather than ran and rolled back.
+        expect(analytics.log).toEqual([]);
+        expect(hot.log).toEqual([]);
+      },
+      { connection: "default" },
+    );
   });
 
   test("a statement naming another connection is refused too", async () => {
@@ -638,19 +660,47 @@ describe("the ambient connection", () => {
   });
 
   test("entering a connection merges the scope rather than replacing it", async () => {
+    await runAsSystem(async () => {
+      await runOnConnection("analytics", async () => {
+        // Suspended policies survive naming a connection — the same rule
+        // `asSystem` and `asUser` follow, and the one that would otherwise make
+        // a connection switch quietly re-enable them for its subtree.
+        expect(currentConnectionName()).toBe("analytics");
+        expect(isSystemScope()).toBe(true);
+      });
+    });
+  });
+
+  /**
+   * Entering a connection is *where* the refusal lives, and this is the reason
+   * it cannot live at the doors instead.
+   *
+   * The scope carries the handle and the connection name together. Switching
+   * the name with a transaction still open would leave a store that reads "a
+   * transaction on analytics" while holding the **default** connection's
+   * handle — after which every check downstream agrees with itself and the
+   * statement runs on the wrong connection's transaction, which is the failure
+   * this whole feature is about.
+   *
+   * Found by `Model.save`: it routes to the connection its row was read on, so
+   * it is the one caller that switches connections with a transaction already
+   * open. Review caught the missing stamp; this is the mechanism underneath it.
+   */
+  test("switching connections under an open transaction is refused, not merged", async () => {
     const pool = fakePool("default");
 
-    await runAsSystem(async () => {
-      await withTransaction(pool, async (tx) => {
-        await runOnConnection("analytics", async () => {
-          // The transaction handle and the suspended policies both survive
-          // naming a connection — the same rule `asSystem` and `asUser` follow,
-          // and the one that would otherwise drop an open handle.
-          expect(currentConnectionName()).toBe("analytics");
-          expect(currentTransaction()).toBe(tx);
-          expect(isSystemScope()).toBe(true);
-        });
-      });
+    await withTransaction(pool, async (tx) => {
+      // Synchronously, like `withTransaction`'s own refusal above — every
+      // caller of this is an `async` function, so an application sees a
+      // rejection.
+      expect(() =>
+        runOnConnection("analytics", async () => "unreachable"),
+      ).toThrow(CrossConnectionTransactionError);
+
+      // The scope the callback would have run in was never entered: the handle
+      // and the name still agree.
+      expect(currentTransaction()).toBe(tx);
+      expect(currentConnectionName()).toBe("default");
     });
   });
 

--- a/packages/gemi/orm/context.test.ts
+++ b/packages/gemi/orm/context.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, test } from "vitest";
 
 import { SLOW_TRANSACTION_THRESHOLD } from "../database/config";
+import { CrossConnectionTransactionError } from "../database/Connection";
 import {
+  assertConnectionUsable,
+  currentConnectionName,
   currentTransaction,
+  isSystemScope,
   ormContext,
+  runAsSystem,
+  runOnConnection,
   slowTransactionThreshold,
   transactionDepth,
   withTransaction,
@@ -529,5 +535,144 @@ describe("the slow-transaction threshold", () => {
   ])("%s falls back to the default", (_label, configured) => {
     inMode("development");
     expect(slowTransactionThreshold(configured)).toBe(2_000);
+  });
+});
+
+/**
+ * Which connection the scope is on, and what happens when a statement names
+ * another one while a transaction is open (#327).
+ *
+ * Tested here, with fake pools, for the same reason the handle is: the
+ * behaviour worth pinning is a property of the *scope*, and a fake pool can
+ * produce the case that matters — one transaction open on A, a statement
+ * naming B — without needing two real databases to prove that no SQL ran. The
+ * end-to-end half, where the two connections are two files and the rows are the
+ * evidence, is the template's `connections.test.ts`.
+ */
+describe("the ambient connection", () => {
+  test("outside any scope it is the default one", () => {
+    expect(currentConnectionName()).toBe("default");
+  });
+
+  test("a named transaction puts its connection in scope, and takes it out again", async () => {
+    const pool = fakePool("analytics");
+
+    await withTransaction(pool, async () => {
+      expect(currentConnectionName()).toBe("analytics");
+    }, { connection: "analytics" });
+
+    expect(currentConnectionName()).toBe("default");
+  });
+
+  /**
+   * The reason an unqualified query inherits rather than defaulting. Inside
+   * `DB.connection("analytics").transaction(...)`, a bare `User.create` has to
+   * join the open transaction — resolving it to the *default* connection
+   * instead would refuse it, and refusing the ordinary case would make the
+   * whole handle unusable.
+   */
+  test("an unqualified statement inside one is not refused by it", async () => {
+    const pool = fakePool("analytics");
+
+    await withTransaction(pool, async () => {
+      expect(() => assertConnectionUsable(currentConnectionName())).not.toThrow();
+    }, { connection: "analytics" });
+  });
+
+  test("naming the same connection again is a savepoint, not a refusal", async () => {
+    const pool = fakePool("analytics");
+
+    await withTransaction(pool, async () => {
+      await withTransaction(pool, async () => {
+        expect(transactionDepth()).toBe(1);
+      }, { connection: "analytics" });
+    }, { connection: "analytics" });
+  });
+
+  /**
+   * The failure the whole feature turns on. Before the check, this took a
+   * savepoint on the *open* handle and ran the callback against it — so
+   * statements meant for one database landed in another, with no error and
+   * usually with tables of the same shape to land in.
+   */
+  test("a transaction on another connection is refused, not savepointed", async () => {
+    const hot = fakePool("default");
+    const analytics = fakePool("analytics");
+
+    await withTransaction(hot, async () => {
+      // Synchronously, before `begin` — this function already throws that way
+      // for a closed pool, and the public doors (`Model.transaction`,
+      // `DB.connection(name).transaction`) are `async`, so what an application
+      // sees is a rejection either way.
+      expect(() =>
+        withTransaction(analytics, async () => "unreachable", {
+          connection: "analytics",
+        }),
+      ).toThrow(CrossConnectionTransactionError);
+
+      // Nothing was issued on either handle, which is the half that says it
+      // refused rather than ran and rolled back.
+      expect(analytics.log).toEqual([]);
+      expect(hot.log).toEqual([]);
+    }, { connection: "default" });
+  });
+
+  test("a statement naming another connection is refused too", async () => {
+    const hot = fakePool("default");
+
+    await withTransaction(hot, async () => {
+      expect(() => assertConnectionUsable("analytics")).toThrow(
+        CrossConnectionTransactionError,
+      );
+    });
+  });
+
+  /**
+   * Outside a transaction there is nothing to straddle, so naming a connection
+   * is always allowed — which is what makes `Model.on("analytics")` free in the
+   * ordinary case rather than something to be justified.
+   */
+  test("outside a transaction any connection may be named", () => {
+    expect(() => assertConnectionUsable("analytics")).not.toThrow();
+    expect(() => assertConnectionUsable("default")).not.toThrow();
+  });
+
+  test("entering a connection merges the scope rather than replacing it", async () => {
+    const pool = fakePool("default");
+
+    await runAsSystem(async () => {
+      await withTransaction(pool, async (tx) => {
+        await runOnConnection("analytics", async () => {
+          // The transaction handle and the suspended policies both survive
+          // naming a connection — the same rule `asSystem` and `asUser` follow,
+          // and the one that would otherwise drop an open handle.
+          expect(currentConnectionName()).toBe("analytics");
+          expect(currentTransaction()).toBe(tx);
+          expect(isSystemScope()).toBe(true);
+        });
+      });
+    });
+  });
+
+  /**
+   * `$exec` calls this on every operation, so the no-op case is the hot one:
+   * re-entering the connection already in scope must not cost a second store.
+   */
+  test("naming the connection already in scope enters nothing", async () => {
+    await runOnConnection("analytics", async () => {
+      const store = ormContext.getStore();
+      await runOnConnection("analytics", async () => {
+        expect(ormContext.getStore()).toBe(store);
+      });
+    });
+  });
+
+  test("the default connection is spelled as an absent name, not as a scope", async () => {
+    await runOnConnection("default", async () => {
+      // Nothing was entered, so an application with one connection pays
+      // nothing for this feature at all.
+      expect(ormContext.getStore()).toBeUndefined();
+      expect(currentConnectionName()).toBe("default");
+    });
   });
 });

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -1,6 +1,10 @@
 import type { SQL, TransactionSQL } from "bun";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { SLOW_TRANSACTION_THRESHOLD } from "../database/config";
+import {
+  CrossConnectionTransactionError,
+  DEFAULT_CONNECTION,
+} from "../database/Connection";
 
 /**
  * The ambient transaction: the ORM's own `AsyncLocalStorage`, holding nothing
@@ -33,6 +37,24 @@ export interface OrmScope {
   tx?: TransactionSQL;
   /** 0 for the outermost transaction, 1+ for each savepoint inside it. */
   depth: number;
+  /**
+   * Which named connection this subtree's queries run on, and — when `tx` is
+   * set — which connection the open transaction belongs to.
+   *
+   * Ambient rather than an argument threaded through `$exec`, for the same
+   * reason the handle above is: a relation read resolves its target through the
+   * registry and calls that class's `$exec`, so an argument would have to be
+   * carried by every intermediate that has no interest in it, and the one that
+   * forgot would silently read a nested `include` off the *other* pool. There
+   * is no error that shape produces; there are just rows from the wrong place.
+   *
+   * `undefined` means the default connection. Kept as absent-rather-than-
+   * `"default"` so that entering a scope on the default connection is
+   * indistinguishable from not entering one, which is what makes the
+   * cross-connection check below cost a comparison of two `undefined`s on every
+   * application that never declares a second connection.
+   */
+  connection?: string;
   /**
    * Whether policies are suspended for this scope. Set only by
    * `Model.asSystem`, and never by anything ambient — the whole point is that
@@ -75,6 +97,71 @@ export const ormContext = new AsyncLocalStorage<OrmScope>();
  */
 export function currentTransaction(): TransactionSQL | undefined {
   return ormContext.getStore()?.tx;
+}
+
+/**
+ * The connection every query in this scope runs on unless it names another.
+ *
+ * `"default"` outside any scope, so callers get a name rather than a
+ * `string | undefined` to normalise themselves — the store keeps it absent,
+ * which is not the same distinction and is nobody else's business.
+ */
+export function currentConnectionName(): string {
+  return ormContext.getStore()?.connection ?? DEFAULT_CONNECTION;
+}
+
+/**
+ * Run `fn` with `name` as the ambient connection.
+ *
+ * Merged into the current scope rather than replacing it, exactly as
+ * `runAsSystem` and `runAsUser` are: naming a connection must not drop an open
+ * transaction handle or re-enable policies underneath it.
+ *
+ * Deliberately absent from `orm/index.ts`, so it is not part of what an
+ * application can reach — `Model.on(name)` and `DB.connection(name)` are the
+ * two doors, and both funnel through here so that a nested relation read,
+ * which resolves its own class out of the registry and calls its `$exec`,
+ * inherits the connection without anything having to pass it along.
+ */
+export function runOnConnection<T>(
+  name: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const current = ormContext.getStore();
+  if (currentConnectionName() === name) return fn();
+
+  return ormContext.run(
+    {
+      ...current,
+      depth: current?.depth ?? 0,
+      connection: name === DEFAULT_CONNECTION ? undefined : name,
+    },
+    fn,
+  );
+}
+
+/**
+ * Refuse a statement that names one connection while a transaction is open on
+ * another.
+ *
+ * The check `withTransaction`'s single-connection note asked for, and the
+ * reasoning for refusing rather than routing is on
+ * `CrossConnectionTransactionError`. Both doors call it — `Model.$exec` for
+ * every model operation, `DB` for a raw fragment — because either one alone
+ * leaves the other free to straddle the two connections, and a raw `DB.execute`
+ * escaping a transaction is the more damaging of the two.
+ *
+ * Only ever fires on a query that *names* a connection: an unqualified one
+ * resolves to the ambient name, which is the transaction's own.
+ */
+export function assertConnectionUsable(name: string): void {
+  const store = ormContext.getStore();
+  if (store?.tx === undefined) return;
+
+  const open = store.connection ?? DEFAULT_CONNECTION;
+  if (open === name) return;
+
+  throw new CrossConnectionTransactionError(open, name);
 }
 
 /** How deeply nested the current transaction is; `null` outside one. */
@@ -274,6 +361,12 @@ function watchForSlowTransaction(configured?: number | false): () => void {
  * taking it as an argument keeps this file free of the container, so a bare
  * `SQL` is still enough to call it. Its tests rely on that.
  *
+ * `options.connection` is the name `pool` belongs to, and follows the same rule
+ * for the same reason: the pool cannot be asked what it is called. Passing it
+ * is what lets a nested `withTransaction` tell "the same connection, so take a
+ * savepoint" from "a different one, so refuse" — omitting it means the default
+ * connection, which is what a two-argument call always meant.
+ *
  * The return type is asserted rather than inferred for one reason worth
  * knowing: Bun's `begin` unwraps a callback that resolves to an *array of
  * promises*, awaiting each. So `Model.transaction(async () => [a, b])` where
@@ -283,23 +376,31 @@ function watchForSlowTransaction(configured?: number | false): () => void {
 export function withTransaction<T>(
   pool: SQL,
   fn: (tx: TransactionSQL) => Promise<T>,
-  options?: { slowTransactionThreshold?: number | false },
+  options?: { slowTransactionThreshold?: number | false; connection?: string },
 ): Promise<T> {
   const current = ormContext.getStore();
 
-  // SINGLE-CONNECTION ASSUMPTION, pinned here so it is found rather than
-  // discovered. The savepoint branch ignores `pool` entirely, which is correct
-  // today: there is one `DatabaseManager` and one `SQL`, so the ambient handle
-  // and whatever pool the caller passed are necessarily the same database.
+  // THE SINGLE-CONNECTION ASSUMPTION, WHICH IS NOW CHECKED RATHER THAN PINNED.
   //
-  // It stops being correct the moment a second connection is configurable. A
-  // `DB.transaction` against connection B, called inside a `Model.transaction`
-  // on A, would open a savepoint on **A** and hand the callback A's handle —
-  // statements landing in the wrong database, with no error. That is the same
-  // failure shape as the "handle on the Application" alternative this file
-  // argues against. Multi-connection support must compare the two and either
-  // join or refuse, not fall through to here.
+  // The savepoint branch below ignores `pool` entirely. That was correct while
+  // there was one `DatabaseManager` and one `SQL` — the ambient handle and
+  // whatever pool the caller passed were necessarily the same database — and
+  // the note that stood here said what would happen when a second connection
+  // became configurable (#327): a `DB.transaction` on B inside a
+  // `Model.transaction` on A would savepoint on **A** and hand the callback A's
+  // handle, so statements landed in the wrong database with no error at all.
   //
+  // So the name is compared before the branch is taken, and a mismatch raises.
+  // Refusing is the whole answer rather than half of one — there is no way to
+  // make one transaction span two pools, and the alternatives are covered on
+  // `CrossConnectionTransactionError`.
+  //
+  // A caller that passes no `connection` is treated as naming the default,
+  // which is what `withTransaction(pool, fn)` meant before this argument
+  // existed.
+  const name = options?.connection ?? DEFAULT_CONNECTION;
+  assertConnectionUsable(name);
+
   // `current?.tx` rather than `current`: since iteration 6 a scope can exist
   // with no open transaction — `Model.asSystem` enters one — and a savepoint
   // needs an actual handle, not merely a store.
@@ -331,10 +432,26 @@ export function withTransaction<T>(
   try {
     // Spread rather than replace: a `Model.transaction` inside a
     // `Model.asSystem` must not silently re-enable policies for its subtree.
+    //
+    // The connection goes into the scope alongside the handle, and the pair is
+    // what makes the check at the top of this function possible: "which
+    // connection is this transaction on" has to be answerable from the store,
+    // because the handle itself does not say. It is also what makes an
+    // unqualified query inside `DB.connection("analytics").transaction(...)`
+    // *join* the transaction instead of being refused by it — the query
+    // inherits the name rather than defaulting to the hot path.
     return (
       pool
         .begin((tx) =>
-          ormContext.run({ ...current, tx, depth: 0 }, () => fn(tx)),
+          ormContext.run(
+            {
+              ...current,
+              tx,
+              depth: 0,
+              connection: name === DEFAULT_CONNECTION ? undefined : name,
+            },
+            () => fn(tx),
+          ),
         )
         // `finally` and not a `then`/`catch` pair: the connection is released on
         // rollback exactly as it is on commit, so a throwing callback must clear

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -130,6 +130,19 @@ export function runOnConnection<T>(
   const current = ormContext.getStore();
   if (currentConnectionName() === name) return fn();
 
+  // ENTERING A CONNECTION IS WHERE THE CROSS-CONNECTION CHECK BELONGS, not at
+  // each door — and it has to be *here*, before the scope is entered, because
+  // entering it is what makes the check impossible afterwards.
+  //
+  // The scope carries `tx` and `connection` together, so overwriting the name
+  // while an open handle stays in place produces a store that says "a
+  // transaction on analytics" while holding the *default* connection's handle.
+  // Every check downstream then agrees with itself and the statement runs on
+  // the wrong connection's transaction. `Model.save` found this: it routes to
+  // the row's own connection, so it is the one caller that switches connections
+  // with a transaction already open.
+  assertConnectionUsable(name);
+
   return ormContext.run(
     {
       ...current,

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -129,6 +129,17 @@ export {
   type OrmScope,
 } from "./context";
 
+// The two failures a named connection can produce, re-exported from
+// `gemi/database` because this is where they are *caught*: both come out of a
+// model operation — `Subscription.on("analytics").findMany()` — and an
+// application should not have to know that the manager rather than the ORM
+// constructed them. `docs/orm.md`'s errors table is the list of what an
+// application can catch, and it is checked against this module's exports.
+export {
+  CrossConnectionTransactionError,
+  UnknownConnectionError,
+} from "../database/Connection";
+
 // Composable raw SQL. `DB.query` / `DB.execute` run what these build — the
 // place every shape the ORM declines is supposed to land.
 export {

--- a/packages/gemi/orm/provenance.ts
+++ b/packages/gemi/orm/provenance.ts
@@ -1,3 +1,4 @@
+import { currentConnectionName } from "./context";
 import { UnsupportedQueryError } from "./errors";
 import type { ModelSchema } from "./schema";
 
@@ -27,6 +28,22 @@ import type { ModelSchema } from "./schema";
 export interface Provenance {
   /** The model name, so `save` compiles against the right schema. */
   model: string;
+  /**
+   * The connection the row was read on, so `save` writes it back to the
+   * database it came from.
+   *
+   * The one piece of ORM state that cannot live in the ambient scope, and the
+   * reason it is recorded here instead. Everything else about a connection is
+   * true for an async subtree; this is true of a *value* that outlives the
+   * query that produced it — a row read on `analytics`, mutated three functions
+   * later, and saved from a scope that never named a connection.
+   *
+   * Without it `save` compiled a correct `update` and sent it to the default
+   * connection. In production, where two connections usually address the same
+   * database with the same id space, that is not a failed write: it is the
+   * *wrong row* updated, with no error to notice.
+   */
+  connection: string;
   /** The primary key values, captured at fetch time so a mutation cannot move the row. */
   key: Record<string, unknown>;
   /**
@@ -53,7 +70,19 @@ const provenance = new WeakMap<object, Provenance>();
  * means structural comparison per row per field, which is exactly the per-row
  * cost this feature is trying to keep off the default path.
  */
-export function track(row: object, schema: ModelSchema): void {
+export function track(
+  row: object,
+  schema: ModelSchema,
+  /**
+   * Defaults to the connection in scope, which is the right answer for the only
+   * caller that matters: `$exec` tracks inside the scope it entered, so a row
+   * from `User.on("analytics")` is stamped `analytics` with nothing passed.
+   *
+   * Explicit for `wrap`, which runs *after* that scope has closed and would
+   * otherwise stamp every wrapped row with the default connection.
+   */
+  connection: string = currentConnectionName(),
+): void {
   const snapshot: Record<string, unknown> = {};
   const key: Record<string, unknown> = {};
   const source = row as Record<string, unknown>;
@@ -80,7 +109,7 @@ export function track(row: object, schema: ModelSchema): void {
     key[name] = source[name];
   }
 
-  provenance.set(row, { model: schema.name, key, snapshot });
+  provenance.set(row, { model: schema.name, connection, key, snapshot });
 }
 
 export function provenanceOf(row: unknown): Provenance | undefined {

--- a/plans/orm/README.md
+++ b/plans/orm/README.md
@@ -611,6 +611,20 @@ makes the *SQLite* suites fail for an unrelated reason afterwards.
   there is no adapter to select and no `userProvider` line in the template. An
   application that must change a query subclasses `UserProvider` and passes it
   as `AuthManager`'s second constructor argument.
+- ~~**One connection per application.**~~ **Settled for #327: named connections,
+  and a transaction that refuses to span two of them.** `app/config/database.ts`
+  takes a `connections` map beside the top-level `url`; `Model.on(name)` and
+  `DB.connection(name)` are the two doors, and the name travels in the ORM's
+  ambient scope so a nested `include` or nested write cannot land on the other
+  pool. What made it a decision rather than a build is the second half: a
+  transaction lives on one reserved connection, so a statement naming another
+  one is refused (`CrossConnectionTransactionError`) rather than run outside the
+  transaction, where it would survive the rollback. The single-connection note
+  in `orm/context.ts` predicted exactly that failure and is now a check.
+
+  The connection is a **per-query** property, not a per-model one — the same
+  model is read on the hot path during sign-in and swept by the nightly audit,
+  so a `connection` on the class would force one of the two to be wrong.
 - ~~**Where this stack merges.**~~ **Settled: it merged to `next`.** PRs #30 and
   #33 were closed as already-shipped — their content had been on
   `release/v0.50.0-rc.2` since 2026-07-28 — and `feat/orm` is now an ancestor of

--- a/templates/saas-starter/app/config/database.ts
+++ b/templates/saas-starter/app/config/database.ts
@@ -18,4 +18,29 @@ export default defineDatabaseConfig({
   // Development-only, and a diagnostic rather than a limit — nothing here
   // cancels a transaction.
   // slowTransactionThreshold: 5_000,
+
+  // Additional connections, reached with `Model.on(name)` and
+  // `DB.connection(name)`. The settings above describe the one called
+  // "default", which is what every query uses unless it names another.
+  //
+  // The case this is for is two pools against the *same* database with
+  // opposite workloads: a hot path that must never block, and an analytics
+  // path whose queries legitimately run for seconds. A pool size and a timeout
+  // that protect one are the wrong values for the other, which is why they
+  // cannot be one connection. The same URL twice is normal here — what differs
+  // is the pool.
+  //
+  // Two things to know before adding one: a transaction cannot span two
+  // connections (a statement that names another one while a transaction is
+  // open raises rather than quietly running outside it), and each connection is
+  // a real pool counted separately against the server's connection cap. See
+  // the ORM docs, "Connections".
+  //
+  // connections: {
+  //   analytics: {
+  //     url: process.env.DATABASE_URL,
+  //     options: { max: 3, idleTimeout: 60 },
+  //     slowTransactionThreshold: 60_000,
+  //   },
+  // },
 });

--- a/templates/saas-starter/app/models/bench/run.ts
+++ b/templates/saas-starter/app/models/bench/run.ts
@@ -753,7 +753,11 @@ async function runDialect(
         get(target, property, receiver) {
           if (property === "sql") return counting;
           const value = Reflect.get(target, property, receiver);
-          return typeof value === "function" ? value.bind(target) : value;
+          // Bound to the **proxy**: `$exec` asks the manager for its connection
+          // by name and gets `this` back for the default one, which bound to
+          // the target would be the unwrapped manager — and every round trip
+          // would go uncounted.
+          return typeof value === "function" ? value.bind(receiver) : value;
         },
       }),
     );

--- a/templates/saas-starter/app/models/connections.test.ts
+++ b/templates/saas-starter/app/models/connections.test.ts
@@ -11,7 +11,14 @@ import {
 import { DB } from "gemi/facades";
 import { Application } from "gemi/foundation";
 import { Model, clearPlanCache, sql } from "gemi/orm";
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
 
 import { applyMigrations } from "./scratch";
 import { User } from "./User";
@@ -104,9 +111,11 @@ describe("named connections", () => {
 
   /** Emails, since `id` restarts from 1 in both files and cannot tell them apart. */
   const emails = async (client: SQL) =>
-    ((await client.unsafe(`select "email" from "User" order by "email"`)) as any[]).map(
-      (row) => row.email,
-    );
+    (
+      (await client.unsafe(
+        `select "email" from "User" order by "email"`,
+      )) as any[]
+    ).map((row) => row.email);
 
   test("a query without a connection goes to the default one", async () => {
     await User.create({ data: { email: "hot@example.dev" } });
@@ -194,7 +203,9 @@ describe("named connections", () => {
     const there = (await analytics.unsafe(
       `select count(*) as c from "Account"`,
     )) as any;
-    const here = (await hot.unsafe(`select count(*) as c from "Account"`)) as any;
+    const here = (await hot.unsafe(
+      `select count(*) as c from "Account"`,
+    )) as any;
 
     expect(there[0].c).toBe(1);
     expect(here[0].c).toBe(0);
@@ -206,9 +217,9 @@ describe("named connections", () => {
    * was configured to prevent, weeks later, with nothing pointing at the typo.
    */
   test("an unknown connection raises rather than falling back", async () => {
-    await expect(
-      User.on("analitycs").findMany({}),
-    ).rejects.toThrow(UnknownConnectionError);
+    await expect(User.on("analitycs").findMany({})).rejects.toThrow(
+      UnknownConnectionError,
+    );
 
     expect(await emails(hot)).toEqual([]);
   });
@@ -329,6 +340,96 @@ describe("named connections", () => {
 
       expect(refused).toBeInstanceOf(CrossConnectionTransactionError);
       expect(await emails(hot)).toEqual(["kept@example.dev"]);
+    });
+  });
+
+  /**
+   * `save` writes back to the connection the row was read on.
+   *
+   * The one piece of connection state that cannot be ambient: a tracked row is
+   * an ordinary object that outlives the scope that produced it, so by the time
+   * it is saved the scope is gone. It was reported in review, and the failure it
+   * produced is the worst shape available here — `save` compiled a correct
+   * `update` and sent it to the *other* database, where in production the same
+   * id names a real and different row. No error, one wrong row.
+   */
+  describe("save", () => {
+    beforeEach(async () => {
+      for (const [client, label] of [
+        [hot, "hot"],
+        [analytics, "cold"],
+      ] as const) {
+        await client.unsafe(
+          `insert into "User" ("id", "publicId", "name", "email", "createdAt", "updatedAt")
+           values (1, 'p-${label}', '${label}-original', '${label}@example.dev', 0, 0)`,
+        );
+      }
+    });
+
+    const names = async (client: SQL) =>
+      ((await client.unsafe(`select "name" from "User"`)) as any[]).map(
+        (row) => row.name,
+      );
+
+    test("a row read on a named connection is saved back to it", async () => {
+      const [row] = await User.on("analytics").findMany({}, { track: true });
+      row.name = "written-by-save";
+
+      await User.save(row);
+
+      expect(await names(analytics)).toEqual(["written-by-save"]);
+      expect(await names(hot)).toEqual(["hot-original"]);
+    });
+
+    test("...including from an instance `wrap` built", async () => {
+      const [row] = await User.on("analytics").findMany({}, { track: true });
+      const user = User.wrap(row);
+      user.name = "written-by-wrap";
+
+      await user.save();
+
+      expect(await names(analytics)).toEqual(["written-by-wrap"]);
+      expect(await names(hot)).toEqual(["hot-original"]);
+    });
+
+    test("naming a different connection is a contradiction, and raises", async () => {
+      const [row] = await User.on("analytics").findMany({}, { track: true });
+      row.name = "written-by-save";
+
+      await expect(User.on("default").save(row)).rejects.toThrow(
+        /read on the "analytics" connection and this save names "default"/,
+      );
+
+      expect(await names(hot)).toEqual(["hot-original"]);
+      expect(await names(analytics)).toEqual(["cold-original"]);
+    });
+
+    /**
+     * The update cannot join a transaction on another connection, so it must
+     * not run at all — the same refusal every other statement gets, reached
+     * through the one path that carries its connection in data.
+     */
+    test("saving into a transaction on another connection is refused", async () => {
+      const [row] = await User.on("analytics").findMany({}, { track: true });
+      row.name = "written-by-save";
+
+      await expect(
+        Model.transaction(async () => {
+          await User.save(row);
+        }),
+      ).rejects.toThrow(CrossConnectionTransactionError);
+
+      expect(await names(analytics)).toEqual(["cold-original"]);
+    });
+
+    test("an ordinary save still goes to the default connection", async () => {
+      const [row] = await User.findMany({}, { track: true });
+      row.name = "written-by-save";
+
+      await User.save(row);
+
+      expect(await names(hot)).toEqual(["written-by-save"]);
+      expect(await names(analytics)).toEqual(["cold-original"]);
     });
   });
 

--- a/templates/saas-starter/app/models/connections.test.ts
+++ b/templates/saas-starter/app/models/connections.test.ts
@@ -1,0 +1,365 @@
+import { SQL } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CrossConnectionTransactionError,
+  DatabaseManager,
+  UnknownConnectionError,
+} from "gemi/database";
+import { DB } from "gemi/facades";
+import { Application } from "gemi/foundation";
+import { Model, clearPlanCache, sql } from "gemi/orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import { applyMigrations } from "./scratch";
+import { User } from "./User";
+
+/**
+ * A second named connection, end to end (#327).
+ *
+ * The case it exists for is one database and two pools with opposite
+ * workloads — a hot path that must never block behind a five-second dashboard
+ * aggregate — so in production both connections usually hold the *same* URL and
+ * differ only in `options`. That is exactly what a test cannot observe: two
+ * pools onto one database are indistinguishable from one pool by looking at the
+ * rows, which is the thing a test has to look at.
+ *
+ * So these run against **two SQLite files**. A statement that went to the wrong
+ * connection lands in the wrong file, and the row is either there or it is not.
+ * The pool split is asserted where it is observable — the manager's own
+ * `connections.test.ts` in the framework — and the routing is asserted here,
+ * where being wrong is a missing row rather than a slower one.
+ *
+ * SQLite only, and deliberately: nothing under test is dialect-specific
+ * (the connection a statement runs on is resolved before a dialect is
+ * consulted at all), and the Postgres scratch database is a single database
+ * that could not tell the two connections apart.
+ */
+const TABLES = [
+  "SocialAccount",
+  "Session",
+  "PasswordResetToken",
+  "MagicLinkToken",
+  "Account",
+  "User",
+  "OrganizationInvitation",
+  "Organization",
+];
+
+describe("named connections", () => {
+  let workspace: string;
+  let database: DatabaseManager;
+  let previous: Application | undefined;
+
+  /** Raw clients, so what a connection holds is read without going through it. */
+  let hot: SQL;
+  let analytics: SQL;
+
+  beforeAll(async () => {
+    workspace = mkdtempSync(join(tmpdir(), "gemi-orm-connections-"));
+    const hotPath = join(workspace, "hot.db");
+    const analyticsPath = join(workspace, "analytics.db");
+
+    await applyMigrations(hotPath);
+    await applyMigrations(analyticsPath);
+
+    database = new DatabaseManager({
+      url: `sqlite://${hotPath}`,
+      connections: {
+        analytics: {
+          url: `sqlite://${analyticsPath}`,
+          // The shape the issue describes: a small pool that may hold a
+          // connection far longer than the hot path ever should.
+          options: { max: 3 },
+          slowTransactionThreshold: 60_000,
+        },
+      },
+    });
+
+    hot = new SQL(`sqlite://${hotPath}`);
+    analytics = new SQL(`sqlite://${analyticsPath}`);
+
+    previous = Application.getInstance();
+    const application = new Application();
+    application.instance(DatabaseManager, database as never);
+    Application.setInstance(application);
+  }, 120_000);
+
+  afterAll(async () => {
+    await hot?.close();
+    await analytics?.close();
+    await database?.close();
+    if (previous) Application.setInstance(previous);
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    clearPlanCache();
+    for (const client of [hot, analytics]) {
+      for (const table of TABLES) await client.unsafe(`DELETE FROM "${table}"`);
+    }
+  });
+
+  /** Emails, since `id` restarts from 1 in both files and cannot tell them apart. */
+  const emails = async (client: SQL) =>
+    ((await client.unsafe(`select "email" from "User" order by "email"`)) as any[]).map(
+      (row) => row.email,
+    );
+
+  test("a query without a connection goes to the default one", async () => {
+    await User.create({ data: { email: "hot@example.dev" } });
+
+    expect(await emails(hot)).toEqual(["hot@example.dev"]);
+    expect(await emails(analytics)).toEqual([]);
+  });
+
+  test("a query naming one goes there instead", async () => {
+    await User.on("analytics").create({
+      data: { email: "analytics@example.dev" },
+    });
+
+    expect(await emails(analytics)).toEqual(["analytics@example.dev"]);
+    expect(await emails(hot)).toEqual([]);
+  });
+
+  /**
+   * The property the issue asks for in as many words: *which connection a model
+   * uses is a per-query property, not a per-model one*. The same class, two
+   * queries, two databases — which a `static connection = "analytics"` on the
+   * model could not express, because the same `Subscription` is read on the hot
+   * path during sign-in and swept by the nightly audit.
+   */
+  test("the same model reads from both, per query", async () => {
+    await hot.unsafe(
+      `insert into "User" ("publicId", "email", "createdAt", "updatedAt")
+       values ('p-hot', 'hot@example.dev', 0, 0)`,
+    );
+    await analytics.unsafe(
+      `insert into "User" ("publicId", "email", "createdAt", "updatedAt")
+       values ('p-cold', 'cold@example.dev', 0, 0)`,
+    );
+
+    expect((await User.findMany({})).map((row) => row.email)).toEqual([
+      "hot@example.dev",
+    ]);
+    expect(
+      (await User.on("analytics").findMany({})).map((row) => row.email),
+    ).toEqual(["cold@example.dev"]);
+  });
+
+  /**
+   * The failure a per-call argument could not have prevented.
+   *
+   * A relation read recurses through the *target* model's `$exec`, resolved out
+   * of the registry — so unless the connection travels in the ambient scope,
+   * the root row comes from the analytics file and its `accounts` come from the
+   * hot one. Both files hold a user and an account here, differing only in the
+   * value under test, so a leak is a wrong row rather than a missing one.
+   */
+  test("an include reads its relation on the same connection", async () => {
+    for (const [client, label] of [
+      [hot, "hot"],
+      [analytics, "cold"],
+    ] as const) {
+      await client.unsafe(
+        `insert into "User" ("id", "publicId", "email", "createdAt", "updatedAt")
+         values (1, 'p-${label}', '${label}@example.dev', 0, 0)`,
+      );
+      await client.unsafe(
+        `insert into "Account" ("id", "publicId", "userId", "organizationRole", "createdAt", "updatedAt")
+         values (1, 'a-${label}', 1, 2, 0, 0)`,
+      );
+    }
+
+    const rows = await User.on("analytics").findMany({
+      include: { accounts: true },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].accounts.map((account: any) => account.publicId)).toEqual([
+      "a-cold",
+    ]);
+  });
+
+  test("a nested write lands entirely on the named connection", async () => {
+    await User.on("analytics").create({
+      data: {
+        email: "nested@example.dev",
+        accounts: { create: [{ organizationRole: 2 }] },
+      },
+    });
+
+    const there = (await analytics.unsafe(
+      `select count(*) as c from "Account"`,
+    )) as any;
+    const here = (await hot.unsafe(`select count(*) as c from "Account"`)) as any;
+
+    expect(there[0].c).toBe(1);
+    expect(here[0].c).toBe(0);
+  });
+
+  /**
+   * Never a fall back to the default. A typo that quietly ran the analytics
+   * sweep on the hot path would produce exactly the incident the second pool
+   * was configured to prevent, weeks later, with nothing pointing at the typo.
+   */
+  test("an unknown connection raises rather than falling back", async () => {
+    await expect(
+      User.on("analitycs").findMany({}),
+    ).rejects.toThrow(UnknownConnectionError);
+
+    expect(await emails(hot)).toEqual([]);
+  });
+
+  test("the bound class is the same object every time", () => {
+    expect(User.on("analytics")).toBe(User.on("analytics"));
+    expect(User.on("analytics")).not.toBe(User.on("default"));
+    expect(User.on("analytics").name).toBe(User.name);
+  });
+
+  describe("transactions", () => {
+    test("one on a named connection rolls back there", async () => {
+      await expect(
+        User.on("analytics").transaction(async () => {
+          await User.on("analytics").create({
+            data: { email: "rolled@example.dev" },
+          });
+          throw new Error("no");
+        }),
+      ).rejects.toThrow("no");
+
+      expect(await emails(analytics)).toEqual([]);
+    });
+
+    /**
+     * The ordinary case, and the reason an unqualified query inherits the
+     * connection instead of resolving to the default one: inside a transaction
+     * on `analytics`, a bare `User.create` has to join *that* transaction. If
+     * it resolved to the default connection it would be refused as a
+     * cross-connection statement, which would make the handle unusable for
+     * everything except explicitly-named queries.
+     */
+    test("an unqualified query inside one joins it", async () => {
+      await expect(
+        DB.connection("analytics").transaction(async () => {
+          await User.create({ data: { email: "inherited@example.dev" } });
+          await DB.execute(
+            sql`update "User" set "name" = ${"changed"} where "email" = ${"inherited@example.dev"}`,
+          );
+          throw new Error("no");
+        }),
+      ).rejects.toThrow("no");
+
+      // Rolled back on the connection the transaction was open on, and never
+      // present on the other one.
+      expect(await emails(analytics)).toEqual([]);
+      expect(await emails(hot)).toEqual([]);
+    });
+
+    test("...and commits there when it does not throw", async () => {
+      await DB.connection("analytics").transaction(async () => {
+        await User.create({ data: { email: "committed@example.dev" } });
+      });
+
+      expect(await emails(analytics)).toEqual(["committed@example.dev"]);
+      expect(await emails(hot)).toEqual([]);
+    });
+
+    /**
+     * The refusal, which is the half of this feature that is a *decision*.
+     *
+     * A transaction lives on one reserved connection; the other pool's
+     * statement cannot join it and cannot be rolled back with it. So it is
+     * refused at the call rather than run outside the transaction, where it
+     * would stay committed while everything around it rolled back.
+     */
+    test("a model query naming another connection is refused", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await User.create({ data: { email: "kept@example.dev" } });
+          await User.on("analytics").create({
+            data: { email: "refused@example.dev" },
+          });
+        }),
+      ).rejects.toThrow(CrossConnectionTransactionError);
+
+      // The refusal took the transaction down with it, as an uncaught error in
+      // a transaction should — so neither row survives, on either connection.
+      expect(await emails(hot)).toEqual([]);
+      expect(await emails(analytics)).toEqual([]);
+    });
+
+    /**
+     * The same for raw SQL, and this is the one that would have hurt most.
+     * `DB.execute` is a statement with no model behind it, so nothing else in
+     * the pipeline would have looked at which connection it was about to run
+     * on.
+     */
+    test("a raw statement naming another connection is refused", async () => {
+      await expect(
+        Model.transaction(async () => {
+          await DB.connection("analytics").execute(
+            sql`insert into "User" ("publicId", "email", "createdAt", "updatedAt")
+                values (${"p"}, ${"raw@example.dev"}, ${0}, ${0})`,
+          );
+        }),
+      ).rejects.toThrow(CrossConnectionTransactionError);
+
+      expect(await emails(analytics)).toEqual([]);
+    });
+
+    /**
+     * Catching it leaves the transaction usable, which is what makes the error
+     * something an application can act on: the analytics work moves outside the
+     * transaction, and the hot-path work still commits.
+     */
+    test("catching the refusal leaves the transaction intact", async () => {
+      let refused: unknown;
+
+      await Model.transaction(async () => {
+        await User.create({ data: { email: "kept@example.dev" } });
+        try {
+          await User.on("analytics").findMany({});
+        } catch (error) {
+          refused = error;
+        }
+      });
+
+      expect(refused).toBeInstanceOf(CrossConnectionTransactionError);
+      expect(await emails(hot)).toEqual(["kept@example.dev"]);
+    });
+  });
+
+  describe("raw SQL", () => {
+    test("runs on the connection the handle names", async () => {
+      await analytics.unsafe(
+        `insert into "User" ("publicId", "email", "createdAt", "updatedAt")
+         values ('p-cold', 'cold@example.dev', 0, 0)`,
+      );
+
+      const rows = await DB.connection("analytics").query<{ email: string }>(
+        sql`select "email" from "User"`,
+      );
+      expect(rows.map((row) => row.email)).toEqual(["cold@example.dev"]);
+
+      // The unqualified facade is still the default connection. Length rather
+      // than `toEqual([])`: Bun hangs `count` and `command` off the array it
+      // returns, so an empty result is not deeply equal to a plain `[]`.
+      expect(await DB.query(sql`select "email" from "User"`)).toHaveLength(0);
+    });
+
+    test("the handle carries the connection's own dialect", () => {
+      expect(DB.connection("analytics").dialect).toBe("sqlite");
+      expect(DB.connection("analytics").name).toBe("analytics");
+      expect(DB.connection("analytics").sql).not.toBe(DB.sql);
+    });
+
+    test("an unknown connection raises there too", async () => {
+      await expect(
+        DB.connection("analitycs").query(sql`select 1`),
+      ).rejects.toThrow(UnknownConnectionError);
+    });
+  });
+});

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -376,7 +376,12 @@ export async function createDifferential(options: {
       get(target, property, receiver) {
         if (property === "sql") return counting;
         const value = Reflect.get(target, property, receiver);
-        return typeof value === "function" ? value.bind(target) : value;
+        // Bound to the **proxy**. `$exec` resolves its connection by name and
+        // the manager answers the default one with `this` — bound to the
+        // target, that is the unwrapped manager, and the statements it runs are
+        // never seen here. The delegation above is only as generic as this
+        // line lets it be.
+        return typeof value === "function" ? value.bind(receiver) : value;
       },
     }),
   );

--- a/templates/saas-starter/app/models/relations.many-to-many.test.ts
+++ b/templates/saas-starter/app/models/relations.many-to-many.test.ts
@@ -290,7 +290,12 @@ async function setup(url: string, ddl: string[]) {
       get(target, property, receiver) {
         if (property === "sql") return counting;
         const value = Reflect.get(target, property, receiver);
-        return typeof value === "function" ? value.bind(target) : value;
+        // Bound to the **proxy**, not to the manager behind it. `$exec` asks
+        // for its connection by name and the manager answers the default one
+        // with `this`; bound to the target, that `this` is the unwrapped
+        // manager, and every statement goes to the real client with nothing
+        // counting it. The symptom is a count of zero rather than an error.
+        return typeof value === "function" ? value.bind(receiver) : value;
       },
     }),
   );

--- a/templates/saas-starter/app/models/select.test-d.ts
+++ b/templates/saas-starter/app/models/select.test-d.ts
@@ -124,3 +124,39 @@ describe("include adds the relation to the type", () => {
     expectTypeOf(rows).toBeArray();
   });
 });
+
+/**
+ * **`on(name)` keeps the typed surface**, which is what makes it a per-query
+ * connection rather than an escape hatch (#327).
+ *
+ * A runtime test can only show that the rows came from the right database. What
+ * it cannot show is that the query in front of it still narrows the way the
+ * unbound class does — and that is the whole reason `on` hands back the model
+ * class rather than an untyped handle. It is also the property most easily lost
+ * by a later implementation that reaches for `any` in order to bind the name.
+ */
+describe("on(connection) narrows exactly as the class does", () => {
+  test("select still narrows the row", async () => {
+    const [user] = await UserModel.on("analytics").findMany({
+      select: { id: true, email: true },
+    });
+
+    expectTypeOf(user.id).toEqualTypeOf<number>();
+    expectTypeOf(user.email).toEqualTypeOf<string | null>();
+
+    // @ts-expect-error `name` was not selected, so it is not on the row
+    user.name;
+  });
+
+  test("include still narrows the relation", async () => {
+    const [user] = await UserModel.on("analytics").findMany({
+      include: { accounts: true },
+    });
+
+    expectTypeOf(user.accounts[0].id).toEqualTypeOf<number>();
+  });
+
+  test("it is still the same model class", () => {
+    expectTypeOf(UserModel.on("analytics")).toEqualTypeOf<typeof UserModel>();
+  });
+});


### PR DESCRIPTION
Closes #327.

`DatabaseManager` held one `SQL` built from one `url`. This adds named connections, a per-query way for a model to use one, and a refusal for the case that cannot work.

## The shape

```typescript
// app/config/database.ts — the top level describes the connection called "default"
export default defineDatabaseConfig({
  url: process.env.DATABASE_URL,
  options: { max: 12 },

  connections: {
    analytics: {
      url: process.env.DATABASE_URL,          // the same database, deliberately
      options: { max: 3, idleTimeout: 60 },   // a pool of its own
      slowTransactionThreshold: 60_000,       // and a threshold that suits it
    },
  },
})
```

```ts
const rows = await Subscription.on("analytics").findMany({ where })
const raw  = await DB.connection("analytics").query(sql`select …`)
await DB.connection("analytics").transaction(async () => { … })
```

## The two decisions the issue asked to make alongside it

**Which connection a model uses is per query, not per model.** The same `Subscription` is read on the hot path during sign-in and swept by the nightly audit, so a `connection` on the class would force one of the two to be wrong. `on(name)` hands back the model class with the name bound to it, so all fifteen operations, `transaction` and `save` are there and `select` / `include` narrow exactly as they do on the class — asserted in `select.test-d.ts`, since a later implementation reaching for `any` to bind the name would lose precisely that and nothing else would notice.

The name travels in the ORM's **ambient scope**, not as an argument. A relation read recurses through the *target* model's `$exec` by way of the registry, so an argument would have to be carried by every intermediate that has no interest in it — and the one that forgot would read a nested `include` off the other pool, with no error and usually a table of the same shape to land in. `connections.test.ts` puts a user and an account in *both* files and asserts the include comes back with the right one, so a leak is a wrong row rather than a missing one.

**A transaction cannot span two connections, and it says so loudly.** The single-connection note in `orm/context.ts` predicted this exactly — a `DB.transaction` on B inside a `Model.transaction` on A would savepoint on **A** and hand the callback A's handle, so statements landed in the wrong database with no error. That note is now a check: both doors call `assertConnectionUsable`, and a statement naming another connection raises `CrossConnectionTransactionError` rather than running outside the transaction, where it would stay committed through the rollback. Catching it leaves the transaction usable, so the fix is local. An *unqualified* query inside a named transaction inherits the name and joins it — otherwise `DB.connection("analytics").transaction(() => Digest.create(…))` would refuse its own contents.

## Notable in the implementation

- **The manager is the default connection.** `connection("default")` returns `this`, so `DB.sql`, `db.dialect`, `db.config` and every wrapper of them keep working unchanged. `Connection` carries what is true of one pool at a time — including SQLite's `pragma foreign_keys`, which is per client and so was per connection all along; a second SQLite connection now gets its own.
- **An unknown name raises and lists the configured ones**, never falling back. `on("analitycs")` quietly running on the hot path is the incident the second pool was configured to prevent, arriving weeks later with nothing pointing at the typo.
- `url` and `options` are not inherited from the top level (a connection that borrowed the default's URL by omission would be a second pool created by a typo); `slowTransactionThreshold` is, since it is a diagnostic about holding any pooled connection.
- A config error part-way through construction closes the clients already built, instead of leaving them to surface as an unhandled rejection with no configuration error nearby.
- The dev-only "the ORM does not implement this dialect" warning now runs per connection.
- `Model.$exec` and `Model.transaction` are `async`, so a refusal *rejects* rather than throwing synchronously — the reasoning `DB.query` already records about `.catch()` missing errors.

## Tests

- `packages/gemi/database/connections.test.ts` — the manager: identity, listing, the reserved name, the errors, the per-connection pragma against two real SQLite files, close-all.
- `packages/gemi/orm/context.test.ts` — the scope: inheriting, merging rather than replacing, the savepoint-vs-refusal split, and that the default connection enters no scope at all.
- `templates/saas-starter/app/models/connections.test.ts` (new, 16 cases) — end to end against **two SQLite files**, so a statement on the wrong connection is a row in the wrong file. In production both connections usually hold the same URL, which is exactly what a test cannot observe.
- `select.test-d.ts` — `on(name)` keeps the typed surface.

Three counting Proxies in the template harnesses now bind their delegated methods to the proxy rather than the target: `connection()` answering the default with `this` would otherwise hand back the unwrapped manager, and the round trips would go uncounted. That failure showed up as a count of zero in `relations.many-to-many.test.ts` and is the reason those tests exist.

## Verification

`packages/gemi`: 2624 passed, 1 skipped. Template models: 268 passed, 32 skipped. Type tests: 64 passed. `oxlint` clean on everything touched.

Three template suites could not run here — `differential`, `writes.differential` and `scalar-list` all fail at import with `Cannot find module './prisma-client'`, which needs a generated Prisma client this environment could not produce (`prisma generate` shells out to `npm i @prisma/client`). They were failing that way before this branch, and CI is where they get their say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DP1faTmyRut7mBC5tZ95VD
