### PR TITLE
Close #363: the owning side's connect displaces its sibling

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4020,18 +4020,25 @@ one that happened to hold the same foreign key. The table above applies unchange
 owning-side `create` reading as "no incumbent by construction" rather than as "displaces" — it mints
 the far row, so nothing can already be pointing at it.
 
-Two things are worth knowing about the owning side specifically.
+Three things are worth knowing about the owning side specifically.
 
-It applies only to a **one-to-one**, which here means the foreign key on your row carries a `@unique`.
-A many-to-one has no incumbent to displace — several rows may point at the same parent, which is the
-whole meaning of the relation — so nothing is detached and both rows end up linked. That is Prisma's
-answer too, and it is why `connect` costs nothing extra on the many-to-one that most nested writes
-are written against.
+It applies only to a **true one-to-one**, and that is more than "the foreign key is `@unique`". The
+other side has to be a single row too — `User.profile Profile?`, not `Team.players Player[]`. Prisma
+accepts a `@unique` foreign key beside a list back-relation, and on that schema it does **not**
+displace: the second `connect` collides on the key instead. A many-to-one likewise has no incumbent,
+since several rows may point at the same parent, which is the whole meaning of the relation. So
+`connect` costs nothing extra on the many-to-one that most nested writes are written against.
 
-And it needs a **nullable** foreign key, because a detach has to leave a value behind. Where yours is
+It needs a **nullable** foreign key, because a detach has to leave a value behind. Where yours is
 required, the repoint collides on the unique key. Prisma refuses the same call slightly earlier and
 more clearly, with P2014 — *"The change you are trying to make would violate the required relation"* —
 so the call fails on both and the class of failure differs.
