### PR TITLE
Close #336: type the JSON path filter the compiler already implements

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3738,15 +3738,25 @@ document, which is a filter on the column rather than on a path.
 **What the type checks, and what it leaves to run time.** The path filter is typed: `path` takes
 either dialect's grammar, the ten operators are the ones above, and their operand types are the
 ones the compiler will compile. A misspelled operator, a `path` that is not one, a non-string under
-`string_contains` and a sentinel at a path are all compile errors. The type carries no dialect —
-the generated artifact does not know which database it will be pointed at — so the table above is
-offered in full on both and the wrong half is refused at run time, naming the dialect. The empty
-path is refused at run time too.
+`string_contains`, a sentinel at a path and a `null` at a path are all compile errors. The type
+carries no dialect — the generated artifact does not know which database it will be pointed at —
+so the table above is offered in full on both and the wrong half is refused at run time, naming the
+dialect. The empty path is refused at run time too.
 
-One consequence worth naming: a JSON document with a **top-level `path` key** cannot be written as
-the bare-value shorthand, because `path` is what tells the compiler the operand is a path filter.
-It never could — `{ metadata: { path: "/a" } }` reached the path compiler and raised — and now says
-so at compile time. Write the document explicitly: `{ metadata: { equals: { path: "/a" } } }`.
+**An object in a `Json` column's `where` is a filter, never a document.** `{ metadata: { a: 1 } }`
+does not ask for the document `{ a: 1 }` — it asks for the operator `a`, which does not exist, and
+raises `InvalidArgumentError`. Only a scalar or an array is read as a value. That has always been
+true and is now a compile error rather than a run-time one, `path` keys included:
+
+```ts
+await User.findMany({ where: { metadata: { equals: { a: 1 } } } })          // the document
+await User.findMany({ where: { metadata: { equals: { path: "/a" } } } })    // and this one
+await User.findMany({ where: { metadata: [1, 2] } })                        // arrays are values
+```
+
+`not` is the exception, and it is a filter too: it takes a whole nested filter, so
+`{ metadata: { not: { path: ["a"], equals: 1 } } }` is a negated path filter, while
+`{ metadata: { equals: { … } } }` binds its operand as a value.
 
 ### Scalar lists (Postgres only)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3735,6 +3735,19 @@ merely unsupported:
 An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
 document, which is a filter on the column rather than on a path.
 
