### PR TITLE
Add `onUserCreated`, and stop handing the OAuth path a dead token

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -173,25 +173,31 @@ The twenty-two methods, all overridable:
 | `createSocialAccount(args)` | Persist an OAuth-linked social account. |
 | `findInvitation(id, email)` / `deleteInvitationById(id)` / `createAccount(args)` | Invitation-based sign-up. |
 
+One more method is not a query: `transaction(fn)` runs `fn` inside a transaction on the
+connection the `User` model lives on. `AuthController` uses it to write a user and everything
+that has to exist beside it — the invited `Account`, the OAuth `SocialAccount`, and whatever
+[`onUserCreated`](#onusercreated) writes — atomically.
+
 ### Changing a query
 
-Subclass `UserProvider` and override the method(s) you need — for example to make sign-up
-atomic by provisioning an organization in the same transaction that creates the user:
+Subclass `UserProvider` and override the method(s) you need — for example so that a
+soft-deleted user cannot sign back in:
 
 ```typescript
 import { UserProvider } from "gemi/kernel";
-import type { CreateUserArgs, User } from "gemi/kernel";
+import type { User } from "gemi/kernel";
 
-import { Organization } from "@/app/models/Organization";
-import { User as UserModel } from "@/app/models/User";
-
-export class OrgProvisioningUserProvider extends UserProvider {
-  async createUser(args: CreateUserArgs): Promise<User> {
-    return UserModel.transaction(async () => {
-      const user = await super.createUser(args);
-      await Organization.create({ data: { name: `${user.name}'s org`, ownerId: user.id } });
-      return user;
-    });
+export class SoftDeleteUserProvider extends UserProvider {
+  async findUserByEmailAddress(email: string, verifyEmail: boolean): Promise<User> {
+    return this.run(() =>
+      this.models.User.findFirst({
+        where: {
+          email,
+          deletedAt: null,
+          ...(verifyEmail ? { emailVerifiedAt: { not: null } } : {}),
+        },
+      }),
+    );
   }
 }
 ```
@@ -209,7 +215,7 @@ argument:
 import { AuthManager } from "gemi/services";
 import { ServiceProvider } from "gemi/support";
 
-import { OrgProvisioningUserProvider } from "@/app/auth/OrgProvisioningUserProvider";
+import { SoftDeleteUserProvider } from "@/app/auth/SoftDeleteUserProvider";
 
 export default class AppServiceProvider extends ServiceProvider {
   register() {
@@ -218,7 +224,7 @@ export default class AppServiceProvider extends ServiceProvider {
       () =>
         new AuthManager(
           this.app.config.get("auth", {}),
-          new OrgProvisioningUserProvider(),
+          new SoftDeleteUserProvider(),
         ),
     );
   }
@@ -229,10 +235,11 @@ The provider has to be listed in your `Kernel`'s `providers` array to run — se
 [Project Structure](./project-structure.md#service-providers). App providers register *after*
 the framework's, so this binding replaces the default `AuthManager` rather than racing it.
 
-> **Note:** gemi runs `createUser` and then fires `onSignUp` *separately*. Provisioning
-> inside the `onSignUp` callback is therefore **not** atomic with user creation — a failure
-> there leaves an orphaned user. Do transactional provisioning inside a `createUser`
-> override, as above.
+> **Note:** provisioning does not need a subclass any more. `onSignUp` fires *after* the user
+> is committed, so provisioning there is not atomic — a failure leaves an orphaned user — but
+> [`onUserCreated`](#onusercreated) runs inside the transaction that writes the user and rolls it
+> back on a throw. Reach for a `createUser` override when you need to change *the query*; use
+> the hook to write rows alongside it.
 
 ### Upgrading from the adapter config
 
@@ -263,7 +270,8 @@ may be sync or async.
 
 | Hook | Signature | Fires when |
 | --- | --- | --- |
-| `onSignUp` | `(user, verificationToken, search)` | A new account is created (email/password, or first OAuth sign-in). `verificationToken` is empty when `verifyEmail` is off. |
+| `onUserCreated` | `(user) => Promise<void>` | A user row is written — **inside the transaction that writes it**, before it commits. A throw rolls the user back. See [onUserCreated](#onusercreated). |
+| `onSignUp` | `(user, verificationToken, search)` | A new account is created (email/password, or first OAuth sign-in), after it is committed. `verificationToken` is empty when `verifyEmail` is off, and on the OAuth path, where there is nothing to verify. |
 | `onSignIn` | `(session, search)` | A user authenticates (password, magic-link/PIN, or returning OAuth). |
 | `onSignOut` | `(session)` | The `/auth/sign-out` endpoint runs. |
 | `onForgotPassword` | `(user, token)` | A password-reset is requested — send the reset email with `token`. |
@@ -273,6 +281,55 @@ may be sync or async.
 
 `search` is the request's query string as a plain object (useful for attribution / redirect
 params).
+
+### onUserCreated
+
+Every other hook in that table is a notification: it fires after its work is committed and
+can only report. `onUserCreated` is not. It runs **inside the transaction that creates the
+user**, after the row is written and before it commits, and if it throws, the user is rolled
+back and the sign-up fails.
+
+That is what it is for. An application that has to create rows *alongside* every user — an
+organization, a workspace, a default settings row — has nowhere else to do it atomically.
+Provisioning in `onSignUp` runs after the commit, so a failed second insert leaves a user
+with no organization: no error the user sees, nothing to retry, and a failure that only
+shows up in production.
+
+```typescript
+import { defineAuthConfig } from "gemi/services";
+
+import { Account } from "@/app/models/Account";
+import { Organization } from "@/app/models/Organization";
+
+export default defineAuthConfig({
+  async onUserCreated(user) {
+    // Both of these join the open transaction automatically. If either throws,
+    // the user is rolled back with them.
+    const org = await Organization.create({ data: { name: `${user.name}'s org` } });
+    await Account.create({
+      data: { userId: user.id, organizationId: org.id, organizationRole: 0 },
+    });
+  },
+});
+```
+
+It fires on all three paths that create a user — email/password sign-up, invited sign-up, and
+first OAuth sign-in — and receives the same password-stripped user the endpoint returns.
+
+Four things to know:
+
+- **Errors reach the client.** A [`ValidationError`](./forms.md) thrown here is a 400 on
+  `POST /sign-up`; anything else is a 500. Either way no user is created.
+- **The invited path already has an `Account`.** When a sign-up carries an `invitationId`, the
+  inviting organization's `Account` row is written before this runs, so a hook that
+  unconditionally provisions an own workspace gives that user two. Check before adding one.
+- **Only ORM queries join the transaction.** They do at any call depth, through any number of
+  services, with nothing threaded through — that is `Model.transaction`'s contract. A raw
+  Prisma or `DB` statement runs outside it and survives the rollback.
+- **One statement at a time.** The transaction holds a single reserved connection, so
+  `Promise.all` over ORM calls is not safe here — await them in sequence. Keep network and
+  filesystem I/O out of the hook entirely; the connection is held for as long as it runs. Send
+  the welcome email from `onSignUp`, which fires after the commit.
 
 ### Example: magic-link PIN emails
 
@@ -400,8 +457,17 @@ The framework mounts two view routes per provider automatically:
 
 - `/auth/oauth/:provider` — redirects the browser to the provider's consent screen.
 - `/auth/oauth/:provider/callback` — exchanges the code, resolves the user's email/name,
-  signs them in (or creates the account + a `SocialAccount` on first login), sets the session
-  cookie, and fires `onSignUp` (new) or `onSignIn` (returning).
+  signs them in (or creates the account + a `SocialAccount` on first login, in one transaction
+  with [`onUserCreated`](#onusercreated)), sets the session cookie, and fires `onSignUp` (new) or
+  `onSignIn` (returning).
+
+> **Note:** `onSignUp`'s `verificationToken` is `""` on this path. A user arriving through
+> OAuth has `emailVerifiedAt` already set, so there is nothing to verify. To mail them a
+> magic link, mint a persisted one with `Auth.createMagicLink(user.email)` from the hook — as
+> in the [example above](#example-magic-link-pin-emails) — rather than expecting a token in
+> the argument. This path previously passed an unpersisted `generateMagicLinkToken` result,
+> which looked like a token and resolved to nothing — `generateMagicLinkToken` is a pure hash,
+> and only `Auth.createMagicLink` writes the row that makes one resolvable.
 
 A "Sign in with Google" button is just a link:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -297,17 +297,21 @@ shows up in production.
 
 ```typescript
 import { defineAuthConfig } from "gemi/services";
