### PR TITLE
Close #359, #360 and #361: the owning side's disconnect grammar, and writing onto an occupied to-one

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3884,7 +3884,7 @@ await List.create({
 | --- | --- |
 | `create` | Writes new related rows. One statement each. On a **to-one that already has a child** the new row takes the link and the old one is detached — orphaned, not deleted. |
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
-| `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
+| `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. On a **to-one that already has a child** it displaces the incumbent, as `create` does. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
 | `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true`, `false` or a filter on a to-one, whichever side holds the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
 | `delete` | Deletes the named rows outright, not just the link. A unique key or a list of them on a to-many; `true`, or a filter, on a to-one whose child holds the key. |
@@ -3969,16 +3969,29 @@ With no policy on the child that is Prisma's `set` exactly. Two of its behaviour
 because the name does not suggest them — it will repoint a row belonging to another parent, exactly
 as `connect` does, and it silently ignores a named row that does not exist.
 
-**A nested `create` on a to-one that already has a child displaces it.** The new row takes the link
-and the incumbent is left in the table with a null foreign key — detached, not deleted, which is
-Prisma's answer and the one worth stating because deleting would be the silent version of the same
-call. What it can displace is what your policies let you see: an incumbent hidden from you is not
-detached, and the insert then collides with it on the child's unique key. `connectOrCreate` and
-`upsert` do *not* displace — they collide, on both clients — so the behaviour belongs to `create`
-rather than to the relation.
+**Writing onto a to-one that already has a child displaces it.** The new or newly-linked row takes
+the link and the incumbent is left in the table with a null foreign key — detached, not deleted,
+which is Prisma's answer and the one worth stating because deleting would be the silent version of
+the same call. What can be displaced is what your policies let you see: an incumbent hidden from you
+is not detached, and the write then collides with it on the child's unique key.
 
-`connect` onto an occupied to-one is the gap in that sentence: Prisma displaces there too, and gemi
-raises `UniqueConstraintError` instead. Detach the incumbent first, or write the child's foreign key
+Which operands displace is Prisma's, measured rather than derived, and it is not "everything that
+ends with a child pointing here":
+
+| operand | on an occupied to-one |
+| --- | --- |
+| `create` | displaces the incumbent |
+| `connect` | displaces the incumbent |
+| `connectOrCreate`, hit | displaces — it *is* a connect |
+| `connectOrCreate`, miss | collides on the child's unique key |
+| `upsert`, create branch | collides on the child's unique key |
+
+So the two branches of one `connectOrCreate` answer differently: linking an existing row displaces,
+and the `create` *inside* a compound operand does not, though a bare `create` does.
+
+One gap remains, on the other side of the key: pointing **this** row at a partner who already has
+one — `Profile.update({ data: { user: { connect: { id } } } })` where that user's profile is taken —
+collides here and displaces in Prisma. Detach the incumbent first, or write the foreign key
 directly.
 
 **On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3882,11 +3882,11 @@ await List.create({
 
 | Operand | What it does |
 | --- | --- |
-| `create` | Writes new related rows. One statement each. |
+| `create` | Writes new related rows. One statement each. On a **to-one that already has a child** the new row takes the link and the old one is detached — orphaned, not deleted. |
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
 | `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
-| `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true` on a to-one, and a filter as well when the child is the side holding the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
+| `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true`, `false` or a filter on a to-one, whichever side holds the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
 | `delete` | Deletes the named rows outright, not just the link. A unique key or a list of them on a to-many; `true`, or a filter, on a to-one whose child holds the key. |
 | `update` | Writes your columns to the named row. The child's own `onUpdate` and scope rules apply to the payload. |
 | `set` | Replaces the whole set — detaches what is linked now, attaches what you name. |
@@ -3969,6 +3969,18 @@ With no policy on the child that is Prisma's `set` exactly. Two of its behaviour
 because the name does not suggest them — it will repoint a row belonging to another parent, exactly
 as `connect` does, and it silently ignores a named row that does not exist.
 
+**A nested `create` on a to-one that already has a child displaces it.** The new row takes the link
+and the incumbent is left in the table with a null foreign key — detached, not deleted, which is
+Prisma's answer and the one worth stating because deleting would be the silent version of the same
+call. What it can displace is what your policies let you see: an incumbent hidden from you is not
+detached, and the insert then collides with it on the child's unique key. `connectOrCreate` and
+`upsert` do *not* displace — they collide, on both clients — so the behaviour belongs to `create`
+rather than to the relation.
+
+`connect` onto an occupied to-one is the gap in that sentence: Prisma displaces there too, and gemi
+raises `UniqueConstraintError` instead. Detach the incumbent first, or write the child's foreign key
+directly.
+
 **On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather
 than a synonym for `true`.** There is one row and nothing to name, so `true` is how you say *the
 one that is linked*. A filter narrows rather than picks: `delete: { status: "draft" }` acts only if
@@ -3982,11 +3994,23 @@ than a choice gemi made: `delete` raises `RecordNotFoundError` when there is no 
 `disconnect` is silent. That holds whichever way the row went missing — no child linked at all, or a
 child present that the filter does not match, or a child your policies hide, which reads as no row
 at all here exactly as it does everywhere else. Note the last one carries a different error from its
-to-many spelling, which reports a hidden row as *not connected*. On the side that holds the foreign
-key *itself* there is nothing to filter — the row being cleared is the one the statement already
-names — so `disconnect` takes `true` alone there, and a `false` is refused rather than ignored. That
-last one is a divergence: Prisma treats it as the no-op it reads like. It is a loud refusal on the
-branch that asked for nothing, which is the wrong answer given noisily rather than quietly.
+to-many spelling, which reports a hidden row as *not connected*.
+
+**All three arms work on either side of the key**, and the side that holds it reaches them
+differently. Where the key is on the row you are writing, `true` is one bound column set to null and
+costs nothing; `false` writes nothing at all; a filter has to read the linked row before it can
+decide, so it costs a lookup — and that lookup goes through the far model's own policies, which
+means a linked row you cannot see reads as one that does not match and the link survives. `true` has
+no lookup to scope, so it clears the column either way. That difference is worth knowing before you
+reach for the filter to enforce something: it narrows *whether* the detach happens, and a policy can
+narrow it further.
+
+One divergence, and it is deliberate. On a **many-to-one** — a to-one whose other side is a list —
+Prisma ignores this operand's value: `disconnect: false` and a filter matching nothing both clear
+the key, though the generated input type is the same `WhereInput | boolean` it honours on a
+one-to-one. gemi answers one grammar the same way on both shapes, because the behaviour to match is
+a silent write on the call that asked for nothing. So `disconnect: shouldDetach` is safe here and is
+not safe through the Prisma client.
 
 **An array is refused on a to-one whose child holds the key** — `create`, `connect`,
 `connectOrCreate`, `update`, `delete` and `upsert` alike — and that is matching Prisma rather than

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -901,7 +901,7 @@ await List.create({
 | --- | --- |
 | `create` | Writes new related rows. One statement each. On a **to-one that already has a child** the new row takes the link and the old one is detached — orphaned, not deleted. |
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
-| `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
+| `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. On a **to-one that already has a child** it displaces the incumbent, as `create` does. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
 | `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true`, `false` or a filter on a to-one, whichever side holds the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
 | `delete` | Deletes the named rows outright, not just the link. A unique key or a list of them on a to-many; `true`, or a filter, on a to-one whose child holds the key. |
@@ -986,16 +986,29 @@ With no policy on the child that is Prisma's `set` exactly. Two of its behaviour
 because the name does not suggest them — it will repoint a row belonging to another parent, exactly
 as `connect` does, and it silently ignores a named row that does not exist.
 
-**A nested `create` on a to-one that already has a child displaces it.** The new row takes the link
-and the incumbent is left in the table with a null foreign key — detached, not deleted, which is
-Prisma's answer and the one worth stating because deleting would be the silent version of the same
-call. What it can displace is what your policies let you see: an incumbent hidden from you is not
-detached, and the insert then collides with it on the child's unique key. `connectOrCreate` and
-`upsert` do *not* displace — they collide, on both clients — so the behaviour belongs to `create`
-rather than to the relation.
+**Writing onto a to-one that already has a child displaces it.** The new or newly-linked row takes
+the link and the incumbent is left in the table with a null foreign key — detached, not deleted,
+which is Prisma's answer and the one worth stating because deleting would be the silent version of
+the same call. What can be displaced is what your policies let you see: an incumbent hidden from you
+is not detached, and the write then collides with it on the child's unique key.
 
-`connect` onto an occupied to-one is the gap in that sentence: Prisma displaces there too, and gemi
-raises `UniqueConstraintError` instead. Detach the incumbent first, or write the child's foreign key
+Which operands displace is Prisma's, measured rather than derived, and it is not "everything that
+ends with a child pointing here":
+
+| operand | on an occupied to-one |
+| --- | --- |
+| `create` | displaces the incumbent |
+| `connect` | displaces the incumbent |
+| `connectOrCreate`, hit | displaces — it *is* a connect |
+| `connectOrCreate`, miss | collides on the child's unique key |
+| `upsert`, create branch | collides on the child's unique key |
+
+So the two branches of one `connectOrCreate` answer differently: linking an existing row displaces,
+and the `create` *inside* a compound operand does not, though a bare `create` does.
+
+One gap remains, on the other side of the key: pointing **this** row at a partner who already has
+one — `Profile.update({ data: { user: { connect: { id } } } })` where that user's profile is taken —
+collides here and displaces in Prisma. Detach the incumbent first, or write the foreign key
 directly.
 
 **On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -899,11 +899,11 @@ await List.create({
 
 | Operand | What it does |
 | --- | --- |
-| `create` | Writes new related rows. One statement each. |
+| `create` | Writes new related rows. One statement each. On a **to-one that already has a child** the new row takes the link and the old one is detached — orphaned, not deleted. |
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
 | `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
-| `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true` on a to-one, and a filter as well when the child is the side holding the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
+| `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true`, `false` or a filter on a to-one, whichever side holds the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
 | `delete` | Deletes the named rows outright, not just the link. A unique key or a list of them on a to-many; `true`, or a filter, on a to-one whose child holds the key. |
 | `update` | Writes your columns to the named row. The child's own `onUpdate` and scope rules apply to the payload. |
 | `set` | Replaces the whole set — detaches what is linked now, attaches what you name. |
@@ -986,6 +986,18 @@ With no policy on the child that is Prisma's `set` exactly. Two of its behaviour
 because the name does not suggest them — it will repoint a row belonging to another parent, exactly
 as `connect` does, and it silently ignores a named row that does not exist.
 
+**A nested `create` on a to-one that already has a child displaces it.** The new row takes the link
+and the incumbent is left in the table with a null foreign key — detached, not deleted, which is
+Prisma's answer and the one worth stating because deleting would be the silent version of the same
+call. What it can displace is what your policies let you see: an incumbent hidden from you is not
+detached, and the insert then collides with it on the child's unique key. `connectOrCreate` and
+`upsert` do *not* displace — they collide, on both clients — so the behaviour belongs to `create`
+rather than to the relation.
+
+`connect` onto an occupied to-one is the gap in that sentence: Prisma displaces there too, and gemi
+raises `UniqueConstraintError` instead. Detach the incumbent first, or write the child's foreign key
+directly.
+
 **On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather
 than a synonym for `true`.** There is one row and nothing to name, so `true` is how you say *the
 one that is linked*. A filter narrows rather than picks: `delete: { status: "draft" }` acts only if
@@ -999,11 +1011,23 @@ than a choice gemi made: `delete` raises `RecordNotFoundError` when there is no 
 `disconnect` is silent. That holds whichever way the row went missing — no child linked at all, or a
 child present that the filter does not match, or a child your policies hide, which reads as no row
 at all here exactly as it does everywhere else. Note the last one carries a different error from its
-to-many spelling, which reports a hidden row as *not connected*. On the side that holds the foreign
-key *itself* there is nothing to filter — the row being cleared is the one the statement already
-names — so `disconnect` takes `true` alone there, and a `false` is refused rather than ignored. That
-last one is a divergence: Prisma treats it as the no-op it reads like. It is a loud refusal on the
-branch that asked for nothing, which is the wrong answer given noisily rather than quietly.
+to-many spelling, which reports a hidden row as *not connected*.
+
+**All three arms work on either side of the key**, and the side that holds it reaches them
+differently. Where the key is on the row you are writing, `true` is one bound column set to null and
+costs nothing; `false` writes nothing at all; a filter has to read the linked row before it can
+decide, so it costs a lookup — and that lookup goes through the far model's own policies, which
+means a linked row you cannot see reads as one that does not match and the link survives. `true` has
+no lookup to scope, so it clears the column either way. That difference is worth knowing before you
+reach for the filter to enforce something: it narrows *whether* the detach happens, and a policy can
+narrow it further.
+
+One divergence, and it is deliberate. On a **many-to-one** — a to-one whose other side is a list —
+Prisma ignores this operand's value: `disconnect: false` and a filter matching nothing both clear
+the key, though the generated input type is the same `WhereInput | boolean` it honours on a
+one-to-one. gemi answers one grammar the same way on both shapes, because the behaviour to match is
+a silent write on the call that asked for nothing. So `disconnect: shouldDetach` is safe here and is
+not safe through the Prisma client.
 
 **An array is refused on a to-one whose child holds the key** — `create`, `connect`,
 `connectOrCreate`, `update`, `delete` and `upsert` alike — and that is matching Prisma rather than

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -9,6 +9,7 @@ import type { Binder } from "./fragment";
 import {
   type Link,
   type NestedWriteStep,
+  type RelationExecutor,
   relatedSchema,
   resolveLink,
   singleFieldLink,
@@ -423,13 +424,36 @@ function planOwningSide(
    * one row to point at, and Prisma refuses an array here too.
    */
   /**
-   * `disconnect: true` on a to-one — clear the foreign key this row holds.
+   * `disconnect` on a to-one whose key is on **this** row — the same three arms
+   * the foreign side takes, through the same two helpers (#359).
    *
-   * No step at all: the key lives on this row, so it is one more bound column
-   * set to `null`, exactly as `connect`'s direct form is one bound column set
-   * to a value. Nothing on the child is read or written, which is why there is
-   * no scoping question on this side — the row being changed is the one the
-   * statement already names.
+   * Prisma's operand here is `XWhereInput | boolean`, read off the generated
+   * client and measured against it:
+   *
+   *     disconnect: true                    clears the link
+   *     disconnect: false                   nothing happens, the link survives
+   *     disconnect: {}                      clears it — the empty filter matches
+   *     disconnect: { name: "Ada" }         clears it only if the linked row matches
+   *     disconnect: { name: "Grace" }       no match, so nothing happens — and
+   *                                         **silently**, not P2025
+   *     disconnect: <filter>, nothing linked   silently nothing
+   *
+   * The silence in the last two is what makes the filter arm a *conditional*
+   * detach rather than a guarded one: there is no miss to report, which is the
+   * same asymmetry the foreign side measured between `disconnect` and `delete`
+   * (M8c). So the arms differ only in what decides the value of one column.
+   *
+   * **The boolean is structural here, where the foreign side re-reads it at
+   * bind time**, and that difference is forced rather than chosen. The foreign
+   * side's operands are *statements* — `listOf(null)` is no statement — so a
+   * plan handed the wrong boolean can still write nothing. This side's is a
+   * *column in the SET list*: `false` emits no assignment and `true` emits one,
+   * so the two spellings cannot share a statement text and no bind-time check
+   * could rescue a cache hit that got it wrong. What makes that sound is
+   * `shapeOfMember`'s guard (#358), which gives a `disconnect` boolean its own
+   * plan key precisely because this decision is made once, at compile time.
+   * Before it, a plan compiled from `true` served `false` and nulled a foreign
+   * key on a call that asked for nothing.
    *
    * `delete` has no meaning here for the same reason it has no `createMany`:
    * this side is a to-one, and deleting the far row through a `data` key would
@@ -438,33 +462,114 @@ function planOwningSide(
    * of an unrelated update is the kind of thing to implement deliberately.
    */
   if (key === "disconnect") {
+    // Before the arms, so a required foreign key is refused whichever one was
+    // spelled — including `false`, which asks for nothing and still cannot be
+    // written. Prisma agrees for a reason of its own: it leaves `disconnect`
+    // out of the input type entirely when the relation is required, so
+    // `disconnect: false` there is *"Unknown argument `disconnect`"* rather
+    // than an accepted no-op. Measured on `SocialAccount.user`.
     assertDisconnectable(schema, relation, fkField, {
       model: schema.name,
       operation,
       argument: `data.${relation.name}.disconnect`,
     });
 
-    // MEASURED, and narrower than what this used to claim: Prisma's owning-side
-    // operand is `XWhereInput | boolean`, so it takes `true`, `false` (a no-op —
-    // the row keeps its link) and a filter. gemi implements the `true` arm only.
-    // The message says that rather than asserting Prisma offers nothing else,
-    // which is what it said before the foreign side was measured and is
-    // contradicted by this repository's own differential suite one directory
-    // over. The gap is real but it is a gap, not the shape of the input.
-    if (operand !== true) {
-      throw new UnsupportedQueryError(
-        `data.${relation.name}.disconnect`,
-        schema.name,
-        operation,
-        `'${relation.name}' is a to-one whose foreign key lives on this row, ` +
-          `and only 'disconnect: true' is implemented for it — that clears ` +
-          `the link. Prisma also accepts 'false', which does nothing, and a ` +
-          `filter; neither is implemented here yet. Pass 'true', or skip the ` +
-          `operand entirely on the branch that should not detach.`,
-      );
+    // `true` -> `{}`, `false` -> `null`, a filter passes through: the same
+    // translation and the same shape check the foreign side runs, reused rather
+    // than restated so the two sides cannot answer one grammar differently
+    // again — which is the defect #359 was filed for.
+    const filter = toOneOperand(key, operand);
+    assertToOneFilter(schema, relation, child, filter, key, operation);
+
+    // `false` — no contribution and no step, so the operand contributes
+    // *nothing at all*: a `data` carrying only this compiles to the read
+    // `compileUpdate` emits for an empty assignment list, and the row comes
+    // back with its link intact. That is Prisma's answer, and the reason the
+    // differential asserts it by value: what this replaces was a write.
+    if (filter === null || filter === undefined) return;
+
+    /**
+     * `true` — one bound column set to `null`, exactly as `connect`'s direct
+     * form is one bound column set to a value. No step, nothing on the child
+     * read or written, and so no scoping question: the row being changed is
+     * the one the statement already names.
+     */
+    if (operand === true) {
+      out.contributions.push({ field: fkField, value: () => null });
+      return;
     }
 
-    out.contributions.push({ field: fkField, value: () => null });
+    /**
+     * A filter — detach only if the row this one points at matches it.
+     *
+     * Two reads, and neither is avoidable from this side. The condition is a
+     * property of the *linked* row, and which row that is lives in a column of
+     * the row being updated, which the arguments do not carry — so the parent
+     * is read first and the child second. The far side needs neither: its
+     * filter goes straight into the `where` of the `updateMany` that clears the
+     * key, because there the key is on the row being filtered.
+     *
+     * **The child read goes through the child's own `$exec`, un-pre-scoped**,
+     * which is what puts this operand on the supported side of this file's
+     * line. A `disconnect` that acts on "whatever is there" has no lookup to
+     * hang a scope on; this one has, so a child the caller's policies hide
+     * reads as absent and the link survives — the same conservative answer
+     * `set` gives, and the same one the foreign side's `disconnect` gives for a
+     * hidden row.
+     *
+     * The parent read is **pre-scoped**: `args.where` is the effective `where`
+     * this call already put through this model's policies, so re-applying them
+     * would `AND` the same predicate twice. It reads one column of one row —
+     * `update` matched its `where` against a unique key — inside the
+     * transaction the nested steps already run in, so the value it returns is
+     * the one the statement below is about to write over.
+     */
+    out.before.push({
+      relation: relation.name,
+      operation: "disconnect",
+      async run(args, context, executor) {
+        // Default to the value that is already there, so a filter that matches
+        // nothing writes the column back unchanged. The contribution is in the
+        // SET list either way — the statement's text cannot depend on a value
+        // read at bind time — so "nothing happens" has to be spelled as an
+        // assignment that changes nothing rather than as an absent one.
+        context.resolved[fkField] = null;
+
+        const parent = (await executor.exec(
+          schema.name,
+          "findFirst",
+          { where: args?.where, select: { [fkField]: true } },
+          true,
+        )) as Record<string, unknown> | null;
+
+        const linked = parent?.[fkField];
+        // Nothing linked: no row for the filter to match, and Prisma is silent
+        // about it. `null` is already what the column holds.
+        if (linked === null || linked === undefined) return;
+
+        context.resolved[fkField] = linked;
+
+        const matched = await executor.exec(
+          relation.model,
+          "findFirst",
+          {
+            // `AND`, not a spread: a filter naming the referenced column itself
+            // must narrow rather than replace the restriction that keeps this
+            // on the linked row. Same rule as everywhere else here.
+            where: conjoin(at(args), { [referenced]: linked }),
+            select: { [referenced]: true },
+          },
+          false,
+        );
+
+        if (matched) context.resolved[fkField] = null;
+      },
+    });
+
+    out.contributions.push({
+      field: fkField,
+      value: (_args, context) => context.resolved[fkField],
+    });
     return;
   }
 
@@ -968,6 +1073,16 @@ function planForeignSide(
    * the scope-escape guard, because it cannot tell a column the ORM wrote from
    * one the caller did. #99 fixes that for every relation operand at once, and
    * this needs no change when it lands.
+   *
+   * **The clearing half stopped inheriting it and the linking half must not,
+   * which is measured rather than tidy.** `clearLinks` names the column as the
+   * ORM's, because a nested `create` on an occupied to-one needs the same clear
+   * and would otherwise be refused for a write nobody made. Naming it on the
+   * *link* too makes `set` succeed — and succeed wrongly: the clear nulls the
+   * key, which puts the row outside the very scope (`{ folderId: 2 }`) the link
+   * then has to select it by, so the row is detached and never re-attached. A
+   * silent half-write in place of a loud refusal. Left refused until #99 can
+   * answer the scope as well as the guard.
    */
   /**
    * `updateMany` and `deleteMany` — a **filter**, applied to this parent's rows.
@@ -1159,24 +1274,7 @@ function planForeignSide(
 
         const parentKey = parent[parentField];
 
-        // Everything currently linked *that this caller can see*. Not
-        // pre-scoped, which is the whole mechanism: the child's own policies
-        // decide what "currently linked" means for this caller.
-        const linked = (await executor.exec(
-          relation.model,
-          "findMany",
-          { where: { [childField]: parentKey }, select: { [childField]: true } },
-          false,
-        )) as Record<string, unknown>[];
-
-        if (linked.length > 0) {
-          await executor.exec(
-            relation.model,
-            "updateMany",
-            { where: { [childField]: parentKey }, data: { [childField]: null } },
-            false,
-          );
-        }
+        await clearLinks(relation, childField, parentKey, executor);
 
         for (const entry of listOf(at(args))) {
           await executor.exec(
@@ -1394,7 +1492,50 @@ function planForeignSide(
     return;
   }
 
+  /**
+   * `create` — insert the child, with this row's key stamped onto it.
+   *
+   * **On a to-one the new row has to displace the old one, and Prisma
+   * *detaches* the incumbent rather than deleting it** (#360). Measured, with
+   * user 1 already carrying a profile:
+   *
+   *     user.update({ data: { profile: { create: { bio: "second" } } } })
+   *       ->  ("seed",   null)   the incumbent, orphaned and still in the table
+   *           ("second", 1)      the new row takes the link
+   *
+   * The orphaning is the half that is not guessable, and getting it wrong in
+   * the other direction — deleting the displaced row — is silent data loss
+   * wearing the same green test. So the differential reads the table back
+   * rather than only checking that the call returned.
+   *
+   * Without the detach the insert simply collides: the child's foreign key
+   * carries the `@unique` that makes the relation a to-one, so this was a
+   * `UniqueConstraintError` on a call Prisma answers. `create` survived #354
+   * because that change was about the operands refused *by name* on this side,
+   * and `create` was never one of them — against an *empty* to-one it has
+   * always been correct, and no fixture had a to-one whose key is on the child
+   * until #358 added one.
+   *
+   * **`clearLinks`, so the scoping consequence is the same one `set` has** —
+   * which is why the two share it. A child hidden by the caller's policies is
+   * not detached, and the incumbent then wins the unique key: a
+   * `UniqueConstraintError` rather than a silent detach of a row the caller
+   * cannot see. Conservative in the direction this file always chooses.
+   *
+   * Only on a to-one, and only where the key is nullable:
+   *
+   *   - a to-many displaces nothing, and clearing every child before a nested
+   *     `create` would be a `set: []` nobody asked for;
+   *   - a **required** child key has no value to leave behind, so there is no
+   *     detach to run — the insert collides, which is what happens today and
+   *     the only thing the schema permits. `assertDisconnectable` is not
+   *     reached here for the same reason: it would refuse the whole `create`,
+   *     including the empty-to-one case that works.
+   */
   if (key === "create") {
+    const displaces =
+      relation.kind !== "many" && child.fields[childField]?.nullable === true;
+
     out.after.push({
       relation: relation.name,
       operation: "create",
@@ -1403,6 +1544,17 @@ function planForeignSide(
         // No row means the statement matched nothing; `update` and `delete`
         // raise before this runs, so there is nothing to attach to.
         if (!parent) return;
+
+        // Runs on a parent `create` too, where nothing can be linked yet and it
+        // finds nothing. Deliberately not skipped by operation: gemi does not
+        // enable SQLite's foreign-key pragma, so "a row that was just inserted
+        // has no children" is a property of the database's enforcement rather
+        // than of the ORM — and a correctness argument resting on a pragma is
+        // the kind that holds until someone reads it. One read, on a path that
+        // already runs several.
+        if (displaces) {
+          await clearLinks(relation, childField, parent[parentField], executor);
+        }
 
         for (const item of listOf(at(args))) {
           await executor.exec(
@@ -2105,6 +2257,54 @@ function conjoin(
     return restriction;
   }
   return { AND: [filter as object, restriction] };
+}
+
+/**
+ * Detach every child currently pointing at this parent **that the caller can
+ * see** — the clearing half of `set`, and the same half a nested `create` on an
+ * occupied to-one needs before it can insert (#360).
+ *
+ * Shared rather than written twice because the *scoping* is the interesting
+ * part and it has to be identical on both: the read goes through the child's
+ * own `findMany` un-pre-scoped, so a row the child's policies hide is not
+ * detached. `set` therefore means "replace the set I can see" (#83), and the
+ * nested `create` means "displace the child I can see" — with a hidden
+ * incumbent the insert collides on the unique key instead, which is the
+ * conservative answer rather than a silent detach of somebody else's row.
+ *
+ * The `findMany` decides whether to issue the write at all. The `updateMany`
+ * would match the same rows on its own; what the read adds is that the common
+ * case — nothing linked — costs a select rather than an update, and that the
+ * scope is consulted through a read before anything is written.
+ *
+ * `[childField]` is ORM-authored: the caller named a row to `set`, or a payload
+ * to `create`, and the ORM chose to null this column. Without it a child scoped
+ * on its own foreign key is refused by the scope-escape guard for a write it
+ * never made — #98, and the reason `disconnect` one operand over passes the
+ * same list.
+ */
+async function clearLinks(
+  relation: RelationSchema,
+  childField: string,
+  parentKey: unknown,
+  executor: RelationExecutor,
+): Promise<void> {
+  const linked = (await executor.exec(
+    relation.model,
+    "findMany",
+    { where: { [childField]: parentKey }, select: { [childField]: true } },
+    false,
+  )) as Record<string, unknown>[];
+
+  if (linked.length === 0) return;
+
+  await executor.exec(
+    relation.model,
+    "updateMany",
+    { where: { [childField]: parentKey }, data: { [childField]: null } },
+    false,
+    [childField],
+  );
 }
 
 /**

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -881,6 +881,37 @@ function planForeignSide(
   out.keyFields.push(parentField);
 
   /**
+   * **Whether linking through this relation has to displace what is linked
+   * already** — the to-one case, where the child's key carries the `@unique`
+   * that makes the relation hold one row, so a second link is a collision
+   * rather than a second row.
+   *
+   * Prisma detaches the incumbent rather than deleting it, and it does so for
+   * some of the operands that link and not others. That split is not derivable
+   * — it is measured, on one fixture, and it is the reason `displaces` is
+   * consulted per operand rather than applied to "anything that links":
+   *
+   *     create                    displaces the incumbent, links the new row
+   *     connect                   displaces the incumbent, links the named row
+   *     connectOrCreate, hit      the same — it *is* a connect (#361)
+   *     connectOrCreate, miss     collides: P2002 on the child's key
+   *     upsert, create branch     collides: P2002 on the child's key
+   *
+   * So the two branches of one `connectOrCreate` answer differently, which is
+   * Prisma's asymmetry and not an embellishment: what displaces is *linking an
+   * existing row*, plus the bare `create` — and the create inside the two
+   * compound operands does not.
+   *
+   * Nullable, because a detach has to leave a value behind. A required child
+   * key cannot be nulled at all, so the insert or repoint collides as it always
+   * did, which is the only thing the schema permits. `assertDisconnectable` is
+   * deliberately not called here: it would refuse the whole operand, including
+   * the empty-to-one case that has always worked.
+   */
+  const displaces =
+    relation.kind !== "many" && child.fields[childField]?.nullable === true;
+
+  /**
    * **A to-one whose key is on the child**, which this function otherwise plans
    * as though the child were a list.
    *
@@ -1522,20 +1553,11 @@ function planForeignSide(
    * `UniqueConstraintError` rather than a silent detach of a row the caller
    * cannot see. Conservative in the direction this file always chooses.
    *
-   * Only on a to-one, and only where the key is nullable:
-   *
-   *   - a to-many displaces nothing, and clearing every child before a nested
-   *     `create` would be a `set: []` nobody asked for;
-   *   - a **required** child key has no value to leave behind, so there is no
-   *     detach to run — the insert collides, which is what happens today and
-   *     the only thing the schema permits. `assertDisconnectable` is not
-   *     reached here for the same reason: it would refuse the whole `create`,
-   *     including the empty-to-one case that works.
+   * A to-many displaces nothing — clearing every child before a nested `create`
+   * would be a `set: []` nobody asked for — which is half of what `displaces`
+   * decides; see it for the other half and for which operands share this.
    */
   if (key === "create") {
-    const displaces =
-      relation.kind !== "many" && child.fields[childField]?.nullable === true;
-
     out.after.push({
       relation: relation.name,
       operation: "create",
@@ -1703,6 +1725,16 @@ function planForeignSide(
           )) as Record<string, unknown> | null;
 
           if (found) {
+            // The hit branch **is** a connect, so it displaces what is linked
+            // exactly as the bare operand does (#361) — and the miss branch
+            // below does not, which is Prisma's own split rather than a
+            // shortcut here. Measured on one fixture: `connectOrCreate` hitting
+            // a row orphans the incumbent and takes the link, while the same
+            // call missing collides on the child's unique key. See `displaces`.
+            if (displaces) {
+              await clearLinks(relation, childField, parent[parentField], executor);
+            }
+
             await executor.exec(
               relation.model,
               "update",
@@ -1748,12 +1780,42 @@ function planForeignSide(
   // table the foreign key is on (#110).
   assertNamedRows(schema, relation, child, operand, key, operation);
 
+  /**
+   * **On a to-one this repoint has to displace what is linked already** (#361),
+   * the same way the nested `create` beside it does and through the same
+   * `clearLinks`. Without it the child's `@unique` foreign key rejects the
+   * second link, so `connect` was a `UniqueConstraintError` on a call Prisma
+   * answers by orphaning the incumbent.
+   *
+   * Measured across the four shapes, because only one of them diverged and the
+   * other three are what kept it hidden:
+   *
+   *     connect onto an empty to-one          attaches           agreed already
+   *     connect a child of another parent     repoints it        agreed already
+   *     connect the row already linked here   no net change      agreed already
+   *     connect onto an occupied to-one       displaces          the divergence
+   *
+   * The third is worth its own line, because the clear and the link cross on
+   * it: `clearLinks` nulls the very row the caller named, and the update below
+   * puts the key straight back. One statement wasted on a call that changes
+   * nothing, and the alternative — excluding the named row from the clear —
+   * would need the caller's key resolved against the child before the clear can
+   * be written, which is a lookup on every `connect` to save one on a rare one.
+   *
+   * **A miss detaches nothing**, which is Prisma's answer (P2025, nothing
+   * written) and is not a special case here: the `update` below raises, and the
+   * clear is inside the transaction the nested steps already run in.
+   */
   out.after.push({
     relation: relation.name,
     operation: "connect",
     async run(args, _context, executor, rows) {
       const parent = rows[0];
       if (!parent) return;
+
+      if (displaces) {
+        await clearLinks(relation, childField, parent[parentField], executor);
+      }
 
       for (const item of listOf(at(args))) {
         await executor.exec(

--- a/packages/gemi/orm/compile/refusals.test.ts
+++ b/packages/gemi/orm/compile/refusals.test.ts
@@ -182,6 +182,18 @@ describe("shape guards", () => {
       "data.profile.create",
       /Expected a single object/,
     ],
+    // The owning side reads the same grammar since #359, through the same
+    // guard — so a bad `disconnect` operand is refused in the same words
+    // wherever the key lives. Pinned on this side too because "the same words"
+    // is the property that was missing: it used to answer with a gap
+    // ("only 'disconnect: true' is implemented") where the far side answered
+    // with a shape.
+    [
+      "a to-one disconnect this row owns is neither a boolean nor a filter",
+      write({ where: { id: 1 }, data: { organization: { disconnect: 5 } } }),
+      "data.organization.disconnect",
+      /takes either a boolean/,
+    ],
     // The owning side's half of the same refusal, pinned because the message
     // now names *which* side holds the key and the two arms can only be told
     // apart by reading both.

--- a/packages/gemi/orm/plan.writes.discrimination.test.ts
+++ b/packages/gemi/orm/plan.writes.discrimination.test.ts
@@ -286,11 +286,19 @@ describe("plan cache discrimination — writes", () => {
    *
    * **Nothing above could catch it**, and that is worth stating precisely
    * because it is what a reader will assume was covered. `plan-key.invariants`
-   * asserts *same key ⇒ same SQL text*, and these two have byte-identical text
-   * — the difference is in which value a `contribution` binds and in whether a
-   * step runs at all. The `DISTINCT` table cannot hold them either: the pair
-   * only exists as a pair, and `disconnect: false` **throws** when it is
-   * compiled, so a table that compiles every entry cannot include it.
+   * asserts *same key ⇒ same SQL text*, and at the time these two had
+   * byte-identical text — the difference was in which value a `contribution`
+   * binds and in whether a step runs at all.
+   *
+   * **The texts have since diverged, and the pin below moved onto them**: #359
+   * implemented `disconnect: false` as the no-op Prisma answers, so it now
+   * contributes no assignment and the statement degenerates to the read
+   * `compileUpdate` emits for an empty `data`. That is a stronger check than
+   * the refusal it replaces, which only ever proved that the compiler had run
+   * again. The hazard is unchanged: the boolean is decided *once*, when the
+   * plan is built, because it decides the SET list — so unlike the foreign
+   * side, where `toOneOperand` re-reads it at bind time, there is no second
+   * guard here and the key is the whole of it.
    *
    * Measured against the real client, so the two ends are pinned rather than
    * assumed: `disconnect: false` with a child present leaves the row untouched,
@@ -313,15 +321,45 @@ describe("plan cache discrimination — writes", () => {
       expect(new Set([on, off, absent]).size).toBe(3);
     });
 
-    // The bug itself: warm the cache with the accepted spelling, then ask for
-    // the one the compiler refuses. Before the guard this returned the cached
-    // plan and wrote a null; now it recompiles and the refusal fires, which is
-    // the answer the first call would have got.
+    // The bug itself: warm the cache with one spelling, then ask for the other
+    // and read what came back. Before the guard this was the *same plan* — the
+    // one that nulls the foreign key — for a call that asked for nothing.
     test("a warm 'true' plan does not serve 'false' on the owning side", () => {
-      expect(() => getOrCompile(user, "update", owning(true), sqlite)).not.toThrow();
-      expect(() => getOrCompile(user, "update", owning(false), sqlite)).toThrow(
-        /only 'disconnect: true' is implemented/,
+      const on = getOrCompile(user, "update", owning(true), sqlite).text;
+      const off = getOrCompile(user, "update", owning(false), sqlite).text;
+
+      // `true` assigns the key; `false` assigns nothing, so there is no update
+      // left to emit and the plan reads the row back instead — which is what
+      // Prisma returns for it.
+      expect(on).toMatch(/^update .* set .*"organizationId" = /);
+      expect(off).toMatch(/^select /);
+      expect(off).not.toContain("set");
+    });
+
+    // The filter arm shares its statement with `true` — one assignment, whose
+    // value the `before` step decides — so what keeps *it* off `true`'s entry
+    // is the operand's structure rather than the boolean guard. Two filters
+    // differing only in their values are one plan, as every other filter is.
+    test("a filter is its own plan, and two filters are one", () => {
+      const filter = (name: string) => ({
+        where: { id: 1 },
+        data: { organization: { disconnect: { name } } },
+      });
+
+      expect(planKey(sqlite, "User", "update", filter("Acme"))).toBe(
+        planKey(sqlite, "User", "update", filter("Globex")),
       );
+      expect(planKey(sqlite, "User", "update", filter("Acme"))).not.toBe(
+        planKey(sqlite, "User", "update", owning(true)),
+      );
+      // ...and the empty filter is neither, though it means what `true` means:
+      // it reaches that meaning through a step, so it may not share the plan.
+      expect(
+        planKey(sqlite, "User", "update", {
+          where: { id: 1 },
+          data: { organization: { disconnect: {} } },
+        }),
+      ).not.toBe(planKey(sqlite, "User", "update", owning(true)));
     });
 
     /**

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -1031,6 +1031,64 @@ describe("policies on nested writes", () => {
       expect(covers[0].caption).toBe("theirs");
       expect(covers[0].folderId).toBe(2);
     });
+
+    /**
+     * `connect` displaces the same way `create` does (#361) and through the
+     * same `clearLinks`, so it inherits the same rule — asserted rather than
+     * assumed, because the two reach it by different routes: `create` writes a
+     * new row and `connect` repoints an existing one, and only the clear is
+     * shared.
+     *
+     * Both halves in one test, because the pair is the point: the loose cover
+     * this caller *can* see takes the link and our incumbent is orphaned; run
+     * against a hidden incumbent instead, nothing is detached and the repoint
+     * collides with the row the caller was never shown.
+     */
+    test("connect displaces a visible incumbent and not a hidden one", async () => {
+      await seedFolder();
+      await raw.unsafe(
+        `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+          `VALUES (53, 2, 'ours', 7), (54, NULL, 'loose', 7)`,
+      );
+
+      await Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: { cover: { connect: { id: 54 } } },
+        }),
+      );
+
+      let covers: any = await raw.unsafe(
+        `SELECT "id", "folderId" FROM "Cover" ORDER BY "id"`,
+      );
+      expect([...covers].map((cover: any) => [cover.id, cover.folderId])).toEqual([
+        [53, null],
+        [54, 2],
+      ]);
+
+      // Now the incumbent is the other tenant's. Same call, same loose row.
+      await raw.unsafe(`DELETE FROM "Cover"`);
+      await hiddenCover();
+      await raw.unsafe(
+        `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+          `VALUES (55, NULL, 'loose', 7)`,
+      );
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { cover: { connect: { id: 55 } } },
+          }),
+        ),
+      ).rejects.toThrow(UniqueConstraintError);
+
+      covers = await raw.unsafe(`SELECT "id", "folderId" FROM "Cover" ORDER BY "id"`);
+      expect([...covers].map((cover: any) => [cover.id, cover.folderId])).toEqual([
+        [50, 2],
+        [55, null],
+      ]);
+    });
   });
 
   /**

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -962,6 +962,190 @@ describe("policies on nested writes", () => {
       const covers: any = await raw.unsafe(`SELECT "caption" FROM "Cover"`);
       expect(covers[0].caption).toBe("theirs");
     });
+
+    /**
+     * A nested `create` **displaces** the child that is already linked (#360),
+     * and the displaced row is orphaned rather than deleted — Prisma's answer,
+     * measured, and the half of it that would be silent data loss to get wrong.
+     *
+     * Here for the policy that decides *which* incumbent it can displace: the
+     * clearing read goes through the child's own `findMany`, so this is `set`'s
+     * rule reached by a different operand.
+     */
+    test("create displaces the linked child the caller can see, orphaning it", async () => {
+      await seedFolder();
+      await raw.unsafe(
+        `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+          `VALUES (52, 2, 'ours', 7)`,
+      );
+
+      await Model.asUser(OURS, () =>
+        Folder.$exec("update", {
+          where: { id: 2 },
+          data: { cover: { create: { caption: "second" } } },
+        }),
+      );
+
+      const covers: any = await raw.unsafe(
+        `SELECT "caption", "folderId", "orgId" FROM "Cover" ORDER BY "id"`,
+      );
+      // Two rows: the incumbent survives with no link, the new one takes it.
+      expect([...covers].map((cover: any) => [cover.caption, cover.folderId])).toEqual([
+        ["ours", null],
+        ["second", 2],
+      ]);
+      // And the new row is ours, through the child's own `onCreate`.
+      expect(covers[1].orgId).toBe(7);
+    });
+
+    /**
+     * ...and the incumbent this caller **cannot see** is not displaced.
+     *
+     * The clearing read misses, so nothing is detached, and the insert then
+     * collides with the row the caller was never shown — `UniqueConstraintError`
+     * naming a column they did not write. That is the same answer the hidden
+     * `upsert` gives two tests up, and it is the conservative one: the
+     * alternative is detaching another tenant's row on a call that never named
+     * it, which is exactly what `set`'s lookup exists to prevent.
+     *
+     * The unhappy reading is worth stating plainly, because it is the cost:
+     * this caller cannot complete the write at all, and the error does not say
+     * why. Nothing is written either way, which is the part that has to hold.
+     */
+    test("create does not displace an incumbent the caller cannot see", async () => {
+      await seedFolder();
+      await hiddenCover();
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { cover: { create: { caption: "second" } } },
+          }),
+        ),
+      ).rejects.toThrow(UniqueConstraintError);
+
+      // Theirs, still linked, still unedited — and no second row beside it.
+      const covers: any = await raw.unsafe(`SELECT * FROM "Cover"`);
+      expect([...covers]).toHaveLength(1);
+      expect(covers[0].caption).toBe("theirs");
+      expect(covers[0].folderId).toBe(2);
+    });
+  });
+
+  /**
+   * The **owning** side of a to-one — `Note.folder`, where the key is on the
+   * row being written (#359).
+   *
+   * The three arms do not consult the child equally, and that is the whole
+   * content of this describe:
+   *
+   *   disconnect: true      no lookup at all — the column is on this row
+   *   disconnect: false     no lookup, and no write either
+   *   disconnect: <filter>  reads the linked row through *its own* `$exec`
+   *
+   * So the filter arm acquires a scoping question the boolean does not have,
+   * and answers it the way every other lookup in this file does: a linked row
+   * the caller cannot see reads as one that does not match, and the link
+   * survives. `true` detaches it regardless, because there is nothing to read —
+   * the caller is writing a column of a row they already hold.
+   */
+  describe("a to-one whose key is on this row", () => {
+    /** Our note, pointing at the *other* tenant's folder. */
+    const seedNote = () =>
+      raw.unsafe(
+        `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+          `VALUES (60, 1, 'ours', 7)`,
+      );
+
+    const folderIdOf = async (id: number) => {
+      const rows: any = await raw.unsafe(
+        `SELECT "folderId" FROM "Note" WHERE "id" = ${id}`,
+      );
+      return rows[0].folderId;
+    };
+
+    test("a filter does not detach a linked row the caller cannot see", async () => {
+      await seedNote();
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Note.$exec("update", {
+            where: { id: 60 },
+            // An empty filter, which is the *widest* one there is: it matches
+            // every row, so the only thing that can make it miss is the scope.
+            data: { folder: { disconnect: {} } },
+          }),
+        ),
+      ).resolves.toBeDefined();
+
+      expect(await folderIdOf(60)).toBe(1);
+    });
+
+    test("a filter detaches a linked row the caller can see", async () => {
+      await raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+      );
+      await raw.unsafe(
+        `INSERT INTO "Note" ("id", "folderId", "label", "orgId") ` +
+          `VALUES (61, 2, 'ours', 7)`,
+      );
+
+      await Model.asUser(OURS, () =>
+        Note.$exec("update", {
+          where: { id: 61 },
+          data: { folder: { disconnect: { code: "ours" } } },
+        }),
+      );
+
+      expect(await folderIdOf(61)).toBeNull();
+      // Detached, not deleted: the far row is nobody's business here.
+      const folders: any = await raw.unsafe(`SELECT "id" FROM "Folder" WHERE "id" = 2`);
+      expect([...folders]).toHaveLength(1);
+    });
+
+    /**
+     * **`true` is not scoped, and that is deliberate rather than an oversight.**
+     *
+     * It writes one column of the row the statement already names, and that row
+     * is this caller's — the parent's own policies decided that before the
+     * statement ran. There is no read of the far model to scope, so hiding the
+     * far row cannot be made to matter without inventing a lookup the operand
+     * does not need. Prisma's `true` means "the connected row" and consults
+     * nothing either.
+     *
+     * Pinned because the pair reads as an inconsistency otherwise: the same
+     * operand, on the same relation, detaches under `true` and does not under
+     * `{}` — with the difference being which model's rows the call touches.
+     */
+    test("true detaches whatever is linked, hidden or not", async () => {
+      await seedNote();
+
+      await Model.asUser(OURS, () =>
+        Note.$exec("update", {
+          where: { id: 60 },
+          data: { folder: { disconnect: true } },
+        }),
+      );
+
+      expect(await folderIdOf(60)).toBeNull();
+    });
+
+    /** And `false` writes nothing at all, hidden far row or not. */
+    test("false leaves the link alone", async () => {
+      await seedNote();
+
+      await Model.asUser(OURS, () =>
+        Note.$exec("update", {
+          where: { id: 60 },
+          data: { label: "renamed", folder: { disconnect: false } },
+        }),
+      );
+
+      expect(await folderIdOf(60)).toBe(1);
+      const notes: any = await raw.unsafe(`SELECT "label" FROM "Note" WHERE "id" = 60`);
+      expect(notes[0].label).toBe("renamed");
+    });
   });
 
   /**
@@ -1064,16 +1248,44 @@ describe("policies on nested writes", () => {
           }),
         );
 
-      // Both operands, so this records that it is a property of the guard
-      // rather than of the one operand this PR added.
+      const linkOf = async () => {
+        const rows: any = await raw.unsafe(
+          `SELECT "folderId" FROM "Note" WHERE "id" = 20`,
+        );
+        return rows[0].folderId;
+      };
+
+      /**
+       * **`set` is still refused, and it goes first because it is the one that
+       * has something to leave behind.**
+       *
+       * It writes the column twice — null to clear, the parent's key to link —
+       * and `clearLinks` now names the clear as the ORM's, because the nested
+       * `create` beside it needs exactly that clear. The link is deliberately
+       * left un-named: with both named the call *succeeds* and leaves the row
+       * detached, because the clear puts it outside the very scope
+       * (`{ folderId: 2 }`) the link then selects it by. A silent half-write in
+       * place of a loud refusal, so the refusal stays until #99 can answer the
+       * scope as well as the guard.
+       *
+       * The row is read back because the clear does run before the link
+       * refuses: what makes that harmless is the transaction around the nested
+       * steps, not the order of the checks.
+       */
+      await expect(attempt({ set: [{ id: 20 }] })).rejects.toThrow(ScopeEscapeError);
+      expect(await linkOf()).toBe(2);
+
+      // Both of the operands #98 landed for, so this records that it is a
+      // property of the guard rather than of the one operand that PR added.
       //
-      // `connect` first, and the order is load-bearing now that both succeed:
-      // `disconnect` nulls `folderId`, which puts the row outside the very
-      // scope (`{ folderId: 2 }`) that has to select it, so a `connect` after
-      // it finds nothing. While both were refusals neither wrote anything and
-      // the order did not matter.
+      // `connect` before `disconnect`, and the order is load-bearing now that
+      // both succeed: `disconnect` nulls `folderId`, which puts the row outside
+      // the scope that has to select it, so a `connect` after it finds nothing.
+      // While both were refusals neither wrote anything and the order did not
+      // matter.
       await expect(attempt({ connect: { id: 20 } })).resolves.toBeDefined();
       await expect(attempt({ disconnect: { id: 20 } })).resolves.toBeDefined();
+      expect(await linkOf()).toBeNull();
     } finally {
       register("Note", Note);
     }

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -674,12 +674,13 @@ const CASES: Case[] = [
   ["M11b to-one create under a create has nothing to displace", "create", {
     data: { email: "fresh@example.dev", profile: { create: { bio: "first" } } },
   }, ["User", "Profile"]],
-  // And the neighbours that do **not** displace, measured rather than assumed
-  // symmetric: Prisma's own `connectOrCreate` and `upsert` collide on the
-  // child's unique foreign key where `create` detaches. So the displacement
-  // belongs to the operand, not to the shape of the relation, and these pin
-  // that both clients raise `unique` rather than quietly detaching.
-  ["M11c to-one connectOrCreate onto an occupied link collides", "update", {
+  // And the neighbours that do **not** displace. Measured rather than assumed
+  // symmetric, and the asymmetry is worth stating because it is not derivable:
+  // the *create branch* of `connectOrCreate` and of `upsert` collides on the
+  // child's unique foreign key, where the bare `create` above detaches. So what
+  // displaces is the bare `create` and anything that **links an existing row**
+  // (M12 below) — not "every operand that ends with a child pointing here".
+  ["M11c to-one connectOrCreate whose where misses collides", "update", {
     where: { id: 1 },
     data: {
       profile: {
@@ -695,8 +696,39 @@ const CASES: Case[] = [
       },
     },
   }, ["User", "Profile"]],
-  // `connect` onto an *occupied* to-one is a **divergence**, not agreement, so
-  // it is not here — see the "still disagree" describe below.
+
+  // M12 — `connect` onto a to-one that **already has a child** (#361), the
+  // neighbour of M11 and the same displacement. Four shapes, and only this one
+  // ever diverged: the three above it — an empty to-one, a steal from another
+  // parent, and the row already linked here — agreed before the fix and are
+  // what kept it hidden.
+  ["M12 to-one connect displaces the incumbent, orphaning it", "update", {
+    where: { id: 1 }, data: { profile: { connect: { id: 2 } } },
+  }, ["User", "Profile"]],
+  // The clear and the link cross on this one: `clearLinks` nulls the very row
+  // the caller named and the repoint puts the key straight back. Net nothing,
+  // which is Prisma's answer, and the case that would catch a clear scoped to
+  // the wrong rows.
+  ["M12b to-one connect of the row already linked changes nothing", "update", {
+    where: { id: 1 }, data: { profile: { connect: { id: 1 } } },
+  }, ["User", "Profile"]],
+  // A miss detaches nothing — the repoint raises and takes the clear down with
+  // it. `notFound` on both sides, so a gemi refusal could not pass for it.
+  ["M12c to-one connect naming no row raises and displaces nothing", "update", {
+    where: { id: 1 }, data: { profile: { connect: { id: 99 } } },
+  }, ["User", "Profile"]],
+  // ...and `connectOrCreate`'s *hit* branch is a connect, so it displaces where
+  // its miss branch (M11c) collides. Both branches of one operand, answering
+  // differently, which is why `displaces` is consulted per branch rather than
+  // per operand.
+  ["M12d to-one connectOrCreate hitting a row displaces the incumbent", "update", {
+    where: { id: 1 },
+    data: {
+      profile: {
+        connectOrCreate: { where: { id: 2 }, create: { bio: "unused" } },
+      },
+    },
+  }, ["User", "Profile"]],
 ];
 
 /**
@@ -2576,54 +2608,57 @@ function suite(label: string, url?: string) {
       });
 
       /**
-       * **BUG (#361) — `connect` onto a to-one that already has a child.**
+       * **BUG (#363) — the owning side linking into an occupied to-one.**
        *
-       * The neighbour of #360, found while fixing it and left for its own
-       * change rather than folded in. Prisma **detaches** the incumbent and
-       * links the named row — the same displacement `create` does, measured the
-       * same way:
+       * The mirror of #361, which this PR fixed, and it is a different piece of
+       * work rather than the same one twice. #361 clears rows of the **child**
+       * model, which `clearLinks` does through the child's own operations. Here
+       * the collision is between two rows of the model being written: pointing
+       * profile 1 at user 2 collides with the profile user 2 already has, and
+       * nothing in `planOwningSide` writes a sibling row.
        *
-       *     user 1 already holds profile 1, and connects profile 2
-       *       prisma  ->  ("seed", null)  the incumbent, orphaned
-       *                   ("loose", 1)    the named row takes the link
+       *     profile 1 -> user 1, and user 2 already holds profile 2
+       *       prisma  ->  (1, "seed",  2)     the row written takes the link
+       *                   (2, "loose", null)  user 2's old profile, orphaned
        *       gemi    ->  UniqueConstraintError on Profile.userId
        *
-       * `CASES` already covers the two neighbouring shapes and they agree: an
-       * *empty* to-one connecting a loose child, and one stealing a child from
-       * another parent. Only the occupied case diverges, which is why nothing
-       * pointed at it.
+       * `connectOrCreate` hitting an existing row does the same; its *miss*
+       * branch creates the far row and so has nothing to displace.
        *
-       * Not fixed here on purpose. `create`'s displacement is #360's, measured
-       * and asked for; carrying an unfiled operand along with it would put a
-       * second behaviour change into a PR whose title names one.
+       * The seed has no profile on user 2 — every other case in this file wants
+       * the opposite — so this one arranges it, which is also why it is not in
+       * `OWNING_CASES`.
        */
-      test("connect onto an occupied to-one collides here and detaches in Prisma", async () => {
-        const args = {
-          where: { id: 1 },
-          data: { profile: { connect: { id: 2 } } },
-        };
+      test("the owning side collides linking into an occupied to-one", async () => {
+        const args = { where: { id: 1 }, data: { user: { connect: { id: 2 } } } };
+        const occupy = () =>
+          differential.prisma.profile.update({
+            where: { id: 2 },
+            data: { userId: 2 },
+          });
+        const profiles = async () =>
+          (
+            await differential.prisma.profile.findMany({ orderBy: { id: "asc" } })
+          ).map((row) => [row.bio, row.userId]);
 
         await differential.reset();
-        await differential.prisma.user.update(args);
-        const afterPrisma = await differential.prisma.profile.findMany({
-          orderBy: { id: "asc" },
-        });
-        expect(afterPrisma.map((row) => [row.bio, row.userId])).toEqual([
-          ["seed", null],
-          ["loose", 1],
+        await occupy();
+        await differential.prisma.profile.update(args as never);
+        expect(await profiles()).toEqual([
+          ["seed", 2],
+          // Detached, not deleted — the half a fix here would have to get right.
+          ["loose", null],
         ]);
 
         await differential.reset();
-        await expect(UserModel.update(args)).rejects.toBeInstanceOf(
+        await occupy();
+        await expect(ProfileModel.update(args as never)).rejects.toBeInstanceOf(
           UniqueConstraintError,
         );
-        // And nothing moved: the failed update rolls back with the statement.
-        const afterGemi = await differential.prisma.profile.findMany({
-          orderBy: { id: "asc" },
-        });
-        expect(afterGemi.map((row) => [row.bio, row.userId])).toEqual([
+        // And nothing moved: the failed statement takes nothing with it.
+        expect(await profiles()).toEqual([
           ["seed", 1],
-          ["loose", null],
+          ["loose", 2],
         ]);
       });
     });

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -657,8 +657,104 @@ const CASES: Case[] = [
   ["a single connect that steals another parent's child", "update", {
     where: { id: 2 }, data: { profile: { connect: { id: 1 } } },
   }, ["User", "Profile"]],
-  // `create` where a child already exists is a **divergence**, not agreement,
-  // so it is not here — see the "still disagree" describe below.
+
+  // M11 — a nested `create` onto a to-one that **already has a child** (#360),
+  // which was a `UniqueConstraintError` here and an answer there until this
+  // graduated out of the "still disagree" describe below.
+  //
+  // The incumbent is **orphaned, not deleted**: three rows afterwards, the old
+  // one holding a null foreign key. That is the half worth reading the table
+  // for — a fix that deleted the displaced row instead would be silent data
+  // loss wearing this same green test, which is why `tables` names `Profile`.
+  ["M11 to-one create displaces the incumbent, orphaning it", "update", {
+    where: { id: 1 }, data: { profile: { create: { bio: "second" } } },
+  }, ["User", "Profile"]],
+  // The control on the other statement: a *new* parent can have nothing linked
+  // to displace, so the same operand costs the same as it always did.
+  ["M11b to-one create under a create has nothing to displace", "create", {
+    data: { email: "fresh@example.dev", profile: { create: { bio: "first" } } },
+  }, ["User", "Profile"]],
+  // And the neighbours that do **not** displace, measured rather than assumed
+  // symmetric: Prisma's own `connectOrCreate` and `upsert` collide on the
+  // child's unique foreign key where `create` detaches. So the displacement
+  // belongs to the operand, not to the shape of the relation, and these pin
+  // that both clients raise `unique` rather than quietly detaching.
+  ["M11c to-one connectOrCreate onto an occupied link collides", "update", {
+    where: { id: 1 },
+    data: {
+      profile: {
+        connectOrCreate: { where: { id: 99 }, create: { bio: "coc" } },
+      },
+    },
+  }, ["User", "Profile"]],
+  ["M11d to-one upsert whose where misses collides", "update", {
+    where: { id: 1 },
+    data: {
+      profile: {
+        upsert: { where: { id: 99 }, create: { bio: "up" }, update: { bio: "x" } },
+      },
+    },
+  }, ["User", "Profile"]],
+  // `connect` onto an *occupied* to-one is a **divergence**, not agreement, so
+  // it is not here — see the "still disagree" describe below.
+];
+
+/**
+ * The **owning** side of the same to-one: `Profile.update`, where the foreign
+ * key is on the row being written (#359).
+ *
+ * A table of its own rather than rows in `CASES`, for one mechanical reason:
+ * every `CASES` entry runs against `User`, and this side is only reachable from
+ * the model that holds the key. Same harness, same comparison, same rule that
+ * a case belongs here exactly when the two clients agree.
+ *
+ * `O5` and `O6` are the ones that decide what the filter arm *means*: a filter
+ * matching nothing is **silent**, not P2025, so this is a conditional detach
+ * rather than a guarded one. Measured on Prisma 6.19.2 before it was written.
+ */
+const OWNING_CASES: [string, string, unknown, string[]?][] = [
+  // User 1 is Ada and holds profile 1; profile 2 (`loose`) is linked to nobody.
+  ["O1 owning disconnect true clears the link", "update", {
+    where: { id: 1 }, data: { user: { disconnect: true } },
+  }, ["Profile", "User"]],
+  // The headline of #359: the branch that asked for *nothing*. A caller writes
+  // `disconnect: shouldDetach`, and this is the value that used to be refused —
+  // after a spell in which a warm `true` plan served it and nulled the key.
+  ["O2 owning disconnect false is a strict no-op", "update", {
+    where: { id: 1 }, data: { user: { disconnect: false } },
+  }, ["Profile", "User"]],
+  ["O3 owning disconnect {} clears the link", "update", {
+    where: { id: 1 }, data: { user: { disconnect: {} } },
+  }, ["Profile", "User"]],
+  ["O4 owning disconnect with a matching filter clears the link", "update", {
+    where: { id: 1 }, data: { user: { disconnect: { name: "Ada" } } },
+  }, ["Profile", "User"]],
+  ["O5 owning disconnect with a non-matching filter is silent", "update", {
+    where: { id: 1 }, data: { user: { disconnect: { name: "Grace" } } },
+  }, ["Profile", "User"]],
+  ["O6 owning disconnect with a filter and nothing linked is silent", "update", {
+    where: { id: 2 }, data: { user: { disconnect: { name: "Ada" } } },
+  }, ["Profile", "User"]],
+  ["O7 owning disconnect true with nothing linked is silent", "update", {
+    where: { id: 2 }, data: { user: { disconnect: true } },
+  }, ["Profile", "User"]],
+  // Beside a real column write, because `false` contributes no assignment at
+  // all: without something else in `data` the statement degenerates to a read,
+  // and this is what shows the two are independent rather than one hiding the
+  // other.
+  ["O8 owning disconnect false beside a column write", "update", {
+    where: { id: 1 }, data: { bio: "changed", user: { disconnect: false } },
+  }, ["Profile", "User"]],
+  ["O9 owning disconnect with a matching filter beside a column write", "update", {
+    where: { id: 1 },
+    data: { bio: "changed", user: { disconnect: { name: "Ada" } } },
+  }, ["Profile", "User"]],
+  // An operator filter, not just an equality: the operand is a `WhereInput`,
+  // and nothing about the implementation narrows it to scalars.
+  ["O10 owning disconnect takes an operator filter", "update", {
+    where: { id: 1 },
+    data: { user: { disconnect: { name: { contains: "Ad" } } } },
+  }, ["Profile", "User"]],
 ];
 
 function suite(label: string, url?: string) {
@@ -692,6 +788,10 @@ function suite(label: string, url?: string) {
 
     test.each(CASES)("%s", async (_name, operation, args, tables) => {
       await differential.expectSameWrite("User", operation, args, { tables });
+    });
+
+    test.each(OWNING_CASES)("%s", async (_name, operation, args, tables) => {
+      await differential.expectSameWrite("Profile", operation, args, { tables });
     });
 
     // Writing through a model whose `@@unique` is composite, which is the only
@@ -2419,55 +2519,88 @@ function suite(label: string, url?: string) {
      * `CASES` and the harness takes over from the prose.
      *
      * Each carries its issue number, and that is the half a test cannot do for
-     * itself. #354 closes when this PR merges, so without them the only record
-     * of these two would be this describe — findable by someone already reading
-     * the file, and by nobody reading the tracker. The issues carry the
-     * measurement and point back here; this points forward. Neither is enough
-     * alone.
+     * itself. The two this describe was opened for — #359 and #360 — are gone
+     * from it and into `CASES` / `OWNING_CASES` above, which is what closing
+     * one looks like. The two below took their place, and both were found by
+     * the same method: measuring the neighbouring spelling of a call that was
+     * being fixed.
+     *
+     * **One of them is not gemi's bug**, which is new here and changes what the
+     * describe is for. The rule stays "pin both answers"; what it cannot stay
+     * is "every one of these is ours to fix".
      */
-    describe("where the two clients still disagree — each of these is a bug", () => {
+    describe("where the two clients still disagree", () => {
       /**
-       * **BUG 1 (#359) — owning-side `disconnect: false`.**
+       * **A deliberate divergence, and the only one in this file: Prisma's
+       * owning-side `disconnect` ignores its operand on a many-to-one.**
        *
-       * #354 made the *foreign* side take a boolean (M5b above, which passes).
-       * The owning side still refuses anything but `true`. Prisma's owning-side
-       * operand is `WhereInput | boolean` and it takes `false` as a no-op, so a
-       * caller passing a flag through — `disconnect: shouldDetach` — gets a
-       * refusal on the branch that asked for nothing.
+       * `OWNING_CASES` above pins the whole grammar against `Profile.user` — a
+       * one-to-one — where Prisma honours it: `false` and a non-matching filter
+       * both leave the link alone. The *same operand type* on a many-to-one is
+       * answered differently by the engine, measured on three relations
+       * (`User.organization`, `Account.user`, `Account.organization`):
        *
-       * This is strictly better than what it replaced, which nulled the foreign
-       * key on that branch through a stale plan-cache entry. It is still wrong.
+       *     disconnect: false               ->  the foreign key is nulled
+       *     disconnect: { name: "Nobody" }  ->  the foreign key is nulled
+       *
+       * The generated input type is identical on both — `XWhereInput | boolean`
+       * — so this is the engine dropping the value, not a narrower grammar.
+       * `delete: false` on the same relation is a correct no-op, which is what
+       * rules out "booleans are ignored here" as the explanation.
+       *
+       * **gemi does not reproduce it.** Matching Prisma is this suite's whole
+       * point and it is overruled exactly here, because the behaviour to match
+       * is a silent destructive write on the call that asked for nothing —
+       * which is, word for word, the defect #358 removed from this ORM's own
+       * plan cache. Reproducing it deliberately would be re-introducing it. So
+       * gemi answers one grammar one way on both shapes, and this pins the
+       * difference rather than hiding it.
        */
-      test("the owning side refuses disconnect: false, which Prisma no-ops", async () => {
-        const args = { where: { id: 1 }, data: { user: { disconnect: false } } };
+      test("Prisma ignores a many-to-one disconnect operand where gemi honours it", async () => {
+        const args = {
+          where: { id: 1 },
+          data: { organization: { disconnect: false } },
+        };
 
         await differential.reset();
-        const fromPrisma = await differential.prisma.profile.update(args as never);
-        expect(fromPrisma.userId).toBe(1);
+        const fromPrisma = await differential.prisma.user.update(args as never);
+        // Prisma detached anyway. User 1 is seeded into Acme.
+        expect(fromPrisma.organizationId).toBe(null);
 
         await differential.reset();
-        await expect(ProfileModel.update(args as never)).rejects.toThrow(
-          /only 'disconnect: true' is implemented/,
-        );
+        const fromGemi: any = await UserModel.update(args as never);
+        expect(fromGemi.organizationId).toBe(1);
+        expect(
+          await differential.prisma.user.findFirstOrThrow({ where: { id: 1 } }),
+        ).toMatchObject({ organizationId: 1 });
       });
 
       /**
-       * **BUG 2 (#360) — `create` on a to-one that already has a child.**
+       * **BUG (#361) — `connect` onto a to-one that already has a child.**
        *
-       * Prisma **detaches** the existing child first: the old row survives with
-       * a null foreign key and the new one takes the link. gemi inserts without
-       * clearing, and the child's `@unique` foreign key rejects it — a unique
-       * violation on a call Prisma answers.
+       * The neighbour of #360, found while fixing it and left for its own
+       * change rather than folded in. Prisma **detaches** the incumbent and
+       * links the named row — the same displacement `create` does, measured the
+       * same way:
        *
-       * Not the same operand family as the three #354 closed, which is why it
-       * survived: `create` was never refused on this side, so nothing pointed at
-       * it. The fix belongs beside `set`, whose whole job is clearing the links
-       * that are in the way before writing the new ones.
+       *     user 1 already holds profile 1, and connects profile 2
+       *       prisma  ->  ("seed", null)  the incumbent, orphaned
+       *                   ("loose", 1)    the named row takes the link
+       *       gemi    ->  UniqueConstraintError on Profile.userId
+       *
+       * `CASES` already covers the two neighbouring shapes and they agree: an
+       * *empty* to-one connecting a loose child, and one stealing a child from
+       * another parent. Only the occupied case diverges, which is why nothing
+       * pointed at it.
+       *
+       * Not fixed here on purpose. `create`'s displacement is #360's, measured
+       * and asked for; carrying an unfiled operand along with it would put a
+       * second behaviour change into a PR whose title names one.
        */
-      test("create on an occupied to-one collides here and detaches in Prisma", async () => {
+      test("connect onto an occupied to-one collides here and detaches in Prisma", async () => {
         const args = {
           where: { id: 1 },
-          data: { profile: { create: { bio: "second" } } },
+          data: { profile: { connect: { id: 2 } } },
         };
 
         await differential.reset();
@@ -2476,18 +2609,22 @@ function suite(label: string, url?: string) {
           orderBy: { id: "asc" },
         });
         expect(afterPrisma.map((row) => [row.bio, row.userId])).toEqual([
-          // The row that was linked, now orphaned rather than deleted.
           ["seed", null],
-          ["loose", null],
-          ["second", 1],
+          ["loose", 1],
         ]);
 
         await differential.reset();
         await expect(UserModel.update(args)).rejects.toBeInstanceOf(
           UniqueConstraintError,
         );
-        // And nothing is left behind: the failed insert rolls back.
-        expect(await differential.prisma.profile.count()).toBe(2);
+        // And nothing moved: the failed update rolls back with the statement.
+        const afterGemi = await differential.prisma.profile.findMany({
+          orderBy: { id: "asc" },
+        });
+        expect(afterGemi.map((row) => [row.bio, row.userId])).toEqual([
+          ["seed", 1],
+          ["loose", null],
+        ]);
       });
     });
 


### PR DESCRIPTION
Three to-one defects from the first Prisma differential port, each verified against a generated client (6.19.2) before anything was written, each graduated out of the "still disagree" describe and into the differential's case tables — which is what closing one looks like here.

#361 was filed by this branch and fixed on it after the fact, on request; its measurements and acceptance criteria are on the issue.

## #359 — the owning side took `true` and nothing else

Prisma's operand is `XWhereInput | boolean` on **both** sides of a to-one. #358 implemented all three arms where the child holds the key; the side that holds it itself still refused everything but `true`, so one grammar had two answers depending on which table the column is on. The spelling that broke is the one a conditional detach is naturally written as — `disconnect: shouldDetach` — and it broke on the branch that asked for *nothing*, at run time.

All three arms now go through `toOneOperand` and `assertToOneFilter`, the same two helpers the foreign side uses, reused rather than restated:

| operand | what happens |
| --- | --- |
| `true` | one bound column set to null, no step |
| `false` | no contribution and no step at all — the statement degenerates to a read |
| `{}` / `{ name: "Ada" }` | detach only if the linked row matches; **silent** when it does not |

The filter arm costs two reads, and neither is avoidable from this side: the condition is a property of the linked row, and which row that is lives in a column of the row being updated, which the arguments do not carry. The parent read is pre-scoped; the child read goes through its own `$exec` un-pre-scoped, so a linked row the caller's policies hide reads as one that does not match and the link survives. `true` has no lookup to scope and clears the column either way — pinned, because the pair reads as an inconsistency otherwise.

The boolean stays a **compile-time** decision here where the foreign side re-reads it at bind time, and that is forced: `false` emits no assignment and `true` emits one, so they cannot share a statement text. #358's plan-key guard is what makes it sound, and `plan.writes.discrimination` moved its pin off the (now gone) refusal and onto the emitted SQL.

## #360 and #361 — writing onto an occupied to-one collided

`create` and `connect` onto a to-one that already has a child were a `UniqueConstraintError` on calls Prisma answers. Prisma takes the link and leaves the incumbent in the table with a null foreign key — **orphaned, not deleted**, which is the half a fix in the other direction turns into silent data loss wearing the same green test. The differential reads the table back for exactly that reason.

`set`'s clearing half became a shared `clearLinks`, and which operands call it is one `displaces` at the top of `planForeignSide`, because the answer turned out to be per *branch*:

| operand | on an occupied to-one |
| --- | --- |
| `create` | displaces |
| `connect` | displaces |
| `connectOrCreate`, hit | displaces — it *is* a connect |
| `connectOrCreate`, miss | collides on the child's unique key |
| `upsert`, create branch | collides on the child's unique key |

Not derivable, so it is measured and consulted per site. The two collide rows are pinned as `M11c` / `M11d`, which is what stops the rule quietly widening to "anything that ends with a child pointing here". #361's own acceptance criteria say `connectOrCreate` keeps colliding — that was written from the miss branch, the only one measured when it was filed, and is still true of it; the hit branch is measured to displace, and leaving it out would have put two spellings of one operation on two answers.

Four `connect` shapes, and only one diverged — the other three are what kept it hidden: an empty to-one attaches, another parent's child is repointed, and the row already linked here comes out unchanged (the clear nulls it and the repoint puts the key straight back). A miss detaches nothing, because the repoint raises and the clear is inside the transaction the nested steps already run in.

`clearLinks` names the column as ORM-authored (#98), which `set`'s clear was not. The *link* half deliberately still does not: naming it too makes `set` succeed and succeed wrongly on a child scoped by its own foreign key — the clear puts the row outside the very scope the link selects it by, so it ends up detached and never re-attached. A silent half-write in place of a loud refusal, so the refusal stays until #99. Asserted rather than left as a comment.

## Two divergences found on the way, neither folded in

**Prisma ignores the owning-side `disconnect` operand on a many-to-one**, measured on three relations: `disconnect: false` and a filter matching nothing both null the foreign key, though the generated input type is the same `WhereInput | boolean` it honours on a one-to-one — and `delete: false` on the same relation is a correct no-op, which rules out "booleans are ignored here". gemi does not reproduce it. Matching Prisma is this suite's whole point and it is overruled exactly here, because the behaviour to match is a silent destructive write on the call that asked for nothing — word for word the defect #358 removed from this ORM's own plan cache. Pinned with both answers, and stated in the docs, since it means `disconnect: shouldDetach` is safe here and is not safe through the Prisma client.

**The owning side linking into an occupied to-one** — `Profile.update({ data: { user: { connect } } })` where that user's profile is taken — collides here and displaces in Prisma. It is a different piece of work rather than the same one twice: the row to clear is a *sibling of the model being written*, not a row of the child model, and nothing in `planOwningSide` writes one. Filed as #363 with the two questions that answers, pinned here with both clients' answers.

## Verification

`packages/gemi` 3,054 · `saas-starter` 770 · the differential suite against a real Postgres 211 · `tsc` clean on `packages/gemi` (the template's 277 errors are pre-existing and unchanged) · `oxlint` clean on every file touched.

Closes #359, closes #360, closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
