### PR TITLE
Keep a relation's nested relations when it carries arguments

### DIFF
--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -58,11 +58,7 @@
 // in a conditional that has to resolve the whole shape — would turn a cyclic
 // schema into an instantiation-depth error rather than a slow compile.
 
-import type {
-  AnyNullValue,
-  DbNullValue,
-  JsonNullValue,
-} from "./json-null";
+import type { AnyNullValue, DbNullValue, JsonNullValue } from "./json-null";
 
 /**
  * Any value a `Json` column can hold, on either dialect.
@@ -94,10 +90,7 @@ export type JsonValue =
  * `metadata: null` compiled while `docs/orm.md` said in this same change that
  * it does not.
  */
-export type JsonInput =
-  | Exclude<JsonValue, null>
-  | DbNullValue
-  | JsonNullValue;
+export type JsonInput = Exclude<JsonValue, null> | DbNullValue | JsonNullValue;
 
 /**
  * Is this column a `Json` one?
@@ -202,10 +195,8 @@ type RelationPayload<R extends RelationInfo, A> = R["kind"] extends "many"
  * `_count` inside a `select` or an `include`: the number of related rows, per
  * relation named.
  */
-type RelationCountPayload<M extends ModelTypeInfo, A> = A extends {
-  select: infer S;
-}
-  ? { [K in Requested<S> & keyof Relations<M>]: number }
+type RelationCountPayload<M extends ModelTypeInfo, A> = "select" extends keyof A
+  ? { [K in Requested<NonNullable<A["select"]>> & keyof Relations<M>]: number }
   : { [K in keyof Relations<M>]: number };
 
 type SelectPayload<M extends ModelTypeInfo, S> = {
@@ -236,25 +227,50 @@ type OmitPayload<M extends ModelTypeInfo, O> = Omit<Scalars<M>, Requested<O>>;
  * follows its `select`. That pairing type-checks and is refused at runtime by
  * `resolveSelection` — parity with Prisma, whose generated args accept it too,
  * and asserted in the template's `select.test-d.ts`.
+ *
+ * ### Why these ask `"k" extends keyof A` rather than `A extends { k: infer V }`
+ *
+ * The structural form is the one you would write, and it was what #326 was: a
+ * relation carrying `orderBy` (or `where`, `take`, `skip`) stopped resolving its
+ * own nested relations, coming back as the target's bare scalars. The row was
+ * there at runtime; only the type fell back, so a filtered, ordered list read —
+ * the products of this list in order, each with its product row — could not be
+ * spelled in a way that typed, in `select` or in `include`.
+ *
+ * The arguments reach here through `Subset`, the excess-property guard the
+ * generated signatures wrap them in. Inferring `T` through that mapped type
+ * leaves the relation's arguments in a shape that is *assignable* to
+ * `{ select: unknown }` — a value of it type-checks against that annotation —
+ * while `A extends { select: unknown }` is false. Assignability and the
+ * conditional's `extends` disagree, and the conditional took its else branch and
+ * returned the default selection. Only relations carrying arguments were
+ * affected: `{ select: … }` on its own never went through that path.
+ *
+ * Asking whether the key exists and then indexing avoids the disagreement
+ * entirely — `A["select"]` resolves correctly in exactly the cases where the
+ * `extends` did not. The `[…] extends [undefined]` guards were already here for
+ * an explicitly-`undefined` key and still are; `NonNullable` is what an optional
+ * key needs once it is reached by indexing rather than by inference.
+ *
+ * Dropping `Subset` also fixes it, and costs more than it saves: it is what
+ * rejects `orderBey` inside a relation's arguments, which nothing else catches.
  */
-export type Payload<M extends ModelTypeInfo, A> = A extends { select: infer S }
-  ? [S] extends [undefined]
+export type Payload<M extends ModelTypeInfo, A> = "select" extends keyof A
+  ? [A["select"]] extends [undefined]
     ? DefaultPayload<M, A>
-    : SelectPayload<M, S>
+    : SelectPayload<M, NonNullable<A["select"]>>
   : DefaultPayload<M, A>;
 
-type DefaultPayload<M extends ModelTypeInfo, A> = A extends { omit: infer O }
-  ? [O] extends [undefined]
+type DefaultPayload<M extends ModelTypeInfo, A> = "omit" extends keyof A
+  ? [A["omit"]] extends [undefined]
     ? WithInclude<M, A, Scalars<M>>
-    : WithInclude<M, A, OmitPayload<M, O>>
+    : WithInclude<M, A, OmitPayload<M, NonNullable<A["omit"]>>>
   : WithInclude<M, A, Scalars<M>>;
 
-type WithInclude<M extends ModelTypeInfo, A, Base> = A extends {
-  include: infer I;
-}
-  ? [I] extends [undefined]
+type WithInclude<M extends ModelTypeInfo, A, Base> = "include" extends keyof A
+  ? [A["include"]] extends [undefined]
     ? Base
-    : Base & IncludePayload<M, I>
+    : Base & IncludePayload<M, NonNullable<A["include"]>>
   : Base;
 
 /** Every column of the model, which is what `wrap` demands and `include` keeps. */
@@ -302,24 +318,26 @@ type BaseFilter<V> = {
  */
 type NoKeys = Record<never, never>;
 
-type OrderingFilter<V> = NonNullable<V> extends Comparable
-  ? {
-      lt?: NonNullable<V>;
-      lte?: NonNullable<V>;
-      gt?: NonNullable<V>;
-      gte?: NonNullable<V>;
-    }
-  : NoKeys;
+type OrderingFilter<V> =
+  NonNullable<V> extends Comparable
+    ? {
+        lt?: NonNullable<V>;
+        lte?: NonNullable<V>;
+        gt?: NonNullable<V>;
+        gte?: NonNullable<V>;
+      }
+    : NoKeys;
 
-type StringFilter<V> = NonNullable<V> extends string
-  ? {
-      contains?: string;
-      startsWith?: string;
-      endsWith?: string;
-      /** Postgres only; `SqliteDialect` refuses it, naming the dialect. */
-      mode?: "default" | "insensitive";
-    }
-  : NoKeys;
+type StringFilter<V> =
+  NonNullable<V> extends string
+    ? {
+        contains?: string;
+        startsWith?: string;
+        endsWith?: string;
+        /** Postgres only; `SqliteDialect` refuses it, naming the dialect. */
+        mode?: "default" | "insensitive";
+      }
+    : NoKeys;
 
 type NestedFilter<V> = BaseFilter<V> & OrderingFilter<V> & StringFilter<V>;
 
@@ -384,12 +402,15 @@ type RelationFilter<R extends RelationInfo> = R["kind"] extends "many"
       none?: WhereInput<R["target"]>;
     }
   : /**
-     * A to-one takes the nested `where` directly — `{ user: { email } }` means
-     * `is` — and takes `null` for "there is no related row". `readOperators` in
-     * the where compiler folds the two spellings together.
-     */
-    | WhereInput<R["target"]>
-      | { is?: WhereInput<R["target"]> | null; isNot?: WhereInput<R["target"]> | null }
+       * A to-one takes the nested `where` directly — `{ user: { email } }` means
+       * `is` — and takes `null` for "there is no related row". `readOperators` in
+       * the where compiler folds the two spellings together.
+       */
+      | WhereInput<R["target"]>
+      | {
+          is?: WhereInput<R["target"]> | null;
+          isNot?: WhereInput<R["target"]> | null;
+        }
       | (R["nullable"] extends true ? null : never);
 
 export type WhereInput<M extends ModelTypeInfo> = {
@@ -516,7 +537,10 @@ export type FindUniqueOrThrowArgs<M extends ModelTypeInfo> = FindUniqueArgs<M>;
 type NestedCreate<R extends RelationInfo> = R["kind"] extends "many"
   ? {
       create?: CreateInput<R["target"]> | CreateInput<R["target"]>[];
-      createMany?: { data: CreateInput<R["target"]>[]; skipDuplicates?: boolean };
+      createMany?: {
+        data: CreateInput<R["target"]>[];
+        skipDuplicates?: boolean;
+      };
       connect?: WhereUniqueInput<R["target"]> | WhereUniqueInput<R["target"]>[];
       connectOrCreate?:
         | ConnectOrCreate<R["target"]>
@@ -540,7 +564,9 @@ type NestedUpdate<R extends RelationInfo> = NestedCreate<R> &
         disconnect?:
           | WhereUniqueInput<R["target"]>
           | WhereUniqueInput<R["target"]>[];
-        delete?: WhereUniqueInput<R["target"]> | WhereUniqueInput<R["target"]>[];
+        delete?:
+          | WhereUniqueInput<R["target"]>
+          | WhereUniqueInput<R["target"]>[];
         deleteMany?: WhereInput<R["target"]> | WhereInput<R["target"]>[];
         update?: NestedUpdateOne<R["target"]> | NestedUpdateOne<R["target"]>[];
         updateMany?:
@@ -711,8 +737,10 @@ export interface CountArgs<M extends ModelTypeInfo> {
   select?: CountSelect<M>;
 }
 
-export interface GroupByArgs<M extends ModelTypeInfo>
-  extends Omit<AggregateArgs<M>, "orderBy"> {
+export interface GroupByArgs<M extends ModelTypeInfo> extends Omit<
+  AggregateArgs<M>,
+  "orderBy"
+> {
   by: (keyof Scalars<M> & string)[] | (keyof Scalars<M> & string);
   having?: WhereInput<M>;
   orderBy?: OrderByInput<M> | OrderByInput<M>[];

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -58,7 +58,11 @@
 // in a conditional that has to resolve the whole shape — would turn a cyclic
 // schema into an instantiation-depth error rather than a slow compile.
 
-import type { AnyNullValue, DbNullValue, JsonNullValue } from "./json-null";
+import type {
+  AnyNullValue,
+  DbNullValue,
+  JsonNullValue,
+} from "./json-null";
 
 /**
  * Any value a `Json` column can hold, on either dialect.
@@ -90,7 +94,10 @@ export type JsonValue =
  * `metadata: null` compiled while `docs/orm.md` said in this same change that
  * it does not.
  */
-export type JsonInput = Exclude<JsonValue, null> | DbNullValue | JsonNullValue;
+export type JsonInput =
+  | Exclude<JsonValue, null>
+  | DbNullValue
+  | JsonNullValue;
 
 /**
  * Is this column a `Json` one?
@@ -239,7 +246,7 @@ type OmitPayload<M extends ModelTypeInfo, O> = Omit<Scalars<M>, Requested<O>>;
  *
  * The arguments reach here through `Subset`, the excess-property guard the
  * generated signatures wrap them in. Inferring `T` through that mapped type
- * leaves the relation's arguments in a shape that is *assignable* to
+ * leaves a relation's arguments in a shape that is *assignable* to
  * `{ select: unknown }` — a value of it type-checks against that annotation —
  * while `A extends { select: unknown }` is false. Assignability and the
  * conditional's `extends` disagree, and the conditional took its else branch and
@@ -318,26 +325,24 @@ type BaseFilter<V> = {
  */
 type NoKeys = Record<never, never>;
 
-type OrderingFilter<V> =
-  NonNullable<V> extends Comparable
-    ? {
-        lt?: NonNullable<V>;
-        lte?: NonNullable<V>;
-        gt?: NonNullable<V>;
-        gte?: NonNullable<V>;
-      }
-    : NoKeys;
+type OrderingFilter<V> = NonNullable<V> extends Comparable
+  ? {
+      lt?: NonNullable<V>;
+      lte?: NonNullable<V>;
+      gt?: NonNullable<V>;
+      gte?: NonNullable<V>;
+    }
+  : NoKeys;
 
-type StringFilter<V> =
-  NonNullable<V> extends string
-    ? {
-        contains?: string;
-        startsWith?: string;
-        endsWith?: string;
-        /** Postgres only; `SqliteDialect` refuses it, naming the dialect. */
-        mode?: "default" | "insensitive";
-      }
-    : NoKeys;
+type StringFilter<V> = NonNullable<V> extends string
+  ? {
+      contains?: string;
+      startsWith?: string;
+      endsWith?: string;
+      /** Postgres only; `SqliteDialect` refuses it, naming the dialect. */
+      mode?: "default" | "insensitive";
+    }
+  : NoKeys;
 
 type NestedFilter<V> = BaseFilter<V> & OrderingFilter<V> & StringFilter<V>;
 
@@ -402,15 +407,12 @@ type RelationFilter<R extends RelationInfo> = R["kind"] extends "many"
       none?: WhereInput<R["target"]>;
     }
   : /**
-       * A to-one takes the nested `where` directly — `{ user: { email } }` means
-       * `is` — and takes `null` for "there is no related row". `readOperators` in
-       * the where compiler folds the two spellings together.
-       */
-      | WhereInput<R["target"]>
-      | {
-          is?: WhereInput<R["target"]> | null;
-          isNot?: WhereInput<R["target"]> | null;
-        }
+     * A to-one takes the nested `where` directly — `{ user: { email } }` means
+     * `is` — and takes `null` for "there is no related row". `readOperators` in
+     * the where compiler folds the two spellings together.
+     */
+    | WhereInput<R["target"]>
+      | { is?: WhereInput<R["target"]> | null; isNot?: WhereInput<R["target"]> | null }
       | (R["nullable"] extends true ? null : never);
 
 export type WhereInput<M extends ModelTypeInfo> = {
@@ -537,10 +539,7 @@ export type FindUniqueOrThrowArgs<M extends ModelTypeInfo> = FindUniqueArgs<M>;
 type NestedCreate<R extends RelationInfo> = R["kind"] extends "many"
   ? {
       create?: CreateInput<R["target"]> | CreateInput<R["target"]>[];
-      createMany?: {
-        data: CreateInput<R["target"]>[];
-        skipDuplicates?: boolean;
-      };
+      createMany?: { data: CreateInput<R["target"]>[]; skipDuplicates?: boolean };
       connect?: WhereUniqueInput<R["target"]> | WhereUniqueInput<R["target"]>[];
       connectOrCreate?:
         | ConnectOrCreate<R["target"]>
@@ -564,9 +563,7 @@ type NestedUpdate<R extends RelationInfo> = NestedCreate<R> &
         disconnect?:
           | WhereUniqueInput<R["target"]>
           | WhereUniqueInput<R["target"]>[];
-        delete?:
-          | WhereUniqueInput<R["target"]>
-          | WhereUniqueInput<R["target"]>[];
+        delete?: WhereUniqueInput<R["target"]> | WhereUniqueInput<R["target"]>[];
         deleteMany?: WhereInput<R["target"]> | WhereInput<R["target"]>[];
         update?: NestedUpdateOne<R["target"]> | NestedUpdateOne<R["target"]>[];
         updateMany?:
@@ -737,10 +734,8 @@ export interface CountArgs<M extends ModelTypeInfo> {
   select?: CountSelect<M>;
 }
 
-export interface GroupByArgs<M extends ModelTypeInfo> extends Omit<
-  AggregateArgs<M>,
-  "orderBy"
-> {
+export interface GroupByArgs<M extends ModelTypeInfo>
+  extends Omit<AggregateArgs<M>, "orderBy"> {
   by: (keyof Scalars<M> & string)[] | (keyof Scalars<M> & string);
   having?: WhereInput<M>;
   orderBy?: OrderByInput<M> | OrderByInput<M>[];

--- a/templates/saas-starter/app/models/select.test-d.ts
+++ b/templates/saas-starter/app/models/select.test-d.ts
@@ -24,9 +24,7 @@ import { OrganizationModel, UserModel } from "./generated";
  */
 describe("select narrows the result type", () => {
   test("a selected column is present and correctly typed", async () => {
-    const [user] = await UserModel.findMany({
-      select: { id: true, email: true },
-    });
+    const [user] = await UserModel.findMany({ select: { id: true, email: true } });
 
     expectTypeOf(user.id).toEqualTypeOf<number>();
     // Nullability survives the narrowing rather than being widened away.

--- a/templates/saas-starter/app/models/select.test-d.ts
+++ b/templates/saas-starter/app/models/select.test-d.ts
@@ -24,7 +24,9 @@ import { OrganizationModel, UserModel } from "./generated";
  */
 describe("select narrows the result type", () => {
   test("a selected column is present and correctly typed", async () => {
-    const [user] = await UserModel.findMany({ select: { id: true, email: true } });
+    const [user] = await UserModel.findMany({
+      select: { id: true, email: true },
+    });
 
     expectTypeOf(user.id).toEqualTypeOf<number>();
     // Nullability survives the narrowing rather than being widened away.
@@ -158,5 +160,108 @@ describe("on(connection) narrows exactly as the class does", () => {
 
   test("it is still the same model class", () => {
     expectTypeOf(UserModel.on("analytics")).toEqualTypeOf<typeof UserModel>();
+  });
+});
+
+/**
+ * **A relation carrying arguments keeps resolving its own relations** — #326.
+ *
+ * `orderBy`, `where`, `take` and `skip` on a to-many used to cost the payload
+ * everything underneath it. The relation came back as the target's scalar type,
+ * so reading a nested relation was a compile error even though the query
+ * returned it at runtime; `include` spelled it identically, so there was no
+ * spelling of a filtered list read that typed.
+ *
+ * The cause was `Payload` asking `A extends { select: infer S }`. `Subset` — the
+ * excess-property guard wrapping the argument — leaves the inferred arguments in
+ * a shape that satisfies *assignability* to `{ select: unknown }` but not that
+ * `extends`, so the check fell to its else branch and returned the default
+ * selection. Only relations with extra keys were affected, because only those
+ * reach the check with arguments that went through that inference path. Asking
+ * `"select" extends keyof A` and indexing instead is what fixed it.
+ *
+ * These are the ordinary shape of a list read — "the products of this list,
+ * ordered by position, each with its product row" — so the regression is worth
+ * pinning at every level it broke.
+ */
+describe("a relation carrying arguments keeps its own relations", () => {
+  test("select + orderBy still resolves the nested relation", async () => {
+    const user = await UserModel.findFirst({
+      select: {
+        accounts: {
+          orderBy: { id: "asc" },
+          select: { organization: { select: { id: true, name: true } } },
+        },
+      },
+    });
+
+    expectTypeOf(user!.accounts[0].organization!.name).toEqualTypeOf<string>();
+  });
+
+  test("include + orderBy spells it identically", async () => {
+    const user = await UserModel.findFirst({
+      include: {
+        accounts: { orderBy: { id: "asc" }, include: { organization: true } },
+      },
+    });
+
+    expectTypeOf(user!.accounts[0].organization!.name).toEqualTypeOf<string>();
+  });
+
+  test("where, take and skip behave the same as orderBy", async () => {
+    const filtered = await UserModel.findFirst({
+      select: {
+        accounts: {
+          where: { organizationId: 1 },
+          select: { organization: { select: { id: true } } },
+        },
+      },
+    });
+    const paged = await UserModel.findFirst({
+      select: {
+        accounts: {
+          take: 5,
+          skip: 1,
+          select: { organization: { select: { id: true } } },
+        },
+      },
+    });
+
+    expectTypeOf(
+      filtered!.accounts[0].organization!.id,
+    ).toEqualTypeOf<number>();
+    expectTypeOf(paged!.accounts[0].organization!.id).toEqualTypeOf<number>();
+  });
+
+  test("the narrowing is still a narrowing — unselected columns stay off", async () => {
+    const user = await UserModel.findFirst({
+      select: {
+        accounts: {
+          orderBy: { id: "asc" },
+          select: { organization: { select: { id: true } } },
+        },
+      },
+    });
+
+    // @ts-expect-error `name` was not selected on the nested organization
+    user!.accounts[0].organization!.name;
+    // @ts-expect-error `id` was not selected on the account itself
+    user!.accounts[0].id;
+  });
+
+  test("arguments at every level, three deep", async () => {
+    const accounts = await OrganizationModel.findFirst({
+      select: {
+        accounts: {
+          take: 2,
+          orderBy: { id: "asc" },
+          select: { user: { select: { email: true } } },
+        },
+      },
+    });
+
+    expectTypeOf(accounts!.accounts[0].user!.email).toEqualTypeOf<
+      string | null
+    >();
   });
 });


### PR DESCRIPTION
Closes #326.

## What was wrong

A to-many carrying `orderBy` / `where` / `take` / `skip` stopped resolving its own nested relations. The relation came back as the target's bare scalars, so reading anything underneath was a compile error even though the query returned it at runtime — and `include` spelled it identically, so no filtered, ordered list read typed at all.

Reproduced on `main` before touching anything, both the template shape from the issue body and the `List.products` shape from your comment.

## The cause

`Payload` asked `A extends { select: infer S }`.

Arguments reach it through `Subset`, the excess-property guard the generated signatures wrap them in. Inferring `T` through that mapped type leaves a relation's arguments in a shape where these two disagree:

```ts
declare const acc: AccWith;
const ok: { select: unknown } = acc;                        // assignable — no error
type Q = AccWith extends { select: unknown } ? "y" : "n";   // "n"
```

So the conditional took its else branch and returned the default selection. Only relations *carrying arguments* went through that path, which is why one level, or two levels without arguments, always looked fine.

The fix asks whether the key is there and then indexes — `"select" extends keyof A` plus `A["select"]`, which resolves in exactly the cases the `extends` did not. Same for `include`, `omit` and `_count`. The `[…] extends [undefined]` guards were already present for an explicitly-`undefined` key and stay.

## Two alternatives, measured rather than assumed

Both fix the payload; both cost more than this does.

| | #326 fixed | rejects `nonExistentColumn` | rejects `orderBey` in relation args |
|---|---|---|---|
| drop `Subset` | ✅ | ✅ | ❌ |
| `T & Subset<T, U>` | ✅ | ✅ | ❌ |
| **this** | ✅ | ✅ | ✅ |

`Subset` is the only thing that catches a typo'd key *inside* a relation's arguments, so both alternatives trade one silent failure for another.

## Compile time on a cyclic schema

`types.ts`'s header warns that a conditional resolving a whole shape "would turn a cyclic schema into an instantiation-depth error rather than a slow compile", and this moves four conditionals from inference to indexing — so that is the first thing to ask of it.

Measured by @nstfkc against Folio (82 models, cycles throughout), two runs each:

| | run 1 | run 2 |
|---|---|---|
| rc.5 | 25.6s | 25.4s |
| rc.5 + this | 24.0s | 23.8s |

No instantiation-depth error, and slightly faster if anything. Full monorepo type-check across three apps and `turbo run test` both pass under the patch.

## Verification

- **Five new type tests** in `select.test-d.ts`, covering select + `orderBy`, include + `orderBy`, `where`/`take`/`skip`, arguments three levels deep, and that the narrowing is still a narrowing. All five fail without the fix (`Type Errors 5 failed`) and pass with it.
- Template `tsc --noEmit`: **277 errors before, 277 after** — the fix introduces none and the remaining ones are the pre-existing backlog.
- `packages/gemi`: 116 files / 2695 tests, `tsc --noEmit` clean.
- Template: 681 tests, type tests 69 passing, no type errors.

## Note for the port

This does not touch runtime behaviour — the rows were always correct, only the type fell back — so nothing needs regenerating and no query changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e9XQt5uXmT2B2KFN5dnBz

