### PR TITLE
Close #371: the JSON path filter treats undefined as absent, and refuses null and a numeric segment

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3718,13 +3718,26 @@ implementing them there would answer a query the differential harness has no ora
 expression's meaning, and both dialects take it natively — Postgres's `#>` accepts a `text[]`,
 SQLite's `json_extract` a string — so the feature fits inside invariant 2 rather than bending it.
 
-Three things a path filter refuses, each because answering would be silently wrong rather than
+**On Postgres a path segment is a string, and an array index is spelled as one** —
+`{ path: ["items", "0"] }`, not `["items", 0]`. `#>` takes a `text[]`, so both reach the same
+element; Prisma's generated `path` is `string[]` and its client refuses a number, so gemi refuses
+one too rather than answering a query the differential harness has no oracle for. On SQLite the
+index lives inside the JSONPath string, `"$.items[0]"`.
+
+Four things a path filter refuses, each because answering would be silently wrong rather than
 merely unsupported:
 
 - **The null sentinels.** `{ path: […], equals: DbNull }` is refused. An extracted value
   cannot tell an absent key from a JSON `null` — `#>>` yields SQL NULL for both — so the
   distinction the sentinels exist to make is already gone by the time the comparison happens.
   Filter the column itself: `{ metadata: { equals: DbNull } }`.
+- **A bare `null`, under every operator**, for the same reason and one more. `= NULL` is NULL
+  rather than true, so `{ path: […], equals: null }` would run and match nothing; and under
+  `array_contains`, `x @> NULL` is NULL as well. Prisma *does* answer this one — it extracts with
+  `#>` and compares as `jsonb`, so it reads `null` as the JSON value and returns the rows holding
+  one, the same answer as `equals: JsonNull`. gemi cannot follow it there without a second,
+  Postgres-only implementation of every operator, so it names the limitation instead. A `null`
+  *inside* an `array_contains` document is an ordinary value and still compiles.
 - **A non-string operand to `string_contains` / `string_starts_with` / `string_ends_with`**, for
   the same reason the scalar `contains` refuses one: the pattern would become `%null%`, which runs
   and returns the wrong rows.
@@ -3735,13 +3748,19 @@ merely unsupported:
 An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
 document, which is a filter on the column rather than on a path.
 
+**An `undefined` operand is an absent one**, as it is everywhere else in `where`:
+`{ path: ["a"], equals: undefined }` is the same query as `{ path: ["a"] }`, and gets the same
+refusal — a path needs a filter beside it. That is Prisma's answer to both, and it is what lets a
+filter assembled from a form or a query string carry an unfilled operator without silently
+compiling to a predicate no row can satisfy.
+
 **What the type checks, and what it leaves to run time.** The path filter is typed: `path` takes
 either dialect's grammar, the ten operators are the ones above, and their operand types are the
-ones the compiler will compile. A misspelled operator, a `path` that is not one, a non-string under
-`string_contains`, a sentinel at a path and a `null` at a path are all compile errors. The type
-carries no dialect — the generated artifact does not know which database it will be pointed at —
-so the table above is offered in full on both and the wrong half is refused at run time, naming the
-dialect. The empty path is refused at run time too.
+ones the compiler will compile. A misspelled operator, a `path` that is not one, a numeric path
+segment, a non-string under `string_contains`, a sentinel at a path and a `null` at a path are all
+compile errors. The type carries no dialect — the generated artifact does not know which database
+it will be pointed at — so the table above is offered in full on both and the wrong half is refused
+at run time, naming the dialect. The empty path is refused at run time too.
 
 **An object in a `Json` column's `where` is a filter, never a document.** `{ metadata: { a: 1 } }`
 does not ask for the document `{ a: 1 }` — it asks for the operator `a`, which does not exist, and

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -735,13 +735,26 @@ implementing them there would answer a query the differential harness has no ora
 expression's meaning, and both dialects take it natively — Postgres's `#>` accepts a `text[]`,
 SQLite's `json_extract` a string — so the feature fits inside invariant 2 rather than bending it.
 
-Three things a path filter refuses, each because answering would be silently wrong rather than
+**On Postgres a path segment is a string, and an array index is spelled as one** —
+`{ path: ["items", "0"] }`, not `["items", 0]`. `#>` takes a `text[]`, so both reach the same
+element; Prisma's generated `path` is `string[]` and its client refuses a number, so gemi refuses
+one too rather than answering a query the differential harness has no oracle for. On SQLite the
+index lives inside the JSONPath string, `"$.items[0]"`.
+
+Four things a path filter refuses, each because answering would be silently wrong rather than
 merely unsupported:
 
 - **The null sentinels.** `{ path: […], equals: DbNull }` is refused. An extracted value
   cannot tell an absent key from a JSON `null` — `#>>` yields SQL NULL for both — so the
   distinction the sentinels exist to make is already gone by the time the comparison happens.
   Filter the column itself: `{ metadata: { equals: DbNull } }`.
+- **A bare `null`, under every operator**, for the same reason and one more. `= NULL` is NULL
+  rather than true, so `{ path: […], equals: null }` would run and match nothing; and under
+  `array_contains`, `x @> NULL` is NULL as well. Prisma *does* answer this one — it extracts with
+  `#>` and compares as `jsonb`, so it reads `null` as the JSON value and returns the rows holding
+  one, the same answer as `equals: JsonNull`. gemi cannot follow it there without a second,
+  Postgres-only implementation of every operator, so it names the limitation instead. A `null`
+  *inside* an `array_contains` document is an ordinary value and still compiles.
 - **A non-string operand to `string_contains` / `string_starts_with` / `string_ends_with`**, for
   the same reason the scalar `contains` refuses one: the pattern would become `%null%`, which runs
   and returns the wrong rows.
@@ -752,13 +765,19 @@ merely unsupported:
 An empty path — `[]` or `""` — is refused on both dialects. On Postgres it would extract the whole
 document, which is a filter on the column rather than on a path.
 
+**An `undefined` operand is an absent one**, as it is everywhere else in `where`:
+`{ path: ["a"], equals: undefined }` is the same query as `{ path: ["a"] }`, and gets the same
+refusal — a path needs a filter beside it. That is Prisma's answer to both, and it is what lets a
+filter assembled from a form or a query string carry an unfilled operator without silently
+compiling to a predicate no row can satisfy.
+
 **What the type checks, and what it leaves to run time.** The path filter is typed: `path` takes
 either dialect's grammar, the ten operators are the ones above, and their operand types are the
