### PR TITLE
Hoist the app CSS into <head> so the first paint is not unstyled

### DIFF
--- a/packages/gemi/client/ClientRouter.tsx
+++ b/packages/gemi/client/ClientRouter.tsx
@@ -292,7 +292,13 @@ const Routes = (props: { componentTree: ComponentTree }) => {
 
       // `fetchRouteCSS` keys off the route manifest, so it needs the pattern
       // rather than the concrete path — `/posts/:id`, not `/posts/123`.
-      fetchRouteCSS(routerState.routePath).catch((e) => console.error(e));
+      // Started here so it runs alongside the payload fetch, but awaited
+      // before the transition commits: a surface that mounts ahead of its own
+      // stylesheet paints unstyled first (#328). Swallowing the rejection is
+      // what keeps a CSS failure from stranding the navigation.
+      const cssReady = fetchRouteCSS(routerState.routePath).catch((e) =>
+        console.error(e),
+      );
       // Through `loadViewModule` so the module registry — and with it each
       // view's `Loading`/`Error` exports — is populated before the
       // transition commits the new surface.
@@ -312,6 +318,8 @@ const Routes = (props: { componentTree: ComponentTree }) => {
           hydrate({ [path]: { [variantKey]: data } });
         },
       });
+
+      await cssReady;
 
       if (payload) {
         const {

--- a/packages/gemi/client/ClientRouterContext.tsx
+++ b/packages/gemi/client/ClientRouterContext.tsx
@@ -77,6 +77,25 @@ interface ClientRouterProviderProps {
   breadcrumbs: Record<string, Breadcrumb>;
 }
 
+/**
+ * Whether `file`'s CSS is already on the page, in either of the two shapes it
+ * can take. A client navigation appends `<style id={file}>`; the styles the
+ * document was served with are hoisted into `<head>` by React, which strips
+ * their `id` and records the files it merged into one space-separated
+ * `data-href` list instead (#328). Missing the second shape means re-fetching
+ * and re-appending the CSS the page already has on every navigation.
+ */
+function isStyleOnPage(file: string) {
+  if (document.getElementById(file)) {
+    return true;
+  }
+  // `Array.from` rather than `for...of`: the browser build compiles without
+  // `DOM.Iterable`, so a `NodeList` is only an ArrayLike there.
+  return Array.from(document.querySelectorAll("style[data-href]")).some(
+    (style) => style.getAttribute("data-href").split(" ").includes(file),
+  );
+}
+
 export const ClientRouterProvider = (
   props: PropsWithChildren<ClientRouterProviderProps>,
 ) => {
@@ -260,7 +279,7 @@ export const ClientRouterProvider = (
         return cssManifest?.[view];
       })
       .filter(Boolean)
-      .filter((file) => !document.getElementById(file));
+      .filter((file) => !isStyleOnPage(file));
 
     if (cssFiles.length === 0) {
       return;

--- a/packages/gemi/client/hoistedStyles.hydration.test.tsx
+++ b/packages/gemi/client/hoistedStyles.hydration.test.tsx
@@ -1,0 +1,81 @@
+/** @vitest-environment jsdom */
+import { createElement, Fragment } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToReadableStream } from "react-dom/server";
+import { act } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createStyles } from "../server/styles";
+
+const APP_CSS = ".app{color:red}";
+
+/**
+ * What `init` hydrates the document with: two empty slots standing in for the
+ * server-only siblings (the stylesheets and the theme script) and then the
+ * app. The stylesheets have no client counterpart at all — the point of this
+ * test is that hoisting them into `<head>` keeps it that way.
+ */
+const Root = () =>
+  createElement(
+    "html",
+    null,
+    createElement("head", null, createElement("title", null, "t")),
+    createElement("body", null, createElement("div", { id: "root" }, "hello")),
+  );
+
+async function serverHTML() {
+  const stream = await renderToReadableStream(
+    createElement(Fragment, {
+      children: [
+        ...(await createStyles([{ id: "assets/app.css", content: APP_CSS }])),
+        createElement("script", {
+          key: "theme-script",
+          dangerouslySetInnerHTML: { __html: "0" },
+        }),
+        createElement(Root, { key: "root" }),
+      ],
+    }),
+  );
+  await stream.allReady;
+  return await new Response(stream).text();
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("hoisted stylesheets", () => {
+  test("survive hydration of the document", async () => {
+    const html = await serverHTML();
+    // jsdom will not let the doctype be assigned through innerHTML.
+    document.documentElement.innerHTML = html
+      .replace("<!DOCTYPE html>", "")
+      .replace(/^<html>/, "")
+      .replace(/<\/html>$/, "");
+
+    expect(document.head.textContent).toContain(APP_CSS);
+
+    const recoverable = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      hydrateRoot(
+        document,
+        createElement(Fragment, {
+          children: [
+            createElement(Fragment, { key: "styles" }),
+            createElement(Fragment, { key: "theme" }),
+            createElement(Root, { key: "root" }),
+          ],
+        }),
+        { onRecoverableError: recoverable },
+      );
+    });
+
+    expect(recoverable).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    // The client never renders the stylesheet, so nothing must evict it.
+    expect(document.head.textContent).toContain(APP_CSS);
+    expect(document.getElementById("root")?.textContent).toBe("hello");
+  });
+});

