### PR TITLE
Mint the nanoid gemi was leaving to a database that has no default

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,21 +67,49 @@ code `1` on a finding, so it is worth a step in CI. It imports what it walks,
 which matters if a file under `app/models` does work on import; `--ignore` takes
 a comma-separated list, and the command prints what it skipped.
 
-## Regenerate, so registration stops guessing
+## Regenerate — this one is required
 
-Nothing breaks if you skip this, and it is one command:
+One command, and unlike the rest of this page it is not optional:
 
 ```sh
 bunx prisma generate
 ```
 
-The generator now marks each base it emits with `static $generated = true`, and
+**The schema artifact's version moved from 1 to 2**, so a `app/models/generated`
+emitted before 0.51 is now refused at registration with `StaleSchemaArtifactError`
+telling you to run exactly that. The bump is deliberate. Artifact version 1 also
+covered a *newer* artifact being read by an *older* runtime — the two do not
+travel together, because the generated directory is committed to git while the
+gemi version lives in a lockfile, so a teammate who pulls without installing had
+a real chance of pairing them. Version 1 said nothing in that case, and the
+mismatch surfaced as a column bound to NULL rather than as an error.
+
+Two things arrive with it, and both need the regenerate to take effect:
+
+- **`@default(nanoid())` and `@default(ulid())` now work.** Both were classified
+  as database-side defaults, and neither has a database default to fall back on
+   — Prisma fills them in its client. Every `create` on a model using one failed
+  on NOT NULL. See [docs/orm.md](./docs/orm.md#column-defaults).
+- **`@default(uuid(7))` mints a v7.** The version argument used to be dropped, so
+  a column declared v7 got random v4s — still valid UUIDs, no longer sorted by
+  creation time, and indistinguishable by eye.
+
+The generator also marks each base it emits with `static $generated = true`, and
 `Kernel.models` reads that mark to decide which of several classes claiming one
 name is the generated one and which is yours. Artifacts generated before 0.51
 carry no mark, so registration falls back to the older signal — whether a class
 declares `$schema` itself — which a subclass that redeclares `static $schema`
-defeats, handing the name to the base. That case fails loudly rather than
-silently: boot refuses it and names both classes. Regenerating removes it.
+defeats, handing the name to the base.
+
+### One schema may now fail to generate
+
+`@default(cuid(2))` is refused, naming the field. Prisma builds a cuid2 through
+`@paralleldrive/cuid2`, which hashes with SHA-3; gemi cannot reproduce that, and
+the two formats do not agree anyway — a cuid2 is 24 characters and letter-first,
+a cuid v1 is 25 and always starts `c`. Before this, gemi dropped the argument and
+wrote v1s into the column, so the rows it created and the rows Prisma created had
+different shapes. Use `@default(cuid(1))`, or keep the Prisma client for that
+model.
 
 ## `@prisma/client` is gone
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2972,6 +2972,75 @@ database than `prisma generate` saw, so refusing here refused the column for Pos
 now declines it at query time instead, with a message naming the dialect. `Decimal[]` is still
 refused, by the row above rather than by a rule about lists.
 
+### Column defaults
+
+`@default(...)` is filled by one of two parties, and the split is not a style choice — it is forced
+by the DDL Prisma emits. Read the migration for a model with the usual four columns:
+
+```sql
+"id"        INTEGER  NOT NULL PRIMARY KEY AUTOINCREMENT,     -- @default(autoincrement())
+"publicId"  TEXT     NOT NULL,                               -- @default(cuid())
+"createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,     -- @default(now())
+"updatedAt" DATETIME NOT NULL,                               -- @updatedAt
+```
+
+`publicId` and `updatedAt` carry **no database default at all**. Prisma generates them in its
+client, so a row inserted without them violates NOT NULL — if gemi does not supply them, nothing
+does.
+
+| `@default(...)` | Filled by | Notes |
+| --- | --- | --- |
+| `autoincrement()` | the database | The one identity column the database really does own. |
+| `dbgenerated(...)` | the database | You said so in as many words. |
+| `cuid()` | gemi | cuid v1, the format Prisma still emits — 25 characters, `c` and 24 lowercase alphanumerics. |
+| `uuid()` | gemi | v4. |
+| `nanoid()` / `nanoid(n)` | gemi | nanoid's url alphabet; 21 characters, or `n`. |
+| `now()` | gemi | Not the database's `CURRENT_TIMESTAMP` — see below. |
+| a literal | gemi | `@default("en-US")`, `@default(2)`, `@default(false)`. |
+| `@updatedAt` | gemi | Not a `@default` at all, and stamped on **create** as well as on update. |
+
+**`now()` is generated in gemi even though the column has a database default**, and the reason is
+storage form rather than correctness. SQLite stores `CURRENT_TIMESTAMP` as the *text*
+`YYYY-MM-DD HH:MM:SS`, while Prisma stores a `DateTime` as integer milliseconds. Letting the
+database fill it would write a different shape than Prisma writes, and drop sub-second precision.
+
+One instant is resolved per operation, not per field, so `createdAt` and `updatedAt` come back from
+a `create` as the *same* timestamp — which is what Prisma does:
+
+```ts
+const user = await User.create({ data: { email: "a@b.c" } })
+user.createdAt.getTime() === user.updatedAt.getTime()   // true
+```
+
+**A value you pass beats the default**, for every row in the table above:
+
+```ts
+await User.create({ data: { email: "a@b.c", publicId: "fixed", createdAt: new Date(2020, 0) } })
+```
+
+And a nullable column with no default is **omitted from the insert** rather than bound as `null`,
+so a database default you added by hand in a migration still applies.
+
+#### A default the generator does not recognise
+
+A function default this generator has no case for — one Prisma adds after your version of gemi, or
+a provider-specific one like `auto()` — is recorded as the database's, because that is the only
+safe guess. On a **required** column that guess may be a row the driver will reject, so
+`prisma generate` says so:
+
+```
+gemi ORM: Organization.publicId is required and defaults to auto(), which this generator
+does not recognise. It is recorded as a database-side default, so the ORM will omit the
+column on insert — and if auto() is a default Prisma fills in its own client, the column
+has none in the database and every write to Organization will fail on NOT NULL. Make the
+field optional, give it a default the ORM knows, or upgrade gemi.
+```
+
+A warning rather than a refusal: most `dbgenerated(...)` columns really are the database's, and a
+nullable one costs nothing either way. It is a warning rather than *nothing* because the generator
+is the only place that still knows the function's **name** — by the time the driver rejects the
+row, all you have is a NOT NULL violation on a column that ought to have had a default.
+
 ### Your model class
 
 The generated base is not the class you write code on. Subclass it, put the subclass in a barrel,

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2988,16 +2988,32 @@ by the DDL Prisma emits. Read the migration for a model with the usual four colu
 client, so a row inserted without them violates NOT NULL — if gemi does not supply them, nothing
 does.
 
+Prisma's client fills **four** id functions this way — `cuid`, `uuid`, `nanoid` and `ulid` — and
+every one of them gets a bare `TEXT NOT NULL`. All four are gemi's to supply:
+
 | `@default(...)` | Filled by | Notes |
 | --- | --- | --- |
 | `autoincrement()` | the database | The one identity column the database really does own. |
 | `dbgenerated(...)` | the database | You said so in as many words. |
-| `cuid()` | gemi | cuid v1, the format Prisma still emits — 25 characters, `c` and 24 lowercase alphanumerics. |
-| `uuid()` | gemi | v4. |
+| `cuid()` / `cuid(1)` | gemi | cuid v1 — 25 characters, `c` and 24 lowercase alphanumerics. |
+| `cuid(2)` | — | **Refused at generate time.** See below. |
+| `uuid()` / `uuid(4)` | gemi | v4: 122 random bits. |
+| `uuid(7)` | gemi | v7: 48 bits of big-endian milliseconds, then randomness — so v7s sort by creation time. |
 | `nanoid()` / `nanoid(n)` | gemi | nanoid's url alphabet; 21 characters, or `n`. |
+| `ulid()` | gemi | 26 characters of Crockford base 32, timestamp first, so ULIDs also sort by creation time. |
 | `now()` | gemi | Not the database's `CURRENT_TIMESTAMP` — see below. |
 | a literal | gemi | `@default("en-US")`, `@default(2)`, `@default(false)`. |
 | `@updatedAt` | gemi | Not a `@default` at all, and stamped on **create** as well as on update. |
+
+**The version argument is part of the default, not a detail of it.** `uuid()` and `uuid(7)` are one
+identical `TEXT` column apart in the DDL and two different kinds of identifier in practice — a v7 is
+time-ordered and a v4 is not, and both render as a UUID, so a column filled with the wrong one looks
+completely normal. gemi records the version in the generated artifact and mints what the schema
+asked for. The same goes for `nanoid(n)`'s length.
+
+`uuid(7)`'s ordering is per *millisecond*: everything after the timestamp is random, so two ids
+minted in the same millisecond have no defined order between them. RFC 9562 makes the monotonic
+counter that would fix that optional, and neither Prisma nor gemi implements it.
 
 **`now()` is generated in gemi even though the column has a database default**, and the reason is
 storage form rather than correctness. SQLite stores `CURRENT_TIMESTAMP` as the *text*
@@ -3021,25 +3037,40 @@ await User.create({ data: { email: "a@b.c", publicId: "fixed", createdAt: new Da
 And a nullable column with no default is **omitted from the insert** rather than bound as `null`,
 so a database default you added by hand in a migration still applies.
 
+#### Defaults the generator refuses
+
+Two, and both are refused for the reason `Decimal` is: emitting a value that silently disagrees with
+what Prisma would have written is worse than a generation error naming the field.
+
+| `@default(...)` | Why |
+| --- | --- |
+| `cuid(2)` | Prisma mints a cuid2 through `@paralleldrive/cuid2`, which hashes with SHA-3. gemi cannot reproduce it, and the formats do not even agree: a cuid2 is 24 characters and letter-first, a v1 is 25 and always starts `c`. Use `cuid(1)`, or keep the Prisma client for this model. |
+| `uuid(n)`, n ∉ {4, 7} | The only UUID versions Prisma generates. Its own client throws for the rest; gemi says so at generate time instead. |
+
 #### A default the generator does not recognise
 
-A function default this generator has no case for — one Prisma adds after your version of gemi, or
-a provider-specific one like `auto()` — is recorded as the database's, because that is the only
-safe guess. On a **required** column that guess may be a row the driver will reject, so
-`prisma generate` says so:
+A function default this generator has no case for — one Prisma adds after your version of gemi, or a
+provider-specific one — is recorded as the database's, because that is the only guess available. If
+that guess is wrong the column has no default anywhere, so `prisma generate` says so:
 
 ```
-gemi ORM: Organization.publicId is required and defaults to auto(), which this generator
-does not recognise. It is recorded as a database-side default, so the ORM will omit the
-column on insert — and if auto() is a default Prisma fills in its own client, the column
-has none in the database and every write to Organization will fail on NOT NULL. Make the
-field optional, give it a default the ORM knows, or upgrade gemi.
+gemi ORM: Organization.publicId defaults to auto(), which this generator does not
+recognise, so it is recorded as a database-side default and the ORM will omit the column
+on insert. If Prisma fills that default in its own client — as it does for cuid, uuid,
+nanoid and ulid — the column has no default in the database either, so every write to
+Organization either fails on NOT NULL or silently stores NULL. Give the field a default
+the ORM knows, or upgrade gemi.
 ```
 
-A warning rather than a refusal: most `dbgenerated(...)` columns really are the database's, and a
-nullable one costs nothing either way. It is a warning rather than *nothing* because the generator
-is the only place that still knows the function's **name** — by the time the driver rejects the
-row, all you have is a NOT NULL violation on a column that ought to have had a default.
+**A nullable column gets the same warning, and it is the one worth reading.** A required column
+fails loudly on the first write. A nullable one takes the NULL, and nothing fails at insert or at
+read — you find out later, when a lookup by that id returns nothing. That is why the warning does
+not suggest making the field optional: it would convert the loud failure into the silent one.
+
+A warning rather than a refusal, though: most `dbgenerated(...)` columns really are the database's,
+and refusing would break schemas that generate and run correctly today. It is a warning rather than
+*nothing* because the generator is the only place that still knows the function's **name** — by the
+time a row is rejected, all you have is a column that ought to have had a default.
 
 ### Your model class
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -174,16 +174,32 @@ by the DDL Prisma emits. Read the migration for a model with the usual four colu
 client, so a row inserted without them violates NOT NULL — if gemi does not supply them, nothing
 does.
 
+Prisma's client fills **four** id functions this way — `cuid`, `uuid`, `nanoid` and `ulid` — and
+every one of them gets a bare `TEXT NOT NULL`. All four are gemi's to supply:
+
 | `@default(...)` | Filled by | Notes |
 | --- | --- | --- |
 | `autoincrement()` | the database | The one identity column the database really does own. |
 | `dbgenerated(...)` | the database | You said so in as many words. |
-| `cuid()` | gemi | cuid v1, the format Prisma still emits — 25 characters, `c` and 24 lowercase alphanumerics. |
-| `uuid()` | gemi | v4. |
+| `cuid()` / `cuid(1)` | gemi | cuid v1 — 25 characters, `c` and 24 lowercase alphanumerics. |
+| `cuid(2)` | — | **Refused at generate time.** See below. |
+| `uuid()` / `uuid(4)` | gemi | v4: 122 random bits. |
+| `uuid(7)` | gemi | v7: 48 bits of big-endian milliseconds, then randomness — so v7s sort by creation time. |
 | `nanoid()` / `nanoid(n)` | gemi | nanoid's url alphabet; 21 characters, or `n`. |
+| `ulid()` | gemi | 26 characters of Crockford base 32, timestamp first, so ULIDs also sort by creation time. |
 | `now()` | gemi | Not the database's `CURRENT_TIMESTAMP` — see below. |
 | a literal | gemi | `@default("en-US")`, `@default(2)`, `@default(false)`. |
 | `@updatedAt` | gemi | Not a `@default` at all, and stamped on **create** as well as on update. |
+
+**The version argument is part of the default, not a detail of it.** `uuid()` and `uuid(7)` are one
+identical `TEXT` column apart in the DDL and two different kinds of identifier in practice — a v7 is
+time-ordered and a v4 is not, and both render as a UUID, so a column filled with the wrong one looks
+completely normal. gemi records the version in the generated artifact and mints what the schema
+asked for. The same goes for `nanoid(n)`'s length.
+
+`uuid(7)`'s ordering is per *millisecond*: everything after the timestamp is random, so two ids
+minted in the same millisecond have no defined order between them. RFC 9562 makes the monotonic
+counter that would fix that optional, and neither Prisma nor gemi implements it.
 
 **`now()` is generated in gemi even though the column has a database default**, and the reason is
 storage form rather than correctness. SQLite stores `CURRENT_TIMESTAMP` as the *text*
@@ -207,25 +223,40 @@ await User.create({ data: { email: "a@b.c", publicId: "fixed", createdAt: new Da
 And a nullable column with no default is **omitted from the insert** rather than bound as `null`,
 so a database default you added by hand in a migration still applies.
 
+#### Defaults the generator refuses
+
+Two, and both are refused for the reason `Decimal` is: emitting a value that silently disagrees with
+what Prisma would have written is worse than a generation error naming the field.
+
+| `@default(...)` | Why |
+| --- | --- |
+| `cuid(2)` | Prisma mints a cuid2 through `@paralleldrive/cuid2`, which hashes with SHA-3. gemi cannot reproduce it, and the formats do not even agree: a cuid2 is 24 characters and letter-first, a v1 is 25 and always starts `c`. Use `cuid(1)`, or keep the Prisma client for this model. |
+| `uuid(n)`, n ∉ {4, 7} | The only UUID versions Prisma generates. Its own client throws for the rest; gemi says so at generate time instead. |
+
 #### A default the generator does not recognise
 
-A function default this generator has no case for — one Prisma adds after your version of gemi, or
-a provider-specific one like `auto()` — is recorded as the database's, because that is the only
-safe guess. On a **required** column that guess may be a row the driver will reject, so
-`prisma generate` says so:
+A function default this generator has no case for — one Prisma adds after your version of gemi, or a
+provider-specific one — is recorded as the database's, because that is the only guess available. If
+that guess is wrong the column has no default anywhere, so `prisma generate` says so:
 
 ```
-gemi ORM: Organization.publicId is required and defaults to auto(), which this generator
-does not recognise. It is recorded as a database-side default, so the ORM will omit the
-column on insert — and if auto() is a default Prisma fills in its own client, the column
-has none in the database and every write to Organization will fail on NOT NULL. Make the
-field optional, give it a default the ORM knows, or upgrade gemi.
+gemi ORM: Organization.publicId defaults to auto(), which this generator does not
+recognise, so it is recorded as a database-side default and the ORM will omit the column
+on insert. If Prisma fills that default in its own client — as it does for cuid, uuid,
+nanoid and ulid — the column has no default in the database either, so every write to
+Organization either fails on NOT NULL or silently stores NULL. Give the field a default
+the ORM knows, or upgrade gemi.
 ```
 
-A warning rather than a refusal: most `dbgenerated(...)` columns really are the database's, and a
-nullable one costs nothing either way. It is a warning rather than *nothing* because the generator
-is the only place that still knows the function's **name** — by the time the driver rejects the
-row, all you have is a NOT NULL violation on a column that ought to have had a default.
+**A nullable column gets the same warning, and it is the one worth reading.** A required column
+fails loudly on the first write. A nullable one takes the NULL, and nothing fails at insert or at
+read — you find out later, when a lookup by that id returns nothing. That is why the warning does
+not suggest making the field optional: it would convert the loud failure into the silent one.
+
+A warning rather than a refusal, though: most `dbgenerated(...)` columns really are the database's,
+and refusing would break schemas that generate and run correctly today. It is a warning rather than
+*nothing* because the generator is the only place that still knows the function's **name** — by the
+time a row is rejected, all you have is a column that ought to have had a default.
 
 ### Your model class
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -158,6 +158,75 @@ database than `prisma generate` saw, so refusing here refused the column for Pos
 now declines it at query time instead, with a message naming the dialect. `Decimal[]` is still
 refused, by the row above rather than by a rule about lists.
 
+### Column defaults
+
+`@default(...)` is filled by one of two parties, and the split is not a style choice — it is forced
+by the DDL Prisma emits. Read the migration for a model with the usual four columns:
+
+```sql
+"id"        INTEGER  NOT NULL PRIMARY KEY AUTOINCREMENT,     -- @default(autoincrement())
+"publicId"  TEXT     NOT NULL,                               -- @default(cuid())
+"createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,     -- @default(now())
+"updatedAt" DATETIME NOT NULL,                               -- @updatedAt
+```
+
+`publicId` and `updatedAt` carry **no database default at all**. Prisma generates them in its
+client, so a row inserted without them violates NOT NULL — if gemi does not supply them, nothing
+does.
+
+| `@default(...)` | Filled by | Notes |
+| --- | --- | --- |
+| `autoincrement()` | the database | The one identity column the database really does own. |
+| `dbgenerated(...)` | the database | You said so in as many words. |
+| `cuid()` | gemi | cuid v1, the format Prisma still emits — 25 characters, `c` and 24 lowercase alphanumerics. |
+| `uuid()` | gemi | v4. |
+| `nanoid()` / `nanoid(n)` | gemi | nanoid's url alphabet; 21 characters, or `n`. |
+| `now()` | gemi | Not the database's `CURRENT_TIMESTAMP` — see below. |
+| a literal | gemi | `@default("en-US")`, `@default(2)`, `@default(false)`. |
+| `@updatedAt` | gemi | Not a `@default` at all, and stamped on **create** as well as on update. |
+
+**`now()` is generated in gemi even though the column has a database default**, and the reason is
+storage form rather than correctness. SQLite stores `CURRENT_TIMESTAMP` as the *text*
+`YYYY-MM-DD HH:MM:SS`, while Prisma stores a `DateTime` as integer milliseconds. Letting the
+database fill it would write a different shape than Prisma writes, and drop sub-second precision.
+
+One instant is resolved per operation, not per field, so `createdAt` and `updatedAt` come back from
+a `create` as the *same* timestamp — which is what Prisma does:
+
+```ts
+const user = await User.create({ data: { email: "a@b.c" } })
+user.createdAt.getTime() === user.updatedAt.getTime()   // true
+```
+
+**A value you pass beats the default**, for every row in the table above:
+
+```ts
+await User.create({ data: { email: "a@b.c", publicId: "fixed", createdAt: new Date(2020, 0) } })
+```
+
+And a nullable column with no default is **omitted from the insert** rather than bound as `null`,
+so a database default you added by hand in a migration still applies.
+
+#### A default the generator does not recognise
+
+A function default this generator has no case for — one Prisma adds after your version of gemi, or
+a provider-specific one like `auto()` — is recorded as the database's, because that is the only
+safe guess. On a **required** column that guess may be a row the driver will reject, so
+`prisma generate` says so:
+
+```
+gemi ORM: Organization.publicId is required and defaults to auto(), which this generator
+does not recognise. It is recorded as a database-side default, so the ORM will omit the
+column on insert — and if auto() is a default Prisma fills in its own client, the column
+has none in the database and every write to Organization will fail on NOT NULL. Make the
+field optional, give it a default the ORM knows, or upgrade gemi.
+```
+
+A warning rather than a refusal: most `dbgenerated(...)` columns really are the database's, and a
+nullable one costs nothing either way. It is a warning rather than *nothing* because the generator
+is the only place that still knows the function's **name** — by the time the driver rejects the
+row, all you have is a NOT NULL violation on a column that ought to have had a default.
+
 ### Your model class
 
 The generated base is not the class you write code on. Subclass it, put the subclass in a barrel,

--- a/packages/gemi/bin/orm-generator.ts
+++ b/packages/gemi/bin/orm-generator.ts
@@ -106,10 +106,18 @@ generatorHandler({
     // Prisma hands the DMMF over directly, so nothing here parses
     // `schema.prisma`. Enums come along for the model bases, which type an enum
     // column as the union of its members.
+    //
+    // `emit.ts` collects its diagnostics rather than printing them, so that it
+    // stays the pure function of the DMMF its header claims to be. This is the
+    // process boundary — where `warnOnPrismaVersion` and `warnOnDatasource`
+    // already are — so this is where they get written.
+    const warnings: string[] = [];
     const files = emitArtifacts(
       options.dmmf.datamodel.models,
       options.dmmf.datamodel.enums,
+      warnings,
     );
+    for (const warning of warnings) console.warn(warning);
 
     await mkdir(output, { recursive: true });
     for (const [name, content] of Object.entries(files)) {

--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -2,11 +2,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { DMMF } from "@prisma/generator-helper";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { SCHEMA_ARTIFACT_VERSION } from "../../orm/schema";
 import {
-  RECOGNISED_DEFAULTS,
   UnsupportedSchemaError,
   buildModelSchemas,
   emitArtifacts,
@@ -283,21 +282,26 @@ describe("buildModelSchemas()", () => {
    * migration emits for it carries no `DEFAULT`, so nothing supplied it and the
    * first `create` on the model failed on NOT NULL.
    */
-  test("classifies nanoid as its own kind, not as dbgenerated", () => {
-    const [only] = buildModelSchemas([
+  /** The `DefaultSpec` one function default translates to. */
+  const specFor = (def: unknown) =>
+    buildModelSchemas([
       model({
         fields: [
           field({
             name: "publicId",
             type: "String",
             hasDefaultValue: true,
-            default: { name: "nanoid", args: [10] },
+            default: def as DMMF.FieldDefault,
           }),
         ],
       }),
-    ]);
+    ])[0].fields.publicId.default;
 
-    expect(only.fields.publicId.default).toEqual({ kind: "nanoid", length: 10 });
+  test("classifies nanoid as its own kind, not as dbgenerated", () => {
+    expect(specFor({ name: "nanoid", args: [10] })).toEqual({
+      kind: "nanoid",
+      length: 10,
+    });
   });
 
   /**
@@ -307,24 +311,40 @@ describe("buildModelSchemas()", () => {
    */
   test("records the length nanoid was written with", () => {
     const lengthOf = (args: (string | number)[]) =>
-      buildModelSchemas([
-        model({
-          fields: [
-            field({
-              name: "publicId",
-              type: "String",
-              hasDefaultValue: true,
-              default: { name: "nanoid", args },
-            }),
-          ],
-        }),
-      ])[0].fields.publicId.default?.length;
+      specFor({ name: "nanoid", args })?.length;
 
     expect(lengthOf([10])).toBe(10);
     // `nanoid()` — written without one, which Prisma means as 21. Recorded
     // rather than left absent, so the artifact says what the column holds
     // instead of making the runtime know Prisma's default.
     expect(lengthOf([])).toBe(21);
+  });
+
+  /**
+   * `ulid()` was the case #350's first fix missed. It had no `case`, so it fell
+   * to `default:` and came out `dbgenerated` — the column omitted from every
+   * insert, against a `TEXT NOT NULL` with no database default. The same bug,
+   * one function over.
+   */
+  test("classifies ulid, the fourth client-side id function", () => {
+    expect(specFor({ name: "ulid", args: [] })).toEqual({ kind: "ulid" });
+  });
+
+  /**
+   * The UUID version is load-bearing in a way the artifact has to carry: a v7
+   * is time-ordered and a v4 is not, and both render as a UUID, so minting the
+   * wrong one is invisible in the column. `uuid()` normalises to `args: [4]` in
+   * the DMMF, which is checked here rather than assumed.
+   */
+  test.each([
+    [[], 4],
+    [[4], 4],
+    [[7], 7],
+  ])("records uuid(%s) as version %i", (args, version) => {
+    expect(specFor({ name: "uuid", args: args as number[] })).toEqual({
+      kind: "uuid",
+      version,
+    });
   });
 
   test("describes an implicit many-to-many join table", () => {
@@ -545,31 +565,30 @@ describe("buildModelSchemas()", () => {
 });
 
 /**
- * The other half of #350: not the `nanoid` fix, but the reason it took an
+ * The other half of #350: not the classification fix, but the reason it took an
  * afternoon to find.
  *
- * A function default this generator does not recognise is recorded as
+ * A function default this generator has no case for is recorded as
  * `dbgenerated` — a guess that the database fills the column. It is the right
  * guess most of the time and there is no way to check it from the DMMF, but
- * when it is wrong on a *required* column the result is a row the driver
- * rejects, and nothing says so until the first `create`. By then the function's
- * name is gone; all the author has is a NOT NULL violation on a column that
- * "should have a default".
+ * when it is wrong the row is either rejected or quietly stores NULL, and
+ * nothing says so until long after generation. By then the function's name is
+ * gone; all the author has is a column that "should have had a default".
  *
  * This is the one moment the name is still in hand, so this is where it gets
  * said. A warning rather than a refusal: a `dbgenerated(...)` column really is
  * the database's, and breaking a schema that generates and runs fine today
  * would be a worse trade than a noisy one.
+ *
+ * **Collected rather than printed.** `emit.ts` opens by promising to be a pure
+ * function of the DMMF, and a `console.warn` inside `fieldSchema` broke that —
+ * every test of `buildModelSchemas` would have had to stub the console. The
+ * diagnostics come back through an out-parameter and `bin/orm-generator.ts`
+ * prints them, beside the two process-boundary warnings already there.
  */
-describe("an unrecognised function default on a required column warns", () => {
-  const warn = () => vi.spyOn(console, "warn").mockImplementation(() => {});
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
+describe("a default the generator cannot translate is reported", () => {
   const withDefault = (
-    name: string,
+    def: unknown,
     over: Partial<DMMF.Field> = {},
   ): DMMF.Model =>
     model({
@@ -578,30 +597,69 @@ describe("an unrecognised function default on a required column warns", () => {
           name: "publicId",
           type: "String",
           hasDefaultValue: true,
-          default: { name, args: [] },
+          default: def as DMMF.FieldDefault,
           ...over,
         }),
       ],
     });
 
-  test("it names the model, the field and the function", () => {
-    const spy = warn();
-    buildModelSchemas([withDefault("auto")]);
+  /** Runs the generator and hands back only what it wanted to say. */
+  const warningsFor = (dmmf: DMMF.Model): string[] => {
+    const warnings: string[] = [];
+    buildModelSchemas([dmmf], warnings);
+    return warnings;
+  };
 
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy.mock.calls[0][0]).toContain("User.publicId");
-    expect(spy.mock.calls[0][0]).toContain("auto()");
+  test("it names the model, the field and the function", () => {
+    const [warning, ...rest] = warningsFor(withDefault({ name: "auto", args: [] }));
+
+    expect(rest).toEqual([]);
+    expect(warning).toContain("User.publicId");
+    expect(warning).toContain("auto()");
   });
 
   /**
-   * A nullable column takes NULL, so the guess costs nothing there and the
-   * warning would be noise — which is how a warning stops being read.
+   * **A nullable column warns too**, and the previous version of this test
+   * asserted the opposite — "a nullable column is nobody's problem" — which is
+   * true for a genuinely database-side default and false for the case the
+   * warning exists to catch.
+   *
+   * An unrecognised *client-side* default on a nullable column is omitted from
+   * the insert, the database has no `DEFAULT` to supply, and the row stores
+   * NULL where an id belonged. Nothing fails at insert or at read; it surfaces
+   * when a lookup by that id finds nothing. That is the silent half of #350,
+   * and the early return was hiding it.
    */
-  test("a nullable column is nobody's problem", () => {
-    const spy = warn();
-    buildModelSchemas([withDefault("auto", { isRequired: false })]);
+  test("a nullable column warns as well, because NULL is the silent failure", () => {
+    expect(
+      warningsFor(withDefault({ name: "auto", args: [] }, { isRequired: false })),
+    ).toHaveLength(1);
+  });
 
-    expect(spy).not.toHaveBeenCalled();
+  /**
+   * ...and the advice no longer offers to make the field optional, which was
+   * the first remedy the old text suggested. It converts a loud NOT NULL
+   * failure into exactly the silent NULL above.
+   */
+  test("it does not suggest making the field optional", () => {
+    const [warning] = warningsFor(withDefault({ name: "auto", args: [] }));
+
+    expect(warning).not.toMatch(/optional/i);
+  });
+
+  /**
+   * `isFunctionDefault` deliberately admits an object default with no `name`,
+   * and its comment argues that path must keep falling through to
+   * `dbgenerated`. That is the case with the *least* evidence behind the guess
+   * — the generator called the column the database's with no name at all — so
+   * it is the last one that should be skipped. It used to be, by a `!name`
+   * early return.
+   */
+  test("a function default with no name warns rather than being skipped", () => {
+    const [warning, ...rest] = warningsFor(withDefault({ args: [] }));
+
+    expect(rest).toEqual([]);
+    expect(warning).toContain("User.publicId");
   });
 
   /**
@@ -609,37 +667,100 @@ describe("an unrecognised function default on a required column warns", () => {
    * the author saying in as many words that the database supplies it — the one
    * case where the guess is not a guess.
    *
-   * Read off `RECOGNISED_DEFAULTS` rather than listed again here: a third copy
-   * of the same six names is one more place for them to drift apart, and this
-   * way a name added to the set has to actually be quiet to pass.
+   * These used to be read from an exported `RECOGNISED_DEFAULTS` set, which was
+   * a hand-maintained copy of the switch's own case labels. The warning now
+   * lives in the switch's `default:` arm, so the set is gone and this list is
+   * the only place the names are written twice — as a test should.
    */
-  test.each([...RECOGNISED_DEFAULTS])(
-    "%s() is recognised and says nothing",
-    (name) => {
-      const spy = warn();
-      buildModelSchemas([withDefault(name)]);
-
-      expect(spy).not.toHaveBeenCalled();
-    },
-  );
+  test.each([
+    { name: "autoincrement", args: [] },
+    { name: "cuid", args: [1] },
+    { name: "uuid", args: [4] },
+    { name: "uuid", args: [7] },
+    { name: "nanoid", args: [] },
+    { name: "nanoid", args: [10] },
+    { name: "ulid", args: [] },
+    { name: "now", args: [] },
+    { name: "dbgenerated", args: [] },
+  ])("$name($args) is recognised and says nothing", (def) => {
+    expect(warningsFor(withDefault(def))).toEqual([]);
+  });
 
   /** A literal is not a function default and never reached the guess. */
   test("a literal default says nothing", () => {
-    const spy = warn();
-    buildModelSchemas([
-      model({
-        fields: [
-          field({
-            name: "locale",
-            type: "String",
-            hasDefaultValue: true,
-            default: "en-US" as unknown as DMMF.FieldDefault,
-          }),
-        ],
-      }),
-    ]);
+    expect(warningsFor(withDefault("en-US"))).toEqual([]);
+  });
 
-    expect(spy).not.toHaveBeenCalled();
+  /**
+   * The DMMF types an argument as `string | number`, so a non-number is not
+   * excluded by the types. Falling back to 21 silently would record an
+   * authoritative-looking width that the schema never asked for — and on a
+   * `@db.VarChar(10)` column every insert would then overflow.
+   */
+  test("a non-numeric nanoid length is reported rather than assumed", () => {
+    const [warning, ...rest] = warningsFor(
+      withDefault({ name: "nanoid", args: ["10"] }),
+    );
+
+    expect(rest).toEqual([]);
+    expect(warning).toContain("User.publicId");
+    expect(warning).toContain("21");
+  });
+});
+
+/**
+ * Two defaults Prisma accepts and gemi cannot reproduce, refused at generation
+ * time rather than silently mis-minted.
+ *
+ * This is `UNSUPPORTED_SCALARS`' argument applied to a default instead of a
+ * type: emitting a value that silently disagrees with what Prisma would have
+ * written is the failure mode the whole artifact exists to prevent, and it is
+ * strictly worse than a generation error naming the field.
+ */
+describe("defaults the generator refuses", () => {
+  const withDefault = (def: unknown): DMMF.Model =>
+    model({
+      fields: [
+        field({
+          name: "publicId",
+          type: "String",
+          hasDefaultValue: true,
+          default: def as DMMF.FieldDefault,
+        }),
+      ],
+    });
+
+  /**
+   * Prisma builds a cuid2 with `@paralleldrive/cuid2`, which hashes with SHA-3.
+   * gemi cannot reproduce that, and the two do not even agree on shape — a
+   * cuid2 is 24 characters and letter-first, a v1 is 25 and always starts `c`.
+   *
+   * Before this, `cuid(2)` dropped its argument and minted a v1, so a column
+   * declared cuid2 got ids of a different format on every gemi-written row.
+   */
+  test("cuid(2), which needs a hash gemi does not carry", () => {
+    expect(() => buildModelSchemas([withDefault({ name: "cuid", args: [2] })])).toThrow(
+      UnsupportedSchemaError,
+    );
+    expect(() => buildModelSchemas([withDefault({ name: "cuid", args: [2] })])).toThrow(
+      /User\.publicId is @default\(cuid\(2\)\)/,
+    );
+  });
+
+  /** Prisma's own client throws for these; this is the same answer, earlier. */
+  test("a UUID version Prisma does not generate", () => {
+    expect(() => buildModelSchemas([withDefault({ name: "uuid", args: [1] })])).toThrow(
+      /only UUID versions Prisma generates are 4 and 7/,
+    );
+  });
+
+  test("cuid(1) and uuid(4)/uuid(7) are not refused", () => {
+    expect(() =>
+      buildModelSchemas([withDefault({ name: "cuid", args: [1] })]),
+    ).not.toThrow();
+    expect(() =>
+      buildModelSchemas([withDefault({ name: "uuid", args: [7] })]),
+    ).not.toThrow();
   });
 });
 

--- a/packages/gemi/bin/orm/emit.test.ts
+++ b/packages/gemi/bin/orm/emit.test.ts
@@ -2,10 +2,11 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { DMMF } from "@prisma/generator-helper";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { SCHEMA_ARTIFACT_VERSION } from "../../orm/schema";
 import {
+  RECOGNISED_DEFAULTS,
   UnsupportedSchemaError,
   buildModelSchemas,
   emitArtifacts,
@@ -276,6 +277,56 @@ describe("buildModelSchemas()", () => {
     expect(Object.keys(only.fields)).toEqual(["id"]);
   });
 
+  /**
+   * #350. `nanoid()` reached the `default:` branch and came out `dbgenerated`,
+   * which reads as "the database supplies this" — and the column Prisma's
+   * migration emits for it carries no `DEFAULT`, so nothing supplied it and the
+   * first `create` on the model failed on NOT NULL.
+   */
+  test("classifies nanoid as its own kind, not as dbgenerated", () => {
+    const [only] = buildModelSchemas([
+      model({
+        fields: [
+          field({
+            name: "publicId",
+            type: "String",
+            hasDefaultValue: true,
+            default: { name: "nanoid", args: [10] },
+          }),
+        ],
+      }),
+    ]);
+
+    expect(only.fields.publicId.default).toEqual({ kind: "nanoid", length: 10 });
+  });
+
+  /**
+   * The argument is part of the default, and this artifact is the only place it
+   * survives: the migration writes a plain `TEXT` for both, so a runtime reading
+   * a spec with no length cannot tell `nanoid(10)` from `nanoid()`.
+   */
+  test("records the length nanoid was written with", () => {
+    const lengthOf = (args: (string | number)[]) =>
+      buildModelSchemas([
+        model({
+          fields: [
+            field({
+              name: "publicId",
+              type: "String",
+              hasDefaultValue: true,
+              default: { name: "nanoid", args },
+            }),
+          ],
+        }),
+      ])[0].fields.publicId.default?.length;
+
+    expect(lengthOf([10])).toBe(10);
+    // `nanoid()` — written without one, which Prisma means as 21. Recorded
+    // rather than left absent, so the artifact says what the column holds
+    // instead of making the runtime know Prisma's default.
+    expect(lengthOf([])).toBe(21);
+  });
+
   test("describes an implicit many-to-many join table", () => {
     const tagged = model({
       name: "Tag",
@@ -490,6 +541,105 @@ describe("buildModelSchemas()", () => {
 
     // ...and the composite primary key it references survives too.
     expect(ledger.primaryKey).toEqual(["tenantId", "code"]);
+  });
+});
+
+/**
+ * The other half of #350: not the `nanoid` fix, but the reason it took an
+ * afternoon to find.
+ *
+ * A function default this generator does not recognise is recorded as
+ * `dbgenerated` — a guess that the database fills the column. It is the right
+ * guess most of the time and there is no way to check it from the DMMF, but
+ * when it is wrong on a *required* column the result is a row the driver
+ * rejects, and nothing says so until the first `create`. By then the function's
+ * name is gone; all the author has is a NOT NULL violation on a column that
+ * "should have a default".
+ *
+ * This is the one moment the name is still in hand, so this is where it gets
+ * said. A warning rather than a refusal: a `dbgenerated(...)` column really is
+ * the database's, and breaking a schema that generates and runs fine today
+ * would be a worse trade than a noisy one.
+ */
+describe("an unrecognised function default on a required column warns", () => {
+  const warn = () => vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const withDefault = (
+    name: string,
+    over: Partial<DMMF.Field> = {},
+  ): DMMF.Model =>
+    model({
+      fields: [
+        field({
+          name: "publicId",
+          type: "String",
+          hasDefaultValue: true,
+          default: { name, args: [] },
+          ...over,
+        }),
+      ],
+    });
+
+  test("it names the model, the field and the function", () => {
+    const spy = warn();
+    buildModelSchemas([withDefault("auto")]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toContain("User.publicId");
+    expect(spy.mock.calls[0][0]).toContain("auto()");
+  });
+
+  /**
+   * A nullable column takes NULL, so the guess costs nothing there and the
+   * warning would be noise — which is how a warning stops being read.
+   */
+  test("a nullable column is nobody's problem", () => {
+    const spy = warn();
+    buildModelSchemas([withDefault("auto", { isRequired: false })]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The defaults the generator handles are handled, and `dbgenerated(...)` is
+   * the author saying in as many words that the database supplies it — the one
+   * case where the guess is not a guess.
+   *
+   * Read off `RECOGNISED_DEFAULTS` rather than listed again here: a third copy
+   * of the same six names is one more place for them to drift apart, and this
+   * way a name added to the set has to actually be quiet to pass.
+   */
+  test.each([...RECOGNISED_DEFAULTS])(
+    "%s() is recognised and says nothing",
+    (name) => {
+      const spy = warn();
+      buildModelSchemas([withDefault(name)]);
+
+      expect(spy).not.toHaveBeenCalled();
+    },
+  );
+
+  /** A literal is not a function default and never reached the guess. */
+  test("a literal default says nothing", () => {
+    const spy = warn();
+    buildModelSchemas([
+      model({
+        fields: [
+          field({
+            name: "locale",
+            type: "String",
+            hasDefaultValue: true,
+            default: "en-US" as unknown as DMMF.FieldDefault,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -124,6 +124,24 @@ function isFunctionDefault(
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Prisma's `nanoid()` with no argument. */
+const NANOID_DEFAULT_LENGTH = 21;
+
+/**
+ * The length `@default(nanoid(n))` was written with.
+ *
+ * DMMF types an argument as `string | number`, so a non-number is not
+ * unreachable by the types even though the Prisma parser rejects one — and the
+ * failure it would cause is the quiet kind: `undefined` reaches
+ * `clientSideValue`, which falls back to 21, and every id is silently the wrong
+ * width. Falling back here instead keeps the wrong width from also being
+ * unrecorded, and there is one place that decides it.
+ */
+function nanoidLength(args: readonly (string | number)[] | undefined): number {
+  const [size] = args ?? [];
+  return typeof size === "number" ? size : NANOID_DEFAULT_LENGTH;
+}
+
 function defaultSpec(field: DMMF.Field): DefaultSpec | undefined {
   if (!field.hasDefaultValue || field.default === undefined) return undefined;
 
@@ -136,15 +154,91 @@ function defaultSpec(field: DMMF.Field): DefaultSpec | undefined {
       case "now":
       case "dbgenerated":
         return { kind: value.name };
+      // `nanoid()` is a *client-side* default, like `cuid()` and `uuid()` and
+      // unlike everything else in this switch: the column Prisma's own
+      // migration emits carries no `DEFAULT`, so a row inserted without the
+      // value violates NOT NULL (#350). It is the only one of the three that
+      // takes an argument, and the argument has to come with it — see
+      // `DefaultSpec.length`.
+      case "nanoid":
+        return { kind: "nanoid", length: nanoidLength(value.args) };
       default:
-        // An unrecognised function default (`auto()`, `nanoid()`, a future
-        // addition) still tells the runtime "the database supplies this", which
-        // is all iteration 4 needs to know when it omits the column on insert.
+        // An unrecognised function default (`auto()`, a future addition) still
+        // tells the runtime "the database supplies this", which is all
+        // iteration 4 needs to know when it omits the column on insert.
+        //
+        // `warnOnUnrecognisedDefault` is the other half: for a *required* column
+        // that guess is a row the driver will reject, and this is the last
+        // moment anything can say so before the first write does.
         return { kind: "dbgenerated" };
     }
   }
 
   return { kind: "value", value: value as unknown };
+}
+
+/**
+ * Every function default `defaultSpec` has a `case` for.
+ *
+ * A second list of the same names, and the duplication is worth naming rather
+ * than hiding: a `switch` is not enumerable, so there is nothing to derive this
+ * from. What drift costs is asymmetric, which is why the copy is tolerable. A
+ * name added to the switch and not to this set produces a warning about a
+ * default that is in fact handled — noise, and noise is how a warning stops
+ * being read. A name added here and not to the switch silences a warning that
+ * should have fired, which is the state before #350.
+ *
+ * Exported so the test that asserts each of these stays quiet reads the set
+ * rather than becoming a third copy of it.
+ */
+export const RECOGNISED_DEFAULTS = new Set([
+  "autoincrement",
+  "cuid",
+  "uuid",
+  "nanoid",
+  "now",
+  "dbgenerated",
+]);
+
+/**
+ * A required column whose default this generator did not recognise.
+ *
+ * The `default:` branch above assumes the database fills the column. When that
+ * assumption is wrong — the default is client-side, as `nanoid()` was — nothing
+ * fails at generation time and nothing fails at boot: the field *looks* handled,
+ * because it was classified. The first `create` on the model is what fails, with
+ * a NOT NULL violation from the driver naming the column but not the reason,
+ * and it fails on every write after that.
+ *
+ * A warning rather than a refusal, and rather than nothing:
+ *
+ * - A refusal would break a schema that generates and runs fine today. Most
+ *   `dbgenerated(...)` columns really are the database's, and a nullable one is
+ *   nobody's problem either way.
+ * - Silence is what made #350 cost an afternoon. The generator is the only place
+ *   that sees the function's *name*; by the time the driver rejects the row, the
+ *   name is gone and all that is left is a column that "should have a default".
+ *
+ * Prisma's own client-side defaults are all handled above, so in practice this
+ * fires for a provider-specific default (`auto()` on MongoDB) or one Prisma adds
+ * after this version of gemi — which is exactly the set worth naming out loud.
+ */
+function warnOnUnrecognisedDefault(model: string, field: DMMF.Field): void {
+  if (!field.isRequired) return;
+
+  const value = field.default;
+  if (!isFunctionDefault(value)) return;
+  if (!value.name || RECOGNISED_DEFAULTS.has(value.name)) return;
+
+  console.warn(
+    `gemi ORM: ${model}.${field.name} is required and defaults to ` +
+      `${value.name}(), which this generator does not recognise. It is ` +
+      `recorded as a database-side default, so the ORM will omit the column on ` +
+      `insert — and if ${value.name}() is a default Prisma fills in its own ` +
+      `client, the column has none in the database and every write to ` +
+      `${model} will fail on NOT NULL. Make the field optional, give it a ` +
+      `default the ORM knows, or upgrade gemi.`,
+  );
 }
 
 function fieldSchema(model: string, field: DMMF.Field): FieldSchema {
@@ -176,6 +270,8 @@ function fieldSchema(model: string, field: DMMF.Field): FieldSchema {
 
   const def = defaultSpec(field);
   if (def) schema.default = def;
+
+  warnOnUnrecognisedDefault(model, field);
 
   return schema;
 }

--- a/packages/gemi/bin/orm/emit.ts
+++ b/packages/gemi/bin/orm/emit.ts
@@ -1,6 +1,7 @@
 import type { DMMF } from "@prisma/generator-helper";
 
 import {
+  NANOID_DEFAULT_LENGTH,
   SCHEMA_ARTIFACT_VERSION,
   type DefaultSpec,
   type FieldSchema,
@@ -124,124 +125,166 @@ function isFunctionDefault(
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-/** Prisma's `nanoid()` with no argument. */
-const NANOID_DEFAULT_LENGTH = 21;
-
 /**
- * The length `@default(nanoid(n))` was written with.
+ * The first argument, when it is a number.
  *
- * DMMF types an argument as `string | number`, so a non-number is not
- * unreachable by the types even though the Prisma parser rejects one — and the
- * failure it would cause is the quiet kind: `undefined` reaches
- * `clientSideValue`, which falls back to 21, and every id is silently the wrong
- * width. Falling back here instead keeps the wrong width from also being
- * unrecorded, and there is one place that decides it.
+ * DMMF types an argument as `string | number`, so a non-number is not excluded
+ * by the types even though Prisma's parser only produces numbers here. The
+ * caller warns rather than falling back silently: a `nanoid` recorded at the
+ * wrong width, or a `uuid` at the wrong version, is authoritative-looking and
+ * wrong, and nothing downstream can tell it apart from what the schema asked
+ * for.
  */
-function nanoidLength(args: readonly (string | number)[] | undefined): number {
-  const [size] = args ?? [];
-  return typeof size === "number" ? size : NANOID_DEFAULT_LENGTH;
+function numericArg(
+  args: readonly (string | number)[] | undefined,
+): number | undefined {
+  const [first] = args ?? [];
+  return typeof first === "number" ? first : undefined;
 }
 
-function defaultSpec(field: DMMF.Field): DefaultSpec | undefined {
+/**
+ * Translates one DMMF default, and reports what it could not translate.
+ *
+ * **The warning lives in the `default:` arm rather than in a second pass over
+ * the same field**, which is where #350's review put it. There used to be a
+ * `RECOGNISED_DEFAULTS` set restating every `case` label so a separate function
+ * could ask "did the switch handle this?" — a hand-maintained copy of a list
+ * the switch already is. This arm *is* that question, so the copy is gone and
+ * the drift it could suffer is now unrepresentable.
+ */
+function defaultSpec(
+  model: string,
+  field: DMMF.Field,
+  warnings: string[],
+): DefaultSpec | undefined {
   if (!field.hasDefaultValue || field.default === undefined) return undefined;
 
   const value = field.default;
-  if (isFunctionDefault(value)) {
-    switch (value.name) {
-      case "autoincrement":
-      case "cuid":
-      case "uuid":
-      case "now":
-      case "dbgenerated":
-        return { kind: value.name };
-      // `nanoid()` is a *client-side* default, like `cuid()` and `uuid()` and
-      // unlike everything else in this switch: the column Prisma's own
-      // migration emits carries no `DEFAULT`, so a row inserted without the
-      // value violates NOT NULL (#350). It is the only one of the three that
-      // takes an argument, and the argument has to come with it — see
-      // `DefaultSpec.length`.
-      case "nanoid":
-        return { kind: "nanoid", length: nanoidLength(value.args) };
-      default:
-        // An unrecognised function default (`auto()`, a future addition) still
-        // tells the runtime "the database supplies this", which is all
-        // iteration 4 needs to know when it omits the column on insert.
-        //
-        // `warnOnUnrecognisedDefault` is the other half: for a *required* column
-        // that guess is a row the driver will reject, and this is the last
-        // moment anything can say so before the first write does.
-        return { kind: "dbgenerated" };
-    }
-  }
+  if (!isFunctionDefault(value)) return { kind: "value", value: value as unknown };
 
-  return { kind: "value", value: value as unknown };
+  const column = `${model}.${field.name}`;
+
+  switch (value.name) {
+    case "autoincrement":
+    case "now":
+    case "dbgenerated":
+      return { kind: value.name };
+
+    // The four Prisma fills in its own client. Each gets a `TEXT NOT NULL` with
+    // no `DEFAULT`, so each is gemi's to supply or the row does not insert —
+    // #350, and `ulid` is the one its first fix still missed.
+    case "ulid":
+      return { kind: "ulid" };
+
+    case "cuid": {
+      // The DMMF normalises a bare `cuid()` to `args: [1]`, so this is always
+      // present in practice; absent means a hand-built DMMF, and v1 is what
+      // `cuid()` has always meant.
+      const version = numericArg(value.args) ?? 1;
+      if (version !== 1) {
+        // Refused rather than recorded, and rather than silently minting a v1.
+        // Prisma builds a cuid2 with `@paralleldrive/cuid2`, which hashes with
+        // SHA-3; gemi cannot reproduce that without vendoring the hash, and the
+        // two formats do not even agree on length — 24 characters against v1's
+        // 25. Emitting a v1 here is what the generator did before, which put
+        // ids of the wrong shape in a column Prisma would fill differently.
+        throw new UnsupportedSchemaError(
+          `${column} is @default(cuid(${version})), which the gemi ORM cannot ` +
+            `generate: Prisma mints a cuid2 through @paralleldrive/cuid2, ` +
+            `whose output gemi cannot reproduce. Use @default(cuid(1)), or ` +
+            `keep the Prisma client for this model.`,
+        );
+      }
+      return { kind: "cuid" };
+    }
+
+    case "uuid": {
+      const version = numericArg(value.args) ?? 4;
+      if (version !== 4 && version !== 7) {
+        // Prisma's own client throws "Invalid UUID generator arguments" for
+        // these; saying so at generation time is the same answer, earlier.
+        throw new UnsupportedSchemaError(
+          `${column} is @default(uuid(${version})), and the only UUID ` +
+            `versions Prisma generates are 4 and 7.`,
+        );
+      }
+      return { kind: "uuid", version };
+    }
+
+    case "nanoid": {
+      const length = numericArg(value.args);
+      if (length === undefined && (value.args?.length ?? 0) > 0) {
+        warnings.push(
+          `gemi ORM: ${column} is @default(nanoid(${String(value.args?.[0])})), ` +
+            `whose argument is not a number. The length was recorded as ` +
+            `${NANOID_DEFAULT_LENGTH}, so every id gemi writes to this column ` +
+            `will be ${NANOID_DEFAULT_LENGTH} characters — check the schema.`,
+        );
+      }
+      return { kind: "nanoid", length: length ?? NANOID_DEFAULT_LENGTH };
+    }
+
+    default:
+      warnings.push(unrecognisedDefaultWarning(column, model, value.name));
+      return { kind: "dbgenerated" };
+  }
 }
 
 /**
- * Every function default `defaultSpec` has a `case` for.
+ * A function default this generator has no case for.
  *
- * A second list of the same names, and the duplication is worth naming rather
- * than hiding: a `switch` is not enumerable, so there is nothing to derive this
- * from. What drift costs is asymmetric, which is why the copy is tolerable. A
- * name added to the switch and not to this set produces a warning about a
- * default that is in fact handled — noise, and noise is how a warning stops
- * being read. A name added here and not to the switch silences a warning that
- * should have fired, which is the state before #350.
+ * It is recorded as the database's, which is the only guess available. When the
+ * guess is wrong — the default is one Prisma fills client-side, as `nanoid()`
+ * and `ulid()` both were — nothing fails at generation time and nothing fails
+ * at boot, because the field *looks* handled: it was classified.
  *
- * Exported so the test that asserts each of these stays quiet reads the set
- * rather than becoming a third copy of it.
+ * **Both outcomes are reported, not just the loud one.** This used to return
+ * early for a nullable column, on the reasoning that "a nullable one is nobody's
+ * problem either way". That is true for a genuinely database-side default and
+ * false for exactly the case the warning exists to catch: an unrecognised
+ * *client-side* default on a nullable column is omitted from the insert, the
+ * database has no `DEFAULT` to supply, and the row lands with NULL where an id
+ * belonged. Nothing fails at insert or at read. It surfaces much later, when a
+ * lookup by that id finds nothing.
+ *
+ * For the same reason the old text's first suggestion — "make the field
+ * optional" — is gone. It converted a loud NOT NULL failure into that silent
+ * one.
+ *
+ * A warning rather than a refusal: most `dbgenerated(...)` columns really are
+ * the database's, and refusing would break schemas that generate and run
+ * correctly today. But silence is what made #350 cost an afternoon — the
+ * generator is the only place that still knows the function's *name*, and by
+ * the time a row is rejected all that is left is a column that "should have had
+ * a default".
  */
-export const RECOGNISED_DEFAULTS = new Set([
-  "autoincrement",
-  "cuid",
-  "uuid",
-  "nanoid",
-  "now",
-  "dbgenerated",
-]);
+function unrecognisedDefaultWarning(
+  column: string,
+  model: string,
+  name: string | undefined,
+): string {
+  // `isFunctionDefault` deliberately admits an object default carrying no
+  // `name`, and that path is the *strongest* case for this warning rather than
+  // one to skip: the generator called the column the database's with no name to
+  // base the guess on at all.
+  const called = name ? `${name}()` : "a function this generator cannot name";
 
-/**
- * A required column whose default this generator did not recognise.
- *
- * The `default:` branch above assumes the database fills the column. When that
- * assumption is wrong — the default is client-side, as `nanoid()` was — nothing
- * fails at generation time and nothing fails at boot: the field *looks* handled,
- * because it was classified. The first `create` on the model is what fails, with
- * a NOT NULL violation from the driver naming the column but not the reason,
- * and it fails on every write after that.
- *
- * A warning rather than a refusal, and rather than nothing:
- *
- * - A refusal would break a schema that generates and runs fine today. Most
- *   `dbgenerated(...)` columns really are the database's, and a nullable one is
- *   nobody's problem either way.
- * - Silence is what made #350 cost an afternoon. The generator is the only place
- *   that sees the function's *name*; by the time the driver rejects the row, the
- *   name is gone and all that is left is a column that "should have a default".
- *
- * Prisma's own client-side defaults are all handled above, so in practice this
- * fires for a provider-specific default (`auto()` on MongoDB) or one Prisma adds
- * after this version of gemi — which is exactly the set worth naming out loud.
- */
-function warnOnUnrecognisedDefault(model: string, field: DMMF.Field): void {
-  if (!field.isRequired) return;
-
-  const value = field.default;
-  if (!isFunctionDefault(value)) return;
-  if (!value.name || RECOGNISED_DEFAULTS.has(value.name)) return;
-
-  console.warn(
-    `gemi ORM: ${model}.${field.name} is required and defaults to ` +
-      `${value.name}(), which this generator does not recognise. It is ` +
-      `recorded as a database-side default, so the ORM will omit the column on ` +
-      `insert — and if ${value.name}() is a default Prisma fills in its own ` +
-      `client, the column has none in the database and every write to ` +
-      `${model} will fail on NOT NULL. Make the field optional, give it a ` +
-      `default the ORM knows, or upgrade gemi.`,
+  return (
+    `gemi ORM: ${column} defaults to ${called}, which this generator does not ` +
+    `recognise, so it is recorded as a database-side default and the ORM will ` +
+    `omit the column on insert. If Prisma fills that default in its own client ` +
+    `— as it does for cuid, uuid, nanoid and ulid — the column has no default ` +
+    `in the database either, so every write to ${model} either fails on NOT ` +
+    `NULL or silently stores NULL. Give the field a default the ORM knows, or ` +
+    `upgrade gemi.`
   );
 }
 
-function fieldSchema(model: string, field: DMMF.Field): FieldSchema {
+function fieldSchema(
+  model: string,
+  field: DMMF.Field,
+  warnings: string[],
+): FieldSchema {
   // Key order here is the key order in the emitted file. Keep it stable.
   const schema: FieldSchema = {
     name: field.name,
@@ -268,10 +311,8 @@ function fieldSchema(model: string, field: DMMF.Field): FieldSchema {
   // admitted as a list of something no dialect can round-trip one of.
   if (field.isList) schema.isList = true;
 
-  const def = defaultSpec(field);
+  const def = defaultSpec(model, field, warnings);
   if (def) schema.default = def;
-
-  warnOnUnrecognisedDefault(model, field);
 
   return schema;
 }
@@ -361,6 +402,7 @@ function uniques(model: DMMF.Model): string[][] {
 export function buildModelSchema(
   model: DMMF.Model,
   byRelationName: Map<string, { model: string; field: DMMF.Field }[]>,
+  warnings: string[] = [],
 ): ModelSchema {
   const fields: Record<string, FieldSchema> = {};
   const relations: Record<string, RelationSchema> = {};
@@ -378,7 +420,7 @@ export function buildModelSchema(
       // types, so omitting them keeps our result shape identical to Prisma's.
       continue;
     }
-    fields[field.name] = fieldSchema(model.name, field);
+    fields[field.name] = fieldSchema(model.name, field, warnings);
   }
 
   const primaryKey = model.primaryKey
@@ -397,6 +439,7 @@ export function buildModelSchema(
 
 export function buildModelSchemas(
   models: readonly DMMF.Model[],
+  warnings: string[] = [],
 ): ModelSchema[] {
   const byRelationName = new Map<
     string,
@@ -415,7 +458,7 @@ export function buildModelSchemas(
   // Prisma schema does not churn the generated diff.
   return [...models]
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
-    .map((model) => buildModelSchema(model, byRelationName));
+    .map((model) => buildModelSchema(model, byRelationName, warnings));
 }
 
 // `JSON.stringify` is the serializer on purpose: the emitted metadata is plain
@@ -1263,11 +1306,29 @@ function enumMap(enums: readonly DMMF.DatamodelEnum[]): EnumMap {
   return out;
 }
 
+/**
+ * `warnings` is an out-parameter rather than a return value or a `console.warn`,
+ * and both alternatives were tried on the way here.
+ *
+ * Printing from this file is what #350's review objected to, and the header
+ * above is why: *"Everything here is a pure function of the DMMF so the emitters
+ * can be unit tested with no Prisma CLI and no database"*. A `console.warn` in
+ * `fieldSchema` makes `buildModelSchemas` write to stderr, so every unit test of
+ * it has to tolerate or stub console output, and the stated invariant stops
+ * being true. `bin/orm-generator.ts` already owns that boundary — it holds
+ * `warnOnPrismaVersion` and `warnOnDatasource` — and now prints these too.
+ *
+ * Widening the return type instead would have rippled through every call in
+ * `emit.test.ts`, which destructures the schemas directly. A defaulted
+ * out-parameter leaves those calls alone and lets the tests that *are* about
+ * diagnostics pass an array and read it.
+ */
 export function emitArtifacts(
   models: readonly DMMF.Model[],
   enums: readonly DMMF.DatamodelEnum[] = [],
+  warnings: string[] = [],
 ): Record<GeneratedFile, string> {
-  const schemas = buildModelSchemas(models);
+  const schemas = buildModelSchemas(models, warnings);
   return {
     "schema.ts": emitSchemaFile(schemas),
     "models.ts": emitModelsFile(schemas, enumMap(enums)),

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -95,25 +95,27 @@ describe("create", () => {
    * fixture changed: what is being pinned is that a `nanoid` spec reaches the
    * statement, not anything about `Account`.
    */
-  test("a nanoid default reaches the insert", () => {
-    const withNanoid = {
+  test.each([
+    [{ kind: "nanoid", length: 10 } as const, 10],
+    // `ulid()` is the one #350's first fix missed — no `case`, so it was
+    // classified `dbgenerated` and omitted exactly as `nanoid` had been.
+    [{ kind: "ulid" } as const, 26],
+  ])("a %s default reaches the insert", (spec, width) => {
+    const withSpec = {
       ...account,
       fields: {
         ...account.fields,
-        publicId: {
-          ...account.fields.publicId,
-          default: { kind: "nanoid", length: 10 } as const,
-        },
+        publicId: { ...account.fields.publicId, default: spec },
       },
     };
 
-    const compiled = compileWrite(withNanoid, "create", { data: {} }, sqlite);
+    const compiled = compileWrite(withSpec, "create", { data: {} }, sqlite);
     expect(compiled.text.split(" values ")[0]).toContain(`"publicId"`);
 
     // And the value is the width the schema wrote, which is the half that only
     // shows up later: an id of the wrong length is still an id.
     const values = compiled.bind({ data: {} }, createBindContext());
-    expect(String(values[0])).toHaveLength(10);
+    expect(String(values[0])).toHaveLength(width);
   });
 
   test("@updatedAt is stamped on create, not only on update", () => {

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -85,6 +85,37 @@ describe("create", () => {
     expect(createdAt).toBe(updatedAt);
   });
 
+  /**
+   * #350, at the level the bug was actually felt: `@default(nanoid())` was
+   * classified `dbgenerated`, so `hasClientSideValue` said no, so the column was
+   * left out of the insert — and the column Prisma's migration emits for it
+   * carries no `DEFAULT`, so the driver rejected the row on NOT NULL.
+   *
+   * The fixtures use `cuid()`, so the field is swapped here rather than a
+   * fixture changed: what is being pinned is that a `nanoid` spec reaches the
+   * statement, not anything about `Account`.
+   */
+  test("a nanoid default reaches the insert", () => {
+    const withNanoid = {
+      ...account,
+      fields: {
+        ...account.fields,
+        publicId: {
+          ...account.fields.publicId,
+          default: { kind: "nanoid", length: 10 } as const,
+        },
+      },
+    };
+
+    const compiled = compileWrite(withNanoid, "create", { data: {} }, sqlite);
+    expect(compiled.text.split(" values ")[0]).toContain(`"publicId"`);
+
+    // And the value is the width the schema wrote, which is the half that only
+    // shows up later: an id of the wrong length is still an id.
+    const values = compiled.bind({ data: {} }, createBindContext());
+    expect(String(values[0])).toHaveLength(10);
+  });
+
   test("@updatedAt is stamped on create, not only on update", () => {
     const compiled = text("create", { data: { email: "a@b.c" } });
     expect(compiled).toContain(`"updatedAt"`);

--- a/packages/gemi/orm/defaults.test.ts
+++ b/packages/gemi/orm/defaults.test.ts
@@ -4,6 +4,8 @@ import {
   clientSideValue,
   createCuid,
   createNanoid,
+  createUlid,
+  createUuid,
   hasClientSideValue,
   isClientSideDefault,
 } from "./defaults";
@@ -276,14 +278,132 @@ describe("createNanoid matches the ids the Prisma client mints", () => {
 });
 
 /**
+ * A ULID is a timestamp and then randomness, and the ordering is the property:
+ * base 32 preserves byte order, so sorting ULIDs as strings sorts them by the
+ * moment they were minted. That is the part a naive `toString(32)` would break,
+ * so it is the part worth pinning.
+ */
+describe("createUlid matches the ids the Prisma client mints", () => {
+  const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+  test("26 characters of Crockford base 32", () => {
+    const ulid = createUlid();
+
+    expect(ulid).toHaveLength(26);
+    for (const symbol of ulid) expect(ALPHABET).toContain(symbol);
+  });
+
+  /** `I`, `L`, `O` and `U` are the four Crockford leaves out. */
+  test("it never emits the ambiguous letters", () => {
+    const ids = Array.from({ length: 200 }, () => createUlid()).join("");
+
+    expect(ids).not.toMatch(/[ILOU]/);
+  });
+
+  /**
+   * The whole point of the format. Two ULIDs a millisecond apart must compare
+   * in that order as plain strings — which is what fails if the timestamp is
+   * rendered with a variable width, because then the fields stop lining up.
+   */
+  test("ids sort lexicographically by the time they were minted", () => {
+    const early = createUlid(1_700_000_000_000);
+    const late = createUlid(1_700_000_000_001);
+    const muchLater = createUlid(1_900_000_000_000);
+
+    expect(early < late).toBe(true);
+    expect(late < muchLater).toBe(true);
+  });
+
+  /** The first ten characters are the clock, so they are shared at one instant. */
+  test("the timestamp block is the first ten characters", () => {
+    const at = 1_700_000_000_000;
+
+    expect(createUlid(at).slice(0, 10)).toBe(createUlid(at).slice(0, 10));
+    // ...and the remaining sixteen are not, or the id would be a constant.
+    expect(createUlid(at).slice(10)).not.toBe(createUlid(at).slice(10));
+  });
+});
+
+/**
+ * v4 and v7 are both UUIDs on the wire and only one of them is time-ordered, so
+ * every field that distinguishes them is invisible in the rendered string. That
+ * is exactly why they are asserted rather than eyeballed.
+ */
+describe("createUuid honours the version the schema asked for", () => {
+  const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-([0-9a-f])[0-9a-f]{3}-([89ab])[0-9a-f]{3}-[0-9a-f]{12}$/;
+
+  test("the default is v4", () => {
+    expect(createUuid()).toMatch(UUID);
+    expect(createUuid().match(UUID)![1]).toBe("4");
+  });
+
+  test("v7 sets the version nibble and the variant", () => {
+    const match = createUuid(7).match(UUID);
+
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("7");
+    // RFC 9562's variant is the two high bits `10`, which renders as 8, 9, a
+    // or b in the first character of the fourth group.
+    expect("89ab").toContain(match![2]);
+  });
+
+  /**
+   * The reason a schema writes `uuid(7)`: the first 48 bits are big-endian
+   * milliseconds, so v7s sort by creation time and land beside each other in a
+   * B-tree. Minting a v4 loses that silently, which is what gemi did.
+   */
+  test("v7 embeds the current time, big-endian, in the first 48 bits", () => {
+    const before = Date.now();
+    const uuid = createUuid(7);
+    const after = Date.now();
+
+    const stamp = Number.parseInt(uuid.slice(0, 8) + uuid.slice(9, 13), 16);
+
+    expect(stamp).toBeGreaterThanOrEqual(before);
+    expect(stamp).toBeLessThanOrEqual(after);
+  });
+
+  /**
+   * The ordering v7 actually guarantees is **per millisecond**, not per call:
+   * inside one millisecond the 74 bits after the timestamp are random, so two
+   * ids minted together have no defined order. RFC 9562 offers a monotonic
+   * counter for that case as an option, and neither Prisma's generator nor this
+   * one takes it.
+   *
+   * Worth pinning at the granularity that is real rather than the one that
+   * sounds better — the first version of this test minted 20 ids in a loop,
+   * which all landed in the same millisecond and compared in random order.
+   */
+  test("v7s from different milliseconds compare in time order", () => {
+    const at = 1_700_000_000_000;
+    const ids = Array.from({ length: 20 }, (_, i) => {
+      vi.spyOn(Date, "now").mockReturnValue(at + i);
+      return createUuid(7);
+    });
+    vi.restoreAllMocks();
+
+    expect([...ids].sort()).toEqual(ids);
+  });
+
+  test("an id is minted per call", () => {
+    expect(createUuid(7)).not.toBe(createUuid(7));
+    expect(createUuid(4)).not.toBe(createUuid(4));
+  });
+});
+
+/**
  * `autoincrement()` and `dbgenerated(...)` stay with the database; everything
  * else gemi supplies. Written as an exhaustive record so that adding a
  * `DefaultKind` without deciding which side of the split it falls on is a type
  * error rather than an untested branch.
  *
- * `nanoid` is the kind that arrived by getting this wrong (#350): it was not a
- * `DefaultKind` at all, so it fell into `dbgenerated`, and the exhaustive record
- * could not notice a member that did not exist.
+ * `nanoid` and `ulid` are the kinds that arrived by getting this wrong (#350
+ * and its review): neither was a `DefaultKind` at all, so both fell into
+ * `dbgenerated`, and an exhaustive record cannot notice a member that does not
+ * exist. What the record *does* catch is the next one, which is why the
+ * predicate below is now an allowlist — a kind added to the union with no arm
+ * in `clientSideValue` is answered `false` and omitted, rather than answered
+ * `true` and bound as NULL.
  */
 describe("isClientSideDefault splits gemi's defaults from the database's", () => {
   const expected: Record<DefaultKind, boolean> = {
@@ -292,6 +412,7 @@ describe("isClientSideDefault splits gemi's defaults from the database's", () =>
     cuid: true,
     uuid: true,
     nanoid: true,
+    ulid: true,
     now: true,
     value: true,
   };
@@ -300,6 +421,21 @@ describe("isClientSideDefault splits gemi's defaults from the database's", () =>
     expect(isClientSideDefault({ kind: kind as DefaultKind })).toBe(
       isClientSide,
     );
+  });
+
+  /**
+   * The property the allowlist exists for, and the one the denylist got wrong.
+   *
+   * A kind this runtime has never heard of — a newer artifact against an older
+   * gemi — used to answer `true`, because it was neither `autoincrement` nor
+   * `dbgenerated`. The column then joined the insert, `clientSideValue` had no
+   * arm for it and returned `undefined`, and the dialect encoded that as NULL:
+   * a required column fails, a nullable one silently stores NULL in every row.
+   *
+   * Answering `false` omits the column instead, which is the loud failure.
+   */
+  test("a kind this runtime does not know is left to the database", () => {
+    expect(isClientSideDefault({ kind: "sequence" as DefaultKind })).toBe(false);
   });
 });
 
@@ -393,7 +529,36 @@ describe("clientSideValue produces one field's value", () => {
     ).toHaveLength(21);
   });
 
-  test.each(["cuid", "uuid", "nanoid"] as const)(
+  test("ulid", () => {
+    expect(
+      String(clientSideValue(field({ default: { kind: "ulid" } }), now)),
+    ).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  /**
+   * The version has to reach `createUuid`, not just sit in the artifact. A spec
+   * that lost it here would hand back a v4 for a column declared `uuid(7)` —
+   * still a valid UUID, no longer time-ordered, and indistinguishable by eye.
+   */
+  test("a uuid is minted at the version the schema wrote", () => {
+    const versionOf = (value: unknown) => String(value).charAt(14);
+
+    expect(
+      versionOf(clientSideValue(field({ default: { kind: "uuid", version: 7 } }), now)),
+    ).toBe("7");
+    expect(
+      versionOf(clientSideValue(field({ default: { kind: "uuid", version: 4 } }), now)),
+    ).toBe("4");
+  });
+
+  /** An artifact old enough to predate `version`, or a hand-written spec. */
+  test("a uuid with no version is v4", () => {
+    expect(
+      String(clientSideValue(field({ default: { kind: "uuid" } }), now)).charAt(14),
+    ).toBe("4");
+  });
+
+  test.each(["cuid", "uuid", "nanoid", "ulid"] as const)(
     "a %s is minted per call",
     (kind) => {
       const one = clientSideValue(field({ default: { kind } }), now);

--- a/packages/gemi/orm/defaults.test.ts
+++ b/packages/gemi/orm/defaults.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, test, vi } from "vitest";
 import {
   clientSideValue,
   createCuid,
+  createNanoid,
   hasClientSideValue,
   isClientSideDefault,
 } from "./defaults";
@@ -210,10 +211,79 @@ describe("the random blocks are not biased toward the low symbols", () => {
 });
 
 /**
+ * A nanoid is `size` independent symbols and nothing else — no timestamp, no
+ * counter, no fingerprint — so unlike a cuid there is no structure to take
+ * apart. What is left to pin is the length, the alphabet, and that the mask
+ * over that alphabet is unbiased.
+ */
+describe("createNanoid matches the ids the Prisma client mints", () => {
+  const ALPHABET =
+    "useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
+
+  /**
+   * The length is the argument, and it is the whole reason `DefaultSpec` grew a
+   * `length` field: `@default(nanoid(10))` and `@default(nanoid())` differ in
+   * nothing else, and the column Prisma emits for either is a plain `TEXT` that
+   * constrains neither.
+   */
+  test.each([1, 10, 21, 36])("nanoid(%i) is %i characters", (size) => {
+    expect(createNanoid(size)).toHaveLength(size);
+  });
+
+  /** `nanoid()` written with no argument. */
+  test("the default length is 21", () => {
+    expect(createNanoid()).toHaveLength(21);
+  });
+
+  test("every character is from nanoid's url alphabet", () => {
+    const symbols = new Set(
+      Array.from({ length: 200 }, () => createNanoid()).join(""),
+    );
+
+    for (const symbol of symbols) expect(ALPHABET).toContain(symbol);
+  });
+
+  test("an id is minted per call", () => {
+    expect(createNanoid()).not.toBe(createNanoid());
+  });
+
+  /**
+   * The alphabet is 64 symbols and the mask is `& 63`, so 256 is exactly four
+   * whole alphabets and every byte maps to one symbol with no tail to reject —
+   * which is why this needs none of `randomBlock`'s resample loop, and why
+   * "unbiased" is worth asserting rather than assumed.
+   *
+   * Sized against flake rather than against the mutant: 64,000 symbols puts the
+   * expected count per symbol at 1000 with a standard deviation of 31.4, and a
+   * ±20% window is over six sd in each direction. A mask that truncated or
+   * doubled part of the alphabet lands far outside it — `& 31` would leave 32
+   * symbols at zero.
+   */
+  test("the alphabet is drawn uniformly", () => {
+    const counts = new Map<string, number>();
+    for (const symbol of Array.from({ length: 1000 }, () =>
+      createNanoid(64),
+    ).join("")) {
+      counts.set(symbol, (counts.get(symbol) ?? 0) + 1);
+    }
+
+    expect(counts.size).toBe(64);
+    for (const count of counts.values()) {
+      expect(count).toBeGreaterThan(800);
+      expect(count).toBeLessThan(1200);
+    }
+  });
+});
+
+/**
  * `autoincrement()` and `dbgenerated(...)` stay with the database; everything
  * else gemi supplies. Written as an exhaustive record so that adding a
  * `DefaultKind` without deciding which side of the split it falls on is a type
  * error rather than an untested branch.
+ *
+ * `nanoid` is the kind that arrived by getting this wrong (#350): it was not a
+ * `DefaultKind` at all, so it fell into `dbgenerated`, and the exhaustive record
+ * could not notice a member that did not exist.
  */
 describe("isClientSideDefault splits gemi's defaults from the database's", () => {
   const expected: Record<DefaultKind, boolean> = {
@@ -221,6 +291,7 @@ describe("isClientSideDefault splits gemi's defaults from the database's", () =>
     dbgenerated: false,
     cuid: true,
     uuid: true,
+    nanoid: true,
     now: true,
     value: true,
   };
@@ -245,6 +316,16 @@ const field = (over: Partial<FieldSchema> = {}): FieldSchema => ({
 describe("hasClientSideValue asks which fields gemi must fill in", () => {
   test("a client-side default", () => {
     expect(hasClientSideValue(field({ default: { kind: "cuid" } }))).toBe(true);
+  });
+
+  /**
+   * The whole of #350 in one assertion: this answered `false`, so the write
+   * compiler never asked for a value and left the column out of the insert.
+   */
+  test("a nanoid, which Prisma also fills client-side", () => {
+    expect(
+      hasClientSideValue(field({ default: { kind: "nanoid", length: 10 } })),
+    ).toBe(true);
   });
 
   test("a database-side default", () => {
@@ -289,12 +370,38 @@ describe("clientSideValue produces one field's value", () => {
     );
   });
 
-  test.each(["cuid", "uuid"] as const)("a %s is minted per call", (kind) => {
-    const one = clientSideValue(field({ default: { kind } }), now);
-    const two = clientSideValue(field({ default: { kind } }), now);
-
-    expect(one).not.toBe(two);
+  /**
+   * The bug in #350: this returned `undefined`, so `Model.create` omitted the
+   * column, and Postgres rejected the row — the column Prisma's migration emits
+   * for a `nanoid()` default carries no `DEFAULT` to fall back on.
+   *
+   * The length is asserted alongside because it is the half that fails quietly:
+   * a spec that reached here without one would still produce an id, 21
+   * characters of the right alphabet, and the column would just be the wrong
+   * width.
+   */
+  test("nanoid, at the length the schema wrote", () => {
+    expect(
+      clientSideValue(field({ default: { kind: "nanoid", length: 10 } }), now),
+    ).toHaveLength(10);
   });
+
+  /** An artifact old enough to predate `length`, or a hand-written spec. */
+  test("a nanoid with no length is 21 characters", () => {
+    expect(
+      clientSideValue(field({ default: { kind: "nanoid" } }), now),
+    ).toHaveLength(21);
+  });
+
+  test.each(["cuid", "uuid", "nanoid"] as const)(
+    "a %s is minted per call",
+    (kind) => {
+      const one = clientSideValue(field({ default: { kind } }), now);
+      const two = clientSideValue(field({ default: { kind } }), now);
+
+      expect(one).not.toBe(two);
+    },
+  );
 
   test("a literal is passed through", () => {
     const spec = { kind: "value", value: false } as const;

--- a/packages/gemi/orm/defaults.ts
+++ b/packages/gemi/orm/defaults.ts
@@ -1,4 +1,9 @@
-import type { DefaultSpec, FieldSchema } from "./schema";
+import {
+  NANOID_DEFAULT_LENGTH,
+  type DefaultKind,
+  type DefaultSpec,
+  type FieldSchema,
+} from "./schema";
 
 /**
  * The values gemi supplies itself on a write, rather than leaving to the
@@ -20,8 +25,14 @@ import type { DefaultSpec, FieldSchema } from "./schema";
  *   `@default(nanoid())` is the same column with a different generator on it,
  *   and was on the wrong side of this split until #350 — classified
  *   `dbgenerated`, so the ORM omitted the column and the driver rejected the
- *   row. `cuid()`, `uuid()` and `nanoid()` are Prisma's three client-side id
- *   functions and all three belong here.
+ *   row.
+ *
+ *   **Prisma's client registers four of these, not three.** Its generator
+ *   registry reads `register("uuid") register("cuid") register("ulid")
+ *   register("nanoid")`, and `prisma migrate diff` gives every one of them a
+ *   `TEXT NOT NULL` with no `DEFAULT`. #350's first fix said "three" and left
+ *   `ulid` falling through to `dbgenerated` — the same bug, one function over,
+ *   which is what its review caught. All four are here now.
  * - `createdAt` does have a default, but it is `CURRENT_TIMESTAMP`, which SQLite
  *   stores as the *text* `YYYY-MM-DD HH:MM:SS` — while Prisma stores a DateTime
  *   as integer milliseconds. Letting the database fill it would write a
@@ -35,9 +46,36 @@ import type { DefaultSpec, FieldSchema } from "./schema";
  * resolved once per logical operation and passed in rather than read per field.
  */
 
+/**
+ * The kinds gemi supplies a value for, as an allowlist.
+ *
+ * **It was a denylist** — `kind !== "autoincrement" && kind !== "dbgenerated"`
+ * — and the difference is what a *future* kind does on a runtime that predates
+ * it. A denylist says "yes, gemi supplies this" for a kind it cannot generate,
+ * so the column joins the insert and `clientSideValue` hands back `undefined`,
+ * which the dialect encodes as **NULL**. A nullable column then takes NULL on
+ * every row, silently, where an id belonged.
+ *
+ * An allowlist answers "no" instead, so the column is omitted and the database
+ * decides — a NOT NULL violation where it matters, and nothing where it does
+ * not. `SCHEMA_ARTIFACT_VERSION` should catch that skew first; this is what
+ * makes it loud if it ever does not.
+ *
+ * Every member must have an arm in `clientSideValue`, which the exhaustive
+ * `Record<DefaultKind, boolean>` in the tests is there to hold.
+ */
+const CLIENT_SIDE_KINDS: ReadonlySet<DefaultKind> = new Set<DefaultKind>([
+  "cuid",
+  "uuid",
+  "nanoid",
+  "ulid",
+  "now",
+  "value",
+]);
+
 /** Whether gemi supplies this default, or leaves the column to the database. */
 export function isClientSideDefault(spec: DefaultSpec): boolean {
-  return spec.kind !== "autoincrement" && spec.kind !== "dbgenerated";
+  return CLIENT_SIDE_KINDS.has(spec.kind);
 }
 
 /**
@@ -64,14 +102,21 @@ export function clientSideValue(field: FieldSchema, now: Date): unknown {
 
   switch (spec.kind) {
     case "cuid":
+      // v1 only. `cuid(2)` is refused by the generator rather than recorded,
+      // because gemi cannot reproduce `@paralleldrive/cuid2`'s output — see
+      // `emit.ts`. So no artifact reaches here carrying a cuid version.
       return createCuid();
     case "uuid":
-      return crypto.randomUUID();
+      // Absent means 4, which is what a bare `uuid()` has always meant. The
+      // DMMF in fact normalises `uuid()` to `args: [4]`, so the generator
+      // always records it; the fallback is for a hand-written spec.
+      return createUuid(spec.version ?? 4);
     case "nanoid":
-      // The generator always records the length, so the fallback is for an
-      // artifact generated before #350 — which cannot carry `kind: "nanoid"` at
-      // all — and for a hand-written spec. 21 is what `nanoid()` means.
+      // Likewise: the generator always records the length, so the fallback is
+      // for a hand-written spec. 21 is what `nanoid()` means.
       return createNanoid(spec.length ?? NANOID_DEFAULT_LENGTH);
+    case "ulid":
+      return createUlid();
     case "now":
       return now;
     case "value":
@@ -80,6 +125,46 @@ export function clientSideValue(field: FieldSchema, now: Date): unknown {
       // autoincrement / dbgenerated — the database's business.
       return undefined;
   }
+}
+
+// --- random symbols --------------------------------------------------------
+
+/**
+ * `size` symbols drawn uniformly from `alphabet`.
+ *
+ * The one place the uniformity argument lives, because it is the same argument
+ * for every id below and it used to be made twice, half in `randomBlock`'s
+ * comment and half in `createNanoid`'s.
+ *
+ * A byte is a draw from 256, and 256 is a multiple of the alphabet's size only
+ * when that size is a power of two. When it is not, `byte % size` would favour
+ * the first `256 % size` symbols — for cuid's 36 that is the first four,
+ * delivered 8 times in 256 against everyone else's 7, which is 12.5% above
+ * uniform and invisible in any single id. `limit` cuts the tail that causes it
+ * and those bytes are redrawn.
+ *
+ * For a 64-symbol alphabet `256 % 64` is 0, so `limit` is 256, the loop never
+ * rejects, and this is exactly the `& 63` mask nanoid ships — reached by
+ * arithmetic rather than by special-casing it.
+ */
+function randomChars(alphabet: string, size: number): string {
+  const base = alphabet.length;
+  const limit = 256 - (256 % base);
+
+  const bytes = new Uint8Array(size);
+  crypto.getRandomValues(bytes);
+
+  let out = "";
+  for (let i = 0; i < size; i++) {
+    let byte = bytes[i];
+    while (byte >= limit) {
+      const resample = new Uint8Array(1);
+      crypto.getRandomValues(resample);
+      byte = resample[0];
+    }
+    out += alphabet[byte % base];
+  }
+  return out;
 }
 
 // --- cuid v1 ---------------------------------------------------------------
@@ -128,24 +213,9 @@ function pad(text: string, size: number): string {
  */
 const FINGERPRINT = randomBlock();
 
+/** One four-character block of cuid's base-36 alphabet. */
 function randomBlock(): string {
-  const bytes = new Uint8Array(BLOCK_SIZE);
-  crypto.getRandomValues(bytes);
-
-  let out = "";
-  for (let i = 0; i < BLOCK_SIZE; i++) {
-    let byte = bytes[i];
-    // 256 is not a multiple of 36 — it is 7*36 + 4 — so taking the remainder of
-    // every byte would make the first four symbols of the alphabet slightly
-    // likelier than the rest. Resampling the 252-255 tail removes the bias.
-    while (byte >= 252) {
-      const resample = new Uint8Array(1);
-      crypto.getRandomValues(resample);
-      byte = resample[0];
-    }
-    out += ALPHABET[byte % BASE];
-  }
-  return out;
+  return randomChars(ALPHABET, BLOCK_SIZE);
 }
 
 export function createCuid(): string {
@@ -160,38 +230,126 @@ export function createCuid(): string {
  * The alphabet, verbatim from the `nanoid` package Prisma bundles. Its order is
  * not alphabetical and not arbitrary — it is what the library ships, and an id
  * is a uniform draw from it, so a reordering changes nothing observable. It is
- * copied exactly anyway, because "the same alphabet" is the property, and a
- * character silently added or dropped would change the width of the mask below
- * from unbiased to not.
+ * copied exactly anyway, because "the same alphabet" is the property.
  *
- * 64 characters, which is the whole reason `& 63` is correct where cuid's
- * `% 36` needed a resample loop: every byte maps to exactly one symbol and
- * 256 is four whole alphabets, so there is no tail to reject.
+ * 64 characters, so `randomChars` computes a `limit` of 256 for it and never
+ * rejects a byte — the same draw as nanoid's own `& 63`.
  */
 const NANOID_ALPHABET =
   "useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
 
-/** What `@default(nanoid())` means when written without an argument. */
-const NANOID_DEFAULT_LENGTH = 21;
-
 /**
  * The id `@default(nanoid(size))` produces in the Prisma client, generated here
- * instead — same alphabet, same mask, same length, so a gemi-written column and
- * a Prisma-written one are indistinguishable.
+ * instead — same alphabet, same length, so a gemi-written column and a
+ * Prisma-written one are indistinguishable.
  *
  * Unlike a cuid there is no structure to match: a nanoid is `size` independent
  * symbols and nothing more. No timestamp, no counter, no fingerprint — which is
  * also why none of the collision reasoning around `createCuid` applies here.
- * Uniformity is the only property, and `& 63` over a 64-symbol alphabet is what
- * gives it.
  */
 export function createNanoid(size: number = NANOID_DEFAULT_LENGTH): string {
-  const bytes = new Uint8Array(size);
+  return randomChars(NANOID_ALPHABET, size);
+}
+
+// --- ulid ------------------------------------------------------------------
+
+/**
+ * Crockford's base32: the digits and the uppercase letters, less `I`, `L`, `O`
+ * and `U` — the four that are misread as `1`, `1`, `0` and each other. Copied
+ * from the string Prisma's client ships, which is the canonical one.
+ *
+ * 32 symbols, a power of two, so `randomChars` never rejects a byte here
+ * either.
+ */
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/** 48 bits of milliseconds, base 32. */
+const ULID_TIME_CHARS = 10;
+/** 80 bits of randomness, base 32 — the width Prisma's generator uses. */
+const ULID_RANDOM_CHARS = 16;
+
+/**
+ * `@default(ulid())`, which #350's first fix missed: it never had a `case`, so
+ * it fell through to `dbgenerated` and the column was omitted from every insert
+ * — the same bug the fix was written for, on a fourth id function.
+ *
+ * A ULID is a timestamp followed by randomness, and the *order* is the point:
+ * the time is big-endian and base 32 preserves byte order, so sorting ULIDs
+ * lexicographically sorts them by creation time. That is why the timestamp is
+ * built here digit by digit rather than through `toString(32)`, which would
+ * emit a variable number of characters and destroy the alignment the ordering
+ * depends on.
+ */
+export function createUlid(now: number = Date.now()): string {
+  let time = "";
+  let remaining = now;
+  for (let i = 0; i < ULID_TIME_CHARS; i++) {
+    time = ULID_ALPHABET[remaining % 32] + time;
+    remaining = Math.floor(remaining / 32);
+  }
+
+  return time + randomChars(ULID_ALPHABET, ULID_RANDOM_CHARS);
+}
+
+// --- uuid ------------------------------------------------------------------
+
+/**
+ * `@default(uuid(v))`. Prisma's client accepts 4 and 7 and throws on anything
+ * else; the generator refuses the rest before an artifact can carry it, so this
+ * only ever sees those two.
+ *
+ * **The version is not cosmetic**, which is why it had to travel with the spec.
+ * A v4 is 122 random bits. A v7 puts 48 bits of big-endian milliseconds at the
+ * front, so v7s sort by creation time and land next to each other in a B-tree —
+ * the entire reason a schema asks for one. Minting a v4 where the schema said 7
+ * loses both properties and leaves a column that still looks like a UUID, which
+ * is how it went unnoticed.
+ */
+export function createUuid(version: number = 4): string {
+  return version === 7 ? createUuidV7() : crypto.randomUUID();
+}
+
+const HEX = Array.from({ length: 256 }, (_, i) =>
+  i.toString(16).padStart(2, "0"),
+);
+
+/**
+ * RFC 9562 §5.7: 48 bits of Unix milliseconds, the 4-bit version `7`, 12 random
+ * bits, the 2-bit variant `0b10`, and 62 more random bits.
+ *
+ * The layout is asserted by the tests rather than trusted, because every field
+ * but the timestamp is invisible in a rendered UUID.
+ *
+ * The ordering this buys is **per millisecond**. Everything after the timestamp
+ * is random, so two ids minted in the same millisecond have no defined order
+ * between them; §6.2's monotonic counter is what would fix that, and neither
+ * Prisma's generator nor this one implements it. Sorting by a v7 orders rows by
+ * the millisecond they were written, which is the property an index cares about.
+ */
+function createUuidV7(): string {
+  const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
 
-  let id = "";
-  for (let i = 0; i < size; i++) {
-    id += NANOID_ALPHABET[bytes[i] & 63];
-  }
-  return id;
+  const now = Date.now();
+  // Big-endian, and `Math.floor(now / 2 ** 32)` rather than a shift: `>>>`
+  // truncates to 32 bits, and the timestamp needs 48.
+  bytes[0] = Math.floor(now / 2 ** 40) & 0xff;
+  bytes[1] = Math.floor(now / 2 ** 32) & 0xff;
+  bytes[2] = (now >>> 24) & 0xff;
+  bytes[3] = (now >>> 16) & 0xff;
+  bytes[4] = (now >>> 8) & 0xff;
+  bytes[5] = now & 0xff;
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x70; // version 7, keeping the random low bits
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 0b10, likewise
+
+  const hex = HEX;
+  return (
+    hex[bytes[0]] + hex[bytes[1]] + hex[bytes[2]] + hex[bytes[3]] +
+    "-" + hex[bytes[4]] + hex[bytes[5]] +
+    "-" + hex[bytes[6]] + hex[bytes[7]] +
+    "-" + hex[bytes[8]] + hex[bytes[9]] +
+    "-" + hex[bytes[10]] + hex[bytes[11]] + hex[bytes[12]] +
+      hex[bytes[13]] + hex[bytes[14]] + hex[bytes[15]]
+  );
 }

--- a/packages/gemi/orm/defaults.ts
+++ b/packages/gemi/orm/defaults.ts
@@ -17,6 +17,11 @@ import type { DefaultSpec, FieldSchema } from "./schema";
  *   generates them in the client, so a row inserted without them violates a
  *   NOT NULL constraint. Missing `@updatedAt` on *create* is the quiet version
  *   of this bug: the column is only nullable on models where Prisma made it so.
+ *   `@default(nanoid())` is the same column with a different generator on it,
+ *   and was on the wrong side of this split until #350 — classified
+ *   `dbgenerated`, so the ORM omitted the column and the driver rejected the
+ *   row. `cuid()`, `uuid()` and `nanoid()` are Prisma's three client-side id
+ *   functions and all three belong here.
  * - `createdAt` does have a default, but it is `CURRENT_TIMESTAMP`, which SQLite
  *   stores as the *text* `YYYY-MM-DD HH:MM:SS` — while Prisma stores a DateTime
  *   as integer milliseconds. Letting the database fill it would write a
@@ -62,6 +67,11 @@ export function clientSideValue(field: FieldSchema, now: Date): unknown {
       return createCuid();
     case "uuid":
       return crypto.randomUUID();
+    case "nanoid":
+      // The generator always records the length, so the fallback is for an
+      // artifact generated before #350 — which cannot carry `kind: "nanoid"` at
+      // all — and for a hand-written spec. 21 is what `nanoid()` means.
+      return createNanoid(spec.length ?? NANOID_DEFAULT_LENGTH);
     case "now":
       return now;
     case "value":
@@ -142,4 +152,46 @@ export function createCuid(): string {
   const timestamp = Date.now().toString(BASE);
   const count = pad((counter++ % DISCRETE_VALUES).toString(BASE), BLOCK_SIZE);
   return `c${timestamp}${count}${FINGERPRINT}${randomBlock()}${randomBlock()}`;
+}
+
+// --- nanoid ----------------------------------------------------------------
+
+/**
+ * The alphabet, verbatim from the `nanoid` package Prisma bundles. Its order is
+ * not alphabetical and not arbitrary — it is what the library ships, and an id
+ * is a uniform draw from it, so a reordering changes nothing observable. It is
+ * copied exactly anyway, because "the same alphabet" is the property, and a
+ * character silently added or dropped would change the width of the mask below
+ * from unbiased to not.
+ *
+ * 64 characters, which is the whole reason `& 63` is correct where cuid's
+ * `% 36` needed a resample loop: every byte maps to exactly one symbol and
+ * 256 is four whole alphabets, so there is no tail to reject.
+ */
+const NANOID_ALPHABET =
+  "useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
+
+/** What `@default(nanoid())` means when written without an argument. */
+const NANOID_DEFAULT_LENGTH = 21;
+
+/**
+ * The id `@default(nanoid(size))` produces in the Prisma client, generated here
+ * instead — same alphabet, same mask, same length, so a gemi-written column and
+ * a Prisma-written one are indistinguishable.
+ *
+ * Unlike a cuid there is no structure to match: a nanoid is `size` independent
+ * symbols and nothing more. No timestamp, no counter, no fingerprint — which is
+ * also why none of the collision reasoning around `createCuid` applies here.
+ * Uniformity is the only property, and `& 63` over a 64-symbol alphabet is what
+ * gives it.
+ */
+export function createNanoid(size: number = NANOID_DEFAULT_LENGTH): string {
+  const bytes = new Uint8Array(size);
+  crypto.getRandomValues(bytes);
+
+  let id = "";
+  for (let i = 0; i < size; i++) {
+    id += NANOID_ALPHABET[bytes[i] & 63];
+  }
+  return id;
 }

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -102,6 +102,7 @@ export {
 
 export {
   createCuid,
+  createNanoid,
   clientSideValue,
   hasClientSideValue,
   isClientSideDefault,

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -103,6 +103,8 @@ export {
 export {
   createCuid,
   createNanoid,
+  createUlid,
+  createUuid,
   clientSideValue,
   hasClientSideValue,
   isClientSideDefault,

--- a/packages/gemi/orm/schema.ts
+++ b/packages/gemi/orm/schema.ts
@@ -18,27 +18,33 @@
  * `app/models/generated` fails with "run prisma generate" rather than with a
  * `TypeError` five stack frames into the compiler.
  *
- * **`FieldSchema.isList` did not bump it**, and the reason is worth stating
- * because the obvious reading says it should have. The hazard a bump guards
- * against is a *new* artifact read by an *old* runtime, which would see a list
- * column, not know the flag, and treat it as a scalar. That pairing cannot
- * occur: the generator is `bin/orm` and the runtime is `orm/`, both shipped by
- * the same `gemi` package and the same version — a runtime old enough to miss
- * the flag came with a generator that refused to emit the column at all. The
- * reverse pairing, an old artifact on a new runtime, is what `isList` being
- * optional already covers.
+ * **`FieldSchema.isList` did not bump it**, and the argument given at the time
+ * was that the generator is `bin/orm` and the runtime is `orm/`, both shipped
+ * by the same `gemi` package at the same version — so a *new* artifact could
+ * never be read by an *old* runtime.
  *
- * **`DefaultKind`'s `nanoid` member did not bump it either**, for the same
- * reason and with a sharper consequence if the reasoning were wrong: an old
- * runtime reading `{ kind: "nanoid" }` falls to `clientSideValue`'s `default:`
- * branch, returns `undefined`, and omits the column — which is #350 exactly.
- * The pairing is still impossible, because a runtime that does not know the
- * kind shipped with a generator that does not emit it. The reverse pairing is
- * the one apps actually hit on upgrade, and it is fine: an artifact generated
- * before #350 says `dbgenerated`, which the new runtime reads as it always did,
- * until `prisma generate` runs again.
+ * **That argument is wrong, and #350's review is what showed it.** The two
+ * halves do not travel together. The artifact is committed to git; the runtime
+ * is a version in a lockfile. A teammate who pulls a branch without installing,
+ * or a deploy box a release behind, reads a freshly committed artifact with the
+ * previous runtime — and because the version literal in that artifact was never
+ * bumped, `assertSchemaArtifactVersion` sees `1 === 1` and says nothing.
+ *
+ * The consequence is worse than being unable to read the column, because
+ * `isClientSideDefault` used to be a *denylist* — anything that was not
+ * `autoincrement` or `dbgenerated` counted as gemi's. An old runtime meeting
+ * `{ kind: "nanoid" }` therefore answered "yes, gemi supplies this", included
+ * the column in the insert, asked `clientSideValue` for a value, got
+ * `undefined` from its `default:` arm, and bound **NULL**. On a required column
+ * that is a NOT NULL violation; on a nullable one it writes NULL into every row
+ * forever, which is strictly harder to find than a column that was omitted.
+ *
+ * So this is now **2**, and `isClientSideDefault` is an allowlist. The bump is
+ * the mechanism that catches the skew — both directions fail with "run
+ * `prisma generate`" — and the allowlist is what makes the failure loud rather
+ * than silent if one ever slips past it.
  */
-export const SCHEMA_ARTIFACT_VERSION = 1;
+export const SCHEMA_ARTIFACT_VERSION = 2;
 
 /**
  * Prisma's scalar types, verbatim. Not SQL types — the mapping from these to a
@@ -56,14 +62,30 @@ export type ScalarType =
   | "Json"
   | "Bytes";
 
+/**
+ * Prisma 6.19.2's parser accepts seven default functions, and its client
+ * registers client-side generators for **four** of them — `cuid`, `nanoid`,
+ * `ulid` and `uuid`. All four produce a column whose DDL carries no `DEFAULT`,
+ * so all four are gemi's to supply; that is the whole of #350, and `ulid` was
+ * the last one still missing when its review was written.
+ *
+ * Read off the shipped artifacts rather than the docs: the parser's own string
+ * table is `autoincrement ulid cuid dbgenerated nanoid now uuid`, and
+ * `prisma migrate diff` on a schema using every one of them emits
+ * `TEXT NOT NULL` with no default for each.
+ */
 export type DefaultKind =
   | "autoincrement"
   | "cuid"
   | "uuid"
   | "nanoid"
+  | "ulid"
   | "now"
   | "dbgenerated"
   | "value";
+
+/** What `@default(nanoid())` means when written without an argument. */
+export const NANOID_DEFAULT_LENGTH = 21;
 
 export interface DefaultSpec {
   kind: DefaultKind;
@@ -79,6 +101,26 @@ export interface DefaultSpec {
    * same id the Prisma client would.
    */
   length?: number;
+  /**
+   * Present only for `kind: "uuid"` — `4` or `7`.
+   *
+   * The same reasoning as `length`, and it took the same bug to notice: `uuid()`
+   * and `uuid(7)` are one `TEXT` column apart in the DDL and two different
+   * *kinds* of identifier in practice. A v7 is time-ordered, which is the entire
+   * reason a schema asks for one — order by it and rows come back in insertion
+   * order, and a B-tree insert lands next to the last one. Minting a v4 where
+   * the schema said 7 loses both, silently, in a column that still looks like a
+   * UUID.
+   *
+   * Absent on an artifact generated before this existed. The runtime reads a
+   * missing version as 4, which is what `uuid()` meant then and means now —
+   * though `SCHEMA_ARTIFACT_VERSION` makes that pairing fail loudly first.
+   *
+   * `cuid` has a version argument too and does **not** get a field here: `cuid(2)`
+   * is refused by the generator rather than recorded, so the only cuid that
+   * reaches an artifact is v1. See `emit.ts`.
+   */
+  version?: number;
 }
 
 export interface FieldSchema {

--- a/packages/gemi/orm/schema.ts
+++ b/packages/gemi/orm/schema.ts
@@ -27,6 +27,16 @@
  * the flag came with a generator that refused to emit the column at all. The
  * reverse pairing, an old artifact on a new runtime, is what `isList` being
  * optional already covers.
+ *
+ * **`DefaultKind`'s `nanoid` member did not bump it either**, for the same
+ * reason and with a sharper consequence if the reasoning were wrong: an old
+ * runtime reading `{ kind: "nanoid" }` falls to `clientSideValue`'s `default:`
+ * branch, returns `undefined`, and omits the column — which is #350 exactly.
+ * The pairing is still impossible, because a runtime that does not know the
+ * kind shipped with a generator that does not emit it. The reverse pairing is
+ * the one apps actually hit on upgrade, and it is fine: an artifact generated
+ * before #350 says `dbgenerated`, which the new runtime reads as it always did,
+ * until `prisma generate` runs again.
  */
 export const SCHEMA_ARTIFACT_VERSION = 1;
 
@@ -50,6 +60,7 @@ export type DefaultKind =
   | "autoincrement"
   | "cuid"
   | "uuid"
+  | "nanoid"
   | "now"
   | "dbgenerated"
   | "value";
@@ -58,6 +69,16 @@ export interface DefaultSpec {
   kind: DefaultKind;
   /** Present only for `kind: "value"` — the literal written in the schema. */
   value?: unknown;
+  /**
+   * Present only for `kind: "nanoid"` — the id's length in characters.
+   *
+   * Part of the default rather than a detail of it: `nanoid()` is 21 characters
+   * and `nanoid(10)` is 10, and the column Prisma's migration emits is a plain
+   * `TEXT` that constrains neither. So the length lives nowhere but the schema,
+   * and if it does not survive into this artifact the runtime cannot mint the
+   * same id the Prisma client would.
+   */
+  length?: number;
 }
 
 export interface FieldSchema {

--- a/templates/saas-starter/app/models/generated/schema.ts
+++ b/templates/saas-starter/app/models/generated/schema.ts
@@ -8,7 +8,7 @@ import type { ModelSchema } from "gemi/orm";
 // Compared against the runtime's own constant when this artifact is
 // registered, so a stale directory fails with "re-run prisma generate"
 // rather than with a TypeError inside the compiler.
-export const ARTIFACT_VERSION = 1;
+export const ARTIFACT_VERSION = 2;
 
 export const Account = {
   "name": "Account",


### PR DESCRIPTION
Closes #350.

## The bug

`@default(nanoid())` is a Prisma **client-side** default. The generated client fills it, and the column Prisma's own migration emits carries no `DEFAULT`:

```sql
CREATE TABLE "Organization" (
    "id"       SERIAL NOT NULL,
    "publicId" TEXT   NOT NULL,   -- @default(nanoid(10)) — no DEFAULT
```

The gemi generator recorded it as `{ kind: "dbgenerated" }`, which `isClientSideDefault` excludes from the values gemi supplies. So `Model.create` omitted the column and the driver rejected the row on NOT NULL — on the first write and every write after. `cuid`, `uuid`, `now` and literals were all handled; `nanoid` was the one Prisma client-side default routed to the other branch.

Nothing failed at generation time or at boot, because the field *looked* handled: the generator had classified it.

## The fix

`nanoid` becomes its own `DefaultKind`, and `defaults.ts` mints the id the way Prisma does — its url alphabet, `& 63`, `size` characters. The alphabet is 64 symbols, so unlike `createCuid`'s `% 36` the mask needs no resample loop: 256 is exactly four whole alphabets and every byte maps to one symbol.

**The length travels with the kind.** `nanoid()` is 21 and `nanoid(10)` is 10, and the migration writes a plain `TEXT` for both — so `DefaultSpec.length` is the only place the width survives. A spec that reached the runtime without it would still produce an id, 21 characters of the right alphabet, and the column would just be silently the wrong size.

`SCHEMA_ARTIFACT_VERSION` does **not** move, for the reason already written beside it. The hazard a bump guards against is a new artifact read by an old runtime — which here would fall to `clientSideValue`'s `default:` branch and reproduce this exact bug. That pairing cannot occur: generator and runtime ship in the same package at the same version, so a runtime that cannot read `kind: "nanoid"` came with a generator that does not emit it. The reverse pairing is the one apps hit on upgrade, and it is fine — an older artifact still says `dbgenerated` and is read as it always was, until `prisma generate` runs again.

## The silence, which is the other half

The issue asked whether an unrecognised default should be detectable at all, rather than only at first write. It should, and the generator is the place — not `gemi check models`, which walks model *classes* and the registry and never reads the schema.

`prisma generate` is the last moment anything knows the function's **name**. By the time the driver rejects the row, all that is left is a NOT NULL violation on a column that ought to have had a default. So a function default with no case for it, on a **required** column, now warns and names model, field and function:

```
gemi ORM: Organization.publicId is required and defaults to auto(), which this generator
does not recognise. It is recorded as a database-side default, so the ORM will omit the
column on insert — and if auto() is a default Prisma fills in its own client, the column
has none in the database and every write to Organization will fail on NOT NULL. Make the
field optional, give it a default the ORM knows, or upgrade gemi.
```

A warning rather than a refusal: most `dbgenerated(...)` columns really are the database's, and breaking a schema that generates and runs fine today is a worse trade than a noisy one. A nullable column says nothing at all — the guess costs nothing there, and noise is how a warning stops being read.

## Tests

Five new tests, one per layer the value passes through:

| Where | What |
| --- | --- |
| `emit.test.ts` | `nanoid` classifies as its own kind, and the length is recorded — including the `nanoid()` → 21 case |
| `defaults.test.ts` | `isClientSideDefault` and `hasClientSideValue` both answer `true`; `clientSideValue` returns an id of the schema's width |
| `compile/write.test.ts` | the column reaches the compiled `insert`, bound at the right length |

Plus a `createNanoid` block covering length, alphabet, per-call freshness and that the `& 63` mask is unbiased across all 64 symbols, and the warning's own block — nullable stays quiet, literals stay quiet, and every name in `RECOGNISED_DEFAULTS` stays quiet. That test reads the exported set rather than listing the six names a third time.

`isClientSideDefault`'s exhaustive `Record<DefaultKind, boolean>` gains `nanoid: true`, so the type makes a future kind a compile error rather than an untested branch. It could not have caught this one: `nanoid` was not a member at all.

**Mutation-checked rather than assumed.** Reintroducing the bug in both places — `isClientSideDefault` excluding `nanoid`, and the generator emitting `dbgenerated` — fails exactly those five and nothing else.

- `vitest run` in `packages/gemi`: 116 files, 2732 passed, 1 skipped
- `tsc --noEmit` clean; `oxlint` 0 warnings, 0 errors over `orm/` and `bin/`

## Docs

`docs/orm.md` had no defaults section at all, so the split this issue turned on was written down only in a source comment — a reader had no way to learn that `cuid()` is gemi's while `autoincrement()` is the database's, or why `now()` is gemi's despite the column having a real `DEFAULT`.

A new **Column defaults** section: the DDL that forces the split, a table of who fills what, and the two consequences that surprise people — `createdAt` and `updatedAt` come back from one `create` as the same instant, and a nullable column with no default is omitted rather than bound as `null`. The warning gets a subsection so its message can be looked up.

`llms-full.txt` carries the page verbatim and was regenerated from it; `docs-scope.test.ts` compares the two exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)