+import { Model } from "gemi/orm";
 
 import { Account } from "@/app/models/Account";
 import { Organization } from "@/app/models/Organization";
 
 export default defineAuthConfig({
   async onUserCreated(user) {
-    // Both of these join the open transaction automatically. If either throws,
-    // the user is rolled back with them.
-    const org = await Organization.create({ data: { name: `${user.name}'s org` } });
-    await Account.create({
-      data: { userId: user.id, organizationId: org.id, organizationRole: 0 },
+    // `asSystem` because a sign-up has no authenticated user yet — see the
+    // first bullet below. Both writes join the open transaction automatically,
+    // so if either throws, the user is rolled back with them.
+    await Model.asSystem(async () => {
+      const org = await Organization.create({ data: { name: `${user.name}'s org` } });
+      await Account.create({
+        data: { userId: user.id, organizationId: org.id, organizationRole: 0 },
+      });
     });
   },
 });
@@ -316,16 +320,32 @@ export default defineAuthConfig({
 It fires on all three paths that create a user — email/password sign-up, invited sign-up, and
 first OAuth sign-in — and receives the same password-stripped user the endpoint returns.
 
-Four things to know:
+Five things to know:
 
+- **Writing to a policied model needs `Model.asSystem`.** This hook runs with no user in
+  scope — a sign-up has not authenticated anybody yet — so a [policy](./orm.md) whose `scope`
+  or `onCreate` reads `ctx.user` raises `PolicyDeniedError` under deny-by-default, and the
+  rollback takes the new user with it. A tenant-scoped `Organization` is exactly that case, so
+  without the wrapper above the first sign-up 500s and nobody can get past it.
+
+  That is the framework working, not a bug to route around: suspending policies for
+  application code is a sentence you write, never something gemi does quietly on your behalf.
+  It is also why the hook is deliberately *not* wrapped in `UserProvider`'s own `asSystem` —
+  that would have made every provisioning write unpoliced with nothing at the call site to say
+  so. Use `Model.asUser(user, …)` instead when the new user is enough to satisfy the scope;
+  for a tenant scope reading `organizationId`, it is not, because that is the row being
+  created.
 - **Errors reach the client.** A [`ValidationError`](./forms.md) thrown here is a 400 on
-  `POST /sign-up`; anything else is a 500. Either way no user is created.
+  `POST /sign-up`; anything else is a 500. On the OAuth path there is no form to fail — a
+  throw is a 500 page mid-redirect. Either way no user is created.
 - **The invited path already has an `Account`.** When a sign-up carries an `invitationId`, the
   inviting organization's `Account` row is written before this runs, so a hook that
   unconditionally provisions an own workspace gives that user two. Check before adding one.
 - **Only ORM queries join the transaction.** They do at any call depth, through any number of
-  services, with nothing threaded through — that is `Model.transaction`'s contract. A raw
-  Prisma or `DB` statement runs outside it and survives the rollback.
+  services, with nothing threaded through — that is `Model.transaction`'s contract, and
+  `asSystem` does not break it: the wrapper merges into the current scope rather than
+  replacing it, so the open transaction survives. A raw Prisma or `DB` statement runs outside
+  it and survives the rollback.
 - **One statement at a time.** The transaction holds a single reserved connection, so
   `Promise.all` over ORM calls is not safe here — await them in sequence. Keep network and
   filesystem I/O out of the hook entirely; the connection is held for as long as it runs. Send

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -549,7 +549,7 @@ The hooks are ordinary config values, so a service reads them the same way it re
 
 | Slice | Hooks |
 | --- | --- |
-| `auth` | `onSignUp`, `onSignIn`, `onSignOut`, `onForgotPassword`, `onResetPassword`, `onMagicLinkCreated`, `extendSession`, `verifyPassword`, `hashPassword`, `generateForgotPasswordToken`, `generateEmailVerificationToken`, `generateMagicLinkToken` |
+| `auth` | `onUserCreated`, `onSignUp`, `onSignIn`, `onSignOut`, `onForgotPassword`, `onResetPassword`, `onMagicLinkCreated`, `extendSession`, `verifyPassword`, `hashPassword`, `generateForgotPasswordToken`, `generateEmailVerificationToken`, `generateMagicLinkToken` |
 | `mail` | `filterRecipients` |
 | `log` | `onLogCreated`, `onLogFileClosed` |
 | `translation` | `detectLocale`, `onLocaleChange` |
@@ -5026,25 +5026,31 @@ The twenty-two methods, all overridable:
 | `createSocialAccount(args)` | Persist an OAuth-linked social account. |
 | `findInvitation(id, email)` / `deleteInvitationById(id)` / `createAccount(args)` | Invitation-based sign-up. |
 
+One more method is not a query: `transaction(fn)` runs `fn` inside a transaction on the
+connection the `User` model lives on. `AuthController` uses it to write a user and everything
+that has to exist beside it — the invited `Account`, the OAuth `SocialAccount`, and whatever
+[`onUserCreated`](#onusercreated) writes — atomically.
+
 ### Changing a query
 
-Subclass `UserProvider` and override the method(s) you need — for example to make sign-up
-atomic by provisioning an organization in the same transaction that creates the user:
+Subclass `UserProvider` and override the method(s) you need — for example so that a
+soft-deleted user cannot sign back in:
 
 ```typescript
 import { UserProvider } from "gemi/kernel";
-import type { CreateUserArgs, User } from "gemi/kernel";
+import type { User } from "gemi/kernel";
 
-import { Organization } from "@/app/models/Organization";
-import { User as UserModel } from "@/app/models/User";
-
-export class OrgProvisioningUserProvider extends UserProvider {
-  async createUser(args: CreateUserArgs): Promise<User> {
-    return UserModel.transaction(async () => {
-      const user = await super.createUser(args);
-      await Organization.create({ data: { name: `${user.name}'s org`, ownerId: user.id } });
-      return user;
-    });
+export class SoftDeleteUserProvider extends UserProvider {
+  async findUserByEmailAddress(email: string, verifyEmail: boolean): Promise<User> {
+    return this.run(() =>
+      this.models.User.findFirst({
+        where: {
+          email,
+          deletedAt: null,
+          ...(verifyEmail ? { emailVerifiedAt: { not: null } } : {}),
+        },
+      }),
+    );
   }
 }
 ```
@@ -5062,7 +5068,7 @@ argument:
 import { AuthManager } from "gemi/services";
 import { ServiceProvider } from "gemi/support";
 
-import { OrgProvisioningUserProvider } from "@/app/auth/OrgProvisioningUserProvider";
+import { SoftDeleteUserProvider } from "@/app/auth/SoftDeleteUserProvider";
 
 export default class AppServiceProvider extends ServiceProvider {
   register() {
@@ -5071,7 +5077,7 @@ export default class AppServiceProvider extends ServiceProvider {
       () =>
         new AuthManager(
           this.app.config.get("auth", {}),
-          new OrgProvisioningUserProvider(),
+          new SoftDeleteUserProvider(),
         ),
     );
   }
@@ -5082,10 +5088,11 @@ The provider has to be listed in your `Kernel`'s `providers` array to run — se
 [Project Structure](./project-structure.md#service-providers). App providers register *after*
 the framework's, so this binding replaces the default `AuthManager` rather than racing it.
 
-> **Note:** gemi runs `createUser` and then fires `onSignUp` *separately*. Provisioning
-> inside the `onSignUp` callback is therefore **not** atomic with user creation — a failure
-> there leaves an orphaned user. Do transactional provisioning inside a `createUser`
-> override, as above.
+> **Note:** provisioning does not need a subclass any more. `onSignUp` fires *after* the user
+> is committed, so provisioning there is not atomic — a failure leaves an orphaned user — but
+> [`onUserCreated`](#onusercreated) runs inside the transaction that writes the user and rolls it
+> back on a throw. Reach for a `createUser` override when you need to change *the query*; use
+> the hook to write rows alongside it.
 
 ### Upgrading from the adapter config
 
@@ -5116,7 +5123,8 @@ may be sync or async.
 
 | Hook | Signature | Fires when |
 | --- | --- | --- |
-| `onSignUp` | `(user, verificationToken, search)` | A new account is created (email/password, or first OAuth sign-in). `verificationToken` is empty when `verifyEmail` is off. |
+| `onUserCreated` | `(user) => Promise<void>` | A user row is written — **inside the transaction that writes it**, before it commits. A throw rolls the user back. See [onUserCreated](#onusercreated). |
+| `onSignUp` | `(user, verificationToken, search)` | A new account is created (email/password, or first OAuth sign-in), after it is committed. `verificationToken` is empty when `verifyEmail` is off, and on the OAuth path, where there is nothing to verify. |
 | `onSignIn` | `(session, search)` | A user authenticates (password, magic-link/PIN, or returning OAuth). |
 | `onSignOut` | `(session)` | The `/auth/sign-out` endpoint runs. |
 | `onForgotPassword` | `(user, token)` | A password-reset is requested — send the reset email with `token`. |
@@ -5126,6 +5134,55 @@ may be sync or async.
 
 `search` is the request's query string as a plain object (useful for attribution / redirect
 params).
+
+### onUserCreated
+
+Every other hook in that table is a notification: it fires after its work is committed and
+can only report. `onUserCreated` is not. It runs **inside the transaction that creates the
+user**, after the row is written and before it commits, and if it throws, the user is rolled
+back and the sign-up fails.
+
+That is what it is for. An application that has to create rows *alongside* every user — an
+organization, a workspace, a default settings row — has nowhere else to do it atomically.
+Provisioning in `onSignUp` runs after the commit, so a failed second insert leaves a user
+with no organization: no error the user sees, nothing to retry, and a failure that only
+shows up in production.
+
+```typescript
+import { defineAuthConfig } from "gemi/services";
+
+import { Account } from "@/app/models/Account";
+import { Organization } from "@/app/models/Organization";
+
+export default defineAuthConfig({
+  async onUserCreated(user) {
+    // Both of these join the open transaction automatically. If either throws,
+    // the user is rolled back with them.
+    const org = await Organization.create({ data: { name: `${user.name}'s org` } });
+    await Account.create({
+      data: { userId: user.id, organizationId: org.id, organizationRole: 0 },
+    });
+  },
+});
+```
+
+It fires on all three paths that create a user — email/password sign-up, invited sign-up, and
+first OAuth sign-in — and receives the same password-stripped user the endpoint returns.
+
+Four things to know:
+
+- **Errors reach the client.** A [`ValidationError`](./forms.md) thrown here is a 400 on
+  `POST /sign-up`; anything else is a 500. Either way no user is created.
+- **The invited path already has an `Account`.** When a sign-up carries an `invitationId`, the
+  inviting organization's `Account` row is written before this runs, so a hook that
+  unconditionally provisions an own workspace gives that user two. Check before adding one.
+- **Only ORM queries join the transaction.** They do at any call depth, through any number of
+  services, with nothing threaded through — that is `Model.transaction`'s contract. A raw
+  Prisma or `DB` statement runs outside it and survives the rollback.
+- **One statement at a time.** The transaction holds a single reserved connection, so
+  `Promise.all` over ORM calls is not safe here — await them in sequence. Keep network and
+  filesystem I/O out of the hook entirely; the connection is held for as long as it runs. Send
+  the welcome email from `onSignUp`, which fires after the commit.
 
 ### Example: magic-link PIN emails
 
@@ -5253,8 +5310,17 @@ The framework mounts two view routes per provider automatically:
 
 - `/auth/oauth/:provider` — redirects the browser to the provider's consent screen.
 - `/auth/oauth/:provider/callback` — exchanges the code, resolves the user's email/name,
-  signs them in (or creates the account + a `SocialAccount` on first login), sets the session
-  cookie, and fires `onSignUp` (new) or `onSignIn` (returning).
+  signs them in (or creates the account + a `SocialAccount` on first login, in one transaction
+  with [`onUserCreated`](#onusercreated)), sets the session cookie, and fires `onSignUp` (new) or
+  `onSignIn` (returning).
+
+> **Note:** `onSignUp`'s `verificationToken` is `""` on this path. A user arriving through
+> OAuth has `emailVerifiedAt` already set, so there is nothing to verify. To mail them a
+> magic link, mint a persisted one with `Auth.createMagicLink(user.email)` from the hook — as
+> in the [example above](#example-magic-link-pin-emails) — rather than expecting a token in
+> the argument. This path previously passed an unpersisted `generateMagicLinkToken` result,
+> which looked like a token and resolved to nothing — `generateMagicLinkToken` is a pure hash,
+> and only `Auth.createMagicLink` writes the row that makes one resolvable.
 
 A "Sign in with Google" button is just a link:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5150,17 +5150,21 @@ shows up in production.
 
 ```typescript
 import { defineAuthConfig } from "gemi/services";
+import { Model } from "gemi/orm";
 
 import { Account } from "@/app/models/Account";
 import { Organization } from "@/app/models/Organization";
 
 export default defineAuthConfig({
   async onUserCreated(user) {
-    // Both of these join the open transaction automatically. If either throws,
-    // the user is rolled back with them.
-    const org = await Organization.create({ data: { name: `${user.name}'s org` } });
-    await Account.create({
-      data: { userId: user.id, organizationId: org.id, organizationRole: 0 },
+    // `asSystem` because a sign-up has no authenticated user yet — see the
+    // first bullet below. Both writes join the open transaction automatically,
+    // so if either throws, the user is rolled back with them.
+    await Model.asSystem(async () => {
+      const org = await Organization.create({ data: { name: `${user.name}'s org` } });
+      await Account.create({
+        data: { userId: user.id, organizationId: org.id, organizationRole: 0 },
+      });
     });
   },
 });
@@ -5169,16 +5173,32 @@ export default defineAuthConfig({
 It fires on all three paths that create a user — email/password sign-up, invited sign-up, and
 first OAuth sign-in — and receives the same password-stripped user the endpoint returns.
 
-Four things to know:
+Five things to know:
 
+- **Writing to a policied model needs `Model.asSystem`.** This hook runs with no user in
+  scope — a sign-up has not authenticated anybody yet — so a [policy](./orm.md) whose `scope`
+  or `onCreate` reads `ctx.user` raises `PolicyDeniedError` under deny-by-default, and the
+  rollback takes the new user with it. A tenant-scoped `Organization` is exactly that case, so
+  without the wrapper above the first sign-up 500s and nobody can get past it.
+
+  That is the framework working, not a bug to route around: suspending policies for
+  application code is a sentence you write, never something gemi does quietly on your behalf.
+  It is also why the hook is deliberately *not* wrapped in `UserProvider`'s own `asSystem` —
+  that would have made every provisioning write unpoliced with nothing at the call site to say
+  so. Use `Model.asUser(user, …)` instead when the new user is enough to satisfy the scope;
+  for a tenant scope reading `organizationId`, it is not, because that is the row being
+  created.
 - **Errors reach the client.** A [`ValidationError`](./forms.md) thrown here is a 400 on
-  `POST /sign-up`; anything else is a 500. Either way no user is created.
+  `POST /sign-up`; anything else is a 500. On the OAuth path there is no form to fail — a
+  throw is a 500 page mid-redirect. Either way no user is created.
 - **The invited path already has an `Account`.** When a sign-up carries an `invitationId`, the
   inviting organization's `Account` row is written before this runs, so a hook that
   unconditionally provisions an own workspace gives that user two. Check before adding one.
 - **Only ORM queries join the transaction.** They do at any call depth, through any number of
-  services, with nothing threaded through — that is `Model.transaction`'s contract. A raw
-  Prisma or `DB` statement runs outside it and survives the rollback.
+  services, with nothing threaded through — that is `Model.transaction`'s contract, and
+  `asSystem` does not break it: the wrapper merges into the current scope rather than
+  replacing it, so the open transaction survives. A raw Prisma or `DB` statement runs outside
+  it and survives the rollback.
 - **One statement at a time.** The transaction holds a single reserved connection, so
   `Promise.all` over ORM calls is not safe here — await them in sequence. Keep network and
   filesystem I/O out of the hook entirely; the connection is held for as long as it runs. Send

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -315,7 +315,7 @@ The hooks are ordinary config values, so a service reads them the same way it re
 
 | Slice | Hooks |
 | --- | --- |
-| `auth` | `onSignUp`, `onSignIn`, `onSignOut`, `onForgotPassword`, `onResetPassword`, `onMagicLinkCreated`, `extendSession`, `verifyPassword`, `hashPassword`, `generateForgotPasswordToken`, `generateEmailVerificationToken`, `generateMagicLinkToken` |
+| `auth` | `onUserCreated`, `onSignUp`, `onSignIn`, `onSignOut`, `onForgotPassword`, `onResetPassword`, `onMagicLinkCreated`, `extendSession`, `verifyPassword`, `hashPassword`, `generateForgotPasswordToken`, `generateEmailVerificationToken`, `generateMagicLinkToken` |
 | `mail` | `filterRecipients` |
 | `log` | `onLogCreated`, `onLogFileClosed` |
 | `translation` | `detectLocale`, `onLocaleChange` |

--- a/packages/gemi/auth/AuthController.ts
+++ b/packages/gemi/auth/AuthController.ts
@@ -324,37 +324,57 @@ export class AuthController extends Controller {
     let invitation: Invitation;
     if (invitationId) {
       invitation = await userProvider.findInvitation(invitationId, email);
-
-      if (invitation) {
-        await userProvider.deleteInvitationById(invitationId);
-      }
     }
 
     let newUser: User;
     let verificationToken: string;
 
+    // Both branches write the user and everything that has to exist alongside
+    // it in one transaction, `config.onUserCreated` last. A throw from the hook
+    // takes the user with it, which is the whole point of the hook: an app
+    // provisioning an organization in `onSignUp` — which fires after the commit
+    // — gets a user with no organization when that insert fails.
     if (invitation) {
-      newUser = await userProvider.createUser({
-        email,
-        name,
-        password: hashedPassword,
-        emailVerifiedAt: new Date(),
-        locale,
-      });
-      await userProvider.createAccount({
-        organizationId: invitation.organizationId,
-        userId: newUser.id,
-        organizationRole: invitation.role,
+      newUser = await userProvider.transaction(async () => {
+        // Consuming the invitation belongs in here too. Deleted before the
+        // transaction, a rollback would leave the invite burned and no user to
+        // show for it, so the invitee could not retry.
+        await userProvider.deleteInvitationById(invitationId);
+
+        const user = await userProvider.createUser({
+          email,
+          name,
+          password: hashedPassword,
+          emailVerifiedAt: new Date(),
+          locale,
+        });
+        await userProvider.createAccount({
+          organizationId: invitation.organizationId,
+          userId: user.id,
+          organizationRole: invitation.role,
+        });
+
+        await config.onUserCreated(user);
+
+        return user;
       });
     } else {
+      // Outside the transaction: it is a hash, not a query, and the
+      // transaction holds a connection for as long as it is open.
       verificationToken = await config.generateEmailVerificationToken(email);
 
-      newUser = await userProvider.createUser({
-        email,
-        name,
-        password: hashedPassword,
-        verificationToken,
-        locale,
+      newUser = await userProvider.transaction(async () => {
+        const user = await userProvider.createUser({
+          email,
+          name,
+          password: hashedPassword,
+          verificationToken,
+          locale,
+        });
+
+        await config.onUserCreated(user);
+
+        return user;
       });
     }
 
@@ -538,23 +558,34 @@ export class AuthController extends Controller {
 
     if (!user) {
       action = "signup";
-      user = await userProvider.createUser({
-        email,
-        name,
-        locale,
-        emailVerifiedAt: new Date(),
-      });
 
-      // TODO: fix missing fields
-      await userProvider.createSocialAccount({
-        provider,
-        userId: user.id,
-        email,
-        username: name,
-        providerId: "",
-        expiresAt: new Date(),
-        accessToken: "",
-        refreshToken: "",
+      // Same shape as `signUp`: the user, the row that has to exist beside it,
+      // and `onUserCreated`, in one transaction. The social account in
+      // particular has a foreign key onto the user — created outside, a rolled
+      // back user would leave it pointing at nothing.
+      user = await userProvider.transaction(async () => {
+        const created = await userProvider.createUser({
+          email,
+          name,
+          locale,
+          emailVerifiedAt: new Date(),
+        });
+
+        // TODO: fix missing fields
+        await userProvider.createSocialAccount({
+          provider,
+          userId: created.id,
+          email,
+          username: name,
+          providerId: "",
+          expiresAt: new Date(),
+          accessToken: "",
+          refreshToken: "",
+        });
+
+        await config.onUserCreated(created);
+
+        return created;
       });
     }
 
@@ -572,8 +603,25 @@ export class AuthController extends Controller {
     });
 
     if (action === "signup") {
-      const magicLink = await config.generateMagicLinkToken(email);
-      await config.onSignUp(user, magicLink, req.search.toJSON());
+      // `""`, and not a token, deliberately.
+      //
+      // This used to hand the hook `config.generateMagicLinkToken(email)`.
+      // That function is a pure hash and nothing here persisted what it
+      // returned — `userProvider.createMagicLinkToken`, which writes the
+      // `MagicLinkToken` row, was never called — so the value resolved in
+      // neither place a token can be looked up: not `User.verificationToken`,
+      // which `createUser` above does not set, and not the `MagicLinkToken`
+      // table. An application doing the obvious thing with the argument, and
+      // mailing a confirmation link carrying it, sent every OAuth signup a link
+      // that could not resolve, and it tested clean against email/password
+      // signup, where the same parameter is the persisted verification token.
+      //
+      // There is nothing to verify on this path — the user arrives with
+      // `emailVerifiedAt` already set — so "no token" is the honest value, and
+      // it is the one the email path already passes under `verifyEmail: false`.
+      // An app that does want to hand new OAuth users a magic link should mint
+      // a persisted one with `Auth.createMagicLink(user.email)` from the hook.
+      await config.onSignUp(user, "", req.search.toJSON());
     } else {
       await config.onSignIn(user, req.search.toJSON());
     }

--- a/packages/gemi/auth/AuthController.ts
+++ b/packages/gemi/auth/AuthController.ts
@@ -327,7 +327,13 @@ export class AuthController extends Controller {
     }
 
     let newUser: User;
-    let verificationToken: string;
+    // `""` rather than left undefined, because only the `else` branch below
+    // assigns it. An invited sign-up sets `emailVerifiedAt` and never writes a
+    // token, so there is nothing to verify — the same reason `oauthCallback`
+    // passes `""` — and `onSignUp` is typed `verificationToken: string`. Left
+    // undeclared, the invited path handed the hook `undefined` against that
+    // signature.
+    let verificationToken = "";
 
     // Both branches write the user and everything that has to exist alongside
     // it in one transaction, `config.onUserCreated` last. A throw from the hook

--- a/packages/gemi/auth/UserProvider.ts
+++ b/packages/gemi/auth/UserProvider.ts
@@ -156,6 +156,27 @@ export class UserProvider {
   }
 
   /**
+   * Runs `fn` inside a transaction on the connection the `User` model lives on.
+   * Every ORM query in it joins automatically, at any call depth — see
+   * `Model.transaction`.
+   *
+   * Here so that `AuthController` can make a sign-up atomic without importing a
+   * model: the controller has none, and reaching for a bare `Model.transaction`
+   * would open on the ambient connection rather than the one this provider's
+   * models are bound to. Nesting is a savepoint, so an application that already
+   * wrapped its own transaction around a sign-up composes instead of breaking.
+   *
+   * Deliberately **not** wrapped in `run`. `asSystem` is applied per query by
+   * the methods below, which keeps it to this class's own reads and writes;
+   * hoisting it here would silently suspend policies for `config.onUserCreated`
+   * too, and an application's provisioning writes should run under the same
+   * policy resolution as the rest of its code.
+   */
+  transaction<T>(fn: () => Promise<T>): Promise<T> {
+    return this.models.User.transaction(fn);
+  }
+
+  /**
    * Note the password is **removed from the returned object**, matching Prisma's
    * adapter, which uses `omit: { password: true }`.
    *

--- a/packages/gemi/auth/config.ts
+++ b/packages/gemi/auth/config.ts
@@ -26,6 +26,48 @@ export interface AuthConfig {
   // Extra claims merged into the session payload.
   extendSession?: <T extends User>(user: T) => Promise<any> | any;
 
+  /**
+   * **This one is not a notification, whatever the name suggests.** It runs
+   * *inside* the transaction that creates the user, after the row is written
+   * and before it commits, and a throw rolls the user back. Every other `onXxx`
+   * here fires after its work is committed and can only report; this one
+   * participates in the write.
+   *
+   * The past tense is worth distrusting, then, and it is deliberate that this
+   * paragraph comes first: an application that mistakes this for `onSignUp`
+   * with better timing, and swallows its own errors inside it, gets exactly the
+   * orphaned user the hook exists to prevent.
+   *
+   * That is what it is for: an application that must create rows *alongside*
+   * every user — an organization, a workspace, a default settings row — has
+   * nowhere else to do it atomically. `onSignUp` fires after the commit on both
+   * paths, so provisioning there leaves an orphaned user when the second insert
+   * fails, which is a failure that only turns up in production.
+   *
+   * Fires on all three creation paths — email/password sign-up, invited
+   * sign-up, and first OAuth sign-in — and receives the same password-stripped
+   * user the endpoint returns, so a hook that logs its argument does not log a
+   * credential hash.
+   *
+   * On the invited path the inviting organization's `Account` row is already
+   * written when this runs, so a hook provisioning an own workspace should
+   * check before adding a second one.
+   *
+   * Three constraints come from running inside the transaction:
+   *
+   * - **Errors thrown here reach the client as-is.** A `ValidationError` is a
+   *   400 on `POST /sign-up`; anything else is a 500. Either way no user is
+   *   created.
+   * - **Raw queries do not join it.** ORM calls at any depth do, automatically;
+   *   a hand-written Prisma or `DB` statement runs outside and survives the
+   *   rollback.
+   * - **`Promise.all` over ORM calls is not safe here.** The transaction holds
+   *   one reserved connection, so await them in sequence. Keep network and
+   *   filesystem I/O out entirely — the connection is held for as long as this
+   *   runs.
+   */
+  onUserCreated?: (user: User) => Promise<void>;
+
   onSignUp?: (
     user: User,
     verificationToken: string,
@@ -91,6 +133,9 @@ export function authConfigDefaults(
 
     extendSession: () => ({}),
 
+    // `async`, unlike its neighbours: the call site awaits it inside a
+    // transaction, so it has to be a promise rather than sometimes one.
+    onUserCreated: async () => {},
     onSignUp: () => {},
     onSignIn: () => {},
     onSignOut: () => {},

--- a/packages/gemi/auth/config.ts
+++ b/packages/gemi/auth/config.ts
@@ -53,14 +53,26 @@ export interface AuthConfig {
    * written when this runs, so a hook provisioning an own workspace should
    * check before adding a second one.
    *
-   * Three constraints come from running inside the transaction:
+   * Four constraints come from where this runs:
+   *
+   * - **Writes to a policied model need `Model.asSystem`.** This runs with no
+   *   user in scope — a sign-up has not authenticated anybody yet — so a policy
+   *   whose `scope` or `onCreate` reads `ctx.user` raises `PolicyDeniedError`
+   *   under deny-by-default, and the rollback takes the user with it. That is
+   *   the correct behaviour and the reason this hook is *not* wrapped in
+   *   `UserProvider.run`: suspending policies for application code is a
+   *   sentence somebody types, never something a framework does quietly. Say it
+   *   at the call site:
+   *
+   *       await Model.asSystem(() => Organization.create({ data }))
    *
    * - **Errors thrown here reach the client as-is.** A `ValidationError` is a
-   *   400 on `POST /sign-up`; anything else is a 500. Either way no user is
-   *   created.
-   * - **Raw queries do not join it.** ORM calls at any depth do, automatically;
-   *   a hand-written Prisma or `DB` statement runs outside and survives the
-   *   rollback.
+   *   400 on `POST /sign-up`; anything else is a 500. On the OAuth path there
+   *   is no form to fail — a throw is a 500 page mid-redirect. Either way no
+   *   user is created.
+   * - **Raw queries do not join the transaction.** ORM calls at any depth do,
+   *   automatically; a hand-written Prisma or `DB` statement runs outside and
+   *   survives the rollback.
    * - **`Promise.all` over ORM calls is not safe here.** The transaction holds
    *   one reserved connection, so await them in sequence. Keep network and
    *   filesystem I/O out entirely — the connection is held for as long as this

--- a/templates/saas-starter/app/config/auth.ts
+++ b/templates/saas-starter/app/config/auth.ts
@@ -19,6 +19,14 @@ export default defineAuthConfig({
   // Change this to true to only allow verified emails to login
   verifyEmail: false,
 
+  async onUserCreated(user: any) {
+    // This hook runs *inside* the transaction that creates the user, before it
+    // commits — provision an organization, a workspace, a default settings row
+    // here, and a throw rolls the user back with them. ORM queries join the
+    // transaction automatically; raw ones do not. Keep email and other I/O in
+    // `onSignUp` below, which fires after the commit.
+  },
+
   async onSignUp(user: any, token: string) {
     // This hook will be called when a user signs up
     // You can send email verification here

--- a/templates/saas-starter/app/config/auth.ts
+++ b/templates/saas-starter/app/config/auth.ts
@@ -25,6 +25,10 @@ export default defineAuthConfig({
     // here, and a throw rolls the user back with them. ORM queries join the
     // transaction automatically; raw ones do not. Keep email and other I/O in
     // `onSignUp` below, which fires after the commit.
+    //
+    // A sign-up has no authenticated user yet, so writes to a model carrying a
+    // policy have to say so: `Model.asSystem(() => Organization.create(...))`.
+    // Without it they raise `PolicyDeniedError` and the sign-up fails.
   },
 
   async onSignUp(user: any, token: string) {

--- a/templates/saas-starter/app/models/user-provider-policy.test.ts
+++ b/templates/saas-starter/app/models/user-provider-policy.test.ts
@@ -1,0 +1,173 @@
+import { SQL } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { UserProvider } from "gemi/kernel";
+import { DatabaseManager } from "gemi/database";
+import { Application } from "gemi/foundation";
+import { Model, clearPlanCache, register } from "gemi/orm";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import { applyMigrations } from "./scratch";
+import {
+  AccountModel,
+  MagicLinkTokenModel,
+  OrganizationInvitationModel,
+  OrganizationModel,
+  PasswordResetTokenModel,
+  SessionModel,
+  SocialAccountModel,
+  UserModel,
+} from "./generated";
+
+/**
+ * What `config.onUserCreated` may and may not do to a **policied** model.
+ *
+ * `UserProvider.transaction` deliberately does not wrap the hook in `asSystem`
+ * — the provider applies it per query, to its own reads and writes, and
+ * hoisting it would leave an application's provisioning writes unpoliced with
+ * nothing at the call site saying so.
+ *
+ * The consequence is the thing worth pinning, because it is a 500 on the very
+ * first sign-up rather than a subtle wrong answer: the hook runs with **no user
+ * in scope**, so a tenant scope reading `ctx.user` denies under
+ * deny-by-default. `docs/authentication.md` now documents `Model.asSystem` in
+ * the provisioning example for exactly this reason, and these two tests are
+ * what keep that documentation honest — the first version of it did not have
+ * the wrapper and would have 500'd for anyone who followed it.
+ *
+ * In its own file because `register` is global: pointing the name
+ * `Organization` at a policied subclass would otherwise change what every other
+ * test in a shared file queries.
+ */
+class PoliciedOrganization extends OrganizationModel {
+  // The ordinary shape of a tenant policy. Both members read `ctx.user`, which
+  // is what raises rather than silently returning or writing everything when
+  // nobody is in scope.
+  //
+  // `onCreate` is not optional decoration here: the ORM refuses a `create` on a
+  // model whose policy scopes reads and says nothing about inserts, because
+  // that combination reads as "confine reads to the caller, let an insert name
+  // any value it likes". So a scope-only policy could not reach the denial this
+  // file is about.
+  static $policies = [
+    {
+      scope: (ctx: any) => ({ id: ctx.user?.organizationId }),
+      onCreate: (ctx: any, data: any) => {
+        const owner = ctx.user;
+        return { ...data, description: `created by ${owner.name}` };
+      },
+    },
+  ];
+}
+
+register("Organization", PoliciedOrganization);
+
+describe("onUserCreated's scope, against a policied model", () => {
+  let workspace: string;
+  let database: DatabaseManager;
+  let raw: SQL;
+  let previous: Application | undefined;
+  let auth: UserProvider;
+
+  beforeAll(async () => {
+    workspace = mkdtempSync(join(tmpdir(), "gemi-auth-policy-"));
+    const path = join(workspace, "policy.db");
+    await applyMigrations(path);
+    const target = `sqlite://${path}`;
+
+    database = new DatabaseManager({ url: target });
+    raw = new SQL(target);
+
+    previous = Application.getInstance();
+    const application = new Application();
+    application.instance(DatabaseManager, database as never);
+    Application.setInstance(application);
+
+    auth = new UserProvider({
+      User: UserModel,
+      Session: SessionModel,
+      Account: AccountModel,
+      PasswordResetToken: PasswordResetTokenModel,
+      MagicLinkToken: MagicLinkTokenModel,
+      OrganizationInvitation: OrganizationInvitationModel,
+      SocialAccount: SocialAccountModel,
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await raw?.close();
+    await database?.close();
+    if (previous) Application.setInstance(previous);
+    if (workspace) rmSync(workspace, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    clearPlanCache();
+    for (const table of ["Account", "User", "Organization"]) {
+      await raw.unsafe(`DELETE FROM "${table}"`);
+    }
+  });
+
+  test("an unwrapped write to a policied model is denied, and rolls the user back", async () => {
+    await expect(
+      auth.transaction(async () => {
+        const user: any = await auth.createUser({
+          name: "A",
+          email: "a@x.test",
+        });
+        await PoliciedOrganization.create({
+          data: { name: `${user.name}'s org` },
+        });
+      }),
+    ).rejects.toThrow(/there is no user in scope/);
+
+    // The denial is the documented failure, and the rollback is what makes it
+    // survivable: no half-provisioned user is left behind to collide with a
+    // retry of the same address.
+    const users: any = await raw.unsafe(`SELECT "id" FROM "User"`);
+    expect([...users]).toHaveLength(0);
+  });
+
+  test("`Model.asSystem` inside the hook is the documented fix, and still joins the transaction", async () => {
+    const user: any = await auth.transaction(async () => {
+      const created: any = await auth.createUser({
+        name: "A",
+        email: "a@x.test",
+      });
+      await Model.asSystem(() =>
+        PoliciedOrganization.create({ data: { name: `${created.name}'s org` } }),
+      );
+      return created;
+    });
+
+    expect(user.email).toBe("a@x.test");
+    const orgs: any = await raw.unsafe(`SELECT "name" FROM "Organization"`);
+    expect([...orgs]).toHaveLength(1);
+  });
+
+  /**
+   * `asSystem` merges into the current scope rather than replacing it
+   * (`orm/context.ts`), so it does not drop the open transaction handle. Worth
+   * a test rather than a comment: the docs tell applications to wrap their
+   * provisioning in it, and if that silently escaped the transaction, the whole
+   * hook would be pointless — the rows it wrote would survive the rollback.
+   */
+  test("a rollback still reaches writes made inside `asSystem`", async () => {
+    await expect(
+      auth.transaction(async () => {
+        await auth.createUser({ name: "A", email: "a@x.test" });
+        await Model.asSystem(() =>
+          PoliciedOrganization.create({ data: { name: "orphan" } }),
+        );
+        throw new Error("provisioning failed");
+      }),
+    ).rejects.toThrow("provisioning failed");
+
+    const users: any = await raw.unsafe(`SELECT "id" FROM "User"`);
+    const orgs: any = await raw.unsafe(`SELECT "id" FROM "Organization"`);
+    expect([...users]).toHaveLength(0);
+    expect([...orgs]).toHaveLength(0);
+  });
+});

--- a/templates/saas-starter/app/models/user-provider.test.ts
+++ b/templates/saas-starter/app/models/user-provider.test.ts
@@ -179,6 +179,89 @@ function suite(label: string, url?: string) {
       expect([...stored][0].password).toBe("new-hash");
     });
 
+    /**
+     * `transaction` is the seam `config.onUserCreated` runs in, and the reason
+     * that hook exists rather than being another `onSignUp`: `AuthController`
+     * writes the user, writes whatever has to exist beside it, and calls the
+     * hook, all in here, so a throw from the hook takes the user with it.
+     *
+     * The hook itself is a config callback the controller invokes, and the
+     * controller needs an HTTP request to reach — what is testable here is the
+     * property the whole design rests on, which is that a throw after the
+     * insert leaves no user behind.
+     */
+    test("transaction rolls the user back when the callback throws", async () => {
+      await expect(
+        auth.transaction(async () => {
+          await auth.createUser({ name: "A", email: "a@x.test" });
+          // Standing in for a `config.onUserCreated` that failed — a
+          // provisioning insert that violated a constraint, say.
+          throw new Error("provisioning failed");
+        }),
+      ).rejects.toThrow("provisioning failed");
+
+      const rows: any = await raw.unsafe(
+        `SELECT "id" FROM "User" WHERE "email" = 'a@x.test'`,
+      );
+      expect([...rows]).toHaveLength(0);
+    });
+
+    /**
+     * The rollback has to cover what the hook itself wrote, not just the user —
+     * otherwise a failure halfway through provisioning leaves the orphan the
+     * hook exists to prevent, pointing at a user that no longer exists.
+     *
+     * Nothing is threaded through to make this happen: `Organization.create` is
+     * an ordinary ORM call several frames down, which is the property that
+     * makes an application's provisioning join the transaction without
+     * gemi handing it a `tx`.
+     */
+    test("transaction covers writes the callback makes through other models", async () => {
+      await expect(
+        auth.transaction(async () => {
+          const user: any = await auth.createUser({
+            name: "A",
+            email: "a@x.test",
+          });
+          await OrganizationModel.create({ data: { name: `${user.name}'s org` } });
+          throw new Error("provisioning failed");
+        }),
+      ).rejects.toThrow("provisioning failed");
+
+      const users: any = await raw.unsafe(`SELECT "id" FROM "User"`);
+      const orgs: any = await raw.unsafe(`SELECT "id" FROM "Organization"`);
+      expect([...users]).toHaveLength(0);
+      expect([...orgs]).toHaveLength(0);
+    });
+
+    test("transaction commits both when the callback returns", async () => {
+      const user: any = await auth.transaction(async () => {
+        const created: any = await auth.createUser({
+          name: "A",
+          email: "a@x.test",
+        });
+        const org: any = await OrganizationModel.create({
+          data: { name: "Acme" },
+        });
+        await auth.createAccount({
+          userId: created.id,
+          organizationId: org.id,
+          organizationRole: 0,
+        });
+        return created;
+      });
+
+      expect(user.email).toBe("a@x.test");
+      // The password strip survives the wrapper — the returned object is still
+      // the one `POST /sign-up` serialises.
+      expect("password" in user).toBe(false);
+
+      const accounts: any = await raw.unsafe(
+        `SELECT "userId" FROM "Account" WHERE "userId" = ${user.id}`,
+      );
+      expect([...accounts]).toHaveLength(1);
+    });
+
     test("findUserByEmailAddress without verification", async () => {
       await auth.createUser({ name: "A", email: "a@x.test" });
       const found: any = await auth.findUserByEmailAddress("a@x.test", false);


### PR DESCRIPTION
Closes #344. Closes #345.

## `onUserCreated`

An application that has to create rows *alongside* a user — an organization, a workspace, a default settings row — had nowhere to do it atomically. `onSignUp` fires after the user is committed on both paths, so provisioning there leaves an orphaned user when the second insert fails, and that is a failure that only turns up in production. The workaround was subclassing `UserProvider` to override `createUser`, which the docs recommended and which requires knowing that `createUser` is the only seam where atomicity is reachable.

`config.onUserCreated(user)` runs *inside* the transaction that writes the user, after the row and before the commit. A throw rolls the user back. It is the one hook here that participates in the write rather than reporting on it, which is what its docblock leads with — the past-tense name reads like its neighbours and is not one of them.

`UserProvider.transaction(fn)` is the seam it runs in. `AuthController` has no model to reach for, and a bare `Model.transaction` would open on the ambient connection rather than the one the provider's models are bound to. Deliberately **not** wrapped in `run`: `asSystem` stays applied per query, so an application's provisioning writes run under the same policy resolution as the rest of its code instead of silently unpoliced.

All three creation paths now write inside one transaction:

| Path | In the transaction |
| --- | --- |
| sign-up | `createUser` → `onUserCreated` |
| invited sign-up | `deleteInvitationById` → `createUser` → `createAccount` → `onUserCreated` |
| OAuth first login | `createUser` → `createSocialAccount` → `onUserCreated` |

Two writes moved inside beyond the hook itself, because the rollback is otherwise incoherent. `createSocialAccount` has a foreign key onto the user. `deleteInvitationById` used to run *before* creation, so a rollback would burn the invitation with no user to show for it and leave the invitee unable to retry.

## The OAuth token argument

`oauthCallback` handed `onSignUp` a `generateMagicLinkToken` result. That function is a pure hash and nothing persisted what it returned — `createMagicLinkToken`, which writes the `MagicLinkToken` row, was never called — so the value resolved in neither place a token can be looked up: not `User.verificationToken`, which `createUser` does not set here, and not the `MagicLinkToken` table. An app mailing a confirmation link carrying it sent every OAuth signup a link that could not resolve, and it tested clean against email/password signup, where the same parameter is the persisted verification token.

It now passes `""`. An OAuth user arrives with `emailVerifiedAt` already set, so there is nothing to verify, and `""` is what the email path already passes under `verifyEmail: false`. An app that does want to hand new OAuth users a magic link should mint a persisted one with `Auth.createMagicLink` from the hook.

## Tests

Three tests in the template's `user-provider.test.ts` cover the property the design rests on: a throw after the insert leaves no user, it also rolls back what the callback wrote through *other* models, and the commit case keeps the password strip. `AuthController` needs an HTTP request to reach, so the hook's own invocation is not covered there.

- `tsc --noEmit` clean, `oxlint` 0 errors
- `vitest run` in `packages/gemi`: 116 files, 2706 passed
- `vitest run app/models/user-provider.test.ts`: 24 passed

## Docs

`docs/authentication.md` gains an `onUserCreated` section and loses the note telling applications to provision inside a `createUser` override. The `Changing a query` example was swapped for one that is actually a query change and that exercises the `this.models` / `this.run` paragraph below it. `llms-full.txt` carries the page verbatim and was updated to match; the two were diffed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
