### PR TITLE
Close #369: the caller-facing types read the compiler's operator lists

### DIFF
--- a/packages/gemi/orm/architecture.test.ts
+++ b/packages/gemi/orm/architecture.test.ts
@@ -240,10 +240,47 @@ describe("the ORM's seams", () => {
    *
    * Test files count as references, because an export existing *for* a test is
    * a real reason — `isTracked` says so in as many words.
+   *
+   * **`export type` and `export interface` count too, and did not until #369.**
+   * The scan was three alternations over `function`, `const` and `class`, so a
+   * type export was invisible to it — which mattered the moment a type export
+   * became load-bearing. #369 makes six caller-facing grammars in `types.ts`
+   * map over the compiler's own operator tuples via exported unions
+   * (`JsonFilterName`, `ListFilterName`, `HavingOperator`, the two relation
+   * unions, the three nested-write unions). Reverting `types.ts` wholesale left
+   * every one of those an export nothing imports, and the whole package stayed
+   * green: typecheck clean, 3110 tests, `oxlint --deny-warnings` 0/0. The one
+   * test whose stated property is exactly "an export nothing else uses" could
+   * not see them. It can now, so the derivation is load-bearing at test time
+   * rather than only by inspection.
+   *
+   * A type export is erased, so this is not an argument about bundle size — it
+   * is the same argument as for a `const`: an `export` is how a name becomes
+   * something another file may reach for, and one that nothing reaches for is a
+   * wider surface for nothing.
    */
   const MAY_BE_EXPORTED_UNUSED: string[] = [
-    // Nothing today. An entry here is a deliberate exception with a reason
-    // beside it, not a place to put whatever this test happens to flag.
+    // The six type exports the widened scan turned up, each a deliberate
+    // exception rather than a name to unexport. All six describe a *parameter
+    // or field of a public signature*: the value they carry is that a caller
+    // reading `orm.d.ts` — or writing an implementation against one of these
+    // shapes — can name what a position holds, which is not a use this scan can
+    // see because it only counts references inside `orm/**`.
+    //
+    // `policy.ts` — the two halves of the policy surface an application writes
+    // against. `PolicedModel` is what `$policies` is declared on and
+    // `PolicyLookup` is the map an application's own resolver returns.
+    "PolicedModel",
+    "PolicyLookup",
+    // The callback shape `warnOnProtocolSkew` takes, so a host embedding the
+    // ORM can declare its own warner rather than inferring the signature.
+    "ProtocolSkewWarner",
+    // The three schema-walk shapes. `RelationNode` and `RelationOrdering` are
+    // the vocabulary the include/order-by planners' public results are built
+    // from, and `SchemaFields` names the record `ModelSchema.fields` holds.
+    "RelationNode",
+    "RelationOrdering",
+    "SchemaFields",
   ];
 
   test("no export is referenced only inside its own file", () => {
@@ -255,10 +292,14 @@ describe("the ORM's seams", () => {
       sources.set(name, content);
       if (name === "index.ts") continue;
 
+      // `export type (\w+)` deliberately does not match `export type { … }`:
+      // a re-export declares nothing here, and counting it would name the
+      // wrong home file.
       for (const match of content.matchAll(
-        /^export (?:async )?function (\w+)|^export const (\w+)|^export class (\w+)/gm,
+        /^export (?:async )?function (\w+)|^export const (\w+)|^export class (\w+)|^export type (\w+)|^export interface (\w+)/gm,
       )) {
-        const exported = match[1] ?? match[2] ?? match[3];
+        const exported =
+          match[1] ?? match[2] ?? match[3] ?? match[4] ?? match[5];
         // A name declared in two files is ambiguous to a text scan; skip rather
         // than guess, since a false positive here reads as a real finding.
         declared.set(exported, declared.has(exported) ? "" : name);
@@ -266,8 +307,15 @@ describe("the ORM's seams", () => {
     }
 
     // Tests are references: an export that exists for a test is justified.
+    //
+    // This file is the exception, and has to be. It is the scanner, and its
+    // prose names the very exports it is scanning for — the docblock above
+    // names three of #369's operator unions, and that alone was enough to make
+    // reverting `types.ts` a *passing* run for those three while the other five
+    // went red. A comment is not a use.
     for (const path of readdirSync(ROOT, { recursive: true, withFileTypes: true })) {
       if (!path.name.endsWith(".test.ts")) continue;
+      if (path.name === "architecture.test.ts") continue;
       const full = join((path as { parentPath?: string }).parentPath ?? ROOT, path.name);
       sources.set(`test:${full}`, read(full));
     }

--- a/packages/gemi/orm/compile/group-by.ts
+++ b/packages/gemi/orm/compile/group-by.ts
@@ -475,15 +475,35 @@ function assertPureAggregate(
   );
 }
 
-/** The comparison operators a `having` operand may use. */
-const OPERATORS: Record<string, string> = {
+/**
+ * The comparison operators a `having` operand may use.
+ *
+ * **`as const`, so `HavingComparison` in `../types` can be a mapped type over
+ * its keys rather than a second copy of them.** The type used to list the same
+ * six names in another file, with nothing making the two agree — the same
+ * mechanism as `JSON_FILTER_NAMES` in `./where.ts`, and the one that let #326,
+ * #333, #336 and #337 each ship a compiler and a type that disagreed.
+ *
+ * Narrower than a `where`'s set on purpose: `having` walks this table and
+ * nothing else, so `contains`, `in`, `startsWith` and `mode` are refused here.
+ */
+const OPERATORS = {
   equals: "=",
   not: "<>",
   lt: "<",
   lte: "<=",
   gt: ">",
   gte: ">=",
-};
+} as const;
+
+/** One of {@link OPERATORS}' keys. `HavingComparison` maps over this. */
+export type HavingOperator = keyof typeof OPERATORS;
+
+/**
+ * The same table, widened for lookup: the key comes from a caller's object and
+ * is `string`, not {@link HavingOperator} — that is the question being asked.
+ */
+const OPERATOR_SQL: Record<string, string | undefined> = OPERATORS;
 
 function comparison(
   lhs: string,
@@ -506,7 +526,7 @@ function comparison(
     const value = source[key];
     if (value === undefined) continue;
 
-    const operator = OPERATORS[key];
+    const operator = OPERATOR_SQL[key];
     if (!operator) {
       throw new UnsupportedQueryError(
         `${argument}.${key}`,

--- a/packages/gemi/orm/compile/group-by.ts
+++ b/packages/gemi/orm/compile/group-by.ts
@@ -502,8 +502,14 @@ export type HavingOperator = keyof typeof OPERATORS;
 /**
  * The same table, widened for lookup: the key comes from a caller's object and
  * is `string`, not {@link HavingOperator} — that is the question being asked.
+ *
+ * `Readonly`, because this alias points at the object {@link HavingOperator} is
+ * derived from: without it `OPERATOR_SQL.contains = "like"` would typecheck and
+ * mutate the source of truth. The `| undefined` is the load-bearing half — it
+ * is what makes the `if (!operator)` guard below honest rather than a cast that
+ * claims every string is a key.
  */
-const OPERATOR_SQL: Record<string, string | undefined> = OPERATORS;
+const OPERATOR_SQL: Readonly<Record<string, string | undefined>> = OPERATORS;
 
 function comparison(
   lhs: string,

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -75,7 +75,7 @@ import { matchUniqueKey, type RefusalOrigin } from "./unique";
  * back the parent row too.
  */
 
-const SUPPORTED = new Set([
+const SUPPORTED_STATEMENTS = [
   "connect",
   "connectOrCreate",
   "create",
@@ -87,7 +87,21 @@ const SUPPORTED = new Set([
   "updateMany",
   "deleteMany",
   "upsert",
-]);
+] as const;
+
+/**
+ * One of {@link SUPPORTED_STATEMENTS}.
+ *
+ * `NestedCreate` and `NestedUpdate` in `../types` are mapped types over this
+ * and the two tuples below, rather than four hand-written key lists in another
+ * file. Which statements exist, and which exist only on a to-many or only on a
+ * statement with a row to act on, are decisions made *here* — and until #369
+ * the caller-facing type made them a second time, with nothing checking that
+ * the two answers matched.
+ */
+export type NestedWriteStatement = (typeof SUPPORTED_STATEMENTS)[number];
+
+const SUPPORTED: ReadonlySet<string> = new Set(SUPPORTED_STATEMENTS);
 
 /**
  * Operands that only exist on a statement with a row to act on.
@@ -97,7 +111,7 @@ const SUPPORTED = new Set([
  * row that does not exist yet. Refused here rather than accepted and made a
  * no-op, so a caller who wrote one on the wrong operation hears about it.
  */
-const EXISTING_ROW_ONLY = new Set([
+const EXISTING_ROW_ONLY_STATEMENTS = [
   "disconnect",
   "delete",
   "update",
@@ -105,7 +119,46 @@ const EXISTING_ROW_ONLY = new Set([
   "updateMany",
   "deleteMany",
   "upsert",
-]);
+] as const;
+
+/** One of {@link EXISTING_ROW_ONLY_STATEMENTS}. `NestedCreate` subtracts it. */
+export type ExistingRowStatement = (typeof EXISTING_ROW_ONLY_STATEMENTS)[number];
+
+const EXISTING_ROW_ONLY: ReadonlySet<string> = new Set(
+  EXISTING_ROW_ONLY_STATEMENTS,
+);
+
+/**
+ * The operands that describe *many* rows, and so exist on a to-many alone.
+ *
+ * Prisma's to-one nested input is `{ create, connectOrCreate, upsert,
+ * disconnect, delete, connect, update }` — measured off a generated client —
+ * with no `createMany`, `set`, `updateMany` or `deleteMany` key at all. Both
+ * {@link planOwningSide} and {@link planForeignSide} refuse all four on a
+ * to-one; this is the list they refuse, named once so the type can subtract it.
+ */
+const COLLECTION_ONLY_STATEMENTS = [
+  "createMany",
+  "set",
+  "updateMany",
+  "deleteMany",
+] as const;
+
+/** One of {@link COLLECTION_ONLY_STATEMENTS}. The to-one arms subtract it. */
+export type CollectionOnlyStatement = (typeof COLLECTION_ONLY_STATEMENTS)[number];
+
+/**
+ * The three of the four that share one refusal message.
+ *
+ * `createMany` is excluded because it is refused on its own, in both planners,
+ * with a message about there being *one related row* rather than about there
+ * being no *set of rows* — and on the foreign side that refusal also guards the
+ * operand check that follows it. Derived by subtraction rather than written out
+ * again, so a fifth collection-shaped operand added above lands here too.
+ */
+const NO_SET_OF_ROWS: ReadonlySet<string> = new Set(
+  COLLECTION_ONLY_STATEMENTS.filter((statement) => statement !== "createMany"),
+);
 
 /** Statements that insert a new row, so nothing is linked to it yet. */
 const CREATE_ONLY_STATEMENTS = new Set(["create", "createMany"]);
@@ -817,8 +870,12 @@ function planOwningSide(
    * in `SUPPORTED` with no branch on this side, so they fell through to the
    * `connect` handling below and reported `connect` back to a caller who wrote
    * something else. Same fall-through as `upsert`'s, found by the same test.
+   *
+   * The fourth collection operand, `createMany`, is refused above this with its
+   * own wording, which is why the set read here is {@link NO_SET_OF_ROWS} and
+   * not {@link COLLECTION_ONLY_STATEMENTS} whole.
    */
-  if (key === "set" || key === "updateMany" || key === "deleteMany") {
+  if (NO_SET_OF_ROWS.has(key)) {
     throw new UnsupportedQueryError(
       `data.${relation.name}.${key}`,
       schema.name,
@@ -1138,7 +1195,10 @@ function planForeignSide(
   const spelledOperand = operand;
 
   if (relation.kind !== "many") {
-    if (key === "set" || key === "updateMany" || key === "deleteMany") {
+    // {@link NO_SET_OF_ROWS} rather than {@link COLLECTION_ONLY_STATEMENTS}:
+    // `createMany` is the fourth of them and is refused further down, where its
+    // own message and its operand check live together.
+    if (NO_SET_OF_ROWS.has(key)) {
       throw new UnsupportedQueryError(
         `data.${relation.name}.${key}`,
         schema.name,

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -673,14 +673,23 @@ function assertCompositeInOperand(
  * about a substring, and on a `String[]` there is no such question — the one
  * Prisma spells is `has`. Sharing the table would have made every scalar
  * operator compile against an array column and answer something.
+ *
+ * A tuple for the same reason {@link JSON_FILTER_NAMES} is one: `ListFilter` in
+ * `../types` said in a comment that it mirrors this list, and a comment is not
+ * something the compiler checks.
  */
-const LIST_FILTERS = new Set([
+const LIST_FILTER_NAMES = [
   "equals",
   "has",
   "hasEvery",
   "hasSome",
   "isEmpty",
-]);
+] as const;
+
+/** One of {@link LIST_FILTER_NAMES}. `ListFilter` maps over this. */
+export type ListFilterName = (typeof LIST_FILTER_NAMES)[number];
+
+const LIST_FILTERS: ReadonlySet<string> = new Set(LIST_FILTER_NAMES);
 
 /**
  * `where: { tags: { has: "urgent" } }`.
@@ -915,8 +924,22 @@ export function assertListDialect(
   );
 }
 
-/** The filters Prisma applies to a value extracted from a JSON path. */
-const JSON_FILTERS = new Set([
+/**
+ * The filters Prisma applies to a value extracted from a JSON path.
+ *
+ * **A tuple, and the caller-facing type is a mapped type over it.**
+ * `JsonPathFilter` in `../types` used to spell these ten names a second time,
+ * in a file that neither imports this one nor is imported by it, so the two
+ * lists could differ with no compile error, no failing test and no diff a
+ * reviewer would flag. That is the mechanism behind #326, #333, #336 and #337 —
+ * the compiler accepting something the type refuses to describe — and #336 was
+ * the worst of them because the undescribed filter was silently absorbed as an
+ * `equals` shorthand rather than refused.
+ *
+ * Deriving the type from this list makes the drift a compile error at the call
+ * sites instead of something the next reviewer has to notice.
+ */
+const JSON_FILTER_NAMES = [
   "equals",
   "not",
   "string_contains",
@@ -927,7 +950,12 @@ const JSON_FILTERS = new Set([
   "lte",
   "gt",
   "gte",
-]);
+] as const;
+
+/** One of {@link JSON_FILTER_NAMES}. `JsonPathFilter` maps over this. */
+export type JsonFilterName = (typeof JSON_FILTER_NAMES)[number];
+
+const JSON_FILTERS: ReadonlySet<string> = new Set(JSON_FILTER_NAMES);
 
 /**
  * `where: { metadata: { path: …, equals: … } }`.

--- a/packages/gemi/orm/relation-filters.ts
+++ b/packages/gemi/orm/relation-filters.ts
@@ -27,9 +27,14 @@ const MANY_FILTER_OPERATORS = ["every", "none", "some"] as const;
 const ONE_FILTER_OPERATORS = ["is", "isNot"] as const;
 
 /**
- * A **third** consumer of the same two tuples, and the reason they are exported
- * at all: `RelationFilter` in `types.ts` is a mapped type over these, rather
- * than a hand-written copy of the five names.
+ * A **third** consumer of the same two tuples, and the reason the two unions
+ * below exist: `RelationFilter` in `types.ts` is a mapped type over these,
+ * rather than a hand-written copy of the five names.
+ *
+ * The tuples themselves stay module-private — `architecture.test.ts` records
+ * that they were deliberately unexported, being used only by the function
+ * directly beneath them, and that is still true. What crosses the file
+ * boundary is the derived type, which is erased.
  *
  * The paragraph above says two places must agree about this shape and must not
  * import each other. The caller-facing type is the place that was left out of

--- a/packages/gemi/orm/relation-filters.ts
+++ b/packages/gemi/orm/relation-filters.ts
@@ -26,6 +26,21 @@
 const MANY_FILTER_OPERATORS = ["every", "none", "some"] as const;
 const ONE_FILTER_OPERATORS = ["is", "isNot"] as const;
 
+/**
+ * A **third** consumer of the same two tuples, and the reason they are exported
+ * at all: `RelationFilter` in `types.ts` is a mapped type over these, rather
+ * than a hand-written copy of the five names.
+ *
+ * The paragraph above says two places must agree about this shape and must not
+ * import each other. The caller-facing type is the place that was left out of
+ * that arrangement — it spelled `some`/`every`/`none` and `is`/`isNot` again,
+ * in a file that imports nothing from here, so nothing failed when the two
+ * drifted. That is the mechanism #369 exists to close, and the same one behind
+ * #326, #333, #336 and #337: a type free to describe a compiler it never reads.
+ */
+export type ManyRelationOperator = (typeof MANY_FILTER_OPERATORS)[number];
+export type OneRelationOperator = (typeof ONE_FILTER_OPERATORS)[number];
+
 export function relationFilterOperators(
   kind: "one" | "many",
 ): readonly string[] {

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -57,12 +57,41 @@
 // eagerly evaluated — mapping over `keyof` at the top level, say, or wrapping one
 // in a conditional that has to resolve the whole shape — would turn a cyclic
 // schema into an instantiation-depth error rather than a slow compile.
+//
+// **The operator grammars below map over a tuple, and that is not the mapping
+// the paragraph above warns about.** `RelationFilter`, `NestedCreate` and
+// `NestedUpdate` are `[K in <five literal strings>]`, not `[K in keyof M]`: the
+// key set is fixed and finite whatever the schema is, and the property types
+// are deferred exactly as an interface's are. Measured rather than assumed —
+// the template's fourteen mutually recursive models typecheck in the same time
+// they did before (1.6–1.8s, warm, either way).
 
 import type {
   AnyNullValue,
   DbNullValue,
   JsonNullValue,
 } from "./json-null";
+// The operator and statement names below are **the compiler's own lists**, not
+// copies of them. Each filter grammar here used to spell its operators a second
+// time, in a file the compiler neither imports nor is imported by, so the two
+// could differ with nothing failing: #326, #333, #336 and #337 are four
+// instances of exactly that, and every one of them ran the same way — the
+// compiler answered a query the type had no spelling for. Mapping over the
+// runtime tuple turns the next such drift into a compile error here.
+//
+// `import type`, so this is erased entirely: no runtime edge is created from
+// the type layer into the compiler, and `orm/index.js` is unchanged.
+import type { HavingOperator } from "./compile/group-by";
+import type {
+  CollectionOnlyStatement,
+  ExistingRowStatement,
+  NestedWriteStatement,
+} from "./compile/nested-writes";
+import type { JsonFilterName, ListFilterName } from "./compile/where";
+import type {
+  ManyRelationOperator,
+  OneRelationOperator,
+} from "./relation-filters";
 
 /**
  * Any value a `Json` column can hold, on either dialect.
@@ -351,18 +380,30 @@ type StringFilter<V> = NonNullable<V> extends string
 type NestedFilter<V> = BaseFilter<V> & OrderingFilter<V> & StringFilter<V>;
 
 /**
+ * What each scalar-list filter compares against.
+ *
+ * `has` asks about one element and `isEmpty` about the array's length; the
+ * other three take a whole array. Split out so {@link ListFilter} can be a
+ * mapped type — the operand still has to be stated per operator, but *which
+ * operators exist* is no longer stated twice.
+ */
+type ListFilterOperand<K extends ListFilterName, E> = K extends "has"
+  ? E
+  : K extends "isEmpty"
+    ? boolean
+    : E[];
+
+/**
  * The filters that apply to a **scalar list** — `tags String[]`.
  *
- * A different set on a different left-hand side, mirroring `LIST_FILTERS` in
- * the where compiler. Postgres only: `SqliteDialect.listFilters` refuses the
- * column outright, because SQLite has no array type.
+ * A different set on a different left-hand side, and the set is
+ * `LIST_FILTER_NAMES` in the where compiler — read from there rather than
+ * mirrored, which is what this comment used to claim it did. Postgres only:
+ * `SqliteDialect.listFilters` refuses the column outright, because SQLite has
+ * no array type.
  */
 type ListFilter<E> = {
-  equals?: E[];
-  has?: E;
-  hasEvery?: E[];
-  hasSome?: E[];
-  isEmpty?: boolean;
+  [K in ListFilterName]?: ListFilterOperand<K, E>;
 };
 
 /**
@@ -493,9 +534,11 @@ type JsonPathScalar = string | number | boolean;
  * `where: { metadata: { path: …, equals: … } }` — a filter on a value *inside*
  * the document rather than on the column.
  *
- * The operator set is `JSON_FILTERS` in `compile/where.ts`, all ten of them, and
- * the operand types are `assertJsonOperand`'s. `array_contains` is the one that
- * takes a document, because containment is the operator that means one.
+ * The operator set **is** `JSON_FILTER_NAMES` in `compile/where.ts`, all ten of
+ * them — mapped over rather than copied, so the compiler's list is this type's
+ * list (#369). The operand types are `assertJsonOperand`'s. `array_contains` is
+ * the one that takes a document, because containment is the operator that means
+ * one.
  *
  * **`path` is required, and that is what makes the union above discriminate.**
  * `compileFieldFilter` dispatches on `filter.path !== undefined`: an operand
@@ -510,19 +553,31 @@ type JsonPathScalar = string | number | boolean;
  * reports a misspelled operator, and the runtime message already names the whole
  * set. Prisma's generated input has the same shape for the same reason.
  */
-type JsonPathFilter = {
-  path: JsonPath;
-  equals?: JsonPathScalar;
-  not?: JsonPathScalar;
-  string_contains?: string;
-  string_starts_with?: string;
-  string_ends_with?: string;
-  array_contains?: JsonValue;
-  lt?: JsonPathScalar;
-  lte?: JsonPathScalar;
-  gt?: JsonPathScalar;
-  gte?: JsonPathScalar;
+type JsonPathFilter = { path: JsonPath } & {
+  [K in JsonFilterName]?: JsonPathOperand<K>;
 };
+
+/**
+ * What each JSON path operator compares the extracted value against, which is
+ * `assertJsonOperand`'s rule restated as a type.
+ *
+ * Three answers for ten operators: the `string_*` three build a `like` pattern
+ * and so need a string; `array_contains` is the one operator whose operand is a
+ * *document*, because containment is the question that means one; the remaining
+ * six compare one bound scalar against one extracted value.
+ *
+ * The default arm is `JsonPathScalar` rather than `never` deliberately. An
+ * eleventh operator added to `JSON_FILTER_NAMES` lands here with the operand
+ * type five of the current six have, which is the likeliest right answer and is
+ * in any case *usable* — where a `never` would give the new operator a key
+ * nothing can be passed under, which is a quieter kind of wrong than the one
+ * this change removes.
+ */
+type JsonPathOperand<K extends JsonFilterName> = K extends "array_contains"
+  ? JsonValue
+  : K extends "string_contains" | "string_starts_with" | "string_ends_with"
+    ? string
+    : JsonPathScalar;
 
 /**
  * The bare-value half of a `Json` column's filter — **`JsonValue` with its
@@ -581,19 +636,25 @@ export type FieldFilter<V> =
       ? E[] | ListFilter<E>
       : V | NestedFilter<V>;
 
+/**
+ * The operator names are `relation-filters.ts`'s two tuples, which is the same
+ * pair `readOperators` iterates and `isOperatorForm` tests against — so the
+ * grammar the caller may write and the grammar the compiler recognises are one
+ * list (#369).
+ *
+ * `relation-filters.ts` already existed to stop the where compiler and the
+ * policy walk disagreeing about this shape; the type was the third party to
+ * that agreement and was not in it.
+ */
 type RelationFilter<R extends RelationInfo> = R["kind"] extends "many"
-  ? {
-      some?: WhereInput<R["target"]>;
-      every?: WhereInput<R["target"]>;
-      none?: WhereInput<R["target"]>;
-    }
+  ? { [K in ManyRelationOperator]?: WhereInput<R["target"]> }
   : /**
      * A to-one takes the nested `where` directly — `{ user: { email } }` means
      * `is` — and takes `null` for "there is no related row". `readOperators` in
      * the where compiler folds the two spellings together.
      */
     | WhereInput<R["target"]>
-      | { is?: WhereInput<R["target"]> | null; isNot?: WhereInput<R["target"]> | null }
+      | { [K in OneRelationOperator]?: WhereInput<R["target"]> | null }
       | (R["nullable"] extends true ? null : never);
 
 export type WhereInput<M extends ModelTypeInfo> = {
@@ -784,24 +845,99 @@ export type FindUniqueOrThrowArgs<M extends ModelTypeInfo> = FindUniqueArgs<M>;
 // ---------------------------------------------------------------------------
 
 /**
- * The nested write statements, from `SUPPORTED` in `compile/nested-writes.ts`.
+ * The statements a nested write may name **under a `create`**, which is
+ * `SUPPORTED` minus `EXISTING_ROW_ONLY` in `compile/nested-writes.ts` —
+ * subtracted rather than listed again, so the two files cannot answer
+ * differently (#369). Concretely: `connect`, `connectOrCreate`, `create`,
+ * `createMany`.
+ *
+ * The subtraction is the compiler's own reasoning, not an approximation of it.
+ * `assertNestedOperand` refuses an `EXISTING_ROW_ONLY` key whenever the
+ * operation is a `create`, because there is nothing linked to a row that does
+ * not exist yet.
+ */
+type NestedCreateStatement = Exclude<NestedWriteStatement, ExistingRowStatement>;
+
+/**
+ * What each statement's operand is on a **to-many**.
+ *
+ * The `| T[]` on nearly every arm is Prisma's own shape and the compiler's:
+ * `listOf` accepts a single object or an array of them everywhere a collection
+ * is being written.
+ *
+ * A statement added to `SUPPORTED_STATEMENTS` with no arm here resolves to
+ * {@link NestedStatementHasNoOperandType}, whose one property is a sentence —
+ * the same device `AggregateNeedsArithmetic` uses two sections down, and for
+ * the same reason: an optional `never` reports *"not assignable to type
+ * 'undefined'"*, which says nothing about what went wrong.
+ */
+type ManyNestedOperand<
+  K extends NestedWriteStatement,
+  M extends ModelTypeInfo,
+> = K extends "create"
+  ? CreateInput<M> | CreateInput<M>[]
+  : K extends "createMany"
+    ? { data: CreateInput<M>[]; skipDuplicates?: boolean }
+    : K extends "connect" | "set" | "disconnect" | "delete"
+      ? WhereUniqueInput<M> | WhereUniqueInput<M>[]
+      : K extends "connectOrCreate"
+        ? ConnectOrCreate<M> | ConnectOrCreate<M>[]
+        : K extends "deleteMany"
+          ? WhereInput<M> | WhereInput<M>[]
+          : K extends "update"
+            ? NestedUpdateOne<M> | NestedUpdateOne<M>[]
+            : K extends "updateMany"
+              ? NestedUpdateMany<M> | NestedUpdateMany<M>[]
+              : K extends "upsert"
+                ? NestedUpsert<M> | NestedUpsert<M>[]
+                : NestedStatementHasNoOperandType;
+
+/**
+ * ...and on a **to-one**, where four statements do not exist at all and none of
+ * the rest takes an array — there is one related row, so there is nothing for a
+ * list of operands to address, and `planForeignSide` refuses one by name.
+ *
+ * Three differ in more than that. `disconnect` and `delete` take a boolean —
+ * "the link, whatever it points at" — where a to-many has to say *which* rows;
+ * and `update` takes the bare `data` as well as `{ where?, data }`, because the
+ * parent's key already names the row.
+ */
+type OneNestedOperand<
+  K extends Exclude<NestedWriteStatement, CollectionOnlyStatement>,
+  M extends ModelTypeInfo,
+> = K extends "create"
+  ? CreateInput<M>
+  : K extends "connect"
+    ? WhereUniqueInput<M>
+    : K extends "connectOrCreate"
+      ? ConnectOrCreate<M>
+      : K extends "disconnect" | "delete"
+        ? boolean | WhereInput<M>
+        : K extends "update"
+          ? UpdateInput<M> | NestedUpdateToOne<M>
+          : K extends "upsert"
+            ? NestedUpsertToOne<M>
+            : NestedStatementHasNoOperandType;
+
+/** @see {@link ManyNestedOperand} */
+type NestedStatementHasNoOperandType = {
+  "this nested-write statement is in SUPPORTED_STATEMENTS but has no operand type here": never;
+};
+
+/**
+ * The nested write statements a `create`'s `data` may carry.
  *
  * A to-one cannot take the collection-shaped ones, which is the only structural
- * difference between the two sides.
+ * difference between the two sides — and `COLLECTION_ONLY_STATEMENTS` is the
+ * list both planners refuse there, subtracted rather than restated.
  */
 type NestedCreate<R extends RelationInfo> = R["kind"] extends "many"
-  ? {
-      create?: CreateInput<R["target"]> | CreateInput<R["target"]>[];
-      createMany?: { data: CreateInput<R["target"]>[]; skipDuplicates?: boolean };
-      connect?: WhereUniqueInput<R["target"]> | WhereUniqueInput<R["target"]>[];
-      connectOrCreate?:
-        | ConnectOrCreate<R["target"]>
-        | ConnectOrCreate<R["target"]>[];
-    }
+  ? { [K in NestedCreateStatement]?: ManyNestedOperand<K, R["target"]> }
   : {
-      create?: CreateInput<R["target"]>;
-      connect?: WhereUniqueInput<R["target"]>;
-      connectOrCreate?: ConnectOrCreate<R["target"]>;
+      [K in Exclude<
+        NestedCreateStatement,
+        CollectionOnlyStatement
+      >]?: OneNestedOperand<K, R["target"]>;
     };
 
 interface ConnectOrCreate<M extends ModelTypeInfo> {
@@ -809,27 +945,23 @@ interface ConnectOrCreate<M extends ModelTypeInfo> {
   create: CreateInput<M>;
 }
 
-type NestedUpdate<R extends RelationInfo> = NestedCreate<R> &
-  (R["kind"] extends "many"
-    ? {
-        set?: WhereUniqueInput<R["target"]> | WhereUniqueInput<R["target"]>[];
-        disconnect?:
-          | WhereUniqueInput<R["target"]>
-          | WhereUniqueInput<R["target"]>[];
-        delete?: WhereUniqueInput<R["target"]> | WhereUniqueInput<R["target"]>[];
-        deleteMany?: WhereInput<R["target"]> | WhereInput<R["target"]>[];
-        update?: NestedUpdateOne<R["target"]> | NestedUpdateOne<R["target"]>[];
-        updateMany?:
-          | NestedUpdateMany<R["target"]>
-          | NestedUpdateMany<R["target"]>[];
-        upsert?: NestedUpsert<R["target"]> | NestedUpsert<R["target"]>[];
-      }
-    : {
-        disconnect?: boolean | WhereInput<R["target"]>;
-        delete?: boolean | WhereInput<R["target"]>;
-        update?: UpdateInput<R["target"]> | NestedUpdateToOne<R["target"]>;
-        upsert?: NestedUpsertToOne<R["target"]>;
-      });
+/**
+ * An `update`'s `data` carries the whole of `SUPPORTED_STATEMENTS`, so this is
+ * the unsubtracted set rather than `NestedCreate` intersected with the rest.
+ *
+ * Stated as one mapped type for a reason beyond brevity: written as an
+ * intersection, the create-half and the update-half were two places a
+ * statement's operand could be given, and a statement listed in both with
+ * different operands would silently intersect to something neither file meant.
+ */
+type NestedUpdate<R extends RelationInfo> = R["kind"] extends "many"
+  ? { [K in NestedWriteStatement]?: ManyNestedOperand<K, R["target"]> }
+  : {
+      [K in Exclude<
+        NestedWriteStatement,
+        CollectionOnlyStatement
+      >]?: OneNestedOperand<K, R["target"]>;
+    };
 
 interface NestedUpdateOne<M extends ModelTypeInfo> {
   where: WhereUniqueInput<M>;
@@ -1053,22 +1185,20 @@ export type GroupByOrderByInput<M extends ModelTypeInfo> = {
 };
 
 /**
- * The six comparisons a `having` operand takes, which is `OPERATORS` in
- * `compile/group-by.ts` and nothing else.
+ * The six comparisons a `having` operand takes, which **is** `OPERATORS` in
+ * `compile/group-by.ts` and nothing else — its keys, mapped over, rather than
+ * the same six names written out again beside a comment saying they match
+ * (#369).
  *
  * Narrower than a `where`'s on purpose, because the compiler is: `having` walks
  * its own operand reader, so `contains`, `in`, `startsWith` and `mode` are not
  * offered here and throw *"A 'having' filter takes equals, gt, gte, lt, lte,
  * not"* if written. A bare value is `equals`, the shorthand `where` accepts too,
- * and `null` under `equals` / `not` becomes `is null` / `is not null`.
+ * and `null` under `equals` / `not` becomes `is null` / `is not null` — which is
+ * why those two alone widen by `null`, and the four orderings do not.
  */
 type HavingComparison<V> = {
-  equals?: V | null;
-  not?: V | null;
-  lt?: V;
-  lte?: V;
-  gt?: V;
-  gte?: V;
+  [K in HavingOperator]?: K extends "equals" | "not" ? V | null : V;
 };
 
 type HavingFilter<V> = V | HavingComparison<V>;

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -59,12 +59,15 @@
 // schema into an instantiation-depth error rather than a slow compile.
 //
 // **The operator grammars below map over a tuple, and that is not the mapping
-// the paragraph above warns about.** `RelationFilter`, `NestedCreate` and
-// `NestedUpdate` are `[K in <five literal strings>]`, not `[K in keyof M]`: the
-// key set is fixed and finite whatever the schema is, and the property types
-// are deferred exactly as an interface's are. Measured rather than assumed —
-// the template's fourteen mutually recursive models typecheck in the same time
-// they did before (1.6–1.8s, warm, either way).
+// the paragraph above warns about.** All six of them — `ListFilter`,
+// `JsonPathFilter`, `HavingComparison`, `RelationFilter`, `NestedCreate` and
+// `NestedUpdate` — are `[K in a fixed tuple of literals]`, not `[K in keyof M]`:
+// the key set is decided by the compiler's own list and is the same size
+// whatever the schema is, and the property types are deferred exactly as an
+// interface's are. (The sizes differ per grammar — two to eleven keys — and
+// none of them is a function of the model.) Measured rather than assumed: the
+// template's fourteen mutually recursive models typecheck in the same time they
+// did before (1.6–1.8s, warm, either way).
 
 import type {
   AnyNullValue,
@@ -572,9 +575,19 @@ type JsonPathFilter = { path: JsonPath } & {
  * in any case *usable* — where a `never` would give the new operator a key
  * nothing can be passed under, which is a quieter kind of wrong than the one
  * this change removes.
+ *
+ * **`array_contains` takes a document but not a bare `null`.** It is the one
+ * operator `assertJsonOperand` waves through without a scalar check, so a bare
+ * `null` reaches `dialect.jsonArrayContains` and binds as SQL NULL — and
+ * `x @> NULL` is NULL, not false, so the filter silently matches no row rather
+ * than asking anything. A `null` *inside* the document is fine and stays
+ * expressible; only the top-level operand is excluded. (#380 found this and
+ * narrows the same property on the hand-written literal this mapped type
+ * replaces; the narrowing lives on the arm here so the two do not resolve to
+ * whichever side of the merge is taken.)
  */
 type JsonPathOperand<K extends JsonFilterName> = K extends "array_contains"
-  ? JsonValue
+  ? Exclude<JsonValue, null>
   : K extends "string_contains" | "string_starts_with" | "string_ends_with"
     ? string
     : JsonPathScalar;

--- a/templates/saas-starter/app/models/filters.test-d.ts
+++ b/templates/saas-starter/app/models/filters.test-d.ts
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest";
 
 import { AnyNull, DbNull, JsonNull } from "gemi/orm";
+import type { FieldFilter } from "gemi/orm";
 
 import {
   AccountModel,
@@ -87,10 +88,11 @@ describe("scalar filters, per storage class", () => {
    * faked with a cast: a type test whose subject is invented proves the type
    * accepts the invention. `Boolean` reaches the same `NoKeys` branches through
    * the same code path as `Bytes`, so it is covered in mechanism if not by name.
-   * `String[]` is likewise absent here — scalar lists are a Postgres-only schema
-   * (`postgres-only.prisma`), whose artifacts are uncommitted and so cannot be
-   * typechecked in the SQLite job. Both are genuine gaps in what this file can
-   * reach, recorded rather than papered over.
+   * `String[]` has no *column* here for the same reason — scalar lists are a
+   * Postgres-only schema (`postgres-only.prisma`), whose artifacts are
+   * uncommitted and so cannot be typechecked in the SQLite job. Its arm is
+   * still asserted, one test down: the list grammar is a function of the
+   * element type alone, so it does not need a model to reach.
    */
   test("Bytes takes equality but not ordering or patterns", async () => {
     await AccountModel.findMany({ where: { token: { equals: null } } });
@@ -98,6 +100,42 @@ describe("scalar filters, per storage class", () => {
       where: { token: { equals: new Uint8Array([1]) } },
     });
     await AccountModel.findMany({ where: { token: { not: null } } });
+  });
+
+  /**
+   * **The scalar-list arm, without a scalar-list column.**
+   *
+   * Every other grammar #369 derived from the compiler's own operator tuple has
+   * something committed pinning it. `ListFilter` was the exception — a
+   * `String[]` is a validation error on SQLite, so there is no column here to
+   * ask through, and the write-up said the derivation therefore could not be
+   * asserted in this repository at all.
+   *
+   * That was true of asking *through a model* and false of the type. `ListFilter`
+   * is reached from `FieldFilter`'s array branch on the element type alone, and
+   * `FieldFilter` is public, so a type argument is enough. No column, no
+   * Postgres, no generated artifact.
+   *
+   * Two assertions rather than one, because they fail on different drift. The
+   * key set is `LIST_FILTER_NAMES` in `compile/where.ts`; the operand of each
+   * key is `ListFilterOperand`'s three-way split — `has` asks about one element,
+   * `isEmpty` about the array's length, the other three take a whole array — and
+   * that split is the part that still has to be stated per operator.
+   */
+  test("the scalar-list arm is the compiler's list, on its element type", () => {
+    type ListArm = Exclude<FieldFilter<string[]>, string[]>;
+
+    expectTypeOf<keyof ListArm>().toEqualTypeOf<
+      "equals" | "has" | "hasEvery" | "hasSome" | "isEmpty"
+    >();
+
+    expectTypeOf<ListArm>().toEqualTypeOf<{
+      equals?: string[];
+      has?: string;
+      hasEvery?: string[];
+      hasSome?: string[];
+      isEmpty?: boolean;
+    }>();
   });
 
   test("an enum column is the union of its members", async () => {
@@ -302,10 +340,25 @@ describe("Json path filters", () => {
    * refused there is nothing else it could be asking. Filed against the runtime
    * as #371 rather than changed here, since this is a type-only change — so a
    * `null` arriving dynamically still reaches the binder.
+   *
+   * **`array_contains` is the same refusal for a different reason**, and it is
+   * the one path operator whose operand is a whole document, so it does not
+   * come along with the scalar arm. A bare `null` there reaches
+   * `dialect.jsonArrayContains` and binds as SQL NULL; `x @> NULL` is NULL, not
+   * false, so the filter matches no row rather than asking anything. Only the
+   * top-level operand goes — a `null` *inside* the document is an ordinary JSON
+   * value, and the line below pins that it stays expressible. (The finding is
+   * #380's, on the hand-written literal this branch replaced with a mapped
+   * type; the narrowing lives on `JsonPathOperand`'s `array_contains` arm so
+   * the two do not come down to which side of a merge is taken.)
    */
   test("null at a path is refused, having no reading left", async () => {
     // @ts-expect-error `= NULL` is never true; say which empty you mean, on the column
     await UserModel.findMany({ where: { metadata: { path: ["a"], equals: null } } });
+    // @ts-expect-error `x @> NULL` is NULL too, so containment against a bare null asks nothing
+    await UserModel.findMany({ where: { metadata: { path: ["a"], array_contains: null } } });
+    // ...and it is only the *top level* that goes: a null inside the document is a value.
+    await UserModel.findMany({ where: { metadata: { path: ["a"], array_contains: [1, null] } } });
   });
 
   /**


### PR DESCRIPTION
Closes #369.

`orm/types.ts` and `orm/compile/*.ts` each encoded the same operator sets, in files that neither imports the other. Six grammars now map over the compiler's own tuple, so the compiler's list **is** the type's list.

## The defect, reproduced as a mutation

Not argued from the issue text. On `main`, deleting one line from `JsonPathFilter` — the caller-facing type:

```diff
-  string_ends_with?: string;
```

leaves `packages/gemi` entirely green:

```
tsc --noEmit -p tsconfig.json    (no output)
vitest run orm                   64 files, 2421 tests, all passed
```

while `compileJsonFilter` goes on implementing `string_ends_with`, `docs/orm.md` goes on documenting it, and the differential case `"json path string_ends_with"` goes on asserting it against Prisma. That is #336 exactly, arrived at by hand: a working, tested, documented filter with no caller-facing spelling.

The one thing that catches it is `filters.test-d.ts`, added by #368 — and that file is a *fourth* hand-written copy of the same ten names, which the issue's last paragraph is about. It fails when the type shrinks. Nothing anywhere fails when the compiler's list grows: adding `"string_matches"` to `JSON_FILTERS` on `main` leaves typecheck and all 2421 tests green.

## The change

Each runtime set becomes an `as const` tuple that exports a string-literal union; `types.ts` type-imports the union and maps over it.

| the compiler's list | the type that used to restate it |
| --- | --- |
| `JSON_FILTER_NAMES` — `compile/where.ts` | `JsonPathFilter` |
| `LIST_FILTER_NAMES` — `compile/where.ts` | `ListFilter` |
| `OPERATORS` — `compile/group-by.ts` | `HavingComparison` |
| `MANY_FILTER_OPERATORS` / `ONE_FILTER_OPERATORS` — `relation-filters.ts` | `RelationFilter` |
| `SUPPORTED_STATEMENTS` / `EXISTING_ROW_ONLY_STATEMENTS` / `COLLECTION_ONLY_STATEMENTS` — `compile/nested-writes.ts` | `NestedCreate` / `NestedUpdate` |

Which operator exists is now stated once. What each operator's *operand* is still has to be stated per operator, and that is a smaller and much noisier surface to get wrong — a wrong operand type is a compile error at the call site, where a missing key was silence.

`import type` throughout, so nothing is emitted: `dist/orm/index.js` is byte-unchanged and `runtime-isolation.test.ts`'s property is untouched. The `.d.ts` half was checked rather than assumed — `bun run build:types` emits `dist/orm/compile/where.d.ts`, `group-by.d.ts`, `nested-writes.d.ts` and `relation-filters.d.ts` beside `types.d.ts`, and `types.d.ts` carries the four `import type` lines that resolve to them. There is no import cycle: nothing under `compile/` imports `../types`.

### The nested-write statements were the one non-mechanical site

The other four are one list against one key set. The write side is three key sets against four, and they turn out to fall out of subtraction rather than needing a fourth list:

```
NestedCreate<many>  = SUPPORTED − EXISTING_ROW_ONLY
NestedCreate<one>   = SUPPORTED − EXISTING_ROW_ONLY − COLLECTION_ONLY
NestedUpdate<many>  = SUPPORTED
NestedUpdate<one>   = SUPPORTED − COLLECTION_ONLY
```

*(Corrected in review — the first line said `= SUPPORTED`, which is `NestedUpdate<many>`'s row. The docblock in `types.ts` had it right, and the reviewer's independent mutual-assignability check against `54d4278`'s `types.ts` confirms all four arms, operands included.)*

`COLLECTION_ONLY_STATEMENTS` is new, and it is not a fifth hand-maintained list: both planners already refused `set` / `updateMany` / `deleteMany` on a to-one through an inline `key === … || key === …` chain, and `planForeignSide`'s docblock already named all four together — *"with no `createMany`, `set`, `updateMany` or `deleteMany` key at all"*. Both chains now read `NO_SET_OF_ROWS`, which is the tuple minus `createMany`, derived by `.filter` rather than written out.

`createMany` is carved out rather than folded in because its refusal is **not** the same refusal. It says "there is one related row at most and nothing to create many of" on the owning side and "there is nothing to create many of" on the foreign side, each next to its own operand check, and `nested-writes.ts` says in as many words that the two are duplicated on purpose because "both are reachable and neither subsumes the other". Merging them would have rewritten two pinned messages for tidiness.

`NestedUpdate` also stops being `NestedCreate<R> & (…)`. As an intersection there were two places a statement's operand could be declared, and one declared in both with different operands would intersect to something neither half meant. One mapped type over the unsubtracted set has one.

### A statement with no operand arm says so

`ManyNestedOperand` / `OneNestedOperand` fall through to a named type rather than `never`, following `AggregateNeedsArithmetic`'s precedent in the same file. Measured, by adding `"replace"` to `SUPPORTED_STATEMENTS`:

```
TypeCheckError: Property '"this nested-write statement is in SUPPORTED_STATEMENTS
but has no operand type here"' is missing in type '{}'
```

rather than *"not assignable to type 'undefined'"*.

`JsonPathOperand` deliberately does **not** do this — its default arm is `JsonPathScalar`, which is what five of the current six non-string operators take. A `never` there would give a new operator a key nothing can be passed under, which is a quieter kind of wrong than the one this removes.

## Evidence that the derivation holds

Five throwaway `@ts-expect-error` probes in the template, run through `bun run test:types` — the harness fails an `@ts-expect-error` whose error stops happening, so the directive flips in both directions:

```ts
// @ts-expect-error present only when JSON_FILTER_NAMES carries it
await UserModel.findMany({ where: { metadata: { path: ["a"], string_matches: "x" } } });
// @ts-expect-error present only when group-by OPERATORS carries it
await UserModel.groupBy({ by: ["globalRole"], having: { name: { startsWith: "a" } } });
// @ts-expect-error present only when MANY_FILTER_OPERATORS carries it
await UserModel.findMany({ where: { accounts: { atLeastOne: {} } } });
// @ts-expect-error present only when SUPPORTED_STATEMENTS carries it
await UserModel.update({ where: { id: 1 }, data: { accounts: { replace: undefined } } });
// @ts-expect-error ...and the to-one arm of the same
await AccountModel.update({ where: { id: 1 }, data: { user: { replace: undefined } } });
```

| state | result |
| --- | --- |
| this branch as it stands | 121 passed, no type errors — all five spellings refused |
| one name added to each of the four runtime lists, **`types.ts` untouched** | all five `@ts-expect-error` directives report *"Unused"* — the type followed |

and the other 116 assertions in `filters.test-d.ts` stayed green through both, so the widening was exactly the five keys and nothing else.

The probes are not committed. They demonstrate a property of the derivation, and the derivation is what makes them redundant: there is no second list left for them to guard.

## Runs

Everything CI runs, in the sqlite job's order:

| | |
| --- | --- |
| `tsc --noEmit -p tsconfig.json` | clean |
| `tsc --noEmit -p tsconfig.generated.json` | clean |
| `vitest run` (packages/gemi) | 120 files, 3110 passed, 1 skipped |
| `vitest run app/models` (template) | 20 files, 792 passed, 133 skipped |
| `bun run test:types` (template) | 6 files, 117 passed, no type errors |
| `bunx prisma generate` (template) | zero-line diff on the committed artifact |
| `gemi check models --ignore bench` | 7 model files against 14 registered models |
| `oxlint orm --deny-warnings` | 0 warnings, 0 errors |
| `bun run lint` | 79 warnings, 0 errors (unchanged) |

`bun install` was run in the worktree first and `readlink -f templates/saas-starter/node_modules/gemi` confirmed to resolve into it, so the template suites exercised this branch rather than the main checkout.

**Postgres was not run** — no service container here. The change is dialect-agnostic by construction (no runtime table changed membership, and `dialect.jsonFilters` is untouched), but that is an argument, not a measurement, and the `postgres` job is what will settle it.

**Compile time was measured**, because `types.ts`'s own header warns that eager evaluation would turn a cyclic schema into an instantiation-depth error. These map over fixed tuples of literals, not over `keyof M`, so the key set is finite whatever the schema is. Warm `test:types` over the template's fourteen mutually recursive models: 1.83 / 1.68 / 1.56s on this branch, 1.80 / 1.72s on `main`. The note is now in the header beside the warning it answers.

## What this does not cover, and why

- **The scalar `OPERATORS` set** in `compile/where.ts` is *not* derived, though it is the same shape. Its twelve names split across `BaseFilter` / `OrderingFilter` / `StringFilter`, and which arm a name belongs to is gated on the column's storage class — a fact the runtime set does not record, since the compiler applies one flat table and lets the operand's type decide. Deriving it would mean inventing a three-way partition here and asserting it sums back, which is a new source of truth rather than a removed one. Left with its comment.
- **The dialect halves** (`dialect.jsonFilters`, `dialect.listFilters`) stay the runtime's job, for the reason the issue gives: the generated artifact is dialect-agnostic, so a dialect-shaped type has nothing to read. Unchanged.
- **`READ_ARGS` / `WRITE_ARGS`** are operation *argument* names rather than operators, and they already have two cross-checks that read them directly — `generated-surface.test.ts` and `plan.coverage.test.ts`. Adding a third mechanism over the same pair is not what the issue asks for.
- ~~**`ListFilter` has no type-level regression test**, and cannot get one here.~~ **Withdrawn in review — it does now.** That was true of asking through a *model*: a `String[]` column is a validation error on SQLite, so scalar lists live in `postgres-only.prisma`, whose artifacts are uncommitted. It was not true of the type. `ListFilter` is reached from the public `FieldFilter` on the element type alone, so `Exclude<FieldFilter<string[]>, string[]>` is the arm, with no column, no Postgres and no generated artifact. `filters.test-d.ts` now pins it twice — the key set against `LIST_FILTER_NAMES`, and `ListFilterOperand`'s three-way operand split — and each mutation fails exactly one. The `Boolean` / `Bytes` gap the file records is unrelated and still real.
- **`NestedUpdate<one>` still offers `upsert` and `delete` on an owning-side to-one, which `planOwningSide` refuses.** Pre-existing and untouched: `RelationInfo` records `kind` but not which side holds the foreign key, so the type cannot tell an owning to-one from a foreign one. Worth its own issue rather than a guess here.

## Review round 1

Six inline comments and one cross-PR comment; five addressed, one was a verification with no change requested, and nothing declined or deferred. Commit `02b8b66`.

- **The derivation had no tripwire.** Reverting `types.ts` to `54d4278` left every derived union an export nothing imports, and the whole package stayed green — including `architecture.test.ts`, whose stated property is exactly that. Its scan matched `export function`, `export const` and `export class` and nothing else. It now matches `export type` and `export interface`, and **skips itself as a source**: its own new docblock names three of the unions, and that alone was enough to keep those three green under the revert while the other five went red. A comment is not a use. Reverting `types.ts` now names all eight. The six pre-existing type exports the wider scan turns up are allow-listed with a reason each — all six name a parameter or field of a public signature, which is a use this scan cannot see.
- **`ListFilter` is asserted** — see the struck-through bullet above.
- **`array_contains` narrows to `Exclude<JsonValue, null>`**, which is #380's finding landed on `JsonPathOperand`'s arm rather than left to a merge to preserve. A bare `null` reaches `dialect.jsonArrayContains` and binds as SQL NULL; `x @> NULL` is NULL, not false. The assertion is in `filters.test-d.ts` beside the existing `equals: null` one, with a companion line pinning that a null *inside* the document is still expressible. Reverting the arm to `JsonValue` reports the directive unused.
- **`OPERATOR_SQL` is `Readonly`**, so the lookup alias can no longer write to the object `HavingOperator` is derived from. The `| undefined` is unchanged and is the half that matters.
- **Two comments corrected.** `relation-filters.ts` claimed the two tuples are exported; they are not, and `architecture.test.ts` records that they were deliberately unexported — what crosses the boundary is the derived type. The `types.ts` header said `[K in <five literal strings>]`, which is the relation-filter count and no other; it now says a fixed tuple of literals, notes the range is two to eleven, and names all six mapped grammars rather than three.
- **The subtraction check needed nothing** beyond the table fix above.

