### PR TITLE
Close #372: a nested connect of the row already linked writes nothing

### DIFF
--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -2008,11 +2008,26 @@ function planForeignSide(
    * right in the table and wrong in the statements** (#372). `clearLinks` nulls
    * the very row the caller named and the repoint puts the key straight back,
    * so the committed state agrees — and that is all `M15b` could see. The two
-   * statements in between are not harmless: with a child whose policy scopes on
-   * *its own foreign key* (`{ folderId: 2 }`), the clear puts the row outside
-   * the scope the repoint then has to select it by, so the repoint matches
-   * nothing and the whole call raises `RecordNotFoundError` naming a model and
-   * an operation the caller never wrote. A call that worked before #361.
+   * statements in between are not harmless. **The repoint has to re-select the
+   * row by the column the clear just changed, so it fails whenever anything in
+   * that `where` depends on the old value** — and there are two ways to get
+   * one, not just the policy shape #372 was reported through:
+   *
+   *   - a child whose policy scopes on *its own foreign key*
+   *     (`{ folderId: 2 }`) — the scope is `AND`ed into the repoint's `where`,
+   *     and the clear has just moved the row out of it;
+   *   - **no policy anywhere**, when the caller names the row *by* that foreign
+   *     key (`connect: { folderId: 2 }`). `assertNamedRows` accepts that
+   *     operand because the column is in `uniques`, which is the same fact that
+   *     makes the relation a to-one in the first place — and then the caller's
+   *     own `where` is the thing the clear invalidates.
+   *
+   * Either way the repoint matches nothing and the whole call raises
+   * `RecordNotFoundError` naming a model and an operation the caller never
+   * wrote. A call that worked before #361. The second shape is what makes this
+   * a plain correctness bug rather than a policy interaction, and it is why the
+   * differential can pin it at all: `M15e` in `writes.differential.test.ts` is
+   * that spelling, `error` against `ok`, with no policy in it.
    *
    * So the named row is resolved first and the operand short-circuits when it
    * already points here — {@link alreadyLinked}. That is Prisma's own shape
@@ -2643,9 +2658,15 @@ async function clearLinks(
  * and the same answer read from the other end of the key: on the owning side
  * the row that must not be cleared is the one being written, here it is the one
  * being named. Both exist because clearing a row and then selecting it by the
- * column just cleared is a contradiction the moment a policy scopes on that
- * column, and both match Prisma, which issues no write for an already-linked
- * `connect` from either end.
+ * column just cleared is a contradiction the moment anything in that `where`
+ * depends on the old value — a policy scoping on the column, or a caller who
+ * named the row by it.
+ *
+ * **Prisma issues no write for an already-linked `connect` from either end, and
+ * only this end matches that outright.** The owning side skips the *clear* and
+ * still emits the repoint — {@link displaceSibling}'s docblock says so in plain
+ * terms, and that residual divergence is #370's class, not something #363/#375
+ * closed. Do not read the symmetry above as parity.
  *
  * **Un-pre-scoped, so the child's own policies decide what this can see** — the
  * same rule every other statement in this step follows, and it is what makes

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -2001,19 +2001,42 @@ function planForeignSide(
    *
    *     connect onto an empty to-one          attaches           agreed already
    *     connect a child of another parent     repoints it        agreed already
-   *     connect the row already linked here   no net change      agreed already
+   *     connect the row already linked here   writes nothing     see below
    *     connect onto an occupied to-one       displaces          the divergence
    *
-   * The third is worth its own line, because the clear and the link cross on
-   * it: `clearLinks` nulls the very row the caller named, and the update below
-   * puts the key straight back. One statement wasted on a call that changes
-   * nothing, and the alternative — excluding the named row from the clear —
-   * would need the caller's key resolved against the child before the clear can
-   * be written, which is a lookup on every `connect` to save one on a rare one.
+   * **The third is the one the clear and the link cross on, and #361 got it
+   * right in the table and wrong in the statements** (#372). `clearLinks` nulls
+   * the very row the caller named and the repoint puts the key straight back,
+   * so the committed state agrees — and that is all `M15b` could see. The two
+   * statements in between are not harmless: with a child whose policy scopes on
+   * *its own foreign key* (`{ folderId: 2 }`), the clear puts the row outside
+   * the scope the repoint then has to select it by, so the repoint matches
+   * nothing and the whole call raises `RecordNotFoundError` naming a model and
+   * an operation the caller never wrote. A call that worked before #361.
+   *
+   * So the named row is resolved first and the operand short-circuits when it
+   * already points here — {@link alreadyLinked}. That is Prisma's own shape
+   * rather than a repair invented for the scope: measured on 6.19.2/SQLite with
+   * query logging, `folder.update({ data: { cover: { connect: { id: 30 } } } })`
+   * where cover 30 already holds folder 2 logs **four selects and no `UPDATE`**
+   * between its `BEGIN` and `COMMIT`, where the same call onto an occupied
+   * folder logs the incumbent clear and the repoint. The lookup itself is
+   * Prisma's too — every `connect` above begins by selecting the operand's row
+   * with its foreign key in the projection.
+   *
+   * #361 declined this as "a lookup on every `connect` to save one write on a
+   * rare one", which was the right trade for the fact it had in view. Two
+   * things changed it: the write it saves is a live failure rather than a
+   * redundancy, and the lookup is not on every `connect` — only where
+   * `displaces` holds, which is a to-one, so every many-to-one and every
+   * to-many `connect` costs exactly what it did.
    *
    * **A miss detaches nothing**, which is Prisma's answer (P2025, nothing
-   * written) and is not a special case here: the `update` below raises, and the
-   * clear is inside the transaction the nested steps already run in.
+   * written) and is not a special case here: a row the lookup cannot find is
+   * left to the repoint, which raises, and the clear is inside the transaction
+   * the nested steps already run in. That covers the row that does not exist
+   * and the row this caller's policies hide alike — both read as absent, and
+   * both get the answer they had before this change.
    */
   out.after.push({
     relation: relation.name,
@@ -2022,11 +2045,35 @@ function planForeignSide(
       const parent = rows[0];
       if (!parent) return;
 
+      // `displaces` is only ever true on a to-one, where the array spelling is
+      // refused above — so this is one extra select at most, never one per item.
+      const pending: unknown[] = [];
+      for (const item of listOf(at(args))) {
+        if (
+          displaces &&
+          (await alreadyLinked(
+            relation.model,
+            childField,
+            item,
+            parent[parentField],
+            executor,
+          ))
+        ) {
+          continue;
+        }
+        pending.push(item);
+      }
+
+      // Nothing left to link means nothing to displace either: the only row that
+      // could hold this parent's key is the one the caller named, and it holds
+      // it already. Returning here is what makes the call write nothing at all.
+      if (pending.length === 0) return;
+
       if (displaces) {
         await clearLinks(relation.model, childField, parent[parentField], executor);
       }
 
-      for (const item of listOf(at(args))) {
+      for (const item of pending) {
         await executor.exec(
           relation.model,
           "update",
@@ -2586,6 +2633,53 @@ async function clearLinks(
     false,
     [field],
   );
+}
+
+/**
+ * **Whether the row a `connect` named already points at this parent** — the
+ * question that turns a clear-then-repoint into no statements at all (#372).
+ *
+ * The foreign-side twin of the `sameKey` test inside {@link displaceSibling},
+ * and the same answer read from the other end of the key: on the owning side
+ * the row that must not be cleared is the one being written, here it is the one
+ * being named. Both exist because clearing a row and then selecting it by the
+ * column just cleared is a contradiction the moment a policy scopes on that
+ * column, and both match Prisma, which issues no write for an already-linked
+ * `connect` from either end.
+ *
+ * **Un-pre-scoped, so the child's own policies decide what this can see** — the
+ * same rule every other statement in this step follows, and it is what makes
+ * the miss answer fall out rather than needing a branch. A row that does not
+ * exist and a row this caller cannot see both read as absent, so both are
+ * treated as "not linked here" and left to the repoint, which raises
+ * `RecordNotFoundError` for them exactly as it did before.
+ *
+ * Getting that direction backwards would be the expensive mistake: a lookup
+ * that ignored the scope could answer "already linked" for another tenant's row
+ * and make the whole operand a silent no-op, which is a `connect` that reports
+ * success and links nothing.
+ *
+ * `findUnique` rather than `findFirst` because `assertNamedRows` has already
+ * run `matchUniqueKey` over this operand — the same lookup, and the same
+ * spelling, that `connectOrCreate`'s hit branch uses one screen up.
+ */
+async function alreadyLinked(
+  model: string,
+  field: string,
+  where: unknown,
+  value: unknown,
+  executor: RelationExecutor,
+): Promise<boolean> {
+  const named = (await executor.exec(
+    model,
+    "findUnique",
+    { where, select: { [field]: true } },
+    false,
+  )) as Record<string, unknown> | null;
+
+  if (named === null || named === undefined) return false;
+
+  return sameKey(named[field], value);
 }
 
 /**

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -1108,8 +1108,17 @@ describe("policies on nested writes", () => {
      * The fix resolves the named row first and short-circuits, which is also
      * what Prisma does — the same call on a generated 6.19.2 client logs four
      * selects and no `UPDATE`. So the assertion is that this succeeds and the
-     * link survives, which is exactly what the same call answers with no policy
-     * at all.
+     * link survives, which is what this call answers when the operand is
+     * `{ id: 56 }` and no policy is registered.
+     *
+     * **The scope is one way to reach the crossing, not the only one.** The
+     * repoint fails whenever anything in its `where` depends on the value the
+     * clear just nulled, and a caller who spells the operand as
+     * `connect: { folderId: 2 }` supplies that himself — no policy needed.
+     * That shape is pinned in the differential as `M15e`, where it shows up as
+     * `error` against `ok`; this file cannot host it, because it is
+     * SQLite-only by construction (its `beforeAll` builds its own `sqlite://`
+     * workspace, so the Postgres job never reaches these three tests).
      *
      * Read this next to `"a foreign-key scope allows relation operands the ORM
      * keyed"` further down, which is the same scope on the to-many side and

--- a/templates/saas-starter/app/models/nested-write-policies.test.ts
+++ b/templates/saas-starter/app/models/nested-write-policies.test.ts
@@ -1089,6 +1089,185 @@ describe("policies on nested writes", () => {
         [55, null],
       ]);
     });
+
+    /**
+     * **`connect` naming the row that is already linked here, under a child
+     * scoped on its own foreign key** — #372, and the case #361's displacement
+     * broke without any test being able to see it.
+     *
+     * `M15b` pins this call in the differential and stays green either way,
+     * because it reads the *table*: `clearLinks` nulled the named row and the
+     * repoint put the key straight back, so the committed state agreed with
+     * Prisma's. What it could not see is that the two statements contradict each
+     * other the moment a policy scopes on the column they both write. The clear
+     * moves the row out of `{ folderId: 2 }`; the repoint has to select it *by*
+     * `{ folderId: 2 }`; so the repoint matched nothing and the call raised
+     * `RecordNotFoundError: No Cover found (Cover.update)` — a model and an
+     * operation the caller never wrote, on a call that worked before #361.
+     *
+     * The fix resolves the named row first and short-circuits, which is also
+     * what Prisma does — the same call on a generated 6.19.2 client logs four
+     * selects and no `UPDATE`. So the assertion is that this succeeds and the
+     * link survives, which is exactly what the same call answers with no policy
+     * at all.
+     *
+     * Read this next to `"a foreign-key scope allows relation operands the ORM
+     * keyed"` further down, which is the same scope on the to-many side and
+     * where `set` is still refused: the two answers are different because
+     * `set`'s *link* half deliberately does not name its column as ORM-authored,
+     * so it is stopped by the guard before it can reach the scope. `connect`
+     * passes the guard (#98) and used to fail on the scope instead.
+     */
+    test("connect of the row already linked here survives a key scope", async () => {
+      class KeyScoped extends Model {
+        static $schema = coverSchema;
+        static $policies = [{ scope: () => ({ folderId: 2 }) } as ModelPolicy];
+      }
+      register("Cover", KeyScoped);
+
+      try {
+        await seedFolder();
+        await raw.unsafe(
+          `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+            `VALUES (56, 2, 'already', 7)`,
+        );
+
+        await Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { cover: { connect: { id: 56 } } },
+          }),
+        );
+
+        const covers: any = await raw.unsafe(
+          `SELECT "id", "folderId" FROM "Cover" ORDER BY "id"`,
+        );
+        expect([...covers].map((cover: any) => [cover.id, cover.folderId])).toEqual([
+          [56, 2],
+        ]);
+      } finally {
+        register("Cover", Cover);
+      }
+    });
+
+    /**
+     * ...and it succeeds by **writing nothing**, which is the half the table
+     * cannot show and the half that fixes the case above.
+     *
+     * Two repairs reach the assertion in the test before this one. Excluding the
+     * named row from the clear leaves the repoint in place, writing the value
+     * that is already there; short-circuiting the whole operand issues neither.
+     * Both leave `[[56, 2]]` behind, and only the second is what Prisma does —
+     * measured on 6.19.2/SQLite with `log: [{ emit: "event", level: "query" }]`,
+     * the call is `BEGIN IMMEDIATE`, four selects, `COMMIT`, with no `UPDATE`
+     * anywhere in it, where the same `connect` onto an *occupied* folder logs
+     * the incumbent clear and the repoint.
+     *
+     * The difference is reachable rather than theoretical: a child carrying
+     * `@updatedAt` would have its stamp bumped by the repoint on a call Prisma
+     * does not write at all. `Cover` has no such column — which is why this is
+     * asserted on the writes rather than on the row.
+     *
+     * **Counted through `onUpdate` rather than through the SQL**, which is not
+     * merely convenient: every write to `Cover` on this path goes through
+     * `Cover`'s own `$exec` and therefore through its policies, so a hook that
+     * counts sees the clear's `updateMany` and the repoint's `update` alike —
+     * `MUTATING` in `policy.ts` carries both. Intercepting statements would have
+     * to reach inside the transaction the nested steps run in, where
+     * `database.sql` is no longer the object issuing them.
+     *
+     * The occupied-folder call is in the same test as the control, so the
+     * counter is shown to count before it is trusted to count zero.
+     */
+    test("that connect writes nothing, where an occupied folder writes twice", async () => {
+      let updates = 0;
+      class Counted extends Model {
+        static $schema = coverSchema;
+        static $policies = [
+          {
+            scope: (context: any) => ({ orgId: context.user.orgId }),
+            onUpdate: (_context: any, data: any) => {
+              updates++;
+              return data;
+            },
+          } as ModelPolicy,
+        ];
+      }
+      register("Cover", Counted);
+
+      try {
+        await seedFolder();
+        await raw.unsafe(
+          `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+            `VALUES (57, 2, 'already', 7)`,
+        );
+
+        await Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { cover: { connect: { id: 57 } } },
+          }),
+        );
+
+        expect(updates).toBe(0);
+
+        // The control: the same operand where the named row is *not* the one
+        // linked here. Two writes — the incumbent's clear and the repoint — so
+        // the zero above is a measurement rather than a hook that never fires.
+        await raw.unsafe(
+          `INSERT INTO "Cover" ("id", "folderId", "caption", "orgId") ` +
+            `VALUES (58, NULL, 'loose', 7)`,
+        );
+
+        await Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { cover: { connect: { id: 58 } } },
+          }),
+        );
+
+        expect(updates).toBe(2);
+      } finally {
+        register("Cover", Cover);
+      }
+    });
+
+    /**
+     * **The short-circuit is scoped, and getting that backwards is the expensive
+     * mistake** — so it is pinned rather than left to the code comment.
+     *
+     * Cover 50 holds folder 2 and belongs to the other tenant. The lookup that
+     * decides "already linked here" runs through `Cover`'s own `$exec`
+     * un-pre-scoped, so this caller's policies apply and the row reads as
+     * absent — the same rule the repoint beside it follows. The operand is
+     * therefore *not* short-circuited, the clear finds nothing it may touch, and
+     * the repoint raises.
+     *
+     * An unscoped lookup would answer "already linked" here and make the whole
+     * `connect` a silent no-op: a call that reports success, links nothing, and
+     * tells the caller a row they cannot see is theirs. That is strictly worse
+     * than the miss, which is why the direction is asserted.
+     */
+    test("the no-op does not fire for a linked row the caller cannot see", async () => {
+      await seedFolder();
+      await hiddenCover();
+
+      await expect(
+        Model.asUser(OURS, () =>
+          Folder.$exec("update", {
+            where: { id: 2 },
+            data: { cover: { connect: { id: 50 } } },
+          }),
+        ),
+      ).rejects.toThrow(RecordNotFoundError);
+
+      const covers: any = await raw.unsafe(
+        `SELECT "id", "folderId" FROM "Cover" ORDER BY "id"`,
+      );
+      expect([...covers].map((cover: any) => [cover.id, cover.folderId])).toEqual([
+        [50, 2],
+      ]);
+    });
   });
 
   /**

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -736,9 +736,11 @@ const CASES: Case[] = [
 
   // M15 — `connect` onto a to-one that **already has a child** (#361), the
   // neighbour of M14 and the same displacement. Four shapes, and only this one
-  // ever diverged: the three above it — an empty to-one, a steal from another
-  // parent, and the row already linked here — agreed before the fix and are
-  // what kept it hidden.
+  // diverged in the *table*: an empty to-one, a steal from another parent, and
+  // the row already linked here all agreed before the fix, and are what kept it
+  // hidden. "Agreed in the table" is not "agreed" — the third of those was
+  // reaching that agreement through a pair of contradictory statements, which
+  // M15e below names in a spelling the table can see (#372).
   ["M15 to-one connect displaces the incumbent, orphaning it", "update", {
     where: { id: 1 }, data: { profile: { connect: { id: 2 } } },
   }, ["User", "Profile"]],
@@ -746,8 +748,30 @@ const CASES: Case[] = [
   // the caller named and the repoint puts the key straight back. Net nothing,
   // which is Prisma's answer, and the case that would catch a clear scoped to
   // the wrong rows.
+  //
+  // **Green either way, and that is its limit** — it reads the table, and the
+  // table is the same whether the pair of statements fires or neither does.
+  // M15e below is the same crossing named so that the table can see it.
   ["M15b to-one connect of the row already linked changes nothing", "update", {
     where: { id: 1 }, data: { profile: { connect: { id: 1 } } },
+  }, ["User", "Profile"]],
+  // ...and the same call with the operand spelled through the **unique foreign
+  // key itself** (#372). This is M15b's crossing made visible from outside: the
+  // repoint has to re-select the row by `userId`, which is the column the clear
+  // just nulled, so on the base commit it raised `RecordNotFoundError` with the
+  // table unchanged while Prisma answers it — measured on 6.19.2/SQLite, four
+  // selects between `BEGIN` and `COMMIT` and no `UPDATE`.
+  //
+  // No policy is involved, which is the whole reason it belongs here rather
+  // than only in `nested-write-policies.test.ts`: an `error` against an `ok`
+  // is exactly what this harness compares (`M15c` already leans on it matching
+  // raised errors), and that file builds its own `sqlite://` workspace, so its
+  // three #372 tests never run under the Postgres job. This one does.
+  //
+  // `Profile.userId` is `Int? @unique`, so `assertNamedRows` accepts it — the
+  // same fact that makes `profile` a to-one and makes `displaces` true.
+  ["M15e to-one connect of the already-linked row named by its unique foreign key", "update", {
+    where: { id: 1 }, data: { profile: { connect: { userId: 1 } } },
   }, ["User", "Profile"]],
   // A miss detaches nothing — the repoint raises and takes the clear down with
   // it. `notFound` on both sides, so a gemi refusal could not pass for it.


### PR DESCRIPTION
#361 gave the foreign-side `connect` a `clearLinks` so it could displace an incumbent. On the one shape where the caller names the row that is **already** linked, the clear nulls that row and the repoint puts the key straight back. The committed state agrees with Prisma — which is all `M15b` can see — and the two statements contradict each other, because **the repoint has to re-select the row by the column the clear just nulled**.

```
gemi @ 54d4278, Cover scoped { folderId: 2 }, cover 30 already holding folder 2

Folder.$exec("update", { where: { id: 2 }, data: { cover: { connect: { id: 30 } } } })
  -> RecordNotFoundError: No Cover found (Cover.update).
     table unchanged: [[30, 2]]   (the clear went back with the statement)

the same call, tenant-scoped Cover  -> ok
the same call, unpolicied Cover     -> ok
```

The clear moves the row out of `{ folderId: 2 }`; the repoint has to select it *by* `{ folderId: 2 }`; so the repoint matches nothing. Nothing is written either way and the error names a model and an operation the caller never wrote. Before #361 the clear did not run and this call succeeded.

**A policy is one way to put that column into the repoint's `where`, not the only one** — this is a correction from review, and the earlier framing of this PR was narrower than the defect. Anything that makes the `where` depend on the old value reaches the same crossing, including a caller who simply names the row *through* the unique foreign key, with no policy registered anywhere:

```
Cover unpolicied, cover 30 holds folderId 2

Folder.$exec("update", { where: { id: 2 }, data: { cover: { connect: { folderId: 2 } } } })
  -> RecordNotFoundError: No Cover found (Cover.update).   table unchanged: [[30, 2]]
```

`assertNamedRows` accepts that operand because `folderId` is in `uniques` — the same fact that makes the relation a to-one and makes `displaces` true. That shape is `error` against Prisma's `ok` with nothing policy-shaped in it, which is exactly what `writes.differential.test.ts` compares, so it is now pinned there as `M15e` (see **Tests**).

## What Prisma actually does, and how that was established

A scratch `Folder` / `Cover` schema (`Cover.folderId Int? @unique`, `Folder.cover Cover?`) pushed to a throwaway SQLite file, a generated 6.19.2 client, `log: [{ emit: "event", level: "query" }]`, and the table read back after each call. Not from the docs and not from `M15b`, which reads state and cannot see this.

`folder.update({ where: { id: 2 }, data: { cover: { connect: { id: 30 } } } })` where cover 30 already holds folder 2:

```
BEGIN IMMEDIATE
select Cover.id, Cover.folderId  where id = 30             resolve the operand
select Folder.id, Folder.code    where id = 2              the row being written
select Cover.id, Cover.folderId  where folderId in (2)     the incumbent
select Folder.id, Folder.code    where id = 2              the return read
COMMIT
```

**No `UPDATE` anywhere in it.** The same call onto an *occupied* folder — the M15 shape — logs the incumbent read twice, then `update Cover set folderId = null where id in (30)`, then `update Cover set folderId = 2 where id in (31)`. So the two shapes differ in Prisma by two statements, and gemi issued the same two for both.

The rest of the matrix, each measured rather than reasoned from that one:

| call | Prisma |
| --- | --- |
| `connect` the row already linked here | **no writes at all** — four selects between BEGIN and COMMIT |
| `connect` a loose row onto an occupied folder | incumbent cleared, named row repointed |
| `connect` onto an empty folder | repoint only, nothing cleared |
| `connect` a row linked to *another* folder | repoint only, nothing cleared |
| `connectOrCreate` hitting the row already linked here | **no writes at all** |

Two things in that log decided the shape of the fix. The first statement is Prisma resolving the operand's row **with its foreign key in the projection** — on every `connect`, not only this one; and the third shows that Prisma's own no-op path still costs it two selects, so what it skips is the pair of `UPDATE`s and nothing else.

**Correction from review**: an earlier wording of that sentence said gemi's skip is "of the writes, not of the reads". It is not — gemi's `return` sits *before* `clearLinks`, which is a `findMany` as well as an `updateMany`, so on the no-op path gemi issues no incumbent read where Prisma issues one. That is deliberate and safe rather than an oversight (`displaces` requires a nullable **unique** child key, so the named row is provably the only possible holder and the read could only ever return it), and the code comment at the `return` says so. Divergence in reads is not what the differential compares; it is recorded here so the next person holding the two logs side by side is not hunting for a select that was dropped on purpose.

## The diff

`alreadyLinked` sits beside `clearLinks`: one `findUnique` on the named row selecting the foreign key, compared with `sameKey` — the same helper `displaceSibling` uses on the other end of the key. When it answers true the operand contributes nothing: no clear, no repoint, and `pending.length === 0` returns before either.

**Only where `displaces` holds**, which is a to-one with a nullable child key. Every many-to-one and every to-many `connect` — nearly all of them — costs exactly what it did, and the array spelling is refused on a to-one above, so this is one extra select at most and never one per item.

**Un-pre-scoped**, so the child's own policies decide what the lookup can see. That is the same rule the repoint beside it follows and it is what makes the miss answer fall out rather than needing a branch: a row that does not exist and a row the caller cannot see both read as absent, both are treated as "not linked here", and both are left to the repoint, which raises `RecordNotFoundError` exactly as before. `M15c` is unchanged.

The direction matters more than the cost. A lookup that ignored the scope would answer "already linked" for another tenant's row and make the whole operand a silent no-op — a `connect` that reports success, links nothing, and tells the caller a row they cannot see is theirs. That is pinned, not just commented.

### Why not exclude the named row from the clear

That is what #361's commit message ruled out on cost grounds, and it reaches the same green table. It is the wrong repair twice over: it still issues the repoint, so a child carrying `@updatedAt` gets a stamp on a call Prisma does not write at all (#370's divergence class, arriving somewhere it does not have to), and it needs the caller's key resolved against the child *anyway* to build the `NOT`. The lookup it was declining is the one Prisma issues on every `connect` regardless.

#361 declined this trade for the fact it had in view — "a lookup on every `connect` to save one write on a rare one". Two things changed it: the write it saves is a live failure rather than a redundancy, and the lookup is not on every `connect`.

## What is *not* in this PR

`connectOrCreate`'s hit branch reaches the same crossing and fails differently — `ScopeEscapeError`, because that branch does not pass `[childField]` as the ORM-authored column list where `connect` does. That is #373, still open, and it is left alone here deliberately: fixing it is a one-line change on a different statement, and its hit branch already has the row in hand (`found[childField]`), so it needs no lookup of its own. After #373 lands, the branch should short-circuit the same way — verified still failing on this branch:

```
connectOrCreate  [fk-scoped]  -> ScopeEscapeError: Cover.update writes 'folderId', …
```

## Tests

Three in `nested-write-policies.test.ts`, in the `a to-one whose key is on the child` describe beside the existing `connect` displacement pair, on `Cover` — which needed no new fixture. Each was mutation-checked: reverting the code path it covers makes it, and only it, fail.

| test | what it pins | mutation that fails it |
| --- | --- | --- |
| `connect of the row already linked here survives a key scope` | the issue's own call, under `{ folderId: 2 }` | the short-circuit (`displaces &&` → `false &&`) |
| `that connect writes nothing, where an occupied folder writes twice` | that it succeeds by issuing **no write**, not by writing a redundant one | the same |
| `the no-op does not fire for a linked row the caller cannot see` | the lookup is scoped | the lookup's `false` → `true` (pre-scoped) |

The second counts through an `onUpdate` hook rather than through SQL, and that is not merely convenient: every write to `Cover` on this path goes through `Cover`'s own `$exec` and so through its policies, and `MUTATING` in `policy.ts` carries `update` and `updateMany` alike, so the hook sees the clear and the repoint both. Intercepting statements would have to reach inside the transaction the nested steps run in, where `database.sql` is no longer the object issuing them. Its second half is the control — the same operand naming a *loose* row counts 2 — so the zero is a measurement rather than a hook that never fires.

**And one in `writes.differential.test.ts`, added in review.** The first version of this PR argued the differential needed no new case, on the reasoning that `M15b` reads the table and the table is unchanged. That is true of `M15b`'s spelling and false of the defect: name the same row through its unique foreign key and it is `error` against `ok`, which is precisely what this harness compares (`M15c` already leans on it matching raised errors). `Profile.userId Int? @unique` makes it one entry beside `M15b`:

```ts
["M15e to-one connect of the already-linked row named by its unique foreign key", "update", {
  where: { id: 1 }, data: { profile: { connect: { userId: 1 } } },
}, ["User", "Profile"]],
```

Mutation-checked like the rest: with `displaces &&` → `false &&`, **`M15e` fails and `M15`, `M15b`, `M15c`, `M15d` all stay green** —

```
{ at: 'User.update({"where":{"id":1},"data":{"profile":{"connect":{"userId":1}}}})',
- kind: "",         threw: false      (prisma)
+ kind: "notFound", threw: true       (gemi, short-circuit reverted) }
```

It earns its place twice. It is a pin `M15b` structurally cannot be, and it is the only one of the four #372 tests that runs under **Postgres** — `nested-write-policies.test.ts` builds its own `sqlite://` workspace in `beforeAll`, so CI's postgres job never reaches the other three. `M15c`, `M15`, `M15d`, `M14`–`M14d`, `M16` and the whole owning-side `O12`–`O15` block are untouched.

## Verification

`packages/gemi` 3,111 passed / 1 skipped · `saas-starter` 799 passed / 133 skipped, SQLite · `bun run test:types` 116 passed, no type errors · the same suites against a real Postgres 16 via `app/models/postgres.sh`, **1,178 passed** — one more than before, which is `M15e` under the second dialect (the two SQLite differential suites fail-rather-than-skip while `TEST_POSTGRES_URL` is set, which is the harness's own design) · `tsc --noEmit` clean on `packages/gemi` · `oxlint` clean on all three files touched.

## Left to other PRs

- **`connectOrCreate`'s hit branch short-circuit** belongs to **#378**, whose own pin (`expect(paired).toBe(bare)`) is the thing that fails without it. See the cross-PR comment below; the repair is three lines using the `found[childField]` that branch already reads, and it is #378's invariant, not this one's.
- **#386's `childField` → `childFields` rename** is merge-time work. #386 is not on `main`, so those names do not exist on any tree this branch can be built against. `alreadyLinked` will need real generalisation there — `sameKey` stays scalar-only under #386, and a partial tuple match must not count as already-linked.

Closes #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

