### PR TITLE
Address review on #362: duplicate case ids, an unrecorded no-op, and two divergences half-written down

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4002,6 +4002,12 @@ is accepted here — Prisma accepts one, and refusing it would refuse a query th
 `false` is the value nobody guesses, and it is the reason to say this out loud: it writes nothing at
 all, so `disconnect: shouldDetach` leaves the row alone on the branch that asked for nothing.
 
+`null` is **not** a third spelling of `false`, on either side of the key: it is refused, with a
+message pointing at `false`. Prisma refuses it too — a `PrismaClientValidationError` — so this is
+matching the client rather than being stricter than it. A `disconnect` key whose value is
+`undefined` is the *absent* key and stays a no-op, which is what an optional argument spread
+produces; only an explicit `null` raises.
+
 The two operands then part company on a miss, still on a to-one, and it is Prisma's asymmetry rather
 than a choice gemi made: `delete` raises `RecordNotFoundError` when there is no row to delete, while
 `disconnect` is silent. That holds whichever way the row went missing — no child linked at all, or a

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1019,6 +1019,12 @@ is accepted here — Prisma accepts one, and refusing it would refuse a query th
 `false` is the value nobody guesses, and it is the reason to say this out loud: it writes nothing at
 all, so `disconnect: shouldDetach` leaves the row alone on the branch that asked for nothing.
 