+
+And **connecting the row you are already connected to writes nothing** — Prisma issues no statement
+at all for it, and gemi detaches nothing. One difference remains: gemi still emits the update that
+sets the key to the value it already holds, so on a one-to-one owner carrying `@updatedAt` gemi bumps
+the stamp where Prisma leaves it. That is the same stamp difference described under nested writes
+above, and it is specific to this case — on a many-to-one both clients update and both stamp.
 
 **On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather
 than a synonym for `true`.** There is one row and nothing to name, so `true` is how you say *the

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3907,7 +3907,7 @@ await List.create({
 | --- | --- |
 | `create` | Writes new related rows. One statement each. On a **to-one that already has a child** the new row takes the link and the old one is detached — orphaned, not deleted. |
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
-| `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. On a **to-one that already has a child** it displaces the incumbent, as `create` does. |
+| `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. On a **one-to-one that is already taken** it displaces the incumbent, as `create` does, from either end of the key. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
 | `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true`, `false` or a filter on a to-one, whichever side holds the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
 | `delete` | Deletes the named rows outright, not just the link. A unique key or a list of them on a to-many; `true`, or a filter, on a to-one whose child holds the key. |
@@ -3996,26 +3996,42 @@ as `connect` does, and it silently ignores a named row that does not exist.
 the link and the incumbent is left in the table with a null foreign key — detached, not deleted,
 which is Prisma's answer and the one worth stating because deleting would be the silent version of
 the same call. What can be displaced is what your policies let you see: an incumbent hidden from you
-is not detached, and the write then collides with it on the child's unique key.
+is not detached, and the write then collides with it on the unique key.
 
 Which operands displace is Prisma's, measured rather than derived, and it is not "everything that
-ends with a child pointing here":
+ends with a row pointing here":
 
 | operand | on an occupied to-one |
 | --- | --- |
 | `create` | displaces the incumbent |
 | `connect` | displaces the incumbent |
 | `connectOrCreate`, hit | displaces — it *is* a connect |
-| `connectOrCreate`, miss | collides on the child's unique key |
-| `upsert`, create branch | collides on the child's unique key |
+| `connectOrCreate`, miss | collides on the unique key |
+| `upsert`, create branch | collides on the unique key |
 
 So the two branches of one `connectOrCreate` answer differently: linking an existing row displaces,
 and the `create` *inside* a compound operand does not, though a bare `create` does.
 
-One gap remains, on the other side of the key: pointing **this** row at a partner who already has
-one — `Profile.update({ data: { user: { connect: { id } } } })` where that user's profile is taken —
-collides here and displaces in Prisma. Detach the incumbent first, or write the foreign key
-directly.
+**This holds from either end of the key.** Pointing *this* row at a partner who already has one —
+`Profile.update({ data: { user: { connect: { id } } } })` where that user's profile is taken —
+detaches that profile and takes the link, the same way the call spelled from the other side does.
+The row detached there is a *sibling* rather than a child: another row of the model you are writing,
+one that happened to hold the same foreign key. The table above applies unchanged, with the bare
+owning-side `create` reading as "no incumbent by construction" rather than as "displaces" — it mints
+the far row, so nothing can already be pointing at it.
+
+Two things are worth knowing about the owning side specifically.
+
+It applies only to a **one-to-one**, which here means the foreign key on your row carries a `@unique`.
+A many-to-one has no incumbent to displace — several rows may point at the same parent, which is the
+whole meaning of the relation — so nothing is detached and both rows end up linked. That is Prisma's
+answer too, and it is why `connect` costs nothing extra on the many-to-one that most nested writes
+are written against.
+
+And it needs a **nullable** foreign key, because a detach has to leave a value behind. Where yours is
+required, the repoint collides on the unique key. Prisma refuses the same call slightly earlier and
+more clearly, with P2014 — *"The change you are trying to make would violate the required relation"* —
+so the call fails on both and the class of failure differs.
 
 **On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather
 than a synonym for `true`.** There is one row and nothing to name, so `true` is how you say *the

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -924,7 +924,7 @@ await List.create({
 | --- | --- |
 | `create` | Writes new related rows. One statement each. On a **to-one that already has a child** the new row takes the link and the old one is detached — orphaned, not deleted. |
 | `createMany` | The same rows in **one** statement. To-many only, and the rows go inside `data`. |
-| `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. On a **to-one that already has a child** it displaces the incumbent, as `create` does. |
+| `connect` | Points at an existing row — a bound column when it names the referenced key, a lookup otherwise. On a **one-to-one that is already taken** it displaces the incumbent, as `create` does, from either end of the key. |
 | `connectOrCreate` | Looks the row up by a unique key and creates it only if it is not there. **A hit ignores `create` entirely** — it is connect-*or*-create, not upsert. |
 | `disconnect` | Clears the link. A unique key, or a list of them, on a to-many; `true`, `false` or a filter on a to-one, whichever side holds the key. The column that goes null is on whichever side holds it, and it has to be nullable. |
 | `delete` | Deletes the named rows outright, not just the link. A unique key or a list of them on a to-many; `true`, or a filter, on a to-one whose child holds the key. |
@@ -1013,26 +1013,42 @@ as `connect` does, and it silently ignores a named row that does not exist.
 the link and the incumbent is left in the table with a null foreign key — detached, not deleted,
 which is Prisma's answer and the one worth stating because deleting would be the silent version of
 the same call. What can be displaced is what your policies let you see: an incumbent hidden from you
-is not detached, and the write then collides with it on the child's unique key.
+is not detached, and the write then collides with it on the unique key.
 
 Which operands displace is Prisma's, measured rather than derived, and it is not "everything that
-ends with a child pointing here":
+ends with a row pointing here":
 
 | operand | on an occupied to-one |
 | --- | --- |
 | `create` | displaces the incumbent |
 | `connect` | displaces the incumbent |
 | `connectOrCreate`, hit | displaces — it *is* a connect |
-| `connectOrCreate`, miss | collides on the child's unique key |
-| `upsert`, create branch | collides on the child's unique key |
+| `connectOrCreate`, miss | collides on the unique key |
+| `upsert`, create branch | collides on the unique key |
 
 So the two branches of one `connectOrCreate` answer differently: linking an existing row displaces,
 and the `create` *inside* a compound operand does not, though a bare `create` does.
 
-One gap remains, on the other side of the key: pointing **this** row at a partner who already has
-one — `Profile.update({ data: { user: { connect: { id } } } })` where that user's profile is taken —
-collides here and displaces in Prisma. Detach the incumbent first, or write the foreign key
-directly.
+**This holds from either end of the key.** Pointing *this* row at a partner who already has one —
+`Profile.update({ data: { user: { connect: { id } } } })` where that user's profile is taken —
+detaches that profile and takes the link, the same way the call spelled from the other side does.
+The row detached there is a *sibling* rather than a child: another row of the model you are writing,
+one that happened to hold the same foreign key. The table above applies unchanged, with the bare
+owning-side `create` reading as "no incumbent by construction" rather than as "displaces" — it mints
+the far row, so nothing can already be pointing at it.
+
+Two things are worth knowing about the owning side specifically.
+
+It applies only to a **one-to-one**, which here means the foreign key on your row carries a `@unique`.
+A many-to-one has no incumbent to displace — several rows may point at the same parent, which is the
+whole meaning of the relation — so nothing is detached and both rows end up linked. That is Prisma's
+answer too, and it is why `connect` costs nothing extra on the many-to-one that most nested writes
+are written against.
+
+And it needs a **nullable** foreign key, because a detach has to leave a value behind. Where yours is
+required, the repoint collides on the unique key. Prisma refuses the same call slightly earlier and
+more clearly, with P2014 — *"The change you are trying to make would violate the required relation"* —
+so the call fails on both and the class of failure differs.
 
 **On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather
 than a synonym for `true`.** There is one row and nothing to name, so `true` is how you say *the

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1037,18 +1037,25 @@ one that happened to hold the same foreign key. The table above applies unchange
 owning-side `create` reading as "no incumbent by construction" rather than as "displaces" — it mints
 the far row, so nothing can already be pointing at it.
 
-Two things are worth knowing about the owning side specifically.
+Three things are worth knowing about the owning side specifically.
 
-It applies only to a **one-to-one**, which here means the foreign key on your row carries a `@unique`.
-A many-to-one has no incumbent to displace — several rows may point at the same parent, which is the
-whole meaning of the relation — so nothing is detached and both rows end up linked. That is Prisma's
-answer too, and it is why `connect` costs nothing extra on the many-to-one that most nested writes
-are written against.
+It applies only to a **true one-to-one**, and that is more than "the foreign key is `@unique`". The
+other side has to be a single row too — `User.profile Profile?`, not `Team.players Player[]`. Prisma
+accepts a `@unique` foreign key beside a list back-relation, and on that schema it does **not**
+displace: the second `connect` collides on the key instead. A many-to-one likewise has no incumbent,
+since several rows may point at the same parent, which is the whole meaning of the relation. So
+`connect` costs nothing extra on the many-to-one that most nested writes are written against.
 
-And it needs a **nullable** foreign key, because a detach has to leave a value behind. Where yours is
+It needs a **nullable** foreign key, because a detach has to leave a value behind. Where yours is
 required, the repoint collides on the unique key. Prisma refuses the same call slightly earlier and
 more clearly, with P2014 — *"The change you are trying to make would violate the required relation"* —
 so the call fails on both and the class of failure differs.
+
+And **connecting the row you are already connected to writes nothing** — Prisma issues no statement
+at all for it, and gemi detaches nothing. One difference remains: gemi still emits the update that
+sets the key to the value it already holds, so on a one-to-one owner carrying `@updatedAt` gemi bumps
+the stamp where Prisma leaves it. That is the same stamp difference described under nested writes
+above, and it is specific to this case — on a many-to-one both clients update and both stamp.
 
 **On a to-one, `disconnect` and `delete` take `true` or a filter — and `false` is a no-op rather
 than a synonym for `true`.** There is one row and nothing to name, so `true` is how you say *the

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -369,18 +369,52 @@ function planOwningSide(
    * makes the far row hold one partner, so pointing at an occupied one is a
    * collision rather than a second link (#363).
    *
-   * **The unique index is the discriminator here, where `planForeignSide` uses
-   * `relation.kind`, and the two are not in disagreement** — they are the same
-   * question asked from the two ends of the key. That function's `displaces`
-   * docblock has the argument in full; the half that matters here is its
-   * conclusion: `kind` says `"one"` for a many-to-one and a one-to-one alike,
-   * because both point at a single far row, so from this side there is nothing
-   * to read it off and the question has to go to `uniques` directly. Measured
-   * rather than assumed to matter: `Player.update({ data: { team: { connect:
-   * { id: 2 } } } })` against a `teamId` with no `@unique` leaves the other
-   * player on team 2 exactly where it was, and Prisma does not even read it —
-   * the logged statements are the operand lookup and the `update`, nothing
-   * else. Displacing there would be a write nobody asked for.
+   * **It takes both halves: the unique index *and* the far side's `kind`.** The
+   * first draft of this used the index alone, on the argument that
+   * `planForeignSide`'s `relation.kind` test and this one were "the same
+   * predicate, two spellings". They are not, and the difference is a silent
+   * destructive write rather than a wording problem.
+   *
+   * The implication holds one way only. P1012 gives *`kind !== "many"` implies
+   * the key is unique* — Prisma will not let a non-list back-relation exist
+   * beside a foreign key with no `@unique`. **The converse is false.** A
+   * `@unique` foreign key beside a *list* back-relation is a schema Prisma
+   * accepts:
+   *
+   *     model Team   { id Int @id  players Player[] }
+   *     model Player { id Int @id  teamId Int? @unique
+   *                    team Team? @relation(fields: [teamId], references: [id]) }
+   *
+   * `prisma validate` on that is *"The schema at b.prisma is valid"* — measured,
+   * not assumed. And the index alone would have displaced there, where Prisma
+   * does not: `Player.update({ where: { id: 2 }, data: { team: { connect:
+   * { id: 2 } } } })` with player 1 already on team 2 answers **P2002** and its
+   * whole statement log is `SELECT Team.id`, the `UPDATE`, `ROLLBACK` — the
+   * sibling is never even read. Against the same key with `keeper Keeper?` in
+   * place of `players Player[]`, the identical call displaces and the log gains
+   * the incumbent `SELECT` and its clear. So the *back-relation* is what
+   * decides, and the index is a necessary condition rather than the answer.
+   *
+   * It is not an exotic shape either: a `@unique` added to a foreign key for
+   * indexing, or a one-to-many half-migrated to a one-to-one, both land on it.
+   * Without the second half gemi's two ends disagreed about one relation — the
+   * foreign side saw `kind === "many"` and refused to displace, this side saw
+   * the index and did.
+   *
+   * So `relation.kind` is still not readable from here — it says `"one"` for a
+   * many-to-one and a one-to-one alike, because both point at a single far row,
+   * which is the part of the original argument that survives. The question goes
+   * to the *child's* copy of the relation instead, found by `relationName`, and
+   * `uniques` narrows it rather than answering it.
+   *
+   * **A back-relation that cannot be identified does not displace.** Absent or
+   * ambiguous, the answer is unknown, and of the two ways to be wrong only one
+   * writes to a row nobody named — so the fallback is the collision this
+   * operand raised before #363, which is also what a schema too malformed to
+   * read should get. The self-relation exclusion is `otherSide`'s, restated
+   * rather than shared because that function *throws* on the same condition and
+   * has never run on this path: turning a schema that compiled yesterday into a
+   * hard error is not this issue's to do.
    *
    * Nullable, for the same reason the foreign side is: a detach has to leave a
    * value behind. A required foreign key cannot be nulled, so the repoint
@@ -401,13 +435,25 @@ function planOwningSide(
    * the schema never said were exclusive. A foreign key that is also the `@id`
    * would not be found in `uniques`, which records `@unique` and `@@unique`
    * rather than the primary key; it is out of reach anyway, since `@id` implies
-   * `NOT NULL` and the guard above has already excluded it.
+   * `NOT NULL` and the nullable guard has already excluded it.
    */
+  const backRelations = Object.values(child.relations).filter(
+    (candidate) =>
+      candidate.relationName === relation.relationName &&
+      // A self-relation names the same model on both ends, so the *field* is
+      // what distinguishes them — `otherSide`'s test, and without it a
+      // self-referencing one-to-many would find its own owning side here,
+      // read `kind: "one"` off it and displace.
+      !(child.name === schema.name && candidate.name === relation.name),
+  );
+
   const displaces =
     schema.fields[fkField]?.nullable === true &&
     schema.uniques.some(
       (unique) => unique.length === 1 && unique[0] === fkField,
-    );
+    ) &&
+    backRelations.length === 1 &&
+    backRelations[0].kind !== "many";
 
   /**
    * Whether there is a row to displace *from* — false under a `create`, where
@@ -1034,24 +1080,29 @@ function planForeignSide(
    * deliberately not called here: it would refuse the whole operand, including
    * the empty-to-one case that has always worked.
    *
-   * **`relation.kind` is the discriminator here and the unique index is the
-   * discriminator on the owning side (#363), and the two are not in
-   * disagreement — they are the same question asked from the two ends of the
-   * key.** `kind` is a property of *this* relation's back-reference, and Prisma
-   * will not let a non-list back-relation exist without `@unique` on the
-   * child's foreign key. Verified against 6.19.2 rather than assumed:
-   * `User.profile Profile?` beside a `Profile.userId` carrying no `@unique` is
-   * refused at parse time with P1012 — *"A one-to-one relation must use unique
-   * fields on the defining side. Either add an `@unique` attribute to the field
-   * `userId`, or change the relation to one-to-many"* — so the only schema that
-   * reaches this line either has the index or has `User.profile` as a list.
-   * `kind !== "many"` on the foreign side *is* "the child's key is
-   * unique", read off the side that records it. From the owning side there is
-   * no such reading available — `relation.kind` says `"one"` for a many-to-one
-   * and a one-to-one alike, because both point at a single far row — so the
-   * question has to be put to the schema directly, as `uniques` containing the
-   * foreign-key column. Same predicate, two spellings, and neither side can
-   * borrow the other's.
+   * **`relation.kind` is the whole discriminator here, and it is *not* the same
+   * predicate as the owning side's (#363) — it is the stronger half of it.**
+   * `kind` is a property of this relation's back-reference, and Prisma will not
+   * let a non-list back-relation exist without `@unique` on the child's foreign
+   * key. Verified against 6.19.2 rather than assumed: `User.profile Profile?`
+   * beside a `Profile.userId` carrying no `@unique` is refused at parse time
+   * with P1012 — *"A one-to-one relation must use unique fields on the defining
+   * side. Either add an `@unique` attribute to the field `userId`, or change
+   * the relation to one-to-many"* — so a schema reaching this line with
+   * `kind !== "many"` **has** the index, and `kind` alone is sufficient here.
+   *
+   * **The converse does not hold, which is why the owning side needs two tests
+   * where this one needs one.** A `@unique` foreign key beside a *list*
+   * back-relation validates: `Player.teamId Int? @unique` next to
+   * `Team.players Player[]` is accepted, and Prisma refuses the displacing
+   * `connect` there with P2002 without reading the sibling. So "the key is
+   * unique" is strictly weaker than `kind !== "many"`, and an owning-side
+   * discriminator built on the index alone displaces on schemas this side
+   * correctly leaves alone. That is a real defect this file shipped for one
+   * review cycle; `planOwningSide`'s `displaces` now reads the *child's* copy of
+   * the relation for its `kind` and uses `uniques` only to narrow. From the
+   * owning side `relation.kind` is still unreadable — it says `"one"` for a
+   * many-to-one and a one-to-one alike, because both point at a single far row.
    */
   const displaces =
     relation.kind !== "many" && child.fields[childField]?.nullable === true;
@@ -2563,20 +2614,37 @@ async function clearLinks(
  * table with a null key — **orphaned, not deleted** — which is the half a fix
  * in the wrong direction turns into silent data loss wearing a green test.
  *
- * **Why the row being written is skipped rather than cleared and re-linked.**
- * Prisma's clear is not exclusive: `connect`ing the row a caller is already
- * connected to nulls that very row and then writes the same value straight
- * back, for a net nothing. Reproducing that literally is wrong *here* because
- * the repoint is not a statement of its own — it is a contribution to the main
- * statement, whose `where` has already been through this model's policies. A
- * model scoped on the foreign key would have its own row put outside that
- * scope by the clear, so the main statement would match nothing and leave the
- * row detached and never re-attached: a silent half-write in place of the
- * no-op Prisma performs. That is #98's hazard arriving on this side, and the
- * same argument #362 used to leave `set`'s *link* half not naming its column.
- * Skipping is observationally identical to Prisma in every other case, because
- * the only row the exclusion removes from the clear is the one the repoint was
- * about to restore.
+ * **Why the row being written is skipped: because Prisma skips it too.**
+ * `connect`ing the far row a caller is already connected to writes *nothing at
+ * all* — measured with logging on, the whole call is
+ *
+ *     BEGIN IMMEDIATE / select the operand / select this row /
+ *     select the operand again / select this row again / COMMIT
+ *
+ * with no `update` in it. So this is not a departure to be justified; it is the
+ * behaviour. (An earlier draft of this docblock claimed Prisma nulls the column
+ * and writes the same value straight back for a net nothing. It does not, and
+ * the claim survived into four places before it was measured rather than
+ * reasoned about.)
+ *
+ * The skip matters *more* here than it would as mere parity, which is worth
+ * keeping: the repoint on this side is not a statement of its own but a
+ * contribution to the main statement, whose `where` has already been through
+ * this model's policies. A model scoped on the foreign key would have its own
+ * row put outside that scope by a clear, so the main statement would match
+ * nothing and leave the row detached and never re-attached — a silent
+ * half-write, #98's hazard arriving on this side, and the same argument #362
+ * used to leave `set`'s *link* half not naming its column.
+ *
+ * **The residual divergence runs the other way and is not fixed here.** Prisma
+ * makes the whole call a no-op; gemi still emits the repoint `UPDATE`, because
+ * the contribution is in the SET list at compile time and cannot be withdrawn
+ * at bind time. Same rows either way — it writes the value already there — but
+ * on a one-to-one owner carrying `@updatedAt` gemi bumps the stamp where Prisma
+ * leaves it. That is an instance of the stamp divergence #370 documented rather
+ * than a new one, no fixture can see it (neither `Profile` nor `Cover` has the
+ * column), and it is specific to *this* path: on a many-to-one both clients
+ * issue the update and both stamp.
  *
  * **Why a `create` reads nothing.** There is no row yet, so there is no self to
  * be the incumbent and no `where` to read one through.
@@ -2637,6 +2705,14 @@ async function displaceSibling(
  * concrete rather than theoretical: `2n === 2` is `false`, and answering "these
  * are different rows" there is what would make the clear fire on the row it is
  * meant to skip.
+ *
+ * The fallback is deliberately loose in the other direction too — it calls the
+ * number `2` and the string `"2"` the same row. Harmless for every key type in
+ * reach: Prisma's unique keys are `Int`, `BigInt`, `String`, `Bytes` and the
+ * date types, and a `String` key whose value is `"2"` can only be compared
+ * against another `String`, since the column it came from decides both sides.
+ * Stated rather than tightened, because the tightening would have to know the
+ * field's type here and the looseness has no reachable victim.
  */
 function sameKey(a: unknown, b: unknown): boolean {
   if (a === null || a === undefined || b === null || b === undefined) {

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -363,6 +363,58 @@ function planOwningSide(
   const fkField = link.parentField;
   const referenced = link.childField;
 
+  /**
+   * **Whether linking through this relation has to displace a sibling** — the
+   * one-to-one case, where this row's foreign key carries the `@unique` that
+   * makes the far row hold one partner, so pointing at an occupied one is a
+   * collision rather than a second link (#363).
+   *
+   * **The unique index is the discriminator here, where `planForeignSide` uses
+   * `relation.kind`, and the two are not in disagreement** — they are the same
+   * question asked from the two ends of the key. That function's `displaces`
+   * docblock has the argument in full; the half that matters here is its
+   * conclusion: `kind` says `"one"` for a many-to-one and a one-to-one alike,
+   * because both point at a single far row, so from this side there is nothing
+   * to read it off and the question has to go to `uniques` directly. Measured
+   * rather than assumed to matter: `Player.update({ data: { team: { connect:
+   * { id: 2 } } } })` against a `teamId` with no `@unique` leaves the other
+   * player on team 2 exactly where it was, and Prisma does not even read it —
+   * the logged statements are the operand lookup and the `update`, nothing
+   * else. Displacing there would be a write nobody asked for.
+   *
+   * Nullable, for the same reason the foreign side is: a detach has to leave a
+   * value behind. A required foreign key cannot be nulled, so the repoint
+   * collides as it always did. That is not what Prisma answers — it refuses
+   * ahead of the write with P2014, *"The change you are trying to make would
+   * violate the required relation"*, measured on a scratch schema, since this
+   * one carries no required one-to-one for a case to reach. Recorded rather
+   * than matched: it is a divergence in the failure's *class* on a call that
+   * fails either way, where every other line of this is about a call that
+   * succeeds. `assertDisconnectable` is deliberately not called, exactly as on
+   * the foreign side: it would refuse the whole operand, including the
+   * empty-far-row case that has always worked.
+   *
+   * A single-column index only, which is what `singleFieldLink` has already
+   * narrowed this whole function to. A composite `@@unique` covering the key
+   * *and something else* does not make the relation one-to-one — Prisma wants
+   * the relation's own `fields` unique — and reading it as one would clear rows
+   * the schema never said were exclusive. A foreign key that is also the `@id`
+   * would not be found in `uniques`, which records `@unique` and `@@unique`
+   * rather than the primary key; it is out of reach anyway, since `@id` implies
+   * `NOT NULL` and the guard above has already excluded it.
+   */
+  const displaces =
+    schema.fields[fkField]?.nullable === true &&
+    schema.uniques.some(
+      (unique) => unique.length === 1 && unique[0] === fkField,
+    );
+
+  /**
+   * Whether there is a row to displace *from* — false under a `create`, where
+   * this row does not exist yet, so nothing it holds can be the incumbent.
+   */
+  const existing = !CREATE_ONLY_STATEMENTS.has(operation);
+
   // This side is a to-one by construction — it holds a single foreign key — so
   // there is nothing for a `createMany` to write many of. Prisma does not offer
   // it here either; refused with the reason rather than the grammar, because a
@@ -773,7 +825,22 @@ function planOwningSide(
         )) as Record<string, unknown> | null;
 
         if (found) {
-          context.resolved[fkField] = found[referenced] ?? null;
+          const value = found[referenced] ?? null;
+          // A hit **is** a connect, so it displaces where the miss below cannot
+          // — measured on both sides, and the reason `displaces` is consulted
+          // per *branch* rather than per operand. `planForeignSide`'s table
+          // records the same split from the other end (M14c / M15d).
+          if (displaces) {
+            await displaceSibling(
+              schema,
+              fkField,
+              value,
+              args?.where,
+              existing,
+              executor,
+            );
+          }
+          context.resolved[fkField] = value;
           return;
         }
 
@@ -785,6 +852,10 @@ function planOwningSide(
           false,
         )) as Record<string, unknown> | null;
 
+        // No displacement on this branch, and it is not an omission: the far
+        // row was minted a line ago, so nothing can already be pointing at it.
+        // Prisma agrees by construction rather than by rule — its miss branch
+        // logs the insert and the repoint and no incumbent lookup at all.
         context.resolved[fkField] = created?.[referenced] ?? null;
       },
     });
@@ -823,6 +894,37 @@ function planOwningSide(
     ).length === 1;
 
   if (direct) {
+    /**
+     * **The direct form still costs a step when it has an incumbent to
+     * displace**, and only then.
+     *
+     * "No query is needed at all" is a claim about resolving the *operand*, and
+     * it survives: the value is still read straight out of the argument tree
+     * and never looked up. What a one-to-one adds is a second row that has to
+     * stop holding it, which no amount of knowing the value answers.
+     *
+     * The condition is the schema's, not the call's, so the two forms are
+     * still decided once at compile time and a many-to-one `connect` — which
+     * is every `connect` in an ordinary schema — keeps the zero-query path it
+     * has always had.
+     */
+    if (displaces) {
+      out.before.push({
+        relation: relation.name,
+        operation: "connect",
+        async run(args, _context, executor) {
+          await displaceSibling(
+            schema,
+            fkField,
+            at(args)?.[referenced],
+            args?.where,
+            existing,
+            executor,
+          );
+        },
+      });
+    }
+
     out.contributions.push({
       field: fkField,
       value: (args) => at(args)?.[referenced],
@@ -854,7 +956,27 @@ function planOwningSide(
         false,
       )) as Record<string, unknown> | null;
 
-      context.resolved[fkField] = found?.[referenced] ?? null;
+      const value = found?.[referenced] ?? null;
+
+      // After the lookup, which is the ordering #363 asked how to get: the
+      // clear cannot be written until the referenced value is known, and
+      // sitting in the same step is what orders it without having to order a
+      // write between two reads that are otherwise independent. It also puts
+      // the *miss* on the right side of the detach — `findUniqueOrThrow` has
+      // already raised, so a `connect` naming no row displaces nothing, which
+      // is Prisma's answer (P2025 with the incumbent untouched).
+      if (displaces) {
+        await displaceSibling(
+          schema,
+          fkField,
+          value,
+          args?.where,
+          existing,
+          executor,
+        );
+      }
+
+      context.resolved[fkField] = value;
     },
   });
   out.contributions.push({
@@ -1334,7 +1456,7 @@ function planForeignSide(
 
         const parentKey = parent[parentField];
 
-        await clearLinks(relation, childField, parentKey, executor);
+        await clearLinks(relation.model, childField, parentKey, executor);
 
         for (const entry of listOf(at(args))) {
           await executor.exec(
@@ -1611,7 +1733,7 @@ function planForeignSide(
         // the kind that holds until someone reads it. One read, on a path that
         // already runs several.
         if (displaces) {
-          await clearLinks(relation, childField, parent[parentField], executor);
+          await clearLinks(relation.model, childField, parent[parentField], executor);
         }
 
         for (const item of listOf(at(args))) {
@@ -1768,7 +1890,7 @@ function planForeignSide(
             // a row orphans the incumbent and takes the link, while the same
             // call missing collides on the child's unique key. See `displaces`.
             if (displaces) {
-              await clearLinks(relation, childField, parent[parentField], executor);
+              await clearLinks(relation.model, childField, parent[parentField], executor);
             }
 
             await executor.exec(
@@ -1850,7 +1972,7 @@ function planForeignSide(
       if (!parent) return;
 
       if (displaces) {
-        await clearLinks(relation, childField, parent[parentField], executor);
+        await clearLinks(relation.model, childField, parent[parentField], executor);
       }
 
       for (const item of listOf(at(args))) {
@@ -2358,51 +2480,169 @@ function conjoin(
 }
 
 /**
- * Detach every child currently pointing at this parent **that the caller can
- * see** — the clearing half of `set`, and the same half a nested `create` on an
- * occupied to-one needs before it can insert (#360).
+ * Null one foreign-key column on every row that currently holds `value` **and
+ * that the caller can see** — the clearing half of `set`, the half a nested
+ * `create` on an occupied to-one needs before it can insert (#360), and the
+ * half the owning side's `connect` needs before it can repoint (#363).
  *
- * Shared rather than written twice because the *scoping* is the interesting
- * part and it has to be identical on both: the read goes through the child's
- * own `findMany` un-pre-scoped, so a row the child's policies hide is not
- * detached. `set` therefore means "replace the set I can see" (#83), and the
- * nested `create` means "displace the child I can see" — with a hidden
- * incumbent the insert collides on the unique key instead, which is the
- * conservative answer rather than a silent detach of somebody else's row.
+ * Shared rather than written three times because the *scoping* is the
+ * interesting part and it has to be identical on all of them: the read goes
+ * through the target model's own `findMany` un-pre-scoped, so a row that
+ * model's policies hide is not detached. `set` therefore means "replace the set
+ * I can see" (#83), the nested `create` means "displace the child I can see",
+ * and the owning-side `connect` means "displace the sibling I can see" — with a
+ * hidden incumbent the insert or repoint collides on the unique key instead,
+ * which is the conservative answer rather than a silent detach of somebody
+ * else's row.
+ *
+ * **`model` is a parameter rather than `relation.model` because the two
+ * directions clear different tables.** On the foreign side the rows holding the
+ * key belong to the *child*; on the owning side they are siblings of the row
+ * being written, in the model the statement is already about. Same statement
+ * pair, same scoping rule, two tables — so the only thing that varies is which
+ * one, and passing it is what let #363 reuse this instead of restating it.
  *
  * The `findMany` decides whether to issue the write at all. The `updateMany`
  * would match the same rows on its own; what the read adds is that the common
  * case — nothing linked — costs a select rather than an update, and that the
  * scope is consulted through a read before anything is written.
  *
- * `[childField]` is ORM-authored: the caller named a row to `set`, or a payload
- * to `create`, and the ORM chose to null this column. Without it a child scoped
- * on its own foreign key is refused by the scope-escape guard for a write it
- * never made — #98, and the reason `disconnect` one operand over passes the
- * same list.
+ * `[field]` is ORM-authored: the caller named a row to `set`, or a payload to
+ * `create`, or a row to `connect`, and the ORM chose to null this column.
+ * Without it a model scoped on that same foreign key is refused by the
+ * scope-escape guard for a write it never made — #98, and the reason
+ * `disconnect` one operand over passes the same list.
  */
 async function clearLinks(
-  relation: RelationSchema,
-  childField: string,
-  parentKey: unknown,
+  model: string,
+  field: string,
+  value: unknown,
   executor: RelationExecutor,
 ): Promise<void> {
   const linked = (await executor.exec(
-    relation.model,
+    model,
     "findMany",
-    { where: { [childField]: parentKey }, select: { [childField]: true } },
+    { where: { [field]: value }, select: { [field]: true } },
     false,
   )) as Record<string, unknown>[];
 
   if (linked.length === 0) return;
 
   await executor.exec(
-    relation.model,
+    model,
     "updateMany",
-    { where: { [childField]: parentKey }, data: { [childField]: null } },
+    { where: { [field]: value }, data: { [field]: null } },
     false,
-    [childField],
+    [field],
   );
+}
+
+/**
+ * **Detach the sibling that already holds this foreign-key value, so the row
+ * being written can take it** — the owning side of #361's displacement, and the
+ * whole of #363.
+ *
+ * The two directions look alike and are not the same operation. On the foreign
+ * side the incumbent is a row of the *child* model, reached through
+ * `planForeignSide`; here it is a row of the model the statement is already
+ * writing, one `@unique` foreign key away. `clearLinks` is shared between them
+ * because the statement pair and the scoping rule are identical; everything
+ * below is what only this side needs.
+ *
+ * Measured against Prisma 6.19.2 on SQLite before it was written, with query
+ * logging on. `Profile.update({ where: { id: 1 }, data: { user: { connect:
+ * { id: 2 } } } })` where user 2's profile is taken issues, in order:
+ *
+ *     select User.id where id = 2                  resolve the operand
+ *     select Profile.* where id = 1                the row being written
+ *     select Profile.id, userId where userId in (2)   the incumbent
+ *     update Profile set userId = null where id in (2) detach it
+ *     update Profile set userId = 2 where id in (1)    take the link
+ *
+ * all inside one `BEGIN IMMEDIATE` / `COMMIT`. The incumbent is left in the
+ * table with a null key — **orphaned, not deleted** — which is the half a fix
+ * in the wrong direction turns into silent data loss wearing a green test.
+ *
+ * **Why the row being written is skipped rather than cleared and re-linked.**
+ * Prisma's clear is not exclusive: `connect`ing the row a caller is already
+ * connected to nulls that very row and then writes the same value straight
+ * back, for a net nothing. Reproducing that literally is wrong *here* because
+ * the repoint is not a statement of its own — it is a contribution to the main
+ * statement, whose `where` has already been through this model's policies. A
+ * model scoped on the foreign key would have its own row put outside that
+ * scope by the clear, so the main statement would match nothing and leave the
+ * row detached and never re-attached: a silent half-write in place of the
+ * no-op Prisma performs. That is #98's hazard arriving on this side, and the
+ * same argument #362 used to leave `set`'s *link* half not naming its column.
+ * Skipping is observationally identical to Prisma in every other case, because
+ * the only row the exclusion removes from the clear is the one the repoint was
+ * about to restore.
+ *
+ * **Why a `create` reads nothing.** There is no row yet, so there is no self to
+ * be the incumbent and no `where` to read one through.
+ *
+ * **Why an absent parent detaches nothing, which is belt and braces and is
+ * kept anyway.** Prisma *does* detach and then rolls the whole thing back —
+ * measured on `update({ where: { id: 99 } })`, which logs the
+ * `update … set userId = null`, then `ROLLBACK`, then answers P2025. gemi
+ * reaches the same committed state by the same route, because `update` raises
+ * `RecordNotFoundError` on a `where` that matches nothing and every plan
+ * carrying a step runs in a transaction — verified by dropping this return and
+ * watching `O12g` stay green. So it buys no correctness today; it buys two
+ * statements on a miss, and it makes this step's effect independent of whether
+ * the statement *after* it raises, which is the assumption that would be
+ * expensive to have baked in silently if that ever changed.
+ */
+async function displaceSibling(
+  schema: ModelSchema,
+  fkField: string,
+  /** The value about to be written into this row's foreign key. */
+  value: unknown,
+  /**
+   * This statement's own `where`, **already through this model's policies** —
+   * so the read below is pre-scoped, exactly as the `disconnect` filter arm's
+   * parent read is, and for the same reason: applying them again would `AND`
+   * the same predicate twice.
+   */
+  where: unknown,
+  /** False on a `create`, where the row does not exist yet. */
+  existing: boolean,
+  executor: RelationExecutor,
+): Promise<void> {
+  if (value === null || value === undefined) return;
+
+  if (existing) {
+    const self = (await executor.exec(
+      schema.name,
+      "findFirst",
+      { where, select: { [fkField]: true } },
+      true,
+    )) as Record<string, unknown> | null;
+
+    if (self === null || self === undefined) return;
+    if (sameKey(self[fkField], value)) return;
+  }
+
+  await clearLinks(schema.name, fkField, value, executor);
+}
+
+/**
+ * Whether two foreign-key values name the same row.
+ *
+ * Not `===`, because the two operands reach this from different places and a
+ * key type can survive the trip differently. One side is read out of the
+ * database through a `select`; the other is either a caller's literal — `connect:
+ * { id: 2 }`, taken straight from the argument tree by the direct form — or a
+ * value read back off the far model. A `BigInt` key is the case that makes this
+ * concrete rather than theoretical: `2n === 2` is `false`, and answering "these
+ * are different rows" there is what would make the clear fire on the row it is
+ * meant to skip.
+ */
+function sameKey(a: unknown, b: unknown): boolean {
+  if (a === null || a === undefined || b === null || b === undefined) {
+    return false;
+  }
+  return a === b || String(a) === String(b);
 }
 
 /**

--- a/packages/gemi/orm/compile/write.test.ts
+++ b/packages/gemi/orm/compile/write.test.ts
@@ -23,6 +23,7 @@ import {
   userWithProfile,
 } from "../fixtures";
 import * as registry from "../registry";
+import type { ModelSchema } from "../schema";
 import { compileWrite } from "./write";
 
 const sqlite = new SqliteDialect();
@@ -1916,7 +1917,6 @@ describe("nested writes", () => {
       // second statement afterwards.
       expect(plan.after).toBeUndefined();
     });
-
     test("the foreign side resolves after it, and returns the key", () => {
       const plan = compileWrite(
         user,
@@ -2006,6 +2006,160 @@ describe("nested writes", () => {
           },
         }),
       ).toThrow();
+    });
+  });
+
+  /**
+   * **What makes an owning-side `connect` displace a sibling (#363), and the
+   * schema shape that must not.**
+   *
+   * The displacement clears a *sibling row of the model being written* — the
+   * one already holding the foreign-key value — so whether it fires at all is
+   * decided from the schema, at compile time, and shows up here as a `before`
+   * step that is present or absent. That makes this the cheapest place to pin
+   * it: the rows follow from the step, and the row-level answers are already
+   * covered by the differential's `O12` group.
+   *
+   * **The near-miss is a `@unique` foreign key beside a *list* back-relation**,
+   * which is a schema Prisma accepts — `prisma validate` says so — and on which
+   * Prisma does **not** displace:
+   *
+   *     model Team   { players Player[] }
+   *     model Player { teamId Int? @unique
+   *                    team Team? @relation(fields: [teamId], references: [id]) }
+   *
+   *     Player.update({ where: { id: 2 }, data: { team: { connect: { id: 2 } } } })
+   *       with player 1 already on team 2
+   *       ->  P2002.  Statements: select Team.id, the update, ROLLBACK.
+   *           The sibling is never read.
+   *
+   * The first version of #363 tested only "is the foreign key unique", on the
+   * argument that P1012 makes that equivalent to the far side's `kind`. P1012
+   * gives the implication one way — a non-list back-relation *forces* the index
+   * — and the converse is what the schema above disproves. So the index is
+   * necessary and not sufficient, and reading it as sufficient silently
+   * detached player 1 on a call that named only player 2.
+   *
+   * Three arms, because two of them are one character apart in the `.prisma`
+   * and opposite in the answer.
+   */
+  describe("an owning-side connect displaces only a true one-to-one", () => {
+    /** `Player.teamId Int? @unique`, holding the key and pointing at `Team`. */
+    const owner: ModelSchema = {
+      name: "Player",
+      table: "Player",
+      fields: {
+        id: {
+          name: "id",
+          column: "id",
+          type: "Int",
+          nullable: false,
+          isId: true,
+          isUpdatedAt: false,
+          default: { kind: "autoincrement" },
+        },
+        teamId: {
+          name: "teamId",
+          column: "teamId",
+          type: "Int",
+          // Nullable, or a detach would have nothing to leave behind and the
+          // discriminator short-circuits before the interesting test.
+          nullable: true,
+          isId: false,
+          isUpdatedAt: false,
+        },
+      },
+      primaryKey: ["id"],
+      uniques: [["teamId"]],
+      relations: {
+        team: {
+          name: "team",
+          model: "Team",
+          kind: "one",
+          relationName: "PlayerToTeam",
+          from: ["teamId"],
+          to: ["id"],
+          nullable: true,
+        },
+      },
+    };
+
+    /** The far model, whose back-relation's `kind` is the whole question. */
+    const far = (kind: "one" | "many"): ModelSchema => ({
+      name: "Team",
+      table: "Team",
+      fields: {
+        id: {
+          name: "id",
+          column: "id",
+          type: "Int",
+          nullable: false,
+          isId: true,
+          isUpdatedAt: false,
+          default: { kind: "autoincrement" },
+        },
+      },
+      primaryKey: ["id"],
+      uniques: [],
+      relations: {
+        players: {
+          name: "players",
+          model: "Player",
+          kind,
+          relationName: "PlayerToTeam",
+          from: [],
+          to: [],
+          nullable: true,
+        },
+      },
+    });
+
+    const planConnect = () =>
+      compileWrite(
+        owner,
+        "update",
+        { where: { id: 2 }, data: { team: { connect: { id: 2 } } } },
+        sqlite,
+      );
+
+    test("a list back-relation does not displace, though the key is unique", () => {
+      registry.register("Team", class { static $schema = far("many") });
+
+      const plan = planConnect();
+
+      // The whole defect in one assertion: no step, so no sibling is read and
+      // none is cleared. The key still lands as a bound column.
+      expect(plan.before).toBeUndefined();
+      expect(plan.text).toContain(`"teamId"`);
+    });
+
+    test("a non-list back-relation displaces, on the same foreign key", () => {
+      registry.register("Team", class { static $schema = far("one") });
+
+      const plan = planConnect();
+
+      expect(plan.before).toHaveLength(1);
+      expect(plan.before?.[0].relation).toBe("team");
+      expect(plan.before?.[0].operation).toBe("connect");
+    });
+
+    /**
+     * And the index is still doing work: drop it from an otherwise identical
+     * one-to-one and there is no unique constraint to collide on, so there is
+     * nothing to displace. Without this the pair above would pass for a
+     * discriminator that had stopped reading `uniques` at all.
+     */
+    test("a non-list back-relation with no unique index does not displace", () => {
+      registry.register("Team", class { static $schema = far("one") });
+
+      const plan = compileWrite(
+        { ...owner, uniques: [] },
+        "update",
+        { where: { id: 2 }, data: { team: { connect: { id: 2 } } } },
+        sqlite,
+      );
+
+      expect(plan.before).toBeUndefined();
     });
   });
 

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -1207,6 +1207,138 @@ describe("policies on nested writes", () => {
   });
 
   /**
+   * **`connect` into an occupied to-one from the owning side (#363)** — where
+   * the incumbent is a *sibling of the model being written* rather than a row
+   * of the child model.
+   *
+   * `Cover` is the fixture for it and needs no new one: its `folderId` is the
+   * unique foreign key, so `Cover.folder` is the one-to-one read from the end
+   * that holds it. Which is exactly why the policy question is different from
+   * every other one in this file. The clearing read goes through `Cover`'s own
+   * `$exec`, un-pre-scoped — the same rule `clearLinks` applies on the far
+   * side — but the statement it runs under is `Cover`'s too, and *that* has
+   * already been through the same policies once. One model's scope, consulted
+   * twice for two purposes: to choose the row being written, and to choose the
+   * rows that may be detached for it.
+   *
+   * The two answers below are what that resolves to, and neither is derivable
+   * from the foreign side's:
+   *
+   *   a visible incumbent   detached, orphaned, and this row takes the link
+   *   a hidden incumbent    nothing detached; the repoint collides on the key
+   *
+   * The second is the conservative one and the same one `set`, a nested
+   * `create` and #361's `connect` give: detaching another tenant's row on a
+   * call that never named it is the failure worth refusing, and the cost is a
+   * caller who cannot complete the write and is not told why.
+   */
+  describe("linking into an occupied to-one from the owning side", () => {
+    const ourFolder = () =>
+      raw.unsafe(
+        `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (2, 'ours', 7)`,
+      );
+
+    const links = async () => {
+      const rows: any = await raw.unsafe(
+        `SELECT "id", "folderId" FROM "Cover" ORDER BY "id"`,
+      );
+      return [...rows].map((row: any) => [row.id, row.folderId]);
+    };
+
+    test("displaces an incumbent sibling the caller can see, orphaning it", async () => {
+      await ourFolder();
+      await raw.unsafe(
+        `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+          `VALUES (70, 2, 'incumbent', 7), (71, NULL, 'mover', 7)`,
+      );
+
+      await Model.asUser(OURS, () =>
+        Cover.$exec("update", {
+          where: { id: 71 },
+          data: { folder: { connect: { id: 2 } } },
+        }),
+      );
+
+      // Orphaned, not deleted — two rows still, one of them unlinked.
+      expect(await links()).toEqual([
+        [70, null],
+        [71, 2],
+      ]);
+    });
+
+    test("does not displace an incumbent sibling the caller cannot see", async () => {
+      await ourFolder();
+      await raw.unsafe(
+        `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+          `VALUES (72, 2, 'theirs', 99), (73, NULL, 'mover', 7)`,
+      );
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Cover.$exec("update", {
+            where: { id: 73 },
+            data: { folder: { connect: { id: 2 } } },
+          }),
+        ),
+      ).rejects.toThrow(UniqueConstraintError);
+
+      // Theirs still linked, ours still loose: the failed repoint took the
+      // clear down with it, and the clear never saw the row anyway.
+      expect(await links()).toEqual([
+        [72, 2],
+        [73, null],
+      ]);
+    });
+
+    /**
+     * **The row being written is itself the incumbent, under a policy that
+     * scopes on the foreign key** — the one arrangement where reproducing
+     * Prisma's clear literally would be a silent half-write.
+     *
+     * Prisma nulls the column and writes the same value straight back, for a
+     * net nothing. Here the repoint is not a statement of its own; it is a
+     * contribution to the main statement, whose `where` carries `folderId = 2`
+     * because the policy put it there. A clear that fired would move the row
+     * out of that scope *before* the statement ran, so the statement would
+     * match nothing and the row would end up detached and never re-attached —
+     * `set`'s hazard from #98/#99, arriving on the other side of the key. So
+     * `displaceSibling` reads this row first and skips the clear when it is
+     * already the incumbent, which is observationally identical to Prisma
+     * everywhere else because the only row the skip removes from the clear is
+     * the one the repoint was about to restore.
+     *
+     * The scope is what makes this assertable. Without it the clear-then-
+     * repoint and the skip land on the same table, and this test cannot fail.
+     */
+    test("connecting the far row already linked here is a no-op under a key scope", async () => {
+      class KeyScoped extends Model {
+        static $schema = coverSchema;
+        static $policies = [{ scope: () => ({ folderId: 2 }) } as ModelPolicy];
+      }
+      register("Cover", KeyScoped);
+
+      try {
+        await ourFolder();
+        await raw.unsafe(
+          `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+            `VALUES (74, 2, 'already', 7)`,
+        );
+
+        await Model.asUser(OURS, () =>
+          KeyScoped.$exec("update", {
+            where: { id: 74 },
+            data: { folder: { connect: { id: 2 } } },
+          }),
+        );
+
+        expect(await links()).toEqual([[74, 2]]);
+      } finally {
+        register("Cover", Cover);
+      }
+    });
+  });
+
+  /**
    * `set` means **"replace the set I can see"** — #83's answer, applied to an
    * ordinary relation.
    *

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -1292,23 +1292,22 @@ describe("policies on nested writes", () => {
 
     /**
      * **The row being written is itself the incumbent, under a policy that
-     * scopes on the foreign key** — the one arrangement where reproducing
-     * Prisma's clear literally would be a silent half-write.
+     * scopes on the foreign key** — the arrangement where clearing it would be
+     * a silent half-write.
      *
-     * Prisma nulls the column and writes the same value straight back, for a
-     * net nothing. Here the repoint is not a statement of its own; it is a
-     * contribution to the main statement, whose `where` carries `folderId = 2`
-     * because the policy put it there. A clear that fired would move the row
-     * out of that scope *before* the statement ran, so the statement would
-     * match nothing and the row would end up detached and never re-attached —
-     * `set`'s hazard from #98/#99, arriving on the other side of the key. So
-     * `displaceSibling` reads this row first and skips the clear when it is
-     * already the incumbent, which is observationally identical to Prisma
-     * everywhere else because the only row the skip removes from the clear is
-     * the one the repoint was about to restore.
+     * Prisma writes nothing at all for an already-linked `connect`: measured
+     * with query logging, the call is four selects between a `BEGIN` and a
+     * `COMMIT`, with no `update` in it. So skipping the clear is parity rather
+     * than a departure — but the reason it is *load-bearing* here is local. The
+     * repoint on this side is not a statement of its own; it is a contribution
+     * to the main statement, whose `where` carries `folderId = 2` because the
+     * policy put it there. A clear that fired would move the row out of that
+     * scope *before* the statement ran, so the statement would match nothing
+     * and the row would end up detached and never re-attached — `set`'s hazard
+     * from #98/#99, arriving on the other side of the key.
      *
-     * The scope is what makes this assertable. Without it the clear-then-
-     * repoint and the skip land on the same table, and this test cannot fail.
+     * The scope is what makes this assertable. Without it a clear-then-repoint
+     * and the skip land on the same table, and this test cannot fail.
      */
     test("connecting the far row already linked here is a no-op under a key scope", async () => {
       class KeyScoped extends Model {
@@ -1335,6 +1334,49 @@ describe("policies on nested writes", () => {
       } finally {
         register("Cover", Cover);
       }
+    });
+
+    /**
+     * **The detach and the write are one unit** — #363's "a failure anywhere
+     * rolls back the detach as well as the repoint", asserted rather than
+     * argued from the fact that `$exec` opens a transaction for a plan carrying
+     * steps.
+     *
+     * Not a policy test, and here only because this file has the fixtures for
+     * it. The differential cannot host it: it needs a call that clears and
+     * *then* fails, and every shape the template's `Profile` can express either
+     * never clears — `O12g`'s parent is absent, so the step returns before
+     * writing — or clears and succeeds. The one shape that works, a `create`
+     * naming a colliding `id`, is not comparable against Prisma, which has no
+     * `id` in `ProfileCreateInput` and answers a validation error where gemi
+     * answers the unique violation.
+     *
+     * So: cover 75 holds folder 2 and is the incumbent. The `create` below
+     * detaches it to free the key, then collides with it again on the *primary*
+     * key. If the clear were outside the transaction, cover 75 would survive
+     * with a null `folderId` — detached by a statement that failed, which is
+     * the silent half-write this bullet exists to rule out.
+     *
+     * Verified to fail with the transaction disabled: it is the only test on
+     * the owning side that does.
+     */
+    test("a failure after the detach rolls the detach back", async () => {
+      await ourFolder();
+      await raw.unsafe(
+        `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+          `VALUES (75, 2, 'incumbent', 7)`,
+      );
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Cover.$exec("create", {
+            data: { id: 75, caption: "collides", folder: { connect: { id: 2 } } },
+          }),
+        ),
+      ).rejects.toThrow(UniqueConstraintError);
+
+      // Still linked. The detach went back with the insert that caused it.
+      expect(await links()).toEqual([[75, 2]]);
     });
   });
 

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -766,6 +766,23 @@ const CASES: Case[] = [
       },
     },
   }, ["User", "Profile"]],
+
+  // M16 — the boundary on the other side of `displaces`, from the **owning**
+  // end of a key (#363): a *many*-to-one connect has no incumbent, so nothing
+  // is detached and both rows end up on the same parent. Measured, and the
+  // logged statements are the operand lookup and the `update` — Prisma does not
+  // even read the sibling.
+  //
+  // Here rather than left implied, because the two relations are one operand
+  // spelled identically and the discriminator between them is a schema property
+  // the caller cannot see. Without this, a `displaces` that widened from "the
+  // foreign key is unique" to "the relation points at one row" would detach
+  // user 1 from Acme on a call about user 2, and every existing case would stay
+  // green — `User.organization` is the ordinary many-to-one that a nested
+  // `connect` is nearly always written against.
+  ["M16 a many-to-one connect leaves the parent's other rows alone", "update", {
+    where: { id: 2 }, data: { organization: { connect: { id: 1 } } },
+  }, ["User", "Organization"]],
 ];
 
 /**
@@ -839,6 +856,106 @@ const OWNING_CASES: [string, string, unknown, string[]?][] = [
   // harmless no-op is not the point, since nothing here would have said so.
   ["O11 owning disconnect null is refused by both", "update", {
     where: { id: 1 }, data: { user: { disconnect: null } },
+  }, ["Profile", "User"]],
+
+  // O12 — `connect` into a to-one that is **already taken** (#363), the mirror
+  // of M15 across the key. gemi raised `UniqueConstraintError` on this and
+  // Prisma detaches the incumbent and takes the link, which is what the pin in
+  // the "still disagree" describe recorded until this graduated.
+  //
+  // **It reads left-to-right as the opposite of the pin it replaces, and that
+  // is the whole reason it can live in this table.** The pin moves profile 1
+  // into an occupied user 2, which the seed does not have and which every to-one
+  // case in `CASES` wants the opposite of — user 2's to-one being *empty* is
+  // what makes `M1`, `M3`, `M6` and `M8` reach their miss branches at all. Read
+  // the other way round the seed already carries the state: profile 2 (`loose`)
+  // holds nobody, and user 1 is occupied by profile 1. So `loose` moving into
+  // user 1 is the same collision with no arrangement at all, and #363's
+  // acceptance — "the case moves into `OWNING_CASES`" — costs nothing.
+  //
+  // The incumbent is **orphaned, not deleted**, which is why `tables` names
+  // `Profile`: a fix that deleted the displaced row would be silent data loss
+  // wearing this same green test.
+  ["O12 owning connect into an occupied to-one displaces the incumbent", "update", {
+    where: { id: 2 }, data: { user: { connect: { id: 1 } } },
+  }, ["Profile", "User"]],
+  // The control on the empty far row — the shape that always worked, and the
+  // one that keeps O12 about the *incumbent* rather than about owning-side
+  // `connect` in general. User 2 holds no profile.
+  ["O12b owning connect into an empty to-one attaches", "update", {
+    where: { id: 2 }, data: { user: { connect: { id: 2 } } },
+  }, ["Profile", "User"]],
+  // The row being written *is* the incumbent. Prisma nulls it and writes the
+  // same value straight back for a net nothing; gemi skips the clear and
+  // reaches the same table. The case that would catch a clear which fired on
+  // the row the repoint was about to restore.
+  ["O12c owning connect of the user already linked here changes nothing", "update", {
+    where: { id: 1 }, data: { user: { connect: { id: 1 } } },
+  }, ["Profile", "User"]],
+  // Beside a real column write, for the reason O8 gives: without something else
+  // in `data` a step and an assignment are hard to tell apart.
+  ["O12d owning connect into an occupied to-one beside a column write", "update", {
+    where: { id: 2 }, data: { bio: "changed", user: { connect: { id: 1 } } },
+  }, ["Profile", "User"]],
+  // The **other** `connect` form, and it is a second code path rather than a
+  // second spelling: naming a unique key the relation does not reference costs
+  // a lookup, so the value the clear needs does not exist until that lookup has
+  // run. Without this case the whole displacing branch of the resolved form is
+  // unexercised — every case above takes the direct one, where the value is
+  // read straight out of the argument tree. `p1` is user 1, seeded by name.
+  ["O12e owning connect by a non-referenced unique displaces too", "update", {
+    where: { id: 2 }, data: { user: { connect: { publicId: "p1" } } },
+  }, ["Profile", "User"]],
+  // A `connect` naming no row detaches nothing: the resolve raises first, and
+  // the clear sits behind it in the same step. `notFound` on both sides.
+  ["O12f owning connect naming no row raises and displaces nothing", "update", {
+    where: { id: 2 }, data: { user: { connect: { publicId: "nobody" } } },
+  }, ["Profile", "User"]],
+  // And a statement with no row to write leaves the incumbent alone. Both
+  // clients get there through the transaction rather than through a guard:
+  // Prisma issues the detach and rolls it back — the logged statements are the
+  // clear, then `ROLLBACK`, then P2025 — and gemi's `update` raises
+  // `RecordNotFoundError`, which takes its own `before` step down with it. The
+  // committed state is the thing either client promises, and this pins it.
+  ["O12g owning connect whose own where matches nothing displaces nothing", "update", {
+    where: { id: 99 }, data: { user: { connect: { id: 1 } } },
+  }, ["Profile", "User"]],
+
+  // O13 — the same displacement under a `create`, which is a different statement
+  // and not a different rule. There is no row yet, so nothing this one holds can
+  // be the incumbent and the step reads nothing before clearing. Measured:
+  // Prisma logs the operand lookup, the incumbent clear and the `INSERT`, in
+  // that order, inside one transaction.
+  ["O13 owning connect into an occupied to-one under a create", "create", {
+    data: { bio: "fresh", user: { connect: { id: 1 } } },
+  }, ["Profile", "User"]],
+  ["O13b owning connect into an empty to-one under a create", "create", {
+    data: { bio: "fresh", user: { connect: { id: 2 } } },
+  }, ["Profile", "User"]],
+
+  // O14 — `connectOrCreate`, whose two branches answer differently for the same
+  // reason they do on the foreign side (M14c / M15d): a **hit** is a connect, so
+  // it displaces; a **miss** mints the far row, which nothing can already be
+  // pointing at.
+  ["O14 owning connectOrCreate hitting an occupied to-one displaces", "update", {
+    where: { id: 2 },
+    data: {
+      user: { connectOrCreate: { where: { id: 1 }, create: { email: "unused@example.dev" } } },
+    },
+  }, ["Profile", "User"]],
+  ["O14b owning connectOrCreate missing creates the far row and displaces nothing", "update", {
+    where: { id: 2 },
+    data: {
+      user: { connectOrCreate: { where: { id: 99 }, create: { email: "coc@example.dev" } } },
+    },
+  }, ["Profile", "User"]],
+
+  // O15 — the owning-side `create`, which has no incumbent by construction: the
+  // far row is minted by this very operand. Here so that "what displaces" is
+  // pinned as a *list* rather than as a rule that could quietly widen to
+  // "anything that ends with this row pointing somewhere".
+  ["O15 owning create mints the far row and displaces nothing", "update", {
+    where: { id: 2 }, data: { user: { create: { email: "minted@example.dev" } } },
   }, ["Profile", "User"]],
 ];
 
@@ -2339,6 +2456,60 @@ function suite(label: string, url?: string) {
           { tables: ["User", "Profile"] },
         );
       });
+
+      /**
+       * **#363, on the arrangement `OWNING_CASES` cannot express: both rows
+       * already linked.**
+       *
+       * This test *was* the pin in the "still disagree" describe, and it is
+       * rewritten rather than deleted. Its Prisma half is unchanged and was
+       * always the measurement; only gemi's half moved, from
+       * `UniqueConstraintError` with nothing written to the same three-row
+       * answer. Keeping it is what makes "the divergence closed" a thing the
+       * suite says rather than a thing a diff implies, and the shape is not a
+       * duplicate of `O12`: there both the mover (`loose`) and its destination
+       * are what the seed happens to hold, so the row being written starts
+       * *unlinked*. Here it starts linked to somebody else, which is the only
+       * arrangement in which one call detaches two rows — the incumbent, and
+       * the far row this one is leaving.
+       *
+       * It stays out of `OWNING_CASES` for the mechanical reason it always
+       * did: `expectSameWrite` resets to the seeded state before each client
+       * runs, so a table-driven case has nowhere to put the `occupy()` below.
+       * That is a property of the harness, not of the divergence, and it is why
+       * #363's acceptance is satisfied by `O12` rather than by this.
+       */
+      test("connect into an occupied to-one displaces the incumbent on both", async () => {
+        const args = { where: { id: 1 }, data: { user: { connect: { id: 2 } } } };
+        const occupy = () =>
+          differential.prisma.profile.update({
+            where: { id: 2 },
+            data: { userId: 2 },
+          });
+        const profiles = async () =>
+          (
+            await differential.prisma.profile.findMany({ orderBy: { id: "asc" } })
+          ).map((row) => [row.bio, row.userId]);
+
+        await differential.reset();
+        await occupy();
+        await differential.prisma.profile.update(args as never);
+        expect(await profiles()).toEqual([
+          ["seed", 2],
+          // Detached, not deleted — the half a fix here had to get right.
+          ["loose", null],
+        ]);
+
+        await differential.reset();
+        await occupy();
+        const fromGemi: any = await ProfileModel.update(args as never);
+        expect(fromGemi.userId).toBe(2);
+        expect(await profiles()).toEqual([
+          ["seed", 2],
+          ["loose", null],
+        ]);
+      });
+
     });
 
     /**
@@ -2604,15 +2775,18 @@ function suite(label: string, url?: string) {
      * `CASES` and the harness takes over from the prose.
      *
      * Each carries its issue number, and that is the half a test cannot do for
-     * itself. The two this describe was opened for — #359 and #360 — are gone
-     * from it and into `CASES` / `OWNING_CASES` above, which is what closing
-     * one looks like. The two below took their place, and both were found by
-     * the same method: measuring the neighbouring spelling of a call that was
-     * being fixed.
+     * itself. The three this describe has held — #359, #360 and #363 — are all
+     * gone from it and into `CASES` / `OWNING_CASES` above, which is what
+     * closing one looks like. #363's went last, and where it went is worth
+     * knowing: `O12` is the same collision spelled from the other end, so the
+     * seeded state expresses it and no arrangement is needed; the arranged
+     * shape it used to pin survives as a positive test beside the other
+     * owning-side to-one cases.
      *
-     * **One of them is not gemi's bug**, which is new here and changes what the
-     * describe is for. The rule stays "pin both answers"; what it cannot stay
-     * is "every one of these is ours to fix".
+     * **What is left is not gemi's bug**, which changes what the describe is
+     * for. The rule stays "pin both answers"; what it cannot stay is "every one
+     * of these is ours to fix" — the entry below is a divergence this ORM
+     * declines to reproduce, and the file has been down to one before.
      */
     describe("where the two clients still disagree", () => {
       /**
@@ -2705,60 +2879,6 @@ function suite(label: string, url?: string) {
         ).toMatchObject({ organizationId: null });
       });
 
-      /**
-       * **BUG (#363) — the owning side linking into an occupied to-one.**
-       *
-       * The mirror of #361, which this PR fixed, and it is a different piece of
-       * work rather than the same one twice. #361 clears rows of the **child**
-       * model, which `clearLinks` does through the child's own operations. Here
-       * the collision is between two rows of the model being written: pointing
-       * profile 1 at user 2 collides with the profile user 2 already has, and
-       * nothing in `planOwningSide` writes a sibling row.
-       *
-       *     profile 1 -> user 1, and user 2 already holds profile 2
-       *       prisma  ->  (1, "seed",  2)     the row written takes the link
-       *                   (2, "loose", null)  user 2's old profile, orphaned
-       *       gemi    ->  UniqueConstraintError on Profile.userId
-       *
-       * `connectOrCreate` hitting an existing row does the same; its *miss*
-       * branch creates the far row and so has nothing to displace.
-       *
-       * The seed has no profile on user 2 — every other case in this file wants
-       * the opposite — so this one arranges it, which is also why it is not in
-       * `OWNING_CASES`.
-       */
-      test("the owning side collides linking into an occupied to-one", async () => {
-        const args = { where: { id: 1 }, data: { user: { connect: { id: 2 } } } };
-        const occupy = () =>
-          differential.prisma.profile.update({
-            where: { id: 2 },
-            data: { userId: 2 },
-          });
-        const profiles = async () =>
-          (
-            await differential.prisma.profile.findMany({ orderBy: { id: "asc" } })
-          ).map((row) => [row.bio, row.userId]);
-
-        await differential.reset();
-        await occupy();
-        await differential.prisma.profile.update(args as never);
-        expect(await profiles()).toEqual([
-          ["seed", 2],
-          // Detached, not deleted — the half a fix here would have to get right.
-          ["loose", null],
-        ]);
-
-        await differential.reset();
-        await occupy();
-        await expect(ProfileModel.update(args as never)).rejects.toBeInstanceOf(
-          UniqueConstraintError,
-        );
-        // And nothing moved: the failed statement takes nothing with it.
-        expect(await profiles()).toEqual([
-          ["seed", 1],
-          ["loose", 2],
-        ]);
-      });
     });
 
     // --- typed errors ---------------------------------------------------

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -885,10 +885,12 @@ const OWNING_CASES: [string, string, unknown, string[]?][] = [
   ["O12b owning connect into an empty to-one attaches", "update", {
     where: { id: 2 }, data: { user: { connect: { id: 2 } } },
   }, ["Profile", "User"]],
-  // The row being written *is* the incumbent. Prisma nulls it and writes the
-  // same value straight back for a net nothing; gemi skips the clear and
-  // reaches the same table. The case that would catch a clear which fired on
-  // the row the repoint was about to restore.
+  // The row being written *is* the incumbent, and **Prisma writes nothing at
+  // all** — measured with logging on, the call is four selects between a
+  // `BEGIN` and a `COMMIT` and no `update`. gemi skips the clear for the same
+  // reason and reaches the same table, though it does still emit the repoint,
+  // which writes the value already there. The case that would catch a clear
+  // firing on the row the repoint was about to restore.
   ["O12c owning connect of the user already linked here changes nothing", "update", {
     where: { id: 1 }, data: { user: { connect: { id: 1 } } },
   }, ["Profile", "User"]],
@@ -932,6 +934,16 @@ const OWNING_CASES: [string, string, unknown, string[]?][] = [
   ["O13b owning connect into an empty to-one under a create", "create", {
     data: { bio: "fresh", user: { connect: { id: 2 } } },
   }, ["Profile", "User"]],
+  // **The atomicity of the detach is asserted in `nested-write-policies.test.ts`
+  // and cannot be asserted here**, which is worth saying because this is where
+  // a reader would look for it. It needs a call that *clears and then fails*,
+  // and every shape reachable through this fixture either never clears (`O12g`
+  // returns before writing) or clears and succeeds — so a clear that escaped
+  // the transaction leaves every case in this table green. The one shape that
+  // does it, a `create` naming an `id` that collides after the detach, is not
+  // comparable: Prisma has no `id` in `ProfileCreateInput`, so it answers a
+  // validation error where gemi answers the unique violation, and the harness
+  // compares failure kinds.
 
   // O14 — `connectOrCreate`, whose two branches answer differently for the same
   // reason they do on the foreign side (M14c / M15d): a **hit** is a connect, so


### PR DESCRIPTION
The last of the four to-one divergences the first Prisma port reported, and the mirror of #361 across the key. Where **this** row holds the foreign key and the row it is pointed at already has a partner, gemi raised `UniqueConstraintError`; Prisma detaches the incumbent — a *sibling row of the model being written* — and takes the link.

## What Prisma actually does, and how that was established

A scratch schema with four relation shapes, pushed to a throwaway SQLite file, a generated 6.19.2 client, `log: [{ emit: "event", level: "query" }]`, and the table read back after each call. Not from memory and not from the docs.

`Profile.update({ where: { id: 1 }, data: { user: { connect: { id: 2 } } } })` where user 2's profile is taken, normalised:

```
BEGIN IMMEDIATE
select User.id            where id = 2                 resolve the operand
select Profile.*          where id = 1                 the row being written
select Profile.id, userId where userId in (2)          the incumbent
update Profile set userId = null where id in (2)       detach it
update Profile set userId = 2    where id in (1)       take the link
COMMIT
```

The incumbent is left in the table holding a null key — **orphaned, not deleted**.

The rest of the matrix, each measured rather than reasoned from that one:

| call | Prisma |
| --- | --- |
| `connect` into an occupied one-to-one | displaces |
| `connect` into an empty one | attaches, nothing read |
| `connect` of the row already linked here | **no writes at all** — four selects between a `BEGIN` and a `COMMIT` |
| `connect` naming no row | P2025, incumbent untouched (the resolve is first) |
| `connectOrCreate`, **hit** | displaces — it *is* a connect |
| `connectOrCreate`, **miss** | mints the far row, nothing to displace |
| owning-side `create` | mints the far row, nothing to displace |
| the same `connect` under a `Profile.create` | **displaces** — the fix is not update-only |
| `update` whose own `where` matches nothing | detaches, then `ROLLBACK`, then P2025 |
| **many-to-one** `connect` into an occupied parent | nothing displaced, and the incumbent is never read |
| `@unique` FK beside a **list** back-relation | **nothing displaced** — P2002, sibling never read |
| required (`NOT NULL`) owning FK | **P2014**, refused ahead of the write |

Two of those changed the shape of the fix. The `create` statement row is why the step is not conditioned on `update`. The many-to-one row is why the discriminator had to be settled rather than borrowed.

## The diff

`clearLinks` now takes a **model name** instead of a relation. That is the whole of the reuse, and it is a rename rather than a redesign: the statement pair (`findMany` to decide, `updateMany` to write, both un-pre-scoped, the column passed as ORM-authored for #98) and the scoping rule were already right. Only the table differs — the *child's* on the foreign side, a *sibling of the row being written* on this one.

`displaceSibling` is what only this side needs. It follows the `before`-step shape #362's `disconnect` filter arm established: read this row through `args.where` **pre-scoped**, because that `where` has already been through this model's policies once and re-applying them would `AND` the same predicate twice.

**When this row is itself the incumbent, the clear is skipped — which is what Prisma does too.** An already-linked `connect` writes nothing at all there: four selects between a `BEGIN` and a `COMMIT`, no `update`. An earlier revision of this PR claimed Prisma nulls the column and writes the same value back; that was reasoned rather than measured, and it was wrong in four places, all now corrected.

The skip is still load-bearing beyond parity, which is the part worth keeping: the repoint on this side is not a statement of its own but a contribution to the main statement, whose `where` carries the policy scope. A model scoped on the foreign key would have its own row moved outside that scope by a clear, so the main statement would match nothing and the row would end up detached and never re-attached — #98/#99's hazard arriving on this side, and the same argument #362 used to leave `set`'s *link* half not naming its column.

One divergence remains, running the other way: Prisma makes the call a complete no-op, gemi still emits the repoint `UPDATE` (the contribution is in the SET list at compile time and cannot be withdrawn at bind time). Same rows — it writes the value already there — but a one-to-one owner carrying `@updatedAt` gets a stamp from gemi that Prisma does not give it. An instance of #370's stamp divergence rather than a new one, invisible to any fixture, and specific to this path: on a many-to-one both clients update and both stamp.

Three call sites, because `connect` has three: the direct form (`connect: { id }` naming the referenced key), the resolved form (`connect: { publicId }`, which needs a lookup first), and `connectOrCreate`'s hit branch. The direct form gains a step **only** when `displaces` is true, so "no query is needed at all" still holds for every many-to-one `connect` — which is nearly all of them.

### Atomicity

`Model.$exec` opens a transaction for any plan whose `before`/`after` is non-empty, and the clear is a `before` step, so the detach and the repoint commit or roll back together. **`O12g` does not prove that** — an earlier revision of this PR said it did. Its parent is absent, so the step returns before writing, and every other differential case either never clears or clears and then succeeds; a clear that escaped the transaction would leave all of them green.

The assertion that can fail is `"a failure after the detach rolls the detach back"` in `nested-write-policies.test.ts`: the incumbent is detached to free the key, then the insert collides with it again on the *primary* key. With `transact` disabled it is the only owning-side test in either suite that fails (6 others do, all pre-existing, including the foreign-side analogue `M15c`). It cannot live in the differential — the shape needs a `create` naming a colliding `id`, and Prisma has no `id` in `ProfileCreateInput`, so it answers a validation error where gemi answers the unique violation and the harness compares failure kinds.

### The discriminator

**Two tests, not one, and the first revision of this PR got it wrong.** It used `uniques` containing the foreign key alone, on the argument that P1012 makes that equivalent to the far side's `relation.kind` — "the same question asked from the two ends of the key". That implication holds one way only. P1012 gives *`kind !== "many"` implies the key is unique*; the converse is false, and this schema is the counter-example:

```prisma
model Team   { id Int @id @default(autoincrement())  players Player[] }
model Player { id Int @id @default(autoincrement())  name String
               teamId Int? @unique
               team   Team? @relation(fields: [teamId], references: [id]) }
```

`prisma validate` → *"The schema at b.prisma is valid 🚀"*. And on it, `Player.update({ where: { id: 2 }, data: { team: { connect: { id: 2 } } } })` with player 1 already on team 2 answers **P2002**, its whole log being `SELECT Team.id`, the `UPDATE`, `ROLLBACK` — the sibling is never read. Swap `players Player[]` for `keeper Keeper?` on the same key and the identical call displaces, with the incumbent `SELECT` and clear appearing in the log. So the index is necessary, not sufficient, and the *back-relation* is what decides.

`displaces` now reads the child's copy of the relation, found by `relationName`, and uses `uniques` only to narrow. `relation.kind` is still unreadable from this side — it says `"one"` for a many-to-one and a one-to-one alike — which is the part of the original argument that survives. `planForeignSide`'s docblock is corrected too: its single `kind` test is *sufficient* there, being the stronger half, and it now says why the owning side needs both rather than claiming they are one predicate.

An unidentifiable back-relation does not displace. Absent or ambiguous, the answer is unknown, and of the two ways to be wrong only one writes to a row nobody named — so the fallback is the collision this operand raised before #363. The self-relation exclusion is `otherSide`'s test restated rather than shared: that function *throws* on the same condition and has never run on this path, and turning a schema that compiled yesterday into a hard error is not this issue's to do.

Nullable too, for the reason the foreign side is: a detach has to leave a value behind. A required foreign key collides as it always did. Prisma answers that call with **P2014** rather than a unique violation — a divergence in the failure's *class* on a call that fails either way, where everything else here is about a call that succeeds. Recorded in the code and the docs rather than matched; the template schema carries no required one-to-one, which is why it was measured on a scratch one.

Single-column indexes only. A composite `@@unique` covering the key and something else does not make the relation one-to-one, and reading it as one would clear rows the schema never said were exclusive.

## The seed vs `OWNING_CASES` decision

**The case is in `OWNING_CASES`, the seed is unchanged, and #363's last acceptance bullet is satisfied as written.** The premise both the issue comment and the old pin were working from turns out to be avoidable.

The comment frames it as needing "a second seeded profile owned by user 2", and it is right that the seed must not grow that way — `loose` being unattached is load-bearing in the *opposite* direction, and user 2's to-one being empty is what makes `M1`, `M1b`, `M2c`, `M3`, `M6`, `M8`, both `connect` controls and the `@updatedAt` case reach their miss branches at all. Seeding a profile onto user 2 would leave every one of them green while quietly moving them onto the hit path, which is the failure the seed's own comment warns about.

But that is a property of *which direction the scenario is written in*, not of the scenario. The seed already carries both halves:

```
profile 1  ->  user 1      user 1 is occupied
profile 2  ->  nobody      `loose` is unattached
```

So `Profile.update({ where: { id: 2 }, data: { user: { connect: { id: 1 } } } })` is the same collision — the unattached row moving into the occupied slot rather than the attached one — with no arrangement at all. That is `O12`.

One correction to the cost analysis while I was there: `expectSameWrite` compares gemi's after-state against **Prisma's**, not against a literal, so a seed row would not have produced "a large mechanical diff across cases whose answers are already pinned". The real cost was always the semantic one above, and it is decisive on its own.

## What happened to #362's pin

Not deleted. `"the owning side collides linking into an occupied to-one"` moved out of the `where the two clients still disagree` describe and into `the same to-one, written from the owning side`, rewritten as `"connect into an occupied to-one displaces the incumbent on both"`. Its Prisma half is unchanged and was always the measurement; only gemi's half moved, from `UniqueConstraintError` with nothing written to the same three-row answer.

It is kept rather than folded into `O12` because it is a different arrangement, not a duplicate: its `occupy()` makes **both** rows linked, so one call detaches two — the incumbent, and the far row this one is leaving. `O12`'s mover starts unlinked. It stays out of `OWNING_CASES` for the mechanical reason it always did — `expectSameWrite` resets to the seeded state before each client runs, so a table-driven case has nowhere to put a per-case arrangement.

The neighbouring refusals that must stay refused are all still green: `M14c` / `M14d` (`connectOrCreate`'s miss and `upsert`'s create branch still collide), `M8d` / `O11` (`disconnect: null` refused by both), `M11` (`disconnect` on a required foreign key), and the many-to-one `disconnect` divergence, which is now the only entry left in that describe.

## Tests

13 new differential cases, 3 compile cases and 4 in the policy suite. Every one was mutation-checked — reverting the code path it covers makes it, and only it, fail:

| id | what it pins | mutation that fails it |
| --- | --- | --- |
| `O12` `O12b` `O12c` `O12d` | the displacement, the empty-far-row control, the self-incumbent no-op, and it beside a column write | `displaces = false` |
| `O12e` | the **resolved** `connect` form (`{ publicId }`), a second code path — every other case takes the direct one | disabling the clear in the lookup branch alone |
| `O12f` | a `connect` naming no row displaces nothing | — (ordering; the resolve raises first) |
| `O12g` | a statement with no row to write leaves the incumbent alone | — (both clients reach it through the transaction; it does **not** pin atomicity) |
| `O13` `O13b` | the same under a `create`, where there is no self to read | `displaces = false` |
| `O14` `O14b` | `connectOrCreate`'s two branches answering differently | `displaces = false` |
| `O15` | the owning-side `create`, pinned as "no incumbent by construction" so the rule cannot quietly widen | — |
| `M16` | a **many-to-one** connect leaves the parent's other rows alone | `displaces = true` |

Three compile-level cases in `packages/gemi/orm/compile/write.test.ts`, which is where the discriminator can actually be isolated — the differential cannot reach the shape without a schema change, and nothing under `packages/gemi/orm/**` executes SQL, so a `before` step being present or absent is the assertion:

| case | what it pins | mutation that fails it |
| --- | --- | --- |
| a list back-relation does not displace | the blocking defect: `@unique` key, `players Player[]`, no step | the index-alone discriminator |
| a non-list back-relation displaces | the same key, `kind: "one"`, one step — so the pair is one character apart in the `.prisma` and opposite in the answer | `displaces = false` |
| no unique index does not displace | that `uniques` is still doing work, so the pair above cannot pass for a discriminator that stopped reading it | dropping the `uniques` test |

`M16` is the one worth having on its own merits. `User.organization` is the ordinary many-to-one a nested `connect` is nearly always written against, and a `displaces` that widened from "the foreign key is unique" to "the relation points at one row" would detach user 1 from Acme on a call about user 2 with every existing case staying green.

Three cases in `nested-write-policies.test.ts`, on `Cover` — which needed no new fixture, since its `folderId` is already the unique foreign key and it already carries a tenant policy:

- a visible incumbent sibling is detached and orphaned;
- a **hidden** one is not, and the repoint collides on the unique key instead — the conservative answer, and the same one `set`, a nested `create` and #361's `connect` give;
- the self-incumbent case **under a policy scoped on the foreign key** — the arrangement where clearing this row would be a silent half-write, and the sole test that fails when the skip is removed;
- **the atomicity assertion**, added on review: the incumbent is detached to free the key and the insert then collides with it on the primary key, so a clear outside the transaction would leave it detached by a statement that failed.

### Case-ID uniqueness

Checked mechanically before pushing, since a `-t` selecting two unrelated tests has happened here once:

```
total ids: 65   distinct: 60
duplicates: {'M10': 6}      <- pre-existing, deliberate group name (6 on main too)
added: M16 O12 O12b O12c O12d O12e O12f O12g O13 O13b O14 O14b O15
```

and by selection, so group prefixes are checked as well as literals:

```
-t "O12"  -> 7 passed   (O12 + O12b..O12g, exactly the group)
-t "O13"  -> 2 passed
-t "O14"  -> 2 passed
-t "O15"  -> 1 passed
-t "O12e" -> 1 passed
-t "M16"  -> 1 passed
```

No unrelated test is selected by any of them.

## Docs

`docs/orm.md`'s "one gap remains, on the other side of the key" paragraph is now the section saying the displacement holds from either end, with the two things specific to the owning side: it needs a one-to-one (a many-to-one has no incumbent), and it needs a nullable key (a required one collides here and is P2014 there). `docs/llms-full.txt` carries `orm.md` verbatim and is asserted to — `orm/docs-scope.test.ts` caught the drift, and the embedded copy is re-synced.

## Coverage

```
packages/gemi     Test Files  120 passed (120)
                       Tests  3110 passed | 1 skipped (3111)     (base 3107)

saas-starter      Test Files  22 passed | 3 skipped (25)
                       Tests  795 passed | 133 skipped (928)     (base 778)
```

**Postgres differential**, brought up through `app/models/postgres.sh`:

```
Test Files  2 failed | 21 passed (23)
     Tests  1174 passed | 487 skipped (1661)
```

The two "failed" files are the SQLite halves of the differential suites, which fail loudly by design under a Postgres-generated client (`assertPrismaSpeaks` — "a silently skipped dialect reads as a passing one"). Every Postgres case passed. Schema restored to `sqlite`, container removed, `git status` clean.

`oxlint` clean on all four touched source files. `tsc --noEmit` clean on `packages/gemi`; the template reports **277** errors, which is exactly its count on the base commit — the one in `writes.differential.test.ts` is the pre-existing `publicId: null` case, at a new line number.

## Two things found on the way

`clearLinks`'s `updateMany` stamps `@updatedAt` on rows it detaches, where Prisma's clear is a bare `UPDATE ... SET fk = null`. That is pre-existing on the foreign side, unchanged by this, and an instance of the `@updatedAt` divergence #370 already documented — gemi stamps on every writing arm, fixed at compile time. No fixture can see it (neither `Profile` nor `Cover` carries the column), so it is noted rather than acted on. The already-linked `connect` above is the second instance of the same thing, and is noted in the same places.

`docs/llms-full.txt` embeds `orm.md` verbatim and `orm/docs-scope.test.ts` asserts it does, so editing the page without re-syncing the bundle fails `packages/gemi`. Worth knowing before the next docs edit; the bundle is re-synced here.

Closes #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChxCkNb4bLwd5aYSgAPByU