--- a/packages/gemi/server/httpProd.ts
+++ b/packages/gemi/server/httpProd.ts
@@ -67,12 +67,18 @@ export async function httpProd(app: App, instrumentation: Instrumentation) {
   const loaders = `{${templates.join(",")}}`;
 
   // Vite's manifest `css` field is a `string[]` — a client entry can emit more
-  // than one CSS chunk. Read and concatenate them all instead of interpolating
-  // the array into a single path (which only works for a one-element array).
+  // than one CSS chunk. Read them all instead of interpolating the array into a
+  // single path (which only works for a one-element array), and keep them as
+  // one entry per file rather than a concatenated blob: each needs its own
+  // stable id for React to hoist it into `<head>` (#328), and that id is what
+  // dedupes it against a route's own CSS.
   const appCssFiles: string[] = manifest["app/client.tsx"]?.css ?? [];
-  const appCSSContent = (
-    await Promise.all(appCssFiles.map((cssFile) => Bun.file(`${distDir}/client/${cssFile}`).text()))
-  ).join("\n");
+  const appStyles = await Promise.all(
+    appCssFiles.map(async (cssFile) => ({
+      id: cssFile,
+      content: await Bun.file(`${distDir}/client/${cssFile}`).text(),
+    })),
+  );
 
   const staticFilePattern = new URLPattern({
     pathname: "/*.:filetype(png|txt|js|css|jpg|svg|jpeg|avif|webp|ico|ttf|map)",
@@ -154,11 +160,7 @@ export async function httpProd(app: App, instrumentation: Instrumentation) {
       if (result instanceof Response) {
         return result;
       } else {
-        const styles = [];
-
-        styles.push({
-          content: appCSSContent,
-        });
+        const styles = [...appStyles];
 
         const getStyles = async (currentViews: string[]) => {
           if (!currentViews) {

--- a/packages/gemi/server/styles.test.ts
+++ b/packages/gemi/server/styles.test.ts
@@ -1,0 +1,70 @@
+/** @vitest-environment node */
+import { createElement, Fragment } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { createStyles } from "./styles";
+
+const Root = () =>
+  createElement(
+    "html",
+    null,
+    createElement("head", null, createElement("title", null, "t")),
+    createElement("body", null, createElement("div", { id: "root" }, "hello")),
+  );
+
+/**
+ * The real render root: styles are spread as siblings *before* the component
+ * that renders `<html>`. That placement is the whole reason hoisting matters —
+ * a style React declines to hoist ends up in `<body>`, where it blocks
+ * nothing.
+ */
+async function renderDocument(styles: Awaited<ReturnType<typeof createStyles>>) {
+  const stream = await renderToReadableStream(
+    createElement(Fragment, {
+      children: [...styles, createElement(Root, { key: "root" })],
+    }),
+  );
+  await stream.allReady;
+  return await new Response(stream).text();
+}
+
+describe("createStyles", () => {
+  test("hoists stylesheets into <head> so the first paint is blocked on them", async () => {
+    const html = await renderDocument(
+      await createStyles([{ id: "assets/app.css", content: ".app{color:red}" }]),
+    );
+
+    const [head, body] = html.split("<body>");
+    expect(head).toContain(".app{color:red}");
+    expect(body).not.toContain(".app{color:red}");
+  });
+
+  test("keeps stylesheets in the order they were passed", async () => {
+    const html = await renderDocument(
+      await createStyles([
+        { id: "assets/app.css", content: ".app{color:red}" },
+        { id: "assets/view.css", content: ".view{color:blue}" },
+      ]),
+    );
+
+    expect(html.indexOf(".app{color:red}")).toBeLessThan(html.indexOf(".view{color:blue}"));
+  });
+
+  /**
+   * React drops the `id` off anything it hoists and records the merged files in
+   * `data-href` instead — which is the only handle `fetchRouteCSS` has for
+   * telling whether a route's CSS is already on the page.
+   */
+  test("records every file it merged in data-href", async () => {
+    const html = await renderDocument(
+      await createStyles([
+        { id: "assets/app.css", content: ".app{color:red}" },
+        { id: "assets/view.css", content: ".view{color:blue}" },
+      ]),
+    );
+
+    const dataHref = html.match(/data-href="([^"]*)"/)?.[1];
+    expect(dataHref?.split(" ")).toEqual(["assets/app.css", "assets/view.css"]);
+  });
+});

--- a/packages/gemi/server/styles.ts
+++ b/packages/gemi/server/styles.ts
@@ -69,23 +69,41 @@ export async function createDevStyles(
     });
   }
 
-  return styles.map((style, i) => {
-    return createElement("style", {
-      key: i,
-      type: "text/css",
-      "data-vite-dev-id": style.id,
-      dangerouslySetInnerHTML: { __html: style.content },
-    });
-  });
+  return styles.map(hoistable);
 }
 
 export async function createStyles(styles = []) {
-  return styles.map((style, i) => {
-    return createElement("style", {
-      key: i,
-      id: style?.id,
-      type: "text/css",
-      dangerouslySetInnerHTML: { __html: style.content },
-    });
+  return styles.map(hoistable);
+}
+
+/**
+ * The precedence every gemi-emitted stylesheet is hoisted under. One shared
+ * name on purpose: React keeps same-precedence styles in a single tag in
+ * insertion order, which is the order the split assumes — the app bundle
+ * first, then the route's own CSS layered over it.
+ */
+const STYLE_PRECEDENCE = "gemi";
+
+/**
+ * A `<style>` React 19 will lift into `<head>` and block the first paint on.
+ *
+ * It only does that when the tag carries both `precedence` and `href` (the
+ * dedupe key). Without them the tag stays where it was rendered, and these are
+ * rendered as siblings *before* `<html>` — so React normalizes them into
+ * `<body>`, nothing in `<head>` is render-blocking, and the browser paints the
+ * whole document unstyled before the CSS applies (#328).
+ *
+ * React strips every other attribute off a hoisted style, `id` and
+ * `data-vite-dev-id` included, and leaves only `data-precedence` +
+ * `data-href`. `fetchRouteCSS` reads that `data-href` list to tell what is
+ * already on the page; nothing reads the dev id, and Vite re-injects its own
+ * tag for HMR rather than adopting this one.
+ */
+function hoistable(style: { id: string; content: string }, i: number) {
+  return createElement("style", {
+    key: i,
+    href: style.id,
+    precedence: STYLE_PRECEDENCE,
+    dangerouslySetInnerHTML: { __html: style.content },
   });
 }


### PR DESCRIPTION
Forward-port of the fix shipped in [v0.49.1](https://github.com/nstfkc/gemi/releases/tag/v0.49.1), which was cut from the `v0.49.0` tag. Without this, 0.51.0 ships the flash back.

## The bug

Every SSR page painted unstyled for a frame before snapping into place — blocks collapsing to their natural height, images to zero, footers flashing near the top.

The app's `<style>` tags are rendered as siblings *before* `Root` (which renders `<html>`), and without a `precedence`. React 19 only lifts a style into `<head>` — and only treats it as render-blocking — when it carries both `precedence` and `href`. Without them React leaves the tag where it was rendered, which normalizes into `<body>`: nothing in `<head>` blocks the paint.

## The change

- `server/styles.ts` — both the dev and prod builders now emit `href` + `precedence`, so React hoists them. One shared precedence keeps them in a single tag in insertion order: app bundle first, then the route's CSS layered over it.
- `server/httpProd.ts` — the app bundle stops being one concatenated blob. Each file needs its own stable id to be hoisted and deduped by.
- `client/ClientRouterContext.tsx` — React strips the `id` off anything it hoists and records the merged files in a space-separated `data-href`. The "do I already have this?" check reads that shape too; without it every navigation re-fetches and re-appends the CSS the page was already served with.
- `client/ClientRouter.tsx` — the second flash: a route's CSS was fetched but never awaited, so a new surface could mount ahead of its stylesheet. The fetch still starts alongside the payload request; the transition now waits for it.

## Verification

Two new test files:

- `server/styles.test.ts` renders through the real document shape — styles as siblings before `<html>` — and asserts the CSS lands in `<head>` and not `<body>`, that order is preserved, and that `data-href` lists every merged file. Dropping `href` again fails all three.
- `client/hoistedStyles.hydration.test.tsx` hydrates that document with the empty-slot shape `init` uses, and asserts no recoverable errors and that nothing evicts the stylesheet the client never renders.

Full suite green (117 files, 2663 tests).

## Note for anyone reading served markup

In dev, `data-vite-dev-id` no longer survives to the HTML — React strips it along with every other attribute on a hoisted style. Vite injects its own tag for HMR rather than adopting the server-rendered one, so hot updates still apply; dev just carries the stylesheet twice.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