+`null` is **not** a third spelling of `false`, on either side of the key: it is refused, with a
+message pointing at `false`. Prisma refuses it too — a `PrismaClientValidationError` — so this is
+matching the client rather than being stricter than it. A `disconnect` key whose value is
+`undefined` is the *absent* key and stays a no-op, which is what an optional argument spread
+produces; only an explicit `null` raises.
+
 The two operands then part company on a miss, still on a to-one, and it is Prisma's asymmetry rather
 than a choice gemi made: `delete` raises `RecordNotFoundError` when there is no row to delete, while
 `disconnect` is silent. That holds whichever way the row went missing — no child linked at all, or a

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -478,8 +478,12 @@ function planOwningSide(
     // translation and the same shape check the foreign side runs, reused rather
     // than restated so the two sides cannot answer one grammar differently
     // again — which is the defect #359 was filed for.
+    //
+    // The check goes **first**, on the operand as written: the translation is
+    // lossy in the one direction that matters, since it maps `false` onto the
+    // same `null` a caller may have spelled outright. See `assertToOneFilter`.
+    assertToOneFilter(schema, relation, child, operand, key, operation);
     const filter = toOneOperand(key, operand);
-    assertToOneFilter(schema, relation, child, filter, key, operation);
 
     // `false` — no contribution and no step, so the operand contributes
     // *nothing at all*: a `data` carrying only this compiles to the read
@@ -907,6 +911,25 @@ function planForeignSide(
    * did, which is the only thing the schema permits. `assertDisconnectable` is
    * deliberately not called here: it would refuse the whole operand, including
    * the empty-to-one case that has always worked.
+   *
+   * **`relation.kind` is the discriminator here and the unique index is the
+   * discriminator on the owning side (#363), and the two are not in
+   * disagreement — they are the same question asked from the two ends of the
+   * key.** `kind` is a property of *this* relation's back-reference, and Prisma
+   * will not let a non-list back-relation exist without `@unique` on the
+   * child's foreign key. Verified against 6.19.2 rather than assumed:
+   * `User.profile Profile?` beside a `Profile.userId` carrying no `@unique` is
+   * refused at parse time with P1012 — *"A one-to-one relation must use unique
+   * fields on the defining side. Either add an `@unique` attribute to the field
+   * `userId`, or change the relation to one-to-many"* — so the only schema that
+   * reaches this line either has the index or has `User.profile` as a list.
+   * `kind !== "many"` on the foreign side *is* "the child's key is
+   * unique", read off the side that records it. From the owning side there is
+   * no such reading available — `relation.kind` says `"one"` for a many-to-one
+   * and a one-to-one alike, because both point at a single far row — so the
+   * question has to be put to the schema directly, as `uniques` containing the
+   * foreign-key column. Same predicate, two spellings, and neither side can
+   * borrow the other's.
    */
   const displaces =
     relation.kind !== "many" && child.fields[childField]?.nullable === true;
@@ -935,6 +958,12 @@ function planForeignSide(
    * the implementation is a *translation* rather than three new bodies: see
    * {@link toOneOperand}.
    */
+  // The operand as the caller wrote it, kept because the rewrite below
+  // overwrites `operand` in place and `assertToOneFilter` has to read the
+  // spelling rather than the translation — `false` and `null` are one value
+  // afterwards and two very different calls before. See that function.
+  const spelledOperand = operand;
+
   if (relation.kind !== "many") {
     if (key === "set" || key === "updateMany" || key === "deleteMany") {
       throw new UnsupportedQueryError(
@@ -1425,7 +1454,14 @@ function planForeignSide(
     if (relation.kind === "many") {
       assertNamedRows(schema, relation, child, operand, key, operation);
     } else {
-      assertToOneFilter(schema, relation, child, operand, key, operation);
+      assertToOneFilter(
+        schema,
+        relation,
+        child,
+        spelledOperand,
+        key,
+        operation,
+      );
     }
 
     out.after.push({
@@ -2525,8 +2561,8 @@ function assertNamedRows(
 }
 
 /**
- * A to-one `disconnect` / `delete` operand, once {@link toOneOperand} has
- * translated the booleans away: `null` for the no-op, or a plain filter object.
+ * A to-one `disconnect` / `delete` operand, **as the caller spelled it** — a
+ * boolean, or a filter object, and nothing else.
  *
  * The counterpart of {@link assertNamedRows}, and deliberately *not* it. That
  * one runs `matchUniqueKey`, which is right where the caller is picking one row
@@ -2536,9 +2572,29 @@ function assertNamedRows(
  * have refused that at compile time with a list of unique keys the caller never
  * had to name.
  *
- * `null` is the normalised `false`, and it is a *value* rather than an
- * omission: `delete: false` is a call that deliberately asks for nothing, so it
- * passes here and reduces to no statement at all further down.
+ * **Run before {@link toOneOperand} rather than after it, which is what makes
+ * `null` reachable at all.** That translation maps `false` to `null`, so a
+ * check downstream of it sees one value for two very different calls: the
+ * deliberate no-op, and an operand of a type Prisma has no arm for. This used
+ * to sit downstream and pass both, and the second is the one that mattered —
+ * before #359 the owning side refused everything but `true`, so `disconnect:
+ * null` was an `UnsupportedQueryError` there, and widening the grammar turned a
+ * refusal into silence. That is the failure class the differential suite exists
+ * to pin, arrived at from the tidy direction, and it is not one to inherit on
+ * the strength of the far side having it too.
+ *
+ * Measured, so the refusal is matching Prisma rather than being stricter than
+ * it (6.19.2, SQLite): `disconnect: null` is a `PrismaClientValidationError` on
+ * all three shapes it can be written against — a one-to-one from either end and
+ * a many-to-one — with nothing written. `undefined` is the *absent* key and
+ * stays a no-op on both clients, which is why only `null` is named here:
+ * `canonicalShape` drops an undefined member outright, so `disconnect:
+ * undefined` and no `disconnect` at all are already one call.
+ *
+ * Sound at plan time for the same reason the boolean guard is (#358):
+ * `canonicalShape` records `null` as `"null"`, the booleans as `"true"` /
+ * `"false"` and a filter by its structure, so no two of them can share a cache
+ * entry and this refusal can never be decided on one call's behalf by another's.
  *
  * `InvalidArgumentError` because the argument is supported and the value is
  * wrong — the same reading `assertCreateManyOperand` uses, and the reason the
@@ -2552,8 +2608,11 @@ function assertToOneFilter(
   key: string,
   operation: string,
 ): void {
-  if (operand === null || operand === undefined) return;
-  if (typeof operand === "object" && !Array.isArray(operand)) return;
+  if (operand === undefined) return;
+  if (typeof operand === "boolean") return;
+  if (operand !== null && typeof operand === "object" && !Array.isArray(operand)) {
+    return;
+  }
 
   throw new InvalidArgumentError(
     `data.${relation.name}.${key}`,
@@ -2562,7 +2621,16 @@ function assertToOneFilter(
     `'${relation.name}' is a to-one, so '${key}' takes either a boolean — ` +
       `'true' for the connected ${child.name}, 'false' for nothing — or an ` +
       `object of filters it has to match. Prisma's operand here is ` +
-      `'${child.name}WhereInput | boolean'.`,
+      `'${child.name}WhereInput | boolean'.` +
+      // Named rather than left to the list above, because `null` is the one
+      // wrong value with an obvious intent: it is what an optional flag
+      // degrades to, and `false` is the spelling that means what it was
+      // reaching for. Prisma refuses it too, so pointing at `false` is a
+      // correction and not a workaround.
+      (operand === null
+        ? ` 'null' is not one of them — write 'false' for the no-op. Prisma ` +
+          `answers 'null' with a validation error rather than accepting it.`
+        : ""),
   );
 }
 

--- a/packages/gemi/orm/compile/refusals.test.ts
+++ b/packages/gemi/orm/compile/refusals.test.ts
@@ -176,6 +176,29 @@ describe("shape guards", () => {
       "data.profile.delete",
       /takes either a boolean/,
     ],
+    // `null` specifically, and on both sides, because it is the wrong value
+    // that a *translation* used to swallow: `toOneOperand` maps `false` onto
+    // `null`, so a check downstream of it could not tell the deliberate no-op
+    // from an operand Prisma has no arm for. Measured on 6.19.2 —
+    // `disconnect: null` is a PrismaClientValidationError there — so refusing
+    // it is matching the client rather than out-stricting it.
+    // `delete` rather than `disconnect` on this side, and not by preference:
+    // the shared fixture's `Profile.userId` is required, so `disconnect` is
+    // refused one guard earlier — on the *key* — and would pin that message
+    // instead of this one. `write.test.ts` has the nullable-key fixture and
+    // covers `disconnect: null` there.
+    [
+      "a to-one delete is null",
+      write({ where: { id: 1 }, data: { profile: { delete: null } } }),
+      "data.profile.delete",
+      /'null' is not one of them/,
+    ],
+    [
+      "a to-one disconnect this row owns is null",
+      write({ where: { id: 1 }, data: { organization: { disconnect: null } } }),
+      "data.organization.disconnect",
+      /'null' is not one of them/,
+    ],
     [
       "an array on a to-one whose child holds the key",
       write({ where: { id: 1 }, data: { profile: { create: [{ bio: "a" }] } } }),

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -1483,6 +1483,42 @@ describe("nested writes", () => {
         expect(error!.message).toMatch(/takes either a boolean/);
         expect(error!.message).toContain("ProfileWhereInput | boolean");
       });
+
+      /**
+       * `null` is refused and `undefined` is not, and the pair has to be
+       * asserted together because they are one line apart in the guard and
+       * mean opposite things.
+       *
+       * `undefined` is the **absent** key: `canonicalShape` drops an undefined
+       * member, so `disconnect: undefined` and no `disconnect` at all are the
+       * same call and the same plan — refusing it would refuse the spelling a
+       * spread of optional arguments naturally produces. `null` is a value the
+       * caller wrote, and Prisma answers it with a validation error (6.19.2,
+       * measured on a one-to-one from both ends and on a many-to-one).
+       *
+       * The regression it guards is a *widening*: before #359 the owning side
+       * refused every operand but `true`, so `disconnect: null` raised there.
+       * Reaching the shared grammar made it silent for as long as the check ran
+       * after `toOneOperand` had folded `false` and `null` together.
+       */
+      test.each([
+        ["disconnect", { disconnect: null }],
+        ["delete", { delete: null }],
+      ])("%s: null is refused and points at false", (operand, value) => {
+        const error = refuse("profile", value as Record<string, unknown>);
+
+        expect(error).toBeInstanceOf(InvalidArgumentError);
+        expect(error!.argument).toBe(`data.profile.${operand}`);
+        expect(error!.message).toMatch(/'null' is not one of them/);
+        expect(error!.message).toMatch(/write 'false' for the no-op/);
+      });
+
+      test.each([
+        ["disconnect", { disconnect: undefined }],
+        ["delete", { delete: undefined }],
+      ])("%s: undefined is the absent key, not a bad value", (_operand, value) => {
+        expect(refuse("profile", value as Record<string, unknown>)).toBeNull();
+      });
     });
 
     /**

--- a/packages/gemi/orm/compile/write.ts
+++ b/packages/gemi/orm/compile/write.ts
@@ -1319,6 +1319,52 @@ function assertNoNestedWrites(
  * `connect`, a hand-written `organizationId: null`, and every other column
  * write already give. Pre-existing, unchanged here, and matching it would mean
  * special-casing one operand to reproduce an inconsistency.
+ *
+ * **...and the *filter* arm (#359) carries it one step further: it stamps even
+ * when it detaches nothing.** `nested-writes.ts`'s owning-side `disconnect`
+ * defaults `context.resolved[fkField]` to the value already in the column and
+ * pushes the contribution unconditionally — it has to, because the statement's
+ * text cannot depend on a value read at bind time — so the assignment is in the
+ * SET list whether or not the linked row matched. Measured on both sides
+ * against a schema built for it, since the template's `Profile` has no
+ * `@updatedAt` (Prisma 6.19.2, SQLite, a one-to-one whose *owner* carries the
+ * attribute, `updatedAt` seeded to the epoch):
+ *
+ *     disconnect: true                update … set "userId" = ?
+ *                                       -> key nulled, updatedAt at the epoch
+ *     disconnect: { name: "Ada" }     update … set "userId" = ? where … and
+ *                                       exists(select … where "name" = ? …)
+ *                                       -> key nulled, updatedAt at the epoch
+ *     disconnect: { name: "Nobody" }  the same statement, matching zero rows
+ *                                       -> nothing written at all
+ *     disconnect: false               no update statement at all
+ *                                       -> nothing written at all
+ *
+ * So Prisma never stamps through this operand, matching filter or not — that is
+ * the paragraph above — and on a miss it writes *no row*, because the filter
+ * rides inside the `UPDATE`'s own `where` as an `exists` subquery. gemi's plan
+ * text is fixed at compile time and reads
+ * `update "User" set "organizationId" = ?, "updatedAt" = ? where "id" = ?` for
+ * every arm that writes, so `User.update({ where: { id: 1 }, data: {
+ * organization: { disconnect: { name: "Nobody" } } } })` leaves
+ * `organizationId` at 1 and moves `updatedAt` from the epoch to now: a call
+ * that changed no column of the row still stamps it.
+ *
+ * **There is no test for the stamp half and there cannot be one in this
+ * fixture**, which is why this docblock is the deliverable rather than a
+ * pointer to one. The template's only one-to-one owner is `Profile`, which has
+ * no `@updatedAt` column, and the differential harness lists `updatedAt` in its
+ * volatile set (`differential.ts`), so both sides compare as the descriptor
+ * `"date"` and two different instants match. The measurements above were taken
+ * against a purpose-built schema, not against the template's.
+ *
+ * **The two statements are also a lost-update window**, which `disconnect: true`
+ * does not have and Prisma does not have on either arm. The filter arm reads the
+ * current key with a `findFirst` and writes it back in a *second* statement, so
+ * under READ COMMITTED a concurrent transaction that `connect`s a different
+ * partner in between has its value silently reverted — by the call that decided
+ * to do nothing. Prisma's single guarded `UPDATE` above cannot lose it: there is
+ * no read to be stale, and on a miss there is no write at all.
  */
 function updateAssignments(
   schema: ModelSchema,

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -583,6 +583,15 @@ const CASES: Case[] = [
   ["M8c to-one disconnect with a non-matching filter is silent", "update", {
     where: { id: 1 }, data: { profile: { disconnect: { bio: "nope" } } },
   }, ["User", "Profile"]],
+  // M8d — and `null` is not a third spelling of the silence. Both clients
+  // refuse it: a `PrismaClientValidationError` there, an `InvalidArgumentError`
+  // here, so `other` on both sides and nothing written. The owning side's
+  // twin is `O11`, and the pair is the point — this is the grammar the two
+  // sides now share, so a value one of them swallowed and the other refused
+  // would be #359 again with the roles reversed.
+  ["M8d to-one disconnect null is refused by both", "update", {
+    where: { id: 1 }, data: { profile: { disconnect: null } },
+  }, ["User", "Profile"]],
 
   // M9 — the `{ data }` wrapper on the **foreign** side. It was measured on the
   // owning side only, and the three spellings (bare, `{ data }`,
@@ -658,20 +667,27 @@ const CASES: Case[] = [
     where: { id: 2 }, data: { profile: { connect: { id: 1 } } },
   }, ["User", "Profile"]],
 
-  // M11 — a nested `create` onto a to-one that **already has a child** (#360),
+  // M14 — a nested `create` onto a to-one that **already has a child** (#360),
   // which was a `UniqueConstraintError` here and an answer there until this
   // graduated out of the "still disagree" describe below.
+  //
+  // **Numbered from M14 rather than M11**, which is where these first landed:
+  // `M11` through `M12d` were already taken further down this file, and a
+  // duplicate id makes `-t "M12b"` select two unrelated tests. #361's
+  // acceptance criteria name `M11c` / `M11d` as the pins that have to stay
+  // green — they are `M14c` / `M14d` below, renamed for that reason and for no
+  // other.
   //
   // The incumbent is **orphaned, not deleted**: three rows afterwards, the old
   // one holding a null foreign key. That is the half worth reading the table
   // for — a fix that deleted the displaced row instead would be silent data
   // loss wearing this same green test, which is why `tables` names `Profile`.
-  ["M11 to-one create displaces the incumbent, orphaning it", "update", {
+  ["M14 to-one create displaces the incumbent, orphaning it", "update", {
     where: { id: 1 }, data: { profile: { create: { bio: "second" } } },
   }, ["User", "Profile"]],
   // The control on the other statement: a *new* parent can have nothing linked
   // to displace, so the same operand costs the same as it always did.
-  ["M11b to-one create under a create has nothing to displace", "create", {
+  ["M14b to-one create under a create has nothing to displace", "create", {
     data: { email: "fresh@example.dev", profile: { create: { bio: "first" } } },
   }, ["User", "Profile"]],
   // And the neighbours that do **not** displace. Measured rather than assumed
@@ -679,8 +695,8 @@ const CASES: Case[] = [
   // the *create branch* of `connectOrCreate` and of `upsert` collides on the
   // child's unique foreign key, where the bare `create` above detaches. So what
   // displaces is the bare `create` and anything that **links an existing row**
-  // (M12 below) — not "every operand that ends with a child pointing here".
-  ["M11c to-one connectOrCreate whose where misses collides", "update", {
+  // (M15 below) — not "every operand that ends with a child pointing here".
+  ["M14c to-one connectOrCreate whose where misses collides", "update", {
     where: { id: 1 },
     data: {
       profile: {
@@ -688,7 +704,7 @@ const CASES: Case[] = [
       },
     },
   }, ["User", "Profile"]],
-  ["M11d to-one upsert whose where misses collides", "update", {
+  ["M14d to-one upsert whose where misses collides", "update", {
     where: { id: 1 },
     data: {
       profile: {
@@ -697,31 +713,31 @@ const CASES: Case[] = [
     },
   }, ["User", "Profile"]],
 
-  // M12 — `connect` onto a to-one that **already has a child** (#361), the
-  // neighbour of M11 and the same displacement. Four shapes, and only this one
+  // M15 — `connect` onto a to-one that **already has a child** (#361), the
+  // neighbour of M14 and the same displacement. Four shapes, and only this one
   // ever diverged: the three above it — an empty to-one, a steal from another
   // parent, and the row already linked here — agreed before the fix and are
   // what kept it hidden.
-  ["M12 to-one connect displaces the incumbent, orphaning it", "update", {
+  ["M15 to-one connect displaces the incumbent, orphaning it", "update", {
     where: { id: 1 }, data: { profile: { connect: { id: 2 } } },
   }, ["User", "Profile"]],
   // The clear and the link cross on this one: `clearLinks` nulls the very row
   // the caller named and the repoint puts the key straight back. Net nothing,
   // which is Prisma's answer, and the case that would catch a clear scoped to
   // the wrong rows.
-  ["M12b to-one connect of the row already linked changes nothing", "update", {
+  ["M15b to-one connect of the row already linked changes nothing", "update", {
     where: { id: 1 }, data: { profile: { connect: { id: 1 } } },
   }, ["User", "Profile"]],
   // A miss detaches nothing — the repoint raises and takes the clear down with
   // it. `notFound` on both sides, so a gemi refusal could not pass for it.
-  ["M12c to-one connect naming no row raises and displaces nothing", "update", {
+  ["M15c to-one connect naming no row raises and displaces nothing", "update", {
     where: { id: 1 }, data: { profile: { connect: { id: 99 } } },
   }, ["User", "Profile"]],
   // ...and `connectOrCreate`'s *hit* branch is a connect, so it displaces where
-  // its miss branch (M11c) collides. Both branches of one operand, answering
+  // its miss branch (M14c) collides. Both branches of one operand, answering
   // differently, which is why `displaces` is consulted per branch rather than
   // per operand.
-  ["M12d to-one connectOrCreate hitting a row displaces the incumbent", "update", {
+  ["M15d to-one connectOrCreate hitting a row displaces the incumbent", "update", {
     where: { id: 1 },
     data: {
       profile: {
@@ -786,6 +802,22 @@ const OWNING_CASES: [string, string, unknown, string[]?][] = [
   ["O10 owning disconnect takes an operator filter", "update", {
     where: { id: 1 },
     data: { user: { disconnect: { name: { contains: "Ad" } } } },
+  }, ["Profile", "User"]],
+  // O11 — the value the grammar does **not** have an arm for, which is a case
+  // in this table rather than a divergence below because both clients refuse
+  // it: `PrismaClientValidationError` there (no `P` code, so `other` on both
+  // sides, which is all the harness can claim for an argument refusal) and
+  // `InvalidArgumentError` here.
+  //
+  // It is here at all because widening this side's grammar to Prisma's (#359)
+  // could have made it *silent*. `null` is what `toOneOperand` translates
+  // `false` into, so a shape check downstream of that translation sees one
+  // value for two calls — and the earlier refusal-of-everything-but-`true` had
+  // been covering the difference. A refusal quietly becoming a no-op is the
+  // failure class this suite exists to catch; that it would have been a
+  // harmless no-op is not the point, since nothing here would have said so.
+  ["O11 owning disconnect null is refused by both", "update", {
+    where: { id: 1 }, data: { user: { disconnect: null } },
   }, ["Profile", "User"]],
 ];
 
@@ -2578,7 +2610,14 @@ function suite(label: string, url?: string) {
        * The generated input type is identical on both — `XWhereInput | boolean`
        * — so this is the engine dropping the value, not a narrower grammar.
        * `delete: false` on the same relation is a correct no-op, which is what
-       * rules out "booleans are ignored here" as the explanation.
+       * rules out "booleans are ignored here" as the explanation. Logging the
+       * engine's own SQL shows the drop directly, quoting normalised: the
+       * lookup it issues for the operand is
+       * `select id from Organization where (1=1 and id in (?))` — the caller's
+       * `name = 'Nobody'` is simply not in it — and the `update` that follows
+       * carries `and 1=1` where the *one-to-one*'s carries an `exists`
+       * subquery over the filter. So the operand is discarded before a
+       * statement is built, rather than evaluated and found to match.
        *
        * **gemi does not reproduce it.** Matching Prisma is this suite's whole
        * point and it is overruled exactly here, because the behaviour to match
@@ -2587,24 +2626,62 @@ function suite(label: string, url?: string) {
        * plan cache. Reproducing it deliberately would be re-introducing it. So
        * gemi answers one grammar one way on both shapes, and this pins the
        * difference rather than hiding it.
+       *
+       * **Both halves the docs claim, not just the boolean.** `docs/orm.md`
+       * says Prisma ignores `disconnect: false` *and* a filter matching
+       * nothing; a pin that asserted only the first would let the second move
+       * without a word, which is exactly the gap a pin is for.
        */
-      test("Prisma ignores a many-to-one disconnect operand where gemi honours it", async () => {
+      test.each([
+        ["disconnect: false", false],
+        ["a filter matching nothing", { name: "Nobody" }],
+      ])(
+        "Prisma ignores a many-to-one disconnect operand where gemi honours it: %s",
+        async (_label, operand) => {
+          const args = {
+            where: { id: 1 },
+            data: { organization: { disconnect: operand } },
+          };
+
+          await differential.reset();
+          const fromPrisma = await differential.prisma.user.update(args as never);
+          // Prisma detached anyway. User 1 is seeded into Acme.
+          expect(fromPrisma.organizationId).toBe(null);
+
+          await differential.reset();
+          const fromGemi: any = await UserModel.update(args as never);
+          expect(fromGemi.organizationId).toBe(1);
+          expect(
+            await differential.prisma.user.findFirstOrThrow({ where: { id: 1 } }),
+          ).toMatchObject({ organizationId: 1 });
+        },
+      );
+
+      /**
+       * The control that keeps the case above about the *operand* rather than
+       * about many-to-one `disconnect` in general: a filter that **does** match
+       * nulls the key on both clients. Without it, "Prisma ignores the operand"
+       * and "gemi never detaches on a many-to-one" produce the same green test.
+       *
+       * In `CASES` it would have to be `Organization`-scoped to read the table
+       * back, and it belongs beside its sibling, so it is asserted here.
+       */
+      test("a matching many-to-one disconnect filter nulls the key on both", async () => {
         const args = {
           where: { id: 1 },
-          data: { organization: { disconnect: false } },
+          data: { organization: { disconnect: { name: "Acme" } } },
         };
 
         await differential.reset();
         const fromPrisma = await differential.prisma.user.update(args as never);
-        // Prisma detached anyway. User 1 is seeded into Acme.
         expect(fromPrisma.organizationId).toBe(null);
 
         await differential.reset();
         const fromGemi: any = await UserModel.update(args as never);
-        expect(fromGemi.organizationId).toBe(1);
+        expect(fromGemi.organizationId).toBe(null);
         expect(
           await differential.prisma.user.findFirstOrThrow({ where: { id: 1 } }),
-        ).toMatchObject({ organizationId: 1 });
+        ).toMatchObject({ organizationId: null });
       });
 
       /**


### PR DESCRIPTION
Review follow-ups for #362, which merged (`65688bf`) before these landed. Same work, new base — one commit, merges cleanly.

### Duplicate differential case IDs

`M11`–`M11d` → `M14`–`M14d` and `M12`–`M12d` → `M15`–`M15d`. Five of those IDs already existed in the same file, so `-t "M12b"` selected two unrelated tests — and #361's acceptance criteria cite case IDs by name as the thing that must stay green.

Renumbered the **whole groups**, not only the five that clashed: leaving `M14` next to `M11b`/`M11c`/`M11d` would produce a group whose members disagree about which group they're in. That renames `M11c`/`M11d`, which #361's acceptance cites, so the group comment records where they went.

### `disconnect: null` — refusal restored

Prisma throws `PrismaClientValidationError` on all three shapes (measured). #362 turned that into a silent no-op, and this file exists to pin exactly that failure class.

The root cause was an ordering bug rather than a judgement call: `assertToOneFilter` ran *downstream* of `toOneOperand`, which maps `false` → `null`, so it saw one value for the deliberate no-op and for a value Prisma has no arm for. Moving it upstream of the translation makes `null` reachable at all. Sound at plan time — `canonicalShape` gives `null` its own key, so there is no #358-style cache hazard. `undefined` stays a no-op (absent key).

Both sides refuse now, so this graduated into `M8d`/`O11` as ordinary agreeing cases rather than being pinned as a divergence.

### `@updatedAt` on a disconnect that detaches nothing — measured, and it is an extension of the documented divergence, not a new one

The fixture cannot express this (no one-to-one owner carries `@updatedAt`), so this was measured against a standalone schema on a scratch SQLite DB with Prisma 6.19.2 and query logging:

```
disconnect: true               UPDATE … SET userId=?                    key nulled,  NOT stamped
disconnect: {name:"Ada"}       UPDATE … WHERE … AND EXISTS(…)           key nulled,  NOT stamped
disconnect: {name:"Nobody"}    the same statement, zero rows            nothing written
disconnect: false              no UPDATE at all                         nothing written
```

Prisma **does** emit an `UPDATE` for the filter arm — the filter rides inside its own `WHERE` as an `EXISTS` subquery and matches zero rows. And it does not stamp even when the filter *matches*. So this extends the existing `KNOWN DIVERGENCE` block rather than opening a new one. gemi's side, measured at compile level: `update "User" set "organizationId" = ?, "updatedAt" = ? where "id" = ?` — fixed at compile time, on every writing arm.

The lost-update note is recorded too, and is narrower than it first looked: Prisma's is one atomic guarded statement, so it has no window on either arm.

### Many-to-one pin completed

The docs claim Prisma ignores both `disconnect: false` and a non-matching filter; only the `false` half was pinned. Now a `test.each` over both, plus a control asserting a *matching* filter nulls on both — without that control, "Prisma ignores the operand" and "gemi never detaches here" are the same green test. Includes the logged SQL showing the operand is dropped before the statement is built (`WHERE (1=1 AND id IN (?))`, filter absent).

### Why `displaces` discriminates on `relation.kind`

Verified rather than asserted: `prisma validate` on a non-`@unique` child FK gives P1012, *"A one-to-one relation must use unique fields on the defining side."* Quoted verbatim in the docblock, since #363's acceptance says the discriminator is the unique index and a follow-up author will otherwise wonder why the two sides disagree.

### Coverage

```
packages/gemi     Test Files  120 passed (120)
                       Tests  3060 passed | 1 skipped (3061)     (base 3054)

saas-starter      Test Files  22 passed | 3 skipped (25)
                       Tests  774 passed | 133 skipped (907)     (base 770)
```

**Postgres differential run** — the coverage #362 claimed but nobody had exercised:

```
Test Files  2 failed | 21 passed (23)
     Tests  1151 passed | 472 skipped (1623)
```

The two "failed" files are the SQLite halves of the differential suites, which fail loudly by design under a Postgres-generated client (`assertPrismaSpeaks` — "a silently skipped dialect reads as a passing one"). Every Postgres case passed; `writes.differential.test.ts` alone is `215 passed | 209 skipped`. Schema restored to sqlite, container removed.

`oxlint` and `tsc --noEmit` clean. `oxfmt --check` fails on all four touched files on the base commit too — not a regression.
