### PR TITLE
Close #321: a `$policies` entry that could never run, refused by name

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4572,13 +4572,24 @@ it as policied. Both are now `InvalidPolicyEntryError`, naming the class and the
 
 ```
 InvalidPolicyEntryError: Account.$policies[0] has none of before, scope, onCreate,
-onUpdate or redact, so it would never run. … It spells 'scopes'. Did you mean `scope`?
+onUpdate or redact, so it would never run. … It spells 'scopes'.
+Is 'scopes' meant to be `scope`?
 ```
 
 Anything *beside* a recognised hook is left alone — a factory's configuration, a policy class's own
 helpers — so only "no hook at all" is refused. `tsc` already rejects every one of these shapes at
 the class declaration; the runtime check is for the paths that import model files without having
-type-checked them, which is `registerModels` at boot and `gemi check models`.
+type-checked them.
+
+**Where it is raised, and what runs when.** `registerModels` and `gemi check models` check every
+entry's *shape* — is it a policy, is a function entry constructable, does it name a hook — without
+constructing anything, so a policy class's constructor still runs where it always did: on the first
+query through the model, not at boot. That is deliberate. A constructor that reads config or a
+service container would otherwise be pulled ahead of whatever wires them, and a guard against a
+policy that does nothing must not be the reason an application stops booting. The consequence is
+that a class whose constructor *throws* is reported by the first query rather than at boot — still
+as `InvalidPolicyEntryError`, still naming the class and the index, with the constructor's own error
+as `cause`.
 
 | Member | When it runs | What it does |
 | --- | --- | --- |
