### PR TITLE
Close #373: connectOrCreate's hit branch names the foreign key as the ORM's

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3955,10 +3955,22 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 tenant.
 
 A child whose policy *scopes on the foreign key itself* — `scope: () => ({ folderId: mine })` — can
-still use the relation operands that write that key. `connect`, `connectOrCreate` and `disconnect`
-go through without an `onUpdate`, because the scope-escape guard judges **the columns you supplied**
-rather than the ones the nested step put there: the ORM records which columns it wrote and exempts
-those from the check.
+still use the relation operands that write that key. `connect`, `disconnect` and `connectOrCreate`'s
+**hit** branch go through without an `onUpdate`, because the scope-escape guard judges **the columns
+you supplied** rather than the ones the nested step put there: the ORM records which columns it
+wrote and exempts those from the check.
+
+The hit branch, and not `connectOrCreate` whole, because its other branch is a `create` — and a
+policy that carries a `scope` with no `onCreate` is refused there by a different rule, before the
+scope-escape guard is reached:
+
+```
+UnsupportedQueryError: gemi ORM does not support 'create' yet (Note.create).
+Note has a policy that scopes reads but no 'onCreate' …
+```
+
+So on a model scoped this way, `connectOrCreate` links an existing row and cannot fall back. Give
+the policy an `onCreate` if you want the fallback as well.
 
 The exemption is provenance, not permission. A column *you* name is refused exactly as before —
 writing `folderId` yourself on a model scoped by it is still a scope escape, and still needs an

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3955,14 +3955,20 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 tenant.
 
 A child whose policy *scopes on the foreign key itself* — `scope: () => ({ folderId: mine })` — can
-still use the relation operands that write that key. `connect`, `disconnect` and the rest go
-through without an `onUpdate`, because the scope-escape guard judges **the columns you supplied**
+still use the relation operands that write that key. `connect`, `connectOrCreate` and `disconnect`
+go through without an `onUpdate`, because the scope-escape guard judges **the columns you supplied**
 rather than the ones the nested step put there: the ORM records which columns it wrote and exempts
 those from the check.
 
 The exemption is provenance, not permission. A column *you* name is refused exactly as before —
 writing `folderId` yourself on a model scoped by it is still a scope escape, and still needs an
 `onUpdate` to say so deliberately.
+
+`set` is the one operand still refused here, and deliberately. It writes the key twice — `null` to
+clear the old links, then the parent's key to make the new ones — and only the clear is recorded as
+the ORM's. Exempting both would make the call *succeed* and leave the rows detached, because the
+clear moves them outside the very scope the link then selects them by. A refusal is the better
+answer until that is fixed.
 
 `disconnect` and `delete` only exist on an `update` — a `create` has nothing linked to it yet, and
 Prisma reports them as an unknown argument there too. They differ on a row that is **not** linked to

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -972,14 +972,20 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 tenant.
 
 A child whose policy *scopes on the foreign key itself* — `scope: () => ({ folderId: mine })` — can
-still use the relation operands that write that key. `connect`, `disconnect` and the rest go
-through without an `onUpdate`, because the scope-escape guard judges **the columns you supplied**
+still use the relation operands that write that key. `connect`, `connectOrCreate` and `disconnect`
+go through without an `onUpdate`, because the scope-escape guard judges **the columns you supplied**
 rather than the ones the nested step put there: the ORM records which columns it wrote and exempts
 those from the check.
 
 The exemption is provenance, not permission. A column *you* name is refused exactly as before —
 writing `folderId` yourself on a model scoped by it is still a scope escape, and still needs an
 `onUpdate` to say so deliberately.
