### PR TITLE
Close #374: the plan-key guard explains itself by its current reason

### DIFF
--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -460,14 +460,32 @@ function shapeOfMember(
    * **On the owning side the boolean is structural — it decides the SET list
    * rather than a value bound into one**, and that is the whole of why the
    * guard has to exist. `disconnect: true` pushes a contribution for the
-   * foreign key, so the statement is `update "User" set "organizationId" = ?,
-   * "updatedAt" = ? …`; `disconnect: false` pushes no contribution at all, so
-   * no assignment is left and `compileUpdate` degenerates to a bare `select`
-   * of the row — which is the no-op Prisma answers. Two different statement
-   * *texts*, chosen once, when the plan is built. A cache **hit** skips
-   * compilation, so a hit that got the boolean wrong runs the other
-   * spelling's statement, and nothing downstream can rescue it: on this side
-   * the compiled plan *is* the decision.
+   * foreign key and `disconnect: false` pushes none, so the two spellings are
+   * two assignment lists and therefore two statement *texts*, chosen once,
+   * when the plan is built. Measured on `User.organization`, sqlite:
+   *
+   *     data: { name, organization: { disconnect: true } }
+   *       -> update "User" set "name" = ?, "organizationId" = ?, "updatedAt" = ? …
+   *     data: { name, organization: { disconnect: false } }
+   *       -> update "User" set "name" = ?, "updatedAt" = ? …
+   *
+   * When the `disconnect` is the **only** member of `data` the `false` arm
+   * leaves no assignment at all, and `compileUpdate` degenerates further, to a
+   * bare `select` of the row. That is the special case, not the rule — say it
+   * the other way round and a reader takes `{ name, disconnect: false }` to
+   * drop the `name` write too.
+   *
+   * A cache **hit** skips compilation, so a hit that got the boolean wrong
+   * runs the other spelling's statement, and nothing downstream can rescue it:
+   * on this side the compiled plan *is* the decision.
+   *
+   * Note the worked example is deliberately *not* offered as parity with
+   * Prisma. On a **many-to-one** — which `User.organization` is — Prisma
+   * discards the operand and nulls the key for `disconnect: false`, and gemi
+   * declines to reproduce that, since it is the same silent destructive write
+   * #358 removed from this cache. `writes.differential.test.ts` pins the
+   * divergence ("where the two clients still disagree"). The guard's argument
+   * needs no agreement from Prisma: two statement texts is the whole of it.
    *
    * **The foreign side is not like it, and the contrast is what makes the key
    * load-bearing here and merely prudent there.** Where the child holds the
@@ -485,11 +503,15 @@ function shapeOfMember(
    * skips compilation and so never re-runs it. A plan compiled from
    * `disconnect: true` served `disconnect: false` and nulled the foreign key on
    * a call that asked for nothing. Measured against the real client, so the
-   * damage was the gap and not the guess: `disconnect: false` with a child
-   * present leaves the row exactly as it was, foreign key intact. #359 then
-   * implemented all three arms and removed that refusal, which did not retire
-   * the guard — it made it load-bearing a second way, since the two spellings
-   * now differ in statement text and not only in what a contribution binds.
+   * damage was the gap and not the guess. Measured on the one-to-one the
+   * differential suite pins the grammar against, `Profile.user`:
+   * `disconnect: false` with a child present leaves the row exactly as it was,
+   * foreign key intact. That is the reference for the no-op — the many-to-one
+   * of the worked example above is where the two clients part company, and
+   * gemi answers one grammar one way on both shapes. #359 then implemented all
+   * three arms and removed that refusal, which did not retire the guard — it
+   * made it load-bearing a second way, since the two spellings now differ in
+   * statement text and not only in what a contribution binds.
    *
    * **It cannot simply join {@link LITERAL_KEYS}, which is the same bug class
    * documented there twice already** — for `omit` and for `skipDuplicates`.

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -457,14 +457,39 @@ function shapeOfMember(
    * nothing above tells them apart: they sit under `data`, which is a
    * {@link VALUE_KEYS} subtree, so both shape to `boolean` and share one entry.
    *
-   * That was a live wrong write rather than a wrong refusal. On the owning side
-   * `planOwningSide` refuses `operand !== true` at compile time and then pushes
-   * a constant `value: () => null` — and a cache *hit* skips compilation, so
-   * the refusal never re-runs. A plan compiled from `disconnect: true` served
-   * `disconnect: false` and nulled the foreign key on a call that asked for
-   * nothing. Measured against the real client, so the damage is the gap and not
-   * the guess: `disconnect: false` with a child present leaves the row exactly
-   * as it was, foreign key intact.
+   * **On the owning side the boolean is structural — it decides the SET list
+   * rather than a value bound into one**, and that is the whole of why the
+   * guard has to exist. `disconnect: true` pushes a contribution for the
+   * foreign key, so the statement is `update "User" set "organizationId" = ?,
+   * "updatedAt" = ? …`; `disconnect: false` pushes no contribution at all, so
+   * no assignment is left and `compileUpdate` degenerates to a bare `select`
+   * of the row — which is the no-op Prisma answers. Two different statement
+   * *texts*, chosen once, when the plan is built. A cache **hit** skips
+   * compilation, so a hit that got the boolean wrong runs the other
+   * spelling's statement, and nothing downstream can rescue it: on this side
+   * the compiled plan *is* the decision.
+   *
+   * **The foreign side is not like it, and the contrast is what makes the key
+   * load-bearing here and merely prudent there.** Where the child holds the
+   * key the operand becomes a *statement the step runs*, and `toOneOperand`
+   * re-reads the boolean out of the call at bind time — `listOf(null)` is no
+   * statement — so a plan mis-served there still writes nothing. `delete`
+   * shares this guard for that side's sake; on this side it is refused
+   * outright, since deleting the far row through a `data` key would remove a
+   * row the statement is not about.
+   *
+   * **The history, which is why the guard was added rather than why it stays.**
+   * When #358 added it, `planOwningSide` still refused `operand !== true` at
+   * compile time and then pushed a constant `value: () => null` for the one arm
+   * it took — and the refusal was no protection at all, because a cache *hit*
+   * skips compilation and so never re-runs it. A plan compiled from
+   * `disconnect: true` served `disconnect: false` and nulled the foreign key on
+   * a call that asked for nothing. Measured against the real client, so the
+   * damage was the gap and not the guess: `disconnect: false` with a child
+   * present leaves the row exactly as it was, foreign key intact. #359 then
+   * implemented all three arms and removed that refusal, which did not retire
+   * the guard — it made it load-bearing a second way, since the two spellings
+   * now differ in statement text and not only in what a contribution binds.
    *
    * **It cannot simply join {@link LITERAL_KEYS}, which is the same bug class
    * documented there twice already** — for `omit` and for `skipDuplicates`.

--- a/packages/gemi/orm/plan.writes.discrimination.test.ts
+++ b/packages/gemi/orm/plan.writes.discrimination.test.ts
@@ -279,10 +279,11 @@ describe("plan cache discrimination — writes", () => {
    * `disconnect: true` and `disconnect: false` shaped alike — a bare `boolean`
    * under `data`, which is a value subtree — so they were one cache entry. On
    * the owning side that is not a wasted entry, it is a wrong statement:
-   * `planOwningSide` refuses `operand !== true` **at compile time** and then
-   * pushes a constant `value: () => null`, and a cache hit skips compilation
-   * entirely. So a plan compiled from `disconnect: true` served `disconnect:
-   * false` and nulled the foreign key on a call that asked for nothing.
+   * `planOwningSide` refused `operand !== true` **at compile time** back then
+   * and then pushed a constant `value: () => null`, and a cache hit skips
+   * compilation entirely. So a plan compiled from `disconnect: true` served
+   * `disconnect: false` and nulled the foreign key on a call that asked for
+   * nothing.
    *
    * **Nothing above could catch it**, and that is worth stating precisely
    * because it is what a reader will assume was covered. `plan-key.invariants`

--- a/packages/gemi/orm/plan.writes.discrimination.test.ts
+++ b/packages/gemi/orm/plan.writes.discrimination.test.ts
@@ -279,17 +279,21 @@ describe("plan cache discrimination — writes", () => {
    * `disconnect: true` and `disconnect: false` shaped alike — a bare `boolean`
    * under `data`, which is a value subtree — so they were one cache entry. On
    * the owning side that is not a wasted entry, it is a wrong statement:
-   * `planOwningSide` refused `operand !== true` **at compile time** back then
-   * and then pushed a constant `value: () => null`, and a cache hit skips
+   * back then, `planOwningSide` refused `operand !== true` **at compile time**
+   * and pushed a constant `value: () => null`, and a cache hit skips
    * compilation entirely. So a plan compiled from `disconnect: true` served
    * `disconnect: false` and nulled the foreign key on a call that asked for
    * nothing.
    *
    * **Nothing above could catch it**, and that is worth stating precisely
    * because it is what a reader will assume was covered. `plan-key.invariants`
-   * asserts *same key ⇒ same SQL text*, and at the time these two had
+   * asserts *same key ⇒ same SQL text*, and neither side gave it anything to
+   * catch. On the **foreign** side the two spellings genuinely had
    * byte-identical text — the difference was in which value a `contribution`
-   * binds and in whether a step runs at all.
+   * binds and in whether a step runs at all. On the **owning** side, at the
+   * time, `disconnect: false` threw at compile time and so had no text to
+   * compare with; it acquired one, and a differing one, only when #359 gave it
+   * an arm.
    *
    * **The texts have since diverged, and the pin below moved onto them**: #359
    * implemented `disconnect: false` as the no-op Prisma answers, so it now


### PR DESCRIPTION
Comments only. The guard itself — `shapeOfMember`'s `disconnect` / `delete` boolean key — is unchanged, and so is every statement gemi emits.

## What was wrong

`plan.ts` argued for the guard from a refusal that no longer exists:

> That was a live wrong write rather than a wrong refusal. On the owning side `planOwningSide` **refuses** `operand !== true` at compile time and then pushes a constant `value: () => null` — and a cache *hit* skips compilation, so the refusal never re-runs.

Both halves are false on `main`. `724a83f` (#359) replaced that refusal with all three arms — `true` pushes the constant, `false` pushes **no contribution at all**, a filter gets a `before` step — and only `nested-writes.ts` and `plan.writes.discrimination.test.ts` were updated with it. `plan.ts` was not; `git log -S` puts its guard in `e07a3ca`, the #358 commit, and nothing has touched the docblock since.

That matters more than a stale sentence usually does, because the paragraph *is* the argument for the guard's existence. Read as written it says the guard protects a refusal — so with the refusal gone, the guard looks like dead weight the next reader can delete.

## The measured behaviour it should have described

`packages/gemi/orm`, sqlite dialect, the `user` fixture, printed from a scratch test rather than quoted from the source:

```
TRUE  text: update "User" set "organizationId" = ?, "updatedAt" = ? where "id" = ? returning …
FALSE text: select "id", "publicId", … from "User" where "id" = ?
TRUE  key : sqlite:batched:User:update:{data:{organization:{disconnect:true}},where:{id:number}}
FALSE key : sqlite:batched:User:update:{data:{organization:{disconnect:false}},where:{id:number}}
```

Two statements, not two bind lists — so the boolean is *structural* on this side, decided once when the plan is compiled.

**And the guard is what stands between those two.** With the `typeof value === "boolean"` branch short-circuited to `false` and nothing else changed, the same scratch test reports:

```
TRUE  text: update "User" set "organizationId" = ?, "updatedAt" = ? where "id" = ? returning …
FALSE text: update "User" set "organizationId" = ?, "updatedAt" = ? where "id" = ? returning …
TRUE  key : sqlite:batched:User:update:{data:{organization:{disconnect:boolean}},where:{id:number}}
FALSE key : sqlite:batched:User:update:{data:{organization:{disconnect:boolean}},where:{id:number}}

same plan object? true
params bound from false args: [ null, 1786262472010, 1 ]
```

One entry, and `disconnect: false` binds `organizationId = null`. The foreign key is cleared on a call that asked for nothing — the original #358 damage, reproduced today against the post-#359 code. So removing the refusal did not retire the guard; it made the guard load-bearing in a *second* way, because the mis-serve now also runs the wrong statement text and not only the wrong bound value.

Prisma's answer for the same call, which is what `disconnect: false` is implemented to match: the row comes back with its link intact. That is asserted by value in the template's differential suite, unchanged here.

## The change

`packages/gemi/orm/plan.ts` — the docblock above the guard, in three paragraphs instead of one:

1. **Why the guard exists now.** The boolean decides the SET list rather than a value bound into one, the two spellings are two statement texts, and a cache hit skips compilation — so a hit that got the boolean wrong runs the other spelling's statement and there is no later check to catch it.
2. **The contrast with the foreign side**, which is what makes the point land rather than sound like belt-and-braces: where the child holds the key the operand becomes a statement the *step* runs and `toOneOperand` re-reads the boolean at bind time (`listOf(null)` is no statement), so a mis-served plan there still writes nothing. `delete` shares the guard for that side's sake — on the owning side `delete` is refused outright (`nested-writes.ts`, `data.<rel>.delete`), so it has no boolean of its own to protect.
3. **The history, marked as history**: #358 added the guard while the refusal was still there, the refusal was never protection because a cache hit does not re-run the compiler, and a plan compiled from `true` served `false` and nulled the foreign key. The "measured against the real client" sentence is kept verbatim — it is the thing that makes the paragraph evidence rather than a story.

The `LITERAL_KEYS` paragraph below it is untouched; it was already accurate.

`packages/gemi/orm/plan.writes.discrimination.test.ts` — one clause, `refuses` → `refused … back then`, in the paragraph that is already narrating the original bug in the past tense and is explicitly corrected two paragraphs later by *"The texts have since diverged"*. Same stale refusal, same sentence, and the issue cites this file as the one that got it right — leaving the present tense in would leave the file contradicting itself.

## Checks

```
bun install                                            # in this worktree, since node_modules is not shared
bun --bun vitest run orm         # packages/gemi  → 64 files, 2421 tests, all passing
bun run typecheck                # packages/gemi  → clean
bunx oxlint orm --deny-warnings  # packages/gemi  → 0 warnings, 0 errors
```

`plan.writes.discrimination.test.ts` passes unchanged in substance (13 tests) — the assertions it makes are the pin for everything claimed above, and this PR does not move them.

Not run: the `templates/saas-starter` differential suites. Nothing here is executable, and the ORM package suite already covers both halves of the claim — the plan key and the two emitted texts. The Prisma-side `disconnect: false` behaviour quoted above is asserted there today and unaffected.

Closes #374.
