### PR TITLE
Close the four defects the first Prisma port reported: #354, #355, #356, #357

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -441,8 +441,15 @@ The value still needs truncating where it is read, because a page number the
 client increments arrives at the server *multiplied* — as a fractional `skip`:
 
 ```tsx
-const page = Math.max(1, Math.trunc(Number(searchParams.get("page"))) || 1);
+const asked = Number(searchParams.get("page"));
+const page = Number.isFinite(asked) ? Math.max(1, Math.trunc(asked)) : 1;
 ```
+
+The `Number.isFinite` is not decoration, and it is the half that is easy to drop:
+`?page=1e400` is `Infinity`, which `Math.trunc` returns unchanged and `Math.max`
+keeps — so a shorter clamp hands the component `Infinity`, writes `?page=Infinity`
+back into the URL on the next click, and renders `NaN` on any `page - 1` control.
+That is the same test the server-side `toWholeNumber` makes, for the same reason.
 
 ## Both of these are annotated by `bunx gemi migrate`
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -483,6 +483,59 @@ time is a marker people learn to skim past. Neither pass rewrites anything.
 The full description, including what each annotation says, is under [Porting a
 Prisma app onto the ORM](./docs/cli.md#porting-a-prisma-app-onto-the-orm).
 
+## `@updatedAt` now needs a column beside it
+
+**This one changes behaviour for apps already on gemi's ORM, not only for apps
+porting off Prisma** — it is the only entry here that does, which is why it is
+worth reading even if you have no Prisma left.
+
+The stamp used to fire on every `update` call. It now fires on every call that
+**sets at least one column**, which is the rule Prisma follows. Measured against
+6.19.2 by seeding the column to the epoch and reading it back:
+
+```
+data: {}                                epoch    not stamped
+data: { profile: { create: … } }        epoch    not stamped     nested write, child holds the key
+upsert hit, update: {}                  epoch    not stamped
+updateMany({ data: {} })                epoch    { count: 0 }
+data: { name: "real" }                  now      stamped
+data: { organization: { connect: … } }  now      stamped          writes this row's foreign key
+```
+
+Nothing that writes a column changes. What changes is the calls that write
+none — and there is one spelling worth searching for before you upgrade:
+
+```ts
+await User.update({ where: { id }, data: {} })   // no longer moves updatedAt
+```
+
+If you used that as a *touch* — a write with an empty payload, to bump the
+timestamp — it is now a read and the stamp stays where it was. It never worked
+that way under Prisma, so a ported app cannot depend on it; an app written
+against gemi's ORM directly could. Set the column yourself where you meant to:
+
+```ts
+await User.update({ where: { id }, data: { updatedAt: new Date() } })
+```
+
+The same applies to a `data` of only nested writes whose child holds the foreign
+key. Those write the *child* and nothing on the parent, so the parent's stamp no
+longer moves — which is what Prisma does, and what the ORM previously did not.
+
+**Why it changed rather than being left alone.** Stamping unconditionally made
+the empty-`data` read unreachable on any model carrying the attribute, because
+the stamp was itself the assignment keeping the statement from being empty — so
+the fix for `data: {}` was the same fix. And it put a timestamp Prisma does not
+write on every nested to-one write, where the differential harness could not see
+it: `updatedAt` is compared as a volatile descriptor, so two different instants
+match. It took asserting the epoch by hand to find.
+
+**One divergence remains, deliberately.** An owning-side `disconnect` writes the
+foreign key and so stamps here; Prisma writes the same column through the same
+operand family and does *not*, while its `connect` one operand over does. That is
+Prisma disagreeing with itself, and matching it would mean special-casing one
+operand to reproduce an inconsistency.
+
 ---
 
 # Upgrading from 0.42 to 0.43

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,9 +1,16 @@
 # Upgrading from 0.50 to 0.51
 
 Three changes need a hand, and the third is a look rather than an edit — it only
-becomes work if you were using an unlisted job as an off switch. There is no
-codemod for any of them — `bunx gemi migrate` is the 0.42→0.43 tool and does not
-touch any of this.
+becomes work if you were using an unlisted job as an off switch. `bunx gemi
+migrate` does none of those three for you; it is the 0.42→0.43 tool, and all
+three are decisions a codemod cannot make.
+
+Two more sections follow them, and they apply only if you are moving queries off
+the Prisma client and onto gemi's ORM. Both are breaks you are not told about —
+the code compiles, runs, and passes its tests on either side of the move — so
+they are worth reading before the port rather than after. Those two the codemod
+*does* now find and annotate; see [Both of these are annotated by `bunx gemi
+migrate`](#both-of-these-are-annotated-by-bunx-gemi-migrate).
 
 ## Declare your model modules on the Kernel
 
@@ -204,6 +211,270 @@ the boot naming itself rather than being quietly left out.
 
 Both directories are covered in [docs/cron.md](./docs/cron.md) and
 [docs/jobs-and-queues.md](./docs/jobs-and-queues.md).
+
+## A `code === "P2002"` check stops firing when its write moves onto the ORM
+
+Do this before you move the first write, because afterwards nothing will tell
+you:
+
+```sh
+rg -n '"P2002"'
+```
+
+From the repository root rather than from `app/`: these guards live wherever the
+retry does, and a shared `lib/errors.ts` is as likely a home as a controller.
+
+Prisma reports a unique collision as a `PrismaClientKnownRequestError` carrying
+`code: "P2002"`. gemi reports it as a `UniqueConstraintError`, which carries
+`model`, `operation`, `fields` and `constraint` — and no `code`, anywhere on its
+prototype chain. So the moment the write inside the `try` becomes an ORM call,
+`error.code === "P2002"` is `false`, the recovery branch stops running, and the
+`throw error` line under it — the one you wrote for *some other error* —
+rethrows the collision you were handling.
+
+Every guard of this shape sits in code that *expects* the collision: catch it,
+re-read, retry. That is the only reason to test for it. So the branch that stops
+running is the branch holding a race together.
+
+**It is silent in four independent ways at once, which is why this is a grep
+rather than a note.**
+
+- **`tsc` is happy.** The guard takes `unknown` and narrows before reading
+  `.code`. That is the correct way to write it, and it stays correct against an
+  error that has no `code` — a type error here would need TypeScript to know
+  which error your `try` can now produce, which is a runtime fact.
+- **The runtime is happy.** Nothing new throws. The `catch` still runs, the
+  condition is false, and the rethrow arm does its job perfectly — that arm
+  exists to absorb exactly this.
+- **The tests are happy.** They reject with `{ code: "P2002" }`, because that is
+  what the code under test used to receive. They still pass, over a branch
+  production can no longer reach.
+- **Production is happy until the race happens.** A unique collision is rare and
+  load-dependent by nature. The symptom is not a missing retry; it is whatever
+  the rethrown error becomes three frames up, at a moment nobody can reproduce.
+
+In the first real port this reached review inside a merge-ready pull request —
+`tsc` clean, ~2700 tests green — carrying two dead guards: one on a credit
+balance read, one on an idempotent credit purchase. A human reading the diff
+caught them, and nothing else in the pipeline was capable of it.
+
+### The replacement
+
+```ts
+import { isUniqueConstraintError } from "gemi/orm";
+
+try {
+  return await Invite.create({ data: { token } });
+} catch (error) {
+  if (!isUniqueConstraintError(error)) throw error;
+  return await Invite.findUniqueOrThrow({ where: { token } });
+}
+```
+
+```ts
+function isUniqueConstraintError(error: unknown): error is UniqueConstraintError
+```
+
+It tests `instanceof UniqueConstraintError` **or** `error.name ===
+"UniqueConstraintError"`, and the second half is why it is worth importing
+instead of writing `instanceof` at the call site. `instanceof` compares against
+*one module instance's* class object, so it is false across a duplicate copy of
+`gemi/orm` — two versions in one dependency tree, a linked build beside a
+bundled one, a monorepo package resolving its own. The error is the right error,
+thrown by the right code, and your guard silently does not fire. That is not
+hypothetical: duck-typing rather than importing the class is precisely what the
+ported application had already done for *Prisma's* error, for precisely this
+reason.
+
+Other `P` codes have gemi errors too — `P2025` is `RecordNotFoundError`, for
+instance — but `P2002` is the one gemi ships a predicate for and the only one the
+codemod looks for. If you branch on others, the full table is under
+[Errors](./docs/orm.md#errors).
+
+### While some writes are still on Prisma
+
+A port is not atomic, and during one a collision on the same table can arrive as
+either error depending on which module wrote the row. Keep both, in one place,
+with the temporary arm marked as temporary:
+
+```ts
+// app/lib/errors.ts
+import { isUniqueConstraintError } from "gemi/orm";
+
+// TODO(port): drop the second arm — and this wrapper with it — when the last
+// write leaves the Prisma client.
+export const isUniqueCollision = (error: unknown) =>
+  isUniqueConstraintError(error) ||
+  (typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === "P2002");
+```
+
+Wrap gemi's predicate rather than re-testing `instanceof` yourself: the name
+branch is the half you cannot write correctly by hand, and it is the half that
+survives a duplicate module copy.
+
+**gemi deliberately does not ship that second arm.** A Prisma code in gemi's
+permanent surface would imply the rest of the taxonomy came with it — `P2003`,
+`P2025`, `P2034`, and the fifty others an application would then reasonably
+expect to catch — and a compatibility surface that covers `P2002` and not
+`P2034` fails in exactly the same silent way, one layer further in. It would
+also be a bridge with no end: inside the framework there is nowhere to write the
+line saying when to delete it. In your own module there is, and it is the
+comment above.
+
+### Fix the tests in the same pass, not after
+
+A mock that rejects with `{ code: "P2002" }` keeps a dead guard green — that is
+the third silence above, and it outlives the fix unless you go and get it.
+Reject with the real error:
+
+```ts
+import { UniqueConstraintError } from "gemi/orm";
+
+vi.mock("@/app/models", () => ({
+  Invite: {
+    create: vi
+      .fn()
+      .mockRejectedValue(new UniqueConstraintError("Invite", "create", ["token"])),
+    findUniqueOrThrow: vi.fn(),
+  },
+}));
+```
+
+`UniqueConstraintError` is exported from `gemi/orm` for exactly this. The
+mocking pattern itself is under **Transactions → Unit-testing code that opens
+one** in [docs/orm.md](./docs/orm.md#transactions).
+
+## `take` and `skip` built from a query string must be integers
+
+The rule is not new and is not changing. gemi refuses a `take` or a `skip` that
+is not an integer, where Prisma truncated it toward zero:
+
+```
+InvalidArgumentError: Invalid 'take' (Post.findMany). Expected an integer, got 1.5.
+```
+
+It refuses rather than coercing because there is no coercion both dialects agree
+on: binding `limit 1.5` is an opaque `SQLITE_MISMATCH` on SQLite and two rows on
+Postgres, which rounds. One rule, failing loudly, beats three behaviours — the
+reasoning is under [Querying](./docs/orm.md#querying) and it stands. What is new
+is only this: a Prisma application has been getting the truncation for free, and
+the code that relied on it keeps compiling.
+
+**It is invisible by construction, in three ways:**
+
+- **`tsc` cannot see it.** `Number(x)` is a `number` and `take` takes a
+  `number`. TypeScript has no integer type, so there is no annotation that would
+  have caught this and none is coming.
+- **The unit tests cannot see it.** Every test passes an integer, because an
+  integer is what a developer types. `take: 25` has never been a bug.
+- **The failing input is not written by your code.** It is a hand-edited URL, a
+  shared link carrying a stale query string, an infinite-scroll client computing
+  a page size from the viewport, or a form's cleared field arriving as
+  `?perPage=` — and `Number("")` is `0`, so that one computes `skip: -25`, which
+  is refused as well.
+
+In the first real port, nine controllers derived pagination straight from the
+query string in the same two copied lines. Seven of them broke. The two that
+were caught were caught by a human reading the diff.
+
+It takes two greps, because the argument and the value that reaches it are
+usually in different files:
+
+```sh
+rg -n '\b(take|skip):' app/
+rg -n 'Number\(' app/ | rg -i 'page|limit|per.?page|offset|take|skip'
+```
+
+### The replacement
+
+```ts
+import { paginate } from "gemi/orm";
+
+async list(req: HttpRequest) {
+  const { take, skip } = paginate({
+    page: req.search.get("page"),
+    perPage: req.search.get("perPage"),
+  });
+  return Post.findMany({ take, skip, orderBy: { createdAt: "desc" } });
+}
+```
+
+```ts
+function paginate(
+  args: { page?: unknown; perPage?: unknown },
+  options?: { perPage?: number; maxPerPage?: number },
+): { take: number; skip: number }
+```
+
+The arguments are `unknown` on purpose: a query string is where these values
+come from, and typing them `number` would mean every caller writes the
+`Number(...)` that is the bug. `req.search.get` hands back `string | string[]`,
+a JSON body hands back whatever was sent, and both go in unconverted.
+
+**The guarantee is that its output cannot be refused.** Every return is a pair
+of integers with `take >= 1` and `skip >= 0`, for every input — `"2.5"`, `"-1"`,
+`""`, `"abc"`, `"1e400"`, an array, `undefined`, a missing key. So a route built
+on it has no page argument that can 500.
+
+- `perPage` defaults to **25**, which is the number gemi's own examples used to
+  teach as `|| 25` — so moving a call site onto the helper does not change
+  anybody's page size.
+- A *request* may not ask for more than **100** rows, because `?perPage=100000`
+  otherwise reads the table into memory. An endpoint that legitimately serves
+  larger pages says so where it is written: `paginate(args, { maxPerPage: 500 })`.
+- A `page` below 1 is clamped up rather than refused. The values that land there
+  are `""`, `"0"` and `"-1"`, and none of them is a request for a page that does
+  not exist; a 500 on a hand-edited link is the wrong answer.
+
+**`Number(x) || 1` is not the fix**, and it is worth knowing how far it does
+get: it rescues `?page=` and `?page=0`, because both are falsy. It does not
+rescue `?page=-1`, `?page=2.5` or `?page=1e400` — a negative `skip` and a
+fractional one are both refused, and `1e400` is `Infinity`, which `Math.trunc`
+cannot fix either.
+
+### On the client
+
+`paginate` belongs to the query layer and has no business in a browser bundle.
+The value still needs truncating where it is read, because a page number the
+client increments arrives at the server *multiplied* — as a fractional `skip`:
+
+```tsx
+const page = Math.max(1, Math.trunc(Number(searchParams.get("page"))) || 1);
+```
+
+## Both of these are annotated by `bunx gemi migrate`
+
+The codemod carries two annotate-only passes over everything under `app/`. They
+are re-run-safe, so this is worth doing even on an app already on 0.43:
+
+```sh
+bunx gemi migrate --dry-run   # print the plan, write nothing
+bunx gemi migrate
+rg 'TODO\(gemi-migrate\)'
+```
+
+- **The `"P2002"` pass** annotates every `P2002` literal in a file that also
+  imports from your model surface (`gemi/orm`, or a path ending in `models`),
+  and points at `isUniqueConstraintError` and the two-armed bridge above. Two
+  things it cannot find: a guard living in a shared `lib/errors.ts` that imports
+  nothing from your models — which is what the plain `rg` above is for — and a
+  check spelled `err.code?.startsWith("P200")`, since it matches the exact
+  literal only.
+- **The `take` / `skip` pass** annotates any `take:` or `skip:` whose value is
+  not provably an integer, and points at `paginate`. Integer literals (including
+  `1_000`), a whole `Math.trunc(…)` / `Math.floor(…)` / `parseInt(…)` call, and
+  `take?: number` in a type declaration are *not* flagged — so a call site you
+  have already truncated is silent for a reason rather than by oversight.
+
+The second pass asks you to confirm rather than telling you it found a bug, and
+it is worded that way on purpose: whether a value holds an integer is a runtime
+fact, most non-literal `take`s are fine, and a marker that is wrong most of the
+time is a marker people learn to skim past. Neither pass rewrites anything.
+
+The full description, including what each annotation says, is under [Porting a
+Prisma app onto the ORM](./docs/cli.md#porting-a-prisma-app-onto-the-orm).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,8 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Getting Started](./getting-started.md)** — install, scaffold, dev/build/start, your first route + view.
 - **[Project Structure & the Kernel](./project-structure.md)** — the `app/` layout, the Kernel, the container, `app/config/*.ts`, service providers, and app bootstrap.
 - **[Configuration](./configuration.md)** — `gemi.config.ts` (build config), `.env` handling, HTML compression, `app/preload.ts`, Vite config.
-- **[CLI](./cli.md)** — `gemi dev`, `build`, `start`, and the codegen/inspection commands.
+- **[CLI](./cli.md)** — `gemi dev`, `build`, `start`, `gemi migrate`, and the codegen/inspection commands.
+- **[Upgrading](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md)** — what to change per release, including the two silent breaks a Prisma-to-ORM port walks into. It lives at the repository root rather than in `docs/`, so this link leaves the documentation site.
 
 ### HTTP layer
 - **[Routing](./routing.md)** — `ApiRouter` / `ViewRouter`, path params, groups, nesting, `resource()`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,6 +76,17 @@ It also annotates APIs retired after 0.43 rather than rewriting them, which is t
 
 > The provider-to-config half only runs when `app/kernel/providers/` exists. Without it that step is skipped and your `Kernel.ts` is left alone — so re-running the command on an already-migrated app is safe, and the retired-API pass above is all it does.
 
+### Porting a Prisma app onto the ORM
+
+Two more annotate-only passes run over every file under `app/`. Both look for a divergence that a Prisma port walks into silently — the code keeps compiling, keeps running and keeps passing its tests, and the thing that broke only shows up under a condition the app itself never produces.
+
+- **`"P2002"` in a file that also imports your models.** Moving a write onto the ORM changes the error it raises: gemi throws `UniqueConstraintError`, which carries `model`, `operation`, `fields` and `constraint` and no `code` at all. A `code === "P2002"` guard therefore returns `false`, the recovery branch it exists to run stops running, and a test that mocks `{ code: "P2002" }` keeps certifying it. The TODO points at `isUniqueConstraintError` from `gemi/orm` and at the two-armed bridge to keep while some writes in the app are still on Prisma. Files with no model import are left alone — there the guard is still correct.
+- **A `take:` or `skip:` whose value is not an integer literal.** The ORM refuses a fractional `take` with `InvalidArgumentError` where Prisma truncated it, so `Number(req.search.get("limit"))` is a 500 waiting for a hand-edited URL — and a fractional `page` is worse, because it reaches the ORM multiplied, as a fractional `skip`. The TODO points at `paginate` from `gemi/orm`, which truncates and clamps in one place.
+
+The second pass has a real false-positive rate and its wording says so: most non-literal `take`s are a constant or an already-truncated value, and the annotation asks you to confirm the value is truncated at the boundary rather than claiming a bug. Values that are integer literals, or a whole `Math.trunc(…)` / `Math.floor(…)` / `parseInt(…)` call, and `take?: number` in a type declaration, are not flagged.
+
+> **What it cannot find:** whether `limit` holds an integer, and whether a given `catch` sits over an ORM call or a Prisma one, are both run-time facts — so these passes annotate and never rewrite. The `"P2002"` pass also misses a guard living in a shared helper that imports nothing from your model surface; [UPGRADE.md](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md) carries the plain grep for that case.
+
 ## `gemi check models`
 
 Reports model classes carrying policies that the modules your Kernel declares do not register.

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -59,12 +59,23 @@ async show(req: HttpRequest<{ name: string }, { orgId: string }>) { /* ... */ }
 `req.search` wraps the query string. `get` returns the value (a string, or `string[]` for repeated keys):
 
 ```typescript
+import { paginate } from "gemi/orm";
+
 async list(req: HttpRequest) {
   const search = req.search.get("search");
-  const limit = Number(req.search.get("limit")) || 25;
+  const { take, skip } = paginate({
+    page: req.search.get("page"),
+    perPage: req.search.get("perPage"),
+  });
   // ...
 }
 ```
+
+Everything the query string holds is a string, so a numeric param has to be converted, and
+`Number(...)` alone is not enough for the ones that become query arguments: `?limit=1.5` is a
+fractional `take`, which the ORM refuses rather than truncates, and a blank `?page=` is `0`,
+which computes a negative `skip`. `paginate` takes them as they arrive and always returns
+integers — see [ORM](./orm.md#querying).
 
 ### Reading the body: `req.input()`
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2840,7 +2840,11 @@ import { useSearchParams } from "gemi/client";
 
 function Pagination() {
   const searchParams = useSearchParams();
-  const page = Math.max(1, Math.trunc(Number(searchParams.get("page"))) || 1);
+  // `Number.isFinite` first: `?page=1e400` is `Infinity`, which `Math.trunc`
+  // returns unchanged and `Math.max` happily keeps — and it would go straight
+  // back into the URL through `goTo` below.
+  const asked = Number(searchParams.get("page"));
+  const page = Number.isFinite(asked) ? Math.max(1, Math.trunc(asked)) : 1;
 
   function goTo(next: number) {
     searchParams.set("page", String(next));

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -17,7 +17,7 @@ gemi is a strong fit for **B2B / SaaS apps** with many API endpoints and non-tri
 
 ```bash
 bunx create-gemi-app
-## then:
+# then:
 cd my-app
 mv .env.example .env
 bunx prisma migrate deploy
@@ -32,7 +32,8 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Getting Started](./getting-started.md)** — install, scaffold, dev/build/start, your first route + view.
 - **[Project Structure & the Kernel](./project-structure.md)** — the `app/` layout, the Kernel, the container, `app/config/*.ts`, service providers, and app bootstrap.
 - **[Configuration](./configuration.md)** — `gemi.config.ts` (build config), `.env` handling, HTML compression, `app/preload.ts`, Vite config.
-- **[CLI](./cli.md)** — `gemi dev`, `build`, `start`, and the codegen/inspection commands.
+- **[CLI](./cli.md)** — `gemi dev`, `build`, `start`, `gemi migrate`, and the codegen/inspection commands.
+- **[Upgrading](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md)** — what to change per release, including the two silent breaks a Prisma-to-ORM port walks into. It lives at the repository root rather than in `docs/`, so this link leaves the documentation site.
 
 ### HTTP layer
 - **[Routing](./routing.md)** — `ApiRouter` / `ViewRouter`, path params, groups, nesting, `resource()`.
@@ -45,8 +46,12 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Forms](./forms.md)** — the `Form` component, surfacing validation errors, form status hooks.
 - **[Navigation](./navigation.md)** — `Link`, `useNavigate`, `useParams`, `useSearchParams`, and the `Redirect` component vs. facade.
 
+### Data
+- **[ORM](./orm.md)** — the Prisma-typed, gemi-executed query layer: models, relations, ambient transactions, named connections, policies, soft deletes.
+- **[Rows & Entities](./orm-rows-and-entities.md)** — plain objects by default, `track` + `save`, and `wrap`.
+
 ### Auth
-- **[Authentication](./authentication.md)** — `app/config/auth.ts`, adapters, sessions, magic links, OAuth, the `Auth` facade, and client auth hooks.
+- **[Authentication](./authentication.md)** — `app/config/auth.ts`, the user provider, sessions, magic links, OAuth, the `Auth` facade, and client auth hooks.
 - **[Authorization](./authorization.md)** — role-based middleware and authorization errors.
 
 ### Services & facades
@@ -1016,6 +1021,17 @@ It also annotates APIs retired after 0.43 rather than rewriting them, which is t
 
 > The provider-to-config half only runs when `app/kernel/providers/` exists. Without it that step is skipped and your `Kernel.ts` is left alone — so re-running the command on an already-migrated app is safe, and the retired-API pass above is all it does.
 
+### Porting a Prisma app onto the ORM
+
+Two more annotate-only passes run over every file under `app/`. Both look for a divergence that a Prisma port walks into silently — the code keeps compiling, keeps running and keeps passing its tests, and the thing that broke only shows up under a condition the app itself never produces.
+
+- **`"P2002"` in a file that also imports your models.** Moving a write onto the ORM changes the error it raises: gemi throws `UniqueConstraintError`, which carries `model`, `operation`, `fields` and `constraint` and no `code` at all. A `code === "P2002"` guard therefore returns `false`, the recovery branch it exists to run stops running, and a test that mocks `{ code: "P2002" }` keeps certifying it. The TODO points at `isUniqueConstraintError` from `gemi/orm` and at the two-armed bridge to keep while some writes in the app are still on Prisma. Files with no model import are left alone — there the guard is still correct.
+- **A `take:` or `skip:` whose value is not an integer literal.** The ORM refuses a fractional `take` with `InvalidArgumentError` where Prisma truncated it, so `Number(req.search.get("limit"))` is a 500 waiting for a hand-edited URL — and a fractional `page` is worse, because it reaches the ORM multiplied, as a fractional `skip`. The TODO points at `paginate` from `gemi/orm`, which truncates and clamps in one place.
+
+The second pass has a real false-positive rate and its wording says so: most non-literal `take`s are a constant or an already-truncated value, and the annotation asks you to confirm the value is truncated at the boundary rather than claiming a bug. Values that are integer literals, or a whole `Math.trunc(…)` / `Math.floor(…)` / `parseInt(…)` call, and `take?: number` in a type declaration, are not flagged.
+
+> **What it cannot find:** whether `limit` holds an integer, and whether a given `catch` sits over an ORM call or a Prisma one, are both run-time facts — so these passes annotate and never rewrite. The `"P2002"` pass also misses a guard living in a shared helper that imports nothing from your model surface; [UPGRADE.md](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md) carries the plain grep for that case.
+
 ## `gemi check models`
 
 Reports model classes carrying policies that the modules your Kernel declares do not register.
@@ -1231,6 +1247,33 @@ routes = {
 };
 ```
 
+### Streaming and range requests
+
+`this.stream(...)` registers a `GET` (and `HEAD`) handler that understands the `Range` header, so browsers can seek within audio and video. Return a `FileStorage.read()` result and the byte window is pushed down to the storage backend, so a seek transfers one window rather than the whole object:
+
+```typescript
+routes = {
+  "/assets/:src*": this.stream(async (req) => FileStorage.read(req.params.src)),
+};
+```
+
+The route handles the HTTP side for you:
+
+- a request with no `Range` gets the complete object with `200` and `Accept-Ranges: bytes`
+- `bytes=S-E`, `bytes=S-` and `bytes=-N` get a `206` with `Content-Range: bytes S-E/TOTAL`
+- a range that starts past the end of the object gets a `416` with `Content-Range: bytes */TOTAL`
+- a malformed or multi-range header is ignored and the complete object is served, as RFC 7233 requires
+
+A handler can also return a `Blob` or a `Bun.file()` directly, and the framework will slice it — no storage driver involved:
+
+```typescript
+"/clip": this.stream(() => Bun.file("/videos/clip.mp4")),
+```
+
+Returning a `Response` yourself opts out of all of the above and is passed through untouched.
+
+Stream routes are excluded from the generated RPC client types, since a typed JSON client has no way to consume a byte stream.
+
 ### Per-route middleware
 
 Every handler returned by `this.get`/`this.post`/… (and `this.resource`) has a fluent `.middleware([...])` that adds middleware to that route only:
@@ -1296,11 +1339,17 @@ The callback also receives the `HttpRequest`, so you can read query params (`req
 
 ```typescript
 "/users": this.view("admin/UserList", (req: HttpRequest) => {
-  const limit = Number(req.search.get("limit")) || 25;
-  const page = Number(req.search.get("page")) || 1;
-  return { limit, page };
+  const { take, skip } = paginate({
+    page: req.search.get("page"),
+    perPage: req.search.get("perPage"),
+  });
+  return { take, skip };
 }),
 ```
+
+Query values are strings, and `paginate` (from `gemi/orm`) is the one to reach for when they
+are page arguments: it truncates and clamps, so `?page=2.5` or a cleared `?perPage=` produces a
+usable page instead of a value the ORM refuses. See [ORM](./orm.md#querying).
 
 ### Layouts
 
@@ -1468,12 +1517,23 @@ async show(req: HttpRequest<{ name: string }, { orgId: string }>) { /* ... */ }
 `req.search` wraps the query string. `get` returns the value (a string, or `string[]` for repeated keys):
 
 ```typescript
+import { paginate } from "gemi/orm";
+
 async list(req: HttpRequest) {
   const search = req.search.get("search");
-  const limit = Number(req.search.get("limit")) || 25;
+  const { take, skip } = paginate({
+    page: req.search.get("page"),
+    perPage: req.search.get("perPage"),
+  });
   // ...
 }
 ```
+
+Everything the query string holds is a string, so a numeric param has to be converted, and
+`Number(...)` alone is not enough for the ones that become query arguments: `?limit=1.5` is a
+fractional `take`, which the ORM refuses rather than truncates, and a blank `?page=` is `0`,
+which computes a negative `skip`. `paginate` takes them as they arrive and always returns
+integers — see [ORM](./orm.md#querying).
 
 ### Reading the body: `req.input()`
 
@@ -2618,13 +2678,111 @@ import { Link } from "gemi/client";
   available.
 - `hash` — appends a `#fragment`.
 - `active` — force the active state.
+- `prefetch` — warm the target route before it is clicked; see below.
 
 `Link` sets `data-active` when its target matches the current URL, and
 `data-pending` while a navigation to it is in flight — style against these:
 
 ```tsx
-<Link className="data-[pending=true]:opacity-50" href="/about">About</Link>
+<Link className="data-[pending=true]:opacity-50" href="/about">
+  About
+</Link>
 ```
+
+## Prefetching
+
+A navigation fetches the target route's page data, stylesheets and component
+chunks, and the visitor waits for it. `prefetch` does that work earlier, so the
+click commits from cache instead of a request. It is **off unless you ask for
+it**:
+
+```tsx
+<Link href="/about" prefetch="hover">
+  About
+</Link>
+```
+
+Pick when it happens:
+
+| strategy   | fires                                                                                        |
+| ---------- | -------------------------------------------------------------------------------------------- |
+| `hover`    | the pointer arrives, or on touch or keyboard focus                                           |
+| `intent`   | the pointer is held ~100ms, so a cursor crossing a nav bar doesn't warm every link it passes |
+| `viewport` | the link scrolls into view (200px ahead of it)                                               |
+| `render`   | the link renders                                                                             |
+
+Strategies combine. The pairing that earns its keep is a bulk strategy plus an
+interactive one — `viewport` warms the link on the way past, and `intent` warms
+it again on approach if the payload has since gone stale:
+
+```tsx
+// Hoisted: an inline array literal is a new value on every render, which
+// defeats the memo on Link.
+const PREFETCH = ["viewport", "intent"] as const;
+
+<Link href="/pricing" prefetch={PREFETCH}>
+  Pricing
+</Link>;
+```
+
+`prefetch` also accepts `false`, so it can be driven by a variable:
+
+```tsx
+<Link href="/pricing" prefetch={isMetered ? false : "hover"}>
+  Pricing
+</Link>
+```
+
+### What it costs
+
+A prefetch **runs the route's handlers on the server** — it is a real request
+for real data, just early. With `viewport` or `render` on a list page that
+multiplies backend work by the number of links on screen. Prefetch requests
+carry a `Purpose: prefetch` header so you can tell them apart in logs and rate
+limiters, and skip side effects that should only happen on a genuine visit:
+
+```typescript
+"/posts/:id": this.view("Post", async () => {
+  if (Request.header("purpose") !== "prefetch") {
+    await recordView(params.id); // don't count a page nobody opened
+  }
+  return { /* … */ };
+}),
+```
+
+gemi keeps the cost bounded on its side: prefetching stands down on metered
+connections (`Save-Data`) and very slow ones (`2g`), links pointing at the
+current path are skipped, at most 12 payloads are retained at a time, and each
+one expires after 10 seconds.
+
+### Staleness
+
+A prefetched payload can be committed up to 10 seconds after it was fetched, and
+it is committed wholesale — including into the `useQuery` cache. Writes through
+`useMutation` (and `Form`, `usePost`, `usePut`, `usePatch`, `useDelete`,
+`useUpload`) drop every warmed payload on success, so your own mutations can't
+be undone by a stale prefetch. Data changed elsewhere is only bounded by the
+10-second window; on a page where that matters, leave `prefetch` off.
+
+### `usePrefetch`
+
+For warming a route outside of a link — the next step of a wizard, the page a
+form submit will land on — `usePrefetch` returns the same machinery as a
+function. It takes a typed path with `params` / `search` / `locale`:
+
+```tsx
+import { usePrefetch } from "gemi/client";
+
+function Wizard({ step }) {
+  const prefetch = usePrefetch();
+
+  useEffect(() => {
+    prefetch("/checkout/:step", { params: { step: String(step + 1) } });
+  }, [step]);
+}
+```
+
+It honours the same guards as the `prefetch` prop, and is a no-op during SSR.
 
 ## `useNavigate`
 
@@ -2682,7 +2840,7 @@ import { useSearchParams } from "gemi/client";
 
 function Pagination() {
   const searchParams = useSearchParams();
-  const page = Number(searchParams.get("page")) || 1;
+  const page = Math.max(1, Math.trunc(Number(searchParams.get("page"))) || 1);
 
   function goTo(next: number) {
     searchParams.set("page", String(next));
@@ -2691,6 +2849,13 @@ function Pagination() {
   // …
 }
 ```
+
+Truncate a page number where you read it, rather than trusting the query string: it holds
+whatever the last link, or a hand edit, left there, and the value is incremented and sent back
+to the server, where a fractional page arrives multiplied — as a fractional `skip`, which the
+ORM refuses. The server-side counterpart is `paginate` from `gemi/orm` (see
+[ORM](./orm.md#querying)); it belongs to the query layer, so on the client the whole of the job
+is the line above.
 
 `.set` accepts either `(key, value)` or an object of updates, and the value may be a
 function of the current value. `.push("hard")` forces a full data reload; the default
@@ -3253,6 +3418,34 @@ number agrees with the row beside it: a `delete` carrying one reads the count *b
 goes, and a write whose nested `create` writes children *after* the statement recomputes it once
 they have — otherwise `include` and `_count` would describe the same relation and disagree.
 
+**An `update` whose `data` sets no column reads the row rather than writing it.** `data: {}` is
+accepted and comes back with the row unchanged, honouring `select`, `include` and `_count` exactly
+as any other `update` does, and a `where` that matches nothing still raises `RecordNotFoundError` —
+it is the same plan with a `select` where the `update … returning` would have been, not a different
+path. Prisma answers the same way. The case is not contrived either: it is what a payload assembled
+from optional fields degenerates to when the caller changed nothing, and it used to turn a Save with
+nothing edited into an error. A `data` carrying only
+nested writes behaves identically, and for the same reason — there is nothing to set on the parent,
+so the statement reads, and the nested steps still run.
+
+`updateMany({ where, data: {} })` answers `{ count: 0 }`, and the count is a **constant** rather
+than the number of rows the filter selected. Measured against Prisma with two of three rows
+matching, again with a filter matching none, and again with no `where` at all: the same zero every
+time, and no row touched. The filter is still compiled, so an unknown field in it is refused whether
+or not there happened to be anything to write.
+
+Both hold on a model carrying `@updatedAt` too, which takes saying because the stamp looks like it
+should get in the way. It does not: **`@updatedAt` follows the column rather than the call.** A
+statement that sets at least one column stamps it; one that sets none — an empty `data`, or a `data`
+of only nested writes whose child holds the foreign key — leaves it alone, because nothing about
+this row was updated. Prisma draws the line in the same place, measured on rows seeded to a known
+instant rather than inferred from the attribute's name.
+
+A `data` of `null` is refused with `InvalidArgumentError`, and the distinction is worth one line:
+now that an empty object reads the row back, a null one would read it back too, which is a malformed
+call answered with a row. The message says the difference — an empty object is accepted, `null` is
+not.
+
 **`take` and `skip` must be integers, and are refused rather than coerced.** They are the only
 arguments whose *sign* decides the SQL — a negative `take` means "the last N", which flips every
 ordering term — so a `take` arriving as a string does not merely have the wrong type, it takes the
@@ -3260,8 +3453,7 @@ wrong branch: `take: "-2"` used to return the **first** two rows, in the opposit
 error. A query string is exactly where a string `take` comes from, so parse it before you pass it:
 
 ```
-UnsupportedQueryError: gemi ORM does not support 'take' yet (User.findMany).
-Expected an integer, got "-2".
+Invalid 'take' (User.findMany). Expected an integer, got "-2".
 ```
 
 A negative `skip` is refused too — it counts rows to pass over — and both rules are the ones that
@@ -3271,6 +3463,16 @@ already applied inside an `include`.
 > zero; this refuses it. Binding one instead is a `datatype mismatch` error from SQLite and a
 > silently different row count on Postgres, which rounds — so the fraction has no single meaning to
 > match. One rule at both levels, failing loudly, beats three behaviours.
+>
+> **Where it bites is the boundary, not the query.** The value has to be truncated where it enters
+> the application, not where it reaches the ORM, and `Number(req.search.get("limit"))` is the exact
+> shape that breaks — `?limit=1.5` is a URL anybody can type or a client can compute, and nothing
+> between the request and the statement narrows it. `page` is the harder one to find, because it
+> never reaches the ORM at all: it reaches it **multiplied**, as a fractional `skip`, so the refusal
+> names an argument the call site never wrote and points at a line that only does arithmetic.
+
+[`paginate`](#paginate) below is the request-facing half of that rule: it takes the query string as
+it arrives and cannot produce a value this section refuses.
 
 `select` and `include` narrow the **return type**, exactly as they do in Prisma — `user.email`
 type-checks, `user.name` does not. A key outside the operation's argument type collapses to
@@ -3287,6 +3489,61 @@ Queries return **plain objects**, never class instances. That is the default and
 stepping stone: a `Pick<User, "id">` hydrated as a `User` would carry methods reading fields the
 query never fetched. See [Rows and entities](./orm-rows-and-entities.md) for the two opt-in levels
 above it — `track` + `save`, and `wrap`.
+
+### `paginate`
+
+The integer rule above is a refusal; this is the spelling that satisfies it, short enough that
+reaching for it is easier than reaching for `Number`:
+
+```ts
+import { paginate } from "gemi/orm"
+
+const { take, skip } = paginate({
+  page: req.search.get("page"),
+  perPage: req.search.get("perPage"),
+})
+
+await Post.findMany({ take, skip, orderBy: { createdAt: "desc" } })
+```
+
+```ts
+paginate(
+  args: { page?: unknown; perPage?: unknown },
+  options?: { perPage?: number; maxPerPage?: number },
+): { take: number; skip: number }
+```
+
+**Both arguments are `unknown` deliberately.** A query string is where these values come from —
+that is the whole point of the helper — and typing them as `number` would mean every caller writes
+the `Number(…)` that is the bug. `req.search.get` hands back `string | string[]`, and a repeated
+key is a case `Number` honours sometimes and not others: `Number(["2"])` is `2`, while
+`Number(["1", "2"])` is `NaN`.
+
+The rules, each of them a shape a real request produces:
+
+- Anything that is not a string or a number is **absent** — an array, an object, a boolean, `null`.
+- An empty or blank string is absent as well, rather than `0`. `Number("")` is `0`, and `page: 0`
+  computes `skip: -25`, so a cleared filter box would otherwise be a 500.
+- A non-finite value is absent. `Number("1e400")` is `Infinity`, which `Math.trunc` cannot repair.
+- What is left is truncated toward zero — the same direction Prisma truncates a fractional `take`,
+  so a call site moving off Prisma keeps the same page instead of trading a crash for a different
+  answer — with `page` clamped up to at least 1 and `perPage` clamped into `[1, maxPerPage]`.
+
+The defaults are **25 rows a page** and a ceiling of **100** on what a *request* may ask for, so
+`?perPage=100000` cannot ask for the whole table. An endpoint that genuinely serves larger pages
+says so where it is called, `paginate(args, { maxPerPage: 500 })`, which is one visible decision
+instead of an invisible default. `skip` is capped at `Number.MAX_SAFE_INTEGER`: `?page=1e300`
+survives every rule above and multiplies out past what either driver will bind.
+
+**The guarantee is the reason to import this rather than copy it.** Every return value is a pair of
+integers with `take >= 1` and `skip >= 0`, for every input — so `paginate`'s output cannot be a
+value the integer rule refuses. `Number(x) || 1` does not have that property: it
+rescues `?page=` and `?page=0`, which are falsy, and passes `?page=-1`, `?page=2.5` and
+`?page=1e400` straight through to a refusal.
+
+`bunx gemi migrate` annotates every `take:` and `skip:` under `app/` whose value is not provably an
+integer, which is how you find the call sites in an application already written — see
+[the CLI page](./cli.md).
 
 ### Aggregates
 
@@ -3625,13 +3882,13 @@ await List.create({
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
 | `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
-| `disconnect` | Clears the link. `true` on a to-one; a unique key, or a list of them, on a to-many. The column has to be nullable. |
-| `delete` | Deletes the named rows outright, not just the link. |
+| `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true` on a to-one, and a filter as well when the child is the side holding the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
+| `delete` | Deletes the named rows outright, not just the link. A unique key or a list of them on a to-many; `true`, or a filter, on a to-one whose child holds the key. |
 | `update` | Writes your columns to the named row. The child's own `onUpdate` and scope rules apply to the payload. |
 | `set` | Replaces the whole set — detaches what is linked now, attaches what you name. |
 | `updateMany` | Writes your columns to this parent's rows matching a filter. |
 | `deleteMany` | Deletes this parent's rows matching a filter — the filter goes directly under the key, not inside a `where`. |
-| `upsert` | Finds the row **among this parent's**, updates it, or creates it. |
+| `upsert` | Finds the row **among this parent's**, updates it, or creates it. A to-one has no `where` to require — the link already names the row. |
 
 **A relation may join on more than one field.** `@relation(fields: [tenantId, orderId], references:
 [tenantId, id])` is the tenant-scoped composite-key style, and every read surface handles it: an
@@ -3691,13 +3948,51 @@ connected" rather than as denied, since that is the same answer a genuinely unli
 your columns like a top-level `update` — so the payload goes through the child's own operation and
 is judged by the child's policies. Naming a column the child scopes on is refused exactly as it
 would be at the top level. On a to-one both spellings work, `update: { … }` and
-`update: { data: { … } }`, because Prisma accepts both.
+`update: { data: { … } }`, because Prisma accepts both — measured on the side that holds the key,
+and again on the side whose child holds it, since the two are separate input types in the generated
+client and only one of them had been checked.
+
+A to-one `update` may also carry a `where`, and it does not mean what the to-many's means. There is
+nothing to choose between, so the filter decides *whether the single linked row is written at all*:
+`update: { where: { status: "draft" }, data: { … } }` writes the child if it is a draft, and raises
+if it is not. That raise is the part to know — a filter that matches nothing is a miss, reported
+with the same error and the same wording as a parent that has no child at all, because Prisma
+answers both with P2025 and does not distinguish them either.
 
 `set` is the one supported operand that acts on rows you did **not** name, so it means *replace the
 set I can see*: it detaches the linked rows your policies let you read, and leaves the rest attached.
 With no policy on the child that is Prisma's `set` exactly. Two of its behaviours are worth knowing
 because the name does not suggest them — it will repoint a row belonging to another parent, exactly
 as `connect` does, and it silently ignores a named row that does not exist.
+
+**On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather
+than a synonym for `true`.** There is one row and nothing to name, so `true` is how you say *the
+one that is linked*. A filter narrows rather than picks: `delete: { status: "draft" }` acts only if
+that single row matches, and it is a filter and not a unique key, so a column with no unique index
+is accepted here — Prisma accepts one, and refusing it would refuse a query the client answers.
+`false` is the value nobody guesses, and it is the reason to say this out loud: it writes nothing at
+all, so `disconnect: shouldDetach` leaves the row alone on the branch that asked for nothing.
+
+The two operands then part company on a miss, still on a to-one, and it is Prisma's asymmetry rather
+than a choice gemi made: `delete` raises `RecordNotFoundError` when there is no row to delete, while
+`disconnect` is silent. That holds whichever way the row went missing — no child linked at all, or a
+child present that the filter does not match, or a child your policies hide, which reads as no row
+at all here exactly as it does everywhere else. Note the last one carries a different error from its
+to-many spelling, which reports a hidden row as *not connected*. On the side that holds the foreign
+key *itself* there is nothing to filter — the row being cleared is the one the statement already
+names — so `disconnect` takes `true` alone there, and a `false` is refused rather than ignored. That
+last one is a divergence: Prisma treats it as the no-op it reads like. It is a loud refusal on the
+branch that asked for nothing, which is the wrong answer given noisily rather than quietly.
+
+**An array is refused on a to-one whose child holds the key** — `create`, `connect`,
+`connectOrCreate`, `update`, `delete` and `upsert` alike — and that is matching Prisma rather than
+being stricter than it. All of them are a `PrismaClientValidationError` against a generated client,
+with nothing written. Because that is an *argument* refusal and carries no Prisma error code, gemi's
+is `InvalidArgumentError`, and the message names the single object the operand wants rather than
+announcing that arrays are unimplemented. What made it worth refusing rather than tolerating: the
+array used to compile, and a `connect` of two rows through a relation that holds one repointed
+**both**, the second silently winning. `connect` and `connectOrCreate` refuse an array on the other
+side too, and always did.
 
 `updateMany` and `deleteMany` take a **filter** rather than a key, and it applies to this parent's
 rows only. Their operands are shaped differently and it is easy to get backwards: `updateMany` wraps
@@ -3714,10 +4009,34 @@ semantics and is the detail that decides what it does: naming a row that exists 
 elsewhere takes the *create* branch and collides on the unique key, rather than updating somebody
 else's row.
 
-Every operand in Prisma's nested grammar is now implemented for an ordinary relation. Ones that act
-on rows already linked to this one — `disconnect`, `delete`, `update`, `updateMany`, `deleteMany`,
-`set`, `upsert` — are available on an `update` and refused on a `create`, which has nothing linked
-to it yet; Prisma reports them as unknown arguments there too.
+On a to-one there is no `where` to require, because the link already names the row — so
+`upsert: { create, update }` is the whole operand and the `update` branch runs against the single
+child. A `where` is still accepted, and it is the same sentence seen from the other side: one that
+does not match takes the **create** branch, and the create then collides with the unique foreign key
+the existing child is holding. That collision is a `UniqueConstraintError` and it is left to happen
+rather than pre-empted, because it is the answer Prisma gives.
+
+The same collision is how a *hidden* child surfaces, which is worth knowing before you meet it: a
+row your policies scope away reads as absent, absent takes the create branch, and the create runs
+into the unique key the row you cannot see is holding. So a to-one `upsert` can fail on a field the
+caller never wrote — the child's foreign key — and that is the shape of the answer, not a leak: it
+is the same refusal an unrelated row holding that key would produce.
+
+Every operand in Prisma's nested grammar is implemented for an ordinary relation — one that is not
+an implicit many-to-many — in the direction where the **child** holds the foreign key. That is every
+to-many, and a to-one read from the side the child points at. Ones that act on rows already linked
+to this one — `disconnect`, `delete`, `update`, `updateMany`, `deleteMany`, `set`, `upsert` — are
+available on an `update` and refused on a `create`, which has nothing linked to it yet; Prisma
+reports them as unknown arguments there too.
+
+**Two are refused on a to-one that holds its own key, and both are decisions rather than unfinished
+work.** `delete` there would remove a row the statement is not about — the far row lives in another
+table and is reached through a column of this one, and a delete firing as a side effect of an
+unrelated update is the kind of thing to implement deliberately or not at all. `upsert` would have
+to create the far row and then write its key back to a parent that has already been inserted, a
+shape no other operand on that side needs. Both refusals name the alternative: write the far row
+directly, then `connect` it. (`set`, `updateMany` and `deleteMany` describe *several* rows, so
+neither side of a to-one offers them, and neither does Prisma.)
 
 Two rules hold across all of them. The **foreign key is the ORM's to set**, so a nested row naming
 it is describing a different parent than the call is, and it is overwritten. And the **parent
@@ -4029,6 +4348,23 @@ vi.mock("@/app/models", () => ({
 `transaction: (cb) => cb()` is the whole trick: the callback runs inline, the assertions are about
 what it called, and no connection is involved. `vi.spyOn` on the model statics does the same job
 when you want the real module for everything else.
+
+**A mocked failure has to reject with the error the runtime really throws**, and this is the one
+place a mock can certify a branch that no longer exists. `create.mockRejectedValue({ code: "P2002" })`
+is the object a Prisma application already has lying around; against gemi it satisfies nothing —
+the guard under test is `isUniqueConstraintError`, that object is not one, so the recovery branch is
+never entered and the test passes anyway, having asserted the fallthrough. Construct the real error
+instead:
+
+```ts
+import { UniqueConstraintError } from "gemi/orm"
+
+User.create.mockRejectedValue(new UniqueConstraintError("User", "create", ["email"]))
+```
+
+The cost of getting this wrong is measured rather than imagined: in the first application ported
+onto this ORM, four `code === "P2002"` guards went dead when their writes moved over, roughly 2,700
+unit tests stayed green throughout, and what caught it was a person reading the diff.
 
 What this does not cover is the behaviour that only a real transaction has — the rollback, the
 savepoint, the Postgres abort described above. Those need a database, and they belong in an
@@ -4386,7 +4722,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | Error | Raised when |
 | --- | --- |
 | `RecordNotFoundError` | An `…OrThrow` operation matched nothing. |
-| `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. |
+| `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. It is gemi's own error and carries no Prisma `code` — see below if a `"P2002"` check is what you have today. |
 | `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
 | `ScopeEscapeError` | An `update` wrote a column its own policy's `scope` selects on, with no `onUpdate`. |
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
@@ -4405,6 +4741,39 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `ReturningUnsupportedError` | A write on a dialect without `RETURNING`, which is the same gap seen from the write path. |
 | `StaleSchemaArtifactError` | Generated files predate the running gemi. Re-run `prisma generate`. |
 | `MalformedRelationError` / `MissingModelSchemaError` / `UnregisteredRelationTargetError` | The generated artifact and the registry disagree — the same family as the two above, and the same fix. |
+
+**`isUniqueConstraintError` is the guard to write in a retry-on-collision `catch`**, which is where
+a unique-violation check almost always is. It is exported from `gemi/orm` beside the class itself:
+
+```ts
+try {
+  return await Invite.create({ data: { token } })
+} catch (error) {
+  if (!isUniqueConstraintError(error)) throw error
+  return await Invite.findUniqueOrThrow({ where: { token } })
+}
+```
+
+```ts
+isUniqueConstraintError(error: unknown): error is UniqueConstraintError
+```
+
+It tests `instanceof` **or** `error.name === "UniqueConstraintError"`, and the second half is the
+reason to import it rather than write `instanceof` yourself. `instanceof` compares against *this*
+module instance's class object, so it is false across a duplicate copy of `gemi/orm` — two versions
+in one dependency tree, a bundled build beside a linked one, a monorepo package resolving its own.
+The error would be the right error, thrown by the right code, and the guard would silently not fire.
+Every error here sets its own `name` for exactly that reason.
+
+> **Porting from Prisma: this is the check that dies quietly.** A collision arrives as
+> `UniqueConstraintError`, which names `model`, `operation`, `fields` and `constraint` and has no
+> `code` anywhere on its prototype chain. So `error.code === "P2002"` is `false` from the moment the
+> write it guards moves onto the ORM — nothing raises, nothing is logged, and the recovery branch
+> the guard exists to run never runs again. It compiles, it runs, and it reads correct. Go and find
+> the string rather than waiting to meet it: `bunx gemi migrate` annotates the occurrences it can
+> see (see [the CLI page](./cli.md)), and
+> [UPGRADE.md](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md) carries the two-armed bridge to
+> write while some of your writes are still on Prisma, with the marker saying when to delete it.
 
 ## Performance
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Getting Started](https://nstfkc.github.io/gemi/getting-started.md): install, scaffold with create-gemi-app, dev/build/start, a first route + view.
 - [Project Structure & the Kernel](https://nstfkc.github.io/gemi/project-structure.md): the app/ layout, the Kernel, the container, app/config/*.ts, service providers, and app bootstrap.
 - [Configuration](https://nstfkc.github.io/gemi/configuration.md): gemi.config.ts (BUILD config, distinct from app/config/), .env handling, HTML compression, app/preload.ts, Vite config.
-- [CLI](https://nstfkc.github.io/gemi/cli.md): gemi dev/build/start, gemi migrate (the 0.42 -> config/container codemod, and the retired-API TODOs), plus codegen and inspection commands.
+- [CLI](https://nstfkc.github.io/gemi/cli.md): gemi dev/build/start, gemi migrate (the 0.42 -> config/container codemod, the retired-API TODOs, and the two annotate-only passes for a Prisma-to-ORM port), plus codegen and inspection commands.
 
 ## HTTP layer
 
@@ -61,3 +61,4 @@ Each link below points to a self-contained Markdown page. For a single file cont
 
 - [Full documentation (single file)](https://nstfkc.github.io/gemi/llms-full.txt): every page concatenated for one-shot LLM context.
 - [Documentation index](https://nstfkc.github.io/gemi/README.md): the human-readable table of contents.
+- [Upgrade notes](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md): per-release migration steps, including moving an app's queries from the Prisma client onto gemi's ORM — a `code === "P2002"` guard stops firing and a `take`/`skip` built with `Number(...)` starts being refused, both silently. Not part of this site; it lives at the repository root.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -193,7 +193,7 @@ import { useSearchParams } from "gemi/client";
 
 function Pagination() {
   const searchParams = useSearchParams();
-  const page = Number(searchParams.get("page")) || 1;
+  const page = Math.max(1, Math.trunc(Number(searchParams.get("page"))) || 1);
 
   function goTo(next: number) {
     searchParams.set("page", String(next));
@@ -202,6 +202,13 @@ function Pagination() {
   // …
 }
 ```
+
+Truncate a page number where you read it, rather than trusting the query string: it holds
+whatever the last link, or a hand edit, left there, and the value is incremented and sent back
+to the server, where a fractional page arrives multiplied — as a fractional `skip`, which the
+ORM refuses. The server-side counterpart is `paginate` from `gemi/orm` (see
+[ORM](./orm.md#querying)); it belongs to the query layer, so on the client the whole of the job
+is the line above.
 
 `.set` accepts either `(key, value)` or an object of updates, and the value may be a
 function of the current value. `.push("hard")` forces a full data reload; the default

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -193,7 +193,11 @@ import { useSearchParams } from "gemi/client";
 
 function Pagination() {
   const searchParams = useSearchParams();
-  const page = Math.max(1, Math.trunc(Number(searchParams.get("page"))) || 1);
+  // `Number.isFinite` first: `?page=1e400` is `Infinity`, which `Math.trunc`
+  // returns unchanged and `Math.max` happily keeps — and it would go straight
+  // back into the URL through `goTo` below.
+  const asked = Number(searchParams.get("page"));
+  const page = Number.isFinite(asked) ? Math.max(1, Math.trunc(asked)) : 1;
 
   function goTo(next: number) {
     searchParams.set("page", String(next));

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -439,6 +439,34 @@ number agrees with the row beside it: a `delete` carrying one reads the count *b
 goes, and a write whose nested `create` writes children *after* the statement recomputes it once
 they have — otherwise `include` and `_count` would describe the same relation and disagree.
 
+**An `update` whose `data` sets no column reads the row rather than writing it.** `data: {}` is
+accepted and comes back with the row unchanged, honouring `select`, `include` and `_count` exactly
+as any other `update` does, and a `where` that matches nothing still raises `RecordNotFoundError` —
+it is the same plan with a `select` where the `update … returning` would have been, not a different
+path. Prisma answers the same way. The case is not contrived either: it is what a payload assembled
+from optional fields degenerates to when the caller changed nothing, and it used to turn a Save with
+nothing edited into an error. A `data` carrying only
+nested writes behaves identically, and for the same reason — there is nothing to set on the parent,
+so the statement reads, and the nested steps still run.
+
+`updateMany({ where, data: {} })` answers `{ count: 0 }`, and the count is a **constant** rather
+than the number of rows the filter selected. Measured against Prisma with two of three rows
+matching, again with a filter matching none, and again with no `where` at all: the same zero every
+time, and no row touched. The filter is still compiled, so an unknown field in it is refused whether
+or not there happened to be anything to write.
+
+Both hold on a model carrying `@updatedAt` too, which takes saying because the stamp looks like it
+should get in the way. It does not: **`@updatedAt` follows the column rather than the call.** A
+statement that sets at least one column stamps it; one that sets none — an empty `data`, or a `data`
+of only nested writes whose child holds the foreign key — leaves it alone, because nothing about
+this row was updated. Prisma draws the line in the same place, measured on rows seeded to a known
+instant rather than inferred from the attribute's name.
+
+A `data` of `null` is refused with `InvalidArgumentError`, and the distinction is worth one line:
+now that an empty object reads the row back, a null one would read it back too, which is a malformed
+call answered with a row. The message says the difference — an empty object is accepted, `null` is
+not.
+
 **`take` and `skip` must be integers, and are refused rather than coerced.** They are the only
 arguments whose *sign* decides the SQL — a negative `take` means "the last N", which flips every
 ordering term — so a `take` arriving as a string does not merely have the wrong type, it takes the
@@ -446,8 +474,7 @@ wrong branch: `take: "-2"` used to return the **first** two rows, in the opposit
 error. A query string is exactly where a string `take` comes from, so parse it before you pass it:
 
 ```
-UnsupportedQueryError: gemi ORM does not support 'take' yet (User.findMany).
-Expected an integer, got "-2".
+Invalid 'take' (User.findMany). Expected an integer, got "-2".
 ```
 
 A negative `skip` is refused too — it counts rows to pass over — and both rules are the ones that
@@ -457,6 +484,16 @@ already applied inside an `include`.
 > zero; this refuses it. Binding one instead is a `datatype mismatch` error from SQLite and a
 > silently different row count on Postgres, which rounds — so the fraction has no single meaning to
 > match. One rule at both levels, failing loudly, beats three behaviours.
+>
+> **Where it bites is the boundary, not the query.** The value has to be truncated where it enters
+> the application, not where it reaches the ORM, and `Number(req.search.get("limit"))` is the exact
+> shape that breaks — `?limit=1.5` is a URL anybody can type or a client can compute, and nothing
+> between the request and the statement narrows it. `page` is the harder one to find, because it
+> never reaches the ORM at all: it reaches it **multiplied**, as a fractional `skip`, so the refusal
+> names an argument the call site never wrote and points at a line that only does arithmetic.
+
+[`paginate`](#paginate) below is the request-facing half of that rule: it takes the query string as
+it arrives and cannot produce a value this section refuses.
 
 `select` and `include` narrow the **return type**, exactly as they do in Prisma — `user.email`
 type-checks, `user.name` does not. A key outside the operation's argument type collapses to
@@ -473,6 +510,61 @@ Queries return **plain objects**, never class instances. That is the default and
 stepping stone: a `Pick<User, "id">` hydrated as a `User` would carry methods reading fields the
 query never fetched. See [Rows and entities](./orm-rows-and-entities.md) for the two opt-in levels
 above it — `track` + `save`, and `wrap`.
+
+### `paginate`
+
+The integer rule above is a refusal; this is the spelling that satisfies it, short enough that
+reaching for it is easier than reaching for `Number`:
+
+```ts
+import { paginate } from "gemi/orm"
+
+const { take, skip } = paginate({
+  page: req.search.get("page"),
+  perPage: req.search.get("perPage"),
+})
+
+await Post.findMany({ take, skip, orderBy: { createdAt: "desc" } })
+```
+
+```ts
+paginate(
+  args: { page?: unknown; perPage?: unknown },
+  options?: { perPage?: number; maxPerPage?: number },
+): { take: number; skip: number }
+```
+
+**Both arguments are `unknown` deliberately.** A query string is where these values come from —
+that is the whole point of the helper — and typing them as `number` would mean every caller writes
+the `Number(…)` that is the bug. `req.search.get` hands back `string | string[]`, and a repeated
+key is a case `Number` honours sometimes and not others: `Number(["2"])` is `2`, while
+`Number(["1", "2"])` is `NaN`.
+
+The rules, each of them a shape a real request produces:
+
+- Anything that is not a string or a number is **absent** — an array, an object, a boolean, `null`.
+- An empty or blank string is absent as well, rather than `0`. `Number("")` is `0`, and `page: 0`
+  computes `skip: -25`, so a cleared filter box would otherwise be a 500.
+- A non-finite value is absent. `Number("1e400")` is `Infinity`, which `Math.trunc` cannot repair.
+- What is left is truncated toward zero — the same direction Prisma truncates a fractional `take`,
+  so a call site moving off Prisma keeps the same page instead of trading a crash for a different
+  answer — with `page` clamped up to at least 1 and `perPage` clamped into `[1, maxPerPage]`.
+
+The defaults are **25 rows a page** and a ceiling of **100** on what a *request* may ask for, so
+`?perPage=100000` cannot ask for the whole table. An endpoint that genuinely serves larger pages
+says so where it is called, `paginate(args, { maxPerPage: 500 })`, which is one visible decision
+instead of an invisible default. `skip` is capped at `Number.MAX_SAFE_INTEGER`: `?page=1e300`
+survives every rule above and multiplies out past what either driver will bind.
+
+**The guarantee is the reason to import this rather than copy it.** Every return value is a pair of
+integers with `take >= 1` and `skip >= 0`, for every input — so `paginate`'s output cannot be a
+value the integer rule refuses. `Number(x) || 1` does not have that property: it
+rescues `?page=` and `?page=0`, which are falsy, and passes `?page=-1`, `?page=2.5` and
+`?page=1e400` straight through to a refusal.
+
+`bunx gemi migrate` annotates every `take:` and `skip:` under `app/` whose value is not provably an
+integer, which is how you find the call sites in an application already written — see
+[the CLI page](./cli.md).
 
 ### Aggregates
 
@@ -811,13 +903,13 @@ await List.create({
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
 | `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
-| `disconnect` | Clears the link. `true` on a to-one; a unique key, or a list of them, on a to-many. The column has to be nullable. |
-| `delete` | Deletes the named rows outright, not just the link. |
+| `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true` on a to-one, and a filter as well when the child is the side holding the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
+| `delete` | Deletes the named rows outright, not just the link. A unique key or a list of them on a to-many; `true`, or a filter, on a to-one whose child holds the key. |
 | `update` | Writes your columns to the named row. The child's own `onUpdate` and scope rules apply to the payload. |
 | `set` | Replaces the whole set — detaches what is linked now, attaches what you name. |
 | `updateMany` | Writes your columns to this parent's rows matching a filter. |
 | `deleteMany` | Deletes this parent's rows matching a filter — the filter goes directly under the key, not inside a `where`. |
-| `upsert` | Finds the row **among this parent's**, updates it, or creates it. |
+| `upsert` | Finds the row **among this parent's**, updates it, or creates it. A to-one has no `where` to require — the link already names the row. |
 
 **A relation may join on more than one field.** `@relation(fields: [tenantId, orderId], references:
 [tenantId, id])` is the tenant-scoped composite-key style, and every read surface handles it: an
@@ -877,13 +969,51 @@ connected" rather than as denied, since that is the same answer a genuinely unli
 your columns like a top-level `update` — so the payload goes through the child's own operation and
 is judged by the child's policies. Naming a column the child scopes on is refused exactly as it
 would be at the top level. On a to-one both spellings work, `update: { … }` and
-`update: { data: { … } }`, because Prisma accepts both.
+`update: { data: { … } }`, because Prisma accepts both — measured on the side that holds the key,
+and again on the side whose child holds it, since the two are separate input types in the generated
+client and only one of them had been checked.
+
+A to-one `update` may also carry a `where`, and it does not mean what the to-many's means. There is
+nothing to choose between, so the filter decides *whether the single linked row is written at all*:
+`update: { where: { status: "draft" }, data: { … } }` writes the child if it is a draft, and raises
+if it is not. That raise is the part to know — a filter that matches nothing is a miss, reported
+with the same error and the same wording as a parent that has no child at all, because Prisma
+answers both with P2025 and does not distinguish them either.
 
 `set` is the one supported operand that acts on rows you did **not** name, so it means *replace the
 set I can see*: it detaches the linked rows your policies let you read, and leaves the rest attached.
 With no policy on the child that is Prisma's `set` exactly. Two of its behaviours are worth knowing
 because the name does not suggest them — it will repoint a row belonging to another parent, exactly
 as `connect` does, and it silently ignores a named row that does not exist.
+
+**On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather
+than a synonym for `true`.** There is one row and nothing to name, so `true` is how you say *the
+one that is linked*. A filter narrows rather than picks: `delete: { status: "draft" }` acts only if
+that single row matches, and it is a filter and not a unique key, so a column with no unique index
+is accepted here — Prisma accepts one, and refusing it would refuse a query the client answers.
+`false` is the value nobody guesses, and it is the reason to say this out loud: it writes nothing at
+all, so `disconnect: shouldDetach` leaves the row alone on the branch that asked for nothing.
+
+The two operands then part company on a miss, still on a to-one, and it is Prisma's asymmetry rather
+than a choice gemi made: `delete` raises `RecordNotFoundError` when there is no row to delete, while
+`disconnect` is silent. That holds whichever way the row went missing — no child linked at all, or a
+child present that the filter does not match, or a child your policies hide, which reads as no row
+at all here exactly as it does everywhere else. Note the last one carries a different error from its
+to-many spelling, which reports a hidden row as *not connected*. On the side that holds the foreign
+key *itself* there is nothing to filter — the row being cleared is the one the statement already
+names — so `disconnect` takes `true` alone there, and a `false` is refused rather than ignored. That
+last one is a divergence: Prisma treats it as the no-op it reads like. It is a loud refusal on the
+branch that asked for nothing, which is the wrong answer given noisily rather than quietly.
+
+**An array is refused on a to-one whose child holds the key** — `create`, `connect`,
+`connectOrCreate`, `update`, `delete` and `upsert` alike — and that is matching Prisma rather than
+being stricter than it. All of them are a `PrismaClientValidationError` against a generated client,
+with nothing written. Because that is an *argument* refusal and carries no Prisma error code, gemi's
+is `InvalidArgumentError`, and the message names the single object the operand wants rather than
+announcing that arrays are unimplemented. What made it worth refusing rather than tolerating: the
+array used to compile, and a `connect` of two rows through a relation that holds one repointed
+**both**, the second silently winning. `connect` and `connectOrCreate` refuse an array on the other
+side too, and always did.
 
 `updateMany` and `deleteMany` take a **filter** rather than a key, and it applies to this parent's
 rows only. Their operands are shaped differently and it is easy to get backwards: `updateMany` wraps
@@ -900,10 +1030,34 @@ semantics and is the detail that decides what it does: naming a row that exists 
 elsewhere takes the *create* branch and collides on the unique key, rather than updating somebody
 else's row.
 
-Every operand in Prisma's nested grammar is now implemented for an ordinary relation. Ones that act
-on rows already linked to this one — `disconnect`, `delete`, `update`, `updateMany`, `deleteMany`,
-`set`, `upsert` — are available on an `update` and refused on a `create`, which has nothing linked
-to it yet; Prisma reports them as unknown arguments there too.
+On a to-one there is no `where` to require, because the link already names the row — so
+`upsert: { create, update }` is the whole operand and the `update` branch runs against the single
+child. A `where` is still accepted, and it is the same sentence seen from the other side: one that
+does not match takes the **create** branch, and the create then collides with the unique foreign key
+the existing child is holding. That collision is a `UniqueConstraintError` and it is left to happen
+rather than pre-empted, because it is the answer Prisma gives.
+
+The same collision is how a *hidden* child surfaces, which is worth knowing before you meet it: a
+row your policies scope away reads as absent, absent takes the create branch, and the create runs
+into the unique key the row you cannot see is holding. So a to-one `upsert` can fail on a field the
+caller never wrote — the child's foreign key — and that is the shape of the answer, not a leak: it
+is the same refusal an unrelated row holding that key would produce.
+
+Every operand in Prisma's nested grammar is implemented for an ordinary relation — one that is not
+an implicit many-to-many — in the direction where the **child** holds the foreign key. That is every
+to-many, and a to-one read from the side the child points at. Ones that act on rows already linked
+to this one — `disconnect`, `delete`, `update`, `updateMany`, `deleteMany`, `set`, `upsert` — are
+available on an `update` and refused on a `create`, which has nothing linked to it yet; Prisma
+reports them as unknown arguments there too.
+
+**Two are refused on a to-one that holds its own key, and both are decisions rather than unfinished
+work.** `delete` there would remove a row the statement is not about — the far row lives in another
+table and is reached through a column of this one, and a delete firing as a side effect of an
+unrelated update is the kind of thing to implement deliberately or not at all. `upsert` would have
+to create the far row and then write its key back to a parent that has already been inserted, a
+shape no other operand on that side needs. Both refusals name the alternative: write the far row
+directly, then `connect` it. (`set`, `updateMany` and `deleteMany` describe *several* rows, so
+neither side of a to-one offers them, and neither does Prisma.)
 
 Two rules hold across all of them. The **foreign key is the ORM's to set**, so a nested row naming
 it is describing a different parent than the call is, and it is overwritten. And the **parent
@@ -1215,6 +1369,23 @@ vi.mock("@/app/models", () => ({
 `transaction: (cb) => cb()` is the whole trick: the callback runs inline, the assertions are about
 what it called, and no connection is involved. `vi.spyOn` on the model statics does the same job
 when you want the real module for everything else.
+
+**A mocked failure has to reject with the error the runtime really throws**, and this is the one
+place a mock can certify a branch that no longer exists. `create.mockRejectedValue({ code: "P2002" })`
+is the object a Prisma application already has lying around; against gemi it satisfies nothing —
+the guard under test is `isUniqueConstraintError`, that object is not one, so the recovery branch is
+never entered and the test passes anyway, having asserted the fallthrough. Construct the real error
+instead:
+
+```ts
+import { UniqueConstraintError } from "gemi/orm"
+
+User.create.mockRejectedValue(new UniqueConstraintError("User", "create", ["email"]))
+```
+
+The cost of getting this wrong is measured rather than imagined: in the first application ported
+onto this ORM, four `code === "P2002"` guards went dead when their writes moved over, roughly 2,700
+unit tests stayed green throughout, and what caught it was a person reading the diff.
 
 What this does not cover is the behaviour that only a real transaction has — the rollback, the
 savepoint, the Postgres abort described above. Those need a database, and they belong in an
@@ -1572,7 +1743,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | Error | Raised when |
 | --- | --- |
 | `RecordNotFoundError` | An `…OrThrow` operation matched nothing. |
-| `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. |
+| `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. It is gemi's own error and carries no Prisma `code` — see below if a `"P2002"` check is what you have today. |
 | `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
 | `ScopeEscapeError` | An `update` wrote a column its own policy's `scope` selects on, with no `onUpdate`. |
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
@@ -1591,6 +1762,39 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `ReturningUnsupportedError` | A write on a dialect without `RETURNING`, which is the same gap seen from the write path. |
 | `StaleSchemaArtifactError` | Generated files predate the running gemi. Re-run `prisma generate`. |
 | `MalformedRelationError` / `MissingModelSchemaError` / `UnregisteredRelationTargetError` | The generated artifact and the registry disagree — the same family as the two above, and the same fix. |
+
+**`isUniqueConstraintError` is the guard to write in a retry-on-collision `catch`**, which is where
+a unique-violation check almost always is. It is exported from `gemi/orm` beside the class itself:
+
+```ts
+try {
+  return await Invite.create({ data: { token } })
+} catch (error) {
+  if (!isUniqueConstraintError(error)) throw error
+  return await Invite.findUniqueOrThrow({ where: { token } })
+}
+```
+
+```ts
+isUniqueConstraintError(error: unknown): error is UniqueConstraintError
+```
+
+It tests `instanceof` **or** `error.name === "UniqueConstraintError"`, and the second half is the
+reason to import it rather than write `instanceof` yourself. `instanceof` compares against *this*
+module instance's class object, so it is false across a duplicate copy of `gemi/orm` — two versions
+in one dependency tree, a bundled build beside a linked one, a monorepo package resolving its own.
+The error would be the right error, thrown by the right code, and the guard would silently not fire.
+Every error here sets its own `name` for exactly that reason.
+
+> **Porting from Prisma: this is the check that dies quietly.** A collision arrives as
+> `UniqueConstraintError`, which names `model`, `operation`, `fields` and `constraint` and has no
+> `code` anywhere on its prototype chain. So `error.code === "P2002"` is `false` from the moment the
+> write it guards moves onto the ORM — nothing raises, nothing is logged, and the recovery branch
+> the guard exists to run never runs again. It compiles, it runs, and it reads correct. Go and find
+> the string rather than waiting to meet it: `bunx gemi migrate` annotates the occurrences it can
+> see (see [the CLI page](./cli.md)), and
+> [UPGRADE.md](https://github.com/nstfkc/gemi/blob/main/UPGRADE.md) carries the two-armed bridge to
+> write while some of your writes are still on Prisma, with the marker saying when to delete it.
 
 ## Performance
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -235,11 +235,17 @@ The callback also receives the `HttpRequest`, so you can read query params (`req
 
 ```typescript
 "/users": this.view("admin/UserList", (req: HttpRequest) => {
-  const limit = Number(req.search.get("limit")) || 25;
-  const page = Number(req.search.get("page")) || 1;
-  return { limit, page };
+  const { take, skip } = paginate({
+    page: req.search.get("page"),
+    perPage: req.search.get("perPage"),
+  });
+  return { take, skip };
 }),
 ```
+
+Query values are strings, and `paginate` (from `gemi/orm`) is the one to reach for when they
+are page arguments: it truncates and clamps, so `?page=2.5` or a cleared `?perPage=` produces a
+usable page instead of a value the ORM refuses. See [ORM](./orm.md#querying).
 
 ### Layouts
 

--- a/packages/gemi/bin/migrate/index.ts
+++ b/packages/gemi/bin/migrate/index.ts
@@ -14,6 +14,7 @@ import type { ClassDecl, ClassMember } from "./classBody";
 import { isUsed, parseImports, printImport, stripLiterals } from "./imports";
 import type { ImportDecl } from "./imports";
 import { renameIdentifier } from "./lex";
+import { annotateOrmPortHazards } from "./orm";
 import {
   DELETED_EXPORTS,
   EXTRACTION_TARGETS,
@@ -195,13 +196,17 @@ export async function runMigrate(options: MigrateOptions) {
   // 4. Provider files whose contents now live in app/config are superseded.
   for (const file of migratedFiles) changes.push({ file, contents: null });
 
-  // 5. Renames across the rest of the app, plus retired fields in app/config.
+  // 5. Renames across the rest of the app, plus retired fields in app/config
+  //    and the two ORM-port hazards. The ORM pass runs over every file, not
+  //    only `app/config`: what it looks for is a guard or a query argument, and
+  //    those live wherever the app writes and reads.
   const touched = new Set(changes.map((change) => change.file));
   for (const file of walk(appDir)) {
     if (touched.has(file)) continue;
     const source = readFileSync(file, "utf8");
     let rewritten = rewriteReferences(source, rel(rootDir, file), notes);
     rewritten = annotateRetiredFields(rewritten, file, rootDir, notes);
+    rewritten = annotateOrmPortHazards(rewritten, rel(rootDir, file), notes);
     if (rewritten !== source) changes.push({ file, contents: rewritten });
   }
 

--- a/packages/gemi/bin/migrate/index.ts
+++ b/packages/gemi/bin/migrate/index.ts
@@ -196,18 +196,60 @@ export async function runMigrate(options: MigrateOptions) {
   // 4. Provider files whose contents now live in app/config are superseded.
   for (const file of migratedFiles) changes.push({ file, contents: null });
 
-  // 5. Renames across the rest of the app, plus retired fields in app/config
-  //    and the two ORM-port hazards. The ORM pass runs over every file, not
-  //    only `app/config`: what it looks for is a guard or a query argument, and
-  //    those live wherever the app writes and reads.
+  // 5. Renames across the rest of the app, plus retired fields in app/config.
   const touched = new Set(changes.map((change) => change.file));
   for (const file of walk(appDir)) {
     if (touched.has(file)) continue;
     const source = readFileSync(file, "utf8");
     let rewritten = rewriteReferences(source, rel(rootDir, file), notes);
     rewritten = annotateRetiredFields(rewritten, file, rootDir, notes);
-    rewritten = annotateOrmPortHazards(rewritten, rel(rootDir, file), notes);
     if (rewritten !== source) changes.push({ file, contents: rewritten });
+  }
+
+  // 6. The two ORM-port hazards, over every file this run will leave behind —
+  //    which is a wider set than the loop above walks, and deliberately so.
+  //
+  //    Step 4 supersedes the provider files by moving their bodies into
+  //    `app/config/*.ts`, and steps 2 and 3 rewrite `Kernel.ts` and write
+  //    `AppServiceProvider.ts`. All of those land in `changes`, so the loop
+  //    above skips them — and they hold *user* code, carried over verbatim from
+  //    a provider's `boot()`. On the one run that matters, the first run on an
+  //    old-layout app, a `"P2002"` guard or a query-string `take` inside any of
+  //    them would never have been looked at. A second run finds them, but only
+  //    because by then the passes that moved them have become no-ops, which is
+  //    not a property to rely on.
+  //
+  //    So this runs last and over `changes` as well as over the tree: what the
+  //    pass looks for is a guard or a query argument, and those live wherever
+  //    the app writes and reads, including in a file this command just created.
+  const pending = new Map<string, number>();
+  const removed = new Set<string>();
+  changes.forEach((change, index) => {
+    if (change.contents === null) removed.add(change.file);
+    else pending.set(change.file, index);
+  });
+
+  const swept = new Set<string>();
+  for (const file of walk(appDir)) {
+    if (removed.has(file)) continue;
+    swept.add(file);
+    const index = pending.get(file);
+    const before =
+      index === undefined ? readFileSync(file, "utf8") : changes[index]!.contents!;
+    const after = annotateOrmPortHazards(before, rel(rootDir, file), notes);
+    if (after === before) continue;
+    if (index === undefined) changes.push({ file, contents: after });
+    else changes[index]!.contents = after;
+  }
+
+  // A file `changes` creates does not exist yet, so `walk` cannot yield it.
+  for (const change of changes) {
+    if (change.contents === null || swept.has(change.file)) continue;
+    change.contents = annotateOrmPortHazards(
+      change.contents,
+      rel(rootDir, change.file),
+      notes,
+    );
   }
 
   // Apply.

--- a/packages/gemi/bin/migrate/migrate.test.ts
+++ b/packages/gemi/bin/migrate/migrate.test.ts
@@ -482,3 +482,157 @@ export const list = (perPage) => Post.findMany({ take: perPage });
     ).toHaveLength(1);
   });
 });
+
+/**
+ * **A file that can hold JSX is reported, never spliced.**
+ *
+ * A `//` line above a hit is a comment in a `.ts` file and page text in a
+ * `.tsx` one — and the `{ code: "P2002" }` inside the P2002 message becomes a
+ * JSX expression container, so the splice stopped the file parsing outright.
+ * A migration command that leaves the app unable to build is worse than one
+ * that says nothing, so these assert the *file* first and the report second.
+ *
+ * The gate is the extension, which TypeScript makes a guarantee: JSX is legal
+ * only in `.tsx` / `.jsx`.
+ */
+describe("a view file, where a comment is not a comment", () => {
+  const VIEW = `import { User } from "@/app/models";
+
+export function SignupForm({ error }: { error?: { code?: string } }) {
+  return (
+    <div>
+      {error?.code === "P2002" ? <p>Email taken</p> : null}
+    </div>
+  );
+}
+`;
+
+  test("the P2002 guard is not annotated, and the file still parses", async () => {
+    write("app/views/SignupForm.tsx", VIEW);
+    await runMigrate({ rootDir: root });
+
+    const after = read("app/views/SignupForm.tsx");
+    expect(after).toBe(VIEW);
+
+    // The assertion that matters is not "unchanged" but "still builds" — the
+    // first is a proxy and this is the property.
+    expect(() =>
+      new Bun.Transpiler({ loader: "tsx" }).transformSync(after),
+    ).not.toThrow();
+  });
+
+  test("it is reported instead, with the line to look at", async () => {
+    write("app/views/SignupForm.tsx", VIEW);
+    await runMigrate({ rootDir: root });
+
+    const summary = logged.join("\n");
+    expect(summary).toContain("app/views/SignupForm.tsx");
+    // The splice carried its location by sitting on it; the report has to say
+    // it, or the reader is left grepping the file the command just declined to
+    // mark.
+    expect(summary).toContain("line 6");
+    expect(summary).toContain("isUniqueConstraintError");
+  });
+
+  test("the take/skip pass holds off there too", async () => {
+    // Worse-exposed than the P2002 pass: no import gate, and its message parses
+    // in children position rather than failing — so it would have rendered a
+    // paragraph of migration advice onto the page instead of erroring.
+    const list = `export function List({ limit }: { limit: string }) {
+  const rows = usePosts({ take: Number(limit) });
+  return <ul>{rows.map((r) => <li key={r.id}>{r.title}</li>)}</ul>;
+}
+`;
+    write("app/views/List.tsx", list);
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/views/List.tsx")).toBe(list);
+    expect(logged.join("\n")).toContain("app/views/List.tsx");
+  });
+
+  test("the same code in a .ts file is still annotated", async () => {
+    // The gate is the extension and nothing else, so the pass must not have
+    // quietly become conservative everywhere.
+    write(
+      "app/services/signup.ts",
+      `import { User } from "@/app/models";
+export const failed = (error: any) => error.code === "P2002";
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/services/signup.ts")).toContain("TODO(gemi-migrate)");
+  });
+});
+
+/**
+ * **The ORM passes sweep the files this command itself writes.**
+ *
+ * Step 4 supersedes a provider by moving its body into `app/config/*.ts`, so
+ * the user code inside it lands in a file the earlier `touched` skip excluded
+ * from the sweep. On the one run that matters — the first run on an old-layout
+ * app — a guard carried over that way was never looked at.
+ */
+describe("hazards inside the files the migration itself produces", () => {
+  const PROVIDER_WITH_HAZARDS = `import { AuthenticationServiceProvider } from "gemi/services";
+import { User } from "@/app/models";
+
+export default class AuthServiceProvider extends AuthenticationServiceProvider {
+  verifyEmail = false;
+  pageSize = { take: Number(process.env.PAGE) };
+}
+`;
+
+  test("a take carried out of a provider into app/config is annotated", async () => {
+    write("app/kernel/providers/AuthServiceProvider.ts", PROVIDER_WITH_HAZARDS);
+    write("app/kernel/Kernel.ts", KERNEL_43);
+
+    await runMigrate({ rootDir: root });
+
+    // The provider is gone and its body is here — user code, in a file that
+    // did not exist when the tree was walked. Before the sweep moved, this was
+    // never looked at on the only run where it could have been.
+    const config = read("app/config/auth.ts");
+    expect(config).toContain("pageSize: { take: Number(process.env.PAGE) }");
+    expect(config).toContain("TODO(gemi-migrate)");
+    expect(logged.join("\n")).toContain("app/config/auth.ts");
+  });
+
+  test("a second run adds nothing, so the sweep is idempotent across both paths", async () => {
+    write("app/kernel/providers/AuthServiceProvider.ts", PROVIDER_WITH_HAZARDS);
+    write("app/kernel/Kernel.ts", KERNEL_43);
+
+    await runMigrate({ rootDir: root });
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/config/auth.ts").match(/TODO\(gemi-migrate\)/g)).toHaveLength(1);
+  });
+
+  /**
+   * The P2002 half does **not** reach this file, and the reason is the import
+   * gate rather than the sweep: the generated config imports `gemi/services`
+   * and not the model surface, because the provider's own model import is not
+   * carried across. That is the gate's documented false negative arriving by a
+   * new route — asserted rather than left for someone to discover, since the
+   * neighbouring `take` hazard in the same file *is* found and the asymmetry
+   * would otherwise read as a bug in the sweep.
+   *
+   * UPGRADE.md carries the plain grep, which is what covers this.
+   */
+  test("the P2002 gate still asks for a model import, even here", async () => {
+    write(
+      "app/kernel/providers/AuthServiceProvider.ts",
+      PROVIDER_WITH_HAZARDS.replace(
+        "  verifyEmail = false;",
+        '  verifyEmail = false;\n  onDuplicate = (error: any) => error.code === "P2002";',
+      ),
+    );
+    write("app/kernel/Kernel.ts", KERNEL_43);
+
+    await runMigrate({ rootDir: root });
+
+    const config = read("app/config/auth.ts");
+    expect(config).toContain('error.code === "P2002"');
+    expect(config).not.toContain("isUniqueConstraintError");
+  });
+});

--- a/packages/gemi/bin/migrate/migrate.test.ts
+++ b/packages/gemi/bin/migrate/migrate.test.ts
@@ -221,3 +221,264 @@ export default class extends Kernel {}
     expect(config).toContain("verifyEmail: false");
   });
 });
+
+/**
+ * The two ORM-port passes (#356, #357).
+ *
+ * Neither is a rename, and neither can be one. What they look for is a *value* —
+ * whether `limit` holds an integer, whether the error a `catch` receives came
+ * from Prisma or from gemi — and a value is the one thing this command cannot
+ * see, because `lex.ts` is a scanner and the answer is only known at run time.
+ *
+ * They earn their place anyway because both failures are invisible to everything
+ * else. `tsc` accepts `Number(x)` as a `number` and accepts a guard over
+ * `unknown` accepting anything; the unit suite passes integer literals and mocks
+ * `{ code: "P2002" }`; and the failing inputs — a race, a hand-edited URL — are
+ * ones the app itself never produces. Four green signals, and a defect under
+ * them.
+ *
+ * The negative cases below are the more important half. A marker that fires on
+ * correct code is one people learn to ignore, and these passes are already
+ * accepting false positives by design — so the shapes that must stay quiet are
+ * pinned as hard as the shapes that must speak.
+ */
+describe("the P2002 pass (#357)", () => {
+  const GUARD = `import { AICredit } from "@/app/models";
+
+export async function grant(userId: number) {
+  try {
+    return await AICredit.create({ data: { userId, amount: 10 } });
+  } catch (error) {
+    if (isRecord(error) && error.code === "P2002") {
+      return AICredit.findFirst({ where: { userId } });
+    }
+    throw error;
+  }
+}
+`;
+
+  test("a P2002 literal beside a model import is annotated", async () => {
+    write("app/services/credits.ts", GUARD);
+    await runMigrate({ rootDir: root });
+
+    const lines = read("app/services/credits.ts").split("\n");
+    const guard = lines.findIndex((line) => line.includes('error.code === "P2002"'));
+    expect(guard).toBeGreaterThan(0);
+
+    const annotation = lines[guard - 1]!;
+    expect(annotation).toContain("TODO(gemi-migrate)");
+    // The three things a reader needs: what replaced the code, what to write
+    // instead, and why nothing told them. The last is the whole point — a
+    // reader whose tests pass will otherwise conclude the guard is fine.
+    expect(annotation).toContain("UniqueConstraintError");
+    expect(annotation).toContain("isUniqueConstraintError");
+    expect(annotation).toContain("gemi/orm");
+    expect(annotation).toContain("still passes");
+    // Annotated, never rewritten: which `catch` arm belongs on which taxonomy
+    // is a fact about which writers this app has already ported.
+    expect(lines[guard]).toBe('    if (isRecord(error) && error.code === "P2002") {');
+  });
+
+  test("the same guard with no model import is left alone", async () => {
+    // Still-Prisma code, where `code === "P2002"` is correct exactly as
+    // written. Annotating it would teach the reader the marker means nothing.
+    write(
+      "app/services/legacy.ts",
+      GUARD.replace(
+        'import { AICredit } from "@/app/models";',
+        'import { prisma } from "@prisma/client";',
+      ).replace(/AICredit/g, "prisma.aICredit"),
+    );
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/services/legacy.ts")).not.toContain("TODO(gemi-migrate)");
+  });
+
+  test("a P2002 inside a comment is not a guard", async () => {
+    // Also the mechanism that makes the pass idempotent: the annotation it
+    // writes quotes `"P2002"` itself, so a pass that searched comments would
+    // annotate its own output on the second run.
+    write(
+      "app/services/note.ts",
+      `import { AICredit } from "@/app/models";
+
+// Prisma used to raise P2002 here; the string "P2002" is only mentioned.
+export const model = AICredit;
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/services/note.ts")).not.toContain("TODO(gemi-migrate)");
+  });
+
+  test("a second run does not stack a second annotation", async () => {
+    write("app/services/credits.ts", GUARD);
+    await runMigrate({ rootDir: root });
+    await runMigrate({ rootDir: root });
+
+    const occurrences = read("app/services/credits.ts").match(
+      /TODO\(gemi-migrate\)/g,
+    );
+    expect(occurrences).toHaveLength(1);
+  });
+
+  test("the report names the file, not just the tree", async () => {
+    write("app/services/credits.ts", GUARD);
+    await runMigrate({ rootDir: root });
+
+    const summary = logged.join("\n");
+    expect(summary).toContain("app/services/credits.ts");
+    expect(summary).toContain("1 occurrence");
+  });
+});
+
+describe("the take/skip pass (#356)", () => {
+  test("a query-string page size is annotated, once per line", async () => {
+    // The exact two lines #356 measured across nine controllers, including the
+    // `skip` that is where a fractional `page` actually lands.
+    write(
+      "app/http/controllers/PostController.ts",
+      `import { Controller } from "gemi/http";
+import { Post } from "@/app/models";
+
+export class PostController extends Controller {
+  async index(req) {
+    const limit = Number(req.search.get("limit")) || 25;
+    const page = Number(req.search.get("page")) || 1;
+    return Post.findMany({ take: limit, skip: limit * (page - 1) });
+  }
+}
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    const lines = read("app/http/controllers/PostController.ts").split("\n");
+    const call = lines.findIndex((line) => line.includes("Post.findMany"));
+    const annotation = lines[call - 1]!;
+    expect(annotation).toContain("TODO(gemi-migrate)");
+    expect(annotation).toContain("paginate");
+    expect(annotation).toContain('Number(req.search.get("limit"))');
+    // `page` gets the louder mention: it never reaches the ORM itself, so a
+    // reader scanning for `take` misses it.
+    expect(annotation).toContain("multiplied");
+    // Both keys are on one line, and one sentence covers the line.
+    expect(
+      read("app/http/controllers/PostController.ts").match(/TODO\(gemi-migrate\)/g),
+    ).toHaveLength(1);
+  });
+
+  test("the wording asks for a confirmation rather than reporting a bug", async () => {
+    // The pass cannot tell a clamped constant from a query-string float, and
+    // most non-literal `take`s are the former. An annotation that claimed a
+    // defect would be wrong more often than right, and a marker that is wrong
+    // more often than right is one that gets filtered out by eye.
+    write(
+      "app/http/controllers/PostController.ts",
+      `import { Post } from "@/app/models";
+export const list = (perPage) => Post.findMany({ take: perPage });
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    const annotation = read("app/http/controllers/PostController.ts")
+      .split("\n")
+      .find((line) => line.includes("TODO(gemi-migrate)"))!;
+    expect(annotation).toContain("usually fine");
+    expect(annotation).toContain("confirm");
+  });
+
+  test("an integer literal is not annotated", async () => {
+    write(
+      "app/http/controllers/FeedController.ts",
+      `import { Post } from "@/app/models";
+export const recent = () => Post.findMany({ take: 25, skip: 0 });
+export const back = () => Post.findMany({ take: -5 });
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/http/controllers/FeedController.ts")).not.toContain(
+      "TODO(gemi-migrate)",
+    );
+  });
+
+  test("a site that already truncates is not annotated", async () => {
+    // Two of #356's nine call sites had already truncated. Flagging the sites
+    // that carry the fix is the fastest way to turn the pass into noise.
+    write(
+      "app/http/controllers/TrimController.ts",
+      `import { Post } from "@/app/models";
+export const list = (raw, page) =>
+  Post.findMany({ take: Math.trunc(raw), skip: parseInt(page, 10) });
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/http/controllers/TrimController.ts")).not.toContain(
+      "TODO(gemi-migrate)",
+    );
+  });
+
+  test("arithmetic on a truncated value is still annotated", async () => {
+    // `Math.trunc(a) / 2` is not integral, and it is the same shape to a
+    // scanner as `Math.trunc(a) * b`. The exemption anchors on the whole value
+    // so only the unambiguous spelling is let through.
+    write(
+      "app/http/controllers/HalfController.ts",
+      `import { Post } from "@/app/models";
+export const list = (raw) => Post.findMany({ take: Math.trunc(raw) / 2 });
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/http/controllers/HalfController.ts")).toContain(
+      "TODO(gemi-migrate)",
+    );
+  });
+
+  test("a type declaration is not a call site", async () => {
+    // The wrapper interface every app writes around its own pagination
+    // arguments. `take?: number` is a shape an object literal cannot even
+    // spell.
+    write(
+      "app/http/PageArgs.ts",
+      `export interface PageArgs {
+  take?: number;
+  skip: number;
+}
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/http/PageArgs.ts")).not.toContain("TODO(gemi-migrate)");
+  });
+
+  test("a `take:` inside a string or comment is not a call site", async () => {
+    write(
+      "app/http/controllers/DocController.ts",
+      `// findMany({ take: limit }) is what this used to do.
+export const doc = "take: limit";
+`,
+    );
+    await runMigrate({ rootDir: root });
+
+    expect(read("app/http/controllers/DocController.ts")).not.toContain(
+      "TODO(gemi-migrate)",
+    );
+  });
+
+  test("a second run does not stack a second annotation", async () => {
+    write(
+      "app/http/controllers/PostController.ts",
+      `import { Post } from "@/app/models";
+export const list = (perPage) => Post.findMany({ take: perPage });
+`,
+    );
+    await runMigrate({ rootDir: root });
+    await runMigrate({ rootDir: root });
+
+    expect(
+      read("app/http/controllers/PostController.ts").match(/TODO\(gemi-migrate\)/g),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/gemi/bin/migrate/orm.ts
+++ b/packages/gemi/bin/migrate/orm.ts
@@ -16,6 +16,26 @@
 // integer or whether the `catch` this `"P2002"` sits in wraps an ORM call or a
 // Prisma one. A rewrite would need that. A sentence beside the line does not,
 // and a sentence beside the line is what both issues asked for.
+//
+// **Except in a file that can hold JSX, where a `//` line is not a comment.**
+// Inside JSX children it is page text, and the `{ code: "P2002" }` this module's
+// own message contains becomes an expression container — so splicing one in
+// stops the file parsing. Measured, on the obvious shape:
+//
+//     {error?.code === "P2002" ? <p>Email taken</p> : null}
+//
+// annotated and fed to Bun's `tsx` loader answers `Expected "}" but found ":"`.
+// A migration command that leaves the app unable to build is worse than one that
+// says nothing, and the `take` pass is exposed further still — it has no import
+// gate, and its message parses in children position, so it would have rendered a
+// paragraph of migration advice onto the page.
+//
+// The gate is the file extension, and that is a guarantee rather than a guess:
+// TypeScript permits JSX only in `.tsx` / `.jsx`, so a `.ts` file cannot contain
+// any. Those files are *reported* instead, with line numbers, which is what the
+// splice was carrying anyway. Neither pass can hit inside a string or template
+// literal — `skipAtomic` steps over both before either finder looks — so on a
+// file that cannot hold JSX every hit is ordinary code and the splice is safe.
 
 import { parseImports } from "./imports";
 import { matchDelims, skipAtomic, skipTrivia } from "./lex";
@@ -91,6 +111,7 @@ export function annotateOrmPortHazards(
   label: string,
   notes: Notes,
 ): string {
+  const spliceable = !JSX_FILE.test(label);
   let result = source;
 
   // The import gate is #357's, and it is what keeps this pass worth reading. A
@@ -105,15 +126,15 @@ export function annotateOrmPortHazards(
   // here. UPGRADE.md carries the plain grep for that, because a codemod that
   // followed call graphs would need the parser this command does not have.
   if (importsModelSurface(result)) {
-    const hits = prismaErrorCodeLiterals(result);
-    const marked = annotateLines(result, hits, P2002_HAZARD);
-    result = marked.text;
-    if (marked.annotated > 0) {
-      notes.push({
-        file: label,
-        message: `\`"P2002"\` (${occurrences(hits.length)}) — ${P2002_HAZARD}`,
-      });
-    }
+    result = runPass(
+      result,
+      prismaErrorCodeLiterals(result),
+      '`"P2002"`',
+      P2002_HAZARD,
+      label,
+      notes,
+      spliceable,
+    );
   }
 
   // No import gate on this one, on purpose. A fractional `skip` is produced
@@ -121,25 +142,83 @@ export function annotateOrmPortHazards(
   // file holding `take: limit` need not import a model at all — it is often a
   // repository or a service that takes the numbers and passes them along. The
   // gate would remove exactly the hop that makes the value hard to trace.
-  {
-    const hits = nonIntegerPageArguments(result);
-    const marked = annotateLines(result, hits, PAGE_ARGUMENT_HAZARD);
-    result = marked.text;
-    if (marked.annotated > 0) {
-      notes.push({
-        file: label,
-        message:
-          `\`take\` / \`skip\` (${occurrences(hits.length)}) — ` +
-          PAGE_ARGUMENT_HAZARD,
-      });
-    }
-  }
+  result = runPass(
+    result,
+    nonIntegerPageArguments(result),
+    "`take` / `skip`",
+    PAGE_ARGUMENT_HAZARD,
+    label,
+    notes,
+    spliceable,
+  );
 
   return result;
 }
 
+/**
+ * TypeScript accepts JSX only in these two extensions, which is what makes the
+ * test a guarantee rather than a heuristic: a `.ts` file cannot contain JSX, so
+ * it cannot contain a position where a `//` line means something else.
+ */
+const JSX_FILE = /\.[jt]sx$/i;
+
+/**
+ * One pass: splice where that is safe, report where it is not.
+ *
+ * The report is not a lesser outcome. It carries the line numbers the splice
+ * carried by sitting on them, and it is what the `--dry-run` reader sees either
+ * way; what it loses is surviving into the diff, which is worth less than the
+ * file continuing to parse.
+ */
+function runPass(
+  src: string,
+  hits: number[],
+  what: string,
+  message: string,
+  label: string,
+  notes: Notes,
+  spliceable: boolean,
+): string {
+  if (!hits.length) return src;
+
+  if (!spliceable) {
+    notes.push({
+      file: label,
+      message:
+        `${what} on ${lineList(src, hits)} — reported rather than annotated: ` +
+        `a \`//\` line inside JSX children is page text, not a comment, so ` +
+        `writing one here would stop the file parsing. ${message}`,
+    });
+    return src;
+  }
+
+  const marked = annotateLines(src, hits, message);
+  if (marked.annotated > 0) {
+    notes.push({
+      file: label,
+      message: `${what} (${occurrences(hits.length)}) — ${message}`,
+    });
+  }
+  return marked.text;
+}
+
 const occurrences = (count: number) =>
   count === 1 ? "1 occurrence" : `${count} occurrences`;
+
+/** `line 12` / `lines 12, 40` — 1-based, deduplicated, in source order. */
+function lineList(src: string, offsets: number[]): string {
+  const numbers: number[] = [];
+  for (const offset of offsets) {
+    let line = 1;
+    for (let i = 0; i < offset && i < src.length; i++) {
+      if (src[i] === "\n") line++;
+    }
+    if (numbers[numbers.length - 1] !== line) numbers.push(line);
+  }
+  return numbers.length === 1
+    ? `line ${numbers[0]}`
+    : `lines ${numbers.join(", ")}`;
+}
 
 // ---------------------------------------------------------------------------
 // #357 — a `"P2002"` literal in a file that also imports the model surface

--- a/packages/gemi/bin/migrate/orm.ts
+++ b/packages/gemi/bin/migrate/orm.ts
@@ -1,0 +1,356 @@
+// The two ORM-port passes: what a Prisma application walks into when a read or
+// a write moves onto gemi's ORM and nothing anywhere says so.
+//
+// Both came off the same port (#356, #357) and both share the shape that makes
+// a documentation line insufficient. The code keeps compiling, keeps running
+// and keeps passing its tests; the thing that broke only surfaces under a
+// condition the application itself never produces — a race, or a hand-edited
+// URL. `tsc` cannot see either (`Number(x)` is a `number`, and a guard over
+// `unknown` is supposed to accept anything), and a grep only helps somebody who
+// already knows what to grep for. So the check has to sweep the tree unprompted,
+// which is the one thing this command already does.
+//
+// Annotate-only, like every other pass in this command. `lex.ts` is a hand-
+// rolled scanner rather than a parser: it can tell a string literal from a
+// comment and match a bracket, and it cannot tell whether `limit` holds an
+// integer or whether the `catch` this `"P2002"` sits in wraps an ORM call or a
+// Prisma one. A rewrite would need that. A sentence beside the line does not,
+// and a sentence beside the line is what both issues asked for.
+
+import { parseImports } from "./imports";
+import { matchDelims, skipAtomic, skipTrivia } from "./lex";
+import { TODO } from "./tables";
+
+/**
+ * The report sink `runMigrate` collects into. Spelled structurally rather than
+ * imported, because `index.ts` imports this module and naming its `Note` here
+ * would close the cycle.
+ */
+type Notes = { file: string; message: string }[];
+
+/**
+ * What a `"P2002"` guard becomes once the write under it is a gemi write.
+ *
+ * The sentence has to carry the *silence*, not just the fact. Every other thing
+ * this command flags announces itself — a missing export is a compile error, a
+ * renamed field is a type error. This one has four independent signals and all
+ * four stay green, so a reader who is told only "the code changed" will
+ * reasonably conclude their guard is fine because their tests pass. It is the
+ * tests passing that is the symptom.
+ */
+const P2002_HAZARD =
+  '`"P2002"` stops matching the moment the write it guards moves onto the ORM. ' +
+  "gemi raises `UniqueConstraintError`, which carries `model`, `operation`, " +
+  "`fields` and `constraint` and no `code` anywhere on its prototype chain — so " +
+  "the check returns false, the recovery branch it exists to run never runs, and " +
+  "nothing reports it: it compiles, it runs, and a test that mocks " +
+  '`{ code: "P2002" }` still passes while the branch it certifies is dead. Use ' +
+  "`isUniqueConstraintError` from `gemi/orm`. While some writes in this app are " +
+  "still on Prisma, keep the old check as a second arm — " +
+  '`isUniqueConstraintError(e) || (isRecord(e) && e.code === "P2002")` — and ' +
+  "delete that arm when the last Prisma writer goes. See UPGRADE.md.";
+
+/**
+ * What a non-literal `take` / `skip` might be.
+ *
+ * Deliberately phrased as a request to confirm rather than a claim of a bug.
+ * Most non-literal `take`s are fine — they are a clamped constant, a page size
+ * the app itself computed, a value already truncated — and this pass cannot
+ * tell those from the broken ones, because the difference is a runtime value.
+ * An annotation that asserted a defect would be wrong most of the times it
+ * fires, and a marker that is wrong most of the time is one people learn to
+ * skip past, which costs more than the pass earns.
+ *
+ * So it names the shape that actually breaks, and it names `page` louder than
+ * `take`: `page` never reaches the ORM at all, it reaches it multiplied, as a
+ * fractional `skip`, which is why the ported application's reviewers found the
+ * `take` sites and missed the `page` ones.
+ */
+const PAGE_ARGUMENT_HAZARD =
+  "`take` and `skip` must be integers — gemi refuses a fractional one with " +
+  "`InvalidArgumentError` where Prisma truncated it, because SQLite answers " +
+  "`limit 1.5` with an opaque driver error and Postgres rounds it up to 2 rows. " +
+  "This value is not an integer literal, which is usually fine: confirm it is " +
+  "truncated where it enters the app rather than reading this as a bug. " +
+  '`Number(req.search.get("limit"))` is the shape that breaks, and a fractional ' +
+  "`page` is the one to look hardest for — it never reaches the ORM itself, it " +
+  "reaches it multiplied, as a fractional `skip`. `paginate({ page, perPage })` " +
+  "from `gemi/orm` truncates and clamps in one place and cannot produce a value " +
+  "the ORM refuses.";
+
+/**
+ * Runs both passes over one file under `app/`.
+ *
+ * Sequential rather than merged: each pass re-scans the text the previous one
+ * produced, which is free (these files are small) and removes the only way the
+ * two could interfere — an offset computed against the pre-insertion text being
+ * applied to the post-insertion one.
+ */
+export function annotateOrmPortHazards(
+  source: string,
+  label: string,
+  notes: Notes,
+): string {
+  let result = source;
+
+  // The import gate is #357's, and it is what keeps this pass worth reading. A
+  // `"P2002"` in a file with no model import is either still-Prisma code, where
+  // the guard is correct exactly as written, or an unrelated string; annotating
+  // those teaches the reader that the marker means nothing. A file mid-port
+  // imports both `@prisma/client` and the app's models, and that file *is* the
+  // one that needs the bridge — so the gate asks only about the model side.
+  //
+  // Its false negative is real and deliberate: a guard living in a shared
+  // `lib/errors.ts` that imports nothing from the model surface is not found
+  // here. UPGRADE.md carries the plain grep for that, because a codemod that
+  // followed call graphs would need the parser this command does not have.
+  if (importsModelSurface(result)) {
+    const hits = prismaErrorCodeLiterals(result);
+    const marked = annotateLines(result, hits, P2002_HAZARD);
+    result = marked.text;
+    if (marked.annotated > 0) {
+      notes.push({
+        file: label,
+        message: `\`"P2002"\` (${occurrences(hits.length)}) — ${P2002_HAZARD}`,
+      });
+    }
+  }
+
+  // No import gate on this one, on purpose. A fractional `skip` is produced
+  // where the query string is read and consumed several layers away, so the
+  // file holding `take: limit` need not import a model at all — it is often a
+  // repository or a service that takes the numbers and passes them along. The
+  // gate would remove exactly the hop that makes the value hard to trace.
+  {
+    const hits = nonIntegerPageArguments(result);
+    const marked = annotateLines(result, hits, PAGE_ARGUMENT_HAZARD);
+    result = marked.text;
+    if (marked.annotated > 0) {
+      notes.push({
+        file: label,
+        message:
+          `\`take\` / \`skip\` (${occurrences(hits.length)}) — ` +
+          PAGE_ARGUMENT_HAZARD,
+      });
+    }
+  }
+
+  return result;
+}
+
+const occurrences = (count: number) =>
+  count === 1 ? "1 occurrence" : `${count} occurrences`;
+
+// ---------------------------------------------------------------------------
+// #357 — a `"P2002"` literal in a file that also imports the model surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Offsets of every `"P2002"` string literal, template included.
+ *
+ * Only `P2002`, not the `P` codes in general. It is the one whose replacement
+ * gemi actually ships a predicate for, and a marker that fires on `P2025` while
+ * having nothing to offer instead would be a complaint rather than a migration
+ * step.
+ *
+ * Comments are stepped over rather than searched, and that is load-bearing for
+ * more than tidiness: the annotation this pass writes quotes `"P2002"` twice, so
+ * scanning comments would make the command annotate its own output on the second
+ * run. The idempotency check below is the belt; this is the braces.
+ */
+function prismaErrorCodeLiterals(src: string): number[] {
+  const hits: number[] = [];
+  let i = 0;
+  while (i < src.length) {
+    const end = skipAtomic(src, i);
+    if (end === null || end <= i) {
+      i++;
+      continue;
+    }
+    const span = src.slice(i, end);
+    if (/^["'`]/.test(span) && span.slice(1, -1) === "P2002") hits.push(i);
+    i = end;
+  }
+  return hits;
+}
+
+/**
+ * `models` as a path segment, which is how every gemi app spells it —
+ * `@/app/models`, `../models/Invoice`, `./models`. `app/models/index.ts` is the
+ * barrel the Kernel registers, so a file that touches a model at all reaches it
+ * through a specifier ending in or passing through `models`.
+ */
+const MODEL_SURFACE = /(^|\/)models(\/|$)/;
+
+function importsModelSurface(src: string): boolean {
+  return parseImports(src).some(
+    (decl) => decl.module === "gemi/orm" || MODEL_SURFACE.test(decl.module),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// #356 — a `take:` / `skip:` whose value is not an integer literal
+// ---------------------------------------------------------------------------
+
+const PAGE_KEYS = ["take", "skip"];
+
+/** Offsets of the `take` / `skip` keys whose value is not provably integral. */
+function nonIntegerPageArguments(src: string): number[] {
+  const hits: number[] = [];
+  let i = 0;
+  while (i < src.length) {
+    const skipped = skipAtomic(src, i);
+    if (skipped !== null && skipped > i) {
+      i = skipped;
+      continue;
+    }
+
+    const key = PAGE_KEYS.find((candidate) => src.startsWith(candidate, i));
+    if (!key || /[\w$.]/.test(src[i - 1] ?? "")) {
+      i++;
+      continue;
+    }
+
+    let after = skipTrivia(src, i + key.length);
+    // `take?:` is an optional property, which only exists in a type — an object
+    // literal cannot spell one. Skipping it keeps every wrapper interface an app
+    // writes around its own pagination arguments out of the report.
+    if (src[after] === "?") after = skipTrivia(src, after + 1);
+    if (src[after] !== ":") {
+      i += key.length;
+      continue;
+    }
+
+    const valueStart = skipTrivia(src, after + 1);
+    const valueEnd = endOfValue(src, valueStart);
+    if (!isIntegerArgument(src.slice(valueStart, valueEnd).trim())) {
+      hits.push(i);
+    }
+    i = Math.max(valueEnd, i + key.length);
+  }
+  return hits;
+}
+
+const CLOSERS: Record<string, string> = { "(": ")", "[": "]", "{": "}" };
+
+/**
+ * End of the expression a property key was given.
+ *
+ * Bounded at the newline as well as at the usual separators. A value continued
+ * onto a second line is therefore read as its first line alone — which can only
+ * make it look *less* integral than it is, never more, so the pass errs toward
+ * annotating rather than toward missing a site. That direction is the right one
+ * here: the annotation already asks the reader to confirm rather than asserting
+ * a defect, so a surplus one costs a glance and a missing one costs a 500.
+ */
+function endOfValue(src: string, from: number): number {
+  let i = from;
+  while (i < src.length) {
+    const skipped = skipAtomic(src, i);
+    if (skipped !== null && skipped > i) {
+      i = skipped;
+      continue;
+    }
+    const c = src[i]!;
+    const closer = CLOSERS[c];
+    if (closer) {
+      i = matchDelims(src, i, c, closer);
+      continue;
+    }
+    if (c === "," || c === ")" || c === "]" || c === "}" || c === ";" || c === "\n") {
+      return i;
+    }
+    i++;
+  }
+  return src.length;
+}
+
+const INTEGER_LITERAL = /^-?\d+(?:_\d+)*$/;
+
+/**
+ * `Math.trunc(x)` and friends as the *whole* value, not merely somewhere in it —
+ * `Math.trunc(perPage) * (page - 1)` is arithmetic on a truncated number and
+ * stays truncated, but `Math.trunc(a) / 2` does not, and the two are the same
+ * shape to a scanner. Anchoring on the whole value keeps the exemption to the
+ * spelling that is unambiguously safe.
+ *
+ * Exempting them at all is a judgement about what the marker is worth. Two of
+ * the nine call sites #356 measured had already truncated, for unrelated
+ * reasons; flagging the sites that already carry the fix is the fastest way to
+ * turn the pass into noise.
+ */
+const TRUNCATING_CALL =
+  /^(?:Math\.(?:trunc|floor|ceil|round)|(?:Number\.)?parseInt)\s*(?=\()/;
+
+/**
+ * A bare `number` is a type annotation in a position this scanner cannot
+ * distinguish from a value — `interface Page { take: number }` with no `?` and
+ * no `;`. Nothing writes an object literal whose value is an identifier called
+ * `number`, so reading it as a type is right far more often than it is wrong.
+ */
+const TYPE_POSITION = /^number(?:\s*\|\s*undefined)?$/;
+
+function isIntegerArgument(value: string): boolean {
+  if (INTEGER_LITERAL.test(value)) return true;
+  if (TYPE_POSITION.test(value)) return true;
+
+  const call = TRUNCATING_CALL.exec(value);
+  if (!call) return false;
+  const open = call[0].length;
+  return value[open] === "(" && matchDelims(value, open, "(", ")") === value.length;
+}
+
+// ---------------------------------------------------------------------------
+// Insertion
+// ---------------------------------------------------------------------------
+
+/**
+ * Puts one `TODO(gemi-migrate):` line above every line an offset falls on.
+ *
+ * Line-oriented for the same reason `annotateRetiredFields` is: the offsets are
+ * computed once against the text as it stands, and rebuilding the file from its
+ * lines cannot outlive the array — where advancing a cursor through a string
+ * that grows as annotations are spliced into it depends on the splice for
+ * termination.
+ *
+ * Idempotent per line, and the annotation is deliberately a single line so that
+ * the one just emitted is the only place a previous run's could be. Two hits on
+ * one line (`{ take: limit, skip: limit * (page - 1) }`, which is exactly how
+ * the ported application wrote it) share one annotation.
+ */
+function annotateLines(
+  src: string,
+  offsets: number[],
+  message: string,
+): { text: string; annotated: number } {
+  if (!offsets.length) return { text: src, annotated: 0 };
+
+  const lines = src.split("\n");
+  const targets = new Set<number>();
+  let cursor = 0;
+  let next = 0;
+  for (let index = 0; index < lines.length && next < offsets.length; index++) {
+    const end = cursor + lines[index]!.length;
+    while (next < offsets.length && offsets[next]! <= end) {
+      targets.add(index);
+      next++;
+    }
+    cursor = end + 1;
+  }
+
+  const out: string[] = [];
+  let annotated = 0;
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]!;
+    if (targets.has(index)) {
+      const previous = out[out.length - 1] ?? "";
+      if (!previous.includes(message)) {
+        out.push(`${/^[ \t]*/.exec(line)![0]}${TODO} ${message}`);
+        annotated++;
+      }
+    }
+    out.push(line);
+  }
+
+  return { text: out.join("\n"), annotated };
+}

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -496,6 +496,13 @@ function planOwningSide(
   if (key === "update") {
     out.keyFields.push(fkField);
 
+    // The same check the foreign side runs, on the same operand grammar. Both
+    // sides accept `{ where?, data }` and both must refuse an unknown key
+    // inside it, or a misspelled `where` silently widens the write on whichever
+    // side missed the check — the asymmetry #116 was filed about, arriving one
+    // operand later.
+    assertToOneWriteOperand(schema, relation, child, key, operand, operation);
+
     out.after.push({
       relation: relation.name,
       operation: "update",
@@ -520,18 +527,52 @@ function planOwningSide(
           throw new RecordNotFoundError(relation.model, "update");
         }
 
+        // `.data !== undefined` rather than `"data" in operandAt`, which is the
+        // test {@link toOneOperand} makes and the one this used to disagree
+        // with. `canonicalShape` drops an `undefined`-valued key, so `update:
+        // {}` and `update: { data: undefined }` are one plan entry — and an
+        // explicit `undefined` is the ordinary way a conditional write is
+        // spelled, which is why `suppliedFields` skips it everywhere else.
+        // Keying on presence sent `data: undefined` down to `updateMany` and
+        // answered a no-op call with `updateMany requires 'data'`, on the side
+        // this file cites as the precedent for the other one.
         const operandAt = at(args);
-        const data =
+        const wrapped =
           operandAt !== null &&
           typeof operandAt === "object" &&
-          "data" in operandAt
-            ? (operandAt as Record<string, unknown>).data
-            : operandAt;
+          (operandAt as Record<string, unknown>).data !== undefined;
+        const record = operandAt as Record<string, unknown> | null;
+        const data = wrapped ? record!.data : operandAt;
+
+        // The caller's filter, conjoined with the link — so `update: { where,
+        // data }` narrows *which* single row is written rather than being
+        // decoration. Ignoring it was a silent wrong write: the operand
+        // type-checks on both sides, the foreign side conjoins it and raises on
+        // a miss, and this side renamed the linked row whether or not it
+        // matched. Prisma answers P2025 for the non-matching case, which is
+        // what the lookup below reproduces.
+        //
+        // The lookup only happens when a `where` is actually present, and that
+        // is shape-stable — `canonicalShape` records a `where` key's presence —
+        // so the common `update: { … }` spelling still costs one statement.
+        const filter = wrapped ? record!.where : undefined;
+        const where = conjoin(filter, { [referenced]: linked });
+
+        if (filter !== undefined) {
+          const found = (await executor.exec(
+            relation.model,
+            "findFirst",
+            { where, select: { [referenced]: true } },
+            false,
+          )) as Record<string, unknown> | null;
+
+          if (!found) throw new RecordNotFoundError(relation.model, "update");
+        }
 
         await executor.exec(
           relation.model,
           "updateMany",
-          { where: { [referenced]: linked }, data },
+          { where, data },
           // NOT pre-scoped: the child's own policies decide whether this row is
           // reachable and whether the payload is allowed to write what it
           // names — its `onUpdate` and its scope-escape guard.
@@ -833,6 +874,11 @@ function planForeignSide(
      * life, precisely because its `true`/`false` decision was made once at
      * compile time and never revisited.
      */
+    // Checked *before* the rewrite, because the rewrite is lossy by
+    // construction: it rebuilds the operand from the keys it knows, so a key it
+    // does not know is gone by the time anything downstream could refuse it.
+    assertToOneWriteOperand(schema, relation, child, key, operand, operation);
+
     const spelled = at;
     at = (args: any) => toOneOperand(key, spelled(args));
     operand = toOneOperand(key, operand);
@@ -2256,6 +2302,104 @@ function assertToOneFilter(
       `object of filters it has to match. Prisma's operand here is ` +
       `'${child.name}WhereInput | boolean'.`,
   );
+}
+
+/**
+ * The plan-time shape check for a to-one `update` / `upsert`, run **before**
+ * {@link toOneOperand} rewrites the operand.
+ *
+ * Three holes it closes, all of the same kind: the to-one path dropped the
+ * `matchUniqueKey` its to-many sibling runs — correctly, since Prisma's to-one
+ * `where` is a `WhereInput` and not a unique key — and then put nothing in its
+ * place, so the operand reached the step unexamined.
+ *
+ *   1. **A key the rewrite does not know is discarded silently.** The wrapper
+ *      branch rebuilds `{ where, data }` from the keys it recognises, so
+ *      `update: { data: { … }, wehre: { … } }` loses the typo and the filter
+ *      with it — and `conjoin(undefined, link)` is the parent link alone, so a
+ *      nested update the caller *guarded* runs unguarded. A write that should
+ *      not have happened, with nothing raised anywhere. Prisma answers `Unknown
+ *      argument 'wehre'`, and `assertConnectOrCreateOperand` in this file
+ *      already refuses extra keys for exactly this reason.
+ *   2. **A `where` that is not an object is dropped by `conjoin`**, whose first
+ *      arm treats an array or a scalar as "no filter". So `upsert: { where:
+ *      [{ bio: "old" }], … }` finds the connected row and takes the *update*
+ *      branch, where Prisma applies the filter, matches nothing and takes the
+ *      *create* branch onto a unique violation. Two different rows written.
+ *   3. **A non-object operand escapes to run time.** `update: null` normalises
+ *      to `{ where: undefined, data: null }`, which `assertNamedUpdates` passes
+ *      because its `data` key is present — and the failure then arrives from
+ *      inside the `after` step as `InvalidArgumentError('data', 'Profile',
+ *      'updateMany')`, naming a model and an operation the caller never wrote,
+ *      after the parent row has already been written and has to be unwound.
+ *      Plan-time validation exists in this file precisely to prevent that.
+ *
+ * The payload spelling is deliberately *not* key-checked. `update: { bio: "x" }`
+ * is the child's own `data`, so every key in it is the child's business and
+ * belongs to the child's schema — checking it here would be checking the wrong
+ * shape, which is the rule {@link assertNamedUpdates} states. The wrapper is
+ * distinguishable because it carries a `data`, which is the same test the
+ * rewrite makes one function down.
+ */
+function assertToOneWriteOperand(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  key: string,
+  operand: unknown,
+  operation: string,
+): void {
+  if (key !== "update" && key !== "upsert") return;
+
+  const argument = `data.${relation.name}.${key}`;
+  const refuse = (reason: string): never => {
+    throw new InvalidArgumentError(argument, schema.name, operation, reason);
+  };
+
+  if (operand === null || typeof operand !== "object" || Array.isArray(operand)) {
+    refuse(
+      `Expected an object, got ${JSON.stringify(operand) ?? typeof operand}. ` +
+        (key === "upsert"
+          ? `'upsert' on a to-one takes { create, update } — and an optional ` +
+            `'where' the connected ${child.name} has to match.`
+          : `'update' on a to-one takes the ${child.name} columns directly, ` +
+            `or { data } — and an optional 'where' the connected row has to ` +
+            `match.`),
+    );
+  }
+
+  const record = operand as Record<string, unknown>;
+  const wrapper = key === "upsert" || record.data !== undefined;
+  if (!wrapper) return;
+
+  const known =
+    key === "upsert" ? ["where", "create", "update"] : ["where", "data"];
+
+  for (const name of Object.keys(record)) {
+    if (record[name] === undefined || known.includes(name)) continue;
+    refuse(
+      `Unknown key '${name}'. '${key}' on a to-one takes ` +
+        `${known.map((one) => `'${one}'`).join(", ")} and nothing else, so ` +
+        `'${name}' would be dropped rather than applied — a misspelled ` +
+        `'where' would turn a filtered write into an unconditional one. ` +
+        `Prisma refuses the same key by name.`,
+    );
+  }
+
+  if (
+    record.where !== undefined &&
+    (record.where === null ||
+      typeof record.where !== "object" ||
+      Array.isArray(record.where))
+  ) {
+    refuse(
+      `'where' has to be an object of filters — Prisma's is a ` +
+        `'${child.name}WhereInput', which narrows *which* single row is ` +
+        `written rather than choosing among several. Anything else is dropped ` +
+        `by the conjunction that keeps this operand on the connected row, so ` +
+        `the write would land unfiltered.`,
+    );
+  }
 }
 
 /**

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -444,13 +444,23 @@ function planOwningSide(
       argument: `data.${relation.name}.disconnect`,
     });
 
+    // MEASURED, and narrower than what this used to claim: Prisma's owning-side
+    // operand is `XWhereInput | boolean`, so it takes `true`, `false` (a no-op —
+    // the row keeps its link) and a filter. gemi implements the `true` arm only.
+    // The message says that rather than asserting Prisma offers nothing else,
+    // which is what it said before the foreign side was measured and is
+    // contradicted by this repository's own differential suite one directory
+    // over. The gap is real but it is a gap, not the shape of the input.
     if (operand !== true) {
       throw new UnsupportedQueryError(
         `data.${relation.name}.disconnect`,
         schema.name,
         operation,
-        `'${relation.name}' is a to-one, so there is one row to clear and ` +
-          `nothing to name. Prisma takes 'true' here.`,
+        `'${relation.name}' is a to-one whose foreign key lives on this row, ` +
+          `and only 'disconnect: true' is implemented for it — that clears ` +
+          `the link. Prisma also accepts 'false', which does nothing, and a ` +
+          `filter; neither is implemented here yet. Pass 'true', or skip the ` +
+          `operand entirely on the branch that should not detach.`,
       );
     }
 
@@ -741,9 +751,12 @@ function planForeignSide(
    *
    * with no `createMany`, `set`, `updateMany` or `deleteMany` key at all — so
    * the first group below is refused for the same reason `planOwningSide`
-   * refuses it, and says so in the same words. The second group exists on that
-   * input but not here yet, and the refusal now says *that* instead of
-   * complaining about the operand's shape.
+   * refuses it, and says so in the same words.
+   *
+   * The rest of that input — `update`, `delete`, `upsert` — was refused here
+   * too, for being spelled unlike the to-many form. It is implemented now, and
+   * the implementation is a *translation* rather than three new bodies: see
+   * {@link toOneOperand}.
    */
   if (relation.kind !== "many") {
     if (key === "set" || key === "updateMany" || key === "deleteMany") {
@@ -758,30 +771,91 @@ function planForeignSide(
       );
     }
 
-    if (key === "update" || key === "delete" || key === "upsert") {
-      throw new UnsupportedQueryError(
+    /**
+     * **An array where the relation holds one row**, which compiled here and
+     * wrote through it.
+     *
+     * Nothing below this point consults `kind`, so `create: [a, b]` inserted
+     * two children, and `connect: [{ id: 1 }, { id: 2 }]` repointed *both* rows
+     * through a relation that can hold one — the second silently winning. That
+     * is a live divergence, not strictness: Prisma refuses all three, measured
+     * off the generated client rather than reasoned from the docs.
+     *
+     *     connect: [{ id: 1 }, { id: 2 }]
+     *       ->  PrismaClientValidationError, neither row repointed
+     *     create: [{ bio: "a" }, { bio: "b" }]
+     *       ->  "Expected ProfileCreateWithoutUserInput or
+     *            ProfileUncheckedCreateWithoutUserInput, provided (Object, Object)"
+     *
+     * `PrismaClientValidationError` carries **no `code`** — it is an argument
+     * refusal rather than a database one — which is why this is
+     * `InvalidArgumentError` and not either `Unsupported*`: the argument is
+     * supported and the value is wrong. So the message names the shape that
+     * would work rather than announcing that arrays are unimplemented.
+     *
+     * Sound at plan time because array-ness is *in the plan key*: an array and
+     * a single object are different structures to `canonicalShape`, so they can
+     * never share a cache entry and this refusal cannot be decided on one
+     * call's behalf by another's.
+     */
+    if (Array.isArray(operand)) {
+      throw new InvalidArgumentError(
         `data.${relation.name}.${key}`,
         schema.name,
         operation,
-        `'${relation.name}' is a to-one whose foreign key lives on ` +
-          `${child.name}, and '${key}' is not implemented for that shape yet. ` +
-          `On a to-one Prisma takes the data directly rather than the ` +
-          `{ where, data } form this side expects. Reach the row through the ` +
-          `${child.name} model directly, or use 'connect' and 'disconnect'.`,
+        `'${relation.name}' is a to-one — ${child.name} holds the foreign key, ` +
+          `so there is one row here at most. Expected a single object for ` +
+          `'${key}', not an array of them. Prisma refuses the array too.`,
       );
     }
+
+    /**
+     * The three that were refused are a **spelling** difference, not missing
+     * machinery. `conjoin` returns the parent restriction alone when the
+     * caller's filter is absent or `{}`, and `listOf(null)` is `[]` — so a
+     * to-one is a to-many of one, and the bodies below already do the work
+     * once the operand is written the way they read.
+     *
+     * **Rebinding `at` — translating at *bind* time and not only while the plan
+     * is compiled — is load-bearing for exactly one branch, and that is the
+     * correctness argument for this whole design.** Every other distinction the
+     * table draws is *structural*, so it may safely be decided once when the
+     * plan is built: `{ data }` against `{ where, data }`, a `where` present
+     * against absent, an array against an object — `canonicalShape` records all
+     * of those, so two calls that differ there are already two plans. The
+     * boolean is the one that is not. `delete: true` and `delete: false` are
+     * the same shape to everything except the guard `shapeOfMember` carries for
+     * exactly this, and a plan key is a cache rather than a contract. Reading
+     * the boolean inside `at` means the step consults the *call's* value on
+     * every execution, so a plan handed the wrong one still writes nothing —
+     * `listOf(null)` is `[]`. Belt and braces on purpose: the owning side's
+     * version of the same collision was a silent wrong write for its whole
+     * life, precisely because its `true`/`false` decision was made once at
+     * compile time and never revisited.
+     */
+    const spelled = at;
+    at = (args: any) => toOneOperand(key, spelled(args));
+    operand = toOneOperand(key, operand);
   }
 
   /**
-   * `disconnect` and `delete` on this side both act on rows the caller named by
+   * `disconnect` and `delete` on this side act on rows the caller named by
    * unique key — which is what makes them expressible at all, and what puts
    * them on the supported side of this file's line.
    *
+   * **On a to-one the caller names a *filter*, or nothing at all**, and that
+   * does not weaken the line: the row is still identified, by the parent's own
+   * key, which is the strongest naming available. `assertToOneFilter` is what
+   * replaces the unique-key match there, and the filter only narrows.
+   *
    * They differ on a row that is *not* linked to this parent, and the
-   * difference is Prisma's, measured rather than chosen:
+   * difference is Prisma's, measured rather than chosen — on both kinds, since
+   * the second pair is the same asymmetry read through the to-one spelling:
    *
    *     disconnect a row linked elsewhere  ->  succeeds, changes nothing
    *     delete     a row linked elsewhere  ->  raises "are not connected"
+   *     disconnect: true, nothing linked   ->  succeeds, changes nothing
+   *     delete: true,     nothing linked   ->  P2025
    *
    * So both filter by the parent key as well as the caller's key, and only
    * `delete` treats a miss as an error. That filter is doing two jobs at once:
@@ -896,8 +970,37 @@ function planForeignSide(
    * filter operand on this parent is what produces the right branch here, not
    * merely what keeps it safe.
    */
+  /**
+   * **The to-one reaches this same body, and it needed nothing added.** Its
+   * `where` is optional — `ProfileUpsertWithoutUserInput` is
+   * `{ update, create, where? }` — so `conjoin(undefined, link)` is the link
+   * alone and the lookup finds the single connected child. Measured on both
+   * branches:
+   *
+   *   no child, no `where`      ->  the create branch runs *and stamps the
+   *                                 foreign key* — Profile { bio: "created",
+   *                                 userId: 1 }
+   *   child present, no `where` ->  the update branch runs against it
+   *   child present, `where` matching nothing
+   *                             ->  the create branch runs and collides:
+   *                                 P2002, "Unique constraint failed on the
+   *                                 fields: (`userId`)"
+   *
+   * The third is the note above transposed to the foreign side, and it is the
+   * one to-one nested-write miss that is *not* P2025. It is left to happen
+   * rather than pre-empted: the create is what Prisma runs, so surfacing
+   * `UniqueConstraintError` from it is agreement, where refusing early would be
+   * a different error for the same query.
+   */
   if (key === "upsert") {
-    assertUpsertOperand(schema, relation, child, operand, operation);
+    assertUpsertOperand(
+      schema,
+      relation,
+      child,
+      operand,
+      operation,
+      relation.kind === "many",
+    );
 
     out.after.push({
       relation: relation.name,
@@ -1043,7 +1146,14 @@ function planForeignSide(
   }
 
   if (key === "update") {
-    assertNamedUpdates(schema, relation, child, operand, operation);
+    assertNamedUpdates(
+      schema,
+      relation,
+      child,
+      operand,
+      operation,
+      relation.kind === "many",
+    );
 
     out.after.push({
       relation: relation.name,
@@ -1080,6 +1190,17 @@ function planForeignSide(
             // *kind* precisely so a refusal cannot pass as agreement with a
             // miss. This one was `other` against Prisma's `notFound` until the
             // harness said so.
+            //
+            // **Fatal on the to-one too, which was the open question and is
+            // now measured.** The worry was that a to-one `update` naming a
+            // non-matching `where` might be a no-op there, which would have
+            // made this branch wrong for one `kind` and forced the two apart.
+            // It does not: with a child present and `where: { bio: "nope" }`
+            // Prisma raises P2025 — *"No 'Profile' record was found for a
+            // nested update on one-to-one relation 'ProfileToUser'"* — with
+            // wording identical to the no-child case, and the parent's own
+            // assignments roll back with it. Absent and not-matching are one
+            // condition to Prisma, so they stay one error here.
             throw new RecordNotFoundError(relation.model, "update");
           }
 
@@ -1102,6 +1223,13 @@ function planForeignSide(
   if (key === "disconnect" || key === "delete") {
     const deleting = key === "delete";
     if (!deleting) {
+      // Before any boolean normalisation would matter, and it has to be:
+      // Prisma leaves `disconnect` out of the input type *entirely* when the
+      // child's foreign key is required, so even `disconnect: false` is
+      // rejected there — *"Unknown argument `disconnect`. Did you mean
+      // `connect`?"*, with the available options listed as create /
+      // connectOrCreate / upsert / connect / update. The refusal is on the
+      // **key**, not on the value, and this one already reads only the schema.
       assertDisconnectable(child, relation, childField, {
         model: schema.name,
         operation,
@@ -1109,7 +1237,21 @@ function planForeignSide(
       });
     }
 
-    assertNamedRows(schema, relation, child, operand, key, operation);
+    /**
+     * **A to-one names a filter here; a to-many names rows by unique key.**
+     *
+     * `ProfileUpdateOneWithoutUserNestedInput` spells both operands
+     * `ProfileWhereInput | boolean`, and it means it — measured:
+     * `delete: { bio: "seed" }` is accepted with no `@unique` anywhere near
+     * `bio`, and it deletes the connected row. Running `matchUniqueKey` on this
+     * path would therefore refuse a query Prisma answers, which is why
+     * `assertToOneFilter` replaces `assertNamedRows` rather than joining it.
+     */
+    if (relation.kind === "many") {
+      assertNamedRows(schema, relation, child, operand, key, operation);
+    } else {
+      assertToOneFilter(schema, relation, child, operand, key, operation);
+    }
 
     out.after.push({
       relation: relation.name,
@@ -1153,6 +1295,34 @@ function planForeignSide(
           )) as Record<string, unknown> | null;
 
           if (!found) {
+            /**
+             * **Two misses, two errors — and this is the third time this exact
+             * mis-classification has had to be corrected** (see the notes at
+             * `planOwningSide`'s `update` and at this file's own `update`
+             * miss).
+             *
+             * On a to-one the caller named no row: `delete: true` means the
+             * connected child, and there is either one or there is not.
+             * Reporting *"the row named by `true` is not connected"* would be
+             * nonsense to read, and worse it classifies as `other` where Prisma
+             * answers P2025 — *"No 'Profile' record was found for a nested
+             * delete on one-to-one relation 'ProfileToUser'"* — so the
+             * differential harness would score a refusal as agreement with a
+             * miss. Measured on both spellings: `delete: true` with no child
+             * and `delete: { bio: "nope" }` with a child present give the same
+             * P2025, so one error covers both.
+             *
+             * **`disconnect` does not come through here at all, and that
+             * asymmetry is Prisma's.** A disconnect that matches nothing —
+             * `disconnect: true` with no child, or a filter matching none — is
+             * a *silent no-op* that still returns the parent, measured both
+             * ways. The two operands share this body but must not share their
+             * miss handling, which is why only `deleting` reaches this branch.
+             */
+            if (relation.kind !== "many") {
+              throw new RecordNotFoundError(relation.model, "delete");
+            }
+
             throw new UnsupportedQueryError(
               `data.${relation.name}.delete`,
               schema.name,
@@ -1299,13 +1469,20 @@ function planForeignSide(
    * answer the caller would get if it truly did not exist.
    */
   if (key === "connectOrCreate") {
+    // `relation.kind === "many"`, not a hardcoded `true`. This side is reached
+    // by both kinds — that is the whole of #116 — so a literal here told
+    // `assertConnectOrCreateOperand` that a to-one takes a list, and its array
+    // guard was unreachable from the one direction that needed it. The outer
+    // to-one guard above now refuses the array first; this keeps the function
+    // honest about which relation it was asked about rather than relying on
+    // the order of two checks.
     assertConnectOrCreateOperand(
       schema,
       relation,
       child,
       operand,
       operation,
-      true,
+      relation.kind === "many",
     );
 
     out.after.push({
@@ -1792,9 +1969,17 @@ async function runPairStatement(
 /**
  * `upsert`'s operand: `{ where, create, update }`, or a list of them.
  *
- * All three are required — the lookup, and one payload per branch. Checked at
- * plan time like every other operand here, so a missing key fails when the
- * query compiles rather than after the parent row is written.
+ * The two payloads are always required — one per branch. **The `where` is
+ * required only on a to-many**, which is Prisma's own split rather than a
+ * looseness: `AccountUpsertWithWhereUniqueWithoutUserInput` has `where:
+ * AccountWhereUniqueInput`, while `ProfileUpsertWithoutUserInput` is
+ * `{ update, create, where? }` — the to-one already knows which row it means,
+ * because the parent's key names it. So the unique-key match is skipped there
+ * too: a to-one `where` is a `WhereInput` filter narrowing the single linked
+ * row, not a key selecting one out of many.
+ *
+ * Checked at plan time like every other operand here, so a missing key fails
+ * when the query compiles rather than after the parent row is written.
  */
 function assertUpsertOperand(
   schema: ModelSchema,
@@ -1802,6 +1987,7 @@ function assertUpsertOperand(
   child: ModelSchema,
   operand: unknown,
   operation: string,
+  many: boolean,
 ): void {
   const at = `data.${relation.name}.upsert`;
   const entries = (Array.isArray(operand) ? operand : [operand]) as unknown[];
@@ -1812,22 +1998,31 @@ function assertUpsertOperand(
         at,
         schema.name,
         operation,
-        `Expected an object with 'where', 'create' and 'update'.`,
+        many
+          ? `Expected an object with 'where', 'create' and 'update'.`
+          : `Expected an object with 'create' and 'update' — on a to-one the ` +
+            `'where' is optional, since the parent's key already names the row.`,
       );
     }
 
     const record = entry as Record<string, unknown>;
-    for (const required of ["where", "create", "update"] as const) {
-      if (record[required] === undefined) {
+    const required = many
+      ? (["where", "create", "update"] as const)
+      : (["create", "update"] as const);
+
+    for (const name of required) {
+      if (record[name] === undefined) {
         throw new UnsupportedQueryError(
           at,
           schema.name,
           operation,
-          `Expected a '${required}' key — 'upsert' names the row to look for, ` +
+          `Expected a '${name}' key — 'upsert' names the row to look for, ` +
             `what to write if it is there, and what to write if it is not.`,
         );
       }
     }
+
+    if (!many) continue;
 
     matchUniqueKey(child, record.where, {
       model: schema.name,
@@ -1922,6 +2117,14 @@ function assertManyOperand(
  * `data` is *not* inspected here — it is the child's, and the child's own
  * `$exec` validates it against the child's schema and policies. Checking it
  * against this model would be checking the wrong shape.
+ *
+ * **On a to-one only `data` is required, and it may have been written bare.**
+ * `toOneOperand` has already turned `update: { bio: "x" }`,
+ * `update: { data: … }` and `update: { where, data }` into the one form this
+ * reads, so what arrives is always `{ where?, data }` — but the `where` is
+ * genuinely optional there (`UpdateToOneWithWhereWithoutUserInput` spells it
+ * `where?`) and it is a filter rather than a key, so `matchUniqueKey` does not
+ * run on it either.
  */
 function assertNamedUpdates(
   schema: ModelSchema,
@@ -1929,6 +2132,7 @@ function assertNamedUpdates(
   child: ModelSchema,
   operand: unknown,
   operation: string,
+  many: boolean,
 ): Record<string, unknown>[] {
   const at = `data.${relation.name}.update`;
   const entries = (Array.isArray(operand) ? operand : [operand]) as unknown[];
@@ -1945,24 +2149,28 @@ function assertNamedUpdates(
     }
 
     const record = entry as Record<string, unknown>;
+    const required = many ? (["where", "data"] as const) : (["data"] as const);
 
-    for (const required of ["where", "data"] as const) {
-      if (record[required] === undefined) {
+    for (const name of required) {
+      if (record[name] === undefined) {
         throw new UnsupportedQueryError(
           at,
           schema.name,
           operation,
-          `Expected a '${required}' key — 'update' names the row to write and ` +
+          `Expected a '${name}' key — 'update' names the row to write and ` +
             `the columns to write to it.`,
         );
       }
     }
 
-    matchUniqueKey(child, record.where, {
-      model: schema.name,
-      operation,
-      argument: `data.${relation.name}.update.where`,
-    });
+    if (many) {
+      matchUniqueKey(child, record.where, {
+        model: schema.name,
+        operation,
+        argument: `data.${relation.name}.update.where`,
+      });
+    }
+
     out.push(record);
   }
 
@@ -2006,6 +2214,48 @@ function assertNamedRows(
   }
 
   return out;
+}
+
+/**
+ * A to-one `disconnect` / `delete` operand, once {@link toOneOperand} has
+ * translated the booleans away: `null` for the no-op, or a plain filter object.
+ *
+ * The counterpart of {@link assertNamedRows}, and deliberately *not* it. That
+ * one runs `matchUniqueKey`, which is right where the caller is picking one row
+ * out of many and wrong here: Prisma's to-one operand is a `WhereInput`, and
+ * `delete: { bio: "seed" }` — a column with no unique index anywhere near it —
+ * is accepted and deletes the connected row. Sharing `assertNamedRows` would
+ * have refused that at compile time with a list of unique keys the caller never
+ * had to name.
+ *
+ * `null` is the normalised `false`, and it is a *value* rather than an
+ * omission: `delete: false` is a call that deliberately asks for nothing, so it
+ * passes here and reduces to no statement at all further down.
+ *
+ * `InvalidArgumentError` because the argument is supported and the value is
+ * wrong — the same reading `assertCreateManyOperand` uses, and the reason the
+ * message names the two shapes that work instead of announcing a gap.
+ */
+function assertToOneFilter(
+  schema: ModelSchema,
+  relation: RelationSchema,
+  child: ModelSchema,
+  operand: unknown,
+  key: string,
+  operation: string,
+): void {
+  if (operand === null || operand === undefined) return;
+  if (typeof operand === "object" && !Array.isArray(operand)) return;
+
+  throw new InvalidArgumentError(
+    `data.${relation.name}.${key}`,
+    schema.name,
+    operation,
+    `'${relation.name}' is a to-one, so '${key}' takes either a boolean — ` +
+      `'true' for the connected ${child.name}, 'false' for nothing — or an ` +
+      `object of filters it has to match. Prisma's operand here is ` +
+      `'${child.name}WhereInput | boolean'.`,
+  );
 }
 
 /**
@@ -2067,13 +2317,26 @@ function assertConnectOrCreateOperand(
   const at = `data.${relation.name}.connectOrCreate`;
 
   if (Array.isArray(operand) && !many) {
-    throw new UnsupportedQueryError(
+    // **Which side holds the key is read off the relation, not assumed.** This
+    // sentence used to say "this row holds the foreign key" unconditionally,
+    // which was true of the only caller that could pass `many: false` — the
+    // owning side — and false the moment the foreign side stopped hardcoding
+    // `true`. `from` is non-empty exactly on the side that holds the key, the
+    // same test `planOne` makes to choose between the two planners, so the two
+    // cannot drift.
+    const owning = relation.from.length > 0;
+
+    throw new InvalidArgumentError(
       at,
       schema.name,
       operation,
-      `'${relation.name}' is a to-one: this row holds the foreign key, so ` +
-        `there is one row to point at and a list has no meaning. Prisma ` +
-        `refuses an array here too.`,
+      `'${relation.name}' is a to-one: ` +
+        (owning
+          ? `this row holds the foreign key`
+          : `${child.name} holds the foreign key`) +
+        `, so there is one row to point at and a list has no meaning. Prisma ` +
+        `refuses an array here too — as a validation error on the argument, ` +
+        `which is why this is a bad value rather than a gap.`,
     );
   }
 
@@ -2204,4 +2467,88 @@ function assertCreateManyOperand(
 function listOf(value: unknown): unknown[] {
   if (value === undefined || value === null) return [];
   return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * A to-one nested-write operand, rewritten in the spelling the to-many bodies
+ * above already read.
+ *
+ * **Prisma's to-one nested input is a different grammar, not a subset of the
+ * to-many one** — quoted from a generated client rather than from the docs
+ * (`ProfileUpdateOneWithoutUserNestedInput`):
+ *
+ *     update      XOR<UpdateToOneWithWhereWithoutUserInput, UpdateWithoutUserInput>
+ *                 where UpdateToOneWithWhereWithoutUserInput = { where?, data }
+ *     upsert      { update, create, where? }
+ *     disconnect  ProfileWhereInput | boolean
+ *     delete      ProfileWhereInput | boolean
+ *     connect     ProfileWhereUniqueInput
+ *
+ * Three of those differences would be got wrong by reading the to-many side and
+ * assuming symmetry, so each is named with the measurement behind it:
+ *
+ *   - **the `where` is optional, and it is a filter.** Not a unique key —
+ *     `WhereInput`, not `WhereUniqueInput` — which is why `assertToOneFilter`
+ *     replaces `assertNamedRows` here and `matchUniqueKey` does not run.
+ *     Measured: `delete: { bio: "seed" }` is accepted against a column with no
+ *     unique index and deletes the connected row.
+ *   - **the data may be written bare.** `update: { bio: "x" }` and
+ *     `update: { data: { bio: "x" } }` are one operation. The owning side
+ *     measured that years ago; this is the same measurement repeated on the
+ *     foreign side, because the owning side's said nothing about this one.
+ *   - **the boolean is not an empty filter.** `true` means the connected row;
+ *     `false` means *nothing at all*, measured — `delete: false` and
+ *     `disconnect: false` with a child present return the parent and leave the
+ *     child exactly as it was, foreign key included.
+ *
+ * So `true` becomes `{}`, which `conjoin` reduces to the parent link alone —
+ * precisely the one connected row — and `false` becomes `null`, which `listOf`
+ * reduces to `[]`, which is no statement.
+ */
+function toOneOperand(key: string, operand: unknown): unknown {
+  if (key === "update") {
+    // A `data` key is the wrapper; anything else is the payload itself. The
+    // same test `planOwningSide`'s `update` makes, deliberately — the two
+    // spellings collapse to one operation, so the compiler should not have two
+    // shapes of its own for them. It carries the same ambiguity, too: a child
+    // with a scalar column called `data` would be read as the wrapper. Prisma's
+    // own input types have that hazard by construction and it has never been
+    // reachable in practice, so it is inherited rather than invented.
+    //
+    // **`!== undefined` rather than `in`**, and the difference is a plan-cache
+    // bug rather than a style choice. `canonicalShape` drops a key whose value
+    // is `undefined` (see its object branch), so `update: {}` and `update: {
+    // data: undefined }` are ONE plan key. Branching on `in` gave them two
+    // compilations: the first normalised and compiled, the second reached
+    // `assertNamedUpdates` and was refused for a missing `data` — so whether
+    // the refusal fired depended on which spelling warmed the cache. Testing
+    // the value instead is what `assertNamedUpdates` itself does, one operand
+    // over, and it puts both spellings on the same branch.
+    //
+    // This is the same defect as the `disconnect` boolean two functions down,
+    // arrived at from the opposite direction: there the key was too coarse for
+    // the code, here the code was finer than the key. Both are decided by
+    // asking what `canonicalShape` actually records.
+    if (
+      operand !== null &&
+      typeof operand === "object" &&
+      (operand as Record<string, unknown>).data !== undefined
+    ) {
+      const record = operand as Record<string, unknown>;
+      return { where: record.where, data: record.data };
+    }
+    return { where: undefined, data: operand };
+  }
+
+  if (key === "delete" || key === "disconnect") {
+    if (operand === true) return {};
+    if (operand === false) return null;
+    return operand;
+  }
+
+  // `upsert` already arrives as `{ where?, create, update }`, and `create`,
+  // `connect` and `connectOrCreate` are already singular. Returned untouched
+  // rather than listed, so an operand added later does not silently acquire a
+  // translation it was never measured for.
+  return operand;
 }

--- a/packages/gemi/orm/compile/refusals.test.ts
+++ b/packages/gemi/orm/compile/refusals.test.ts
@@ -165,6 +165,32 @@ describe("shape guards", () => {
     ["update's operand is not an object", write({ where: { id: 1 }, data: { accounts: { update: 5 } } }), "data.accounts.update", /Expected an object with 'where' and 'data'/],
     ["disconnect's operand is not an object", write({ where: { id: 1 }, data: { accounts: { disconnect: 5 } } }), "data.accounts.disconnect", /Expected an object naming a unique field, or an array of them/],
     ["connectOrCreate's operand is not an object", write({ where: { id: 1 }, data: { accounts: { connectOrCreate: 5 } } }), "data.accounts.connectOrCreate", /Expected an object with 'where' and 'create'/],
+    // --- the to-one operands, whose grammar is Prisma's other one ----------
+    // `assertToOneFilter` is the guard `assertNamedRows` cannot be on this
+    // path: the operand is a filter, so there is no unique key to match. Born
+    // reachable, which is what this file exists to make true — the 36 sites
+    // #114 found were all reachable-in-principle and unreached in fact.
+    [
+      "a to-one delete is neither a boolean nor a filter",
+      write({ where: { id: 1 }, data: { profile: { delete: 5 } } }),
+      "data.profile.delete",
+      /takes either a boolean/,
+    ],
+    [
+      "an array on a to-one whose child holds the key",
+      write({ where: { id: 1 }, data: { profile: { create: [{ bio: "a" }] } } }),
+      "data.profile.create",
+      /Expected a single object/,
+    ],
+    // The owning side's half of the same refusal, pinned because the message
+    // now names *which* side holds the key and the two arms can only be told
+    // apart by reading both.
+    [
+      "an array of connectOrCreate on a to-one this row owns",
+      write({ where: { id: 1 }, data: { organization: { connectOrCreate: [{ where: { id: 1 }, create: {} }] } } }),
+      "data.organization.connectOrCreate",
+      /this row holds the foreign key/,
+    ],
 
     // --- the operation itself ---------------------------------------------
     // Both `default:` arms after an exhaustive-looking partition. Reachable,

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -2118,6 +2118,111 @@ describe("nested writes", () => {
       ).toThrow(/is a to-one/);
     });
   });
+
+  /**
+   * **What a to-one `update` / `upsert` operand is allowed to contain.**
+   *
+   * The to-many path gets this from `matchUniqueKey`. The to-one path cannot —
+   * Prisma's `where` here is a `WhereInput`, so there is no unique key to match
+   * — and for a while it had nothing in its place, which let three shapes
+   * through to places they should never have reached.
+   *
+   * All three are silent by construction, which is why they are asserted
+   * together: each one *writes*, and none of them raises where the caller wrote
+   * the query.
+   */
+  describe("a to-one update or upsert is shape-checked before it is rewritten", () => {
+    beforeEach(() => {
+      registry.register("Profile", class { static $schema = profile });
+      registry.register("User", class { static $schema = userWithProfile });
+    });
+
+    const write = (relation: string, operand: Record<string, unknown>) =>
+      compileWrite(
+        userWithProfile,
+        "update",
+        { where: { id: 1 }, data: { [relation]: operand } },
+        sqlite,
+      );
+
+    /**
+     * The rewrite rebuilds the operand from the keys it knows, so a key it does
+     * not know is gone before anything downstream could object — and what is
+     * lost here is the *filter*, so a guarded write becomes an unguarded one.
+     */
+    test.each(["profile", "organization"])(
+      "a misspelled where is refused rather than dropped (%s)",
+      (relation) => {
+        expect(() =>
+          write(relation, {
+            update: { data: { bio: "x" }, wehre: { bio: "old" } },
+          }),
+        ).toThrow(/Unknown key 'wehre'/);
+      },
+    );
+
+    // Both sides, because the operand grammar is shared and the whole point of
+    // the check is that neither side may be the lenient one.
+    test.each(["profile", "organization"])(
+      "a where that is not an object is refused (%s)",
+      (relation) => {
+        expect(() =>
+          write(relation, { update: { where: [{ bio: "x" }], data: {} } }),
+        ).toThrow(/'where' has to be an object of filters/);
+        expect(() =>
+          write(relation, { update: { where: 7, data: {} } }),
+        ).toThrow(/'where' has to be an object of filters/);
+      },
+    );
+
+    /**
+     * `conjoin` treats a non-object filter as no filter at all, so an unchecked
+     * one does not fail — it widens. `upsert` is the sharper case: Prisma
+     * applies the filter, matches nothing and takes the *create* branch onto a
+     * unique violation, where dropping it finds the connected row and takes the
+     * *update* branch. Two different rows written, no error either way.
+     */
+    test("an upsert where is checked too", () => {
+      expect(() =>
+        write("profile", {
+          upsert: {
+            where: [{ bio: "old" }],
+            create: { bio: "new" },
+            update: { bio: "touched" },
+          },
+        }),
+      ).toThrow(/'where' has to be an object of filters/);
+    });
+
+    /**
+     * Refused here rather than mid-transaction. Without this the parent row is
+     * already written when the step calls `updateMany` with a `null` payload,
+     * so the error names `Profile.updateMany` — a model and an operation the
+     * caller never wrote — and a written row has to be unwound to report it.
+     */
+    test.each([
+      ["null", null],
+      ["a number", 5],
+      ["a string", "bio"],
+    ])("a %s operand is refused at compile time", (_name, operand) => {
+      const call = () => write("profile", { update: operand });
+      expect(call).toThrow(InvalidArgumentError);
+      expect(call).toThrow(/Expected an object/);
+    });
+
+    /**
+     * The payload spelling stays unchecked, deliberately: those keys are the
+     * child's columns and belong to the child's schema, so checking them here
+     * would be checking the wrong shape. The wrapper is told apart by carrying
+     * a `data`, which is the same test the rewrite makes.
+     */
+    test("the payload spelling is not key-checked", () => {
+      expect(() => write("profile", { update: { bio: "x" } })).not.toThrow();
+      // ...and a key that is wrong there is the child's to refuse, which it
+      // does — through its own `$exec`, at the point the payload is applied.
+      expect(() => write("profile", { update: { nosuchcolumn: 1 } })).not.toThrow();
+    });
+  });
 });
 
 describe("arguments", () => {

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -460,10 +460,166 @@ describe("update", () => {
     ).toContain(`set "name" = ?`);
   });
 
-  test("an empty data object is refused rather than emitting invalid SQL", () => {
-    expect(() =>
-      compileWrite(organization, "update", { where: { id: 1 }, data: {} }, sqlite),
-    ).toThrow(/At least one field must be updated/);
+  /**
+   * #355. An empty `data` used to be refused here — "At least one field must be
+   * updated" — on the reasoning that there is nothing to do. Prisma disagrees:
+   * measured on 6.19.2/SQLite, `update({ where: { id: 1 }, data: {} })` returns
+   * the row unchanged, honours `include` and `select` while doing it, and still
+   * raises P2025 when the `where` matches nothing.
+   *
+   * **Every test below uses `organization`, and that is not incidental.**
+   * `updateAssignments` stamps `@updatedAt` unconditionally, so a model
+   * carrying one *always* has an assignment and can never reach this branch or
+   * the relation-only one — `user` would compile a real `UPDATE` here and prove
+   * nothing. `organization` has no `@updatedAt`. The last test in this block
+   * pins that difference so the choice of fixture stays legible.
+   */
+  describe("an empty data reads the row rather than writing it", () => {
+    const empty = (args: any, schema = organization) =>
+      compileWrite(schema, "update", { where: { id: 1 }, ...args }, sqlite);
+
+    test("it selects instead of emitting an UPDATE with no assignments", () => {
+      const plan = empty({ data: {} });
+      expect(plan.text).toBe(
+        `select "id", "publicId", "name", "logoUrl", "description" ` +
+          `from "Organization" where "id" = ?`,
+      );
+      expect(plan.text).not.toContain("update");
+    });
+
+    /**
+     * The invariant #355's acceptance rests on: the empty `data` is not a new
+     * code path, it is the *existing* relation-only one with its guard removed.
+     * If these two ever stop agreeing, something has grown a second way to read
+     * a row on the write path — which is how the `include` and `_count` cases
+     * below would start diverging silently.
+     */
+    test("it is byte-identical to a data of only nested writes", () => {
+      registry.clearRegistry();
+      registry.register("User", class { static $schema = user });
+      registry.register("Organization", class { static $schema = organization });
+
+      const relationOnly = empty({ data: { users: { connect: { id: 2 } } } });
+      expect(empty({ data: {} }).text).toBe(relationOnly.text);
+      // …and the nested step is still planned, so the agreement is about the
+      // statement rather than about both of them doing nothing.
+      expect(relationOnly.after).toHaveLength(1);
+
+      registry.clearRegistry();
+    });
+
+    // Measured: `post.update({ where, data: {} , include: { tags: true } })`
+    // comes back with the tags. It goes through the same `plan()` call as every
+    // other update, so this needs no clause of its own — but a bare row fetch
+    // that ignored `include` would pass every other test in this block.
+    test("include is honoured", () => {
+      registry.clearRegistry();
+      registry.register("User", class { static $schema = user });
+      registry.register("Organization", class { static $schema = organization });
+
+      const plan = empty({ data: {}, include: { users: true } });
+      expect(plan.relations).toHaveLength(1);
+      expect(plan.relations![0]).toMatchObject({ as: "users", kind: "many" });
+
+      registry.clearRegistry();
+    });
+
+    // Measured: `select: { title: true }` returns `{ title: "p1" }` with no
+    // `id`, exactly as it narrows a normal update.
+    test("select narrows the read", () => {
+      expect(empty({ data: {}, select: { name: true } }).text).toBe(
+        `select "name" from "Organization" where "id" = ?`,
+      );
+    });
+
+    // The `where` is still the caller's, so a miss returns no row — and
+    // `update` is in ORTHROW, where `$exec` turns that into
+    // `RecordNotFoundError`, Prisma's P2025 for the same call.
+    test("a miss shapes to null, which is what ORTHROW raises on", () => {
+      expect(empty({ data: {} }).shape([])).toBeNull();
+    });
+
+    // Not a divergence to fix: Prisma's client rejects this before the query
+    // engine sees it. The point is that it must not fall into the branch above
+    // and answer a malformed call with a row.
+    test("a null data is still refused, and says what a good one looks like", () => {
+      expect(() => empty({ data: null })).toThrow(InvalidArgumentError);
+      expect(() => empty({ data: null })).toThrow(/like \{ name: 'new name' \}/);
+    });
+
+    // `@updatedAt` does not keep a model out of this branch, and the fact that
+    // it used to is the reason #355 shipped half-finished the first time: the
+    // stamp was the assignment that kept the count off zero, so the read was
+    // dead on every model carrying the attribute — which is most of them, and
+    // is the one the issue was filed from.
+    //
+    // MEASURED (Prisma 6.19.2, SQLite), seeding `updatedAt` to the epoch and
+    // reading it back: `user.update({ where, data: {} })` leaves it at 0. So
+    // Prisma does not stamp a call that sets no column, and the same select is
+    // right here as on a model without one. See `updateAssignments`.
+    test("a model with @updatedAt reads too, and does not stamp", () => {
+      const plan = compileWrite(user, "update", { where: { id: 1 }, data: {} }, sqlite);
+      expect(plan.text).toBe(
+        `select "id", "publicId", "name", "email", "emailVerifiedAt", ` +
+          `"verificationToken", "locale", "globalRole", "password", ` +
+          `"organizationId", "createdAt", "updatedAt", "deletedAt" ` +
+          `from "User" where "id" = ?`,
+      );
+    });
+
+    // The other half of the same rule, so the fix cannot be read as "never
+    // stamp": one real column brings the stamp back. Measured alongside —
+    // `data: { name: "real" }` does move `updatedAt`.
+    test("one supplied column brings the stamp back", () => {
+      const plan = compileWrite(
+        user,
+        "update",
+        { where: { id: 1 }, data: { name: "real" } },
+        sqlite,
+      );
+      expect(plan.text).toContain(`set "name" = ?, "updatedAt" = ?`);
+    });
+  });
+
+  /**
+   * MEASURED (Prisma 6.19.2, SQLite): `updateMany({ where, data: {} })` answers
+   * `{ count: 0 }` — with two of three rows matching the filter, with a filter
+   * matching none, and with no `where` at all. The count is a constant, not a
+   * row count, and no row is touched.
+   *
+   * So this is `createMany([])`'s plan, and these assert it is *literally* that
+   * plan: the same constant-false select, so nothing is read and the filter is
+   * never evaluated.
+   */
+  describe("an empty data in updateMany counts zero", () => {
+    const many = (args: any) =>
+      compileWrite(organization, "updateMany", { data: {}, ...args }, sqlite);
+
+    test("it is the constant-zero plan, whatever the filter", () => {
+      const expected = `select "id" from "Organization" where false`;
+      expect(many({ where: { name: "x" } }).text).toBe(expected);
+      expect(many({ where: { name: "nope" } }).text).toBe(expected);
+      expect(many({}).text).toBe(expected);
+      expect(many({ where: { name: "x" } }).shape([])).toEqual({ count: 0 });
+    });
+
+    // The filter is discarded, not skipped: an unknown field is refused whether
+    // or not there was anything to write, for the reason `createMany` validates
+    // `skipDuplicates` ahead of its own empty-list shortcut.
+    test("the discarded where is still validated", () => {
+      expect(() => many({ where: { nosuchfield: 1 } })).toThrow(UnknownFieldError);
+    });
+
+    // A model with `@updatedAt` takes the same branch, exactly as on `update`.
+    // MEASURED: `user.updateMany({ where: { name: "n" }, data: {} })` answers
+    // `{ count: 0 }` against a matching row and leaves `updatedAt` at the epoch
+    // — so the constant is Prisma's answer here too, and the stamp that used to
+    // make this model write was a divergence rather than the attribute working.
+    test("a model with @updatedAt counts zero too, and does not stamp", () => {
+      const plan = compileWrite(user, "updateMany", { where: { name: "x" }, data: {} }, sqlite);
+      expect(plan.text).toBe(`select "id" from "User" where false`);
+      expect(plan.shape([])).toEqual({ count: 0 });
+    });
   });
 });
 
@@ -605,14 +761,36 @@ describe("upsert", () => {
     ).toContain(`set "globalRole" = "globalRole" + ?`);
   });
 
-  test("@updatedAt is stamped on the conflict branch too", () => {
+  /**
+   * The conflict branch follows the same rule as an ordinary update: a column
+   * beside the stamp, or no stamp. MEASURED (Prisma 6.19.2, SQLite), seeding
+   * `updatedAt` to the epoch:
+   *
+   *     upsert hit, update: {}              epoch   not stamped
+   *     upsert hit, update: { name: "x" }   now     stamped
+   *
+   * This test used to assert the first case stamped, which was gemi's answer
+   * and not Prisma's. `do update set "email" = "User"."email"` is the no-op
+   * self-assignment the compiler already emits to keep `on conflict do update`
+   * valid SQL with nothing to set, so the branch still fires and still returns
+   * the row — it simply writes no column, which is what was asked.
+   */
+  test("@updatedAt follows the column on the conflict branch too", () => {
     expect(
       text("upsert", {
         where: { email: "a@b.c" },
         create: { email: "a@b.c" },
         update: {},
       }),
-    ).toContain(`do update set "updatedAt" = ?`);
+    ).not.toContain(`"updatedAt" = ?`);
+
+    expect(
+      text("upsert", {
+        where: { email: "a@b.c" },
+        create: { email: "a@b.c" },
+        update: { name: "x" },
+      }),
+    ).toContain(`do update set "name" = ?, "updatedAt" = ?`);
   });
 
   // `on conflict` only fires when the inserted row actually collides on the
@@ -1039,6 +1217,14 @@ describe("nested writes", () => {
    *
    * Walked as a table over both sides, because the two disagreeing *is* the
    * defect and a one-sided test cannot see it.
+   *
+   * **The three refusals this describe used to pin have inverted**: `update`,
+   * `delete` and `upsert` compile on the foreign side now. What is left is a
+   * genuine asymmetry — `delete` and `upsert` are still refused *by name* on
+   * the owning side, each for a reason of its own — and it is asserted below
+   * rather than left implicit. An unasserted asymmetry in a describe titled
+   * "answers the same on both sides" is exactly how #116 happened: the sentence
+   * reads like a guarantee and nothing was checking the half it did not cover.
    */
   describe("a to-one answers the same on both sides", () => {
     beforeEach(() => {
@@ -1046,14 +1232,25 @@ describe("nested writes", () => {
       registry.register("User", class { static $schema = userWithProfile });
     });
 
-    const refuse = (relation: string, operand: Record<string, unknown>) => {
+    const write = (
+      relation: string,
+      operand: Record<string, unknown>,
+      schema: typeof user = userWithProfile,
+    ) =>
+      compileWrite(
+        schema,
+        "update",
+        { where: { id: 1 }, data: { [relation]: operand } } as never,
+        sqlite,
+      );
+
+    const refuse = (
+      relation: string,
+      operand: Record<string, unknown>,
+      schema: typeof user = userWithProfile,
+    ) => {
       try {
-        compileWrite(
-          userWithProfile,
-          "update",
-          { where: { id: 1 }, data: { [relation]: operand } } as never,
-          sqlite,
-        );
+        write(relation, operand, schema);
         return null;
       } catch (error) {
         return error as UnsupportedQueryError;
@@ -1082,22 +1279,68 @@ describe("nested writes", () => {
     });
 
     /**
-     * The three that *are* on Prisma's to-one input. Not implemented on the
-     * foreign side — the point is that the refusal now says so, instead of
-     * blaming the operand's shape.
+     * The three that *are* on Prisma's to-one input, and now compile on the
+     * side whose child holds the key.
+     *
+     * Each is one `after` step labelled with the operand it implements — the
+     * plan is what a later reader has to be able to trust, and a step labelled
+     * `connect` for a `delete` is how the fall-through bugs above went unseen.
      */
     test.each([
       ["update", { update: { bio: "y" } }],
       ["delete", { delete: true }],
       ["upsert", { upsert: { create: {}, update: {} } }],
-    ])("%s on the foreign side names the shape, not the spelling", (operand, value) => {
-      const error = refuse("profile", value);
+    ])("%s compiles on the foreign side, as one labelled step", (operand, value) => {
+      const plan = write("profile", value);
 
-      expect(error).not.toBeNull();
-      expect(error!.argument).toBe(`data.profile.${operand}`);
-      expect(error!.message).toMatch(/foreign key lives on Profile/);
-      // The old refusals complained about the operand's spelling instead.
-      expect(error!.message).not.toMatch(/Expected an object/);
+      expect(plan.after).toHaveLength(1);
+      expect(plan.after![0].relation).toBe("profile");
+      expect(plan.after![0].operation).toBe(operand);
+
+      // The child is reached after this row exists, so its key has to come
+      // back — and it does, whichever statement carries it. Both spellings are
+      // asserted rather than one, because which one this compiles to depends on
+      // something the operand does not say: a relation-only `data` writes no
+      // column of *this* row, so `User` reads (`select "id", …`) while a model
+      // whose `data` also set a scalar would write (`update … returning "id"`).
+      // Prisma agrees that nothing is written here — measured, it leaves
+      // `updatedAt` at the epoch for exactly these three calls — so the select
+      // is the match rather than a shortcut. See `updateAssignments`.
+      expect(plan.text).toMatch(/^(?:select|update .* returning) "id",/);
+    });
+
+    /**
+     * **The asymmetry that remains, asserted rather than implied.**
+     *
+     * Neither of these is the shape gap #116 was about; both are decisions with
+     * their own reasons, written at their refusal sites. `delete` through a key
+     * on *this* row would remove a row the statement is not about; `upsert`
+     * there would have to create the far row and then write back to a parent
+     * that has already been inserted.
+     *
+     * `update` is deliberately absent from this table: it works on both sides,
+     * which is what makes the two above a real difference rather than a general
+     * one.
+     */
+    test.each([
+      ["delete", { delete: true }, /would remove a row this statement is not about/],
+      ["upsert", { upsert: { create: {}, update: {} } }, /already been inserted/],
+    ])("%s stays refused by name on the owning side", (operand, value, why) => {
+      const error = refuse("organization", value);
+
+      expect(error, `organization.${operand} compiled`).not.toBeNull();
+      expect(error!.argument).toBe(`data.organization.${operand}`);
+      expect(error!.model).toBe("User");
+      expect(error!.message).toMatch(why);
+
+      // ...and the same operand on the other side does not refuse, which is
+      // what makes this an asymmetry rather than a shared refusal.
+      expect(refuse("profile", value)).toBeNull();
+    });
+
+    test("update is the one of the three that works on both sides", () => {
+      expect(refuse("organization", { update: { name: "n" } })).toBeNull();
+      expect(refuse("profile", { update: { bio: "b" } })).toBeNull();
     });
 
     // The operands that work on this shape, so the refusals above are not
@@ -1109,6 +1352,156 @@ describe("nested writes", () => {
     ])("%s still compiles on the foreign side", (_operand, value) => {
       expect(refuse("profile", value)).toBeNull();
     });
+
+    /**
+     * **The spellings, which are the whole of what #354 was.** Prisma's to-one
+     * input is a different grammar from its to-many one, so each of these is a
+     * legal query that used to be refused for looking wrong:
+     *
+     *   - `update` takes its data bare *and* wrapped, and both mean the same
+     *     write — measured on this side, not inherited from the owning side's
+     *     measurement.
+     *   - the `where` is optional on `update` and on `upsert`, and it is a
+     *     **filter**: `{ bio: … }` has no unique index behind it and Prisma
+     *     accepts it. A `matchUniqueKey` on this path would refuse it.
+     *   - `delete` takes a boolean or a filter.
+     */
+    test.each([
+      ["update, bare data", { update: { bio: "y" } }],
+      ["update, wrapped in data", { update: { data: { bio: "y" } } }],
+      ["update, with a non-unique filter", { update: { where: { bio: "old" }, data: { bio: "y" } } }],
+      ["delete: true", { delete: true }],
+      ["delete: false", { delete: false }],
+      ["delete by filter", { delete: { bio: "old" } }],
+      ["upsert without a where", { upsert: { create: { bio: "x" }, update: { bio: "y" } } }],
+      ["upsert with a non-unique where", { upsert: { where: { bio: "old" }, create: { bio: "x" }, update: { bio: "y" } } }],
+    ])("%s compiles on a to-one", (_label, value) => {
+      expect(refuse("profile", value)).toBeNull();
+    });
+
+    /**
+     * `delete: false` is a call that asks for nothing, and it has to compile —
+     * refusing it would be stricter than Prisma, which accepts it and leaves
+     * the child untouched, foreign key included.
+     *
+     * It still plans a step. That is deliberate and it is what makes the design
+     * safe: the step reads the boolean out of the *call* at bind time, so the
+     * emptiness is decided per execution rather than baked into a plan that a
+     * later call with the other boolean could be served. See `toOneOperand`.
+     */
+    test("delete: false plans a step that reads the boolean at bind time", () => {
+      const plan = write("profile", { delete: false });
+      expect(plan.after).toHaveLength(1);
+      expect(plan.after![0].operation).toBe("delete");
+    });
+
+    /**
+     * **Arrays on a to-one**, which compiled and wrote through a relation that
+     * holds one row: `create: [a, b]` inserted two children and
+     * `connect: [x, y]` repointed both. Prisma refuses every one of these as a
+     * validation error on the argument, so gemi refusing them is agreement
+     * rather than strictness — and the error class says which: a supported
+     * argument with a bad value.
+     */
+    test.each([
+      ["create", { create: [{ bio: "a" }, { bio: "b" }] }],
+      ["connect", { connect: [{ userId: 1 }, { userId: 2 }] }],
+      ["connectOrCreate", { connectOrCreate: [{ where: { userId: 1 }, create: { bio: "a" } }] }],
+      ["update", { update: [{ where: { userId: 1 }, data: { bio: "a" } }] }],
+      ["delete", { delete: [{ bio: "a" }] }],
+      ["upsert", { upsert: [{ create: { bio: "a" }, update: { bio: "b" } }] }],
+    ])("an array of %s is refused on a to-one", (operand, value) => {
+      const error = refuse("profile", value);
+
+      expect(error, `an array of ${operand} compiled`).not.toBeNull();
+      expect(error).toBeInstanceOf(InvalidArgumentError);
+      expect(error!.argument).toBe(`data.profile.${operand}`);
+      expect(error!.model).toBe("User");
+      // The message names the shape that works, rather than saying arrays are
+      // unimplemented — they are refused, not missing.
+      expect(error!.message).toMatch(/Expected a single object/);
+      // ...and it names the side that actually holds the key.
+      expect(error!.message).toContain("Profile holds the foreign key");
+    });
+
+    // The same operands, singular, are the compiling cases above — asserted
+    // here too so the table cannot pass by refusing everything.
+    test("...while the same operands compile as a single object", () => {
+      expect(refuse("profile", { create: { bio: "a" } })).toBeNull();
+      expect(refuse("profile", { connect: { userId: 1 } })).toBeNull();
+    });
+
+    /**
+     * `disconnect` needs a **nullable** foreign key, and the shared fixture's
+     * is required on purpose — that pairing is what makes the relation a to-one
+     * in Prisma's own terms. So the clone is built here rather than in
+     * `fixtures.ts`, following `strictAccount` below: four suites compare the
+     * fixtures wholesale, and a churned fixture is a diff in all of them.
+     */
+    describe("disconnect, where the child's key is nullable", () => {
+      const nullableProfile = {
+        ...profile,
+        fields: {
+          ...profile.fields,
+          userId: { ...profile.fields.userId, nullable: true },
+        },
+        relations: {
+          ...profile.relations,
+          user: { ...profile.relations.user, nullable: true },
+        },
+      } as typeof profile;
+
+      beforeEach(() => {
+        registry.register("Profile", class { static $schema = nullableProfile });
+      });
+
+      test.each([
+        ["disconnect: true", { disconnect: true }],
+        ["disconnect: false", { disconnect: false }],
+        ["disconnect by filter", { disconnect: { bio: "old" } }],
+      ])("%s compiles", (_label, value) => {
+        const plan = write("profile", value);
+        expect(plan.after).toHaveLength(1);
+        expect(plan.after![0].operation).toBe("disconnect");
+      });
+
+      // A filter, not a unique key — the same operand Prisma types as
+      // `ProfileWhereInput | boolean`. `bio` has no unique index, and
+      // `assertNamedRows` would have listed the ones it does have.
+      test("a non-unique filter is not refused", () => {
+        expect(refuse("profile", { disconnect: { bio: "old" } })).toBeNull();
+      });
+
+      test.each([
+        ["disconnect", { disconnect: 5 }],
+        ["delete", { delete: 5 }],
+      ])("%s of the wrong type says what a good value is", (operand, value) => {
+        const error = refuse("profile", value as Record<string, unknown>);
+
+        expect(error).toBeInstanceOf(InvalidArgumentError);
+        expect(error!.argument).toBe(`data.profile.${operand}`);
+        expect(error!.message).toMatch(/takes either a boolean/);
+        expect(error!.message).toContain("ProfileWhereInput | boolean");
+      });
+    });
+
+    /**
+     * ...and with the *required* key the shared fixture has, `disconnect` is
+     * still refused — on the **key**, not the value, which is why even
+     * `disconnect: false` is refused rather than quietly accepted as a no-op.
+     * Prisma leaves the field out of the input type entirely on a required
+     * relation, so both spellings are unknown arguments there.
+     */
+    test.each([[true], [false], [{ bio: "old" }]])(
+      "disconnect: %s is refused when the child's key is required",
+      (value) => {
+        const error = refuse("profile", { disconnect: value });
+
+        expect(error).not.toBeNull();
+        expect(error!.argument).toBe("data.profile.disconnect");
+        expect(error!.message).toContain("'Profile.userId' is required");
+      },
+    );
   });
 
   /**

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -192,24 +192,9 @@ function compileCreateMany(
   const ignore = skipDuplicatesClause(schema, op, args, dialect);
 
   // Prisma returns `{ count: 0 }` for an empty list without touching the
-  // database, but a plan must have a statement. A constant-false select is the
-  // cheapest thing that yields zero rows on both dialects, and it keeps the
-  // empty case on exactly the same code path as every other — no branch in the
-  // choke point, no plan that is a plan in name only.
+  // database. See {@link zeroCountPlan} for how that is spelled as a plan.
   if (rows.length === 0) {
-    const key = keyColumn(schema, dialect);
-    const { text, binders } = render(
-      sql(
-        `select ${key} from ${dialect.quoteIdent(schema.table)} where false`,
-      ),
-      dialect,
-      { model: schema.name, operation: op },
-    );
-    return {
-      text,
-      bind: bindValues(binders),
-      shape: (returned) => ({ count: returned.length }),
-    };
+    return zeroCountPlan(schema, op, dialect);
   }
 
   const grid = createManyColumns(schema, rows, op, dialect);
@@ -475,6 +460,26 @@ function compileUpdate(
 ): QueryPlan {
   const many = op === "updateMany";
 
+  // `data: null` reaches here: `requiredArgs` asks only about `undefined`, and
+  // `updateAssignments` admits a nullish `data` because `upsert`'s halves may
+  // legitimately be absent. It used to land on "At least one field must be
+  // updated", which was a poor message but a refusal. Now that an empty `data`
+  // reads the row back, a null one would read it back too — a malformed call
+  // answered with a row. Refused on the shape rather than on a Prisma code,
+  // because Prisma's client rejects this at the type level and the query engine
+  // never sees it, so there is no behaviour to match here, only one to not
+  // invent.
+  if (args?.data === null) {
+    throw new InvalidArgumentError(
+      "data",
+      schema.name,
+      op,
+      "Expected an object of the fields to set, like { name: 'new name' }. " +
+        "An empty object is accepted and reads the row back unchanged; null " +
+        "is not.",
+    );
+  }
+
   if (!many) {
     matchUniqueKey(schema, args?.where, {
       model: schema.name,
@@ -487,9 +492,14 @@ function compileUpdate(
   // relation keys — and rejects one with `Unknown argument 'organization'`.
   // Refused by name here for the same reason `createMany` refuses it: without
   // this the key is neither executed nor reported, since `planNestedWrites`
-  // never runs and `suppliedFields` skips relation keys silently. A `data` of
-  // only a relation key would then reach "At least one field must be updated",
-  // which names the wrong problem.
+  // never runs and `suppliedFields` skips relation keys silently.
+  //
+  // This guard carries more weight than it used to. A `data` of only a relation
+  // key leaves no assignment behind, so it used to land on "At least one field
+  // must be updated" — the wrong problem, but still a refusal. Now that an
+  // empty `data` is a legitimate `{ count: 0 }` (see below), the same call would
+  // instead *succeed*, having written nothing and said nothing. Remove this and
+  // the failure mode goes from a misleading error to no error at all.
   if (many) {
     assertNoNestedWrites(
       schema,
@@ -513,32 +523,6 @@ function compileUpdate(
     dialect,
   );
 
-  // An `update` whose `data` is *only* nested relation writes has no column to
-  // set — `Post.update({ where, data: { tags: { connect: … } } })` changes the
-  // join table and nothing on `Post` itself. Prisma accepts it, and there is no
-  // `UPDATE … SET` that expresses it.
-  //
-  // So the row is *selected* instead. The nested steps need the parent's key
-  // and the caller's `select` / `include` still has to be honoured, and both
-  // come from the same `returning` list — which a select produces just as well
-  // as an `update … returning` does. Same plan shape, same steps, one statement
-  // that happens to read rather than write.
-  //
-  // Only reachable when there are steps to run: with neither an assignment nor
-  // a nested write there is genuinely nothing to do, and that stays an error.
-  const relationOnly =
-    assignments.length === 0 &&
-    ((nested?.before.length ?? 0) > 0 || (nested?.after.length ?? 0) > 0);
-
-  if (assignments.length === 0 && !relationOnly) {
-    throw new UnsupportedQueryError(
-      "data",
-      schema.name,
-      op,
-      "At least one field must be updated.",
-    );
-  }
-
   const where = compileWhere(
     schema,
     args?.where,
@@ -546,9 +530,63 @@ function compileUpdate(
     (callArgs) => callArgs?.where,
   );
 
+  // MEASURED (Prisma 6.19.2, SQLite): `updateMany({ where, data: {} })` is
+  // accepted and answers `{ count: 0 }` — with three rows in the table and two
+  // matching the filter, again with a filter matching none, and again with no
+  // `where` at all. The count is a *constant*, not a row count: Prisma's own
+  // answer does not depend on how many rows the filter selects, and no row is
+  // touched. So there is nothing here to derive from the filter, and the
+  // cheapest honest match is the `createMany([])` plan — same shape, same
+  // reason, same `{ count: <rows returned> }` shaping, no special case in the
+  // choke point.
+  //
+  // The `where` above is compiled and then discarded on this path, deliberately:
+  // an unknown field in a filter must be refused whether or not there happened
+  // to be anything to write, for the reason `createMany` gives for validating
+  // `skipDuplicates` ahead of its own empty-list shortcut — validation that
+  // depends on how much data was supplied is the kind that passes in a test and
+  // fails in production.
+  if (many && assignments.length === 0) {
+    return zeroCountPlan(schema, op, dialect);
+  }
+
+  // An `update` whose `data` sets no column has no `UPDATE … SET` to emit, and
+  // there are two ways to get there. `Post.update({ where, data: { tags: {
+  // connect: … } } })` changes the join table and nothing on `Post` itself; and
+  // `data: {}` changes nothing at all. Prisma accepts both.
+  //
+  // So the row is *selected* instead. The nested steps need the parent's key
+  // and the caller's `select` / `include` still has to be honoured, and both
+  // come from the same `returning` list — which a select produces just as well
+  // as an `update … returning` does. Same plan shape, same steps, one statement
+  // that happens to read rather than write.
+  //
+  // The empty `data` used to be refused here, on the reasoning that with
+  // neither an assignment nor a nested write there is genuinely nothing to do.
+  // That is true of the *write* and false of the *call*. MEASURED, same client:
+  // `post.update({ where: { id: 1 }, data: {} })` returns `{ id: 1, title:
+  // "p1" }` with the row unchanged; with `include: { tags: true }` it returns
+  // the tags as well; with `select: { title: true }` it returns `{ title:
+  // "p1" }` and no `id`. A caller who passed an `include` asked a question with
+  // a defined answer, and this select is already exactly that answer — which is
+  // why the fix is deleting a condition rather than adding a branch.
+  //
+  // A miss is still fatal and costs nothing here: `{ where: { id: 99 }, data:
+  // {} }` raises P2025, and `update` is in `ORTHROW`, so `RecordNotFoundError`
+  // comes out of the existing machinery.
+  //
+  // Reachable on every model, including one carrying `@updatedAt`. That took a
+  // change in `updateAssignments`: the stamp used to be unconditional, so it
+  // was itself the assignment that kept this count off zero and made the whole
+  // branch dead on the models most likely to want it. Prisma does not stamp a
+  // call that sets no column — measured, see that function's docblock — so the
+  // two fixes are the same fix. `many` is excluded by the branch above, so this
+  // is `update` alone.
+  const readInstead = assignments.length === 0;
+
   const returning = returningClause(schema, args, dialect, op, nested);
 
-  const statement = relationOnly
+  const statement = readInstead
     ? concat(
         sql(`select `),
         returning.selected,
@@ -1245,6 +1283,42 @@ function assertNoNestedWrites(
  * *create* as well is handled by `hasClientSideValue`; missing that half is the
  * easy and quiet version of this bug, since the column is usually NOT NULL and
  * only fails on the models where Prisma made it nullable.
+ *
+ * **The stamp needs a column beside it**, which is not what "every write stamps
+ * `@updatedAt`" would suggest and is the rule Prisma actually follows. Measured
+ * against 6.19.2/SQLite, seeding `updatedAt` to the epoch and reading it back:
+ *
+ *     data: {}                                     epoch    not stamped
+ *     data: { profile: { create: … } }             epoch    not stamped
+ *     data: { profile: { update: … } }             epoch    not stamped
+ *     data: { name: "real" }                       now      stamped
+ *     data: { organization: { connect: … } }       now      stamped
+ *     data: { organizationId: null }               now      stamped
+ *
+ * The first three write no column of *this* row — a to-one whose key is on the
+ * child changes the child — and Prisma leaves the stamp alone for all three. So
+ * the condition is "this statement sets at least one other column", which is
+ * what `writesAColumn` asks, rather than "this call happened".
+ *
+ * Stamping unconditionally was load-bearing in the wrong direction twice. It
+ * made #355's empty-`data` read unreachable on any model carrying the attribute
+ * — the majority case, and the one the issue was filed from — because the stamp
+ * *was* the assignment that kept `assignments.length` off zero. And it put a
+ * timestamp Prisma does not write on every nested to-one write #354 added,
+ * where the differential harness could not see it: `updatedAt` is volatile, so
+ * both sides compare as the descriptor `"date"` and two different instants
+ * match. It took a by-value assertion to catch.
+ *
+ * **KNOWN DIVERGENCE — an owning-side `disconnect` stamps here and does not in
+ * Prisma.** Measured beside the rest: `data: { organization: { disconnect: true
+ * } }` writes `organizationId = NULL` (verified, the column really is cleared)
+ * and leaves `updatedAt` at the epoch, while `connect` one line above stamps
+ * it. Both write the same column through the same operand family, so this is
+ * Prisma disagreeing with itself rather than a rule to follow. gemi contributes
+ * the null as an ordinary assignment and therefore stamps, which is the answer
+ * `connect`, a hand-written `organizationId: null`, and every other column
+ * write already give. Pre-existing, unchanged here, and matching it would mean
+ * special-casing one operand to reproduce an inconsistency.
  */
 function updateAssignments(
   schema: ModelSchema,
@@ -1281,6 +1355,13 @@ function updateAssignments(
     contributions.map((contribution) => [contribution.field, contribution]),
   );
 
+  // Asked before the loop rather than from `out.length`, so the answer does not
+  // depend on where `@updatedAt` happens to sit in schema order: a model that
+  // declares it first would otherwise see an empty `out` and skip a stamp it
+  // owes. Both sets hold scalar field names only — `suppliedFields` skips
+  // relation keys, which is exactly the distinction being drawn here.
+  const writesAColumn = contributed.size > 0 || supplied.size > 0;
+
   const out: Fragment[] = [];
 
   for (const field of Object.values(schema.fields)) {
@@ -1315,8 +1396,9 @@ function updateAssignments(
       continue;
     }
 
-    // Every write stamps `@updatedAt` — that is the whole of the attribute.
-    if (field.isUpdatedAt) {
+    // A write that sets a column stamps `@updatedAt`; one that sets none does
+    // not, because there is no write to date. See the docblock's table.
+    if (field.isUpdatedAt && writesAColumn) {
       out.push(
         concat(
           sql(`${column} = `),
@@ -1615,8 +1697,8 @@ function returningClause(
       ...fields.map((field) => sql(dialect.quoteIdent(field.column))),
       // Last, for the same reason they go last on a read: the shaper reads
       // scalars by position and `_count` is attached afterwards from the raw
-      // row. The relation-only `select` below projects the same list, so a
-      // `_count` survives that path too.
+      // row. The reading `update` below projects the same list, so a `_count`
+      // survives that path too.
       ...counts.map((count) => count.column),
     ],
     ", ",
@@ -1625,12 +1707,47 @@ function returningClause(
   return {
     clause: concat(sql(" returning "), columns),
     // The same list without the keyword, for the one statement that reads the
-    // row rather than writing it — a relation-only `update`. See `compileUpdate`.
+    // row rather than writing it — an `update` with no column to set, whether
+    // because its `data` held only nested writes or because it was empty. See
+    // `compileUpdate`.
     selected: columns,
     fields,
     hidden,
     relations: plans,
     counts,
+  };
+}
+
+/**
+ * The plan for a counting write that Prisma answers `{ count: 0 }` to without
+ * touching the database: `createMany` with an empty list, and `updateMany` with
+ * an empty `data`.
+ *
+ * A plan must have a statement, so there is one. A constant-false select is the
+ * cheapest thing that yields zero rows on both dialects, and it keeps these
+ * cases on exactly the same code path as every other write — no branch in the
+ * choke point, no plan that is a plan in name only, and the count still comes
+ * from the number of rows returned rather than from a hard-coded zero, so the
+ * shaper is the shaper every other counting write uses.
+ *
+ * It costs one round trip that Prisma does not make. That is the price of the
+ * uniformity above, and it is paid only by calls that asked for nothing.
+ */
+function zeroCountPlan(
+  schema: ModelSchema,
+  op: Operation,
+  dialect: SqlDialect,
+): QueryPlan {
+  const key = keyColumn(schema, dialect);
+  const { text, binders } = render(
+    sql(`select ${key} from ${dialect.quoteIdent(schema.table)} where false`),
+    dialect,
+    { model: schema.name, operation: op },
+  );
+  return {
+    text,
+    bind: bindValues(binders),
+    shape: (returned) => ({ count: returned.length }),
   };
 }
 

--- a/packages/gemi/orm/corpus.ts
+++ b/packages/gemi/orm/corpus.ts
@@ -85,6 +85,34 @@ export const WRITES: [string, unknown][] = [
   ["update", { where: { id: 1 }, data: { accounts: { disconnect: { id: 1 } } } }],
   ["update", { where: { id: 1 }, data: { accounts: { delete: { id: 1 } } } }],
   ["update", { where: { id: 1 }, data: { accounts: { deleteMany: {} } } }],
+  // A to-one whose foreign key is on the **child** — `User.profile`, which is
+  // why both invariant suites compile against `userWithProfile`. Its operands
+  // are a different grammar from the to-many ones above rather than a subset,
+  // so each spelling is its own entry: the plan-key suite is what would catch
+  // one of them minting an entry per bound value, and the binding suite is what
+  // would catch a filter value reaching the SQL text through the new
+  // normaliser.
+  //
+  // What neither suite can catch is two of these *collapsing into one entry*.
+  // The plan-key invariant is "same key implies same SQL", and these operands
+  // all compile the parent statement identically — the difference is in the
+  // `after` step, which is not SQL text. `plan.writes.discrimination.test.ts`
+  // is the only thing standing under that, which is worth knowing before
+  // trusting this list to protect the boolean pair below.
+  ["update", { where: { id: 1 }, data: { profile: { update: { bio: "x" } } } }],
+  ["update", { where: { id: 1 }, data: { profile: { update: { data: { bio: "x" } } } } }],
+  ["update", { where: { id: 1 }, data: { profile: { update: { where: { bio: "old" }, data: { bio: "x" } } } } }],
+  // The two booleans, which are one *shape* to everything except the guard
+  // `shapeOfMember` carries for them — and they are opposite writes. `vary`
+  // perturbs numbers and strings only, so it leaves them alone and the pair
+  // stays meaningful here.
+  ["update", { where: { id: 1 }, data: { profile: { delete: true } } }],
+  ["update", { where: { id: 1 }, data: { profile: { delete: false } } }],
+  ["update", { where: { id: 1 }, data: { profile: { delete: { bio: "old" } } } }],
+  ["update", { where: { id: 1 }, data: { profile: { upsert: { create: { bio: "x" }, update: { bio: "y" } } } } }],
+  ["update", { where: { id: 1 }, data: { profile: { upsert: { where: { bio: "old" }, create: { bio: "x" }, update: { bio: "y" } } } } }],
+  ["update", { where: { id: 1 }, data: { profile: { create: { bio: "x" } } } }],
+  ["update", { where: { id: 1 }, data: { profile: { connect: { userId: 1 } } } }],
   ["updateMany", { where: { id: 1 }, data: { name: "x" } }],
   ["updateMany", { data: { name: "x" } }],
   ["delete", { where: { id: 1 } }],

--- a/packages/gemi/orm/errors.test.ts
+++ b/packages/gemi/orm/errors.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  RecordNotFoundError,
+  UniqueConstraintError,
+  isUniqueConstraintError,
+} from "./errors";
+
+/**
+ * `isUniqueConstraintError`, and specifically the half of it that is not
+ * `instanceof`.
+ *
+ * The predicate exists because a retry-on-collision `catch` written against
+ * `instanceof` is silently dead across a duplicate copy of `gemi/orm` — two
+ * versions in one dependency tree, a bundled build beside a linked one. That is
+ * the same failure mode #357 measured with `code === "P2002"`: the `catch` runs,
+ * the condition is false, the recovery does not happen, and nothing is logged.
+ *
+ * So the interesting test is not that a real error matches. It is that an error
+ * from a *second class of the same name* matches, and that the surrounding
+ * near-misses do not.
+ */
+describe("isUniqueConstraintError", () => {
+  const real = new UniqueConstraintError("User", "create", ["email"], "User_email_key");
+
+  test("matches the error the ORM throws", () => {
+    expect(isUniqueConstraintError(real)).toBe(true);
+  });
+
+  /**
+   * The duplicate-copy case, built the way it actually occurs: a second
+   * evaluation of the same module gives a *different class object* with the
+   * same behaviour. `instanceof` against this file's class is false for it, and
+   * that is exactly what the name branch is for.
+   */
+  test("matches an instance from a duplicate copy of the module", () => {
+    class UniqueConstraintError extends Error {
+      constructor(
+        public readonly model: string,
+        public readonly operation: string,
+        public readonly fields: string[],
+      ) {
+        super("Unique constraint violated");
+        this.name = "UniqueConstraintError";
+      }
+    }
+    const duplicate = new UniqueConstraintError("User", "create", ["email"]);
+
+    // The premise: this is the case a hand-written `instanceof` gets wrong.
+    expect(duplicate instanceof real.constructor).toBe(false);
+    expect(isUniqueConstraintError(duplicate)).toBe(true);
+  });
+
+  /**
+   * `P2002` is deliberately not matched. Keeping a Prisma code out of gemi's
+   * permanent surface is what the DECISION note in `errors.ts` decided, and the
+   * bridge for a half-ported codebase lives in `UPGRADE.md` where it can carry
+   * a delete-me marker. Pinned here so that "it would be so convenient" cannot
+   * quietly add it later.
+   */
+  test("does not match a Prisma P2002", () => {
+    const prisma = Object.assign(new Error("Unique constraint failed"), {
+      name: "PrismaClientKnownRequestError",
+      code: "P2002",
+      meta: { target: ["email"] },
+    });
+
+    expect(isUniqueConstraintError(prisma)).toBe(false);
+  });
+
+  test.each([
+    ["another gemi error", new RecordNotFoundError("User", "findUniqueOrThrow")],
+    ["a plain Error", new Error("Unique constraint violated on User.create")],
+    ["a string that says so", "UniqueConstraintError"],
+    ["null", null],
+    ["undefined", undefined],
+    ["a number", 42],
+    ["an empty object", {}],
+    ["an object with the wrong name", { name: "UnknownFieldError" }],
+    ["an object with no name at all", { model: "User", fields: ["email"] }],
+  ])("does not match %s", (_label, value) => {
+    expect(isUniqueConstraintError(value)).toBe(false);
+  });
+
+  /** The narrowing is the reason this is a predicate rather than a boolean. */
+  test("narrows to the error's own fields", () => {
+    const error: unknown = real;
+
+    if (!isUniqueConstraintError(error)) throw new Error("unreachable");
+
+    expect(error.model).toBe("User");
+    expect(error.operation).toBe("create");
+    expect(error.fields).toEqual(["email"]);
+    expect(error.constraint).toBe("User_email_key");
+  });
+
+  /**
+   * The name branch only works because every error in this file sets
+   * `this.name` in its constructor rather than relying on the class name. A
+   * subclass that forgot to would be invisible to the predicate, so the
+   * property the predicate reads is asserted rather than assumed.
+   */
+  test("the class sets the name the predicate reads", () => {
+    expect(real.name).toBe("UniqueConstraintError");
+  });
+
+  test("gemi/orm exports it", async () => {
+    const orm = await import("./index");
+    expect(orm.isUniqueConstraintError).toBe(isUniqueConstraintError);
+  });
+});

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -191,12 +191,34 @@ export class RecordNotFoundError extends Error {
  *
  * Prisma raises `PrismaClientKnownRequestError` with code `P2002` and
  * `meta.target` holding the field names. Mirroring that would ease a migration
- * for code already branching on `P2002` — but nothing in this repository does
- * (checked), and carrying a `P` code implies the rest of the taxonomy is
- * implemented too: `P2003`, `P2025`, and the fifty others an application might
- * reasonably then expect to catch. Claiming a compatibility surface we have not
- * built is worse than asking the few call sites that need it to catch a gemi
- * error instead.
+ * for code already branching on `P2002`.
+ *
+ * **The premise this note used to rest on was wrong, and the conclusion is
+ * unchanged.** It said "nothing in this repository does (checked)", which was
+ * true of *this* repository and was never the question — the code that branches
+ * on `P2002` lives in the applications the ORM is for. The first real port
+ * measured four such guards, every one of them in concurrency-recovery code
+ * (catch the collision, re-read, retry), and every one of them silently dead the
+ * moment the write moved onto gemi: the `catch` still ran, the condition was
+ * false, the recovery did not happen. Nor was the repository itself clean —
+ * `templates/saas-starter/app/models/differential.ts:621` branches on `P2002`
+ * today, and did when this was written.
+ *
+ * What the premise was doing was answering "would anyone notice?", and the
+ * answer is that four people noticed at once. The decision never depended on it.
+ * Carrying a `P` code implies the rest of the taxonomy is implemented too:
+ * `P2003`, `P2025`, and the fifty others an application might reasonably then
+ * expect to catch. Claiming a compatibility surface we have not built is worse
+ * than asking the call sites that need it to catch a gemi error instead —
+ * *especially* when the code in question is a retry loop, because a
+ * compatibility surface that covers `P2002` and not `P2034` fails in exactly
+ * the same silent way, one layer further in.
+ *
+ * A porter reaches for `isUniqueConstraintError` below. `UPGRADE.md` carries
+ * the temporary `|| error.code === "P2002"` bridge, for a codebase halfway
+ * through the move, with the marker that says when to delete it; it is
+ * deliberately not exported, because a Prisma code in gemi's permanent surface
+ * is the thing this note declined.
  *
  * What the contract does promise is the part that matters: the error is typed,
  * catchable, and names the fields — as *field* names, the way Prisma's
@@ -221,6 +243,62 @@ export class UniqueConstraintError extends Error {
     );
     this.name = "UniqueConstraintError";
   }
+}
+
+/**
+ * The guard to write in a retry-on-collision `catch`, which is where a
+ * `code === "P2002"` test almost always was:
+ *
+ *     try {
+ *       return await Invite.create({ data: { token } })
+ *     } catch (error) {
+ *       if (!isUniqueConstraintError(error)) throw error
+ *       return await Invite.findUniqueOrThrow({ where: { token } })
+ *     }
+ *
+ * **Why this is worth shipping rather than telling people to write
+ * `instanceof`**, which is the obvious objection and the reason it nearly was
+ * not shipped. The second half of the test is the whole of it:
+ *
+ *     error instanceof UniqueConstraintError   ||   error.name === "UniqueConstraintError"
+ *
+ * `instanceof` compares against *this module instance's* class object, so it is
+ * false across a duplicate copy of `gemi/orm` — two versions in one dependency
+ * tree, a bundled build alongside a linked one, a monorepo package resolving
+ * its own. The error is the right error, thrown by the right code, and the
+ * guard silently does not fire. That is not a hypothetical: duck-typing rather
+ * than importing the class is precisely what the ported application had already
+ * done for Prisma's error, for precisely this reason, and shipping a predicate
+ * that only does `instanceof` would hand it back the same trap under a new
+ * name.
+ *
+ * So the name is load-bearing rather than a convenience: it is the identity
+ * that survives module duplication, which is why every error in this file sets
+ * `this.name` explicitly instead of relying on the class name surviving
+ * minification.
+ *
+ * **The narrowing is a claim, and this is what it rests on.** The name branch
+ * asserts `UniqueConstraintError` on the strength of a string — a second copy
+ * of this module really does carry `model`, `operation` and `fields`, so the
+ * claim holds for the case it exists for. An unrelated object named
+ * `"UniqueConstraintError"` would defeat it, and that is not something that
+ * happens by accident.
+ *
+ * **It deliberately does not match `code === "P2002"`.** See the DECISION
+ * above: the temporary bridge for a half-ported codebase is in `UPGRADE.md`,
+ * where it can carry a delete-me marker, rather than in gemi's permanent
+ * surface, where it would have neither.
+ */
+export function isUniqueConstraintError(
+  error: unknown,
+): error is UniqueConstraintError {
+  if (error instanceof UniqueConstraintError) return true;
+
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { name?: unknown }).name === "UniqueConstraintError"
+  );
 }
 
 /**

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -77,6 +77,16 @@ export {
   type JsonNullKind,
 } from "./json-null";
 
+// The errors an application can catch, plus `isUniqueConstraintError` — the
+// predicate rather than the `instanceof`, because it also matches across a
+// duplicate copy of this module. See the note on it in `errors.ts`.
+//
+// The comment sits above the clause rather than inside it because
+// `docs-imports.test.ts` derives this module's export list by splitting the
+// clause on commas: a comment carrying one there is read as two names, and the
+// export it annotates becomes invisible to the scan. The symptom is a doc page
+// that cannot show `import { isUniqueConstraintError } from "gemi/orm"` in a
+// fenced block without failing a test that has nothing to do with the doc.
 export {
   AmbiguousModelRegistrationError,
   DecodeError,
@@ -98,6 +108,7 @@ export {
   InvalidArgumentError,
   UnsupportedByDesignError,
   UnsupportedQueryError,
+  isUniqueConstraintError,
 } from "./errors";
 
 export {
@@ -170,6 +181,12 @@ export {
   softDeletes,
   type SoftDeleteOptions,
 } from "./soft-deletes";
+
+// `take` / `skip` from a request's `page` / `perPage`. It lives in
+// `page-args.ts`, not `compile/paginate.ts` — the compiler's file of the same
+// idea is the *validator* this one exists to keep satisfied, and one of them
+// having a distinguishable filename is worth more than the tidier name.
+export { paginate } from "./page-args";
 
 export {
   Policy,

--- a/packages/gemi/orm/page-args.test.ts
+++ b/packages/gemi/orm/page-args.test.ts
@@ -177,6 +177,28 @@ describe("paginate's page size", () => {
     expect(paginate({ perPage: "500" }, { maxPerPage: 500 }).take).toBe(500);
   });
 
+  /**
+   * `Infinity` is the natural spelling of "no ceiling", and it used to be read
+   * by the same rule that refuses a non-finite *request* — so an internal
+   * export written to opt out of the cap silently got the default 100 back,
+   * returned a plausible first page, and lost the rest without a word.
+   *
+   * The distinction is who wrote it: `?perPage=1e400` is hostile input and is
+   * still refused, and this is the application saying so on purpose.
+   */
+  test("Infinity lifts the ceiling rather than falling back to the default", () => {
+    expect(paginate({ perPage: "1000" }, { maxPerPage: Infinity }).take).toBe(1000);
+  });
+
+  test("...and the request still cannot spell Infinity itself", () => {
+    // The guarantee has to survive the lifted ceiling: whatever comes back is
+    // an integer the ORM accepts, so a hostile `perPage` falls to the default
+    // rather than through the gap the option just opened.
+    const lifted = paginate({ perPage: "1e400" }, { maxPerPage: Infinity });
+    expect(lifted.take).toBe(25);
+    expect(Number.isSafeInteger(lifted.take)).toBe(true);
+  });
+
   test("the caller's default is used when the request names none", () => {
     expect(paginate({}, { perPage: 10 })).toEqual({ take: 10, skip: 0 });
     expect(paginate({ page: "2" }, { perPage: 10 })).toEqual({

--- a/packages/gemi/orm/page-args.test.ts
+++ b/packages/gemi/orm/page-args.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from "vitest";
+
+import { assertPageArgument } from "./compile/paginate";
+import { InvalidArgumentError } from "./errors";
+import { MAX_SKIP, paginate } from "./page-args";
+
+/**
+ * The hostile inputs, which are the point of the whole file.
+ *
+ * Every entry is a value a query string can actually deliver — `req.search.get`
+ * returns `string | string[]`, and a JSON body returns whatever was sent — and
+ * every entry breaks `Number(...)` in its own way. They are listed once and used
+ * by both suites below, because "the arithmetic is right" and "the compiler
+ * accepts the result" are two different claims about the same set of values, and
+ * the second is the one this helper exists to make.
+ */
+const HOSTILE: Array<[label: string, value: unknown]> = [
+  ["a fraction", "2.5"],
+  ["a negative", "-1"],
+  ["a large negative", "-999999"],
+  ["a word", "abc"],
+  ["the empty string, which Number() reads as 0", ""],
+  ["whitespace", "   "],
+  ["an overflowing exponent, which Number() reads as Infinity", "1e400"],
+  ["zero", "0"],
+  ["absent", undefined],
+  ["explicitly null, as JSON delivers it", null],
+  ["a repeated query param", ["1", "2"]],
+  ["a single repeated param, which Number() does coerce", ["2"]],
+  ["an object", { page: 2 }],
+  ["a boolean, which Number() reads as 1", true],
+  ["a number that is already fractional", 2.5],
+  ["NaN itself", Number.NaN],
+  ["Infinity itself", Number.POSITIVE_INFINITY],
+  ["a page past the exact-integer boundary", "1e300"],
+  ["scientific notation a browser can send", "1e2"],
+  ["a leading-plus integer", "+3"],
+  ["a hex literal, which Number() accepts", "0x10"],
+];
+
+/**
+ * **The assertion this file is for.**
+ *
+ * `assertPageArgument` (`compile/paginate.ts:64`) is the refusal `paginate`
+ * exists to make unreachable: an integer `take`, an integer `skip`, and no
+ * negative `skip`. Running the real validator over the real output — rather than
+ * re-checking the arithmetic against a second copy of the same rules — is what
+ * makes this a guarantee rather than a pair of implementations that agree.
+ *
+ * It is run over the cross product, because `page` and `perPage` reach different
+ * clamps and the failure that motivated the helper is a *product*: `page: 0`
+ * with a valid `perPage` computes `skip: -25`, which is refused, and no single
+ * argument in that call is wrong on its own.
+ */
+describe("paginate cannot produce a value the compiler refuses", () => {
+  const accepts = (args: { take: number; skip: number }) => {
+    assertPageArgument("Post", "findMany", "take", "take", args.take);
+    assertPageArgument("Post", "findMany", "skip", "skip", args.skip);
+  };
+
+  test.each(HOSTILE)("page: %s", (_label, page) => {
+    expect(() => accepts(paginate({ page }))).not.toThrow();
+  });
+
+  test.each(HOSTILE)("perPage: %s", (_label, perPage) => {
+    expect(() => accepts(paginate({ perPage }))).not.toThrow();
+  });
+
+  test.each(HOSTILE)("page and perPage both: %s", (_label, value) => {
+    expect(() =>
+      accepts(paginate({ page: value, perPage: value })),
+    ).not.toThrow();
+  });
+
+  /**
+   * ...including when the *options* are wrong, which is the case a caller
+   * cannot see. `perPage: 0` there would otherwise return `take: 0` — an
+   * integer, so nothing refuses it, and every page is empty for ever.
+   */
+  test.each(HOSTILE)("with a bad options.perPage: %s", (_label, value) => {
+    expect(() =>
+      accepts(paginate({ page: "2" }, { perPage: value as number })),
+    ).not.toThrow();
+  });
+
+  test.each(HOSTILE)("with a bad options.maxPerPage: %s", (_label, value) => {
+    expect(() =>
+      accepts(paginate({ perPage: "50" }, { maxPerPage: value as number })),
+    ).not.toThrow();
+  });
+
+  /**
+   * The other half of the guarantee: a page is never empty. `take: 0` passes
+   * `assertPageArgument` — it is an integer — so the check above cannot catch
+   * it, and it is the quieter of the two failures.
+   */
+  test.each(HOSTILE)("take is at least 1, for %s", (_label, value) => {
+    expect(paginate({ page: value, perPage: value }).take).toBeGreaterThanOrEqual(1);
+  });
+});
+
+/**
+ * The proof that the suite above is not vacuous: the naive spelling gemi's own
+ * documentation used to teach *does* get refused, for three of these inputs.
+ *
+ * Without this, "paginate's output is accepted" would pass equally well against
+ * a helper that returned `{ take: 25, skip: 0 }` and ignored its arguments.
+ */
+describe("the spelling paginate replaces is refused", () => {
+  test.each([
+    ["a fraction", "2.5", "take"],
+    ["an overflowing exponent", "1e400", "take"],
+    ["a word", "abc", "take"],
+  ] as const)("Number(%s) is not a take", (_label, raw, key) => {
+    expect(() =>
+      assertPageArgument("Post", "findMany", key, key, Number(raw)),
+    ).toThrow(InvalidArgumentError);
+  });
+
+  /**
+   * The `|| 1` in `Number(req.search.get("page")) || 1` rescues `?page=` and
+   * `?page=0`, because both coerce to a falsy `0`. It does not rescue a
+   * *negative* one, which is where that idiom turns a hand-edited link into a
+   * refused `skip`.
+   */
+  test("a negative page through the naive arithmetic is a negative skip", () => {
+    const perPage = 25;
+    const page = Number("-1") || 1;
+    expect(() =>
+      assertPageArgument("Post", "findMany", "skip", "skip", (page - 1) * perPage),
+    ).toThrow(InvalidArgumentError);
+
+    // ...and the same query string through the helper is page one.
+    expect(paginate({ page: "-1" })).toEqual({ take: 25, skip: 0 });
+    expect(paginate({ page: "" })).toEqual({ take: 25, skip: 0 });
+  });
+});
+
+/** The arithmetic itself, on the values a working link actually carries. */
+describe("paginate's page arithmetic", () => {
+  test.each([
+    ["the first page", { page: "1" }, { take: 25, skip: 0 }],
+    ["the second", { page: "2" }, { take: 25, skip: 25 }],
+    ["the tenth", { page: "10" }, { take: 25, skip: 225 }],
+    ["a number rather than a string", { page: 3 }, { take: 25, skip: 50 }],
+    ["no arguments at all", {}, { take: 25, skip: 0 }],
+    ["a page size", { page: "3", perPage: "10" }, { take: 10, skip: 20 }],
+  ])("%s", (_label, args, expected) => {
+    expect(paginate(args)).toEqual(expected);
+  });
+
+  test("a fractional page truncates toward zero, as Prisma does with take", () => {
+    expect(paginate({ page: "2.9" })).toEqual(paginate({ page: "2" }));
+    expect(paginate({ perPage: "10.9" }).take).toBe(10);
+  });
+
+  test.each([
+    ["zero", "0"],
+    ["negative", "-4"],
+    ["a word", "abc"],
+    ["empty", ""],
+  ])("page %s is page one rather than a refusal", (_label, page) => {
+    expect(paginate({ page })).toEqual({ take: 25, skip: 0 });
+  });
+});
+
+describe("paginate's page size", () => {
+  test("defaults to 25 — the number docs/controllers.md already taught", () => {
+    expect(paginate({}).take).toBe(25);
+  });
+
+  test("a request cannot ask for the whole table", () => {
+    expect(paginate({ perPage: "1000000" }).take).toBe(100);
+  });
+
+  test("an endpoint can raise the ceiling at the call site", () => {
+    expect(paginate({ perPage: "500" }, { maxPerPage: 500 }).take).toBe(500);
+  });
+
+  test("the caller's default is used when the request names none", () => {
+    expect(paginate({}, { perPage: 10 })).toEqual({ take: 10, skip: 0 });
+    expect(paginate({ page: "2" }, { perPage: 10 })).toEqual({
+      take: 10,
+      skip: 10,
+    });
+  });
+
+  /**
+   * A default above the ceiling is a contradiction the caller wrote, and the
+   * ceiling wins — the alternative is an `options` object whose two fields
+   * disagree and whose behaviour depends on which one the reader noticed.
+   */
+  test("a default above the ceiling is clamped to the ceiling", () => {
+    expect(paginate({}, { perPage: 500, maxPerPage: 50 }).take).toBe(50);
+  });
+
+  test.each([
+    ["zero", 0],
+    ["negative", -10],
+    ["fractional", 10.7],
+  ])("a %s options.perPage still yields a usable page", (_label, perPage) => {
+    const { take } = paginate({}, { perPage });
+    expect(Number.isInteger(take)).toBe(true);
+    expect(take).toBeGreaterThanOrEqual(1);
+  });
+});
+
+/**
+ * The cap, which exists because `?page=1e300` is finite and therefore survives
+ * every other check. Measured through Bun against SQLite: an offset of `1e18`
+ * binds, `9223372036854775807` and `1e20` raise `SQLiteError: datatype
+ * mismatch` — the same `SQLITE_MISMATCH` the fractional-`take` note records,
+ * reached from the other end.
+ */
+describe("paginate caps skip at the exact-integer boundary", () => {
+  test("a page nobody can count to is capped rather than bound", () => {
+    const { skip } = paginate({ page: "1e300" });
+    expect(skip).toBe(MAX_SKIP);
+    expect(Number.isSafeInteger(skip)).toBe(true);
+  });
+
+  test.each(HOSTILE)("skip stays a safe integer, for %s", (_label, value) => {
+    const { skip } = paginate({ page: value, perPage: value });
+    expect(Number.isSafeInteger(skip)).toBe(true);
+    expect(skip).toBeGreaterThanOrEqual(0);
+  });
+
+  test("an ordinary large page is not capped", () => {
+    expect(paginate({ page: "1000000" })).toEqual({
+      take: 25,
+      skip: 24_999_975,
+    });
+  });
+});
+
+/**
+ * `paginate` is reachable from `gemi/orm`, which is the only import path an
+ * application has. The helper being correct and unexported would be the same
+ * failure as not shipping it.
+ */
+describe("paginate is on the public surface", () => {
+  test("gemi/orm exports it", async () => {
+    const orm = await import("./index");
+    expect(orm.paginate).toBe(paginate);
+  });
+});

--- a/packages/gemi/orm/page-args.ts
+++ b/packages/gemi/orm/page-args.ts
@@ -164,7 +164,20 @@ export function paginate(
   // them. They are clamped anyway, because the guarantee this function makes is
   // unconditional — `paginate(args, { perPage: 0 })` returning `take: 0` would
   // be an empty page for ever, with the helper's own name on it.
-  const maxPerPage = Math.max(1, toWholeNumber(options.maxPerPage) ?? DEFAULT_MAX_PER_PAGE);
+  //
+  // `Infinity` is honoured rather than rejected, and it is the one place the
+  // options are read differently from the arguments. `toWholeNumber` refuses a
+  // non-finite value because that rule is about hostile input — `?perPage=1e400`
+  // is `Infinity`, and binding it as a `take` is not a page size. Reusing the
+  // same rule here made `{ maxPerPage: Infinity }`, the natural spelling of "no
+  // ceiling", fall back to the default 100 instead: an internal export written
+  // to opt out of the cap silently got it back, returned a plausible first page,
+  // and was found when somebody noticed 900 rows missing. The caller who writes
+  // `Infinity` here is the application, saying so deliberately.
+  const maxPerPage =
+    options.maxPerPage === Infinity
+      ? Infinity
+      : Math.max(1, toWholeNumber(options.maxPerPage) ?? DEFAULT_MAX_PER_PAGE);
   const fallback = clamp(
     toWholeNumber(options.perPage) ?? DEFAULT_PER_PAGE,
     1,

--- a/packages/gemi/orm/page-args.ts
+++ b/packages/gemi/orm/page-args.ts
@@ -1,0 +1,188 @@
+/**
+ * `take` / `skip` built from a request, so that a query string cannot produce a
+ * value the compiler refuses.
+ *
+ * **This file is not `compile/paginate.ts`, and the two do opposite jobs.** That
+ * one is the compiler's *validator*: `assertPageArgument` refuses a `take` or a
+ * `skip` that is not an integer, and its note explains at length why refusing is
+ * the only honest answer — a fraction is an opaque `SQLITE_MISMATCH` on one
+ * dialect and a silent disagreement with both Prisma and the other dialect on
+ * the second. Read that note (`compile/paginate.ts:9-63`) for the reasoning; it
+ * is not restated here.
+ *
+ * This file is the other half, and the half that was missing. A refusal is only
+ * useful if the correct spelling is available and short — otherwise the fix a
+ * caller reaches for is `Math.floor` sprinkled at whichever call site happened
+ * to throw, which fixes one of them. `paginate` is the shorter spelling:
+ *
+ *     const { take, skip } = paginate({
+ *       page: req.search.get("page"),
+ *       perPage: req.search.get("perPage"),
+ *     })
+ *     await Post.findMany({ take, skip, orderBy: { createdAt: "desc" } })
+ *
+ * against the shape gemi's own documentation used to teach, which breaks:
+ *
+ *     const limit = Number(req.search.get("limit")) || 25   // ?limit=1.5
+ *
+ * **Why the arguments are `unknown` and not `number`.** A query string is where
+ * these values come from — that is the entire point of the helper, and typing
+ * them as `number` would mean every caller writes the `Number(...)` that is the
+ * bug. `req.search.get` hands back `string | string[]` (`http/HttpRequest.ts:211-223`
+ * collects repeated keys into an array), a JSON body hands back whatever was
+ * sent, and both arrive here unconverted.
+ *
+ * **The coercions, measured rather than assumed.** Each of these is a shape a
+ * real query string produces, and each one is why the rules below are not simply
+ * `Number(...)`:
+ *
+ *     Number("")           0          `?perPage=` — a form's blank field
+ *     Number("  ")         0          the same, url-encoded
+ *     Number(null)         0          an absent key read off a plain object
+ *     Number(["2"])        2          a single repeated key
+ *     Number(["1","2"])    NaN        two of them — so `Number` honours a
+ *                                     repeated param sometimes and not others
+ *     Number("1e400")      Infinity   not a number `Math.trunc` can fix
+ *     Number(true)         1
+ *
+ * The `0`s are the dangerous ones. `page: 0` computes `skip: -25`, and
+ * `assertPageArgument` refuses a negative `skip` outright — so a blank field in
+ * a form is a 500. `perPage: 0` is worse, because it is *not* refused: `take: 0`
+ * is a perfectly good integer and returns an empty page for ever.
+ *
+ * So an empty or blank string means **absent**, not zero, and anything that is
+ * not a number or a string is absent too. Coercing a boolean or a one-element
+ * array would be honouring input no HTTP surface can actually send, at the cost
+ * of the rule being explainable.
+ *
+ * **Why `skip` is capped.** `?page=1e300` is finite, so it survives every check
+ * above and multiplies out to a `skip` of `2.5e301`. Measured through Bun
+ * against SQLite, binding an offset past int64:
+ *
+ *     offset 1e18                  ->  ok
+ *     offset 9223372036854775807   ->  SQLiteError: datatype mismatch
+ *     offset 1e20                  ->  SQLiteError: datatype mismatch
+ *
+ * — the same `SQLITE_MISMATCH` the fractional-`take` note records, reached from
+ * the other end. The cap is `Number.MAX_SAFE_INTEGER` rather than int64's
+ * ceiling: it is well inside what both drivers bind, it needs no per-dialect
+ * measurement, and above it JavaScript's own arithmetic stops being exact, so a
+ * number past it was never a page anybody could count to.
+ *
+ * **The guarantee, which is the whole contract:** every return value is a pair
+ * of integers with `take >= 1` and `skip >= 0`, for every input. It is therefore
+ * impossible for `paginate`'s output to be something `assertPageArgument`
+ * refuses, and `page-args.test.ts` asserts exactly that by running the validator
+ * over the output of a table of hostile query-string values rather than by
+ * re-checking the arithmetic.
+ */
+
+/**
+ * The default page size, and it is not an invented number: `docs/controllers.md`
+ * and `docs/routing.md` both taught `Number(req.search.get("limit")) || 25`. The
+ * helper replaces those examples, and picking a different default would silently
+ * change the page size of every call site rewritten onto it.
+ */
+const DEFAULT_PER_PAGE = 25;
+
+/**
+ * The ceiling on a *request-supplied* page size. Its job is that `?perPage=100000`
+ * cannot ask for the whole table — one request that reads a million rows into
+ * memory is a denial of service the caller did not have to authenticate for.
+ *
+ * A hundred rather than "no ceiling at all", because a helper whose ceiling is
+ * opt-in has no ceiling in the code that most needs one. An endpoint that
+ * genuinely serves larger pages says so at the call site — `paginate(args,
+ * { maxPerPage: 500 })` — which is one visible decision instead of an invisible
+ * default.
+ */
+const DEFAULT_MAX_PER_PAGE = 100;
+
+/**
+ * See the cap discussion above. Exported so the test can assert the boundary
+ * against the same constant the implementation clamps to, rather than repeating
+ * the literal and agreeing with itself.
+ */
+export const MAX_SKIP = Number.MAX_SAFE_INTEGER;
+
+/**
+ * A query-string value as a whole number, or `null` for "absent".
+ *
+ * `null` rather than a default, so the two callers below can apply *their* own
+ * default — the page defaults to 1 and the size defaults to `perPage`, and
+ * folding that in here would mean one of them lying about which.
+ */
+function toWholeNumber(value: unknown): number | null {
+  if (typeof value === "string") {
+    // Measured above: `Number("")` is 0. `?perPage=` is what a browser sends
+    // for a blank field, and reading it as zero rather than as absent is how a
+    // cleared filter box becomes an empty page.
+    if (value.trim() === "") return null;
+  } else if (typeof value !== "number") {
+    // Arrays, objects, booleans, `null`, `undefined`. Every one of them has a
+    // `Number()` answer and not one of them has a *meaning* — see the table.
+    return null;
+  }
+
+  const parsed = Number(value);
+  // Catches `NaN` and both infinities in one test, which is what `Math.trunc`
+  // cannot do: `Math.trunc(Infinity)` is `Infinity`, and `Number.isInteger`
+  // then says false, so an untruncatable value would reach the compiler and be
+  // refused there — by this helper, which exists so that cannot happen.
+  if (!Number.isFinite(parsed)) return null;
+
+  // Toward zero, which is what Prisma does with a fractional `take` (measured
+  // in `compile/paginate.ts`). Matching it means a caller who moves off Prisma
+  // keeps the same page, rather than trading a crash for a different answer.
+  return Math.trunc(parsed);
+}
+
+const clamp = (value: number, low: number, high: number) =>
+  Math.min(Math.max(value, low), high);
+
+/**
+ * Turn `{ page, perPage }` — as read off a query string, in whatever state the
+ * client left them — into a `take` / `skip` pair the ORM accepts.
+ *
+ *     paginate({ page: "2" })                        { take: 25, skip: 25 }
+ *     paginate({ page: "2.5" })                      { take: 25, skip: 25 }
+ *     paginate({ page: "0" })                        { take: 25, skip: 0 }
+ *     paginate({ page: "abc" })                      { take: 25, skip: 0 }
+ *     paginate({ perPage: "1000" })                  { take: 100, skip: 0 }
+ *     paginate({ perPage: "10" }, { maxPerPage: 5 }) { take: 5, skip: 0 }
+ */
+export function paginate(
+  args: { page?: unknown; perPage?: unknown },
+  options: {
+    /** The page size when the request does not name one. Default 25. */
+    perPage?: number;
+    /** The largest page size a *request* may ask for. Default 100. */
+    maxPerPage?: number;
+  } = {},
+): { take: number; skip: number } {
+  // The options are code rather than user input, so it is tempting to trust
+  // them. They are clamped anyway, because the guarantee this function makes is
+  // unconditional — `paginate(args, { perPage: 0 })` returning `take: 0` would
+  // be an empty page for ever, with the helper's own name on it.
+  const maxPerPage = Math.max(1, toWholeNumber(options.maxPerPage) ?? DEFAULT_MAX_PER_PAGE);
+  const fallback = clamp(
+    toWholeNumber(options.perPage) ?? DEFAULT_PER_PAGE,
+    1,
+    maxPerPage,
+  );
+
+  const perPage = clamp(toWholeNumber(args?.perPage) ?? fallback, 1, maxPerPage);
+
+  // Page 1 is the first page, and there is no page 0 — a `page` below 1 is
+  // clamped up rather than refused, because the values that land there are
+  // `""`, `"0"` and `"-1"`, and none of them is a request for a page that does
+  // not exist. Refusing would put a 500 on a link somebody edited by hand.
+  const page = Math.max(toWholeNumber(args?.page) ?? 1, 1);
+
+  // Clamped after multiplying rather than by bounding `page` first: the product
+  // is the thing that has to stay exact, and `page` alone cannot be bounded
+  // without knowing `perPage` anyway.
+  const skip = Math.min((page - 1) * perPage, MAX_SKIP);
+
+  return { take: perPage, skip };
+}

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -452,6 +452,34 @@ function shapeOfMember(
     );
   }
 
+  /**
+   * `disconnect: true` and `disconnect: false` are two different writes, and
+   * nothing above tells them apart: they sit under `data`, which is a
+   * {@link VALUE_KEYS} subtree, so both shape to `boolean` and share one entry.
+   *
+   * That was a live wrong write rather than a wrong refusal. On the owning side
+   * `planOwningSide` refuses `operand !== true` at compile time and then pushes
+   * a constant `value: () => null` — and a cache *hit* skips compilation, so
+   * the refusal never re-runs. A plan compiled from `disconnect: true` served
+   * `disconnect: false` and nulled the foreign key on a call that asked for
+   * nothing. Measured against the real client, so the damage is the gap and not
+   * the guess: `disconnect: false` with a child present leaves the row exactly
+   * as it was, foreign key intact.
+   *
+   * **It cannot simply join {@link LITERAL_KEYS}, which is the same bug class
+   * documented there twice already** — for `omit` and for `skipDuplicates`.
+   * Those keys match by *name at any depth* and raise `literal` over the whole
+   * subtree below them, so a to-many `disconnect: { id: 1 }` would record the
+   * `1` verbatim and mint one cache entry per id — the unbounded growth
+   * `VALUE_KEYS`' own comment exists to prevent, and user data in a long-lived
+   * global map. Only the boolean spelling is structural, so only the boolean is
+   * guarded; every other operand shape reaches the key through its structure,
+   * as it always did.
+   */
+  if ((key === "disconnect" || key === "delete") && typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+
   if (VALUE_KEYS.has(key)) {
     return canonicalShape(value, false, collapseLists, inHaving);
   }

--- a/packages/gemi/orm/plan.writes.discrimination.test.ts
+++ b/packages/gemi/orm/plan.writes.discrimination.test.ts
@@ -3,7 +3,13 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { createBindContext } from "./compile/fragment";
 import { PostgresDialect } from "./dialect/postgres";
 import { SqliteDialect } from "./dialect/sqlite";
-import { account, organization, user } from "./fixtures";
+import {
+  account,
+  organization,
+  profile,
+  user,
+  userWithProfile,
+} from "./fixtures";
 import * as registry from "./registry";
 import {
   clearPlanCache,
@@ -264,6 +270,122 @@ describe("plan cache discrimination — writes", () => {
     expect(planKey(sqlite, "User", "update", args)).not.toBe(
       planKey(sqlite, "User", "updateMany", args),
     );
+  });
+
+  /**
+   * **The one the whole suite could not see, and the only live wrong *write*
+   * this file has ever had to pin.**
+   *
+   * `disconnect: true` and `disconnect: false` shaped alike — a bare `boolean`
+   * under `data`, which is a value subtree — so they were one cache entry. On
+   * the owning side that is not a wasted entry, it is a wrong statement:
+   * `planOwningSide` refuses `operand !== true` **at compile time** and then
+   * pushes a constant `value: () => null`, and a cache hit skips compilation
+   * entirely. So a plan compiled from `disconnect: true` served `disconnect:
+   * false` and nulled the foreign key on a call that asked for nothing.
+   *
+   * **Nothing above could catch it**, and that is worth stating precisely
+   * because it is what a reader will assume was covered. `plan-key.invariants`
+   * asserts *same key ⇒ same SQL text*, and these two have byte-identical text
+   * — the difference is in which value a `contribution` binds and in whether a
+   * step runs at all. The `DISTINCT` table cannot hold them either: the pair
+   * only exists as a pair, and `disconnect: false` **throws** when it is
+   * compiled, so a table that compiles every entry cannot include it.
+   *
+   * Measured against the real client, so the two ends are pinned rather than
+   * assumed: `disconnect: false` with a child present leaves the row untouched,
+   * foreign key intact, and returns the parent.
+   */
+  describe("a to-one disconnect/delete boolean is part of the key", () => {
+    const owning = (value: boolean) => ({
+      where: { id: 1 },
+      data: { organization: { disconnect: value } },
+    });
+
+    test("true, false and absent are three keys", () => {
+      const on = planKey(sqlite, "User", "update", owning(true));
+      const off = planKey(sqlite, "User", "update", owning(false));
+      const absent = planKey(sqlite, "User", "update", {
+        where: { id: 1 },
+        data: { organization: { connect: { id: 1 } } },
+      });
+
+      expect(new Set([on, off, absent]).size).toBe(3);
+    });
+
+    // The bug itself: warm the cache with the accepted spelling, then ask for
+    // the one the compiler refuses. Before the guard this returned the cached
+    // plan and wrote a null; now it recompiles and the refusal fires, which is
+    // the answer the first call would have got.
+    test("a warm 'true' plan does not serve 'false' on the owning side", () => {
+      expect(() => getOrCompile(user, "update", owning(true), sqlite)).not.toThrow();
+      expect(() => getOrCompile(user, "update", owning(false), sqlite)).toThrow(
+        /only 'disconnect: true' is implemented/,
+      );
+    });
+
+    /**
+     * The foreign side, where both booleans are *legal* — so there is no
+     * refusal to fall back on and the plan has to be right on its own.
+     *
+     * Deliberately runs the **`true` plan** with `false` arguments, which is
+     * the mis-serve the plan key now prevents. It still writes nothing, because
+     * `toOneOperand` reads the boolean out of the call inside `at` rather than
+     * deciding it when the plan was built. Two independent guards on purpose:
+     * the key is a cache and caches are the thing that gets subtly wrong, while
+     * this one holds however the plan was reached.
+     */
+    describe("the child holds the key", () => {
+      beforeEach(() => {
+        registry.register("Profile", class { static $schema = profile });
+        registry.register("User", class { static $schema = userWithProfile });
+      });
+
+      const args = (value: boolean) => ({
+        where: { id: 1 },
+        data: { profile: { delete: value } },
+      });
+
+      // Every child statement the step runs, in order. The step reaches the
+      // child through `exec` alone, so this is the whole of what it writes.
+      const run = async (plan: ReturnType<typeof getOrCompile>, called: unknown) => {
+        const calls: string[] = [];
+        const executor = {
+          exec: async (model: string, operation: string) => {
+            calls.push(`${model}.${operation}`);
+            // A connected child, so the `true` control gets past the lookup.
+            return { userId: 1 };
+          },
+          query: async () => [],
+        };
+
+        for (const step of plan.after ?? []) {
+          await step.run(called, { now: new Date(0), resolved: {} }, executor as never, [
+            { id: 1 },
+          ]);
+        }
+        return calls;
+      };
+
+      test("the plan compiled from delete: true writes nothing when bound with false", async () => {
+        const plan = getOrCompile(userWithProfile, "update", args(true), sqlite);
+
+        // The control first: this plan does have a live step, so the assertion
+        // below is not passing because there was nothing to run.
+        expect(await run(plan, args(true))).toEqual([
+          "Profile.findFirst",
+          "Profile.deleteMany",
+        ]);
+
+        expect(await run(plan, args(false))).toEqual([]);
+      });
+
+      test("...and the two booleans are two keys here as well", () => {
+        expect(planKey(sqlite, "User", "update", args(true))).not.toBe(
+          planKey(sqlite, "User", "update", args(false)),
+        );
+      });
+    });
   });
 
   test("model is part of the key", () => {

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -648,15 +648,39 @@ type NestedUpdate<R extends RelationInfo> = NestedCreate<R> &
         upsert?: NestedUpsert<R["target"]> | NestedUpsert<R["target"]>[];
       }
     : {
-        disconnect?: boolean | WhereUniqueInput<R["target"]>;
-        delete?: boolean | WhereUniqueInput<R["target"]>;
-        update?: UpdateInput<R["target"]> | NestedUpdateOne<R["target"]>;
-        upsert?: Omit<NestedUpsert<R["target"]>, "where">;
+        disconnect?: boolean | WhereInput<R["target"]>;
+        delete?: boolean | WhereInput<R["target"]>;
+        update?: UpdateInput<R["target"]> | NestedUpdateToOne<R["target"]>;
+        upsert?: NestedUpsertToOne<R["target"]>;
       });
 
 interface NestedUpdateOne<M extends ModelTypeInfo> {
   where: WhereUniqueInput<M>;
   data: UpdateInput<M>;
+}
+
+/**
+ * The to-one forms of `update` and `upsert`, which are **not** the to-many ones
+ * with a key made optional.
+ *
+ * Both take a `WhereInput` rather than a `WhereUniqueInput`, and on both it is
+ * optional. That is Prisma's own split, read off a generated client:
+ * `UpdateToOneWithWhereWithoutUserInput` is `{ where?: ProfileWhereInput, data }`
+ * and `ProfileUpsertWithoutUserInput` is `{ update, create, where? }`, where
+ * their to-many siblings require a unique key. The parent's key already names
+ * the row here, so the filter only narrows it — and typing it as a unique key
+ * would refuse `update: { where: { bio: "x" }, data }`, which the compiler
+ * accepts and Prisma answers.
+ */
+interface NestedUpdateToOne<M extends ModelTypeInfo> {
+  where?: WhereInput<M>;
+  data: UpdateInput<M>;
+}
+
+interface NestedUpsertToOne<M extends ModelTypeInfo> {
+  where?: WhereInput<M>;
+  create: CreateInput<M>;
+  update: UpdateInput<M>;
 }
 
 interface NestedUpdateMany<M extends ModelTypeInfo> {

--- a/templates/saas-starter/app/http/controllers/PartialRenderController.ts
+++ b/templates/saas-starter/app/http/controllers/PartialRenderController.ts
@@ -27,6 +27,29 @@ function stamp(segment: string) {
   };
 }
 
+/**
+ * The `page` the two sides of the Reports demo have to agree on: the view
+ * prefetches `/partial-render/reports` under a `page` search key, and the
+ * endpoint answers under one it derives the same way. If those two strings ever
+ * disagree the prefetch silently misses and the browser fetches anyway — which
+ * is the one behaviour this page exists to make visible, so it is one function
+ * rather than two copies of an expression.
+ *
+ * Truncated and clamped rather than passed through, because a query string
+ * holds whatever the last link or a hand edit left in it: `?page=2.5` is page
+ * 2, and `?page=-1`, `?page=abc` and a blank `?page=` are page 1, rather than
+ * each minting a cache key of its own that nothing prefetched. Nothing here
+ * reads a database — but a demo is a shape people copy, and the moment `page`
+ * is copied onto a query, `Number(req.search.get("page"))` is the shape that
+ * breaks: gemi refuses a fractional or negative `skip` where Prisma truncated
+ * it. On a call that does reach the ORM, use `paginate` from `gemi/orm`, which
+ * does this and hands back the `take` / `skip` pair directly.
+ */
+function pageOf(req: HttpRequest<any, any>) {
+  const page = Math.trunc(Number(req.search.get("page")));
+  return String(Number.isFinite(page) && page > 0 ? page : 1);
+}
+
 const calls = new Map<string, number>();
 
 function call(endpoint: string, extra: Record<string, unknown> = {}) {
@@ -61,7 +84,7 @@ export class PartialRenderController extends Controller {
     // Prefetched by a *view*, and a view always runs — so this one is fetched
     // on every navigation into Reports. Note the search key: only the page the
     // handler asked for lands in the cache.
-    const page = String(req.search.get("page") ?? "1");
+    const page = pageOf(req);
     Query.prefetch("/partial-render/reports", { search: { page } });
     return { stamp: stamp("Reports"), page };
   }
@@ -99,7 +122,7 @@ export class PartialRenderController extends Controller {
 
   /** Prefetched by the Reports view, one variant per page. */
   reportsData(req: HttpRequest<any, any>) {
-    const page = String(req.search.get("page") ?? "1");
+    const page = pageOf(req);
     return call(`/reports?page=${page}`, { page });
   }
 

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -171,19 +171,34 @@ function schemaOf(registry: ModelMap, model: string): RegisteredSchema | undefin
  * `select` may not have asked for one. That makes the comparison a multiset
  * comparison: two different sets of children still fail, which is the assertion
  * worth keeping.
+ *
+ * **A node that asked for an `orderBy` keeps its order**, and that exception is
+ * the whole reason `selection` is threaded through. The flake above is a
+ * property of an *unordered* include — where neither client emits an `ORDER BY`,
+ * so neither promises anything and the heap decides. An include that named an
+ * `orderBy` is the opposite: the order is the answer, both clients emit the
+ * sort, and comparing it positionally is exactly what this suite is for.
+ * Sorting there would have made six existing cases unable to fail — a relation
+ * strategy that stopped honouring a nested `orderBy` and returned children in
+ * join-table order would compare equal, because both sides get re-sorted by the
+ * same comparator first.
  */
 export function stabilizeRelations(
   value: unknown,
   model: string,
   registry: ModelMap,
+  /** The `include` / `select` subtree that produced `value`, when there is one. */
+  selection?: unknown,
 ): unknown {
   if (Array.isArray(value)) {
-    return value.map((row) => stabilizeRelations(row, model, registry));
+    return value.map((row) => stabilizeRelations(row, model, registry, selection));
   }
   if (value === null || typeof value !== "object") return value;
 
   const relations = schemaOf(registry, model)?.relations;
   if (!relations) return value;
+
+  const nodes = selectionNodes(selection);
 
   const out: Record<string, unknown> = {};
   for (const [key, member] of Object.entries(value as Record<string, unknown>)) {
@@ -192,14 +207,39 @@ export function stabilizeRelations(
       out[key] = member;
       continue;
     }
-    const child = stabilizeRelations(member, relation.model, registry);
-    out[key] = Array.isArray(child)
-      ? [...child].sort((a, b) =>
-          JSON.stringify(a) < JSON.stringify(b) ? -1 : 1,
-        )
-      : child;
+    const node = nodes?.[key];
+    const child = stabilizeRelations(member, relation.model, registry, node);
+    out[key] =
+      Array.isArray(child) && !askedForAnOrder(node)
+        ? [...child].sort((a, b) =>
+            JSON.stringify(a) < JSON.stringify(b) ? -1 : 1,
+          )
+        : child;
   }
   return out;
+}
+
+const askedForAnOrder = (node: unknown) =>
+  node !== null &&
+  typeof node === "object" &&
+  (node as Record<string, unknown>).orderBy !== undefined;
+
+/**
+ * The relation keys one level down, from whichever of `include` / `select`
+ * carried them. Both may appear on the same node, and a relation reached
+ * through `select` is as ordered as one reached through `include`.
+ */
+function selectionNodes(
+  selection: unknown,
+): Record<string, unknown> | undefined {
+  if (selection === null || typeof selection !== "object") return undefined;
+
+  const merged: Record<string, unknown> = {};
+  for (const which of ["include", "select"] as const) {
+    const node = (selection as Record<string, unknown>)[which];
+    if (node !== null && typeof node === "object") Object.assign(merged, node);
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
 /**
@@ -589,8 +629,16 @@ export async function createDifferential(options: {
         // order from Prisma's would be a real difference to an application even
         // though no `ORDER BY` promises otherwise. It is only a *write* that
         // makes the order move under the comparison.
+        // `args` is threaded in so a node carrying an `orderBy` keeps its order:
+        // the flake is a property of an include that promised nothing, and one
+        // that named a sort is the case this suite most wants to compare.
         const comparable = (value: unknown) =>
-          stabilizeRelations(normalize(value, volatile), model, options.models);
+          stabilizeRelations(
+            normalize(value, volatile),
+            model,
+            options.models,
+            args,
+          );
 
         expect(comparable(fromGemi.value), `${label}: returned value`).toEqual(
           comparable(fromPrisma.value),

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -118,6 +118,90 @@ function prismaDelegate(client: PrismaClient, model: string) {
   return delegate;
 }
 
+/** The generated `ModelSchema` behind a registered class, or nothing. */
+type RegisteredSchema = {
+  primaryKey?: string[];
+  relations?: Record<string, { model: string }>;
+};
+
+function schemaOf(registry: ModelMap, model: string): RegisteredSchema | undefined {
+  return (registry[model] as unknown as { $schema?: RegisteredSchema })?.$schema;
+}
+
+/**
+ * Sorts the rows of every **relation** array in a payload, so the comparison is
+ * of a set of children rather than of a storage order neither client promises.
+ *
+ * This is the rule `readTables` already applies to the after-state, arriving in
+ * the half that compares what the call *returned*. It is not a nicety:
+ *
+ * Prisma loads an `include` with a second query and, measured against 6.19.2 on
+ * Postgres by logging what it sends,
+ *
+ *     SELECT … FROM "public"."Account" WHERE "public"."Account"."userId" IN ($1) OFFSET $2
+ *
+ * there is no `ORDER BY` in it, and gemi's is unordered too. So the order is
+ * whatever a sequential scan hands back, and on Postgres an `UPDATE` writes a
+ * new tuple wherever there is room: usually at the end of the page, which puts
+ * the updated child *last*, but at a reclaimed line pointer once the page has
+ * been pruned, which puts it back where it was. Pruning is opportunistic, so
+ * which of the two happens depends on how much churn the table has already seen
+ * — and `expectSameWrite` runs the two clients one after the other, so they meet
+ * the heap in different states.
+ *
+ * The failure that came from this is worth writing down because it reads as a
+ * real divergence: "upsert updates the row when it is this parent's" reported
+ * gemi returning the accounts as `[4, 3]` against Prisma's `[3, 4]`, with every
+ * field of every row identical. It appeared only in the whole-suite run, not
+ * when the file ran alone, and a second whole-suite run moved it to a different
+ * case — which is the tell.
+ *
+ * Deliberately schema-guided rather than "sort any array of objects". A `Json`
+ * column holds arrays whose order *is* the value (`metadata: []` in
+ * `differential.test.ts`), and scalar lists (#300) are ordered by definition;
+ * sorting either would erase a divergence this suite exists to catch. Only keys
+ * the generated schema declares as relations are touched.
+ *
+ * Exported only so `writes.differential.test.ts` can assert it directly. The
+ * flake it closes is unreproducible on demand, so leaving it to be covered by
+ * the Postgres run would mean it is covered on the runs where it happens to
+ * matter and nowhere else.
+ *
+ * Sorted by the serialised row rather than by the primary key, because a
+ * `select` may not have asked for one. That makes the comparison a multiset
+ * comparison: two different sets of children still fail, which is the assertion
+ * worth keeping.
+ */
+export function stabilizeRelations(
+  value: unknown,
+  model: string,
+  registry: ModelMap,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((row) => stabilizeRelations(row, model, registry));
+  }
+  if (value === null || typeof value !== "object") return value;
+
+  const relations = schemaOf(registry, model)?.relations;
+  if (!relations) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, member] of Object.entries(value as Record<string, unknown>)) {
+    const relation = relations[key];
+    if (!relation) {
+      out[key] = member;
+      continue;
+    }
+    const child = stabilizeRelations(member, relation.model, registry);
+    out[key] = Array.isArray(child)
+      ? [...child].sort((a, b) =>
+          JSON.stringify(a) < JSON.stringify(b) ? -1 : 1,
+        )
+      : child;
+  }
+  return out;
+}
+
 /**
  * Prisma returns `Decimal` and `BigInt` instances that do not structurally
  * compare, and `undefined` where a `select` omitted a key. Normalising both
@@ -273,6 +357,11 @@ export async function createDifferential(options: {
     "PasswordResetToken",
     "MagicLinkToken",
     "Account",
+    // `Profile` is the to-one whose foreign key is on the *child* (#354), so it
+    // is a child of `User` and has to be cleared first — the same rule the
+    // comment below states, and the third model in this suite's history to
+    // need it said out loud.
+    "Profile",
     "User",
     "OrganizationInvitation",
     "Organization",
@@ -312,6 +401,13 @@ export async function createDifferential(options: {
     await prisma.passwordResetToken.deleteMany({});
     await prisma.magicLinkToken.deleteMany({});
     await prisma.account.deleteMany({});
+    // Before `user`, for the same reason as in `TABLES`: `Profile.userId` is a
+    // foreign key into `User`. Its `ON DELETE SET NULL` means the wrong order
+    // would not raise here — it would leave a detached `Profile` row behind on
+    // the dialect that enforces the key and none on the one that does not,
+    // which is the shape of divergence this harness exists to catch and would
+    // instead be manufacturing.
+    await prisma.profile.deleteMany({});
     await prisma.user.deleteMany({});
     await prisma.organizationInvitation.deleteMany({});
     await prisma.organization.deleteMany({});
@@ -482,10 +578,23 @@ export async function createDifferential(options: {
           at: label,
         });
       } else {
-        expect(
-          normalize(fromGemi.value, volatile),
-          `${label}: returned value`,
-        ).toEqual(normalize(fromPrisma.value, volatile));
+        // `stabilizeRelations` on both sides, for the reason written on it: an
+        // `include` is unordered in both clients, and a write moves the row it
+        // touched within the Postgres heap.
+        //
+        // Only here, not in `expectSame` above. A read leaves the heap alone, so
+        // the two clients there see the same physical order and comparing it
+        // positionally still holds — and that comparison is worth keeping,
+        // because a relation strategy that returned children in a different
+        // order from Prisma's would be a real difference to an application even
+        // though no `ORDER BY` promises otherwise. It is only a *write* that
+        // makes the order move under the comparison.
+        const comparable = (value: unknown) =>
+          stabilizeRelations(normalize(value, volatile), model, options.models);
+
+        expect(comparable(fromGemi.value), `${label}: returned value`).toEqual(
+          comparable(fromPrisma.value),
+        );
       }
 
       // The half that catches a write which returned something plausible and
@@ -575,8 +684,7 @@ async function readTables(
     // A stable order still matters: the two clients write from the same seeded
     // state, so an unordered read could differ by storage order alone and
     // report a divergence that is not one.
-    const schema = (registry[model] as unknown as { $schema?: { primaryKey?: string[] } })
-      ?.$schema;
+    const schema = schemaOf(registry, model);
     const key = schema?.primaryKey?.length ? schema.primaryKey : ["id"];
 
     out[model] = await prismaDelegate(prisma, model).findMany({

--- a/templates/saas-starter/app/models/generated/index.ts
+++ b/templates/saas-starter/app/models/generated/index.ts
@@ -16,6 +16,7 @@ import {
   OrganizationInvitationModel,
   PasswordResetTokenModel,
   PostModel,
+  ProfileModel,
   SessionModel,
   SocialAccountModel,
   TagModel,
@@ -36,6 +37,7 @@ register("Organization", OrganizationModel);
 register("OrganizationInvitation", OrganizationInvitationModel);
 register("PasswordResetToken", PasswordResetTokenModel);
 register("Post", PostModel);
+register("Profile", ProfileModel);
 register("Session", SessionModel);
 register("SocialAccount", SocialAccountModel);
 register("Tag", TagModel);

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -1809,6 +1809,198 @@ export class PostModel extends Model {
   }
 }
 
+export type ProfileScalars = {
+  id: number;
+  bio: string | null;
+  userId: number | null;
+};
+
+export type ProfileCreateScalars = {
+  id?: number;
+  bio?: string | null;
+  userId?: number | null;
+};
+
+export type ProfileRelations = {
+  user: { kind: "one"; nullable: true; target: UserTypes };
+};
+
+export type ProfileUnique = { id: number } | { userId: number };
+
+export interface ProfileTypes extends ModelTypeInfo {
+  scalars: ProfileScalars;
+  relations: ProfileRelations;
+  unique: ProfileUnique;
+  create: ProfileCreateScalars;
+}
+
+// Merges the row's columns into the instance type, so a method on a subclass can
+// read `this.email`. No runtime output.
+//
+// oxlint flags class/interface merging because TypeScript does not check the
+// merged properties are initialised — a directly constructed instance would type
+// as carrying every column while holding none. That hazard is closed rather than
+// accepted: `Model`'s constructor is `protected`, so the only way to get an
+// instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
+export interface ProfileModel extends ProfileScalars {}
+
+export type ProfilePolicy = ModelPolicy<
+  WhereInput<ProfileTypes>,
+  CreateInput<ProfileTypes>,
+  ProfileScalars
+>;
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class ProfileScopedPolicy extends ScopedPolicy<
+  WhereInput<ProfileTypes>,
+  CreateInput<ProfileTypes>,
+  ProfileScalars
+> {}
+
+export class ProfileModel extends Model {
+  static $schema = schema.Profile;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    WhereInput<ProfileTypes>,
+    CreateInput<ProfileTypes>,
+    ProfileScalars
+  >[];
+
+  static findMany<T extends FindManyArgs<ProfileTypes>>(
+    args?: Subset<T, FindManyArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T>[]> {
+    return this.$exec("findMany", args, options) as Promise<Payload<ProfileTypes, T>[]>;
+  }
+
+  static findFirst<T extends FindFirstArgs<ProfileTypes>>(
+    args?: Subset<T, FindFirstArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T> | null> {
+    return this.$exec("findFirst", args, options) as Promise<Payload<ProfileTypes, T> | null>;
+  }
+
+  static findFirstOrThrow<T extends FindFirstOrThrowArgs<ProfileTypes>>(
+    args?: Subset<T, FindFirstOrThrowArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T>> {
+    return this.$exec("findFirstOrThrow", args, options) as Promise<Payload<ProfileTypes, T>>;
+  }
+
+  static findUnique<T extends FindUniqueArgs<ProfileTypes>>(
+    args: Subset<T, FindUniqueArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T> | null> {
+    return this.$exec("findUnique", args, options) as Promise<Payload<ProfileTypes, T> | null>;
+  }
+
+  static findUniqueOrThrow<T extends FindUniqueOrThrowArgs<ProfileTypes>>(
+    args: Subset<T, FindUniqueOrThrowArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T>> {
+    return this.$exec("findUniqueOrThrow", args, options) as Promise<Payload<ProfileTypes, T>>;
+  }
+
+  static count(args?: Omit<CountArgs<ProfileTypes>, "select">): Promise<number>;
+  static count<T extends CountArgs<ProfileTypes>>(
+    args: SelectSubset<T, CountArgs<ProfileTypes>> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<CountPayload<T["select"]>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends AggregateArgs<ProfileTypes>>(
+    args: Subset<T, AggregateArgs<ProfileTypes>>,
+  ): Promise<AggregatePayload<ProfileTypes, T>> {
+    return this.$exec("aggregate", args) as Promise<
+      AggregatePayload<ProfileTypes, T>
+    >;
+  }
+
+  static groupBy<T extends GroupByArgs<ProfileTypes>>(
+    args: Subset<T, GroupByArgs<ProfileTypes>>,
+  ): Promise<GroupByPayload<ProfileTypes, T>> {
+    return this.$exec("groupBy", args) as Promise<
+      GroupByPayload<ProfileTypes, T>
+    >;
+  }
+
+  static create<T extends CreateArgs<ProfileTypes>>(
+    args: Subset<T, CreateArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T>> {
+    return this.$exec("create", args, options) as Promise<Payload<ProfileTypes, T>>;
+  }
+
+  static update<T extends UpdateArgs<ProfileTypes>>(
+    args: Subset<T, UpdateArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T>> {
+    return this.$exec("update", args, options) as Promise<Payload<ProfileTypes, T>>;
+  }
+
+  static delete<T extends DeleteArgs<ProfileTypes>>(
+    args: Subset<T, DeleteArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T>> {
+    return this.$exec("delete", args, options) as Promise<Payload<ProfileTypes, T>>;
+  }
+
+  static upsert<T extends UpsertArgs<ProfileTypes>>(
+    args: Subset<T, UpsertArgs<ProfileTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<ProfileTypes, T>> {
+    return this.$exec("upsert", args, options) as Promise<Payload<ProfileTypes, T>>;
+  }
+
+  static createMany(
+    args?: CreateManyArgs<ProfileTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: UpdateManyArgs<ProfileTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: DeleteManyArgs<ProfileTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
+
+  static wrap<C extends { prototype: unknown }, R extends ProfileScalars>(
+    this: C,
+    row: R,
+  ): C["prototype"] & R {
+    return (Model.wrap as (row: object) => any).call(this, row);
+  }
+}
+
 export type SessionScalars = {
   id: number;
   token: string;
@@ -2453,6 +2645,7 @@ export type UserRelations = {
   session: { kind: "many"; nullable: false; target: SessionTypes };
   passwordResetToken: { kind: "many"; nullable: false; target: PasswordResetTokenTypes };
   socialAccount: { kind: "many"; nullable: false; target: SocialAccountTypes };
+  profile: { kind: "one"; nullable: true; target: ProfileTypes };
 };
 
 export type UserUnique = { id: number } | { publicId: string } | { email: string };

--- a/templates/saas-starter/app/models/generated/schema.ts
+++ b/templates/saas-starter/app/models/generated/schema.ts
@@ -699,6 +699,63 @@ export const Post = {
   }
 } satisfies ModelSchema;
 
+export const Profile = {
+  "name": "Profile",
+  "table": "Profile",
+  "fields": {
+    "id": {
+      "name": "id",
+      "column": "id",
+      "type": "Int",
+      "nullable": false,
+      "isId": true,
+      "isUpdatedAt": false,
+      "default": {
+        "kind": "autoincrement"
+      }
+    },
+    "bio": {
+      "name": "bio",
+      "column": "bio",
+      "type": "String",
+      "nullable": true,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "userId": {
+      "name": "userId",
+      "column": "userId",
+      "type": "Int",
+      "nullable": true,
+      "isId": false,
+      "isUpdatedAt": false
+    }
+  },
+  "primaryKey": [
+    "id"
+  ],
+  "uniques": [
+    [
+      "userId"
+    ]
+  ],
+  "relations": {
+    "user": {
+      "name": "user",
+      "model": "User",
+      "kind": "one",
+      "relationName": "ProfileToUser",
+      "from": [
+        "userId"
+      ],
+      "to": [
+        "id"
+      ],
+      "nullable": true
+    }
+  }
+} satisfies ModelSchema;
+
 export const Session = {
   "name": "Session",
   "table": "Session",
@@ -1184,6 +1241,15 @@ export const User = {
       "from": [],
       "to": [],
       "nullable": false
+    },
+    "profile": {
+      "name": "profile",
+      "model": "Profile",
+      "kind": "one",
+      "relationName": "ProfileToUser",
+      "from": [],
+      "to": [],
+      "nullable": true
     }
   }
 } satisfies ModelSchema;

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -10,6 +10,7 @@ import {
   Model,
   RecordNotFoundError,
   ScopeEscapeError,
+  UniqueConstraintError,
   clearPlanCache,
   register,
   type ModelPolicy,
@@ -44,6 +45,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest"
  */
 
 const DDL = [
+  `DROP TABLE IF EXISTS "Cover"`,
   `DROP TABLE IF EXISTS "Note"`,
   `DROP TABLE IF EXISTS "Folder"`,
   `CREATE TABLE "Folder" (
@@ -55,6 +57,15 @@ const DDL = [
      "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
      "folderId" INTEGER,
      "label" TEXT NOT NULL,
+     "orgId" INTEGER
+   )`,
+  // The to-one half, and the `UNIQUE` is the whole point of it: a relation that
+  // holds one row is a foreign key with a unique index on it, which is what
+  // turns the `upsert` case below into a collision rather than a second row.
+  `CREATE TABLE "Cover" (
+     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+     "folderId" INTEGER UNIQUE,
+     "caption" TEXT NOT NULL,
      "orgId" INTEGER
    )`,
 ];
@@ -91,6 +102,27 @@ const folderSchema: ModelSchema = {
       to: [],
       nullable: false,
     },
+    /**
+     * The **to-one whose key is on the child** — the shape #354 implemented,
+     * and the one this harness could not otherwise reach: every relation above
+     * that a policy can hide is a list, so a hidden row is always a *narrowing*
+     * of a set the caller named. Here the caller names nothing, so hiding the
+     * one row is the whole operand.
+     *
+     * Copied from the generated shape rather than guessed — `User.profile` in
+     * `app/models/generated/schema.ts` is exactly
+     * `{ kind: "one", from: [], to: [], nullable: true }`, and `from` being
+     * empty is what routes this to `planForeignSide`.
+     */
+    cover: {
+      name: "cover",
+      model: "Cover",
+      kind: "one",
+      relationName: "CoverToFolder",
+      from: [],
+      to: [],
+      nullable: true,
+    },
   },
 };
 
@@ -118,6 +150,32 @@ const noteSchema: ModelSchema = {
   },
 };
 
+const coverSchema: ModelSchema = {
+  name: "Cover",
+  table: "Cover",
+  fields: {
+    id: field("id", "Int", { isId: true, default: { kind: "autoincrement" } }),
+    folderId: field("folderId", "Int", { nullable: true }),
+    caption: field("caption", "String"),
+    orgId: field("orgId", "Int", { nullable: true }),
+  },
+  primaryKey: ["id"],
+  // The foreign key is the unique one, which is what makes the relation hold a
+  // single row — `Profile.userId @unique` in the template's schema.
+  uniques: [["folderId"]],
+  relations: {
+    folder: {
+      name: "folder",
+      model: "Folder",
+      kind: "one",
+      relationName: "CoverToFolder",
+      from: ["folderId"],
+      to: ["id"],
+      nullable: true,
+    },
+  },
+};
+
 const tenant = (): ModelPolicy => ({
   scope: (context) => ({ orgId: (context.user as any).orgId }),
   onCreate: (context, data) => ({
@@ -133,6 +191,11 @@ class Folder extends Model {
 
 class Note extends Model {
   static $schema = noteSchema;
+  static $policies = [tenant()];
+}
+
+class Cover extends Model {
+  static $schema = coverSchema;
   static $policies = [tenant()];
 }
 
@@ -164,9 +227,11 @@ describe("policies on nested writes", () => {
 
     register("Folder", Folder);
     register("Note", Note);
+    register("Cover", Cover);
   }, 120_000);
 
   afterAll(async () => {
+    await raw?.unsafe(`DROP TABLE IF EXISTS "Cover"`).catch(() => {});
     await raw?.unsafe(`DROP TABLE IF EXISTS "Note"`).catch(() => {});
     await raw?.unsafe(`DROP TABLE IF EXISTS "Folder"`).catch(() => {});
     await raw?.close();
@@ -177,6 +242,7 @@ describe("policies on nested writes", () => {
 
   beforeEach(async () => {
     clearPlanCache();
+    await raw.unsafe(`DELETE FROM "Cover"`);
     await raw.unsafe(`DELETE FROM "Note"`);
     await raw.unsafe(`DELETE FROM "Folder"`);
     // A folder belonging to somebody else, reachable only by its unique `code`.
@@ -484,6 +550,17 @@ describe("policies on nested writes", () => {
    * but carries the other tenant's `orgId`. So the link is right and the policy
    * is what has to refuse: without the child's scope this clears a foreign key
    * on a row we cannot see, and reports success.
+   *
+   * **`data` carries no scalar assignment, and that used to be impossible.**
+   * Both of these tests used to set `code` to the value it already had, with a
+   * note saying a relation-only `update` was refused for having nothing to
+   * `SET` and that #83 would make it compile to a select. #83 landed (`Writes
+   * through an implicit many-to-many join table`), and an empty `data` now
+   * takes the same select — so the no-op assignment is gone from both, which is
+   * what the note said should happen to it. It is worth removing rather than
+   * leaving: a stray `code: "ours"` reads as part of what is being tested, and
+   * it is the difference between this call emitting an `UPDATE` and emitting
+   * the `SELECT` a caller would really get.
    */
   test("disconnect cannot clear a row the child's policy hides", async () => {
     await raw.unsafe(
@@ -497,12 +574,7 @@ describe("policies on nested writes", () => {
     await Model.asUser(OURS, () =>
       Folder.$exec("update", {
         where: { id: 2 },
-        // `code` is here only to satisfy "at least one field must be
-        // updated": `Folder` has no `@updatedAt`, so a relation-only update has
-        // no scalar assignment and is refused on this branch. #83 makes that
-        // compile to a select of the same returning list; until it lands, a
-        // no-op assignment keeps the test about the disconnect.
-        data: { code: "ours", notes: { disconnect: { id: 10 } } },
+        data: { notes: { disconnect: { id: 10 } } },
       }),
     );
 
@@ -510,7 +582,7 @@ describe("policies on nested writes", () => {
     expect(notes[0].folderId).toBe(2);
   });
 
-  /** ...and a visible one is cleared. */
+  /** ...and a visible one is cleared. Relation-only `data`, as above. */
   test("disconnect clears a row the caller can see", async () => {
     await raw.unsafe(
       `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
@@ -523,12 +595,7 @@ describe("policies on nested writes", () => {
     await Model.asUser(OURS, () =>
       Folder.$exec("update", {
         where: { id: 2 },
-        // `code` is here only to satisfy "at least one field must be
-        // updated": `Folder` has no `@updatedAt`, so a relation-only update has
-        // no scalar assignment and is refused on this branch. #83 makes that
-        // compile to a select of the same returning list; until it lands, a
-        // no-op assignment keeps the test about the disconnect.
-        data: { code: "ours", notes: { disconnect: { id: 11 } } },
+        data: { notes: { disconnect: { id: 11 } } },
       }),
     );
 
@@ -627,6 +694,274 @@ describe("policies on nested writes", () => {
 
     const notes: any = await raw.unsafe(`SELECT "orgId" FROM "Note"`);
     expect(notes[0].orgId).toBe(7);
+  });
+
+  /**
+   * **A to-one whose key is on the child**, now that `update`, `delete` and
+   * `upsert` are implemented there.
+   *
+   * The normalisation that implemented them rewrites the operand's *shape* and
+   * nothing else — `delete: true` becomes `{}`, `false` becomes `null`, a bare
+   * `update` payload becomes `{ where, data }` — and then falls through to the
+   * same bodies the to-many uses. Read rather than assumed: every `executor.exec`
+   * on that path still passes `false` for pre-scoping, so the child's `$exec`
+   * runs its own policies exactly as it does for a list. The scope, the
+   * `onCreate`/`onUpdate` hooks and the scope-escape guard therefore need no
+   * to-one cases — they are the same calls, and the tests above already own
+   * them.
+   *
+   * **One thing is genuinely different, and it changes the answer's kind.** On a
+   * to-many the caller names the rows, so a row the child's policy hides is a
+   * *narrowing*: `disconnect: { id: 10 }` above quietly acts on nothing and the
+   * other operands still have the rows that were visible. On a to-one the caller
+   * names no row at all — `delete: true` means "the connected one" — so hiding
+   * that row does not narrow the operand, it empties it. The lookup misses, and
+   * a miss is the whole operand.
+   *
+   * Which matters because Prisma answers a to-one miss with P2025 rather than
+   * with silence. So a policy can turn a to-one nested write into an error where
+   * the same policy on a list turned it into a no-op.
+   */
+  describe("a to-one whose key is on the child", () => {
+    /** Ours; the cover seeded against it is the other tenant's. */
+    const seedFolder = () =>
+      raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+      );
+
+    const hiddenCover = () =>
+      raw.unsafe(
+        `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+          `VALUES (50, 2, 'theirs', 99)`,
+      );
+
+    /**
+     * `delete: true` against a child the policy hides answers **exactly what it
+     * answers when there is no child at all**, and both assertions are here
+     * together because the point is that they are indistinguishable.
+     *
+     * That is the same conservative direction the to-many `delete` takes one
+     * screen up — a hidden row reports as not connected rather than as denied —
+     * arrived at through a different route. There the reason is that the row the
+     * caller named cannot be found among this parent's children; here the caller
+     * named nothing, so what cannot be found is the relation's single row. The
+     * error is `RecordNotFoundError` rather than the to-many's "is not
+     * connected", because on a to-one there is no name to quote back and because
+     * Prisma answers P2025.
+     *
+     * Reading it the other way round is what makes it worth pinning: a caller
+     * who can see a folder but not its cover is told the folder has no cover.
+     * They cannot tell a folder whose cover belongs to another tenant from one
+     * that has none, which is the property that stops the operand being a probe.
+     */
+    test("delete: true reads a hidden child as no child at all", async () => {
+      await seedFolder();
+      await hiddenCover();
+      await raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (3, 'bare', 7)`,
+      );
+
+      const hidden = Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: { cover: { delete: true } },
+        }),
+      );
+      await expect(hidden).rejects.toThrow(RecordNotFoundError);
+
+      // Folder 3 genuinely has no cover, and says the same thing.
+      const absent = Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 3 },
+          data: { cover: { delete: true } },
+        }),
+      );
+      await expect(absent).rejects.toThrow(RecordNotFoundError);
+
+      // Observed raw, because a scoped read could not see the row either way.
+      const covers: any = await raw.unsafe(`SELECT * FROM "Cover"`);
+      expect([...covers]).toHaveLength(1);
+      expect(covers[0].orgId).toBe(99);
+    });
+
+    /**
+     * The non-vacuity half: the same call against a visible child deletes it. A
+     * `delete: true` that raised for some reason of its own — the operand not
+     * reaching the child at all, say — would pass the test above for the wrong
+     * reason.
+     */
+    test("delete: true deletes a child the caller can see", async () => {
+      await seedFolder();
+      await raw.unsafe(
+        `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+          `VALUES (51, 2, 'ours', 7)`,
+      );
+
+      await Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: { cover: { delete: true } },
+        }),
+      );
+
+      expect(await raw.unsafe(`SELECT * FROM "Cover"`)).toHaveLength(0);
+    });
+
+    /**
+     * ...and `disconnect: true` against the *same* hidden child is silent.
+     *
+     * The two operands share one body and differ only in whether a miss is
+     * fatal — Prisma's asymmetry, measured, not a choice made here. This asserts
+     * that the asymmetry survives a miss the *policy* caused rather than the
+     * data: a scoped-away child produces the same silence a genuinely absent one
+     * does, and does not acquire `delete`'s error by sharing its code path.
+     */
+    test("disconnect: true is silent about the same hidden child", async () => {
+      await seedFolder();
+      await hiddenCover();
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { cover: { disconnect: true } },
+          }),
+        ),
+      ).resolves.toBeDefined();
+
+      const covers: any = await raw.unsafe(`SELECT "folderId" FROM "Cover"`);
+      expect(covers[0].folderId).toBe(2);
+    });
+
+    /**
+     * **The one that could genuinely surprise somebody.**
+     *
+     * A nested `upsert` decides its branch with a lookup, and the lookup runs
+     * through the child's own `$exec` — so a child the policy hides reads as a
+     * miss, and the miss takes the **create** branch. The create then stamps the
+     * parent's key into the child's foreign key, which on a to-one carries a
+     * unique index. It collides with the row the caller was not allowed to see.
+     *
+     * This is the to-one reading of a note already in `planForeignSide`: an
+     * upsert aimed at a row belonging to *another parent* takes the create
+     * branch and collides, and Prisma does the same, measured — `where` matching
+     * nothing with a child present gives P2002, *"Unique constraint failed on
+     * the fields: (`userId`)"*. What the implementation's comment does not
+     * predict is that a **policy** reaches the same place: the child is this
+     * parent's, the relation is right, and the reason the lookup misses is that
+     * this caller may not see the row.
+     *
+     * So the error a caller gets is `UniqueConstraintError` naming a field they
+     * never wrote. It does not leak the row's contents, and it is the same
+     * answer they would get from a genuine key collision — but it is a
+     * *different* answer from the one `delete` gives one test up, and that is
+     * worth having written down: the two hidden-child cases are not uniform, and
+     * only `delete` and `update` reduce to "no such row".
+     *
+     * Nothing is written either way, which is the part that has to hold.
+     */
+    test("an upsert whose child is hidden collides on the child's unique key", async () => {
+      await seedFolder();
+      await hiddenCover();
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: {
+              cover: {
+                upsert: {
+                  create: { caption: "mine" },
+                  update: { caption: "updated" },
+                },
+              },
+            },
+          }),
+        ),
+      ).rejects.toThrow(UniqueConstraintError);
+
+      // The other tenant's row is still there, still theirs, still unedited —
+      // and no second row was written beside it.
+      const covers: any = await raw.unsafe(`SELECT * FROM "Cover"`);
+      expect([...covers]).toHaveLength(1);
+      expect(covers[0].caption).toBe("theirs");
+      expect(covers[0].orgId).toBe(99);
+    });
+
+    /**
+     * Both branches against rows the caller *can* see, which is what says the
+     * test above is about the policy rather than about the upsert.
+     *
+     * The create half also pins that the child's `onCreate` runs on this path:
+     * the row it writes carries our tenant, and its foreign key comes from the
+     * parent rather than from the payload.
+     */
+    test("an upsert takes its branches normally when nothing is hidden", async () => {
+      await seedFolder();
+
+      await Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: {
+            cover: {
+              upsert: {
+                create: { caption: "made" },
+                update: { caption: "unused" },
+              },
+            },
+          },
+        }),
+      );
+
+      let covers: any = await raw.unsafe(`SELECT * FROM "Cover"`);
+      expect([...covers]).toHaveLength(1);
+      expect(covers[0].caption).toBe("made");
+      expect(covers[0].folderId).toBe(2);
+      // The child's `onCreate`, through its own `$exec`.
+      expect(covers[0].orgId).toBe(7);
+
+      // Now that one exists and is visible, the same call updates it.
+      await Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: {
+            cover: {
+              upsert: {
+                create: { caption: "unused" },
+                update: { caption: "updated" },
+              },
+            },
+          },
+        }),
+      );
+
+      covers = await raw.unsafe(`SELECT * FROM "Cover"`);
+      expect([...covers]).toHaveLength(1);
+      expect(covers[0].caption).toBe("updated");
+    });
+
+    /**
+     * The remaining to-one operand with a policy answer of its own: a nested
+     * `update` naming no row. It reduces to "no such row" like `delete`, so it
+     * is one assertion rather than a pair — but it is the operand a ported
+     * application reaches for most, and the scoped miss is what it gets.
+     */
+    test("update on a hidden child is a miss, and writes nothing", async () => {
+      await seedFolder();
+      await hiddenCover();
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { cover: { update: { caption: "hacked" } } },
+          }),
+        ),
+      ).rejects.toThrow(RecordNotFoundError);
+
+      const covers: any = await raw.unsafe(`SELECT "caption" FROM "Cover"`);
+      expect(covers[0].caption).toBe("theirs");
+    });
   });
 
   /**

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -2,12 +2,18 @@ import { Prisma as PrismaNamespace, type PrismaClient } from "./prisma-client";
 import { UniqueConstraintError } from "gemi/orm";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 
-import { createDifferential, type Differential } from "./differential";
+import {
+  createDifferential,
+  stabilizeRelations,
+  type Differential,
+} from "./differential";
 import {
   AccountModel,
   MembershipModel,
   OrganizationModel,
+  PasswordResetTokenModel,
   PostModel,
+  ProfileModel,
   TagModel,
   SocialAccountModel,
   UserModel,
@@ -111,6 +117,29 @@ async function seed(prisma: PrismaClient) {
       { publicId: "acc-mine-2", userId: users[0].id, organizationRole: 2 },
       { publicId: "acc-theirs", userId: users[1].id, organizationRole: 1 },
     ],
+  });
+
+  // The to-one whose foreign key is on the **child** (#354) — the shape this
+  // schema had none of, so the foreign side of a nested write had never been
+  // compared against a real client at all.
+  //
+  // Two rows, and the split is the whole point. It is the same role `acc-theirs`
+  // plays for the to-many above: without a parent that has *no* child, every
+  // miss branch is unreachable and the cases below would all take the hit path
+  // and pass whatever the miss path did.
+  //
+  //   `seed`  -> the first user, so `update` / `delete` / `upsert` / `disconnect`
+  //             each have a child to act on
+  //   `loose` -> nobody, so the second user misses on all four, and `connect`
+  //             has an unattached row to attach
+  //
+  // Measured against this client before the cases were written: every to-one
+  // miss is P2025 — the same error and the same wording for "no child" as for
+  // "the child did not match the filter" — except an `upsert` whose `where`
+  // does not match, which takes the create branch and collides on
+  // `Profile.userId`'s unique index (P2002). Both are pinned below.
+  await prisma.profile.createMany({
+    data: [{ bio: "seed", userId: users[0].id }, { bio: "loose" }],
   });
 }
 
@@ -418,6 +447,218 @@ const CASES: Case[] = [
       accounts: { create: { organizationRole: 1, organizationId: 99999 } },
     },
   }, ["User", "Account"]],
+
+  // --- a to-one whose foreign key is on the child (#354) -----------------
+  //
+  // `update`, `delete` and `upsert` were refused by name on this side, and the
+  // reason nothing caught how much that mattered is that the harness had no
+  // relation of this shape to reach: every child-side relation in the schema
+  // was a list. `Profile` is that relation, and these are the measurements the
+  // implementation was written from, one case per answer, so the answer is
+  // pinned rather than remembered.
+  //
+  // The `M<n>` labels are the rows of the measurement table in the plan. They
+  // are in the test names on purpose: a failure here names the measurement it
+  // contradicts, which is the only way to tell "gemi regressed" from "Prisma
+  // changed its mind" without re-deriving the whole table.
+  //
+  // User 1 has a profile, user 2 does not — see the seed. Every case compares
+  // both tables, because the interesting half of a to-one write is usually the
+  // child's foreign key rather than the parent row that comes back.
+
+  // M1 — a nested `update` on a parent with no child. The open question was
+  // P2025 or a silent no-op; it is P2025, and the parent's own assignments do
+  // not land either. `notFound` on both sides, so a gemi refusal cannot pass
+  // for it: `failureKind` classifies an `UnsupportedQueryError` as `other`.
+  ["M1 to-one update with no child raises", "update", {
+    where: { id: 2 }, data: { profile: { update: { bio: "changed" } } },
+  }, ["User", "Profile"]],
+  // M1b — the `{ data }` wrapper makes no difference to the miss.
+  ["M1b to-one update with no child, wrapped in data", "update", {
+    where: { id: 2 }, data: { profile: { update: { data: { bio: "changed" } } } },
+  }, ["User", "Profile"]],
+
+  // M2 — the one the plan flagged as possibly changing the code's shape,
+  // because a `findFirst` miss is treated as fatal one level down. It does not:
+  // a `where` that matches nothing with a child *present* is the same P2025,
+  // with the same wording, as no child at all. Fatal-on-miss was already right.
+  ["M2 to-one update whose where matches nothing raises", "update", {
+    where: { id: 1 },
+    data: { profile: { update: { where: { bio: "nope" }, data: { bio: "changed" } } } },
+  }, ["User", "Profile"]],
+  // M2b — the control, and the one that shows the `where` is a **filter**:
+  // `bio` carries no unique index, and Prisma takes it anyway.
+  ["M2b to-one update whose where matches", "update", {
+    where: { id: 1 },
+    data: { profile: { update: { where: { bio: "seed" }, data: { bio: "changed" } } } },
+  }, ["User", "Profile"]],
+  // M2c — no child *and* a non-matching filter. One error for both, which is
+  // why gemi needs only one `RecordNotFoundError` message here.
+  ["M2c to-one update, no child and a non-matching where", "update", {
+    where: { id: 2 },
+    data: { profile: { update: { where: { bio: "nope" }, data: { bio: "changed" } } } },
+  }, ["User", "Profile"]],
+
+  // M3 — `delete: true` with nothing linked. P2025, *not* the to-many
+  // "the row named by `true` is not connected" refusal, which would classify as
+  // `other` here and disagree.
+  ["M3 to-one delete true with no child raises", "update", {
+    where: { id: 2 }, data: { profile: { delete: true } },
+  }, ["User", "Profile"]],
+  // M3b — the control. `delete: true` removes the row rather than unlinking it.
+  ["M3b to-one delete true removes the row", "update", {
+    where: { id: 1 }, data: { profile: { delete: true } },
+  }, ["User", "Profile"]],
+
+  // M4 — a `delete` filter that matches nothing, with a child present. Fatal,
+  // exactly like M3, so the filter form needs no miss handling of its own.
+  ["M4 to-one delete with a non-matching filter raises", "update", {
+    where: { id: 1 }, data: { profile: { delete: { bio: "nope" } } },
+  }, ["User", "Profile"]],
+  // M4b — the control, and the case that rules out `assertNamedRows` on this
+  // path: `bio` is not unique and the operand is accepted regardless.
+  ["M4b to-one delete takes a filter, not a unique key", "update", {
+    where: { id: 1 }, data: { profile: { delete: { bio: "seed" } } },
+  }, ["User", "Profile"]],
+
+  // M5 / M5b — the booleans that mean *nothing happens*, and the pair the plan
+  // cache used to collide: `disconnect`/`delete` recorded a non-literal boolean
+  // as `"boolean"`, so a plan compiled from `true` served `false` and cleared a
+  // foreign key on a call that asked for nothing. Both must leave the child
+  // untouched, which the table comparison is what actually checks.
+  ["M5 to-one delete false is a strict no-op", "update", {
+    where: { id: 1 }, data: { profile: { delete: false } },
+  }, ["User", "Profile"]],
+  ["M5b to-one disconnect false is a strict no-op", "update", {
+    where: { id: 1 }, data: { profile: { disconnect: false } },
+  }, ["User", "Profile"]],
+
+  // M6 — `upsert` with no child: the create branch runs **and stamps the
+  // child's foreign key** from the parent's key. `where` is genuinely optional
+  // on a to-one, which is why it is absent here.
+  ["M6 to-one upsert with no child creates and links", "update", {
+    where: { id: 2 },
+    data: {
+      profile: { upsert: { create: { bio: "created" }, update: { bio: "updated" } } },
+    },
+  }, ["User", "Profile"]],
+  // M6b — the other branch, still with no `where`: the single linked child.
+  ["M6b to-one upsert with a child updates it", "update", {
+    where: { id: 1 },
+    data: {
+      profile: { upsert: { create: { bio: "created" }, update: { bio: "updated" } } },
+    },
+  }, ["User", "Profile"]],
+  // M7 — the only to-one miss that is *not* P2025. A `where` that matches
+  // nothing takes the create branch, which then collides with the child's
+  // unique foreign key: `unique`, not `notFound`. gemi has to let the create
+  // run and surface the collision rather than pre-empting it, and the harness
+  // compares the kind, so pre-empting would show up here as a disagreement.
+  ["M7 to-one upsert whose where misses collides on the unique key", "update", {
+    where: { id: 1 },
+    data: {
+      profile: {
+        upsert: {
+          where: { bio: "nope" },
+          create: { bio: "created" },
+          update: { bio: "updated" },
+        },
+      },
+    },
+  }, ["User", "Profile"]],
+
+  // M8 — the asymmetry that keeps `delete` and `disconnect` from sharing their
+  // miss handling even though they share a body: a `disconnect` that finds
+  // nothing is **silent**, where the same `delete` is P2025 (M3).
+  ["M8 to-one disconnect true with no child is silent", "update", {
+    where: { id: 2 }, data: { profile: { disconnect: true } },
+  }, ["User", "Profile"]],
+  // M8b — the control, and adjacent defect 2: this used to be refused outright.
+  // The row survives; only the foreign key is cleared.
+  ["M8b to-one disconnect true clears the child's key", "update", {
+    where: { id: 1 }, data: { profile: { disconnect: true } },
+  }, ["User", "Profile"]],
+  // M8c — and a `disconnect` filter that matches nothing is silent too, so the
+  // silence is about the operand rather than about the spelling.
+  ["M8c to-one disconnect with a non-matching filter is silent", "update", {
+    where: { id: 1 }, data: { profile: { disconnect: { bio: "nope" } } },
+  }, ["User", "Profile"]],
+
+  // M9 — the `{ data }` wrapper on the **foreign** side. It was measured on the
+  // owning side only, and the three spellings (bare, `{ data }`,
+  // `{ where, data }`) are one operation, which is what lets the normaliser
+  // collapse them at compile time.
+  ["M9 to-one update wrapped in data, child present", "update", {
+    where: { id: 1 }, data: { profile: { update: { data: { bio: "changed" } } } },
+  }, ["User", "Profile"]],
+
+  // M10 — arrays on a to-one. Prisma refuses every one of them at *validation*
+  // time, with no `P` code: the generated operand types are singular, with no
+  // `| X[]` arm, unlike their to-many siblings. So this is not gemi being
+  // stricter than Prisma — compiling these was a live divergence that wrote or
+  // repointed several rows through a relation that holds one.
+  //
+  // `other` on both sides, which is all the harness can honestly claim for an
+  // argument-shape refusal; `refusals.test.ts` asserts the error class and the
+  // wording. What these add is the half that suite cannot see: that Prisma
+  // refuses them too, and that **nothing is written** by either client.
+  ["M10 an array of create on a to-one", "update", {
+    where: { id: 2 }, data: { profile: { create: [{ bio: "a" }, { bio: "b" }] } },
+  }, ["User", "Profile"]],
+  ["M10 an array of connect on a to-one", "update", {
+    where: { id: 2 }, data: { profile: { connect: [{ id: 1 }, { id: 2 }] } },
+  }, ["User", "Profile"]],
+  ["M10 an array of connectOrCreate on a to-one", "update", {
+    where: { id: 2 },
+    data: {
+      profile: {
+        connectOrCreate: [
+          { where: { id: 2 }, create: { bio: "a" } },
+          { where: { id: 99 }, create: { bio: "b" } },
+        ],
+      },
+    },
+  }, ["User", "Profile"]],
+  ["M10 an array of update on a to-one", "update", {
+    where: { id: 1 },
+    data: {
+      profile: {
+        update: [
+          { where: { bio: "seed" }, data: { bio: "a" } },
+          { where: { bio: "loose" }, data: { bio: "b" } },
+        ],
+      },
+    },
+  }, ["User", "Profile"]],
+  ["M10 an array of delete on a to-one", "update", {
+    where: { id: 1 }, data: { profile: { delete: [{ bio: "seed" }] } },
+  }, ["User", "Profile"]],
+  ["M10 an array of upsert on a to-one", "update", {
+    where: { id: 1 },
+    data: {
+      profile: {
+        upsert: [{ create: { bio: "a" }, update: { bio: "b" } }],
+      },
+    },
+  }, ["User", "Profile"]],
+  // The controls for the two operands that were *not* refused before, so the
+  // array refusal cannot have been bought by refusing the singular form too.
+  ["a single create on a to-one", "update", {
+    where: { id: 2 }, data: { profile: { create: { bio: "made" } } },
+  }, ["User", "Profile"]],
+  // `loose` belongs to nobody, so this attaches rather than repointing.
+  ["a single connect on a to-one", "update", {
+    where: { id: 2 }, data: { profile: { connect: { id: 2 } } },
+  }, ["User", "Profile"]],
+  // And the one whose answer is not guessable: connecting a child that is
+  // already somebody else's **repoints** it, leaving the first parent with no
+  // profile — measured, because the alternative (a unique violation) is just as
+  // plausible a thing for a one-to-one to do.
+  ["a single connect that steals another parent's child", "update", {
+    where: { id: 2 }, data: { profile: { connect: { id: 1 } } },
+  }, ["User", "Profile"]],
+  // `create` where a child already exists is a **divergence**, not agreement,
+  // so it is not here — see the "still disagree" describe below.
 ];
 
 function suite(label: string, url?: string) {
@@ -434,6 +675,11 @@ function suite(label: string, url?: string) {
           SocialAccount: SocialAccountModel as never,
           Account: AccountModel as never,
           Organization: OrganizationModel as never,
+          // `readTables` reads `$schema.primaryKey` off the registered class to
+          // order its comparison read, so a model that is compared but not
+          // listed here is not a missing convenience — it throws.
+          Profile: ProfileModel as never,
+          PasswordResetToken: PasswordResetTokenModel as never,
         },
         seed,
         url,
@@ -1800,6 +2046,373 @@ function suite(label: string, url?: string) {
       expect(Object.keys(created)).toEqual(["email"]);
     });
 
+    /**
+     * The same relation, written from the **child** — the owning side of the
+     * very to-one the `M…` cases above write from the parent.
+     *
+     * `write.test.ts` has a describe titled "a to-one answers the same on both
+     * sides", and an unasserted symmetry claim in a suite with that title is
+     * how #116 happened. It asserts the claim against the *compiler*; these
+     * assert it against a real client, which is the half that can tell a
+     * matching pair of statements from a matching pair of answers.
+     */
+    describe("the same to-one, written from the owning side", () => {
+      test("update reaches the parent through the child's relation", async () => {
+        await differential.expectSameWrite(
+          "Profile",
+          "update",
+          {
+            where: { id: 1 },
+            data: { user: { update: { name: "From the child" } } },
+          },
+          { tables: ["User", "Profile"] },
+        );
+      });
+
+      /**
+       * The owning side of the same operand as M8b, and the reason
+       * `Profile.userId` is nullable on purpose: Prisma omits `disconnect` from
+       * the input type entirely when the foreign key is required, so a required
+       * one would leave this unreachable rather than refused.
+       */
+      test("disconnect clears this row's own foreign key", async () => {
+        await differential.expectSameWrite(
+          "Profile",
+          "update",
+          { where: { id: 1 }, data: { user: { disconnect: true } } },
+          { tables: ["User", "Profile"] },
+        );
+      });
+    });
+
+    /**
+     * M11 — `disconnect` on a **required** foreign key, which is the case that
+     * keeps `assertDisconnectable` as it is.
+     *
+     * Prisma does not refuse a value here; it does not have the key at all.
+     * `PasswordResetTokenUpdateInput`'s `user` operand lists only
+     * create / connectOrCreate / upsert / connect / update, and the error is
+     * "Unknown argument `disconnect`. Did you mean `connect`?". So `false` is
+     * refused exactly as `true` is — the refusal is on the **key**, not on the
+     * value, which is why it has to fire ahead of any boolean normalisation.
+     * That is the assertion below that is easy to lose.
+     *
+     * Not in the seed and not through `expectSameWrite`: a `PasswordResetToken`
+     * row would make `deleteMany empty where` — which deletes every user — fail
+     * a foreign key on both clients, silently turning an existing case from a
+     * successful delete into a mutual error. The row is written here instead,
+     * after the reset that the case needs anyway.
+     */
+    test("M11 disconnect on a required foreign key is refused by both", async () => {
+      await differential.reset();
+      await differential.prisma.passwordResetToken.create({
+        data: { token: "reset-1", userId: 1 },
+      });
+
+      for (const operand of [true, false]) {
+        const args = { where: { token: "reset-1" }, data: { user: { disconnect: operand } } };
+
+        await expect(
+          differential.prisma.passwordResetToken.update(args as never),
+        ).rejects.toThrow(/Unknown argument `disconnect`/);
+
+        await expect(
+          PasswordResetTokenModel.update(args as never),
+        ).rejects.toThrow();
+      }
+
+      // Neither client got as far as the database.
+      const row = await differential.prisma.passwordResetToken.findFirstOrThrow({
+        where: { token: "reset-1" },
+      });
+      expect(row.userId).toBe(1);
+    });
+
+    /**
+     * #355 — an `update` whose `data` sets no column.
+     *
+     * Every case here uses a model with **no `@updatedAt`**, and that is not a
+     * detail: `updateAssignments` stamps one unconditionally, so on `User` there
+     * is always an assignment and this branch is unreachable. A version of these
+     * written against `User` would pass without ever running the code they are
+     * for.
+     *
+     * `Post` has neither timestamp; `Organization` has none either and has two
+     * seeded rows, which is what M13 needs.
+     */
+    describe("an empty data", () => {
+      // M12 — it is a **read**. Prisma returns the row, unchanged, rather than
+      // refusing or emitting an `UPDATE` with nothing to set.
+      test("M12 update with an empty data returns the row", async () => {
+        await differential.expectSameWrite(
+          "Post",
+          "update",
+          { where: { id: 1 }, data: {} },
+          { tables: ["Post"] },
+        );
+      });
+
+      // M12b — and it is a read through the *same* projection machinery: the
+      // `include` is honoured in full, which a bare row fetch would drop.
+      test("M12b the include is honoured", async () => {
+        await differential.expectSameWrite(
+          "Post",
+          "update",
+          {
+            where: { id: 1 },
+            data: {},
+            include: { tags: { orderBy: { id: "asc" } } },
+          },
+          { tables: ["Post", "Tag"] },
+        );
+      });
+
+      // M12c — a miss still raises P2025, so `update` staying in `ORTHROW` is
+      // both required and sufficient. `notFound` on both sides.
+      test("M12c a miss still raises", async () => {
+        await differential.expectSameWrite(
+          "Post",
+          "update",
+          { where: { id: 99999 }, data: {} },
+          { tables: ["Post"] },
+        );
+      });
+
+      // M12d — `select` narrows it exactly as it narrows a normal update.
+      test("M12d select narrows the read", async () => {
+        await differential.expectSameWrite(
+          "Post",
+          "update",
+          { where: { id: 1 }, data: {}, select: { title: true } },
+          { tables: ["Post"] },
+        );
+      });
+
+      /**
+       * M13 — the half that decided whether #355 implements or documents.
+       *
+       * `updateMany` answers `{ count: 0 }`, and the count is a **constant**
+       * rather than a row count: "Acme" matches one of the two seeded
+       * organisations and the answer is still 0. That is what makes it cheap to
+       * match — skip the statement, return the constant, never evaluate the
+       * filter — and it is surprising enough that it has to be pinned rather
+       * than remembered.
+       */
+      test("M13 updateMany counts zero even when rows match", async () => {
+        await differential.expectSameWrite(
+          "Organization",
+          "updateMany",
+          { where: { name: "Acme" }, data: {} },
+          { tables: ["Organization"] },
+        );
+      });
+
+      test("M13b a filter that matches nothing is indistinguishable", async () => {
+        await differential.expectSameWrite(
+          "Organization",
+          "updateMany",
+          { where: { name: "no such organisation" }, data: {} },
+          { tables: ["Organization"] },
+        );
+      });
+
+      test("M13c and no filter at all is still zero", async () => {
+        await differential.expectSameWrite(
+          "Organization",
+          "updateMany",
+          { data: {} },
+          { tables: ["Organization"] },
+        );
+      });
+    });
+
+    /**
+     * **The `@updatedAt` stamp follows the column, and both clients agree.**
+     *
+     * These two were bugs 1 and 2 in the describe below — gemi stamped where
+     * Prisma did not — and they are kept here, by value, rather than graduated
+     * into `CASES`, because `CASES` cannot see them: `updatedAt` is in
+     * `VOLATILE`, so `expectSameWrite` compares both sides as the descriptor
+     * `"date"` and two different instants match. That blindness is why the
+     * divergence survived the first pass; asserting the epoch by hand is what
+     * caught it and is what keeps it caught.
+     *
+     * The rule both clients follow: a statement that sets at least one column
+     * stamps, one that sets none does not. Measured on rows whose `updatedAt`
+     * was seeded to the epoch, so this is the stamp and not two clocks.
+     */
+    describe("the @updatedAt stamp follows the column, as Prisma's does", () => {
+      test("update with an empty data leaves the stamp alone on both", async () => {
+        const args = { where: { id: 1 }, data: {} };
+
+        await differential.reset();
+        const fromPrisma: any = await differential.prisma.user.update(args);
+
+        await differential.reset();
+        const fromGemi: any = await UserModel.update(args);
+        const storedByGemi = await differential.prisma.user.findFirstOrThrow({
+          where: { id: 1 },
+        });
+
+        expect(fromPrisma.updatedAt.getTime()).toBe(EPOCH);
+        expect(fromGemi.updatedAt.getTime()).toBe(EPOCH);
+        // And nothing was written, not merely nothing returned.
+        expect(storedByGemi.updatedAt.getTime()).toBe(EPOCH);
+      });
+
+      test("updateMany with an empty data counts zero and writes nothing on both", async () => {
+        const args = { where: { globalRole: { gte: 0 } }, data: {} };
+        const seeded = [EPOCH, EPOCH + 1000, EPOCH + 2000];
+
+        await differential.reset();
+        const fromPrisma = await differential.prisma.user.updateMany(args);
+        const afterPrisma = await differential.prisma.user.findMany({
+          orderBy: { id: "asc" },
+        });
+
+        await differential.reset();
+        const fromGemi = await UserModel.updateMany(args);
+        const afterGemi = await differential.prisma.user.findMany({
+          orderBy: { id: "asc" },
+        });
+
+        expect(fromPrisma).toEqual({ count: 0 });
+        expect(fromGemi).toEqual({ count: 0 });
+        expect(afterPrisma.map((row) => row.updatedAt.getTime())).toEqual(seeded);
+        expect(afterGemi.map((row) => row.updatedAt.getTime())).toEqual(seeded);
+      });
+
+      /**
+       * The half that keeps the fix from being read as "never stamp", and the
+       * one a regression would most likely break: a real column brings it back.
+       */
+      test("a supplied column still stamps on both", async () => {
+        const args = { where: { id: 1 }, data: { name: "written" } };
+
+        await differential.reset();
+        const fromPrisma: any = await differential.prisma.user.update(args);
+
+        await differential.reset();
+        const fromGemi: any = await UserModel.update(args);
+
+        expect(fromPrisma.updatedAt.getTime()).toBeGreaterThan(EPOCH);
+        expect(fromGemi.updatedAt.getTime()).toBeGreaterThan(EPOCH);
+      });
+
+      /**
+       * The shape #354 ships, and the reason this describe is not only about
+       * #355: a nested write whose child holds the foreign key sets no column
+       * of *this* row, so it must not stamp either. Measured — Prisma leaves it
+       * at the epoch for a nested `create`, `update` and `upsert` alike.
+       */
+      test("a relation-only nested write leaves the stamp alone on both", async () => {
+        const args = {
+          where: { id: 2 },
+          data: { profile: { create: { bio: "nested" } } },
+        };
+
+        await differential.reset();
+        const fromPrisma: any = await differential.prisma.user.update(args as never);
+
+        await differential.reset();
+        const fromGemi: any = await UserModel.update(args as never);
+        const storedByGemi = await differential.prisma.user.findFirstOrThrow({
+          where: { id: 2 },
+        });
+
+        expect(fromPrisma.updatedAt.getTime()).toBe(EPOCH + 1000);
+        expect(fromGemi.updatedAt.getTime()).toBe(EPOCH + 1000);
+        expect(storedByGemi.updatedAt.getTime()).toBe(EPOCH + 1000);
+        // The child still landed — the parent reading rather than writing must
+        // not cost the nested step.
+        expect(
+          await differential.prisma.profile.findFirst({ where: { userId: 2 } }),
+        ).toMatchObject({ bio: "nested" });
+      });
+    });
+
+    /**
+     * Where gemi and Prisma **still disagree**. Every one of these is a bug,
+     * found by running the measurements above through both clients, and none of
+     * them is a decision anybody made.
+     *
+     * They are not in `CASES`, because `expectSameWrite` asserts agreement: a
+     * case put there to disagree is a red suite carrying no information. Each
+     * one instead pins **both** answers — Prisma's *and* gemi's — so the day
+     * either side moves, this fails and says which one moved. That is the only
+     * form in which a known divergence is worth committing; a `test.skip` would
+     * record nothing and a comment would record it where nothing checks it.
+     *
+     * Fixing any of them is a compiler change, in files this suite does not own.
+     * Deleting the case is what closing the bug looks like: it graduates into
+     * `CASES` and the harness takes over from the prose.
+     */
+    describe("where the two clients still disagree — each of these is a bug", () => {
+      /**
+       * **BUG 1 — owning-side `disconnect: false`.**
+       *
+       * #354 made the *foreign* side take a boolean (M5b above, which passes).
+       * The owning side still refuses anything but `true`. Prisma's owning-side
+       * operand is `WhereInput | boolean` and it takes `false` as a no-op, so a
+       * caller passing a flag through — `disconnect: shouldDetach` — gets a
+       * refusal on the branch that asked for nothing.
+       *
+       * This is strictly better than what it replaced, which nulled the foreign
+       * key on that branch through a stale plan-cache entry. It is still wrong.
+       */
+      test("the owning side refuses disconnect: false, which Prisma no-ops", async () => {
+        const args = { where: { id: 1 }, data: { user: { disconnect: false } } };
+
+        await differential.reset();
+        const fromPrisma = await differential.prisma.profile.update(args as never);
+        expect(fromPrisma.userId).toBe(1);
+
+        await differential.reset();
+        await expect(ProfileModel.update(args as never)).rejects.toThrow(
+          /only 'disconnect: true' is implemented/,
+        );
+      });
+
+      /**
+       * **BUG 2 — `create` on a to-one that already has a child.**
+       *
+       * Prisma **detaches** the existing child first: the old row survives with
+       * a null foreign key and the new one takes the link. gemi inserts without
+       * clearing, and the child's `@unique` foreign key rejects it — a unique
+       * violation on a call Prisma answers.
+       *
+       * Not the same operand family as the three #354 closed, which is why it
+       * survived: `create` was never refused on this side, so nothing pointed at
+       * it. The fix belongs beside `set`, whose whole job is clearing the links
+       * that are in the way before writing the new ones.
+       */
+      test("create on an occupied to-one collides here and detaches in Prisma", async () => {
+        const args = {
+          where: { id: 1 },
+          data: { profile: { create: { bio: "second" } } },
+        };
+
+        await differential.reset();
+        await differential.prisma.user.update(args);
+        const afterPrisma = await differential.prisma.profile.findMany({
+          orderBy: { id: "asc" },
+        });
+        expect(afterPrisma.map((row) => [row.bio, row.userId])).toEqual([
+          // The row that was linked, now orphaned rather than deleted.
+          ["seed", null],
+          ["loose", null],
+          ["second", 1],
+        ]);
+
+        await differential.reset();
+        await expect(UserModel.update(args)).rejects.toBeInstanceOf(
+          UniqueConstraintError,
+        );
+        // And nothing is left behind: the failed insert rolls back.
+        expect(await differential.prisma.profile.count()).toBe(2);
+      });
+    });
+
     // --- typed errors ---------------------------------------------------
 
     test("a unique violation is typed, catchable, and names the field", async () => {
@@ -1968,3 +2581,65 @@ if (POSTGRES_URL) {
     });
   });
 }
+
+/**
+ * The harness's own relation-order stabilisation, tested directly because the
+ * thing it fixes cannot be reproduced on demand.
+ *
+ * `expectSameWrite` compares what the call returned, and an `include` is
+ * unordered in *both* clients — measured, by logging what Prisma 6.19.2 sends:
+ * `SELECT … FROM "public"."Account" WHERE … IN ($1) OFFSET $2`, with no
+ * `ORDER BY`. On Postgres an `UPDATE` relocates the row within the heap, so the
+ * child that was written comes back last, or first again once the page has been
+ * pruned. The two clients run one after the other and meet the heap in
+ * different states, so the same passing case fails perhaps one run in three —
+ * always as a plausible-looking divergence in which every field of every row is
+ * identical and only the array order differs.
+ *
+ * That is unreproducible by construction, which is why the guard is asserted
+ * here rather than left to the Postgres run to notice. Deleting the sort in
+ * `differential.ts` fails the first two cases below.
+ *
+ * Dialect-independent — it is a pure function — so it sits outside `suite`.
+ */
+describe("the harness compares relations as a set, not in storage order", () => {
+  const registry = { User: UserModel, Account: AccountModel } as any;
+
+  test("a relation array is reordered and a Json column is not", () => {
+    const out: any = stabilizeRelations(
+      {
+        id: 1,
+        // A `Json` column whose value *is* the order. The reason the walk is
+        // guided by the schema instead of sorting every array of objects.
+        metadata: [{ z: 1 }, { a: 2 }],
+        accounts: [
+          { id: 4, organizationRole: 2 },
+          { id: 3, organizationRole: 9 },
+        ],
+      },
+      "User",
+      registry,
+    );
+
+    expect(out.accounts.map((account: any) => account.id)).toEqual([3, 4]);
+    expect(out.metadata).toEqual([{ z: 1 }, { a: 2 }]);
+  });
+
+  test("the two orders a write can return collapse to one value", () => {
+    expect(
+      stabilizeRelations({ accounts: [{ id: 4 }, { id: 3 }] }, "User", registry),
+    ).toEqual(
+      stabilizeRelations({ accounts: [{ id: 3 }, { id: 4 }] }, "User", registry),
+    );
+  });
+
+  // The half that keeps the case above from being a way to pass anything: it is
+  // a multiset comparison, so a different *set* of children still fails.
+  test("a genuinely different set of children still differs", () => {
+    expect(
+      stabilizeRelations({ accounts: [{ id: 4 }, { id: 3 }] }, "User", registry),
+    ).not.toEqual(
+      stabilizeRelations({ accounts: [{ id: 4 }, { id: 5 }] }, "User", registry),
+    );
+  });
+});

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -1753,6 +1753,77 @@ function suite(label: string, url?: string) {
     });
 
     /**
+     * **The owning side honours its `where`**, which for a while it accepted and
+     * ignored — writing the linked row whether or not the filter matched, while
+     * the foreign side conjoined the same filter and raised. One spelling, two
+     * answers, and the owning one was the silent wrong write.
+     *
+     * Both directions are pinned, because only the pair distinguishes "the
+     * filter is applied" from "the filter is dropped": with the filter dropped
+     * the matching case still passes.
+     */
+    test("a to-one update with a matching where writes", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            organization: {
+              update: { where: { name: "Acme" }, data: { name: "Filtered" } },
+            },
+          },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    test("a to-one update whose where matches nothing raises rather than writing", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: {
+            organization: {
+              update: {
+                where: { name: "NotTheOrganisation" },
+                data: { name: "MustNotLand" },
+              },
+            },
+          },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    /**
+     * `data: undefined` — the ordinary spelling of a conditional write, and the
+     * reason `suppliedFields` skips `undefined` everywhere else.
+     *
+     * `canonicalShape` drops an `undefined`-valued key, so this and `update: {}`
+     * are one plan entry; the owning side used to branch on the key's
+     * *presence*, pass `data: undefined` down to `updateMany`, and answer a
+     * no-op call with `updateMany requires 'data'`. Both sides now read the
+     * value, which is what Prisma does — it treats an explicit `undefined` as
+     * absent.
+     */
+    test("a to-one update with data: undefined is a no-op, on both sides", async () => {
+      await differential.expectSameWrite(
+        "User",
+        "update",
+        {
+          where: { id: 1 },
+          data: { organization: { update: { data: undefined } } },
+          include: { organization: true },
+        },
+        { tables: ["User", "Organization"] },
+      );
+    });
+
+    /**
      * The owning-side miss — the case that was missing, and the reason its
      * twin's fix did not carry over.
      *
@@ -2640,6 +2711,71 @@ describe("the harness compares relations as a set, not in storage order", () => 
       stabilizeRelations({ accounts: [{ id: 4 }, { id: 3 }] }, "User", registry),
     ).not.toEqual(
       stabilizeRelations({ accounts: [{ id: 4 }, { id: 5 }] }, "User", registry),
+    );
+  });
+
+  /**
+   * **An include that named an `orderBy` keeps its order.**
+   *
+   * Without this the relaxation would reach past the flake it was for: the
+   * flake is a property of an *unordered* include, where neither client emits
+   * an `ORDER BY` and the heap decides. When the caller asked for a sort, the
+   * order is the answer — so a relation strategy that stopped honouring a
+   * nested `orderBy` has to still fail here, and several existing cases in this
+   * file pass exactly that argument.
+   */
+  test("a node that asked for an orderBy is compared positionally", () => {
+    const ordered = { include: { accounts: { orderBy: { id: "asc" } } } };
+
+    expect(
+      stabilizeRelations(
+        { accounts: [{ id: 4 }, { id: 3 }] },
+        "User",
+        registry,
+        ordered,
+      ),
+    ).not.toEqual(
+      stabilizeRelations(
+        { accounts: [{ id: 3 }, { id: 4 }] },
+        "User",
+        registry,
+        ordered,
+      ),
+    );
+  });
+
+  // ...and the exception is the `orderBy`, not the presence of a selection: an
+  // include with no sort is still the unordered case the sort exists for.
+  test("an include with no orderBy is still sorted", () => {
+    const plain = { include: { accounts: true } };
+
+    expect(
+      stabilizeRelations({ accounts: [{ id: 4 }, { id: 3 }] }, "User", registry, plain),
+    ).toEqual(
+      stabilizeRelations({ accounts: [{ id: 3 }, { id: 4 }] }, "User", registry, plain),
+    );
+  });
+
+  // A relation reached through `select` is as ordered as one through `include`.
+  test("select carries the orderBy too", () => {
+    const viaSelect = {
+      select: { id: true, accounts: { orderBy: { id: "asc" } } },
+    };
+
+    expect(
+      stabilizeRelations(
+        { accounts: [{ id: 4 }, { id: 3 }] },
+        "User",
+        registry,
+        viaSelect,
+      ),
+    ).not.toEqual(
+      stabilizeRelations(
+        { accounts: [{ id: 3 }, { id: 4 }] },
+        "User",
+        registry,
+        viaSelect,
+      ),
     );
   });
 });

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -2417,10 +2417,17 @@ function suite(label: string, url?: string) {
      * Fixing any of them is a compiler change, in files this suite does not own.
      * Deleting the case is what closing the bug looks like: it graduates into
      * `CASES` and the harness takes over from the prose.
+     *
+     * Each carries its issue number, and that is the half a test cannot do for
+     * itself. #354 closes when this PR merges, so without them the only record
+     * of these two would be this describe — findable by someone already reading
+     * the file, and by nobody reading the tracker. The issues carry the
+     * measurement and point back here; this points forward. Neither is enough
+     * alone.
      */
     describe("where the two clients still disagree — each of these is a bug", () => {
       /**
-       * **BUG 1 — owning-side `disconnect: false`.**
+       * **BUG 1 (#359) — owning-side `disconnect: false`.**
        *
        * #354 made the *foreign* side take a boolean (M5b above, which passes).
        * The owning side still refuses anything but `true`. Prisma's owning-side
@@ -2445,7 +2452,7 @@ function suite(label: string, url?: string) {
       });
 
       /**
-       * **BUG 2 — `create` on a to-one that already has a child.**
+       * **BUG 2 (#360) — `create` on a to-one that already has a child.**
        *
        * Prisma **detaches** the existing child first: the old row survives with
        * a null foreign key and the new one takes the link. gemi inserts without

--- a/templates/saas-starter/prisma/differential.prisma
+++ b/templates/saas-starter/prisma/differential.prisma
@@ -118,6 +118,9 @@ model User {
   session            Session[]
   passwordResetToken PasswordResetToken[]
   socialAccount      SocialAccount[]
+  // The foreign side of a to-one — see `model Profile` below. Every other
+  // relation on this model is a list.
+  profile            Profile?
 
   @@index([organizationId])
 }
@@ -203,6 +206,27 @@ model Membership {
   createdAt      DateTime @default(now())
 
   @@id([organizationId, userId])
+}
+
+// A to-one whose foreign key lives on the **child**, which this schema had none
+// of — every child-side relation here is a list. So the foreign side of a
+// nested write was only ever reachable with `kind: "many"`, and nothing in this
+// harness could ask Prisma what `update`, `upsert`, `delete` or `disconnect`
+// does through a relation that holds one row. That gap is why #116 went
+// unnoticed for as long as it did, and it is the shape #354 is measured
+// against: the answers below (P2025 or no-op, and on which operand) cannot be
+// reasoned out, only run.
+//
+// `userId` is nullable **on purpose**. Prisma omits `disconnect` from the
+// nested input type entirely when the foreign key is required, so a required
+// one would leave that operand unreachable — the same "the harness cannot get
+// there" problem one level down. Nullable makes all four operands reachable at
+// once, and the required-FK refusal is asserted against the fixtures instead.
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  userId Int?    @unique
+  user   User?   @relation(fields: [userId], references: [id])
 }
 
 model MagicLinkToken {

--- a/templates/saas-starter/prisma/migrations/20260807120000_profile_to_one/migration.sql
+++ b/templates/saas-starter/prisma/migrations/20260807120000_profile_to_one/migration.sql
@@ -1,0 +1,28 @@
+-- A to-one whose foreign key is on the child, so the differential harness has
+-- one to compare against Prisma. Every other child-side relation in this schema
+-- is a list, which is why the foreign side of a nested write was never measured.
+--
+-- Not hand-written: this is verbatim what
+--
+--     prisma migrate diff --from-schema-datamodel <the schema before Profile> \
+--                         --to-schema-datamodel prisma/schema.prisma --script
+--
+-- emits for SQLite on prisma 6.19.2. Two details are worth naming because they
+-- are the ones a hand-written version gets wrong. A nullable relation field
+-- gets `ON DELETE SET NULL`, not the `ON DELETE RESTRICT` that the required
+-- relations in the earlier migrations here carry — so deleting a User orphans
+-- its Profile rather than refusing. And the single-field `@unique` becomes a
+-- unique index named `<Table>_<column>_key`, which is also what covers the
+-- foreign key for `foreign-key-indexes.test.ts`: no separate `@@index` is
+-- needed, and adding one would be a second index over the same column.
+
+-- CreateTable
+CREATE TABLE "Profile" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "bio" TEXT,
+    "userId" INTEGER,
+    CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId");

--- a/templates/saas-starter/prisma/schema.prisma
+++ b/templates/saas-starter/prisma/schema.prisma
@@ -120,6 +120,9 @@ model User {
   session            Session[]
   passwordResetToken PasswordResetToken[]
   socialAccount      SocialAccount[]
+  // The foreign side of a to-one — see `model Profile` below. Every other
+  // relation on this model is a list.
+  profile            Profile?
 
   @@index([organizationId])
 }
@@ -205,6 +208,27 @@ model Membership {
   createdAt      DateTime @default(now())
 
   @@id([organizationId, userId])
+}
+
+// A to-one whose foreign key lives on the **child**, which this schema had none
+// of — every child-side relation here is a list. So the foreign side of a
+// nested write was only ever reachable with `kind: "many"`, and nothing in this
+// harness could ask Prisma what `update`, `upsert`, `delete` or `disconnect`
+// does through a relation that holds one row. That gap is why #116 went
+// unnoticed for as long as it did, and it is the shape #354 is measured
+// against: the answers below (P2025 or no-op, and on which operand) cannot be
+// reasoned out, only run.
+//
+// `userId` is nullable **on purpose**. Prisma omits `disconnect` from the
+// nested input type entirely when the foreign key is required, so a required
+// one would leave that operand unreachable — the same "the harness cannot get
+// there" problem one level down. Nullable makes all four operands reachable at
+// once, and the required-FK refusal is asserted against the fixtures instead.
+model Profile {
+  id     Int     @id @default(autoincrement())
+  bio    String?
+  userId Int?    @unique
+  user   User?   @relation(fields: [userId], references: [id])
 }
 
 model MagicLinkToken {


### PR DESCRIPTION
Closes #354, closes #355, closes #356, closes #357.

Four defects reported from the first Prisma application ported onto the ORM. Two are missing implementations that make ported code fail at run time; two are silent divergences where the port compiles, passes its whole suite, and breaks only under conditions the tests do not reproduce. They land together because they overlap in the files they touch — `docs/orm.md`, `UPGRADE.md`, `orm/index.ts` and two test files are each touched by more than one.

## #354 — a to-one whose foreign key is on the child

`planForeignSide` refused `update` / `delete` / `upsert` by name whenever `relation.kind !== "many"`, so Prisma's ordinary one-to-one had no supported spelling for any of them.

It turned out to be translation rather than implementation. `conjoin` already returns the parent restriction alone when the caller's filter is absent, and `listOf(null)` is `[]` — so **a to-one is a to-many of one**, and the existing step bodies are already correct. `toOneOperand` rewrites the spellings and the operands fall through to them:

| operand | normalises to |
| --- | --- |
| `update: <data>` / `{ data }` / `{ where?, data }` | `{ where, data }` |
| `upsert: { create, update, where? }` | `{ where, create, update }` |
| `delete` / `disconnect`: `true` | `{}` — the link alone |
| `delete` / `disconnect`: `false` | `null` — no statement |
| `delete` / `disconnect`: `<filter>` | itself |

Measured off the generated client rather than reasoned about: `ProfileUpdateToOneWithWhereWithoutUserInput` carries an **optional** `where` and it is a `WhereInput`, not a unique key — so `assertNamedRows` cannot serve this path and `assertToOneFilter` replaces it there. A miss raises `RecordNotFoundError`, since Prisma answers P2025 and the differential harness compares failures by *kind*; the to-many refusal would have classified as `other` and scored a refusal as agreement with a miss.

### Three adjacent defects in the same code

- **A live wrong write.** `canonicalShape` records a non-literal boolean as `"boolean"` and `disconnect` is not in `LITERAL_KEYS`, so `disconnect: true` and `disconnect: false` shared one plan entry. The owning side refuses `false` at compile time and then pushes a constant `() => null` — so a cached `true` plan served `false` and **nulled the foreign key on a call that asked for nothing**, because the compile-time refusal never re-runs on a cache hit. Same bug class `LITERAL_KEYS` already documents for `omit` and `skipDuplicates`; it cannot join that set, which matches by name at any depth and would record a to-many `disconnect: { id: 1 }` verbatim, so the guard is boolean-only.
- **`disconnect: true` on the foreign side** was refused by `assertNamedRows` with a message about unique keys. Same operand family, closed by the same normaliser.
- **Arrays on a to-one** — `create: [...]`, `connect: [...]` and `connectOrCreate: [...]` compiled and wrote or repointed several rows through a relation that holds one.

`templates/saas-starter` had no to-one whose key is on the child — every child-side relation there is a list, which is exactly why #116 never reached this path — so `Profile` joins the schema with a nullable `@unique userId`, making all four operands reachable. Its migration is `prisma migrate diff` output, not hand-written.

## #355 — `update` with an empty `data`

Refused where Prisma reads the row back. The relation-only branch already emits the exact select this needs, through the same `plan()` call, honouring `select` / `include` / `_count`, with `ORTHROW` still raising on a miss. The fix deletes a condition.

`updateMany({ data: {} })` is measured and matched rather than documented away: `{ count: 0 }` as a **constant**, verified against a filter matching two of three rows, one matching none, and no `where` at all.

## #356 — the fractional `take` divergence had no porter-facing surface

**The refusal is unchanged and correct.** What was missing was any way to find the call sites it breaks: `tsc` cannot express "integer", every unit test passes integer literals, and the failing input is external. `paginate()` ships from `gemi/orm`, taking `unknown` because a query string is where the values come from, truncating and clamping so its output *cannot* be a value `assertPageArgument` refuses — asserted by running the real validator over a table of hostile inputs.

gemi's own documentation taught the breaking shape: `docs/routing.md`, `docs/controllers.md`, `docs/navigation.md` and `PartialRenderController` all carried `Number(req.search.get("limit")) || 25`. All four are rewritten. The divergence note now names that shape and the `page`-reaches-the-ORM-multiplied case, and the stale error block quoting `UnsupportedQueryError` is replaced by the `InvalidArgumentError` the code actually throws.

## #357 — the error taxonomy switches silently

`errors.ts` argued against mirroring `P2002` from the premise that *"nothing in this repository does (checked)"*. True of this repo, false of the applications it is for: a real port had four such guards, all in concurrency-recovery code, all dead after the switch — no type error, no runtime error, no test failure (the tests inject `{ code: "P2002" }`, which production no longer produces), and no symptom until the race. The conclusion stands; the premise is restated.

`isUniqueConstraintError` ships — `instanceof` **or** the name, which is why it is worth shipping over telling people to write `instanceof`: it survives duplicate module copies, the actual reason the ported app duck-typed. The `|| code === "P2002"` bridge for the mid-port window is documented in `UPGRADE.md` with a delete-when-done marker and deliberately **not** exported.

`bunx gemi migrate` gains two annotation passes — a `"P2002"` literal beside a model import, and a non-integer-literal `take` / `skip`.

## `@updatedAt` follows the column, not the call

Found by adversarial review of the above, then measured directly by seeding the column to the epoch and reading it back (Prisma 6.19.2, SQLite):

| call | Prisma |
| --- | --- |
| `data: {}` | epoch — not stamped |
| `data: { profile: { create: … } }` | epoch — not stamped |
| `upsert` hit, `update: {}` | epoch — not stamped |
| `updateMany({ data: {} })` | epoch, `{ count: 0 }` |
| `data: { name: "real" }` | **stamped** |
| `data: { organization: { connect: … } }` | **stamped** |

Stamping unconditionally was load-bearing in the wrong direction twice. It made #355's read dead on every model carrying the attribute — the majority case, and the one the issue was filed from — because the stamp *was* the assignment keeping the count off zero. And it put a timestamp Prisma does not write on every nested to-one write #354 adds, where the differential harness could not see it: `updatedAt` is volatile, so both sides compare as the descriptor `"date"` and two different instants match. **Six tests failed on the fix, and all six had been pinning gemi's divergence as though it were the specification.**

An owning-side `disconnect` stamps here and does not in Prisma, whose `connect` one operand over does. That is Prisma disagreeing with itself; matching it would mean special-casing one operand to reproduce an inconsistency. Recorded as a known divergence instead.

## Still open, pinned rather than described

Each asserts **both** clients' answers, so it fails the day either side moves:

- the owning side takes only `disconnect: true`, where Prisma also takes `false` and a filter;
- `create` on an occupied to-one collides, where Prisma detaches the incumbent.

## One judgement call worth a look

`expectSameWrite` now compares relation arrays as a multiset rather than positionally. Neither client emits an `ORDER BY` and Postgres relocates an updated tuple, so the positional assertion was passing on physical storage order and had begun failing at random. It is scoped to schema-declared relations, so Json arrays and scalar lists keep their ordered comparison, and a test pins that a genuinely different *set* still fails. It is the one assertion in this diff that got **smaller**.

## Verification

| | |
| --- | --- |
| `packages/gemi` | 3,014 passed |
| `templates/saas-starter` (SQLite) | 739 passed |
| Postgres (`app/models/postgres.sh`) | 1,116 passed |
| `tsc --noEmit` | clean |
| `oxlint orm/ bin/migrate/` | 0 warnings, 0 errors |

Every measurement is pinned as a differential case against a real Prisma client, so each answer is checked rather than remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