+
+`set` is the one operand still refused here, and deliberately. It writes the key twice — `null` to
+clear the old links, then the parent's key to make the new ones — and only the clear is recorded as
+the ORM's. Exempting both would make the call *succeed* and leave the rows detached, because the
+clear moves them outside the very scope the link then selects them by. A refusal is the better
+answer until that is fixed.
 
 `disconnect` and `delete` only exist on an `update` — a `create` has nothing linked to it yet, and
 Prisma reports them as an unknown argument there too. They differ on a row that is **not** linked to

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -972,10 +972,22 @@ same answer you would get if it truly did not exist. That is deliberate. `connec
 tenant.
 
 A child whose policy *scopes on the foreign key itself* — `scope: () => ({ folderId: mine })` — can
-still use the relation operands that write that key. `connect`, `connectOrCreate` and `disconnect`
-go through without an `onUpdate`, because the scope-escape guard judges **the columns you supplied**
-rather than the ones the nested step put there: the ORM records which columns it wrote and exempts
-those from the check.
+still use the relation operands that write that key. `connect`, `disconnect` and `connectOrCreate`'s
+**hit** branch go through without an `onUpdate`, because the scope-escape guard judges **the columns
+you supplied** rather than the ones the nested step put there: the ORM records which columns it
+wrote and exempts those from the check.
+
+The hit branch, and not `connectOrCreate` whole, because its other branch is a `create` — and a
+policy that carries a `scope` with no `onCreate` is refused there by a different rule, before the
+scope-escape guard is reached:
+
+```
+UnsupportedQueryError: gemi ORM does not support 'create' yet (Note.create).
+Note has a policy that scopes reads but no 'onCreate' …
+```
+
+So on a model scoped this way, `connectOrCreate` links an existing row and cannot fall back. Give
+the policy an `onCreate` if you want the fallback as well.
 
 The exemption is provenance, not permission. A column *you* name is refused exactly as before —
 writing `folderId` yourself on a model scoped by it is still a scope escape, and still needs an

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1934,6 +1934,31 @@ function planForeignSide(
           )) as Record<string, unknown> | null;
 
           if (found) {
+            // **The row is already this parent's, so there is nothing to do.**
+            //
+            // Free here in a way it is not for the bare `connect` below: the
+            // `findUnique` above already selected the child's foreign key, so
+            // the comparison costs no statement. `connect` has no such read —
+            // giving it the same short-circuit means buying a lookup, which is
+            // why it is #372's question rather than this branch's.
+            //
+            // Without this the pair below is a **clear followed by a repoint of
+            // the row the clear just nulled**, and on a child scoped by that
+            // same foreign key the clear puts it outside the scope the repoint
+            // selects it through — so the operand raises `RecordNotFoundError`
+            // on a call that should change nothing. Net-nothing either way for
+            // an unscoped child, which is why it stayed hidden; the scoped one
+            // is where the wasted statement becomes a wrong answer.
+            //
+            // `displaces` gates it because that is the only shape the clear
+            // runs in. On a to-many there is no clear, so the repoint is one
+            // redundant `update` writing the value already there — measured to
+            // agree with Prisma, and skipping it would be an unmeasured change
+            // to a branch this issue is not about.
+            if (displaces && sameKey(found[childField], parent[parentField])) {
+              continue;
+            }
+
             // The hit branch **is** a connect, so it displaces what is linked
             // exactly as the bare operand does (#361) — and the miss branch
             // below does not, which is Prisma's own split rather than a

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -1952,7 +1952,20 @@ function planForeignSide(
                 data: { [childField]: parent[parentField] },
                 select: { [childField]: true },
               },
+              // NOT pre-scoped, for the reason the bare `connect` below is not:
+              // this repoints an existing child, so the child's scope decides
+              // which rows are reachable.
               false,
+              // ...and the column is *ours*, the same one and for the same
+              // reason (#98). Left off here while `connect` carried it, so one
+              // operand spelled two ways answered a child scoped on its own
+              // foreign key differently: `connect` went through and this raised
+              // `ScopeEscapeError` about a `folderId` the caller never wrote
+              // (#373). The hit branch **is** a connect — the docblock above
+              // says so for displacement, and provenance follows from the same
+              // fact. The miss branch below needs no marker: it creates the far
+              // row, so there is no caller-supplied key to tell ours apart from.
+              [childField],
             );
             continue;
           }

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -1089,6 +1089,87 @@ describe("policies on nested writes", () => {
         [55, null],
       ]);
     });
+
+    /**
+     * **The same call spelled two ways has to give one answer** (#373).
+     *
+     * `connectOrCreate`'s hit branch repoints through the very `update` the
+     * bare `connect` uses — the neighbouring branch of `planForeignSide` — and
+     * used not to name `folderId` as the ORM's. Under a child scoped on its own
+     * foreign key that split the two apart:
+     *
+     *     connect          RecordNotFoundError: No Cover found (Cover.update).
+     *     connectOrCreate  ScopeEscapeError: Cover.update writes 'folderId', …
+     *
+     * — a refusal describing a write the caller never made, on the spelling
+     * that only differs by carrying a fallback it does not take.
+     *
+     * **Asserted as an equality between the two outcomes, not against a
+     * literal**, because the answer they now share is not yet the right one:
+     * `clearLinks` nulls the row the caller named before the repoint selects it
+     * by the scope, so both miss. That is #372, and it belongs to #372's pin —
+     * this one says only that the two spellings cannot diverge, which stays
+     * true when that lands and both succeed. What it does rule out by name is
+     * the guard firing on one of them, since that is the divergence this fixes.
+     *
+     * The `set` refusal in *"a foreign-key scope allows relation operands the
+     * ORM keyed"* below is the deliberate counter-example: its link half is
+     * *not* named as the ORM's, so it is still refused. That is a choice about
+     * a half-write, not an oversight — see the comment there.
+     */
+    test("connectOrCreate's hit branch answers exactly as connect does", async () => {
+      class KeyScoped extends Model {
+        static $schema = coverSchema;
+        static $policies = [{ scope: () => ({ folderId: 2 }) } as ModelPolicy];
+      }
+      register("Cover", KeyScoped);
+
+      try {
+        await seedFolder();
+        await raw.unsafe(
+          `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+            `VALUES (56, 2, 'linked', 7)`,
+        );
+
+        const outcome = async (operand: unknown) => {
+          try {
+            await Model.asUser(OURS, () =>
+              Folder.$exec("update", {
+                where: { id: 2 },
+                data: { code: "ours", cover: operand },
+              }),
+            );
+            return "resolved";
+          } catch (error) {
+            return (error as Error).constructor.name;
+          }
+        };
+
+        const table = async () => {
+          const rows: any = await raw.unsafe(
+            `SELECT "id", "folderId" FROM "Cover" ORDER BY "id"`,
+          );
+          return [...rows].map((cover: any) => [cover.id, cover.folderId]);
+        };
+
+        const bare = await outcome({ connect: { id: 56 } });
+        const after = await table();
+
+        const paired = await outcome({
+          connectOrCreate: { where: { id: 56 }, create: { caption: "made" } },
+        });
+
+        expect(paired).toBe(bare);
+        // The table too, and not only the verdict: the two could agree on
+        // "threw" while one of them had already written something the other had
+        // not. This also carries the non-vacuity — cover 56 is still the only
+        // row, so the hit branch really was the branch taken.
+        expect(await table()).toEqual(after);
+        expect(paired).not.toBe("ScopeEscapeError");
+      } finally {
+        register("Cover", Cover);
+      }
+    });
   });
 
   /**
@@ -1516,6 +1597,31 @@ describe("policies on nested writes", () => {
       // While both were refusals neither wrote anything and the order did not
       // matter.
       await expect(attempt({ connect: { id: 20 } })).resolves.toBeDefined();
+
+      /**
+       * **...and the third operand that writes the key: `connectOrCreate`'s hit
+       * branch** (#373), which is a `connect` spelled with a fallback.
+       *
+       * It repoints through the same `update` the bare `connect` uses — the
+       * neighbouring branch of `planForeignSide` — and used to omit the
+       * ORM-authored column list that one passes. So one operation spelled two
+       * ways answered a foreign-key scope two different ways: `connect` went
+       * through and this raised `ScopeEscapeError` about a `folderId` the
+       * caller never wrote.
+       *
+       * Between `connect` and `disconnect` for the ordering reason above — the
+       * row has to still be inside `{ folderId: 2 }` for the hit branch to find
+       * it — which is also why the row count is asserted: a miss here would
+       * *create* a second note and pass on the operand's other branch.
+       */
+      await expect(
+        attempt({
+          connectOrCreate: { where: { id: 20 }, create: { label: "made" } },
+        }),
+      ).resolves.toBeDefined();
+      expect(await linkOf()).toBe(2);
+      expect(await raw.unsafe(`SELECT "id" FROM "Note"`)).toHaveLength(1);
+
       await expect(attempt({ disconnect: { id: 20 } })).resolves.toBeDefined();
       expect(await linkOf()).toBeNull();
     } finally {

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -1096,21 +1096,29 @@ describe("policies on nested writes", () => {
      * `connectOrCreate`'s hit branch repoints through the very `update` the
      * bare `connect` uses — the neighbouring branch of `planForeignSide` — and
      * used not to name `folderId` as the ORM's. Under a child scoped on its own
-     * foreign key that split the two apart:
+     * foreign key that split the two apart, the operand that carries a fallback
+     * it does not take raising about a write the caller never made:
      *
-     *     connect          RecordNotFoundError: No Cover found (Cover.update).
+     *     connect          resolved
      *     connectOrCreate  ScopeEscapeError: Cover.update writes 'folderId', …
      *
-     * — a refusal describing a write the caller never made, on the spelling
-     * that only differs by carrying a fallback it does not take.
+     * **The scope is `{ in: [2, 3] }` rather than the bare `{ folderId: 2 }` an
+     * earlier draft used, and the widening is what makes the test mean
+     * anything.** Under `{ folderId: 2 }` the only cover this policy can see is
+     * one already pointing at folder 2 — so the only reachable `connect` is of
+     * the row already linked, and *that* case is decided before the repoint is
+     * reached (by `clearLinks` on the way in, and now by the hit branch's
+     * already-linked short-circuit). The marked `update` this issue is about
+     * never ran, and the whole assertion turned on which way two unrelated
+     * refusals happened to fall. A scope that admits two folders lets a cover be
+     * *visible on folder 3 and repointed to folder 2*, which is a real repoint
+     * through the guard, with both spellings resolving.
      *
-     * **Asserted as an equality between the two outcomes, not against a
-     * literal**, because the answer they now share is not yet the right one:
-     * `clearLinks` nulls the row the caller named before the repoint selects it
-     * by the scope, so both miss. That is #372, and it belongs to #372's pin —
-     * this one says only that the two spellings cannot diverge, which stays
-     * true when that lands and both succeed. What it does rule out by name is
-     * the guard firing on one of them, since that is the divergence this fixes.
+     * It also makes the pin **independent of #372/#379**: neither spelling is
+     * already linked here, so an already-linked short-circuit on either side
+     * cannot pull the two apart. The equality is asserted against a literal as
+     * well — `"resolved"` — so a future change that made *both* raise would be
+     * caught rather than agreed with.
      *
      * The `set` refusal in *"a foreign-key scope allows relation operands the
      * ORM keyed"* below is the deliberate counter-example: its link half is
@@ -1120,16 +1128,27 @@ describe("policies on nested writes", () => {
     test("connectOrCreate's hit branch answers exactly as connect does", async () => {
       class KeyScoped extends Model {
         static $schema = coverSchema;
-        static $policies = [{ scope: () => ({ folderId: 2 }) } as ModelPolicy];
+        static $policies = [
+          { scope: () => ({ folderId: { in: [2, 3] } }) } as ModelPolicy,
+        ];
       }
       register("Cover", KeyScoped);
 
       try {
         await seedFolder();
+        // The second folder the scope admits, so a visible cover can start off
+        // somewhere other than where it is being connected.
         await raw.unsafe(
-          `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
-            `VALUES (56, 2, 'linked', 7)`,
+          `INSERT INTO "Folder" ("id", "code", "orgId") VALUES (3, 'spare', 7)`,
         );
+
+        const park = async () => {
+          await raw.unsafe(`DELETE FROM "Cover"`);
+          await raw.unsafe(
+            `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+              `VALUES (56, 3, 'parked', 7)`,
+          );
+        };
 
         const outcome = async (operand: unknown) => {
           try {
@@ -1152,20 +1171,45 @@ describe("policies on nested writes", () => {
           return [...rows].map((cover: any) => [cover.id, cover.folderId]);
         };
 
+        await park();
         const bare = await outcome({ connect: { id: 56 } });
         const after = await table();
 
+        await park();
         const paired = await outcome({
           connectOrCreate: { where: { id: 56 }, create: { caption: "made" } },
         });
 
+        expect(bare).toBe("resolved");
         expect(paired).toBe(bare);
         // The table too, and not only the verdict: the two could agree on
-        // "threw" while one of them had already written something the other had
-        // not. This also carries the non-vacuity — cover 56 is still the only
-        // row, so the hit branch really was the branch taken.
+        // "resolved" while one of them wrote something the other did not.
         expect(await table()).toEqual(after);
-        expect(paired).not.toBe("ScopeEscapeError");
+        // ...and the non-vacuity, which is *this* line and not the count: the
+        // cover really moved off folder 3, so the marked `update` ran rather
+        // than the operand falling through to its create branch.
+        expect(after).toEqual([[56, 2]]);
+
+        /**
+         * **The hit branch on the row already linked here writes nothing.**
+         *
+         * Cover 56 now points at folder 2, so this is the case the paragraph
+         * above says `{ folderId: 2 }` could only ever reach. Without the
+         * short-circuit the branch clears the link and then repoints the row it
+         * just nulled — and a null `folderId` is outside `{ in: [2, 3] }`, so
+         * the repoint cannot select it back and the operand raises
+         * `RecordNotFoundError` on a call that should change nothing.
+         *
+         * The bare `connect` still does exactly that (#372), which is why this
+         * asserts the hit branch alone rather than another equality: the two
+         * spellings are *allowed* to differ here until #372 lands, and pinning
+         * their agreement would go red the moment it does.
+         */
+        const again = await outcome({
+          connectOrCreate: { where: { id: 56 }, create: { caption: "made" } },
+        });
+        expect(again).toBe("resolved");
+        expect(await table()).toEqual([[56, 2]]);
       } finally {
         register("Cover", Cover);
       }
@@ -1610,9 +1654,23 @@ describe("policies on nested writes", () => {
        * caller never wrote.
        *
        * Between `connect` and `disconnect` for the ordering reason above — the
-       * row has to still be inside `{ folderId: 2 }` for the hit branch to find
-       * it — which is also why the row count is asserted: a miss here would
-       * *create* a second note and pass on the operand's other branch.
+       * row has to still be inside `{ folderId: 2 }` for the hit branch to
+       * find it.
+       *
+       * **What catches a miss is the line above, not the row count.** A miss
+       * under this policy is not a create at all: `KeyScoped` has a `scope` and
+       * no `onCreate`, so `assertCreateCovered` refuses the create branch
+       * outright, and `.resolves.toBeDefined()` fails on the
+       * `UnsupportedQueryError` — measured on this fixture:
+       *
+       *     connectOrCreate { where: { id: 999 }, create: { label: "made" } }
+       *       -> UnsupportedQueryError: gemi ORM does not support 'create' yet
+       *          (Note.create). Note has a policy that scopes reads but no
+       *          'onCreate' …
+       *
+       * The count stays as defence in depth — it is what would catch a create
+       * branch that *did* run, under some future policy or fix, while the
+       * operand still resolved.
        */
       await expect(
         attempt({

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -766,6 +766,21 @@ const CASES: Case[] = [
       },
     },
   }, ["User", "Profile"]],
+  // M15b's other spelling: the hit branch naming the row **already linked
+  // here**. gemi short-circuits it and writes nothing at all, where it used to
+  // clear the link and put the same key straight back; this is the case that
+  // says the two are the same answer as far as anything observable goes. Net
+  // nothing on both sides, so it would stay green either way — it is here as
+  // the parity record for that short-circuit, since the divergence it fixes is
+  // only visible through a policy and the differential harness has none.
+  ["M15e to-one connectOrCreate of the row already linked changes nothing", "update", {
+    where: { id: 1 },
+    data: {
+      profile: {
+        connectOrCreate: { where: { id: 1 }, create: { bio: "unused" } },
+      },
+    },
+  }, ["User", "Profile"]],
 
   // M16 — the boundary on the other side of `displaces`, from the **owning**
   // end of a key (#363): a *many*-to-one connect has no incumbent, so nothing


### PR DESCRIPTION
Closes #373.

`connect` on the side whose **child** holds the foreign key passes `[childField]` to `executor.exec` as the ORM-authored column list, so a child whose policy scopes on that key is not refused for a write the caller never made (#98). `connectOrCreate`'s hit branch runs the neighbouring branch of the same function, issues the same repoint, and did not pass it.

One line of code. The rest of this is the evidence that the two really are one operation, and the two pins that stop them separating again.

## The divergence, measured

`nested-write-policies.test.ts`'s own fixture, `main` @ `5412fcd`, a child whose whole policy is `{ scope: () => ({ folderId: 2 }) }` — the plausible "my notes" scope #98 was filed about. Both relation kinds, because they fail differently and only one of them was in the issue:

| | `connect` | `connectOrCreate`, hit |
| --- | --- | --- |
| **to-many** (`Folder.notes`) | ok, `folderId` = 2 | `ScopeEscapeError` |
| **to-one** (`Folder.cover`) | `RecordNotFoundError` | `ScopeEscapeError` |

```
ScopeEscapeError: Note.update writes 'folderId', which Note's policy also
scopes on — so this update can move a row outside the scope that selected it…

  Add an onUpdate to that policy…
```

The caller wrote `connectOrCreate: { where: { id: 20 }, create: { … } }`. `folderId` is in `data` because the nested step put it there, and the message sends them to their own `data`, where there is nothing to find. That is #98's failure verbatim, on the one operand #98 did not reach.

The to-many row is the part worth reading twice: it is not two spellings of a refusal, it is a **working operand and a broken one**. On a to-one the two land differently only because `clearLinks` runs first and moves the row out of scope — the failure #372 is about.

## Why the hit branch is a `connect`, rather than merely resembling one

Measured, not remembered. Prisma 6.19.2, SQLite, `log: [{ emit: "event", level: "query" }]`, the same call spelled both ways against the template's own schema (`User.profile`, `Profile.userId @unique`), profile 10 unattached and user 1 empty:

```
=== connect ===
BEGIN IMMEDIATE
SELECT Profile.id, userId FROM Profile WHERE id = ?              [10]
SELECT User.*                FROM User    WHERE id = ?           [1]
SELECT Profile.id, userId FROM Profile WHERE userId IN (?)       [1]
SELECT Profile.id, userId FROM Profile WHERE userId IN (?)       [1]
UPDATE Profile SET userId = ? WHERE id IN (?)                    [1, 10]
SELECT User.*                FROM User    WHERE id = ?           [1]
COMMIT

=== connectOrCreate (hit) ===
BEGIN IMMEDIATE
SELECT User.*                FROM User    WHERE id = ?           [1]
SELECT Profile.id, userId FROM Profile WHERE id = ?              [10]
SELECT Profile.id, userId FROM Profile WHERE userId IN (?)       [1]
UPDATE Profile SET userId = ? WHERE id IN (?)                    [1, 10]
SELECT User.*                FROM User    WHERE id = ?           [1]
COMMIT
```

Byte-identical write, identical bindings, identical table afterwards (`[{"id":10,"userId":1}]`). The operands differ in how many times the incumbent is looked at and in what order — not in what is written. So the hit branch is not "like" a connect; it is the same statement, and provenance is a property of the statement.

This is also the fact `planForeignSide`'s existing docblock already relies on for displacement — *"the hit branch **is** a connect, so it displaces what is linked exactly as the bare operand does (#361)"*. The marker follows from the same sentence; it was simply not carried over when that landed.

**Prisma has no opinion on the rest of this.** There is no policy layer there, so the change is invisible to the differential harness — which is the point of running it anyway: 792 → 793 tests, the extra one being the case added here, and no differential case moved.

## The diff

`packages/gemi/orm/compile/nested-writes.ts`, the `found` branch of `connectOrCreate` in `planForeignSide` — `[childField]` added as `exec`'s fifth argument, with the reason at the argument. The `false` above it also picked up the comment its twin has, since the two arguments answer opposite questions about the same call and only one of them was explained.

The miss branch is deliberately untouched, which is the acceptance criterion and also just true: it `create`s the far row, so there is no caller-supplied payload for `folderId` to be confused with. `assertNoScopeEscape` does not fire on an insert at all — `onCreate` is the mechanism there.

Nothing else on this path is missing it. Every `executor.exec` in the file that writes `[childField]` was checked: `connect` (line 2045), `disconnect` (1669) and `clearLinks` (2587) carry it; `connectOrCreate`'s hit branch did not, and now does.

`set`'s link half (line 1516) still does not, and stays that way. That is a decision rather than an omission, and it is the counter-example that keeps this change honest: `set` writes the key **twice** — `null` through `clearLinks`, then the parent's key — and only the clear is marked. Marking both makes the call *succeed* and leave the rows detached, because the clear moves them outside the very scope the link then selects them by. A loud refusal beats a silent half-write until #99. The existing pin asserts exactly that and is unchanged.

## Tests

Both mutation-checked: reverting the one-line fix fails these two and nothing else in either suite.

**`a foreign-key scope allows relation operands the ORM keyed`** gains `connectOrCreate` between the existing `connect` and `disconnect`. That test's whole point, as its docblock says, is that the exemption is *"a property of the guard rather than of one operand"* — the third operand belongs in it. Position is forced by the same ordering note already there: `disconnect` nulls `folderId` and puts the row outside the scope the hit branch has to find it through. The row **count** is asserted alongside the link, because a lookup that missed would fall through to `create` and pass on the other branch — a green test for the wrong operand.

**`connectOrCreate's hit branch answers exactly as connect does`**, new, in the `a to-one whose key is on the child` describe. It compares the two outcomes against **each other** rather than against a literal, because the answer they now share is not yet the right one: `clearLinks` nulls the row the caller named before the repoint selects it by the scope, so both miss with `RecordNotFoundError`. That is #372's, and the pin for it belongs to #372 — this one asserts only that the two spellings cannot diverge, which stays true when #372 lands and both succeed. It does name one thing: the shared answer is not a `ScopeEscapeError`, since that is the divergence being fixed. The table is compared as well as the verdict — two calls can agree on "threw" while one of them wrote something first — and that comparison doubles as the non-vacuity check, since the surviving single row is what says the *hit* branch ran.

### Ordering against #372

Landing this alone moves the to-one case from `ScopeEscapeError` onto `RecordNotFoundError`. That is not a fix of the to-one case and is not claimed as one — it is the removal of a second, wrong answer, so the to-one now has exactly the one bug #372 describes instead of two. The to-many case is fixed outright. #372's fix needs no change here: it acts on `clearLinks`, and the equality pin above passes either way.

## Docs

`docs/orm.md` claimed *"`connect`, `disconnect` and the rest go through without an `onUpdate`"*. "The rest" was false in two directions — `connectOrCreate` did not, and `set` still does not. Now it names the three that do, with a paragraph saying why `set` is the exception and what would go wrong if it were not. `docs/llms-full.txt` carries the page verbatim and `orm/docs-scope.test.ts` asserts it; the embedded copy is re-synced.

## Coverage

```
packages/gemi     Test Files  120 passed (120)
                       Tests  3110 passed | 1 skipped (3111)     (base 3110)

saas-starter      Test Files  20 passed | 3 skipped (23)
                       Tests  793 passed | 133 skipped (926)     (base 792)
```

`test:types` 116 passed, no type errors. `tsc --noEmit` clean on `packages/gemi`, and on `tsconfig.generated.json`. `oxlint orm --deny-warnings` clean; `bun run lint` 79 warnings / 0 errors, unchanged. `oxfmt --check` reports the same two files as on the base commit — both were already non-conforming there, so no reformatting is included.

Postgres was **not** run locally: the change is in the plan step rather than in any SQL, and no statement text moves. CI's `postgres` job covers it.

The worktree symlink trap was checked before trusting any of the above — `readlink -f templates/saas-starter/node_modules/gemi` resolves inside this worktree, not the main checkout.



---

## Review round 1

The blocking finding was right, and chasing it found that the to-one pin was weaker than it read.

**The hit branch now short-circuits the row already linked here.** #379 gives the bare `connect` an
`alreadyLinked` guard and leaves this branch clear-then-repointing, which pulls the two spellings
apart again. The repair belongs here and is free here: the `findUnique` above already selects the
child's foreign key, so the comparison costs no statement. Gated on `displaces` — on a to-many
there is no clear, so the repoint writes the value already there, and skipping it would be an
unmeasured change to a branch this issue is not about (and would take the to-many pin's mutation
check with it).

**The to-one fixture was degenerate, and that is why it was fragile.** Under `scope: () => ({
folderId: 2 })` the only cover the policy can see is one already pointing at folder 2 — so the only
reachable `connect` is of the already-linked row, the marked `update` never ran, and the assertion
turned on which way two unrelated refusals happened to fall. Measured: with the fix reverted *and*
the short-circuit in place, that pin passed.

The scope is now `{ folderId: { in: [2, 3] } }` (`scopeOwnedFields` takes top-level keys, so the
guard still fires on `folderId`) and cover 56 starts on folder 3. Both spellings then perform a real
repoint through the guard and both resolve — pinned against the literal `"resolved"`, not only
against each other. That makes the pin **independent of #372/#379**: neither spelling is already
linked, so an already-linked short-circuit on either side cannot separate them. The already-linked
case is pinned separately, immediately after, as what the new short-circuit buys.

**Prisma parity for the short-circuit** is recorded as differential case `M15e to-one
connectOrCreate of the row already linked changes nothing`. Net nothing on both sides, so it would
be green either way — it is the parity record, since the divergence the short-circuit fixes is only
visible through a policy and the harness has none.

**Two reasons corrected, both re-measured on this fixture rather than repeated.** A miss under a
`scope` with no `onCreate` is refused by `assertCreateCovered` before anything is written:

```
connectOrCreate { where: { id: 999 }, create: { label: "made" } }
  -> UnsupportedQueryError: gemi ORM does not support 'create' yet (Note.create).
     Note has a policy that scopes reads but no 'onCreate' …
```

So `.resolves.toBeDefined()` is what catches a fall-through and the row count is defence in depth;
and `docs/orm.md` now names `connectOrCreate`'s **hit** branch rather than the operand whole, with
the refusal quoted. `docs/llms-full.txt` re-synced (`docs-scope.test.ts` asserts byte equality).

**Deferred:** #386's `childField` → `childFields` rename. #386 is not on `main`, so the new names
cannot be referenced from here; the two references this branch adds (the ORM-authored list and the
new `sameKey` comparison) become `childFields` and `childFields.every(...)` at merge time.

### Coverage after the round

```
packages/gemi     typecheck                        clean
packages/gemi     bun --bun vitest run             120 files, 3110 passed | 1 skipped
packages/gemi     oxlint orm --deny-warnings       0 warnings, 0 errors
saas-starter      TZ=UTC vitest run app/models     20 passed | 3 skipped, 794 passed | 133 skipped
saas-starter      bun run test:types               116 passed, no type errors
```

794 rather than 793: the new differential case. Both mutation checks re-run — reverting
`[childField]` fails the to-many pin *and* the to-one equality (`ScopeEscapeError` where `connect`
resolves); reverting the short-circuit fails the already-linked pin with `RecordNotFoundError`.
