### PR TITLE
Take the session's organizations from the accounts, not from a User column

### DIFF
--- a/packages/gemi/auth/UserProvider.ts
+++ b/packages/gemi/auth/UserProvider.ts
@@ -114,6 +114,25 @@ function registryModels(): AuthModels {
  * `./types.ts` carries `accounts[].organization`, which is a relation two levels
  * down — and because naming the columns is what keeps the *session* queries from
  * selecting `password` into something that is handed to a client.
+ *
+ * **Organizations come from the accounts, not from a column on `User`.** A user
+ * belongs to an organization by having an `Account` in it, which is the shape
+ * the rest of `auth/` already writes: `AuthController`'s invited sign-up creates
+ * the membership with `createAccount`, and nothing in this file has ever set an
+ * organization on the user row.
+ *
+ * This used to also select `User.organizationId`. Nothing in the framework read
+ * it — it was selected here and nowhere else — and selecting it made every
+ * application's `User` table have to carry the starter template's column: a
+ * schema without it fails `UnknownFieldError` inside `findSession`, which
+ * catches, logs, and returns null, so every request looks like an expired
+ * session rather than a misconfiguration.
+ *
+ * Note for a policy that scopes by tenant: `ctx.user.organizationId` is
+ * therefore no longer a thing to read. Scope through the membership —
+ * `{ accounts: { some: { organizationId: … } } }` — and take the organization
+ * from `user.accounts`. A scope naming a key the session user does not carry
+ * evaluates to `undefined`, which is an *absent* filter rather than an error.
  */
 const SESSION_USER = {
   select: {
@@ -123,7 +142,6 @@ const SESSION_USER = {
     name: true,
     locale: true,
     globalRole: true,
-    organizationId: true,
     accounts: {
       select: {
         id: true,

--- a/packages/gemi/auth/types.ts
+++ b/packages/gemi/auth/types.ts
@@ -75,6 +75,13 @@ export type Account = {
   organization: Organization;
 };
 
+/**
+ * A user's organizations are reached through `accounts`, each of which carries
+ * the organization it is a membership in. There is deliberately no
+ * `organizationId` here: a user may be in more than one organization, so a
+ * single column could not answer the question, and `SESSION_USER` no longer
+ * selects one — see the note there.
+ */
 export interface User {
   id: number;
   publicId: string;
@@ -83,7 +90,6 @@ export interface User {
   emailVerifiedAt: Date | null;
   globalRole: number;
   password: string | null;
-  organizationId: number | null;
   accounts: Account[];
   // TODO: Add type
   extension: Record<string, any>;

--- a/templates/saas-starter/app/models/User.ts
+++ b/templates/saas-starter/app/models/User.ts
@@ -18,8 +18,8 @@ import { UserModel } from "./generated";
 //   export class User extends UserModel {
 //     static $policies: UserPolicy[] = [
 //       softDeletes<User>(),
-//       { scope: (ctx) => ({ organizationId: ctx.user.organizationId }),
-//         onCreate: (ctx, data) => ({ ...data, organizationId: ctx.user.organizationId }),
+//       { scope: (ctx) => ({ accounts: { some: { organizationId: orgOf(ctx) } } }),
+//         onCreate: (ctx, data) => data,
 //         onUpdate: (_ctx, data) => data },
 //     ]
 //   }
@@ -27,6 +27,15 @@ import { UserModel } from "./generated";
 // The `UserPolicy` annotation is what types `ctx`, `data` and the returned
 // `where` against this model — without it the entries are inferred from the
 // literal and the parameters are implicitly `any`.
+//
+// The scope goes through `accounts` because that is where a membership lives: a
+// user belongs to an organization by having an account in it, and may have
+// several. `ctx.user` is the session user, which carries `accounts[].organization`
+// and no `organizationId` of its own — so `ctx.user.organizationId` would be
+// `undefined`, and an undefined value in a scope is an *absent* filter rather
+// than an error. The scope would silently vanish and the read would return every
+// tenant's rows. Whatever picks the current organization out of `ctx.user.accounts`
+// is the application's own decision, which is what `orgOf` stands in for here.
 export class User extends UserModel {}
 
 // Registers the name against *this* class, replacing the generated base that

--- a/templates/saas-starter/app/models/user-provider.test.ts
+++ b/templates/saas-starter/app/models/user-provider.test.ts
@@ -257,6 +257,13 @@ function suite(label: string, url?: string) {
       // The narrowed select must not carry the password into something handed
       // to a client.
       expect("password" in created.user).toBe(false);
+
+      // The organizations arrive through the accounts, and the user row itself
+      // carries no organization column. This schema happens to have one, so
+      // selecting it would pass here — which is exactly how the framework came
+      // to require a column no application should have to declare. Asserted as
+      // an absence so that re-adding it fails.
+      expect("organizationId" in created.user).toBe(false);
     });
 
     test("findSession returns the session with its user", async () => {


### PR DESCRIPTION
`SESSION_USER` selected `User.organizationId`. Nothing in the framework read it.

Grepping all of `packages/gemi`, the column appears exactly twice: selected at `UserProvider.ts:126`, and declared on the `User` interface that mirrors that select. The two places that genuinely use an organization id use different ones — `createAccount` writes `Account.organizationId`, `AuthController:345` reads `invitation.organizationId`. Sign-up never sets an organization on the user row; the invited path creates the membership with `createAccount`.

The organizations already arrive through `accounts[].organization`, which is where a membership lives and which allows more than one of them. A single column on `User` could not answer the question anyway.

## Why it was worth removing rather than leaving

Selecting it made every application's `User` table have to carry the starter template's column. A schema without it — the ordinary shape when membership lives on `Account` — throws:

```
UnknownFieldError: 'organizationId' is not a field on model User.
```

And it fails **two different ways depending on the path**, which is the part that costs an afternoon:

| path | catch | symptom |
|---|---|---|
| `findSession` | `:250`, returns null | every request looks like an expired session |
| `createSessionV2`, `updateSession` | none | throws |

`findSession`'s catch documents itself as being for "the *connection* case — a sign-in path that throws on a database blip becomes a 500 where returning null is a redirect to the login page". Sound for a blip, which is transient and worth retrying. Wrong for a schema error, which is permanent, and where returning null hides the one message that would explain it.

## The policy consequence, measured

`ctx.user` is the session user, so removing the column means `ctx.user.organizationId` is now `undefined` in a policy. I probed what the engine does with that rather than reasoning about it:

```ts
scope: (ctx) => ({ organizationId: ctx.user.organizationId })
// -> { where: { id: 5, AND: [{}] } }      no error, no filter
```

An undefined value is an *absent* filter. A policy still written that way does not fail — it silently stops scoping and returns every tenant's rows.

`policy.ts:63-66` already describes exactly this leak, but its guard fires on a **null user**; a present user with a missing key walks straight through. So the commented policy example on `app/models/User.ts` had to change with this, because it was handing people that snippet on the `User` model itself. It now scopes through the membership:

```ts
{ scope: (ctx) => ({ accounts: { some: { organizationId: orgOf(ctx) } } }), … }
```

`orgOf` stands in for whatever picks the current organization out of `ctx.user.accounts`. With several memberships that is an application decision, and there is no active-organization concept on `Session` to infer one from.

## Scope

**Not** changing `User.organizationId` in the template's `schema.prisma`. The ORM's relation tests (`order-relation`, `lateral`, `relation-filter`) use `User -> Organization` as their to-one fixture, and the column staying is what makes the new assertion meaningful.

The test asserts the **absence** of `organizationId` on the session user, not the presence of the accounts. The template's schema still has the column, so selecting it would pass — which is precisely how the framework came to require one, and why an absence is the thing to pin.

## Verification

- gemi **2706 passed | 1 skipped**, `tsc` 0.
- template **681 passed**, **102** type tests, `tsc` 277 — the unchanged baseline.
- `user-provider.test.ts` exercises the real three-level select against SQLite, so `findSession` / `createSessionV2` / `updateSession` all run their narrowed selects here rather than being reasoned about.

## Two follow-ups this does not do

1. **The policy engine should refuse a scope whose value is `undefined`** rather than dropping the key. That is the general fix; this PR only removes one instance of the trap.
2. **`findSession`'s catch is too wide.** It should let a schema error through and keep swallowing connection errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e9XQt5uXmT2B2KFN5dnBz