@@ -4783,7 +4794,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. It is gemi's own error and carries no Prisma `code` — see below if a `"P2002"` check is what you have today. |
 | `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
 | `ScopeEscapeError` | An `update` wrote a column its own policy's `scope` selects on, with no `onUpdate`. |
-| `InvalidPolicyEntryError` | A `$policies` entry that cannot run — a factory nobody called, or an entry whose keys are none of `before` / `scope` / `onCreate` / `onUpdate` / `redact`. Names the class and the index. Raised at boot by `registerModels`, not on the query. |
+| `InvalidPolicyEntryError` | A `$policies` entry that cannot run — a factory nobody called, a policy class whose constructor throws, or an entry whose keys are none of `before` / `scope` / `onCreate` / `onUpdate` / `redact`. Names the class and the index. Raised wherever the entry is first read: by `registerModels` and `gemi check models` at boot, and on the first query through a class neither of those was given. |
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
 | `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4526,6 +4526,23 @@ class TenantPolicy extends AccountScopedPolicy {
 Each level of the prototype chain contributes its own array and they concatenate **base first**, so
 a shared model base can impose a policy a subclass can only narrow, never drop.
 
+**An entry that could never run is refused, by name.** A class entry is constructed with no
+arguments, so a factory nobody called — `softDeletes` rather than `softDeletes({ field })` — is not
+one; and an entry has to spell at least one of `before`, `scope`, `onCreate`, `onUpdate` or
+`redact`, because those are the only names anything dispatches on. `{ scopes: … }` is a typo that
+used to register in silence and leave the model reading unscoped while `gemi check models` reported
+it as policied. Both are now `InvalidPolicyEntryError`, naming the class and the index:
+
+```
+InvalidPolicyEntryError: Account.$policies[0] has none of before, scope, onCreate,
+onUpdate or redact, so it would never run. … It spells 'scopes'. Did you mean `scope`?
+```
+
+Anything *beside* a recognised hook is left alone — a factory's configuration, a policy class's own
+helpers — so only "no hook at all" is refused. `tsc` already rejects every one of these shapes at
+the class declaration; the runtime check is for the paths that import model files without having
+type-checked them, which is `registerModels` at boot and `gemi check models`.
+
 | Member | When it runs | What it does |
 | --- | --- | --- |
 | `before(ctx)` | First | Return `false` (or throw) to deny outright. |
@@ -4729,6 +4746,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. It is gemi's own error and carries no Prisma `code` — see below if a `"P2002"` check is what you have today. |
 | `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
 | `ScopeEscapeError` | An `update` wrote a column its own policy's `scope` selects on, with no `onUpdate`. |
+| `InvalidPolicyEntryError` | A `$policies` entry that cannot run — a factory nobody called, or an entry whose keys are none of `before` / `scope` / `onCreate` / `onUpdate` / `redact`. Names the class and the index. Raised at boot by `registerModels`, not on the query. |
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
 | `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1589,13 +1589,24 @@ it as policied. Both are now `InvalidPolicyEntryError`, naming the class and the
 
 ```
 InvalidPolicyEntryError: Account.$policies[0] has none of before, scope, onCreate,
-onUpdate or redact, so it would never run. … It spells 'scopes'. Did you mean `scope`?
+onUpdate or redact, so it would never run. … It spells 'scopes'.
+Is 'scopes' meant to be `scope`?
 ```
 
 Anything *beside* a recognised hook is left alone — a factory's configuration, a policy class's own
 helpers — so only "no hook at all" is refused. `tsc` already rejects every one of these shapes at
 the class declaration; the runtime check is for the paths that import model files without having
-type-checked them, which is `registerModels` at boot and `gemi check models`.
+type-checked them.
+
+**Where it is raised, and what runs when.** `registerModels` and `gemi check models` check every
+entry's *shape* — is it a policy, is a function entry constructable, does it name a hook — without
+constructing anything, so a policy class's constructor still runs where it always did: on the first
+query through the model, not at boot. That is deliberate. A constructor that reads config or a
+service container would otherwise be pulled ahead of whatever wires them, and a guard against a
+policy that does nothing must not be the reason an application stops booting. The consequence is
+that a class whose constructor *throws* is reported by the first query rather than at boot — still
+as `InvalidPolicyEntryError`, still naming the class and the index, with the constructor's own error
+as `cause`.
 
 | Member | When it runs | What it does |
 | --- | --- | --- |
@@ -1800,7 +1811,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. It is gemi's own error and carries no Prisma `code` — see below if a `"P2002"` check is what you have today. |
 | `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
 | `ScopeEscapeError` | An `update` wrote a column its own policy's `scope` selects on, with no `onUpdate`. |
-| `InvalidPolicyEntryError` | A `$policies` entry that cannot run — a factory nobody called, or an entry whose keys are none of `before` / `scope` / `onCreate` / `onUpdate` / `redact`. Names the class and the index. Raised at boot by `registerModels`, not on the query. |
+| `InvalidPolicyEntryError` | A `$policies` entry that cannot run — a factory nobody called, a policy class whose constructor throws, or an entry whose keys are none of `before` / `scope` / `onCreate` / `onUpdate` / `redact`. Names the class and the index. Raised wherever the entry is first read: by `registerModels` and `gemi check models` at boot, and on the first query through a class neither of those was given. |
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
 | `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1543,6 +1543,23 @@ class TenantPolicy extends AccountScopedPolicy {
 Each level of the prototype chain contributes its own array and they concatenate **base first**, so
 a shared model base can impose a policy a subclass can only narrow, never drop.
 
+**An entry that could never run is refused, by name.** A class entry is constructed with no
+arguments, so a factory nobody called — `softDeletes` rather than `softDeletes({ field })` — is not
+one; and an entry has to spell at least one of `before`, `scope`, `onCreate`, `onUpdate` or
+`redact`, because those are the only names anything dispatches on. `{ scopes: … }` is a typo that
+used to register in silence and leave the model reading unscoped while `gemi check models` reported
+it as policied. Both are now `InvalidPolicyEntryError`, naming the class and the index:
+
+```
+InvalidPolicyEntryError: Account.$policies[0] has none of before, scope, onCreate,
+onUpdate or redact, so it would never run. … It spells 'scopes'. Did you mean `scope`?
+```
+
+Anything *beside* a recognised hook is left alone — a factory's configuration, a policy class's own
+helpers — so only "no hook at all" is refused. `tsc` already rejects every one of these shapes at
+the class declaration; the runtime check is for the paths that import model files without having
+type-checked them, which is `registerModels` at boot and `gemi check models`.
+
 | Member | When it runs | What it does |
 | --- | --- | --- |
 | `before(ctx)` | First | Return `false` (or throw) to deny outright. |
@@ -1746,6 +1763,7 @@ Every failure is a typed error from `gemi/orm`, not a driver string.
 | `UniqueConstraintError` | A unique constraint was violated, with the constraint identified. It is gemi's own error and carries no Prisma `code` — see below if a `"P2002"` check is what you have today. |
 | `PolicyDeniedError` | A `before` denied, or `ctx.user` was read with no user. |
 | `ScopeEscapeError` | An `update` wrote a column its own policy's `scope` selects on, with no `onUpdate`. |
+| `InvalidPolicyEntryError` | A `$policies` entry that cannot run — a factory nobody called, or an entry whose keys are none of `before` / `scope` / `onCreate` / `onUpdate` / `redact`. Names the class and the index. Raised at boot by `registerModels`, not on the query. |
 | `UnknownFieldError` / `UnknownRelationError` | A name that is not on the model. |
 | `UnsupportedQueryError` | A query shape the compiler does not implement — with what and why. |
 | `ModelNotRegisteredError` / `UnregisteredPolicyClassError` | Registry problems (see [Setup](#your-model-class)). |

--- a/packages/gemi/bin/check-models.test.ts
+++ b/packages/gemi/bin/check-models.test.ts
@@ -704,11 +704,13 @@ describe("the printed report", () => {
  * A `$policies` entry the ORM cannot use at all — #321, seen from the command
  * this issue was found with.
  *
- * The audit reports divergences as values and *throws* for an entry that could
- * never run, because there is no ranked finding to make of one: the file's
- * answer does not exist. `InvalidPolicyEntryError` names the class and the
- * index; only this walk knows the file, which was the third of the three things
- * the original bare `TypeError` failed to answer on a 79-model app.
+ * The audit reports divergences as values and *raises* for an entry that could
+ * never run, because there is no ranked finding to make of one: a finding is
+ * printed with an `export … from` line as its fix and counted among the things
+ * the file got wrong, and an entry the runtime cannot dispatch to is none of
+ * those. `InvalidPolicyEntryError` names the class and the index; only this walk
+ * knows the file, which was the third of the three things the original bare
+ * `TypeError` failed to answer on a 79-model app.
  */
 describe("a file whose $policies cannot run", () => {
   test("stops the run and names the file, the class and the index", () => {
@@ -728,7 +730,6 @@ describe("a file whose $policies cannot run", () => {
     expect(thrown).toBeInstanceOf(CheckModelsError);
     expect((thrown as Error).message).toContain("app/models/x.ts");
     expect((thrown as Error).message).toContain("ScopedAccount.$policies[0]");
-    expect((thrown as Error).cause).toBeInstanceOf(orm.InvalidPolicyEntryError);
   });
 
   test("a typo'd hook is refused here too, rather than passing green", () => {
@@ -740,7 +741,82 @@ describe("a file whose $policies cannot run", () => {
 
     expect(() =>
       auditModules(orm, [module({ ScopedAccount })], snapshotRegistry(orm)),
-    ).toThrow(/Did you mean `scope`\?/);
+    ).toThrow(/Is 'scopes' meant to be `scope`\?/);
+  });
+
+  /**
+   * **Every unreadable file, not the first one.**
+   *
+   * The silent-typo case is the one where an author has several, because nothing
+   * was telling them about any of them — so stopping at the first turns a
+   * checker back into fix-one, rerun, find-the-next. The findings this command
+   * normally prints are already reported all at once for that reason.
+   */
+  test("all of them are reported together", () => {
+    class BadOne extends UserBase {
+      static $policies = [{ scopes: () => ({}) }] as any;
+    }
+    class BadTwo extends UserBase {
+      static $policies = [{ redacts: () => ({}) }] as any;
+    }
+
+    orm.registerModels({ UserBase });
+
+    let thrown: unknown;
+    try {
+      auditModules(
+        orm,
+        [
+          { label: "app/models/a.ts", specifier: "./a", module: { BadOne } },
+          { label: "app/models/b.ts", specifier: "./b", module: { BadTwo } },
+        ],
+        snapshotRegistry(orm),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(CheckModelsError);
+    expect((thrown as Error).message).toContain("2 files could not be checked");
+    expect((thrown as Error).message).toContain("app/models/a.ts");
+    expect((thrown as Error).message).toContain("app/models/b.ts");
+  });
+
+  // A good file beside a bad one is still walked, so the reader is not told to
+  // fix the entry and then handed the findings on the next run.
+  test("a readable file beside an unreadable one is still audited", () => {
+    class Bad extends UserBase {
+      static $policies = [{ scopes: () => ({}) }] as any;
+    }
+    class Membership extends UserBase {
+      static $policies = [scope];
+    }
+
+    orm.registerModels({ UserBase });
+
+    let thrown: unknown;
+    try {
+      auditModules(
+        orm,
+        [
+          { label: "app/models/a.ts", specifier: "./a", module: { Bad } },
+          {
+            label: "app/models/b.ts",
+            specifier: "./b",
+            module: { Membership },
+          },
+        ],
+        snapshotRegistry(orm),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    // It still refuses — but `b.ts` was reached, which is what says the loop
+    // carried on rather than unwinding at `a.ts`.
+    expect(thrown).toBeInstanceOf(CheckModelsError);
+    expect((thrown as Error).message).toContain("A file could not be checked");
+    expect((thrown as Error).message).not.toContain("app/models/b.ts");
   });
 
   /**

--- a/packages/gemi/bin/check-models.test.ts
+++ b/packages/gemi/bin/check-models.test.ts
@@ -700,3 +700,66 @@ describe("the printed report", () => {
     ).toContain("2 model classes are not registered");
   });
 });
+/**
+ * A `$policies` entry the ORM cannot use at all — #321, seen from the command
+ * this issue was found with.
+ *
+ * The audit reports divergences as values and *throws* for an entry that could
+ * never run, because there is no ranked finding to make of one: the file's
+ * answer does not exist. `InvalidPolicyEntryError` names the class and the
+ * index; only this walk knows the file, which was the third of the three things
+ * the original bare `TypeError` failed to answer on a 79-model app.
+ */
+describe("a file whose $policies cannot run", () => {
+  test("stops the run and names the file, the class and the index", () => {
+    class ScopedAccount extends UserBase {
+      static $policies = [() => ({ scope: () => ({ id: 0 }) })] as any;
+    }
+
+    orm.registerModels({ UserBase });
+
+    let thrown: unknown;
+    try {
+      auditModules(orm, [module({ ScopedAccount })], snapshotRegistry(orm));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(CheckModelsError);
+    expect((thrown as Error).message).toContain("app/models/x.ts");
+    expect((thrown as Error).message).toContain("ScopedAccount.$policies[0]");
+    expect((thrown as Error).cause).toBeInstanceOf(orm.InvalidPolicyEntryError);
+  });
+
+  test("a typo'd hook is refused here too, rather than passing green", () => {
+    class ScopedAccount extends UserBase {
+      static $policies = [{ scopes: () => ({ organizationId: 7 }) }] as any;
+    }
+
+    orm.registerModels({ UserBase });
+
+    expect(() =>
+      auditModules(orm, [module({ ScopedAccount })], snapshotRegistry(orm)),
+    ).toThrow(/Did you mean `scope`\?/);
+  });
+
+  /**
+   * The registry is process-wide and the walk clears it per file, so a throw
+   * that skipped the final restore would leave whatever the failing file's
+   * import happened to register — for a test, or a dev server, to read next.
+   */
+  test("the baseline registry is restored even though it threw", () => {
+    class ScopedAccount extends UserBase {
+      static $policies = [{}] as any;
+    }
+
+    orm.registerModels({ UserBase });
+    const baseline = snapshotRegistry(orm);
+
+    expect(() =>
+      auditModules(orm, [module({ ScopedAccount })], baseline),
+    ).toThrow(CheckModelsError);
+
+    expect(snapshotRegistry(orm)).toEqual(baseline);
+  });
+});

--- a/packages/gemi/bin/check-models.ts
+++ b/packages/gemi/bin/check-models.ts
@@ -213,15 +213,36 @@ export function auditModules(
 
   const findings: Finding[] = [];
 
-  // `try`/`finally`, because `auditOne` throws for a file whose `$policies` the
-  // ORM cannot use at all. The registry is process-wide, so leaving it as that
-  // file happened to leave it would hand the next caller — a test, or a dev
-  // server that keeps going — an arrangement nobody chose.
+  /**
+   * Files whose audit raised rather than answered — a `$policies` entry the ORM
+   * cannot use at all.
+   *
+   * **Collected and reported together at the end, rather than thrown on the
+   * first one.** Stopping at the first was the obvious shape and it undoes half
+   * of what this command is for: the silent-typo case is the one where an author
+   * has *several*, because nothing was telling them about any of them, and
+   * fix-one-rerun-find-the-next is exactly the loop a checker exists to replace.
+   * The findings this command normally prints are already reported all at once
+   * for that reason.
+   *
+   * It is still a throw and not a finding. A finding is ranked, printed with an
+   * `export … from` line as the fix, and counted as one of the things the file
+   * got wrong; an entry the runtime cannot construct or dispatch to is none of
+   * those — it is the reason this file has no answer.
+   */
+  const unreadable: string[] = [];
+
+  // `try`/`finally`, because the loop can leave the registry as whichever file
+  // it stopped in left it. The registry is process-wide, so that would hand the
+  // next caller — a test, or a dev server that keeps going — an arrangement
+  // nobody chose.
   try {
     for (const file of files) {
       restore();
 
-      for (const problem of auditOne(orm, file)) {
+      const problems = auditOne(orm, file, unreadable);
+
+      for (const problem of problems) {
         // Only `queried` — "this class carries policies the registered one does
         // not" — is this command's business. The other two are shapes it would
         // be wrong to report:
@@ -253,6 +274,13 @@ export function auditModules(
     restore();
   }
 
+  if (unreadable.length > 0) {
+    throw new CheckModelsError(
+      `${unreadable.length === 1 ? "A file" : `${unreadable.length} files`} ` +
+        `could not be checked:\n\n${unreadable.join("\n\n")}`,
+    );
+  }
+
   return findings;
 }
 
@@ -261,15 +289,12 @@ export function auditModules(
  *
  * `auditModelRegistrations` reports divergences as *values*, and separately
  * refuses a model whose `$policies` cannot run at all — a factory nobody called,
- * an entry whose only key is a typo of a hook. That refusal is a throw, and it
- * has to be: an entry the runtime cannot use is not a finding to rank against
- * others, it is a reason the audit's answer for that file does not exist.
- *
- * The error names the class and the index (#321). What it cannot know is the
- * file, because it is raised inside the ORM, from a class object — and "which
- * file" is the third of the three things the original bare `TypeError` failed to
- * answer on a 79-model app. This walk is the one place that knows, so it says
- * so, and keeps the original as `cause`.
+ * an entry whose only key is a typo of a hook. The error names the class and the
+ * index (#321). What it cannot know is the **file**, because it is raised inside
+ * the ORM from a class object — and "which file" is the third of the three
+ * things the original bare `TypeError` failed to answer on a 79-model app. This
+ * walk is the one place that knows, so it records it and carries on to the next
+ * file; the caller reports them together.
  *
  * Deliberately catches everything rather than testing for a class: the ORM is
  * resolved from the project being checked, so `instanceof` against a class
@@ -280,14 +305,13 @@ export function auditModules(
 function auditOne(
   orm: OrmSurface,
   file: { label: string; module: Record<string, unknown> },
+  unreadable: string[],
 ): UnregisteredPolicyClassError[] {
   try {
     return orm.auditModelRegistrations(file.module);
   } catch (error) {
-    throw new CheckModelsError(
-      `${file.label} could not be checked:\n    ${(error as Error).message}`,
-      { cause: error },
-    );
+    unreadable.push(`${file.label}:\n    ${(error as Error).message}`);
+    return [];
   }
 }
 

--- a/packages/gemi/bin/check-models.ts
+++ b/packages/gemi/bin/check-models.ts
@@ -213,41 +213,82 @@ export function auditModules(
 
   const findings: Finding[] = [];
 
-  for (const file of files) {
-    restore();
+  // `try`/`finally`, because `auditOne` throws for a file whose `$policies` the
+  // ORM cannot use at all. The registry is process-wide, so leaving it as that
+  // file happened to leave it would hand the next caller — a test, or a dev
+  // server that keeps going — an arrangement nobody chose.
+  try {
+    for (const file of files) {
+      restore();
 
-    for (const problem of orm.auditModelRegistrations(file.module)) {
-      // Only `queried` — "this class carries policies the registered one does
-      // not" — is this command's business. The other two are shapes it would be
-      // wrong to report:
-      //
-      //   `narrowing` is a policied view, which `registerModels` refuses
-      //   *because* registering it would apply its scope to every nested read,
-      //   and whose error tells the author to keep it out of the declared
-      //   modules. Being absent from them is what following that advice looks
-      //   like.
-      //
-      //   `registered` is the mirror image: an *unpolicied* class claiming a
-      //   name the registered class carries policies for. That contradicts this
-      //   command's own rule about unpolicied classes, and its message is
-      //   written for a call site — "query the registered one instead" — under
-      //   which the export line printed below would land two unrelated classes
-      //   in one namespace and turn a working boot into
-      //   `AmbiguousModelRegistrationError`.
-      if (problem.carries !== "queried") continue;
+      for (const problem of auditOne(orm, file)) {
+        // Only `queried` — "this class carries policies the registered one does
+        // not" — is this command's business. The other two are shapes it would
+        // be wrong to report:
+        //
+        //   `narrowing` is a policied view, which `registerModels` refuses
+        //   *because* registering it would apply its scope to every nested
+        //   read, and whose error tells the author to keep it out of the
+        //   declared modules. Being absent from them is what following that
+        //   advice looks like.
+        //
+        //   `registered` is the mirror image: an *unpolicied* class claiming a
+        //   name the registered class carries policies for. That contradicts
+        //   this command's own rule about unpolicied classes, and its message
+        //   is written for a call site — "query the registered one instead" —
+        //   under which the export line printed below would land two unrelated
+        //   classes in one namespace and turn a working boot into
+        //   `AmbiguousModelRegistrationError`.
+        if (problem.carries !== "queried") continue;
 
-      findings.push({
-        file: file.label,
-        specifier: file.specifier,
-        className: problem.queried,
-        message: problem.message,
-      });
+        findings.push({
+          file: file.label,
+          specifier: file.specifier,
+          className: problem.queried,
+          message: problem.message,
+        });
+      }
     }
+  } finally {
+    restore();
   }
 
-  restore();
-
   return findings;
+}
+
+/**
+ * One file's audit, with the file's name attached to anything it raises.
+ *
+ * `auditModelRegistrations` reports divergences as *values*, and separately
+ * refuses a model whose `$policies` cannot run at all — a factory nobody called,
+ * an entry whose only key is a typo of a hook. That refusal is a throw, and it
+ * has to be: an entry the runtime cannot use is not a finding to rank against
+ * others, it is a reason the audit's answer for that file does not exist.
+ *
+ * The error names the class and the index (#321). What it cannot know is the
+ * file, because it is raised inside the ORM, from a class object — and "which
+ * file" is the third of the three things the original bare `TypeError` failed to
+ * answer on a 79-model app. This walk is the one place that knows, so it says
+ * so, and keeps the original as `cause`.
+ *
+ * Deliberately catches everything rather than testing for a class: the ORM is
+ * resolved from the project being checked, so `instanceof` against a class
+ * imported here compares across two copies of the module and is false exactly
+ * when it matters — the reason `isUniqueConstraintError` exists in the first
+ * place. Whatever the reason, a file that could not be audited is worth naming.
+ */
+function auditOne(
+  orm: OrmSurface,
+  file: { label: string; module: Record<string, unknown> },
+): UnregisteredPolicyClassError[] {
+  try {
+    return orm.auditModelRegistrations(file.module);
+  } catch (error) {
+    throw new CheckModelsError(
+      `${file.label} could not be checked:\n    ${(error as Error).message}`,
+      { cause: error },
+    );
+  }
 }
 
 /** A condition that makes the check meaningless, phrased for the terminal. */

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -498,6 +498,110 @@ export class UnregisteredPolicyClassError extends Error {
 }
 
 /**
+ * Thrown when a `$policies` array holds something that is not a usable policy.
+ *
+ * Every case it covers is refused today — by `tsc`, at the class declaration,
+ * with `TS2417`, because `Model` declares `static $policies?: readonly
+ * PolicyEntry[]` and `ModelPolicy`'s members are all optional, so a typo'd key
+ * trips weak-type detection. This is therefore a guard on the paths that import
+ * user code *without* having type-checked it: `registerModels` at boot, and
+ * `gemi check models`, whose whole job is to find mistakes in a file somebody is
+ * still writing.
+ *
+ * Two failures, and the second is the one that matters.
+ *
+ * **A function that cannot be constructed.** `resolveEntry` instantiates every
+ * function entry with no arguments, so a factory nobody called — `softDeletes`
+ * rather than `softDeletes({ field })` — used to reach `new entry` and produce a
+ * bare `TypeError: function is not a constructor`. Loud, and it named neither
+ * the model nor the index nor the file, which on a 79-model app leaves the first
+ * question unanswered.
+ *
+ * **An entry with no recognised hook.** `{ scopes: … }` and
+ * `{ default: { scope: … } }` were accepted in silence: `applyPolicies`
+ * dispatches on `before` / `scope` / `onCreate` / `onUpdate` and
+ * `applyRedaction` on `redact`, so an entry spelling none of them contributes
+ * nothing. The model then carries a visible `$policies` array, passes
+ * `gemi check models` as correctly registered, and **reads unscoped** — the same
+ * written-believed-not-in-effect shape `UnregisteredPolicyClassError` exists
+ * for, arriving through a typo instead of through the registry.
+ *
+ * The line between *empty but valid* and *malformed* is drawn at "would this
+ * ever run": an entry with at least one recognised hook that is callable is
+ * accepted whatever else it carries, because a factory's return value and a
+ * policy class routinely hold configuration and helpers beside the hooks, and
+ * refusing unknown *extra* keys would reject code that works. An entry with no
+ * callable hook at all is refused, `{}` included — it is indistinguishable from
+ * a policy that was meant to do something, and a conditional policy belongs in
+ * the array rather than in the entry.
+ */
+export class InvalidPolicyEntryError extends Error {
+  constructor(
+    /**
+     * The class whose **own** `$policies` array holds the entry — the class the
+     * author wrote the array on, which is not necessarily the model being
+     * queried when the array is on a base.
+     */
+    public readonly model: string,
+    /** The entry's index in that array. */
+    public readonly index: number,
+    public readonly reason:
+      | "not-a-policy"
+      | "not-constructable"
+      | "no-hooks"
+      | "hook-not-callable",
+    /** What was found in the entry's place, rendered for a human. */
+    public readonly found: string,
+    /**
+     * The hook names the runtime dispatches on, supplied by `policy.ts` so the
+     * list lives beside the code that reads it rather than being restated here.
+     */
+    hooks: readonly string[],
+    /**
+     * The nearest recognised hook to something the entry actually spells, when
+     * one is close enough to be worth naming.
+     */
+    public readonly suggestion?: string,
+  ) {
+    const where = `${model}.$policies[${index}]`;
+    const named =
+      hooks.length > 1
+        ? `${hooks.slice(0, -1).join(", ")} or ${hooks[hooks.length - 1]}`
+        : (hooks[0] ?? "");
+
+    super(
+      reason === "not-a-policy"
+        ? `${where} is ${found}, which is not a policy. An entry is either a ` +
+            `policy object — { scope, onCreate, … } — or a class the ORM ` +
+            `constructs with no arguments.\n\n` +
+            `A policy that only sometimes applies belongs in the array rather ` +
+            `than in the entry:\n\n` +
+            `    static $policies = [...(multiTenant ? [tenantScope] : [])]\n`
+        : reason === "not-constructable"
+          ? `${where} is ${found}, and a function entry is instantiated with ` +
+            `no arguments — so an arrow function, a plain function, or a ` +
+            `factory that was never called cannot be one.\n\n` +
+            `If it is a factory, call it:\n\n` +
+            `    static $policies = [softDeletes({ field: "deletedAt" })]\n\n` +
+            `If it is a class whose constructor takes arguments, construct ` +
+            `it yourself and put the instance in the array.\n`
+          : reason === "hook-not-callable"
+            ? `${where} has a ${found}, and every hook is called — so this ` +
+              `would throw on the first query that reached it rather than ` +
+              `doing whatever it was meant to do. Give it a function, or ` +
+              `leave the key out.\n`
+            : `${where} has none of ${named}, so it would never run. The ` +
+              `model carries a visible $policies array and nothing in it ` +
+              `applies to any query — which for a scope means the model ` +
+              `reads unscoped. ${found}` +
+              (suggestion ? ` Did you mean \`${suggestion}\`?` : "") +
+              `\n`,
+    );
+    this.name = "InvalidPolicyEntryError";
+  }
+}
+
+/**
  * Thrown when `registerModels` finds two unrelated classes in one module both
  * claiming the same model name.
  *

--- a/packages/gemi/orm/errors.ts
+++ b/packages/gemi/orm/errors.ts
@@ -510,12 +510,18 @@ export class UnregisteredPolicyClassError extends Error {
  *
  * Two failures, and the second is the one that matters.
  *
- * **A function that cannot be constructed.** `resolveEntry` instantiates every
- * function entry with no arguments, so a factory nobody called — `softDeletes`
- * rather than `softDeletes({ field })` — used to reach `new entry` and produce a
- * bare `TypeError: function is not a constructor`. Loud, and it named neither
- * the model nor the index nor the file, which on a 79-model app leaves the first
- * question unanswered.
+ * **A function the ORM cannot get a policy out of.** `resolveEntry` instantiates
+ * every function entry with no arguments, and there are two ways that goes
+ * wrong. A factory nobody called — `softDeletes` rather than
+ * `softDeletes({ field })` — is not constructable at all and reached `new entry`
+ * to produce `TypeError: function is not a constructor`. A class that *is*
+ * constructable and whose constructor wants an argument gets through that check
+ * and dies inside its own body instead, with
+ * `TypeError: undefined is not an object (evaluating 'opts.field')`. Both are
+ * loud and neither named the model, the index or the file, which on a 79-model
+ * app leaves the first question unanswered; the second is the case that survived
+ * a first pass at this error, because "constructable" is a fact about
+ * `[[Construct]]` and says nothing about what the constructor then does.
  *
  * **An entry with no recognised hook.** `{ scopes: … }` and
  * `{ default: { scope: … } }` were accepted in silence: `applyPolicies`
@@ -548,6 +554,7 @@ export class InvalidPolicyEntryError extends Error {
     public readonly reason:
       | "not-a-policy"
       | "not-constructable"
+      | "constructor-threw"
       | "no-hooks"
       | "hook-not-callable",
     /** What was found in the entry's place, rendered for a human. */
@@ -558,10 +565,17 @@ export class InvalidPolicyEntryError extends Error {
      */
     hooks: readonly string[],
     /**
-     * The nearest recognised hook to something the entry actually spells, when
-     * one is close enough to be worth naming.
+     * A key the entry actually spells and the hook it is within one edit of.
+     *
+     * **The pair, not the hook alone.** An unattributed "Did you mean `scope`?"
+     * after a list of five keys does not say which of them was read as a
+     * misspelling, so a reader who can see that none of them are has no way to
+     * dismiss it — and this error is about an authorization rule that is not in
+     * effect, where a suggestion followed wrongly costs a rename of something
+     * that was never the problem.
      */
-    public readonly suggestion?: string,
+    public readonly suggestion?: { key: string; hook: string },
+    options?: { cause?: unknown },
   ) {
     const where = `${model}.$policies[${index}]`;
     const named =
@@ -582,20 +596,30 @@ export class InvalidPolicyEntryError extends Error {
             `no arguments — so an arrow function, a plain function, or a ` +
             `factory that was never called cannot be one.\n\n` +
             `If it is a factory, call it:\n\n` +
-            `    static $policies = [softDeletes({ field: "deletedAt" })]\n\n` +
-            `If it is a class whose constructor takes arguments, construct ` +
-            `it yourself and put the instance in the array.\n`
-          : reason === "hook-not-callable"
-            ? `${where} has a ${found}, and every hook is called — so this ` +
-              `would throw on the first query that reached it rather than ` +
-              `doing whatever it was meant to do. Give it a function, or ` +
-              `leave the key out.\n`
-            : `${where} has none of ${named}, so it would never run. The ` +
-              `model carries a visible $policies array and nothing in it ` +
-              `applies to any query — which for a scope means the model ` +
-              `reads unscoped. ${found}` +
-              (suggestion ? ` Did you mean \`${suggestion}\`?` : "") +
-              `\n`,
+            `    static $policies = [softDeletes({ field: "deletedAt" })]\n`
+          : reason === "constructor-threw"
+            ? `${where} is ${found}\n\n` +
+              `A class entry is constructed with no arguments. If this one ` +
+              `needs some, construct it yourself and put the instance in the ` +
+              `array:\n\n` +
+              `    static $policies = [new TenantPolicy({ field: "orgId" })]\n\n` +
+              `If the constructor reaches for something that is not ready yet, ` +
+              `note that it runs on the first query through this model, not at ` +
+              `boot.\n`
+            : reason === "hook-not-callable"
+              ? `${where} has a ${found}, and every hook is called — so this ` +
+                `would throw on the first query that reached it rather than ` +
+                `doing whatever it was meant to do. Give it a function, or ` +
+                `leave the key out.\n`
+              : `${where} has none of ${named}, so it would never run. The ` +
+                `model carries a visible $policies array and nothing in it ` +
+                `applies to any query — which for a scope means the model ` +
+                `reads unscoped. ${found}` +
+                (suggestion
+                  ? ` Is '${suggestion.key}' meant to be \`${suggestion.hook}\`?`
+                  : "") +
+                `\n`,
+      options,
     );
     this.name = "InvalidPolicyEntryError";
   }

--- a/packages/gemi/orm/index.ts
+++ b/packages/gemi/orm/index.ts
@@ -90,6 +90,7 @@ export {
 export {
   AmbiguousModelRegistrationError,
   DecodeError,
+  InvalidPolicyEntryError,
   MalformedRelationError,
   MissingModelSchemaError,
   MissingRequiredValueError,

--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -1605,6 +1605,58 @@ describe("a malformed $policies entry", () => {
       expect(entry(Tenant.bind(null))).not.toThrow();
     });
 
+    /**
+     * #321's case A3, and the one this error missed on its first pass.
+     *
+     * "Constructable" is a fact about `[[Construct]]` and says nothing about the
+     * body, so a class whose constructor wants an argument passes the check
+     * above and then dies inside `new` — which is where the bare `TypeError`
+     * naming no model, no index and no file came back. The `not-constructable`
+     * message even prints the advice for this shape, and that branch is
+     * unreachable for it.
+     */
+    test("a constructor that needs an argument is named rather than crashing raw", () => {
+      class TenantPolicy {
+        field: string;
+        constructor(options: { field: string }) {
+          this.field = options.field;
+        }
+        scope() {
+          return { [this.field]: null };
+        }
+      }
+
+      const thrown = (() => {
+        try {
+          entry(TenantPolicy)();
+        } catch (error) {
+          return error as InvalidPolicyEntryError;
+        }
+        return undefined;
+      })();
+
+      expect(thrown).toBeInstanceOf(InvalidPolicyEntryError);
+      expect(thrown!.reason).toBe("constructor-threw");
+      expect(thrown!.model).toBe("Account");
+      expect(thrown!.index).toBe(0);
+      expect(thrown!.message).toContain("Account.$policies[0]");
+      expect(thrown!.message).toContain("TenantPolicy");
+      // The constructor's own words are quoted, and kept.
+      expect(thrown!.message).toContain("constructing it threw");
+      expect(thrown!.cause).toBeInstanceOf(TypeError);
+    });
+
+    test("and so is a constructor that throws for any other reason", () => {
+      class Unready {
+        constructor() {
+          throw new Error("service container not ready");
+        }
+      }
+
+      expect(entry(Unready)).toThrow(/service container not ready/);
+      expect(entry(Unready)).toThrow(InvalidPolicyEntryError);
+    });
+
     // `Reflect.construct` validates its `newTarget` before running the target's
     // body, so the probe answers the question without executing user code. This
     // runs at boot over every class in a declared module, so it matters.
@@ -1641,14 +1693,16 @@ describe("a malformed $policies entry", () => {
       );
     });
 
-    test("and the near miss is suggested", () => {
+    // Attributed to the key it is about, so a reader who can see that none of
+    // their keys are misspellings has something to dismiss.
+    test("and the near miss is suggested, with the key it is about", () => {
       expect(entry({ scopes: () => ({ id: 0 }) })).toThrow(
-        /It spells 'scopes'\. Did you mean `scope`\?/,
+        /It spells 'scopes'\. Is 'scopes' meant to be `scope`\?/,
       );
     });
 
     // A wrong suggestion in an authorization error is worse than none, so the
-    // threshold is two edits and `default` is six from `scope`.
+    // threshold is one edit and `default` is six from `scope`.
     test("a key that is not a near miss gets no suggestion", () => {
       const thrown = (() => {
         try {
@@ -1661,9 +1715,47 @@ describe("a malformed $policies entry", () => {
 
       expect(thrown!.reason).toBe("no-hooks");
       expect(thrown!.suggestion).toBeUndefined();
-      expect(thrown!.message).not.toContain("Did you mean");
+      expect(thrown!.message).not.toContain("meant to be");
       // ...and the shape it actually is gets named instead.
       expect(thrown!.message).toContain("module namespace");
+    });
+
+    /**
+     * The mislead direction, which two edits got wrong and nothing was testing.
+     *
+     * `store`, `code` and `copy` are each two edits from `scope`, and `reduce`
+     * is two from `redact` — all ordinary names for things that sit beside a
+     * policy, none of them a misspelling of anything. At the old threshold every
+     * one of these produced a confident "Did you mean `scope`?" to an author who
+     * had not typed `scope` at all.
+     */
+    test.each([
+      ["store", { store: {}, currentOrg: () => 1 }],
+      ["code / copy / lookup", { code: 1, copy: () => 1, lookup: () => 1 }],
+      ["reduce", { reduce: () => 1 }],
+    ])("a key that merely resembles a hook is not suggested (%s)", (_l, shape) => {
+      const thrown = (() => {
+        try {
+          entry(shape)();
+        } catch (error) {
+          return error as InvalidPolicyEntryError;
+        }
+        return undefined;
+      })();
+
+      expect(thrown!.reason).toBe("no-hooks");
+      expect(thrown!.suggestion).toBeUndefined();
+      expect(thrown!.message).not.toContain("meant to be");
+    });
+
+    // An error whose useful sentence is buried under forty keys is a worse
+    // error than one that says "and 32 more".
+    test("the key list has a ceiling", () => {
+      const wide = Object.fromEntries(
+        Array.from({ length: 40 }, (_value, index) => [`key${index}`, 1]),
+      );
+
+      expect(entry(wide)).toThrow(/'key7' and 32 more/);
     });
 
     test("an entry with nothing in it at all is refused", () => {
@@ -1749,8 +1841,16 @@ describe("a malformed $policies entry", () => {
       ["undefined", undefined],
       ["false, from a && that did not hold", false],
       ["a string", "softDeletes"],
+      // `$policies = [[a, b]]` is a plausible slip, and reading the inner array
+      // as a policy listed `length`, `concat`, `pop` and the rest of
+      // `Array.prototype` as the keys it "spells".
+      ["a nested array", [{ scope: () => ({}) }]],
     ])("%s is refused", (_label, value) => {
       expect(entry(value)).toThrow(/is not a policy/);
+    });
+
+    test("a nested array does not print Array.prototype as its keys", () => {
+      expect(entry([{ scope: () => ({}) }])).not.toThrow(/concat/);
     });
 
     test("a recognised hook that is not a function is refused before it can throw", () => {

--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  InvalidPolicyEntryError,
   PolicyDeniedError,
   ScopeEscapeError,
   UnsupportedQueryError,
 } from "./errors";
 import { organization, user } from "./fixtures";
+import { softDeletes } from "./soft-deletes";
 import {
   applyNestedPolicies,
   applyPolicies,
@@ -1519,5 +1521,287 @@ describe("the old $policy name", () => {
     }
 
     expect(() => policiesFor(Derived)).toThrow(/\$policies/);
+  });
+});
+
+/**
+ * A `$policies` entry that could never do what it was written to do — #321.
+ *
+ * Two failures with one cause, and the file had nothing about either, which is
+ * how both survived: every test above hands `policiesFor` a well-formed entry.
+ *
+ * **A function that is not constructable** used to reach `new entry` and die
+ * with `TypeError: function is not a constructor`, naming neither the class nor
+ * the index nor the file. It is the boot path as well as the CLI's, because
+ * `registerModels` resolves policies to run its audit.
+ *
+ * **An entry with no recognised hook** used to register in silence. `applyPolicies`
+ * dispatches on `before` / `scope` / `onCreate` / `onUpdate` and `applyRedaction`
+ * on `redact`, so `{ scopes: … }` contributes nothing while the class visibly
+ * carries an array and `gemi check models` reports it as policied — a model that
+ * reads unscoped with nothing raised, which is #316 and #318's shape arriving
+ * through a typo.
+ *
+ * The boundary the tests below pin is the one that could break a working app:
+ * everything *beside* a recognised hook is left alone, and only "no callable
+ * hook at all" is refused.
+ */
+describe("a malformed $policies entry", () => {
+  const entry = (value: unknown) => {
+    class Account {
+      static $policies = [value] as unknown as ModelPolicy[];
+    }
+    return () => policiesFor(Account);
+  };
+
+  describe("a function that cannot be constructed", () => {
+    test("a factory nobody called is refused, and the factory is named", () => {
+      const softDeletes = (_options: { field: string }) => ({
+        scope: () => ({ deletedAt: null }),
+      });
+
+      expect(entry(softDeletes)).toThrow(InvalidPolicyEntryError);
+      expect(entry(softDeletes)).toThrow(
+        /Account\.\$policies\[0\] is the function `softDeletes`/,
+      );
+    });
+
+    // The issue's own reproduction. An arrow function has no name to report, so
+    // the class and the index are the whole of what identifies it — which is
+    // exactly what the bare TypeError did not carry.
+    test("an inline arrow entry names the class and the index", () => {
+      const thrown = (() => {
+        try {
+          entry(() => ({ scope: () => ({ id: 0 }) }))();
+        } catch (error) {
+          return error as InvalidPolicyEntryError;
+        }
+        return undefined;
+      })();
+
+      expect(thrown).toBeInstanceOf(InvalidPolicyEntryError);
+      expect(thrown!.model).toBe("Account");
+      expect(thrown!.index).toBe(0);
+      expect(thrown!.reason).toBe("not-constructable");
+      expect(thrown!.message).toContain("Account.$policies[0]");
+      expect(thrown!.message).toContain("softDeletes({ field:");
+    });
+
+    test("a generator function is refused too — it has a prototype and is not a constructor", () => {
+      expect(entry(function* () {})).toThrow(InvalidPolicyEntryError);
+    });
+
+    // The over-strict direction. `SomeClass.bind(null)` has no own `prototype`,
+    // which is the property the obvious implementation of this check reads — and
+    // it is perfectly constructable. Refusing it would stop an app booting over
+    // a policy that works.
+    test("a bound class is accepted, because it really is constructable", () => {
+      class Tenant {
+        scope() {
+          return { orgId: 1 };
+        }
+      }
+
+      expect(entry(Tenant.bind(null))).not.toThrow();
+    });
+
+    // `Reflect.construct` validates its `newTarget` before running the target's
+    // body, so the probe answers the question without executing user code. This
+    // runs at boot over every class in a declared module, so it matters.
+    test("the constructability probe does not run the policy's constructor", () => {
+      let constructed = 0;
+
+      class Counting {
+        constructor() {
+          constructed++;
+        }
+        scope() {
+          return {};
+        }
+      }
+      class Owner {
+        static $policies = [Counting] as unknown as ModelPolicy[];
+      }
+
+      policiesFor(Owner);
+      policiesFor(Owner);
+
+      // Once, by `resolveEntry` — the probe adds none.
+      expect(constructed).toBe(1);
+    });
+  });
+
+  describe("an entry with no hook the runtime dispatches on", () => {
+    test("a typo'd hook is refused rather than accepted in silence", () => {
+      expect(entry({ scopes: () => ({ id: 0 }) })).toThrow(
+        InvalidPolicyEntryError,
+      );
+      expect(entry({ scopes: () => ({ id: 0 }) })).toThrow(
+        /has none of before, scope, onCreate, onUpdate or redact/,
+      );
+    });
+
+    test("and the near miss is suggested", () => {
+      expect(entry({ scopes: () => ({ id: 0 }) })).toThrow(
+        /It spells 'scopes'\. Did you mean `scope`\?/,
+      );
+    });
+
+    // A wrong suggestion in an authorization error is worse than none, so the
+    // threshold is two edits and `default` is six from `scope`.
+    test("a key that is not a near miss gets no suggestion", () => {
+      const thrown = (() => {
+        try {
+          entry({ default: { scope: () => ({ id: 0 }) } })();
+        } catch (error) {
+          return error as InvalidPolicyEntryError;
+        }
+        return undefined;
+      })();
+
+      expect(thrown!.reason).toBe("no-hooks");
+      expect(thrown!.suggestion).toBeUndefined();
+      expect(thrown!.message).not.toContain("Did you mean");
+      // ...and the shape it actually is gets named instead.
+      expect(thrown!.message).toContain("module namespace");
+    });
+
+    test("an entry with nothing in it at all is refused", () => {
+      expect(entry({})).toThrow(/It is empty/);
+    });
+
+    // "has none of scope, …" beside "it spells 'scope'" is a contradiction the
+    // reader would have to resolve, so the nullish case says which key it is.
+    test("a hook written down and left unset says so, rather than reading as a typo", () => {
+      expect(entry({ scope: undefined })).toThrow(
+        /writes 'scope' down and leaves it unset/,
+      );
+    });
+
+    // The class form keeps its hooks on a prototype, so `Object.keys` of the
+    // instance is empty and every hook is still there. Reading the resolved
+    // instance rather than the entry is what makes this pass.
+    test("a policy class whose hooks are prototype methods is accepted", () => {
+      class Tenant {
+        scope() {
+          return { orgId: 1 };
+        }
+        onCreate(_context: PolicyContext, data: any) {
+          return data;
+        }
+      }
+
+      expect(entry(Tenant)).not.toThrow();
+    });
+
+    test("a policy class with no hooks is refused, and named", () => {
+      class Nothing {
+        helper() {
+          return 1;
+        }
+      }
+
+      expect(entry(Nothing)).toThrow(/has none of before, scope/);
+    });
+  });
+
+  /**
+   * The line between *empty but valid* and *malformed*, drawn where refusing
+   * would be worse than accepting.
+   *
+   * A factory's return value and a policy class both routinely carry
+   * configuration and helpers beside the hooks, so an unknown-key check would
+   * reject code that works. Only "no callable hook at all" is refused.
+   */
+  describe("what stays valid", () => {
+    test("extra keys beside a real hook are nobody's business", () => {
+      expect(
+        entry({ field: "deletedAt", scope: () => ({}), helper: () => 1 }),
+      ).not.toThrow();
+    });
+
+    test("a hook explicitly set to undefined is absence, not error", () => {
+      expect(
+        entry({ scope: undefined, onCreate: (_c: any, d: any) => d }),
+      ).not.toThrow();
+    });
+
+    test("each of the five hooks alone is enough on its own", () => {
+      for (const hook of [
+        "before",
+        "scope",
+        "onCreate",
+        "onUpdate",
+        "redact",
+      ]) {
+        expect(entry({ [hook]: () => undefined }), hook).not.toThrow();
+      }
+    });
+
+    test("softDeletes() — the shipped factory — passes", () => {
+      expect(entry(softDeletes())).not.toThrow();
+    });
+  });
+
+  describe("an entry that is not a policy at all", () => {
+    test.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["false, from a && that did not hold", false],
+      ["a string", "softDeletes"],
+    ])("%s is refused", (_label, value) => {
+      expect(entry(value)).toThrow(/is not a policy/);
+    });
+
+    test("a recognised hook that is not a function is refused before it can throw", () => {
+      expect(entry({ scope: { orgId: 7 } })).toThrow(
+        /has a 'scope' that is an object rather than a function/,
+      );
+    });
+  });
+
+  /**
+   * The check runs where the array is *declared*, so the class in the message is
+   * the one the author typed the entry under — not whichever subclass a query
+   * happened to arrive through.
+   */
+  test("names the class that declares the array, not the one queried", () => {
+    class TenantBase {
+      static $policies = [{ scopes: () => ({}) }] as unknown as ModelPolicy[];
+    }
+    class Account extends TenantBase {}
+
+    expect(() => policiesFor(Account)).toThrow(/TenantBase\.\$policies\[0\]/);
+  });
+
+  test("the index is the entry's own, not the chain's", () => {
+    class Owner {
+      static $policies = [
+        { scope: () => ({}) },
+        { scope: () => ({}) },
+        { scopes: () => ({}) },
+      ] as unknown as ModelPolicy[];
+    }
+
+    expect(() => policiesFor(Owner)).toThrow(/Owner\.\$policies\[2\]/);
+  });
+
+  /**
+   * Checked once per array, not once per entry per query. `policiesFor` runs per
+   * query per node of an include tree and is deliberately uncached, so the guard
+   * has to cost a `WeakSet` lookup rather than a walk — and a reassigned
+   * `$policies` is a new array, so a test or a feature flag that swaps one is
+   * checked again.
+   */
+  test("a reassigned array is checked again", () => {
+    class Owner {
+      static $policies = [{ scope: () => ({}) }] as unknown as ModelPolicy[];
+    }
+
+    expect(() => policiesFor(Owner)).not.toThrow();
+
+    Owner.$policies = [{ scopes: () => ({}) }] as unknown as ModelPolicy[];
+
+    expect(() => policiesFor(Owner)).toThrow(InvalidPolicyEntryError);
   });
 });

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -361,22 +361,58 @@ const instantiated = new WeakMap<object, ModelPolicy>();
 /**
  * Turns one `$policies` entry into the object the hooks are read off.
  *
- * **Every entry reaching here has been through `assertPolicyEntries`**, which is
- * what makes the unchecked `new` below safe — a function entry has already been
- * proved constructable. The check is there rather than here because the useful
- * message names the class and the array index, and this function has neither:
- * two of its three call sites are `.map(resolveEntry)` over an array held from a
- * *different* level of the prototype walk than the one currently in hand.
+ * Takes the declaring class's name and the entry's index so that **everything
+ * construction can go wrong with is named**. `assertPolicyEntries` has already
+ * proved a function entry constructable, which is a fact about `[[Construct]]`
+ * and says nothing about the body: a class whose constructor takes a required
+ * argument is perfectly constructable and dies inside `new` with
+ * `TypeError: undefined is not an object (evaluating 'opts.field')`. That is
+ * #321's case A3, it is the shape the issue's own `not-constructable` advice was
+ * written for, and it reaches here rather than the check — so the `try` is not
+ * defensive, it is the third of the three cases.
+ *
+ * The hook check for the class form is here too, and can only be here: a policy
+ * class keeps its hooks on a prototype, or assigns them in the constructor, so
+ * there is nothing to read until an instance exists.
  */
-function resolveEntry(entry: PolicyEntry): ModelPolicy {
+function resolveEntry(
+  entry: PolicyEntry,
+  owner: unknown,
+  index: number,
+): ModelPolicy {
   if (typeof entry !== "function") return entry;
 
   const existing = instantiated.get(entry);
   if (existing !== undefined) return existing;
 
-  const made = new (entry as new () => ModelPolicy)();
+  let made: ModelPolicy;
+  try {
+    made = new (entry as new () => ModelPolicy)();
+  } catch (cause) {
+    throw new InvalidPolicyEntryError(
+      nameOfOwner(owner),
+      index,
+      "constructor-threw",
+      `${describeFunction(entry)}, and constructing it threw:\n\n    ` +
+        `${(cause as Error)?.message ?? String(cause)}`,
+      RECOGNISED_HOOKS,
+      undefined,
+      { cause },
+    );
+  }
+
+  assertHasCallableHook(made as Record<string, unknown>, owner, index);
+
   instantiated.set(entry, made);
   return made;
+}
+
+/** One level's entries resolved, each knowing where it was written. */
+function resolveLevel(
+  entries: readonly PolicyEntry[],
+  owner: unknown,
+): ModelPolicy[] {
+  return entries.map((entry, index) => resolveEntry(entry, owner, index));
 }
 
 /**
@@ -387,13 +423,22 @@ function resolveEntry(entry: PolicyEntry): ModelPolicy {
  * of case B in #321 — so this list is the definition of "a policy that would
  * run", and it has to stay the same list.
  *
- * **Adding a member to {@link ModelPolicy} without adding it here is a compile
+ * **Adding a hook to {@link ModelPolicy} without adding it here is a compile
  * error**, by the assertion below. That direction is the dangerous one: a new
  * hook missing from this list would make an entry carrying only that hook look
  * like a typo and be refused at boot — a working policy rejected — which is
  * exactly the over-strictness this guard must not produce. The other direction
  * is checked too, so a name removed from `ModelPolicy` cannot linger here and go
  * on being accepted.
+ *
+ * **The pin is over `ModelPolicy`'s *callable* members, not over `keyof`**, and
+ * that distinction is load-bearing rather than fussy. Entries in this list are
+ * required to be functions — `hook-not-callable` refuses anything else — so a
+ * `keyof` pin would force a future non-function member (`priority?: number`,
+ * `appliesTo?: string[]`) into the list to satisfy the compiler, and every entry
+ * that then set it would be refused at boot. A data member simply is not a hook:
+ * it is left out, it is not required to be callable, and it does not on its own
+ * make an entry one that would run.
  */
 const RECOGNISED_HOOKS = [
   "before",
@@ -403,19 +448,29 @@ const RECOGNISED_HOOKS = [
   "redact",
 ] as const;
 
+/** The members of `T` whose value, when present, is callable. */
+type CallableKeys<T> = {
+  [K in keyof T]-?: NonNullable<T[K]> extends (...args: never[]) => unknown
+    ? K
+    : never;
+}[keyof T];
+
 type _MissingHook = Exclude<
-  keyof ModelPolicy,
+  CallableKeys<ModelPolicy>,
   (typeof RECOGNISED_HOOKS)[number]
 >;
-type _ExtraHook = Exclude<(typeof RECOGNISED_HOOKS)[number], keyof ModelPolicy>;
+type _ExtraHook = Exclude<
+  (typeof RECOGNISED_HOOKS)[number],
+  CallableKeys<ModelPolicy>
+>;
 
 // Assigning `true` is what fails: either branch resolves to a string literal
 // type when the two lists disagree, and the message is the diagnostic.
 const _hooksExhaustive: [_MissingHook] extends [never]
   ? [_ExtraHook] extends [never]
     ? true
-    : "RECOGNISED_HOOKS names a hook ModelPolicy does not declare"
-  : "ModelPolicy declares a hook RECOGNISED_HOOKS does not list — an entry carrying only that hook would be refused at boot" =
+    : "RECOGNISED_HOOKS names something ModelPolicy does not declare as a callable member"
+  : "ModelPolicy declares a callable member RECOGNISED_HOOKS does not list — an entry carrying only that hook would be refused at boot" =
   true;
 void _hooksExhaustive;
 
@@ -455,23 +510,46 @@ function assertPolicyEntries(
 ): void {
   if (checkedEntries.has(entries)) return;
 
-  const model = (owner as { name?: string })?.name ?? "This model";
-
   for (let index = 0; index < entries.length; index++) {
-    assertPolicyEntry(entries[index] as PolicyEntry, model, index);
+    assertPolicyEntry(entries[index] as PolicyEntry, owner, index);
   }
 
   checkedEntries.add(entries);
 }
 
+/**
+ * What can be known about an entry **without constructing it**.
+ *
+ * The split matters, and it is the reviewer's question answered rather than a
+ * layering preference: this half runs at boot over every model class an
+ * application declares, and constructing a policy class there would move
+ * whatever its constructor touches — a config slice, an environment variable, a
+ * service container — from first-query time to `registerModels` time. A class
+ * that was fine because it was built lazily would take the app's boot with it,
+ * and the entry it was refusing might have been perfectly good.
+ *
+ * So: an object entry is fully checkable here (case B is an object entry in both
+ * of the shapes #321 reports), a function entry is checked for `[[Construct]]`
+ * and nothing more, and the class form's hooks are checked in `resolveEntry`
+ * where an instance exists because one was needed anyway.
+ */
 function assertPolicyEntry(
   entry: PolicyEntry,
-  model: string,
+  owner: unknown,
   index: number,
 ): void {
+  const model = nameOfOwner(owner);
   const kind = typeof entry;
 
-  if (entry === null || (kind !== "object" && kind !== "function")) {
+  // Arrays are refused here rather than falling through as objects. A nested
+  // array is a plausible slip — `$policies = [[a, b]]` — and reading one as a
+  // policy produced a message listing `length`, `concat`, `pop` and the rest of
+  // `Array.prototype` as the keys it "spells".
+  if (
+    entry === null ||
+    Array.isArray(entry) ||
+    (kind !== "object" && kind !== "function")
+  ) {
     throw new InvalidPolicyEntryError(
       model,
       index,
@@ -491,14 +569,28 @@ function assertPolicyEntry(
         RECOGNISED_HOOKS,
       );
     }
+
+    // Everything else about a class is a property of its instance.
+    return;
   }
 
-  // Resolved rather than inspected, because the class form puts its hooks on a
-  // prototype: `Object.keys(new TenantPolicy())` is empty and every one of them
-  // is still there. `resolveEntry` memoises, so the instance this proves things
-  // about is the instance every later call gets.
-  const policy = resolveEntry(entry) as Record<string, unknown>;
+  assertHasCallableHook(entry as Record<string, unknown>, owner, index);
+}
 
+/**
+ * The hook check itself, over a policy that already exists — an object entry, or
+ * an instance `resolveEntry` has just built.
+ *
+ * A property read rather than `Object.keys`, so it walks the prototype chain and
+ * sees a class's methods, an inherited hook, a getter and a `defineProperty`
+ * alike. That is the whole reason the class form works at all.
+ */
+function assertHasCallableHook(
+  policy: Record<string, unknown>,
+  owner: unknown,
+  index: number,
+): void {
+  const model = nameOfOwner(owner);
   let callable = 0;
   /** Hooks written down and left nullish — reported, so "it spells 'scope'"
    * beside "it has no scope" is not a contradiction the reader has to resolve. */
@@ -542,6 +634,7 @@ function assertPolicyEntry(
   }
 
   const spelled = spelledKeys(policy);
+  const near = nearestHook(spelled);
 
   throw new InvalidPolicyEntryError(
     model,
@@ -549,7 +642,7 @@ function assertPolicyEntry(
     "no-hooks",
     spelled.length === 0
       ? "It is empty."
-      : `It spells ${spelled.map((key) => `'${key}'`).join(", ")}.` +
+      : `It spells ${listKeys(spelled)}.` +
           // The other half of #321's case B, and it is not a misspelling, so
           // "did you mean" has nothing to offer it: an entry whose only key is
           // `default` is a module namespace — `import * as p` or a CJS interop
@@ -560,8 +653,22 @@ function assertPolicyEntry(
               `policy by name.`
             : ""),
     RECOGNISED_HOOKS,
-    nearestHook(spelled),
+    near,
   );
+}
+
+/**
+ * The keys, listed, with a ceiling.
+ *
+ * A policy-shaped object that happens to carry no hook can hold a great many
+ * keys, and an error whose useful sentence is buried under forty of them is a
+ * worse error than one that says "and 32 more".
+ */
+function listKeys(keys: readonly string[]): string {
+  const shown = keys.slice(0, 8).map((key) => `'${key}'`);
+  return keys.length > shown.length
+    ? `${shown.join(", ")} and ${keys.length - shown.length} more`
+    : shown.join(", ");
 }
 
 /**
@@ -615,23 +722,37 @@ function spelledKeys(policy: object): string[] {
 }
 
 /**
- * The recognised hook a spelled key most plausibly meant, or nothing.
+ * The recognised hook a spelled key most plausibly meant, **with the key it is
+ * about** — or nothing.
  *
- * Two edits, which covers the misspellings that reach here — `scopes`,
- * `Scope`, `onCreated` — and stops short of the ones where a suggestion would
- * be a guess: `default` is six edits from `scope` and gets no "did you mean",
- * because a wrong suggestion in an authorization error is worse than none.
+ * Two things were wrong with the obvious version, and both produced a confident
+ * suggestion to an author who had not misspelled anything.
+ *
+ * **The threshold was two edits.** `store` and `code` and `copy` are each two
+ * from `scope`, and `reduce` is two from `redact` — all ordinary names for
+ * things that sit beside a policy. One edit is what an actual typo costs
+ * (`scopes`, `onCreat`), and case is free because the comparison is lowered
+ * first, so `Scope` still lands. Anything further away is a guess, and this
+ * error's whole subject is an authorization rule that is not in effect: a wrong
+ * suggestion there sends someone to rename a key that was never the problem.
+ *
+ * **And it was reported unattributed.** "Did you mean `scope`?" after a list of
+ * five keys does not say which of them it read as a misspelling, so it cannot be
+ * dismissed by a reader who can see that none of them are. The pair travels
+ * together now, and the error prints both.
  */
-function nearestHook(spelled: readonly string[]): string | undefined {
-  let best: string | undefined;
-  let bestDistance = 3;
+function nearestHook(
+  spelled: readonly string[],
+): { key: string; hook: string } | undefined {
+  let best: { key: string; hook: string } | undefined;
+  let bestDistance = 2;
 
   for (const key of spelled) {
     for (const hook of RECOGNISED_HOOKS) {
       const distance = editDistance(key.toLowerCase(), hook.toLowerCase());
       if (distance < bestDistance) {
         bestDistance = distance;
-        best = hook;
+        best = { key, hook };
       }
     }
   }
@@ -707,6 +828,9 @@ function describeFunction(value: Function): string {
 export function policiesFor(model: unknown): readonly ModelPolicy[] {
   let found: ModelPolicy[] | undefined;
   let only: readonly PolicyEntry[] | undefined;
+  // Held beside `only`, because the class that *declared* the held array is not
+  // the one the walk is standing on by the time it gets resolved.
+  let onlyOwner: unknown;
 
   let current = model as PolicedModel | null;
   while (current && current !== Function.prototype) {
@@ -735,20 +859,26 @@ export function policiesFor(model: unknown): readonly ModelPolicy[] {
         // Before anything is resolved, and with the declaring class in hand —
         // which is what lets the refusal say `ScopedAccount.$policies[0]`
         // instead of dying inside `new entry` with nothing named. Memoised on
-        // the array, so the per-query cost is one `WeakSet.has` per level.
-        assertPolicyEntries(current, level);
+        // the array, so the per-query cost is one `WeakSet.has` per level; the
+        // class is passed rather than its name so that even reading `.name` is
+        // something only a refusal pays for.
+        const owner = current;
+        assertPolicyEntries(owner, level);
 
         if (only === undefined && found === undefined) {
           // First contributing level, walking derived to base. Held rather than
-          // copied, in case it turns out to be the only one.
+          // copied, in case it turns out to be the only one — and the class that
+          // declared it is held beside it, because `current` will have moved on
+          // by the time the array is resolved.
           only = level;
+          onlyOwner = owner;
         } else {
           // A second level exists, so the held one has to be materialised.
           // Unshifted, so the walk's derived-to-base order comes back
           // base-first.
-          found ??= (only as readonly PolicyEntry[]).map(resolveEntry);
+          found ??= resolveLevel(only as readonly PolicyEntry[], onlyOwner);
           only = undefined;
-          found.unshift(...level.map(resolveEntry));
+          found.unshift(...resolveLevel(level, owner));
         }
       }
     }
@@ -762,8 +892,48 @@ export function policiesFor(model: unknown): readonly ModelPolicy[] {
   // without copying when every entry is already an object, which is every
   // factory-authored policy.
   return only.some((entry) => typeof entry === "function")
-    ? only.map(resolveEntry)
+    ? resolveLevel(only, onlyOwner)
     : (only as readonly ModelPolicy[]);
+}
+
+/**
+ * Every `$policies` entry a model class carries, checked as far as it can be
+ * **without constructing anything** — the boot-time half of #321's guard.
+ *
+ * `auditModelRegistrations` calls this for every model class in every declared
+ * module, and that is the whole point: it is the one walk that sees a class
+ * regardless of whether anything registered it, whether it registered itself, or
+ * whether its name is claimed at all. `policiesFor` is only reached there for
+ * the classes whose registration diverges, so the two commonest arrangements —
+ * a class that owns its name, and a name nothing else claims — would boot with
+ * their entries unexamined, which is exactly the `{ scopes: … }` typo shipping.
+ *
+ * **Shape only, deliberately.** The alternative was to resolve, which is one
+ * line and would also catch a class whose constructor throws. It would also
+ * construct every policy class in the application at `registerModels` time,
+ * moving whatever a constructor touches — config, environment, a service
+ * container — ahead of where it is wired. A guard against a policy that does
+ * nothing must not be a reason a working application stops booting, so the
+ * cases that need an instance wait for one to be needed.
+ */
+export function assertPolicyShapes(model: unknown): void {
+  let current = model as PolicedModel | null;
+
+  while (current && current !== Function.prototype) {
+    // Note what is *not* here: the `$policy` rename tripwire that `policiesFor`
+    // carries. It belongs to resolution, and firing it from a walk that reaches
+    // strictly more classes would turn a first-query error into a boot failure
+    // for models this function has no business having an opinion about.
+    if (Object.hasOwn(current, "$policies") && current.$policies) {
+      const level = current.$policies;
+      if (level.length > 0) assertPolicyEntries(current, level);
+    }
+    current = Object.getPrototypeOf(current);
+  }
+}
+
+function nameOfOwner(owner: unknown): string {
+  return (owner as { name?: string })?.name ?? "This model";
 }
 
 const EMPTY: readonly ModelPolicy[] = Object.freeze([]);

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -1,6 +1,7 @@
 import { RequestContext } from "../http/requestContext";
 import { currentActor } from "./context";
 import {
+  InvalidPolicyEntryError,
   PolicyDeniedError,
   ScopeEscapeError,
   UnsupportedQueryError,
@@ -357,6 +358,16 @@ const INSERTING = new Set<string>(["create", "createMany"]);
  */
 const instantiated = new WeakMap<object, ModelPolicy>();
 
+/**
+ * Turns one `$policies` entry into the object the hooks are read off.
+ *
+ * **Every entry reaching here has been through `assertPolicyEntries`**, which is
+ * what makes the unchecked `new` below safe — a function entry has already been
+ * proved constructable. The check is there rather than here because the useful
+ * message names the class and the array index, and this function has neither:
+ * two of its three call sites are `.map(resolveEntry)` over an array held from a
+ * *different* level of the prototype walk than the one currently in hand.
+ */
 function resolveEntry(entry: PolicyEntry): ModelPolicy {
   if (typeof entry !== "function") return entry;
 
@@ -366,6 +377,309 @@ function resolveEntry(entry: PolicyEntry): ModelPolicy {
   const made = new (entry as new () => ModelPolicy)();
   instantiated.set(entry, made);
   return made;
+}
+
+/**
+ * The hooks the runtime actually dispatches on, in the order it consults them.
+ *
+ * `applyPolicies` reads the first four and `applyRedaction` the fifth. An entry
+ * that spells none of them contributes nothing to any query, which is the whole
+ * of case B in #321 — so this list is the definition of "a policy that would
+ * run", and it has to stay the same list.
+ *
+ * **Adding a member to {@link ModelPolicy} without adding it here is a compile
+ * error**, by the assertion below. That direction is the dangerous one: a new
+ * hook missing from this list would make an entry carrying only that hook look
+ * like a typo and be refused at boot — a working policy rejected — which is
+ * exactly the over-strictness this guard must not produce. The other direction
+ * is checked too, so a name removed from `ModelPolicy` cannot linger here and go
+ * on being accepted.
+ */
+const RECOGNISED_HOOKS = [
+  "before",
+  "scope",
+  "onCreate",
+  "onUpdate",
+  "redact",
+] as const;
+
+type _MissingHook = Exclude<
+  keyof ModelPolicy,
+  (typeof RECOGNISED_HOOKS)[number]
+>;
+type _ExtraHook = Exclude<(typeof RECOGNISED_HOOKS)[number], keyof ModelPolicy>;
+
+// Assigning `true` is what fails: either branch resolves to a string literal
+// type when the two lists disagree, and the message is the diagnostic.
+const _hooksExhaustive: [_MissingHook] extends [never]
+  ? [_ExtraHook] extends [never]
+    ? true
+    : "RECOGNISED_HOOKS names a hook ModelPolicy does not declare"
+  : "ModelPolicy declares a hook RECOGNISED_HOOKS does not list — an entry carrying only that hook would be refused at boot" =
+  true;
+void _hooksExhaustive;
+
+/**
+ * Entry arrays already checked, so the guard costs one lookup per contributing
+ * level per call rather than a walk of every entry.
+ *
+ * Keyed on the **array** and not on the entries, because that is the granularity
+ * the hot path already has: `policiesFor` runs per query per node of an include
+ * tree, and `$policies` is an ordinary static that a test or a feature flag
+ * reassigns — a reassignment produces a new array, which is unchecked and gets
+ * checked. Mutating an array in place after it has been read once is the one
+ * thing this does not re-examine, and it is not a shape anything writes.
+ */
+const checkedEntries = new WeakSet<readonly PolicyEntry[]>();
+
+/**
+ * Refuses a `$policies` entry that could not do what it was written to do,
+ * naming the class, the index, and what was found there.
+ *
+ * Called from `policiesFor` once per contributing level, with `owner` being the
+ * class that **declares** the array rather than the model being queried — so the
+ * name in the message is the one the author typed the entry under, which on a
+ * shared base is not the model whose query happened to reach it.
+ *
+ * One placement, and it is `policiesFor` rather than the audit the issue
+ * proposed, because `policiesFor` is what every path already goes through:
+ * `registerModels` at boot and `gemi check models` reach it through
+ * `auditModelRegistrations`, and `Model.$exec` reaches it directly on a class
+ * neither of those ever saw. Putting the check in the audit alone would leave
+ * the crash live on the query path and leave the naming problem unsolved, since
+ * the audit knows the model but not which level of the chain declared the array.
+ */
+function assertPolicyEntries(
+  owner: unknown,
+  entries: readonly PolicyEntry[],
+): void {
+  if (checkedEntries.has(entries)) return;
+
+  const model = (owner as { name?: string })?.name ?? "This model";
+
+  for (let index = 0; index < entries.length; index++) {
+    assertPolicyEntry(entries[index] as PolicyEntry, model, index);
+  }
+
+  checkedEntries.add(entries);
+}
+
+function assertPolicyEntry(
+  entry: PolicyEntry,
+  model: string,
+  index: number,
+): void {
+  const kind = typeof entry;
+
+  if (entry === null || (kind !== "object" && kind !== "function")) {
+    throw new InvalidPolicyEntryError(
+      model,
+      index,
+      "not-a-policy",
+      describeValue(entry),
+      RECOGNISED_HOOKS,
+    );
+  }
+
+  if (kind === "function") {
+    if (!isConstructable(entry as Function)) {
+      throw new InvalidPolicyEntryError(
+        model,
+        index,
+        "not-constructable",
+        describeFunction(entry as Function),
+        RECOGNISED_HOOKS,
+      );
+    }
+  }
+
+  // Resolved rather than inspected, because the class form puts its hooks on a
+  // prototype: `Object.keys(new TenantPolicy())` is empty and every one of them
+  // is still there. `resolveEntry` memoises, so the instance this proves things
+  // about is the instance every later call gets.
+  const policy = resolveEntry(entry) as Record<string, unknown>;
+
+  let callable = 0;
+  /** Hooks written down and left nullish — reported, so "it spells 'scope'"
+   * beside "it has no scope" is not a contradiction the reader has to resolve. */
+  const unset: string[] = [];
+
+  for (const hook of RECOGNISED_HOOKS) {
+    const value = policy[hook];
+    // `undefined` and `null` are absence, not error: `{ scope: undefined }` is
+    // what a conditionally-built policy leaves behind and `applyPolicies` skips
+    // it exactly as it skips a key that was never written.
+    if (value === undefined || value === null) {
+      if (hook in policy) unset.push(hook);
+      continue;
+    }
+
+    if (typeof value !== "function") {
+      throw new InvalidPolicyEntryError(
+        model,
+        index,
+        "hook-not-callable",
+        `'${hook}' that is ${describeValue(value)} rather than a function`,
+        RECOGNISED_HOOKS,
+      );
+    }
+
+    callable++;
+  }
+
+  if (callable > 0) return;
+
+  if (unset.length > 0) {
+    throw new InvalidPolicyEntryError(
+      model,
+      index,
+      "no-hooks",
+      `It writes ${unset.map((hook) => `'${hook}'`).join(", ")} down and ` +
+        `leaves ${unset.length === 1 ? "it" : "them"} unset, which reads as ` +
+        `absent — so nothing is left to run.`,
+      RECOGNISED_HOOKS,
+    );
+  }
+
+  const spelled = spelledKeys(policy);
+
+  throw new InvalidPolicyEntryError(
+    model,
+    index,
+    "no-hooks",
+    spelled.length === 0
+      ? "It is empty."
+      : `It spells ${spelled.map((key) => `'${key}'`).join(", ")}.` +
+          // The other half of #321's case B, and it is not a misspelling, so
+          // "did you mean" has nothing to offer it: an entry whose only key is
+          // `default` is a module namespace — `import * as p` or a CJS interop
+          // — put in the array instead of the policy inside it.
+          (spelled.length === 1 && spelled[0] === "default"
+            ? ` A lone 'default' is a module namespace rather than the policy ` +
+              `inside it — put \`entry.default\` in the array, or import the ` +
+              `policy by name.`
+            : ""),
+    RECOGNISED_HOOKS,
+    nearestHook(spelled),
+  );
+}
+
+/**
+ * Whether `new value()` is a thing that can be written.
+ *
+ * The language exposes `[[Construct]]` nowhere directly, and every syntactic
+ * proxy for it is wrong somewhere. `value.prototype === undefined` is the usual
+ * one — true of arrow functions, method shorthand and `async` functions, which
+ * are three of the four shapes a forgotten factory call takes — and it is also
+ * true of `SomeClass.bind(null)`, which *is* constructable. Refusing that would
+ * be the over-strict direction, where a policy somebody legitimately wrote stops
+ * an app from booting. A generator function fails the other way: it has a
+ * `prototype` and is not constructable.
+ *
+ * So the engine is asked outright. `Reflect.construct` validates `newTarget` as
+ * a constructor **before** it runs the target's body, so putting the entry there
+ * and a do-nothing constructor in the target position answers the question
+ * without executing the policy's own constructor — which matters, because that
+ * is user code and this runs at boot on every class in a declared module.
+ */
+function isConstructable(value: Function): boolean {
+  try {
+    Reflect.construct(NOOP, [], value as new () => unknown);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The do-nothing target of the probe above. Its body is what does not run. */
+const NOOP = function () {} as unknown as new () => unknown;
+
+/**
+ * The keys an entry spells, own and inherited, so the message can say what was
+ * found. Prototype methods are included because the class form is where the
+ * hooks live there; `Object.prototype` and `constructor` are not, because they
+ * are not something the author wrote.
+ */
+function spelledKeys(policy: object): string[] {
+  const keys = new Set<string>();
+
+  let current: object | null = policy;
+  while (current !== null && current !== Object.prototype) {
+    for (const key of Object.getOwnPropertyNames(current)) {
+      if (key !== "constructor") keys.add(key);
+    }
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+
+  return [...keys];
+}
+
+/**
+ * The recognised hook a spelled key most plausibly meant, or nothing.
+ *
+ * Two edits, which covers the misspellings that reach here — `scopes`,
+ * `Scope`, `onCreated` — and stops short of the ones where a suggestion would
+ * be a guess: `default` is six edits from `scope` and gets no "did you mean",
+ * because a wrong suggestion in an authorization error is worse than none.
+ */
+function nearestHook(spelled: readonly string[]): string | undefined {
+  let best: string | undefined;
+  let bestDistance = 3;
+
+  for (const key of spelled) {
+    for (const hook of RECOGNISED_HOOKS) {
+      const distance = editDistance(key.toLowerCase(), hook.toLowerCase());
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = hook;
+      }
+    }
+  }
+
+  return best;
+}
+
+/** Levenshtein, iterative over one row. Inputs here are hook names. */
+function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+
+  let row = Array.from({ length: b.length + 1 }, (_value, index) => index);
+
+  for (let i = 1; i <= a.length; i++) {
+    let previous = row[0]!;
+    row[0] = i;
+
+    for (let j = 1; j <= b.length; j++) {
+      const held = row[j]!;
+      row[j] = Math.min(
+        row[j]! + 1,
+        row[j - 1]! + 1,
+        previous + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+      previous = held;
+    }
+  }
+
+  return row[b.length]!;
+}
+
+/**
+ * A value as a message names it: what it is, not what it holds. Objects are not
+ * stringified — `[object Object]` names nothing, and a policy's own data is not
+ * something to print into a log line.
+ */
+function describeValue(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "string") return `the string ${JSON.stringify(value)}`;
+  if (typeof value === "function") return describeFunction(value);
+  if (Array.isArray(value)) return "an array";
+  if (typeof value === "object") return "an object";
+  return `the ${typeof value} ${String(value)}`;
+}
+
+function describeFunction(value: Function): string {
+  return value.name ? `the function \`${value.name}\`` : "an anonymous function";
 }
 
 /**
@@ -418,6 +732,12 @@ export function policiesFor(model: unknown): readonly ModelPolicy[] {
     if (Object.hasOwn(current, "$policies") && current.$policies) {
       const level = current.$policies;
       if (level.length > 0) {
+        // Before anything is resolved, and with the declaring class in hand —
+        // which is what lets the refusal say `ScopedAccount.$policies[0]`
+        // instead of dying inside `new entry` with nothing named. Memoised on
+        // the array, so the per-query cost is one `WeakSet.has` per level.
+        assertPolicyEntries(current, level);
+
         if (only === undefined && found === undefined) {
           // First contributing level, walking derived to base. Held rather than
           // copied, in case it turns out to be the only one.

--- a/packages/gemi/orm/registration.test.ts
+++ b/packages/gemi/orm/registration.test.ts
@@ -685,15 +685,18 @@ describe("the generator's mark on its own output", () => {
  * A malformed `$policies` entry is caught at **boot**, not on the query — #321.
  *
  * `registerModels` is what an application's Kernel calls, so this walk is the
- * last point before a policy that cannot run is live in production. It resolves
- * policies to run its divergence comparison anyway; what #321 changed is *when*.
+ * last point before a policy that cannot run is live in production, and
+ * `assertPolicyShapes` runs over every model class in every declared module
+ * rather than only the ones whose registration diverges. Below the
+ * `registered === undefined || registered === model` return there are the two
+ * ordinary arrangements — a class that already owns its name, and a name nothing
+ * else claims — and both booted with the entry unexamined, which is how a
+ * `{ scopes: … }` typo reached a running app: registered, reported by
+ * `gemi check models` as correctly registered, and reading unscoped.
  *
- * The resolution used to sit below `if (registered === undefined || registered
- * === model) continue`, and those two branches are the ordinary arrangements —
- * a class that already owns its name, and a name nothing else claims. Both
- * booted with the entry unexamined, which is how a `{ scopes: … }` typo reached
- * a running app: registered, reported by `gemi check models` as correctly
- * registered, and reading unscoped.
+ * **Shape, and nothing that needs an instance.** The tests at the end of this
+ * block are the other half of the rule, and they are the ones that would catch a
+ * regression nobody would notice until an application failed to start.
  */
 describe("a malformed $policies entry at boot", () => {
   test("a typo'd hook stops registerModels rather than registering", () => {
@@ -752,5 +755,82 @@ describe("a malformed $policies entry at boot", () => {
     expect(() => registerModels({ UserBase, User })).not.toThrow();
     expect(registry.get("User")).toBe(User);
     expect(policiesFor(registry.get("User"))).toEqual([scope]);
+  });
+
+  /**
+   * **The boot walk constructs nothing**, and these are the tests that say so.
+   *
+   * Resolving here instead of checking shapes is one line, and it catches one
+   * more case — a policy class whose constructor throws. It also drags every
+   * policy class in the application into `registerModels`, ahead of whatever
+   * wires the config, the environment or the service container its constructor
+   * reaches for. A class that was fine because it was built lazily then takes
+   * the app's boot with it, reported as whatever its constructor happened to
+   * throw, and the entry it was refusing may have been perfectly good: a guard
+   * against a policy that does nothing turned into a working application that
+   * does not start.
+   *
+   * The three arrangements below are exactly the ones a resolving walk changes.
+   */
+  describe("and the check does not construct anything to find it", () => {
+    let ready = false;
+
+    class Unready {
+      constructor() {
+        if (!ready) throw new Error("service container not ready");
+      }
+      scope() {
+        return {};
+      }
+    }
+
+    test("a class that owns its name boots", () => {
+      class Owns extends UserBase {
+        static $policies = [Unready] as any;
+      }
+
+      register("User", Owns);
+
+      expect(() => registerModels({ Owns })).not.toThrow();
+    });
+
+    test("a class whose name nothing claims boots", () => {
+      class Solo extends UserBase {
+        static $policies = [Unready] as any;
+      }
+
+      expect(() => registerModels({ Solo })).not.toThrow();
+    });
+
+    /**
+     * The `$policy` rename tripwire lives in `policiesFor`, and the boot walk
+     * deliberately does not carry it. Firing it from a walk that reaches
+     * strictly more classes would turn a first-query error into a boot failure
+     * for models this check has no opinion about.
+     */
+    test("a class still carrying the old $policy name boots, and fails on the query", () => {
+      class Legacy extends UserBase {
+        static $policy = { scope: () => ({ organizationId: 7 }) };
+      }
+
+      register("User", Legacy);
+
+      expect(() => registerModels({ Legacy })).not.toThrow();
+      expect(() => policiesFor(Legacy)).toThrow(/\$policies/);
+    });
+
+    // ...and the deferral is a deferral, not a hole: the same class refuses on
+    // the first query through it, with the class and the index named.
+    test("the constructor that throws is still refused, at the first query", () => {
+      class Owns extends UserBase {
+        static $policies = [Unready] as any;
+      }
+
+      register("User", Owns);
+      registerModels({ Owns });
+
+      expect(() => policiesFor(Owns)).toThrow(InvalidPolicyEntryError);
+      expect(() => policiesFor(Owns)).toThrow(/Owns\.\$policies\[0\]/);
+    });
   });
 });

--- a/packages/gemi/orm/registration.test.ts
+++ b/packages/gemi/orm/registration.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "vitest";
 
 import {
   AmbiguousModelRegistrationError,
+  InvalidPolicyEntryError,
   UnregisteredPolicyClassError,
 } from "./errors";
 import { user } from "./fixtures";
@@ -678,5 +679,78 @@ describe("the generator's mark on its own output", () => {
     expect(Object.hasOwn(MarkedBase, "$generated")).toBe(true);
     expect(Object.hasOwn(User, "$generated")).toBe(false);
     expect("$generated" in User).toBe(true);
+  });
+});
+/**
+ * A malformed `$policies` entry is caught at **boot**, not on the query — #321.
+ *
+ * `registerModels` is what an application's Kernel calls, so this walk is the
+ * last point before a policy that cannot run is live in production. It resolves
+ * policies to run its divergence comparison anyway; what #321 changed is *when*.
+ *
+ * The resolution used to sit below `if (registered === undefined || registered
+ * === model) continue`, and those two branches are the ordinary arrangements —
+ * a class that already owns its name, and a name nothing else claims. Both
+ * booted with the entry unexamined, which is how a `{ scopes: … }` typo reached
+ * a running app: registered, reported by `gemi check models` as correctly
+ * registered, and reading unscoped.
+ */
+describe("a malformed $policies entry at boot", () => {
+  test("a typo'd hook stops registerModels rather than registering", () => {
+    class User extends UserBase {
+      static $policies = [{ scopes: () => ({ organizationId: 7 }) }] as any;
+    }
+
+    expect(() => registerModels({ User })).toThrow(InvalidPolicyEntryError);
+  });
+
+  /**
+   * The branch the check was moved above. Nothing else claims the name, so the
+   * audit's comparison never runs — and before #321 neither did the resolution
+   * that would have refused the entry.
+   */
+  test("...even when nothing else claims the name", () => {
+    class Solo extends UserBase {
+      static $policies = [() => ({ scope: () => ({}) })] as any;
+    }
+
+    expect(() => registerModels({ Solo })).toThrow(InvalidPolicyEntryError);
+  });
+
+  test("...and when the class is the one already registered", () => {
+    class User extends UserBase {
+      static $policies = [{}] as any;
+    }
+
+    register("User", User);
+
+    expect(() => registerModels({ User })).toThrow(InvalidPolicyEntryError);
+  });
+
+  /**
+   * A refused boot must not leave the arrangement it refused installed. Same
+   * rule `registerModels` already keeps for a failed audit, and the same reason:
+   * a dev server that catches and keeps serving would serve the rest of the
+   * process from a registry this call rejected.
+   */
+  test("the registry is put back when the entry is refused", () => {
+    register("User", UserBase);
+
+    class User extends UserBase {
+      static $policies = [{ scopes: () => ({}) }] as any;
+    }
+
+    expect(() => registerModels({ User })).toThrow(InvalidPolicyEntryError);
+    expect(registry.get("User")).toBe(UserBase);
+  });
+
+  test("a well-formed list still registers", () => {
+    class User extends UserBase {
+      static $policies = [scope];
+    }
+
+    expect(() => registerModels({ UserBase, User })).not.toThrow();
+    expect(registry.get("User")).toBe(User);
+    expect(policiesFor(registry.get("User"))).toEqual([scope]);
   });
 });

--- a/packages/gemi/orm/registration.ts
+++ b/packages/gemi/orm/registration.ts
@@ -103,6 +103,20 @@ export function auditModelRegistrations(
       const model = asModelClass(exported);
       if (model === null) continue;
 
+      // Resolved **before** the early return below, and that ordering is the
+      // whole of #321's coverage. `policiesFor` is what refuses a malformed
+      // `$policies` entry — a factory nobody called, or an entry whose only key
+      // is a typo of a hook — and this walk is the one place every model class
+      // an application declares passes through. Left below the return, the two
+      // commonest arrangements were never checked at all: a class that already
+      // owns its name, and one whose name nothing else claims. Both boot, and
+      // both read unscoped.
+      //
+      // It costs one prototype walk per exported class per boot, against a
+      // silent authorization hole. `registerModels` and `gemi check models` are
+      // both callers, so one placement covers both.
+      const ours = policiesFor(model);
+
       const name = model.$schema.name;
       const registered = registry.has(name)
         ? (registry.get<unknown>(name) as object)
@@ -114,7 +128,6 @@ export function auditModelRegistrations(
       // `ModelNotRegisteredError`. Not this function's business.
       if (registered === undefined || registered === model) continue;
 
-      const ours = policiesFor(model);
       const theirs = policiesFor(registered);
       const diverges =
         ours.length !== theirs.length ||

--- a/packages/gemi/orm/registration.ts
+++ b/packages/gemi/orm/registration.ts
@@ -2,7 +2,7 @@ import {
   AmbiguousModelRegistrationError,
   UnregisteredPolicyClassError,
 } from "./errors";
-import { policiesFor } from "./policy";
+import { assertPolicyShapes, policiesFor } from "./policy";
 import * as registry from "./registry";
 import type { ModelSchema } from "./schema";
 
@@ -103,19 +103,23 @@ export function auditModelRegistrations(
       const model = asModelClass(exported);
       if (model === null) continue;
 
-      // Resolved **before** the early return below, and that ordering is the
-      // whole of #321's coverage. `policiesFor` is what refuses a malformed
-      // `$policies` entry — a factory nobody called, or an entry whose only key
-      // is a typo of a hook — and this walk is the one place every model class
-      // an application declares passes through. Left below the return, the two
-      // commonest arrangements were never checked at all: a class that already
-      // owns its name, and one whose name nothing else claims. Both boot, and
-      // both read unscoped.
+      // #321's boot-time half, run **before** the early return below and for
+      // every class rather than only the diverging ones. Left below the return,
+      // the two commonest arrangements were never checked at all — a class that
+      // already owns its name, and one whose name nothing else claims — so a
+      // `{ scopes: … }` typo registered, reported green, and read unscoped.
       //
-      // It costs one prototype walk per exported class per boot, against a
-      // silent authorization hole. `registerModels` and `gemi check models` are
-      // both callers, so one placement covers both.
-      const ours = policiesFor(model);
+      // `assertPolicyShapes` and not `policiesFor`, and the difference is the
+      // point: this walk checks the entries and constructs nothing. Resolving
+      // here instead is one line and would additionally catch a policy class
+      // whose constructor throws — at the price of constructing every policy
+      // class in the application at `registerModels` time, ahead of whatever
+      // config or container the constructor reaches for. A guard against a
+      // policy that does nothing must not become the reason a working
+      // application stops booting, so the cases that need an instance are left
+      // to `policiesFor`, which is reached below, on the first query, and by
+      // `Model.$exec`.
+      assertPolicyShapes(model);
 
       const name = model.$schema.name;
       const registered = registry.has(name)
@@ -128,6 +132,7 @@ export function auditModelRegistrations(
       // `ModelNotRegisteredError`. Not this function's business.
       if (registered === undefined || registered === model) continue;
 
+      const ours = policiesFor(model);
       const theirs = policiesFor(registered);
       const diverges =
         ours.length !== theirs.length ||


### PR DESCRIPTION
Two failures of one array, found while running `gemi check models` over a 79-model app. Both reproduce on `origin/main`; the reproduction is below, before anything was written.

**Not a security hole, and worth saying why.** `Model` declares `static $policies?: readonly PolicyEntry[]` and every member of `ModelPolicy` is optional, so a typo'd key trips TypeScript's weak-type detection and every shape here is already `TS2417` at the class declaration, with the class named. What reaches the runtime is a file nobody has type-checked yet — which is the normal state of code somebody is in the middle of writing, and the normal input to a command whose job is to find mistakes in it. `registerModels` and `gemi check models` import user code by design, so the guard belongs there.

## Before

```
A/policiesFor:      TypeError | function is not a constructor (evaluating 'new entry')
A/registerModels:   TypeError | function is not a constructor (evaluating 'new entry')
A/forgotten-call:   TypeError | function is not a constructor (evaluating 'new entry')
B/scopes:           length = 1 | keys = ["scopes"]
B/default:          length = 1 | keys = ["default"]
B/registerModels threw: NOTHING
B/empty-object:     length = 1
```

The issue's guess that the published build minifies the identifier to `new J` could not be confirmed; from source it is `new entry`. Cosmetic, and not chased.

## A — a crash that named nothing

`resolveEntry` was `if (typeof entry !== "function") return entry` and then `new entry`. Every function is a constructor as far as that test is concerned, so an arrow function, a plain function, or a factory somebody forgot to *call* — `softDeletes` rather than `softDeletes({ field })` — reached the `new` and died with no model, no index and no file. Both `policiesFor` call sites map over `$policies`, and `registerModels` reaches them through `assertPoliciesRegistered`, so this was a **boot** crash and not only a CLI one.

```
InvalidPolicyEntryError: Account.$policies[0] is the function `softDeletes`, and a
function entry is instantiated with no arguments — so an arrow function, a plain
function, or a factory that was never called cannot be one.

If it is a factory, call it:

    static $policies = [softDeletes({ field: "deletedAt" })]

If it is a class whose constructor takes arguments, construct it yourself and put
the instance in the array.
```

**A constructable class can still die inside `new`,** which is the issue's case A3 and the case a first pass at this missed. `Reflect.construct` answers a question about `[[Construct]]` and says nothing about the body, so `class TenantPolicy { constructor(opts) { this.field = opts.field } }` passes the check and then throws `TypeError: undefined is not an object (evaluating 'opts.field')` — a bare `TypeError` naming no model, no index and no file, for a shape the `not-constructable` message even prints the advice for. Construction is inside a `try` now:

```
InvalidPolicyEntryError: Account.$policies[0] is the function `TenantPolicy`, and
constructing it threw:

    undefined is not an object (evaluating 'opts.field')

A class entry is constructed with no arguments. If this one needs some, construct
it yourself and put the instance in the array:

    static $policies = [new TenantPolicy({ field: "orgId" })]

If the constructor reaches for something that is not ready yet, note that it runs
on the first query through this model, not at boot.
```

The constructor's own error is kept as `cause`.

**Constructability is asked of the engine, not inferred.** Every syntactic proxy is wrong somewhere: `value.prototype === undefined` catches arrow functions, method shorthand and `async` functions, and it also rejects `SomeClass.bind(null)`, which really is constructable — the over-strict direction, where a policy somebody legitimately wrote stops an app booting. A generator function fails the other way, having a `prototype` and no `[[Construct]]`. So `Reflect.construct(NOOP, [], entry)` puts the entry in the `newTarget` position, where it is validated as a constructor **before** the target's body runs — the probe never executes the policy's own constructor, which matters because that is user code and this runs at boot over every class in a declared module. Both edges are pinned by tests.

## B — silence, which is the half that matters

`applyPolicies` dispatches on `before` / `scope` / `onCreate` / `onUpdate` and `applyRedaction` on `redact`. An entry spelling none of them was taken as-is and contributed nothing, so the class carried a visible `$policies` array, `gemi check models` reported it as policied and correctly registered, and the model **read unscoped**. Same written-believed-not-in-effect shape as #316 and #318, arriving through a typo instead of through the registry.

```
InvalidPolicyEntryError: Account.$policies[0] has none of before, scope, onCreate,
onUpdate or redact, so it would never run. The model carries a visible $policies
array and nothing in it applies to any query — which for a scope means the model
reads unscoped. It spells 'scopes'. Is 'scopes' meant to be `scope`?
```

**The suggestion is one edit, and it names the key it is about.** At two edits it
fired on `store`, `code` and `copy` (each two from `scope`) and `reduce` (two from
`redact`) — ordinary names for things that sit beside a policy, none of them a
misspelling — and reported them unattributed, so an author who could see that none
of their keys were typos had nothing to dismiss. This PR's own standard is that a
wrong suggestion in an authorization error is worse than none, and the first pass
did not meet it. A nested array is refused outright rather than reading as an
object whose keys are `length`, `concat` and `pop`, and the printed list stops at
eight.

The issue's other example gets the answer its shape deserves rather than a guessed suggestion — `default` is six edits from `scope`, and a wrong suggestion in an authorization error is worse than none:

```
… It spells 'default'. A lone 'default' is a module namespace rather than the
policy inside it — put `entry.default` in the array, or import the policy by name.
```

Two more shapes fall out of the same walk and were refused rather than left: an entry that is not a policy at all (`null`, `undefined`, a `false` from a `&&` that did not hold, a string), and a recognised hook whose value is not callable — `{ scope: { orgId: 7 } }` throws on the first query that reaches it, so refusing it at boot with the key named is strictly better.

## Where the line is drawn, and why there

**Malformed** is "no callable hook at all". **Valid** is everything else, `{}` excepted.

- **Extra keys are nobody's business.** A factory's return value carries its configuration and a policy class carries its helpers, both beside the hooks. An unknown-key check would refuse code that works today, which is the one outcome worse than the bug.
- **A hook set to `undefined` is absence, not error** — it is what a conditionally-built policy leaves behind, and `applyPolicies` already skips it exactly as it skips a key that was never written. An entry with *only* nullish hooks is still refused, and says so in those words rather than reading as a typo.
- **`{}` is refused.** It is indistinguishable from a policy that was meant to do something, and a policy that only sometimes applies belongs in the array — `[...(multiTenant ? [tenantScope] : [])]` — which the error prints.

The `not-a-policy` and `no-hooks` refusals are the two that could bite a working app; nothing in this repository or the template writes either shape, and the four "what stays valid" tests are there so a future tightening has to argue with them.

**`RECOGNISED_HOOKS` is pinned to `ModelPolicy`'s *callable* members by a type-level assertion**, both directions. That is not tidiness: a hook added to `ModelPolicy` and forgotten here would make an entry carrying only that hook look like a typo and be refused at boot — a working policy rejected by the guard against over-strictness.

Callable members rather than `keyof`, because entries in this list are required to be functions. A `keyof` pin has a bomb in it: a future `priority?: number` on `ModelPolicy` would be *forced* into the list to satisfy the compiler, and every entry that then set it would throw `hook-not-callable` at boot. A data member is simply not a hook — it is left out, and not required to be callable.

Verified with three real `tsc` runs: adding `onDelete?()` fails with the missing-hook message, adding a bogus name to the list fails with the extra-name message, and adding `priority?: number` compiles clean.

## Where the check went, and why not where the issue said

The issue proposed `registration.ts:117`, where the model name and index are both in hand. The check is in `policiesFor` instead, for two reasons that only showed up on inspection:

- **`resolveEntry` is reachable without the audit.** `Model.$exec` calls `policiesFor(this)` directly, on a class `registerModels` may never have seen — a bare `register("User", User)`, a test. A check in the audit alone leaves the crash live there.
- **The audit knows the model but not which level declared the array.** `policiesFor` walks the prototype chain, so it knows the class whose *own* `$policies` holds the entry — which on a shared base is not the model the query arrived through. `TenantBase.$policies[0]` is the line the author can go and look at; `Account.$policies[0]` would send them to a file with nothing in it.

`auditModelRegistrations` still changed, in the other direction: a check runs **above** the `registered === undefined || registered === model` early return. Those two branches are the ordinary arrangements — a class that already owns its name, and a name nothing else claims — and both used to boot with the entry unexamined.

**That check is `assertPolicyShapes`, not `policiesFor`, and the difference is the whole of it.** Resolving there is one line and catches one more case; it also constructs every policy class in the application at `registerModels` time, ahead of whatever wires the config, the environment or the service container its constructor reaches for. Measured against the merge base, hoisting `policiesFor` turned three arrangements that booted into three that did not:

```
== base ==                    == first pass ==              == now ==
owns-its-name        BOOTS    THROWS: container not ready   BOOTS
name-not-registered  BOOTS    THROWS: container not ready   BOOTS
legacy $policy owner BOOTS    THROWS: declares `$policy`    BOOTS
```

A guard against a policy that does nothing must not be the reason a working application stops booting. So the boot walk checks what can be known without an instance — is it a policy, is a function entry constructable, does an object entry name a hook — which is all of case B in both shapes the issue reports, and all of case A's first half. The cases that need an instance wait for one to be needed: `policiesFor`, reached by the audit below, by the first query, and by `Model.$exec`. The `$policy` rename tripwire stays out of the boot walk for the same reason, so a class still carrying the old name fails on its first query as it did before rather than at boot.

Pinned by tests in both directions — the three rows above, and that the deferred case is still refused with the class and index named.

`gemi check models` adds the third thing the original message could not carry. The error names the class and the index; only the file walk knows the *file*, so it records it and carries on, and every unreadable file is reported together at the end. Stopping at the first was the first pass's shape and it undoes half of what the command is for: the silent-typo case is the one where an author has several, because nothing was telling them about any of them, and fix-one-rerun-find-the-next is the loop a checker exists to replace. It stays a throw rather than a finding — a finding is printed with an `export … from` line as its fix and counted among the things the file got wrong, and an entry the runtime cannot dispatch to is none of those. It catches everything rather than testing for a class, because the ORM is resolved from the project being checked and `instanceof` across two copies of a module is false exactly when it matters — the reason `isUniqueConstraintError` exists. The walk's registry restore moved into a `finally` on the way, so a refused file cannot leave a process-wide registry nobody chose.

## Cost

`policiesFor` runs per query per node of an include tree and is deliberately uncached, so the guard is memoised on the **array** — one `WeakSet.has` per contributing level per call, no allocation, and the declaring class passed rather than its name so that even reading `.name` is something only a refusal pays for. Measured against the merge base, same process, median of seven runs of 200k calls:

```
unpolicied           5.6ns -> 5.5ns
two-level policied  67.4ns -> 78.3ns
```

Nothing for a model with no policies; two `WeakSet.has` for a model with two levels of them. Keyed on the array rather than the entries because a reassigned `$policies` is a new array and gets checked again, which is what a test or a feature flag swapping one needs; mutating an array in place after it has been read is the one thing that is not re-examined, and nothing writes that.

## Coverage

`orm/policy.test.ts` had nothing about constructor, factory, invalid or typo'd entries — every test in it hands `policiesFor` a well-formed entry, which is how both halves survived. It now has 37, split across the three ways a function entry fails, the typo half, the valid-shape boundary, the mislead direction (`store`, `code`/`copy`/`lookup`, `reduce` — none suggested), and the two naming properties (declaring class, own index). `orm/registration.test.ts` covers the boot path including the two branches the check moved above, the registry restore, and the three arrangements that must keep booting; `bin/check-models.test.ts` covers the CLI path, the file name, and that a good file beside a bad one is still walked.

## Verification

Rebased onto `main` at `65688bf`; both baselines below were re-measured on that commit in this environment.

`packages/gemi` 3,101 passed / 1 skipped (baseline 3,054 / 1) · `saas-starter` 296 passed / 32 skipped, byte-identical to the baseline — its 4 failing files are a missing generated `prisma-client` and an unlinked `gemi-orm-generator`, both environmental and present on `65688bf` · `tsc --noEmit` clean on `packages/gemi` · `oxlint` clean on `packages/gemi/orm` and `packages/gemi/bin` · the docs' Errors table no longer says "at boot, not on the query", which the placement contradicts, and its verbatim copy in `llms-full.txt` is in step, which their own tests require.

Closes #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChxCkNb4bLwd5aYSgAPByU