-ones the compiler will compile. A misspelled operator, a `path` that is not one, a non-string under
-`string_contains`, a sentinel at a path and a `null` at a path are all compile errors. The type
-carries no dialect — the generated artifact does not know which database it will be pointed at —
-so the table above is offered in full on both and the wrong half is refused at run time, naming the
-dialect. The empty path is refused at run time too.
+ones the compiler will compile. A misspelled operator, a `path` that is not one, a numeric path
+segment, a non-string under `string_contains`, a sentinel at a path and a `null` at a path are all
+compile errors. The type carries no dialect — the generated artifact does not know which database
+it will be pointed at — so the table above is offered in full on both and the wrong half is refused
+at run time, naming the dialect. The empty path is refused at run time too.
 
 **An object in a `Json` column's `where` is a filter, never a document.** `{ metadata: { a: 1 } }`
 does not ask for the document `{ a: 1 }` — it asks for the operator `a`, which does not exist, and

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -1259,6 +1259,21 @@ describe("json path filters", () => {
       pgText({ where: { metadata: { path: ["a"], equalz: 1 } } }),
     ).toThrow(/A JSON path filter takes/);
 
+    // `path: undefined` is absent too — the dispatch into this branch tests
+    // `filter.path !== undefined`, so the filter falls through to the column
+    // arm rather than becoming a bare path. That half was already right before
+    // this change; asserted here so the rule holds on both sides of the
+    // dispatch. Prisma answers it the same way — `{ path: undefined,
+    // equals: { a: 1 } }` is a filter on the column there too.
+    const columnArgs = {
+      where: { metadata: { path: undefined, equals: { a: 1 } } },
+    };
+    expect(pgText(columnArgs)).toContain(`"metadata" = $1::text::jsonb`);
+    expect(pgText(columnArgs)).not.toContain("#>>");
+    expect(
+      compileRead(jsonUser, "findMany", columnArgs, postgres).bind(columnArgs),
+    ).toEqual([`{"a":1}`]);
+
     // ...and one live operator beside it is still a filter, so the guard drops
     // keys rather than the whole operand.
     const args = { where: { metadata: { path: ["a"], equals: 1, gt: undefined } } };
@@ -1420,31 +1435,49 @@ describe("json path filters", () => {
    * containment test.
    */
   describe("null at a path is refused", () => {
-    const operators = [
-      "equals",
-      "not",
-      "string_contains",
-      "array_contains",
-      "gt",
-      "lte",
+    /**
+     * **Each row asserts its message, not just `InvalidArgumentError`**, and
+     * that is what pins the two things the class alone cannot see.
+     *
+     * The `string_*` rows already threw before this change, from the non-string
+     * guard, with the `'%null%'` reasoning — so a class assertion passes either
+     * way and leaves the new guard's *placement* unpinned. It sits deliberately
+     * **after** that guard so the better message survives; moving it above used
+     * to leave all 153 tests green while `string_contains: null` silently swapped
+     * its message for the generic one.
+     *
+     * The `array_contains` row asserts the other sentence for the same kind of
+     * reason: that operator does not extract with `#>>`, so its refusal names
+     * the raw bind and `x @> NULL` instead of the text collapse.
+     */
+    const postgresOperators = [
+      ["equals", /null cannot be compared through a JSON path/],
+      ["not", /null cannot be compared through a JSON path/],
+      ["gt", /null cannot be compared through a JSON path/],
+      ["lte", /null cannot be compared through a JSON path/],
+      ["string_contains", /'%null%', which runs and returns the wrong rows/],
+      ["array_contains", /null cannot be tested for containment/],
     ] as const;
 
-    test.each(operators)("%s on postgres", (key) => {
-      expect(() =>
-        pgText({ where: { metadata: { path: ["a"], [key]: null } } }),
-      ).toThrow(InvalidArgumentError);
+    test.each(postgresOperators)("%s on postgres", (key, message) => {
+      const compile = () =>
+        pgText({ where: { metadata: { path: ["a"], [key]: null } } });
+      expect(compile).toThrow(InvalidArgumentError);
+      expect(compile).toThrow(message);
     });
 
     // SQLite offers only the six its dialect answers; the other four raise the
     // dialect refusal first, which is a different message and already pinned.
-    test.each(["equals", "not", "string_ends_with"] as const)(
-      "%s on sqlite",
-      (key) => {
-        expect(() =>
-          sqliteText({ where: { metadata: { path: "$.a", [key]: null } } }),
-        ).toThrow(InvalidArgumentError);
-      },
-    );
+    test.each([
+      ["equals", /null cannot be compared through a JSON path/],
+      ["not", /null cannot be compared through a JSON path/],
+      ["string_ends_with", /'%null%', which runs and returns the wrong rows/],
+    ] as const)("%s on sqlite", (key, message) => {
+      const compile = () =>
+        sqliteText({ where: { metadata: { path: "$.a", [key]: null } } });
+      expect(compile).toThrow(InvalidArgumentError);
+      expect(compile).toThrow(message);
+    });
 
     /**
      * The load-bearing negative: only the *bare* operand is refused. A `null`
@@ -1460,14 +1493,21 @@ describe("json path filters", () => {
       ]);
     });
 
-    /** Nothing of it reaches the SQL, which is the actual defect. */
+    /**
+     * Nothing of it reaches the SQL, which is the actual defect. The message is
+     * asserted alongside because a bare `text === ""` passes for *any* throw,
+     * including one from an unrelated future guard — it would say "no SQL was
+     * built" where it means "this guard built no SQL".
+     */
     test("it never becomes a bound NULL", () => {
       let text = "";
+      let message = "";
       try {
         text = pgText({ where: { metadata: { path: ["a"], equals: null } } });
-      } catch {
-        // expected
+      } catch (error) {
+        message = (error as Error).message;
       }
+      expect(message).toMatch(/null cannot be compared through a JSON path/);
       expect(text).toBe("");
     });
   });
@@ -1525,6 +1565,29 @@ describe("json path filters", () => {
     expect(() =>
       pgText({ where: { metadata: { path: ["a", null], equals: "x" } } }),
     ).toThrow(/path\[1\] is null/);
+
+    // Every other non-string reads grammatically too — `a ${typeof part}`
+    // alone gives "a undefined" and "a object", and the number is the only
+    // segment it happens to fit.
+    expect(() =>
+      pgText({ where: { metadata: { path: ["a", undefined], equals: "x" } } }),
+    ).toThrow(/path\[1\] is undefined\./);
+    expect(() =>
+      pgText({ where: { metadata: { path: ["a", { b: 1 }], equals: "x" } } }),
+    ).toThrow(/path\[1\] is an object\./);
+    expect(() =>
+      pgText({ where: { metadata: { path: ["a", ["b"]], equals: "x" } } }),
+    ).toThrow(/path\[1\] is an array\./);
+
+    // And the array-index advice is advice for *one* mistake, so it is emitted
+    // for the number and withheld from the rest — a caller who wrote `null`
+    // did not write an index.
+    expect(() =>
+      pgText({ where: { metadata: { path: ["items", 0], equals: "x" } } }),
+    ).toThrow(/write \["items", "0"\] rather than \["items", 0\]/);
+    expect(() =>
+      pgText({ where: { metadata: { path: ["a", null], equals: "x" } } }),
+    ).not.toThrow(/An array index is a key too/);
 
     // The string spelling reaches the element, and the bound path is identical
     // to what the numeric one used to produce — which is why this is a

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -1226,6 +1226,52 @@ describe("json path filters", () => {
   });
 
   /**
+   * #371, the first of three. `applied` was built from `Object.keys` alone, so
+   * the one branch in this file that did **not** treat `undefined` as absent
+   * was the one where the operand goes on to be bound: the scalar loop skips it
+   * (`if (operand === undefined …) continue`) and the dispatch into this branch
+   * skips a `path` that is `undefined`.
+   *
+   * The two spellings therefore disagreed — the key omitted got a loud, correct
+   * refusal, and the key present-but-undefined compiled to `= NULL`, a
+   * predicate no row can satisfy. An optional filter assembled from a form or a
+   * query string carries exactly that.
+   *
+   * Prisma answers both identically: P2019 *"A JSON path cannot be set without
+   * a scalar filter."* Measured on a generated 6.19.2 client against Postgres.
+   */
+  test("an undefined operand is absent, so the path is bare", () => {
+    for (const key of ["equals", "not", "string_contains", "array_contains"]) {
+      expect(() =>
+        pgText({ where: { metadata: { path: ["a"], [key]: undefined } } }),
+      ).toThrow(/needs a filter beside it/);
+    }
+
+    // A *misspelled* key holding `undefined` is absent too, so the bare-path
+    // refusal wins over the unknown-operator one — which is the order Prisma
+    // resolves them in: `{ path: ["a"], equalz: undefined }` answers P2019
+    // there, and `{ path: ["a"], equalz: 1 }` answers *"Unknown argument
+    // `equalz`. Did you mean `equals`?"*.
+    expect(() =>
+      pgText({ where: { metadata: { path: ["a"], equalz: undefined } } }),
+    ).toThrow(/needs a filter beside it/);
+    expect(() =>
+      pgText({ where: { metadata: { path: ["a"], equalz: 1 } } }),
+    ).toThrow(/A JSON path filter takes/);
+
+    // ...and one live operator beside it is still a filter, so the guard drops
+    // keys rather than the whole operand.
+    const args = { where: { metadata: { path: ["a"], equals: 1, gt: undefined } } };
+    expect(pgText(args)).toContain(`("metadata" #>> $1) = $2`);
+    // `gt` compiles to `cast(… as real) >`, so its absence is visible.
+    expect(pgText(args)).not.toContain("as real");
+    expect(compileRead(jsonUser, "findMany", args, postgres).bind(args)).toEqual([
+      `{"a"}`,
+      "1",
+    ]);
+  });
+
+  /**
    * `array_contains` and the numeric comparisons are refused by Prisma's own
    * client on SQLite — *"Unknown argument"* — so implementing them would make
    * gemi answer a query the oracle cannot check. The message says it is a
@@ -1352,6 +1398,81 @@ describe("json path filters", () => {
   });
 
   /**
+   * #371, the second of three. `null` fell between `assertJsonOperand`'s two
+   * branches — the string branch refuses a non-string, the object branch tested
+   * `operand !== null` first — so it reached the binder and compiled to
+   * `("metadata" #>> $1) = $2` bound to NULL. `= NULL` is NULL rather than true
+   * on both dialects: the query runs, raises nothing, and matches no row.
+   *
+   * **Prisma does answer this one**, which is why it is a refusal rather than a
+   * gap being closed. Measured on a generated 6.19.2 client against Postgres:
+   * `{ path: ["a"], equals: null }` compiles to
+   * `("metadata"#>ARRAY[$1]::text[])::jsonb::jsonb = $2` and returns the rows
+   * whose `a` is the JSON value `null` — byte-identical SQL and identical rows
+   * to `equals: Prisma.JsonNull`. It can, because it extracts with `#>` and
+   * compares as `jsonb`; gemi extracts with `#>>`, which yields SQL NULL for an
+   * absent key and a JSON null alike. That is the same collapse the sentinel
+   * refusal above names, so the same answer follows.
+   *
+   * `array_contains` is refused too, and its mechanism is the other one:
+   * `jsonArrayContains` binds the operand raw, so `null` arrives as SQL NULL
+   * and `x @> NULL` is NULL. Prisma binds it as the JSON value and runs a real
+   * containment test.
+   */
+  describe("null at a path is refused", () => {
+    const operators = [
+      "equals",
+      "not",
+      "string_contains",
+      "array_contains",
+      "gt",
+      "lte",
+    ] as const;
+
+    test.each(operators)("%s on postgres", (key) => {
+      expect(() =>
+        pgText({ where: { metadata: { path: ["a"], [key]: null } } }),
+      ).toThrow(InvalidArgumentError);
+    });
+
+    // SQLite offers only the six its dialect answers; the other four raise the
+    // dialect refusal first, which is a different message and already pinned.
+    test.each(["equals", "not", "string_ends_with"] as const)(
+      "%s on sqlite",
+      (key) => {
+        expect(() =>
+          sqliteText({ where: { metadata: { path: "$.a", [key]: null } } }),
+        ).toThrow(InvalidArgumentError);
+      },
+    );
+
+    /**
+     * The load-bearing negative: only the *bare* operand is refused. A `null`
+     * inside a document under `array_contains` is an ordinary JSON value, and
+     * containment against `[null]` is a question Postgres answers.
+     */
+    test("a null inside an array_contains document still compiles", () => {
+      const args = { where: { metadata: { path: ["a"], array_contains: [null] } } };
+      expect(pgText(args)).toContain(`("metadata" #> $1) @> $2::jsonb`);
+      expect(compileRead(jsonUser, "findMany", args, postgres).bind(args)).toEqual([
+        `{"a"}`,
+        [null],
+      ]);
+    });
+
+    /** Nothing of it reaches the SQL, which is the actual defect. */
+    test("it never becomes a bound NULL", () => {
+      let text = "";
+      try {
+        text = pgText({ where: { metadata: { path: ["a"], equals: null } } });
+      } catch {
+        // expected
+      }
+      expect(text).toBe("");
+    });
+  });
+
+  /**
    * `[]` on Postgres extracts the whole document — `[].every` is vacuously
    * true, so it passed the grammar check — and `""` on SQLite raises inside
    * `json_extract` at execution time. Neither is a path.
@@ -1377,6 +1498,49 @@ describe("json path filters", () => {
       "{\"n\"}",
       2,
     ]);
+  });
+
+  /**
+   * #371, the third of three, and the one that was a *choice* rather than a
+   * defect. `assertPathShape` accepted `typeof part === "number"`, where
+   * Prisma's generated `path` on Postgres is `string[]` — so gemi answered a
+   * query the oracle could not express, which is the situation
+   * `compileJsonFilter`'s docblock refuses on purpose for the SQLite operators:
+   * "implementing them would make gemi answer a query the oracle cannot, which
+   * is precisely where a differential test stops being able to check anything."
+   *
+   * Prisma's refusal is a run-time one as well as a type one. Measured on a
+   * generated 6.19.2 client: `path: ["items", 0]` answers *"Argument `path`:
+   * Invalid value provided. Expected String, provided Int."* before any SQL is
+   * built.
+   *
+   * **Nothing is lost by narrowing**, which is what makes it the cheap answer:
+   * `#>` takes a `text[]`, so `["items", "0"]` reaches the same array element.
+   * Both spellings bind the identical path on Prisma and on gemi.
+   */
+  test("a path segment is a string, matching the oracle", () => {
+    expect(() =>
+      pgText({ where: { metadata: { path: ["items", 0], equals: "x" } } }),
+    ).toThrow(/path\[1\] is a number/);
+    expect(() =>
+      pgText({ where: { metadata: { path: ["a", null], equals: "x" } } }),
+    ).toThrow(/path\[1\] is null/);
+
+    // The string spelling reaches the element, and the bound path is identical
+    // to what the numeric one used to produce — which is why this is a
+    // narrowing rather than a removal.
+    const args = { where: { metadata: { path: ["items", "0"], equals: "x" } } };
+    expect(pgText(args)).toContain(`("metadata" #>> $1) = $2`);
+    expect(compileRead(jsonUser, "findMany", args, postgres).bind(args)).toEqual([
+      `{"items","0"}`,
+      "x",
+    ]);
+
+    // SQLite is untouched: its grammar is a JSONPath string, where an index is
+    // spelled inside the string and never reaches this check.
+    expect(() =>
+      sqliteText({ where: { metadata: { path: "$.items[0]", equals: "x" } } }),
+    ).not.toThrow();
   });
 
   test("two filters on one path are ANDed", () => {

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -974,8 +974,23 @@ function compileJsonFilter(
   assertPathShape(schema, field, filter.path, context);
 
   const path: Binder = (args) => locate(args)?.path;
+  // **An `undefined` operand is an absent one**, which is the rule the scalar
+  // operator loop already follows (`if (operand === undefined …) continue`) and
+  // the rule the dispatch above follows for `path` itself
+  // (`filter.path !== undefined`). Building `applied` from `Object.keys` alone
+  // made this branch the one place that broke it: a filter assembled from a
+  // form or a query string carries `equals: undefined` for the field nobody
+  // filled in, and that compiled to `= NULL` — a predicate no row can satisfy —
+  // where the same query with the key simply omitted got the bare-path refusal
+  // below.
+  //
+  // Prisma answers both spellings identically. Measured on a generated 6.19.2
+  // client against Postgres: `{ path: ["a"], equals: undefined }` and
+  // `{ path: ["a"] }` both raise P2019 *"A JSON path cannot be set without a
+  // scalar filter."*, and `{ path: ["a"], equals: 1, gt: undefined }` compiles
+  // the `equals` alone.
   const applied = Object.keys(filter)
-    .filter((key) => key !== "path")
+    .filter((key) => key !== "path" && filter[key] !== undefined)
     .sort();
 
   if (applied.length === 0) {
@@ -1078,8 +1093,8 @@ function compileJsonFilter(
 /**
  * What each JSON filter will accept as its operand.
  *
- * Two defects, both of them the shape the scalar path is already careful about
- * and both silent:
+ * Three defects, all of them the shape the scalar path is already careful about
+ * and all silent:
  *
  *   - **The string filters had no non-string guard.** Their scalar siblings
  *     refuse one, with a comment explaining that `String(null)` makes the
@@ -1092,14 +1107,19 @@ function compileJsonFilter(
  *     binds `String(raw)` because `#>>` yields text, so `equals: { b: 1 }` bound
  *     the string `"[object Object]"` and matched nothing.
  *
- * The second is a **refusal rather than an implementation**, deliberately.
+ *   - **`null` fell between the two.** The string branch refuses a non-string
+ *     and the object branch tests `operand !== null` first, so `equals: null`
+ *     reached the binder and compiled to `= NULL` — see the guard below.
+ *
+ * The last two are a **refusal rather than an implementation**, deliberately.
  * Prisma does accept an object or an array there, and answering it properly
  * means the `#>` + `::jsonb` form `array_contains` already uses — which is
  * Postgres-only, so implementing it would give SQLite either a second wrong
  * answer or a silent divergence. Refusing names the limitation on both
  * dialects, which is what this file does everywhere else it cannot answer.
- * `array_contains` is exempt because containment is precisely the operator that
- * takes a document.
+ * `array_contains` is exempt from the object rule because containment is
+ * precisely the operator that takes a document — but not from the `null` one,
+ * because a bound SQL NULL is not a JSON `null` on either side of `@>`.
  */
 function assertJsonOperand(
   key: string,
@@ -1125,11 +1145,54 @@ function assertJsonOperand(
     );
   }
 
+  // **`null` is refused under every path operator, and it is a refusal rather
+  // than a gap.**
+  //
+  // Measured on a generated 6.19.2 client against Postgres, with query-event
+  // logging and the rows read back: Prisma extracts with `#>` and compares as
+  // `jsonb`, so `{ path: ["a"], equals: null }` asks for the JSON value `null`
+  // and returns the rows that hold one — the same SQL and the same rows as
+  // `equals: Prisma.JsonNull`. gemi extracts with `#>>`, which yields *text*,
+  // and NULL for an absent key and for a JSON null alike. That collapse is
+  // exactly why the sentinels are refused a few lines above, and it leaves this
+  // operand nothing to mean.
+  //
+  // Left alone it reached the binder and compiled to `("metadata" #>> $1) = $2`
+  // bound to NULL — `= NULL` is NULL rather than true on both dialects, so the
+  // query ran, raised nothing, and matched no row where Prisma matched some.
+  // The `string_contains` guard above names that failure in this file's own
+  // words, "runs and returns the wrong rows"; only the arithmetic differs.
+  //
+  // `array_contains` is included rather than exempt. It takes the `#>` form, so
+  // the collapse argument does not apply to it — but `jsonArrayContains` binds
+  // `null` as SQL NULL, and `x @> NULL` is NULL too. Prisma binds it as the
+  // JSON value and runs a real containment test.
+  //
+  // Answering any of them properly means the `#> … ::jsonb` form on Postgres
+  // and `json_type` on SQLite, which is a second implementation of the same
+  // operator per dialect rather than a guard — the same reason the object
+  // operand below is refused instead of compiled.
+  if (operand === null) {
+    throw new InvalidArgumentError(
+      `where.${field.name}.${key}`,
+      schema.name,
+      context.operation,
+      `null cannot be compared through a JSON path: the extraction yields ` +
+        `SQL NULL for an absent key and for a JSON null alike, and the ` +
+        `comparison against it is NULL rather than true — the query would run ` +
+        `and match nothing. Prisma reads it as the JSON value null and does ` +
+        `answer it; gemi does not yet. Filter the column itself — ` +
+        `{ ${field.name}: { equals: Prisma.JsonNull } } — or test the path ` +
+        `against the value you mean.`,
+    );
+  }
+
   if (key === "array_contains" || stringly) return;
 
   // `equals`, `not`, and the four numeric comparisons all compare an extracted
-  // scalar against one bound value.
-  if (operand !== null && typeof operand === "object") {
+  // scalar against one bound value. No `!== null` here: `typeof null` is
+  // `"object"`, and the guard above has already refused it with its own reason.
+  if (typeof operand === "object") {
     throw new UnsupportedQueryError(
       `where.${field.name}.${key}`,
       schema.name,
@@ -1209,7 +1272,7 @@ function jsonComparison(
   );
 }
 
-/** The path is a string on SQLite and an array of keys on Postgres. */
+/** The path is a string on SQLite and an array of string keys on Postgres. */
 function assertPathShape(
   schema: ModelSchema,
   field: FieldSchema,
@@ -1246,9 +1309,41 @@ function assertPathShape(
 
   if (got === wanted) {
     if (wanted !== "array") return;
-    if ((path as unknown[]).every((part) => typeof part === "string" || typeof part === "number")) {
-      return;
-    }
+
+    // **Every segment is a string, and the number that used to be allowed here
+    // was a superset of the oracle.** Prisma's generated `path` on Postgres is
+    // `string[]`, and its client refuses a number at run time as well as at
+    // compile time — measured on 6.19.2: `path: ["items", 0]` answers
+    // *"Argument `path`: Invalid value provided. Expected String, provided
+    // Int."* before any SQL is built.
+    //
+    // Refused rather than kept, because this file already states the rule that
+    // decides it: answering a query the oracle cannot express is "precisely
+    // where a differential test stops being able to check anything"
+    // (`compileJsonFilter`'s docblock, on the SQLite operators). Nothing is
+    // lost — `["items", "0"]` reaches the same array element, since `#>` takes
+    // a `text[]` and the segment arrives as text either way. Measured: both
+    // spellings bind `["items", "0"]` and return the same row on Prisma, and
+    // gemi's binder already stringifies through the `text[]` cast.
+    //
+    // Its own sentence rather than the grammar message below, which would tell
+    // a caller who wrote an array to write an array.
+    const offending = (path as unknown[]).findIndex(
+      (part) => typeof part !== "string",
+    );
+    if (offending === -1) return;
+
+    const part = (path as unknown[])[offending];
+    throw new UnsupportedQueryError(
+      `${field.name}.path`,
+      schema.name,
+      context.operation,
+      `A JSON path is an array of strings, and path[${offending}] is ` +
+        `${part === null ? "null" : `a ${typeof part}`}. An array index is a ` +
+        `key too — write ["items", "0"] rather than ["items", 0]; it reaches ` +
+        `the same element, because ${dialect.name} takes the path as text. ` +
+        `Prisma's path is string[] and its client refuses a number here too.`,
+    );
   }
 
   throw new UnsupportedQueryError(

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -989,6 +989,21 @@ function compileJsonFilter(
   // `{ path: ["a"] }` both raise P2019 *"A JSON path cannot be set without a
   // scalar filter."*, and `{ path: ["a"], equals: 1, gt: undefined }` compiles
   // the `equals` alone.
+  //
+  // **This is also what makes the plan cache safe here**, which is the stronger
+  // reason and the one a reader will otherwise have to re-derive.
+  // `canonicalShape` drops `undefined` members, so the two spellings were
+  // already *one* cache key — measured:
+  //
+  //     planKey(postgres, "User", "findMany", { where: { metadata: { path: ["a"] } } })
+  //     planKey(postgres, "User", "findMany", { where: { metadata: { path: ["a"], equals: undefined } } })
+  //       both -> postgres:batched:User:findMany:{where:{metadata:{path:[string]}}}
+  //
+  // while they compiled to two different things, a refusal and a `= NULL` plan.
+  // Whichever compiled first decided for the other, so a bare `path` arriving
+  // second was served the never-true plan instead of the refusal it raises
+  // cold. Both throw now, so there is nothing left for the shared key to
+  // collide on.
   const applied = Object.keys(filter)
     .filter((key) => key !== "path" && filter[key] !== undefined)
     .sort();
@@ -1163,10 +1178,15 @@ function assertJsonOperand(
   // The `string_contains` guard above names that failure in this file's own
   // words, "runs and returns the wrong rows"; only the arithmetic differs.
   //
-  // `array_contains` is included rather than exempt. It takes the `#>` form, so
-  // the collapse argument does not apply to it — but `jsonArrayContains` binds
-  // `null` as SQL NULL, and `x @> NULL` is NULL too. Prisma binds it as the
-  // JSON value and runs a real containment test.
+  // `array_contains` is included rather than exempt, **and its mechanism is a
+  // different one**. It takes the `#>` form, so the text collapse above does
+  // not apply to it — but `jsonArrayContains` binds the operand raw, so `null`
+  // arrives as SQL NULL and `x @> NULL` is NULL too. Prisma binds it as the
+  // JSON value and runs a real containment test. The message below branches for
+  // that reason: telling an `array_contains` caller about `#>>` would name a
+  // mechanism this operator does not have, and pointing them at
+  // `{ equals: Prisma.JsonNull }` would answer a containment question with an
+  // equality on the column.
   //
   // Answering any of them properly means the `#> … ::jsonb` form on Postgres
   // and `json_type` on SQLite, which is a second implementation of the same
@@ -1177,13 +1197,21 @@ function assertJsonOperand(
       `where.${field.name}.${key}`,
       schema.name,
       context.operation,
-      `null cannot be compared through a JSON path: the extraction yields ` +
-        `SQL NULL for an absent key and for a JSON null alike, and the ` +
-        `comparison against it is NULL rather than true — the query would run ` +
-        `and match nothing. Prisma reads it as the JSON value null and does ` +
-        `answer it; gemi does not yet. Filter the column itself — ` +
-        `{ ${field.name}: { equals: Prisma.JsonNull } } — or test the path ` +
-        `against the value you mean.`,
+      key === "array_contains"
+        ? `null cannot be tested for containment through a JSON path: the ` +
+          `operand binds as SQL NULL rather than as the JSON value, and ` +
+          `'x @> NULL' is NULL rather than true — the query would run and ` +
+          `match nothing. Prisma binds it as the JSON value and runs a real ` +
+          `containment test; gemi does not yet. A null *inside* the document ` +
+          `is an ordinary value and still compiles: ` +
+          `{ ${field.name}: { path: […], array_contains: [null] } }.`
+        : `null cannot be compared through a JSON path: the extraction yields ` +
+          `SQL NULL for an absent key and for a JSON null alike, and the ` +
+          `comparison against it is NULL rather than true — the query would ` +
+          `run and match nothing. Prisma reads it as the JSON value null and ` +
+          `does answer it; gemi does not yet. Filter the column itself — ` +
+          `{ ${field.name}: { equals: Prisma.JsonNull } } — or test the path ` +
+          `against the value you mean.`,
     );
   }
 
@@ -1333,16 +1361,35 @@ function assertPathShape(
     );
     if (offending === -1) return;
 
+    // `a ${typeof part}` alone reads as "a undefined" / "a object" for every
+    // segment but the number, so the description is spelled out. And the array
+    // index sentence is advice for one mistake in particular — a caller who
+    // wrote `null` did not write an index — so it is gated on the number
+    // rather than emitted for everything.
     const part = (path as unknown[])[offending];
+    const described =
+      part === null
+        ? "null"
+        : part === undefined
+          ? "undefined"
+          : Array.isArray(part)
+            ? "an array"
+            : typeof part === "object"
+              ? "an object"
+              : `a ${typeof part}`;
+
     throw new UnsupportedQueryError(
       `${field.name}.path`,
       schema.name,
       context.operation,
       `A JSON path is an array of strings, and path[${offending}] is ` +
-        `${part === null ? "null" : `a ${typeof part}`}. An array index is a ` +
-        `key too — write ["items", "0"] rather than ["items", 0]; it reaches ` +
-        `the same element, because ${dialect.name} takes the path as text. ` +
-        `Prisma's path is string[] and its client refuses a number here too.`,
+        `${described}. ` +
+        (typeof part === "number"
+          ? `An array index is a key too — write ["items", "0"] rather than ` +
+            `["items", 0]; it reaches the same element, because ` +
+            `${dialect.name} takes the path as text. Prisma's path is ` +
+            `string[] and its client refuses a number here too.`
+          : `Prisma's path is string[] too.`),
     );
   }
 

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -433,28 +433,27 @@ type JsonObject = { [key: string]: JsonValue };
  * array type to answer it with. The dialect refusal stays where it can name the
  * dialect and say "it works on postgres".
  *
- * **Numbers are in, and that is not the same choice as the dialect one above.**
- * `assertPathShape` accepts a numeric segment, where Prisma's generated `path`
- * is `string[]`, so gemi is a superset here — and this file refuses to be a
- * superset on dialect operators for a stated reason: answering a query the
+ * **Every segment is a string, and #371 is what settled that.** This type
+ * briefly read `readonly (string | number)[]`, because `assertPathShape`
+ * accepted a numeric segment and a type-only change could not remove a superset
+ * the compiler had. `assertPathShape` refuses one now — Prisma's generated
+ * `path` is `string[]` and its client refuses a number at run time too
+ * (*"Argument `path`: Invalid value provided. Expected String, provided Int."*,
+ * measured on 6.19.2) — so the two agree again, and they agree on the narrow
+ * side for the reason this file gives everywhere else: answering a query the
  * oracle cannot is "precisely where a differential test stops being able to
- * check anything" (`where.ts:945`). The two are consistent because that rule
- * governs what the *compiler* answers, and a type cannot enforce it. Excluding
- * numbers here would not remove the superset — `assertPathShape` would still
- * accept `["items", 0]` from a `string[]`-typed variable, from `any`, from
- * JSON off the wire — it would only stop the type describing what the compiler
- * does, which is #336 again in the other direction. If the superset should go,
- * the place to remove it is `assertPathShape` — #371, with both answers written
- * out, rather than decided quietly here.
+ * check anything". Nothing is lost, because `["items", "0"]` reaches the same
+ * array element on Postgres: `#>` takes a `text[]`, so the segment arrives as
+ * text either way.
  *
  * **`readonly`, because a path is the natural thing to hoist.**
  * `const PATH = ["operation"] as const` and a whole filter object written
  * `as const` both produce a `readonly` tuple. `assertPathShape` uses
- * `Array.isArray` and `.every`, which a frozen array answers, and the path is
- * bound rather than mutated. A mutable array still assigns to a `readonly`
+ * `Array.isArray` and `.findIndex`, which a frozen array answers, and the path
+ * is bound rather than mutated. A mutable array still assigns to a `readonly`
  * parameter, so nothing that compiled before stops.
  */
-type JsonPath = string | readonly (string | number)[];
+type JsonPath = string | readonly string[];
 
 /**
  * A scalar a JSON path filter can be compared against.
@@ -473,19 +472,21 @@ type JsonPath = string | readonly (string | number)[];
  * happens. They stay on `JsonFilter`, which compiles against the column, where
  * the distinction survives.
  *
- * **`null` is absent too, and this one is the type going *further* than the
- * compiler — the only place in this change that does.** `assertJsonOperand`
- * lets `null` through and `{ path: […], equals: null }` compiles to
- * `("metadata" #>> $1) = $2` bound to NULL, which is NULL rather than true on
- * both dialects: a predicate no row can satisfy. Once the sentinels are refused
- * there is no other reading of it — the two questions `null` could be asking
- * are exactly the two the sentinels ask. The same operand under
- * `string_contains` is already a runtime refusal, in this file's own words
- * because the pattern "runs and returns the wrong rows", so refusing it here
- * finishes a rule the compiler states rather than inventing one. The compiler
- * should follow — #371 — and until it does a `null` arriving dynamically still
- * reaches the binder, which is why this is stated and not claimed as a
- * guarantee.
+ * **`null` is absent too, and the compiler now agrees — #371.** This comment
+ * used to record it as the one place the type went further than the runtime:
+ * `assertJsonOperand` let `null` through and `{ path: […], equals: null }`
+ * compiled to `("metadata" #>> $1) = $2` bound to NULL, which is NULL rather
+ * than true on both dialects — a predicate no row can satisfy. It is an
+ * `InvalidArgumentError` now, so a `null` arriving dynamically is refused
+ * rather than silently answered wrong.
+ *
+ * The refusal is a *divergence*, not a gap in the type. Prisma extracts with
+ * `#>` and compares as `jsonb`, so it reads `equals: null` as the JSON value
+ * `null` and returns the rows holding one — measured on 6.19.2, identical SQL
+ * and identical rows to `equals: Prisma.JsonNull`. gemi extracts with `#>>`,
+ * which yields SQL NULL for an absent key and a JSON null alike, so the
+ * question cannot be asked at a path here at all — the same collapse that
+ * keeps the sentinels off this type.
  */
 type JsonPathScalar = string | number | boolean;
 
@@ -509,6 +510,12 @@ type JsonPathScalar = string | number | boolean;
  * Requiring one would mean a ten-way union in the position where the compiler
  * reports a misspelled operator, and the runtime message already names the whole
  * set. Prisma's generated input has the same shape for the same reason.
+ *
+ * **Writing `undefined` is writing nothing**, on every operator, which is what
+ * `?:` already says and what `compileJsonFilter` now does — a key holding
+ * `undefined` is dropped before the bare-path check, so
+ * `{ path: ["a"], equals: undefined }` raises the same refusal as
+ * `{ path: ["a"] }`. That is Prisma's answer to both, measured.
  */
 type JsonPathFilter = {
   path: JsonPath;
@@ -517,7 +524,13 @@ type JsonPathFilter = {
   string_contains?: string;
   string_starts_with?: string;
   string_ends_with?: string;
-  array_contains?: JsonValue;
+  /**
+   * A document, minus a bare `null` — `assertJsonOperand` refuses that one for
+   * the reason `JsonPathScalar` gives, since `jsonArrayContains` binds it as
+   * SQL NULL and `x @> NULL` is NULL. A `null` *inside* the document is an
+   * ordinary JSON value and still compiles.
+   */
+  array_contains?: Exclude<JsonValue, null>;
   lt?: JsonPathScalar;
   lte?: JsonPathScalar;
   gt?: JsonPathScalar;

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -1079,6 +1079,22 @@ const POSTGRES_ONLY: [string, string, unknown][] = [
     where: { metadata: { path: ["nope"], equals: "x" } },
     orderBy: { id: "asc" },
   }],
+  // **An array index, spelled as a string** — which is the whole of #371's
+  // third answer. `assertPathShape` used to accept `["tags", 0]` as well,
+  // where Prisma's generated `path` is `string[]` and its client refuses a
+  // number outright: *"Argument `path`: Invalid value provided. Expected
+  // String, provided Int."* So the superset went, and this pair is the proof
+  // that nothing went with it — `#>` takes a `text[]`, so the string reaches
+  // the element either way. The miss is here because a hit alone would also
+  // pass against a path that silently selected the whole array.
+  ["json path with a string array index", "findMany", {
+    where: { metadata: { path: ["tags", "0"], equals: "a" } },
+    orderBy: { id: "asc" },
+  }],
+  ["json path with a string array index that misses", "findMany", {
+    where: { metadata: { path: ["tags", "1"], equals: "a" } },
+    orderBy: { id: "asc" },
+  }],
   ["json array_contains a scalar", "findMany", {
     where: { metadata: { path: ["tags"], array_contains: "a" } },
     orderBy: { id: "asc" },

--- a/templates/saas-starter/app/models/filters.test-d.ts
+++ b/templates/saas-starter/app/models/filters.test-d.ts
@@ -239,8 +239,22 @@ describe("Json path filters", () => {
       where: { metadata: { path: ["operation"], equals: "video" } },
     });
     await UserModel.findMany({ where: { metadata: { path: "$.operation", equals: "video" } } });
-    // An array index is a key too, which is why numbers are in the union.
-    await UserModel.findMany({ where: { metadata: { path: ["items", 0, "id"], gt: 3 } } });
+    // An array index is a key too, and it is spelled as one — `#>` takes a
+    // `text[]`, so this reaches the same element a numeric segment used to.
+    await UserModel.findMany({ where: { metadata: { path: ["items", "0", "id"], gt: 3 } } });
+  });
+
+  /**
+   * **#371's third gap, closed on the narrow side.** This type read
+   * `readonly (string | number)[]` because `assertPathShape` accepted a numeric
+   * segment, and a type-only change (#368) could not remove a superset the
+   * compiler had. `assertPathShape` refuses one now: Prisma's generated `path`
+   * is `string[]` and its client answers *"Argument `path`: Invalid value
+   * provided. Expected String, provided Int."* at run time, measured on 6.19.2.
+   */
+  test("a numeric path segment is refused, as Prisma refuses one", async () => {
+    // @ts-expect-error write ["items", "0"]; it reaches the same element
+    await UserModel.findMany({ where: { metadata: { path: ["items", 0], equals: "x" } } });
   });
 
   test("take the ten operators JSON_FILTERS accepts", async () => {
@@ -295,17 +309,25 @@ describe("Json path filters", () => {
   });
 
   /**
-   * **`null` is refused, and it is the one place the type goes further than the
-   * compiler.** `assertJsonOperand` lets it through and the query compiles to
-   * `("metadata" #>> $1) = $2` bound to NULL, which is NULL and not true on
-   * both dialects — a predicate no row can satisfy. With the sentinels already
-   * refused there is nothing else it could be asking. Filed against the runtime
-   * as #371 rather than changed here, since this is a type-only change — so a
-   * `null` arriving dynamically still reaches the binder.
+   * **`null` is refused, and the compiler agrees now — #371.** This was the one
+   * place the type went further than the runtime: `assertJsonOperand` let it
+   * through and the query compiled to `("metadata" #>> $1) = $2` bound to NULL,
+   * which is NULL and not true on both dialects — a predicate no row can
+   * satisfy. It is an `InvalidArgumentError` there now, so a `null` arriving
+   * dynamically is refused rather than answered wrong.
+   *
+   * The refusal is a divergence rather than a gap in the type: Prisma extracts
+   * with `#>` and compares as `jsonb`, so it reads this as the JSON value
+   * `null` and answers it. gemi's `#>>` yields SQL NULL for an absent key and a
+   * JSON null alike, which is the same collapse that keeps the sentinels off
+   * this filter.
    */
   test("null at a path is refused, having no reading left", async () => {
     // @ts-expect-error `= NULL` is never true; say which empty you mean, on the column
     await UserModel.findMany({ where: { metadata: { path: ["a"], equals: null } } });
+    // @ts-expect-error `x @> NULL` is NULL too — a null *inside* the document is fine
+    await UserModel.findMany({ where: { metadata: { path: ["a"], array_contains: null } } });
+    await UserModel.findMany({ where: { metadata: { path: ["a"], array_contains: [null] } } });
   });
 
   /**

--- a/templates/saas-starter/app/models/filters.test-d.ts
+++ b/templates/saas-starter/app/models/filters.test-d.ts
@@ -322,7 +322,7 @@ describe("Json path filters", () => {
    * JSON null alike, which is the same collapse that keeps the sentinels off
    * this filter.
    */
-  test("null at a path is refused, having no reading left", async () => {
+  test("null at a path is refused, because gemi cannot ask Prisma's question", async () => {
     // @ts-expect-error `= NULL` is never true; say which empty you mean, on the column
     await UserModel.findMany({ where: { metadata: { path: ["a"], equals: null } } });
     // @ts-expect-error `x @> NULL` is NULL too — a null *inside* the document is fine


### PR DESCRIPTION
The three runtime gaps #368 surfaced and could not close, because #368 was type-only. All three are in the JSON path filter, none is reachable from the type any more, and each is the same failure class: **a query that runs, raises nothing, and answers wrong**.

## How this was established

A scratch schema — `model Doc { id Int @id, label String, metadata Json? }` — pushed to a throwaway `postgres:16`, a generated `@prisma/client` **6.19.2**, `log: [{ emit: "event", level: "query" }]`, and the rows read back after every call. Five seeded documents, chosen so the answers can differ:

```
a-is-1      { a: 1 }
a-is-null   { a: null }          <- the row that separates the two readings of `null`
no-a        { b: 2 }
items       { items: ["zero", "one"] }
col-null    metadata IS NULL
```

Not from the docs, and not from what #371's own text asserted — **one of its three claims turned out to be wrong**, and that changed the shape of the fix. See §2.

## 1. `undefined` under a path operator was not absent

`compileJsonFilter` built `applied` from `Object.keys` alone, which made it the one branch in `where.ts` that does not treat an `undefined` operand as absent: the scalar loop skips it (`if (operand === undefined || key === "mode") continue`), and the dispatch *into* this branch skips a `path` that is `undefined` (`if (filter.path !== undefined)`).

So the two spellings of the same query disagreed:

| gemi, before | |
| --- | --- |
| `{ path: ["a"] }` | `UnsupportedQueryError` — a path needs a filter beside it |
| `{ path: ["a"], equals: undefined }` | `("metadata" #>> $1) = $2` bound `["{\"a\"}", null]` |

The second is `= NULL`, which is NULL rather than true — it runs and matches nothing. Confirmed directly against the seeded table: `select label from "Doc" where ("metadata" #>> '{a}') = NULL` → **0 rows**. An optional filter assembled from a form or a query string carries exactly that operand for the field nobody filled in, which is why the scalar path was given the guard in the first place.

Prisma answers both spellings identically, measured:

| Prisma 6.19.2 | |
| --- | --- |
| `{ path: ["a"] }` | P2019 *"A JSON path cannot be set without a scalar filter."* |
| `{ path: ["a"], equals: undefined }` | the same P2019 |
| `{ path: ["a"], array_contains: undefined }` | the same P2019 |
| `{ path: ["a"], equals: 1, gt: undefined }` | compiles the `equals` alone, returns `a-is-1` |
| `{ path: undefined, equals: { a: 1 } }` | a filter on the **column** |

The last row was already right here — the dispatch tests `!== undefined` — and is now asserted so it stays right (`"metadata" = $1::text::jsonb`, bound `{"a":1}`). It was *claimed* asserted in the first revision of this body and was not; review caught that, and writing the assertion also corrected the SQL quoted here.

One ordering detail fell out and is pinned: dropping the key happens *before* the unknown-operator check, so `{ path: ["a"], equalz: undefined }` gets the bare-path refusal and `{ path: ["a"], equalz: 1 }` gets *"A JSON path filter takes …"*. Prisma resolves them in the same order — P2019 for the first, *"Unknown argument `equalz`. Did you mean `equals`?"* for the second.

## 2. `null` under a path operator — and the issue's reasoning for it was wrong

#371 argued that once the sentinels are refused there is "no reading of `equals: null` left", because the two questions it could be asking are the two `DbNull` and `JsonNull` ask. **Measured, that is false.** Prisma has a third reading and gives it:

```
{ metadata: { path: ["a"], equals: null } }
  SQL     ("Doc"."metadata"#>ARRAY[$1]::text[])::jsonb::jsonb = $2
  PARAMS  ["a", null]
  ROWS    ["a-is-null"]
```

Byte-identical SQL and identical rows to `equals: Prisma.JsonNull`. Prisma can ask it because it extracts with `#>` and compares as **jsonb**, where `'null'::jsonb = 'null'::jsonb` is true. `DbNull` is a genuinely different query there — `#> … IS NULL`, returning `no-a`, `items`, `col-null`.

gemi extracts with `#>>`, which yields *text*, and SQL NULL for an absent key and for a JSON null alike. Measured on the same table:

```
where ("metadata" #>> '{a}') = NULL           -> 0 rows     <- what gemi emitted
where ("metadata" #> '{a}') @> NULL           -> 0 rows     <- and under array_contains
where ("metadata" #> '{a}')::jsonb = 'null'   -> a-is-null  <- what Prisma emits
```

So this is **a divergence gemi refuses rather than a gap it closes**, and the distinction matters for the message. `null` is now an `InvalidArgumentError` under every path operator, saying that Prisma does answer it and gemi does not yet — the same shape as the object-operand refusal three lines below (*"Prisma accepts one here; gemi does not yet"*), and for the same reason: answering it means the `#> … ::jsonb` form on Postgres and `json_type` on SQLite, a second implementation of every operator per dialect rather than a guard.

`array_contains` is **included rather than exempt**, which is a scope decision worth naming. Its exemption from the object rule is because containment is the operator that takes a document; that has nothing to do with `null`. `jsonArrayContains` binds the operand raw, so `null` arrives as SQL NULL and `x @> NULL` is NULL — the same silent zero-row answer, arrived at differently. Prisma binds it as the JSON value and runs a real containment test. A `null` *inside* the document (`array_contains: [null]`) is an ordinary JSON value and still compiles; that negative is pinned, because refusing it would have been the easy over-reach.

Prisma's own behaviour under the remaining operators, for completeness — it is not uniform:

| Prisma 6.19.2 | |
| --- | --- |
| `equals: null`, `not: null` | compile, jsonb comparison, real answers |
| `array_contains: null` | compiles, real containment |
| `gt: null`, `lt: null` | **query-engine panic** — *"JSON target types only accept strings or numbers, found: null"* |
| `string_contains: null` | validation error, *"Argument `string_contains` must not be null"* |

gemi already refused the `string_*` row, with its own better message (`%null%` "runs and returns the wrong rows"); that message is kept and the new guard sits after it. The `gt`/`lt` row is a Prisma bug, so there is no oracle to match — refusing is the only answer that is not a crash or a wrong row.

## 3. `path: ["items", 0]` was a superset of the oracle

`assertPathShape` accepted `typeof part === "number"`. Prisma's generated `path` on Postgres is `string[]` and its client refuses a number **at run time as well as in the type**:

```
{ path: ["items", 0], equals: "zero" }    PrismaClientValidationError:
    Argument `path`: Invalid value provided. Expected String, provided Int.
{ path: ["items", "0"], equals: "zero" }  #>ARRAY[$1, $2]::text[]  ["items","0"]  -> items
```

That is the situation `compileJsonFilter`'s docblock refuses on purpose for the SQLite operators — *"implementing them would make gemi answer a query the oracle cannot, which is precisely where a differential test stops being able to check anything."* #371 offered two answers and had no view; this takes the first, because the rule is already written down in this file and because **nothing is lost**: `#>` takes a `text[]`, so `["items", "0"]` reaches the same element. gemi's own binder already proved it — before this change both spellings bound the identical `{"items","0"}`.

`JsonPath` narrows to `string | readonly string[]` with it. #368 typed it `string | readonly (string | number)[]` and said so explicitly: *"If the superset should go, the place is `assertPathShape`."* It has gone there, so the type follows — otherwise the type would describe a query the compiler refuses, which is #336 in the other direction. `readonly` stays, for the `as const` hoisting reason #368 gives.

SQLite is untouched: its grammar is a JSONPath string and the index lives inside it, `"$.items[0]"`.

## The diff

- **`orm/compile/where.ts`** — the three guards. The `undefined` filter in `applied`; the `null` refusal in `assertJsonOperand`, placed after the `string_*` branch so that message survives; the string-segment check in `assertPathShape`, with its own sentence rather than the grammar message, which would tell a caller who wrote an array to write an array. `assertJsonOperand`'s object check drops its now-dead `operand !== null &&`, with a line saying why it is gone.
- **`orm/types.ts`** — `JsonPath` narrowed; `array_contains` narrowed to `Exclude<JsonValue, null>`; the two docblocks that recorded these as open (*"the one place the type goes further than the compiler"*, *"If the superset should go…"*) rewritten to what is now true.
- **`docs/orm.md`** — the refusal list goes from three to four, the string-index rule is stated, and `undefined`-is-absent is stated. `docs/llms-full.txt` re-embedded, which `docs-scope.test.ts` compares verbatim.

## Tests

**`packages/gemi/orm/compile/read.test.ts` — 153 pass**, up from 140. Three new blocks, each mutation-checked: reverting the guard it covers makes it, and only it, fail.

| test | mutation that fails it |
| --- | --- |
| `an undefined operand is absent, so the path is bare` — four operators, the misspelled-key ordering, and one live operator beside an undefined one | dropping `filter[key] !== undefined` → 1 failure |
| `null at a path is refused` — six operators on Postgres, three on SQLite, `array_contains: [null]` still compiling, and nothing reaching the SQL | restoring the old `assertJsonOperand` → 8 failures, all in this block |
| `a path segment is a string, matching the oracle` — the number, a `null` segment, the string spelling's exact bind, and SQLite unaffected | re-admitting `typeof part === "number"` → 1 failure |

**`templates/saas-starter` differential — 2 new Postgres cases**, run against Prisma on a live `postgres:16`:

- `json path with a string array index` — `{ path: ["tags", "0"], equals: "a" }` against the seeded `metadata: { tags: ["a", "b"] }`;
- `json path with a string array index that misses` — `["tags", "1"]`, because a hit alone would also pass against a path that silently selected the whole array.

These do **not** pin the refusal — a result comparison cannot see one, and both would still pass with the numeric segment re-admitted. They pin the half the narrowing rests on: that the string spelling reaches the element on both clients, so nothing was removed but a spelling. The refusal is pinned at compile level, where it can be.

**`filters.test-d.ts` — 117 pass**, up from 116. The numeric segment becomes a `@ts-expect-error`, `array_contains: null` joins the `null` refusal, and `array_contains: [null]` is pinned as still valid. The positive path case is respelled `["items", "0", "id"]`.

## Verification

| | |
| --- | --- |
| `packages/gemi` unit | **3123 pass, 1 skipped**, 120 files, via `bun --bun vitest run` |
| `packages/gemi` typecheck | clean, and `tsc -p tsconfig.generated.json` clean |
| `oxlint orm --deny-warnings` | 0 warnings, 0 errors; `bun run lint` unchanged at 79 warnings |
| template, SQLite | **792 pass**, 20 files |
| template, Postgres (`-t postgres`, `--no-file-parallelism`, live `postgres:16`) | **875 pass**, 14 files |
| template type tests | **117 pass**, no type errors |

Both dialects were run locally against a real Postgres in a container, with the client regenerated for each provider the way `ci.yml` does it — the schema flip and the two generated clients are reverted in the tree.

## Loose ends a reviewer may want to argue with

- **`array_contains: null` being refused is the one judgement call beyond the issue's letter.** #371 names `assertJsonOperand`'s gap between its two branches, and `array_contains` returns before it. Left alone it goes on compiling `@> NULL` — zero rows, silently, where Prisma answers. Refusing it is four lines and one message; the alternative was to leave a known silent-wrong inside the function this PR is about.
- **`null` could be implemented on Postgres instead**, as `("metadata" #> $1)::jsonb = 'null'::jsonb`. Not done, because SQLite would then need `json_type` to answer the same question and the two would have to be kept in step — the exact split the object-operand refusal already declined. If it is ever wanted, it is one dialect method, not a guard change.
- **Narrowing `JsonPath` is a compile-time break** for anyone who wrote `path: ["items", 0]` since #368 landed — one day. The runtime refuses it either way now, so the type break is what makes the refusal visible before the query runs.
- **`oxfmt --check` reports these three files as unformatted**, and did so identically at the base commit. Not reformatted here; CI runs `oxlint`, not `oxfmt`.

Closes #371.

## Review round 1

Six points from review, all addressed; two cross-PR points deferred to the PRs that own them.

| point | disposition |
| --- | --- |
| the `null` message gave `array_contains` a mechanism it does not have | **fixed** — the message branches on the key. `array_contains` now names the raw bind and `x @> NULL`, and points at `array_contains: [null]` rather than at `equals: Prisma.JsonNull`, which would answer a containment question with an equality on the column |
| `path[1] is a undefined` / `a object`, and the array-index advice emitted for segments that are not indexes | **fixed** — the description is spelled out (`null`, `undefined`, `an object`, `an array`, `a number`), and the index sentence is gated on `typeof part === "number"` |
| `toThrow(InvalidArgumentError)` left the new guard's *placement* unpinned | **fixed** — every row asserts its message. Moving the `null` guard above the `string_*` one used to leave 153 green; it now fails 2 (`string_contains on postgres`, `string_ends_with on sqlite`) |
| `{ path: undefined, … }` claimed asserted, was not | **fixed** — asserted in the `undefined` block, and the SQL quoted in this body was wrong and is corrected |
| `it never becomes a bound NULL` passed for any throw | **fixed** — asserts the message alongside `text === ""` |
| the `undefined` fix also closes a plan-cache shape collision | **taken** — written into the `applied` comment, with the two `planKey` calls that collapse to one key |
| #385 ships `["a", 0]`, which this PR now refuses | **deferred to #385** — the three sites are in #385's files; respelling to `["a", "0"]` is its repair. Merge #380 first |
| #381 × `types.ts`: taking #381's mapped type reverts the `array_contains` narrowing | **deferred to merge time** — #381 is not on `main`, so the arm (`K extends "array_contains" ? Exclude<JsonValue, null> : …`) cannot be written against a type that does not exist here yet |

Mutation checks re-run on every test touched: reverting `filter[key] !== undefined` → 1 failure; the dispatch's `filter.path !== undefined` → `"path" in filter` → 1 failure (new); restoring the old `assertJsonOperand` in full → 8 failures; moving the `null` guard above the `string_*` one → 2 failures (new — it was 0 before this round); collapsing the `array_contains` message branch → 1 failure (new); reverting the segment description and the gating → 1 failure (new); re-admitting `typeof part === "number"` → 1 failure.

Green after: `packages/gemi` **3123 pass / 1 skipped**, typecheck clean, `oxlint orm --deny-warnings` clean, template SQLite **792 pass**, `test:types` **117 pass**. `git status` clean of generated artifacts after both `prisma generate` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