+**What the type checks, and what it leaves to run time.** The path filter is typed: `path` takes
+either dialect's grammar, the ten operators are the ones above, and their operand types are the
+ones the compiler will compile. A misspelled operator, a `path` that is not one, a non-string under
+`string_contains` and a sentinel at a path are all compile errors. The type carries no dialect —
+the generated artifact does not know which database it will be pointed at — so the table above is
+offered in full on both and the wrong half is refused at run time, naming the dialect. The empty
+path is refused at run time too.
+
+One consequence worth naming: a JSON document with a **top-level `path` key** cannot be written as
+the bare-value shorthand, because `path` is what tells the compiler the operand is a path filter.
+It never could — `{ metadata: { path: "/a" } }` reached the path compiler and raised — and now says
+so at compile time. Write the document explicitly: `{ metadata: { equals: { path: "/a" } } }`.
+
 ### Scalar lists (Postgres only)
 
 ```ts

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -755,15 +755,25 @@ document, which is a filter on the column rather than on a path.
 **What the type checks, and what it leaves to run time.** The path filter is typed: `path` takes
 either dialect's grammar, the ten operators are the ones above, and their operand types are the
 ones the compiler will compile. A misspelled operator, a `path` that is not one, a non-string under
-`string_contains` and a sentinel at a path are all compile errors. The type carries no dialect —
-the generated artifact does not know which database it will be pointed at — so the table above is
-offered in full on both and the wrong half is refused at run time, naming the dialect. The empty
-path is refused at run time too.
+`string_contains`, a sentinel at a path and a `null` at a path are all compile errors. The type
+carries no dialect — the generated artifact does not know which database it will be pointed at —
+so the table above is offered in full on both and the wrong half is refused at run time, naming the
+dialect. The empty path is refused at run time too.
 
-One consequence worth naming: a JSON document with a **top-level `path` key** cannot be written as
-the bare-value shorthand, because `path` is what tells the compiler the operand is a path filter.
-It never could — `{ metadata: { path: "/a" } }` reached the path compiler and raised — and now says
-so at compile time. Write the document explicitly: `{ metadata: { equals: { path: "/a" } } }`.
+**An object in a `Json` column's `where` is a filter, never a document.** `{ metadata: { a: 1 } }`
+does not ask for the document `{ a: 1 }` — it asks for the operator `a`, which does not exist, and
+raises `InvalidArgumentError`. Only a scalar or an array is read as a value. That has always been
+true and is now a compile error rather than a run-time one, `path` keys included:
+
+```ts
+await User.findMany({ where: { metadata: { equals: { a: 1 } } } })          // the document
+await User.findMany({ where: { metadata: { equals: { path: "/a" } } } })    // and this one
+await User.findMany({ where: { metadata: [1, 2] } })                        // arrays are values
+```
+
+`not` is the exception, and it is a filter too: it takes a whole nested filter, so
+`{ metadata: { not: { path: ["a"], equals: 1 } } }` is a negated path filter, while
+`{ metadata: { equals: { … } } }` binds its operand as a value.
 
 ### Scalar lists (Postgres only)
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -752,6 +752,19 @@ merely unsupported:
 An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
 document, which is a filter on the column rather than on a path.
 
+**What the type checks, and what it leaves to run time.** The path filter is typed: `path` takes
+either dialect's grammar, the ten operators are the ones above, and their operand types are the
+ones the compiler will compile. A misspelled operator, a `path` that is not one, a non-string under
+`string_contains` and a sentinel at a path are all compile errors. The type carries no dialect —
+the generated artifact does not know which database it will be pointed at — so the table above is
+offered in full on both and the wrong half is refused at run time, naming the dialect. The empty
+path is refused at run time too.
+
+One consequence worth naming: a JSON document with a **top-level `path` key** cannot be written as
+the bare-value shorthand, because `path` is what tells the compiler the operand is a path filter.
+It never could — `{ metadata: { path: "/a" } }` reached the path compiler and raised — and now says
+so at compile time. Write the document explicitly: `{ metadata: { equals: { path: "/a" } } }`.
+
 ### Scalar lists (Postgres only)
 
 ```ts

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -379,11 +379,131 @@ type ListFilter<E> = {
  * `{ [key: string]: JsonValue }`, and `{ equals: null }` is itself a valid JSON
  * object. Prisma has the same gap. Stated rather than papered over: a comment
  * claiming the type rejects it would be read as a guarantee.
+ *
+ * **This is the filter on the *column*, which is why `path` is excluded.** A
+ * `path` sends the whole operand to `compileJsonFilter`, where the sentinels are
+ * refused — `#>>` cannot tell an absent key from a JSON `null`. Without the
+ * `path?: never`, `{ path: […], equals: DbNull }` landed here instead of on
+ * `JsonPathFilter`, because a union ignores a property one member declares and
+ * excess-property checking counts it known if *any* member has it.
  */
 type JsonFilter = {
+  path?: never;
   equals?: JsonValue | DbNullValue | JsonNullValue | AnyNullValue;
   not?: JsonValue | DbNullValue | JsonNullValue | AnyNullValue;
 };
+
+/**
+ * `JsonValue`'s object member, named so that `JsonValueOperand` can subtract it
+ * from the union and put it back with one property forbidden.
+ */
+type JsonObject = { [key: string]: JsonValue };
+
+/**
+ * Where inside the document to look — and it is **one union covering two
+ * dialects**, which each refuse the other's half at runtime.
+ *
+ * Postgres takes `["a", "b"]` and refuses a string; SQLite takes `"$.a.b"` and
+ * refuses an array. That is Prisma's own split, measured on both through a
+ * generated client, and `assertPathShape` reproduces it with a message naming
+ * which form *this* database wants.
+ *
+ * **Typed flat rather than per-dialect, deliberately.** The generated artifact
+ * is dialect-agnostic — `ModelTypeInfo` records no dialect, and the dialect is
+ * chosen from `DATABASE_URL` at connect time — so there is nothing for a
+ * dialect-shaped type to read, and shaping it would mean threading a parameter
+ * the generator does not know through every model, every `WhereInput` and every
+ * call site. It is also how this file already handles the same divergence
+ * elsewhere: `mode: "insensitive"` is Postgres-only and is a flat property with
+ * a comment, and `ListFilter` is offered on both dialects though SQLite has no
+ * array type to answer it with. The dialect refusal stays where it can name the
+ * dialect and say "it works on postgres".
+ *
+ * Numbers are in because `assertPathShape` accepts them — a JSON array index is
+ * how you reach into a list — where Prisma's generated `path` is `string[]`.
+ * The type describes this compiler, not that one.
+ */
+type JsonPath = string | (string | number)[];
+
+/**
+ * A scalar a JSON path filter can be compared against.
+ *
+ * `assertJsonOperand`'s rule: `equals`, `not` and the four comparisons compile
+ * to one bound value against one extracted value, so an object or array operand
+ * "would bind as '[object Object]' and match nothing" and is refused. That is a
+ * refusal rather than a gap — answering it properly needs the `#> … ::jsonb`
+ * form, which is Postgres-only — so the type says the same thing rather than
+ * offering a query only one dialect could answer.
+ *
+ * **The sentinels are absent, and their absence is the point.** `DbNull`,
+ * `JsonNull` and `AnyNull` are refused at a path by `compileJsonFilter`, because
+ * `#>>` yields SQL NULL for an absent key and for a JSON `null` alike — the
+ * distinction the sentinels exist to draw is gone before the comparison
+ * happens. They stay on `JsonFilter`, which compiles against the column, where
+ * the distinction survives.
+ */
+type JsonPathScalar = string | number | boolean | null;
+
+/**
+ * `where: { metadata: { path: …, equals: … } }` — a filter on a value *inside*
+ * the document rather than on the column.
+ *
+ * The operator set is `JSON_FILTERS` in `compile/where.ts`, all ten of them, and
+ * the operand types are `assertJsonOperand`'s. `array_contains` is the one that
+ * takes a document, because containment is the operator that means one.
+ *
+ * **`path` is required, and that is what makes the union above discriminate.**
+ * `compileFieldFilter` dispatches on `filter.path !== undefined`: an operand
+ * carrying a `path` *is* a path filter to the compiler, whatever else is in it.
+ * So a JSON document that happens to have a top-level `path` key cannot be
+ * written as the bare-value shorthand — it never could, the compiler always read
+ * it as a path filter — and `{ equals: { path: … } }` is the spelling that
+ * means the document.
+ *
+ * Every operator is optional, so `{ path: ["a"] }` alone still type-checks and
+ * still raises Prisma's *"A JSON path cannot be set without a scalar filter."*
+ * Requiring one would mean a ten-way union in the position where the compiler
+ * reports a misspelled operator, and the runtime message already names the whole
+ * set. Prisma's generated input has the same shape for the same reason.
+ */
+type JsonPathFilter = {
+  path: JsonPath;
+  equals?: JsonPathScalar;
+  not?: JsonPathScalar;
+  string_contains?: string;
+  string_starts_with?: string;
+  string_ends_with?: string;
+  array_contains?: JsonValue;
+  lt?: JsonPathScalar;
+  lte?: JsonPathScalar;
+  gt?: JsonPathScalar;
+  gte?: JsonPathScalar;
+};
+
+/**
+ * The bare-value half of a `Json` column's filter, **with `path` excluded** —
+ * and that exclusion is the whole fix for #336, not the operators.
+ *
+ * `JsonValue` contains `{ [key: string]: JsonValue }`, so before this any object
+ * literal at all satisfied the value arm as an `equals` shorthand, a union
+ * permits a property present in any member, and excess-property checking never
+ * fired. Adding `path` and the operators to a sibling arm does nothing on its
+ * own: `{ path: 123, notAFilter: true }` is a perfectly good JSON *document* and
+ * would go on compiling. The union has to stop being able to absorb it.
+ *
+ * `path?: never` on the object arm is what does that. It makes `path` a
+ * discriminant, so an operand carrying one is matched against `JsonPathFilter`
+ * alone and is then checked — operand types, and excess properties, which the
+ * index signature had been suppressing for the whole union.
+ *
+ * Written as an intersection rather than a property of the object type on
+ * purpose: a declared `path?: never` beside a `[key: string]: JsonValue` is an
+ * error, because `undefined` is not a `JsonValue`. The intersection is checked
+ * member by member and has no such conflict.
+ */
+type JsonValueOperand =
+  | Exclude<JsonValue, JsonObject>
+  | (JsonObject & { path?: never });
 
 /**
  * A filter on one column.
@@ -399,7 +519,12 @@ type JsonFilter = {
  */
 export type FieldFilter<V> =
   IsJson<V> extends true
-    ? JsonValue | DbNullValue | JsonNullValue | JsonFilter
+    ?
+        | JsonValueOperand
+        | DbNullValue
+        | JsonNullValue
+        | JsonFilter
+        | JsonPathFilter
     : [NonNullable<V>] extends [Array<infer E>]
       ? E[] | ListFilter<E>
       : V | NestedFilter<V>;

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -386,16 +386,30 @@ type ListFilter<E> = {
  * `path?: never`, `{ path: […], equals: DbNull }` landed here instead of on
  * `JsonPathFilter`, because a union ignores a property one member declares and
  * excess-property checking counts it known if *any* member has it.
+ *
+ * **`equals` and `not` are asymmetric, and the compiler is what makes them so.**
+ * `equals` binds its operand as a *value*, so an object under it is a document
+ * — `{ equals: { a: 1 } }` compiles to `"metadata" = $1::text::jsonb`. `not`
+ * delegates to `compileNot`, which sends any object operand back through
+ * `compileFieldFilter` as a *nested filter*: `{ not: { equals: { a: 1 } } }`
+ * compiles, `{ not: { path: […], equals: 1 } }` compiles to a negated path
+ * filter, and `{ not: { a: 1 } }` raises on the key `a`. So `not` recurses here
+ * and `equals` does not. Measured against `compileRead`, not inferred.
  */
 type JsonFilter = {
   path?: never;
   equals?: JsonValue | DbNullValue | JsonNullValue | AnyNullValue;
-  not?: JsonValue | DbNullValue | JsonNullValue | AnyNullValue;
+  not?:
+    | JsonValueOperand
+    | DbNullValue
+    | JsonNullValue
+    | AnyNullValue
+    | JsonFilter
+    | JsonPathFilter;
 };
 
 /**
- * `JsonValue`'s object member, named so that `JsonValueOperand` can subtract it
- * from the union and put it back with one property forbidden.
+ * `JsonValue`'s object member, named so that `JsonValueOperand` can subtract it.
  */
 type JsonObject = { [key: string]: JsonValue };
 
@@ -419,11 +433,28 @@ type JsonObject = { [key: string]: JsonValue };
  * array type to answer it with. The dialect refusal stays where it can name the
  * dialect and say "it works on postgres".
  *
- * Numbers are in because `assertPathShape` accepts them — a JSON array index is
- * how you reach into a list — where Prisma's generated `path` is `string[]`.
- * The type describes this compiler, not that one.
+ * **Numbers are in, and that is not the same choice as the dialect one above.**
+ * `assertPathShape` accepts a numeric segment, where Prisma's generated `path`
+ * is `string[]`, so gemi is a superset here — and this file refuses to be a
+ * superset on dialect operators for a stated reason: answering a query the
+ * oracle cannot is "precisely where a differential test stops being able to
+ * check anything" (`where.ts:945`). The two are consistent because that rule
+ * governs what the *compiler* answers, and a type cannot enforce it. Excluding
+ * numbers here would not remove the superset — `assertPathShape` would still
+ * accept `["items", 0]` from a `string[]`-typed variable, from `any`, from
+ * JSON off the wire — it would only stop the type describing what the compiler
+ * does, which is #336 again in the other direction. If the superset should go,
+ * the place to remove it is `assertPathShape` — #371, with both answers written
+ * out, rather than decided quietly here.
+ *
+ * **`readonly`, because a path is the natural thing to hoist.**
+ * `const PATH = ["operation"] as const` and a whole filter object written
+ * `as const` both produce a `readonly` tuple. `assertPathShape` uses
+ * `Array.isArray` and `.every`, which a frozen array answers, and the path is
+ * bound rather than mutated. A mutable array still assigns to a `readonly`
+ * parameter, so nothing that compiled before stops.
  */
-type JsonPath = string | (string | number)[];
+type JsonPath = string | readonly (string | number)[];
 
 /**
  * A scalar a JSON path filter can be compared against.
@@ -441,8 +472,22 @@ type JsonPath = string | (string | number)[];
  * distinction the sentinels exist to draw is gone before the comparison
  * happens. They stay on `JsonFilter`, which compiles against the column, where
  * the distinction survives.
+ *
+ * **`null` is absent too, and this one is the type going *further* than the
+ * compiler — the only place in this change that does.** `assertJsonOperand`
+ * lets `null` through and `{ path: […], equals: null }` compiles to
+ * `("metadata" #>> $1) = $2` bound to NULL, which is NULL rather than true on
+ * both dialects: a predicate no row can satisfy. Once the sentinels are refused
+ * there is no other reading of it — the two questions `null` could be asking
+ * are exactly the two the sentinels ask. The same operand under
+ * `string_contains` is already a runtime refusal, in this file's own words
+ * because the pattern "runs and returns the wrong rows", so refusing it here
+ * finishes a rule the compiler states rather than inventing one. The compiler
+ * should follow — #371 — and until it does a `null` arriving dynamically still
+ * reaches the binder, which is why this is stated and not claimed as a
+ * guarantee.
  */
-type JsonPathScalar = string | number | boolean | null;
+type JsonPathScalar = string | number | boolean;
 
 /**
  * `where: { metadata: { path: …, equals: … } }` — a filter on a value *inside*
@@ -455,10 +500,9 @@ type JsonPathScalar = string | number | boolean | null;
  * **`path` is required, and that is what makes the union above discriminate.**
  * `compileFieldFilter` dispatches on `filter.path !== undefined`: an operand
  * carrying a `path` *is* a path filter to the compiler, whatever else is in it.
- * So a JSON document that happens to have a top-level `path` key cannot be
- * written as the bare-value shorthand — it never could, the compiler always read
- * it as a path filter — and `{ equals: { path: … } }` is the spelling that
- * means the document.
+ * A JSON document with a top-level `path` key therefore has to be written
+ * `{ equals: { path: … } }` — which is the only spelling that ever worked, since
+ * an object operand is a filter here and never a document.
  *
  * Every operator is optional, so `{ path: ["a"] }` alone still type-checks and
  * still raises Prisma's *"A JSON path cannot be set without a scalar filter."*
@@ -481,29 +525,37 @@ type JsonPathFilter = {
 };
 
 /**
- * The bare-value half of a `Json` column's filter, **with `path` excluded** —
- * and that exclusion is the whole fix for #336, not the operators.
+ * The bare-value half of a `Json` column's filter — **`JsonValue` with its
+ * object member removed**, and that removal is the whole fix for #336, not the
+ * operators.
  *
  * `JsonValue` contains `{ [key: string]: JsonValue }`, so before this any object
- * literal at all satisfied the value arm as an `equals` shorthand, a union
- * permits a property present in any member, and excess-property checking never
- * fired. Adding `path` and the operators to a sibling arm does nothing on its
- * own: `{ path: 123, notAFilter: true }` is a perfectly good JSON *document* and
- * would go on compiling. The union has to stop being able to absorb it.
+ * literal at all satisfied the value arm, a union permits a property present in
+ * any member, and excess-property checking never fired. Adding `path` and the
+ * operators to a sibling arm does nothing on its own: `{ path: 123, notAFilter:
+ * true }` is a perfectly good JSON *document* and would go on compiling. The
+ * union has to stop being able to absorb it.
  *
- * `path?: never` on the object arm is what does that. It makes `path` a
- * discriminant, so an operand carrying one is matched against `JsonPathFilter`
- * alone and is then checked — operand types, and excess properties, which the
- * index signature had been suppressing for the whole union.
+ * **The object member is not merely absorbing — it was never true.** `where` has
+ * no bare-document branch for a `Json` column. `isFilterObject` reports any
+ * non-`Date`, non-array object as a filter, so `{ metadata: { a: 1 } }` reaches
+ * the scalar operator loop and raises *"A scalar filter takes contains,
+ * endsWith, equals, …"* on the key `a`. Only scalars and arrays fall through to
+ * `equals`, which is exactly what is left here. Measured against `compileRead`
+ * on Postgres, not read off the code:
  *
- * Written as an intersection rather than a property of the object type on
- * purpose: a declared `path?: never` beside a `[key: string]: JsonValue` is an
- * error, because `undefined` is not a `JsonValue`. The intersection is checked
- * member by member and has no such conflict.
+ * | operand | compiler |
+ * | --- | --- |
+ * | `{ metadata: "s" }`, `{ metadata: [1, 2] }` | `"metadata" = $1::text::jsonb` |
+ * | `{ metadata: { equals: { a: 1 } } }` | `"metadata" = $1::text::jsonb` |
+ * | `{ metadata: { a: 1 } }` | `InvalidArgumentError` on `where.metadata.a` |
+ *
+ * So the document goes under `equals`, which is the only spelling `docs/orm.md`
+ * has ever shown. An earlier draft of this type kept the object member with
+ * `path?: never` intersected onto it — clever, and its entire effect was to go
+ * on admitting operands that always throw.
  */
-type JsonValueOperand =
-  | Exclude<JsonValue, JsonObject>
-  | (JsonObject & { path?: never });
+type JsonValueOperand = Exclude<JsonValue, JsonObject>;
 
 /**
  * A filter on one column.

--- a/templates/saas-starter/app/models/filters.test-d.ts
+++ b/templates/saas-starter/app/models/filters.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, test } from "vitest";
 
-import { DbNull, JsonNull } from "gemi/orm";
+import { AnyNull, DbNull, JsonNull } from "gemi/orm";
 
 import {
   AccountModel,
@@ -206,6 +206,131 @@ describe("Json columns", () => {
   test("filter by sentinel", async () => {
     await UserModel.findMany({ where: { metadata: { equals: DbNull } } });
     await UserModel.findMany({ where: { metadata: { equals: JsonNull } } });
+  });
+});
+
+/**
+ * **The path filter, which the compiler has implemented since `cc22399` and the
+ * type described not at all** — #336, and the fourth of the same kind after
+ * #326, #333 and #337.
+ *
+ * It is the worst of the four because the type did not *refuse* the argument,
+ * it **accepted anything**. `FieldFilter`'s `Json` arm unions in `JsonValue`,
+ * whose `{ [key: string]: JsonValue }` member absorbs any object literal as an
+ * `equals` shorthand; a union permits a property present in any member, so
+ * excess-property checking never fired and `{ path: 123, notAFilter: true }`
+ * compiled clean. Every refusal `orm.md` specifies was discoverable only by
+ * running the query, and the feature worked by accident for anyone who spelled
+ * it correctly.
+ *
+ * So the negatives below are the point of the file, not the trimmings — each
+ * one compiled before this and the runtime threw. `path?: never` on the value
+ * arm is what turns `path` into a discriminant and lets them be caught.
+ */
+describe("Json path filters", () => {
+  /**
+   * Both path grammars are offered, because the type has no dialect to consult
+   * — `ModelTypeInfo` records none, and `DATABASE_URL` picks it at connect
+   * time. `assertPathShape` refuses the other dialect's form with a message
+   * naming this one, the way `mode: "insensitive"` and `ListFilter` already do.
+   */
+  test("take either dialect's path grammar", async () => {
+    await UserModel.findMany({
+      where: { metadata: { path: ["operation"], equals: "video" } },
+    });
+    await UserModel.findMany({ where: { metadata: { path: "$.operation", equals: "video" } } });
+    // An array index is a key too, which is why numbers are in the union.
+    await UserModel.findMany({ where: { metadata: { path: ["items", 0, "id"], gt: 3 } } });
+  });
+
+  test("take the ten operators JSON_FILTERS accepts", async () => {
+    await UserModel.findMany({ where: { metadata: { path: ["a"], not: "x" } } });
+    await UserModel.findMany({ where: { metadata: { path: ["a"], string_contains: "x" } } });
+    await UserModel.findMany({ where: { metadata: { path: ["a"], string_starts_with: "x" } } });
+    await UserModel.findMany({ where: { metadata: { path: ["a"], string_ends_with: "x" } } });
+    await UserModel.findMany({
+      where: { metadata: { path: ["a"], lt: 1, lte: 2, gt: 3, gte: 4 } },
+    });
+    // The one operator whose operand is a document, because containment is the
+    // operator that means one.
+    await UserModel.findMany({ where: { metadata: { path: ["a"], array_contains: { b: 1 } } } });
+  });
+
+  test("a path that is not a path is refused", async () => {
+    // @ts-expect-error a path is an array of keys or a JSONPath string
+    await UserModel.findMany({ where: { metadata: { path: 123, notAFilter: true } } });
+  });
+
+  test("an operand the operator cannot compile is refused", async () => {
+    // @ts-expect-error `string_contains` builds a `like` pattern; 4 becomes '%4%'
+    await UserModel.findMany({ where: { metadata: { path: [], string_contains: 4 } } });
+  });
+
+  /**
+   * The misspelling, which is the case a half-fix lets through: adding the
+   * operators without excluding `path` from the value arm leaves the index
+   * signature answering "yes, `equalz` is a known property" on the union's
+   * behalf.
+   */
+  test("an operator that is not an operator is refused", async () => {
+    // @ts-expect-error `equalz` is not in JSON_FILTERS
+    await UserModel.findMany({ where: { metadata: { path: ["operation"], equalz: "video" } } });
+  });
+
+  /**
+   * `compileJsonFilter` refuses the sentinels at a path, and refuses the same
+   * shape one level down — `{ equals: { not: DbNull } }` — because `#>>` yields
+   * SQL NULL for an absent key and a JSON `null` alike, so the distinction the
+   * sentinels exist to draw is gone before the comparison happens. Folio's
+   * `{ payload: { path: […], equals: AnyNull } }` is exactly this, and typing
+   * it as valid is what this pair prevents.
+   */
+  test("a sentinel at a path is refused, and so is one a level down", async () => {
+    // @ts-expect-error an extracted value cannot tell the two empties apart
+    await UserModel.findMany({ where: { metadata: { path: ["a"], equals: DbNull } } });
+    // @ts-expect-error nor can it under `not`
+    await UserModel.findMany({ where: { metadata: { path: ["a"], not: JsonNull } } });
+    // @ts-expect-error and the nested operator object is refused with them
+    await UserModel.findMany({ where: { metadata: { path: ["a"], equals: { not: AnyNull } } } });
+  });
+
+  /**
+   * The narrowing must not have cost the column filter anything. A `Json`
+   * column still takes any document as the `equals` shorthand — including one
+   * whose keys are spelled like operators — and the sentinels still apply *to
+   * the column*, which is where the distinction survives.
+   */
+  test("the column filter is untouched", async () => {
+    await UserModel.findMany({ where: { metadata: { a: 1 } } });
+    await UserModel.findMany({ where: { metadata: { equalz: "video" } } });
+    await UserModel.findMany({ where: { metadata: [1, 2] } });
+    await UserModel.findMany({ where: { metadata: { equals: { a: 1 } } } });
+    await UserModel.findMany({ where: { metadata: { not: AnyNull } } });
+  });
+
+  /**
+   * The one thing the discrimination costs, and it costs nothing the compiler
+   * had not already taken: `compileFieldFilter` dispatches on
+   * `filter.path !== undefined`, so a document with a top-level `path` key was
+   * *never* readable as the bare shorthand — it reached `compileJsonFilter` and
+   * threw. The explicit `equals` is the spelling that means the document, and
+   * it always was.
+   */
+  test("a document with a `path` key is written as an explicit equals", async () => {
+    await UserModel.findMany({ where: { metadata: { equals: { path: "/a", method: "GET" } } } });
+    // @ts-expect-error the bare form is a path filter to the compiler, not a value
+    await UserModel.findMany({ where: { metadata: { path: "/a", method: "GET" } } });
+  });
+
+  test("and it narrows the same one level down, inside a relation filter", async () => {
+    await AccountModel.findMany({
+      where: { user: { metadata: { path: ["a"], equals: 1 } } },
+    });
+
+    await AccountModel.findMany({
+      // @ts-expect-error the same refusal reached through a to-one
+      where: { user: { metadata: { path: ["a"], equalz: 1 } } },
+    });
   });
 });
 

--- a/templates/saas-starter/app/models/filters.test-d.ts
+++ b/templates/saas-starter/app/models/filters.test-d.ts
@@ -295,31 +295,104 @@ describe("Json path filters", () => {
   });
 
   /**
-   * The narrowing must not have cost the column filter anything. A `Json`
-   * column still takes any document as the `equals` shorthand — including one
-   * whose keys are spelled like operators — and the sentinels still apply *to
-   * the column*, which is where the distinction survives.
+   * **`null` is refused, and it is the one place the type goes further than the
+   * compiler.** `assertJsonOperand` lets it through and the query compiles to
+   * `("metadata" #>> $1) = $2` bound to NULL, which is NULL and not true on
+   * both dialects — a predicate no row can satisfy. With the sentinels already
+   * refused there is nothing else it could be asking. Filed against the runtime
+   * as #371 rather than changed here, since this is a type-only change — so a
+   * `null` arriving dynamically still reaches the binder.
    */
-  test("the column filter is untouched", async () => {
-    await UserModel.findMany({ where: { metadata: { a: 1 } } });
-    await UserModel.findMany({ where: { metadata: { equalz: "video" } } });
-    await UserModel.findMany({ where: { metadata: [1, 2] } });
-    await UserModel.findMany({ where: { metadata: { equals: { a: 1 } } } });
-    await UserModel.findMany({ where: { metadata: { not: AnyNull } } });
+  test("null at a path is refused, having no reading left", async () => {
+    // @ts-expect-error `= NULL` is never true; say which empty you mean, on the column
+    await UserModel.findMany({ where: { metadata: { path: ["a"], equals: null } } });
   });
 
   /**
-   * The one thing the discrimination costs, and it costs nothing the compiler
-   * had not already taken: `compileFieldFilter` dispatches on
-   * `filter.path !== undefined`, so a document with a top-level `path` key was
-   * *never* readable as the bare shorthand — it reached `compileJsonFilter` and
-   * threw. The explicit `equals` is the spelling that means the document, and
-   * it always was.
+   * The column filter must not have lost anything — but "anything" is what the
+   * *compiler* accepts, and an object operand on a `Json` column is a filter to
+   * it, never a document. `isFilterObject` sends every non-`Date`, non-array
+   * object to the operator loop; only scalars and arrays reach `equals`. So the
+   * document goes under `equals`, which is the only spelling `docs/orm.md` has
+   * ever shown.
+   */
+  test("the column filter still takes every operand the compiler answers", async () => {
+    await UserModel.findMany({ where: { metadata: [1, 2] } });
+    await UserModel.findMany({ where: { metadata: "video" } });
+    await UserModel.findMany({ where: { metadata: { equals: { a: 1 } } } });
+    await UserModel.findMany({ where: { metadata: { not: AnyNull } } });
+    await UserModel.findMany({ where: { metadata: { equals: DbNull } } });
+  });
+
+  /**
+   * And refuses the ones it raises on. Both of these compiled before this
+   * change and threw `InvalidArgumentError` naming the key — the same
+   * type-checks-but-throws divergence #336 is about, reached from the value arm
+   * instead of the path arm.
+   */
+  test("a bare document is refused, because the compiler raises on it", async () => {
+    // @ts-expect-error InvalidArgumentError on `where.metadata.a` — write { equals: { a: 1 } }
+    await UserModel.findMany({ where: { metadata: { a: 1 } } });
+    // @ts-expect-error and `equalz` is not an operator either — same error, same fix
+    await UserModel.findMany({ where: { metadata: { equalz: "video" } } });
+  });
+
+  /**
+   * A document with a top-level `path` key is the same story with the key that
+   * happens to be the discriminant: `compileFieldFilter` dispatches on
+   * `filter.path !== undefined`, so the bare form reached `compileJsonFilter`
+   * and raised. `{ equals: … }` is the spelling, as it is for every other
+   * document.
    */
   test("a document with a `path` key is written as an explicit equals", async () => {
     await UserModel.findMany({ where: { metadata: { equals: { path: "/a", method: "GET" } } } });
     // @ts-expect-error the bare form is a path filter to the compiler, not a value
     await UserModel.findMany({ where: { metadata: { path: "/a", method: "GET" } } });
+  });
+
+  /**
+   * **The discriminant must not leak downwards.** `path` is only special as the
+   * *operand's* own key; one level into a document it is an ordinary string
+   * key, and an index signature does not synthesise a property that would trip
+   * the check. If it did, this change would have broken every payload that
+   * stores a URL path.
+   */
+  test("a `path` key inside the document is an ordinary key", async () => {
+    await UserModel.findMany({ where: { metadata: { equals: { config: { path: "/x" } } } } });
+    await UserModel.findMany({ where: { metadata: { equals: { a: { b: { path: [1, 2] } } } } } });
+    await UserModel.findMany({ where: { metadata: [{ path: "/x" }, { path: "/y" }] } });
+  });
+
+  /**
+   * `not` is the asymmetric one, and the type now says so. `equals` binds its
+   * operand as a value; `not` hands an object operand back to
+   * `compileFieldFilter` as a nested filter, so a negated path filter is a real
+   * query and a misspelled operator under `not` is a real error. Both measured.
+   */
+  test("`not` carries a whole filter, including a path one", async () => {
+    await UserModel.findMany({ where: { metadata: { not: { path: ["a"], equals: 1 } } } });
+    await UserModel.findMany({ where: { metadata: { not: { equals: { a: 1 } } } } });
+    await UserModel.findMany({ where: { metadata: { not: [1, 2] } } });
+
+    // @ts-expect-error the recursion reaches the same refusal
+    await UserModel.findMany({ where: { metadata: { not: { path: ["a"], equalz: 1 } } } });
+    // @ts-expect-error and `a` is not an operator here either
+    await UserModel.findMany({ where: { metadata: { not: { a: 1 } } } });
+  });
+
+  /**
+   * A path is the natural thing to hoist out of a query, and hoisting it makes
+   * it `readonly`. `assertPathShape` uses `Array.isArray` and `.every`, which a
+   * frozen array answers, and the path is bound rather than mutated — so the
+   * type takes a `readonly` array. Without it, `as const` on the filter object
+   * was a compile error against a query that runs.
+   */
+  test("a hoisted or `as const` path still compiles", async () => {
+    const PATH = ["operation"] as const;
+    await UserModel.findMany({ where: { metadata: { path: PATH, equals: "video" } } });
+
+    const filter = { path: ["a"], equals: "x" } as const;
+    await UserModel.findMany({ where: { metadata: filter } });
   });
 
   test("and it narrows the same one level down, inside a relation filter", async () => {


### PR DESCRIPTION
A type-only change. `compileJsonFilter` already implements the whole feature — both path grammars, the `#>`/`#>>` vs `json_extract` split, the bound path, the bare-path refusal reproducing Prisma's *"A JSON path cannot be set without a scalar filter."*, the sentinel refusals — and `read.test.ts`'s 22 `json path filters` tests cover it. Nothing in the runtime is touched, and nothing in it moved.

What was broken is the compile-time surface, and it is the fourth of the same kind as #326, #333 and #337. It is also the worst of the four: those three *refused* an argument the compiler accepts, so a caller got an error and knew. This one accepted anything, silently.

| written | before | after | compiler |
| --- | --- | --- | --- |
| `{ path: ["operation"], equals: "video" }` | compiles | compiles | works |
| `{ path: 123, notAFilter: true }` | **compiles** | error | raises |
| `{ path: [], string_contains: 4 }` | **compiles** | error | raises |
| `{ path: ["operation"], equalz: "video" }` | **compiles** | error | raises |
| `{ metadata: { a: 1 } }` | **compiles** | error | raises |
| `{ metadata: { not: { a: 1 } } }` | **compiles** | error | raises |
| `{ path: ["a"], equals: DbNull }` | **compiles** | error | raises |

Measured with `tsc --noEmit --pretty false` on both sides, not read off the type.

## The absorption is the defect; the operators are the easy half

`JsonFilter` was `{ equals?, not? }` — no `path`, none of the ten operators `JSON_FILTERS` accepts. But adding them changes nothing on its own, and that is the part worth being explicit about.

`FieldFilter`'s `Json` arm unioned in `JsonValue`, which contains `{ [key: string]: JsonValue }`. `{ path: 123, notAFilter: true }` is a perfectly good JSON *document*, so it landed in the value arm; a union permits a property present in any member, so excess-property checking never fired either. A `JsonPathFilter` added beside that arm is just one more member the nonsense does not have to match.

**The object member does not need excluding, narrowing or discriminating. It needs deleting.** `where` has no bare-document branch for a `Json` column at all: `isFilterObject` reports any non-`Date`, non-array object as a filter, so `{ metadata: { a: 1 } }` reaches the scalar operator loop and raises *"A scalar filter takes contains, endsWith, equals, …"* on the key `a`. Only scalars and arrays fall through to `equals`. Measured against `compileRead` on Postgres:

| operand | compiler |
| --- | --- |
| `{ metadata: { a: 1 } }` | `InvalidArgumentError` on `where.metadata.a` |
| `{ metadata: [1, 2] }`, `{ metadata: "s" }` | `"metadata" = $1::text::jsonb` |
| `{ metadata: { equals: { a: 1 } } }` | `"metadata" = $1::text::jsonb` |
| `{ metadata: {} }` | `true` |

So the value arm is `Exclude<JsonValue, JsonObject>`, with no index signature left anywhere in the union — which is what lets excess-property checking work at all, and what makes `path` discriminate for free. A document goes under `equals`, which is the only spelling `docs/orm.md` has ever shown. `{}` still compiles, matching `where true`.

`JsonFilter` keeps a `path?: never`, and that one is load-bearing: without it `{ path: […], equals: DbNull }` satisfied `JsonFilter` structurally with `path` counting as "known" because `JsonPathFilter` declares it, so the sentinel-at-a-path case went on compiling. Found by a test, not by reading.

An earlier revision of this branch kept the object member with `path?: never` intersected onto it — the trick worked, and its entire effect was to go on admitting operands that always throw. Recorded here because the review that caught it is the reason the change is smaller than it was.

## `equals` binds a value; `not` recurses

`compileNot` hands any object operand back through `compileFieldFilter`, so `{ not: { path: […], equals: 1 } }` is a real negated path filter and `{ not: { a: 1 } }` raises, while `{ equals: { a: 1 } }` binds a document. `not` therefore takes the filter union — `JsonValueOperand | sentinels | JsonFilter | JsonPathFilter` — and `equals` keeps `JsonValue`. The asymmetry is the compiler's; it is now written down.

## Flat across the dialects, and why

The operator set and the path grammar are both dialect-dependent — Postgres takes `["a","b"]` and all ten operators, SQLite takes `"$.a.b"` and has neither `array_contains` nor the four comparisons — and `compileJsonFilter` refuses the wrong dialect's grammar at run time, naming the dialect.

Typed as one union of both anyway. The generated artifact is **dialect-agnostic**: `ModelTypeInfo` records no dialect, and the dialect is chosen from `DATABASE_URL` at connect time, so there is nothing for a dialect-shaped type to read. Shaping it means threading a parameter the generator does not know through every model, every `WhereInput` and every call site — and it is not how this file already handles the identical divergence. `mode: "insensitive"` is Postgres-only and is a flat property with a one-line comment; `ListFilter` is offered on both dialects though SQLite has no array type to answer it, with `assertListDialect` refusing at run time. The refusal stays where it can name the dialect and say "it works on postgres", which a type cannot do.

`path` is `string | readonly (string | number)[]`. `readonly` because hoisting a path — `const PATH = ["operation"] as const`, or the whole filter object written `as const` — is the natural thing to do and produced a compile error against a query that runs; `assertPathShape` uses `Array.isArray` and `.every`, both of which a frozen array answers.

Numbers because `assertPathShape` accepts them, where Prisma's generated `path` is `string[]`. That is a superset of the oracle, and this file refuses to be one on dialect operators for a stated reason — *"implementing them would make gemi answer a query the oracle cannot"* (`where.ts:945`). The two are consistent because that rule governs what the **compiler** answers and a type cannot enforce it: excluding numbers here would not remove the superset, since `assertPathShape` would still take `["items", 0]` from a `string[]`-typed variable or from `any`. It would only stop the type describing the compiler, which is #336 again in the other direction. If the superset should go, the place is `assertPathShape` — filed as #371 with both answers written out, rather than decided quietly in a type.

## What is deliberately still refused

The sentinels are absent from `JsonPathFilter`, and their absence is what keeps folio's `{ payload: { path: […], equals: AnyNull } }` — #336's original example — from typechecking. `#>>` yields SQL NULL for an absent key and for a JSON `null` alike, so the distinction the sentinels exist to draw is gone before the comparison happens. They stay on `JsonFilter`, which compiles against the column, where it survives. The same shape one level down — `{ path: […], equals: { not: DbNull } }` — falls out of the same scalar operand type, and both are pinned.

`null` is refused too, and **this is the one place the type goes further than the compiler.** `{ path: […], equals: null }` compiles to `("metadata" #>> $1) = $2` bound to NULL, which is NULL rather than true on both dialects — a predicate no row can satisfy. Once the sentinels are refused there is no other reading of it, and the same operand under `string_contains` is already a runtime refusal, in this file's own words because the pattern "runs and returns the wrong rows". Marked as a divergence rather than smuggled in, and filed against the runtime as #371.

Every operator stays optional, so `{ path: ["a"] }` alone still typechecks and still raises the bare-path error. Requiring one means a ten-way union in exactly the position where the compiler reports a misspelled operator, and the runtime message already names the whole set. Prisma's generated input has the same shape. The empty path stays a run-time refusal, for the same reason a non-empty tuple type would break `path: somePathVariable`.

## Verification

`packages/gemi/orm` **2,305 pass · 1 fail**, the 22 `json path filters` tests among them; the failure is `defaults.test.ts`'s `vi.resetModules` under `bun test`, pre-existing and identical on a clean tree at the same commit. `saas-starter` type tests **116 pass**, up from 102 — fourteen new, covering both path grammars, all ten operators, each nonsense form, the sentinel and its one-level-down shape, `null` at a path, the bare document, `not`'s recursion, the `as const` forms, a `path` key *inside* a document staying an ordinary key, and the same narrowing reached through a to-one. `saas-starter` runtime **296 pass**, byte-identical to baseline. `tsc --noEmit` clean on `packages/gemi`; `oxlint` and `oxfmt` clean on both files touched. `docs/llms-full.txt` re-embedded, which `docs-scope.test.ts` checks verbatim.

Closes #336. Files #371 for the three runtime operand gaps this surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChxCkNb4bLwd5aYSgAPByU
