### PR TITLE
Close #376: a raw `::jsonb` parameter binds as JSON text, as it did under Prisma

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4965,13 +4965,14 @@ stops at this door.
 
 Values are handed to the driver as they arrive, with two exceptions that exist so a fragment means
 the same thing on both dialects: a `Date` binds as milliseconds on SQLite — which is what the ORM
-stores — and a boolean as `0`/`1`.
+stores — and a boolean as `0`/`1`. A third applies only where the statement itself says the
+parameter is JSON — see [below](#a-jsonb-cast-you-write-types-the-parameter-as-text).
 
-A plain object is **not** JSON-encoded for you. The compiler only knows to do that because a field
-says `Json`, and guessing from the value would turn a mistyped parameter into a successfully-written
-string. What the driver then does with it differs: Bun binds an object into a Postgres `jsonb`
-column correctly, and on SQLite binds it to something no row matches. Stringify it yourself if the
-column is JSON and you want the same answer on both.
+A plain object is otherwise **not** JSON-encoded for you. The compiler only knows to do that because
+a field says `Json`, and guessing from the value would turn a mistyped parameter into a
+successfully-written string. What the driver then does with it differs: Bun binds an object into a
+Postgres `jsonb` column correctly, and on SQLite binds it to something no row matches. Stringify it
+yourself if the column is JSON and you want the same answer on both.
 
 **The separator `join` takes is written into the SQL**, so it is not a free string: whitespace,
 commas, or `and` / `or`, and nothing else. Anything more expressive is legitimate but has to say so
@@ -4991,6 +4992,63 @@ through, which has none of them and is still an injection.
 interpolation slot is bound — including an object that merely *looks* like a fragment, which is what
 a parsed request body can be made to contain. That check is membership, not shape, precisely so that
 `{"text": "…", "binders": []}` arriving from outside the program is a parameter and not a statement.
+
+### A `::jsonb` cast you write types the parameter as `text`
+
+**Read this before porting a raw statement off Prisma's `$executeRaw`.** On Postgres this is the one
+place a byte-identical statement used to change meaning, and it changed it silently.
+
+```ts
+// Merges the patch into the document, on both clients.
+await DB.execute(
+  sql`update "AsyncJob" set "payload" = "payload" || ${JSON.stringify(patch)}::jsonb
+      where "id" = ${id}`,
+)
+```
+
+The divergence is in the **parameter's** type, not the cast's. Prisma sends a JS string as `text` and
+lets Postgres parse it into the target type. Bun asks the server what the statement wants, is told
+`jsonb`, and JSON-encodes the string it was handed — so the document arrives as a jsonb *string*.
+Measured on Postgres 16, binding the JS string `'{"version":1}'`:
+
+| statement | Prisma | Bun, unassisted |
+| --- | --- | --- |
+| `values ($1)` | error: `jsonb` vs `text` | `"{\"version\":1}"` — a jsonb string |
+| `values ($1::jsonb)` | `{"version": 1}` | `"{\"version\":1}"` |
+| `values (cast($1 as jsonb))` | `{"version": 1}` | `"{\"version\":1}"` |
+| `values ($1::text::jsonb)` | `{"version": 1}` | `{"version": 1}` |
+
+The `||` case is the sharp end: concatenating an object with a jsonb *string* is **array
+concatenation, not a merge**, so a statement written to merge metadata appends the serialised text as
+a new element. The write succeeds, nothing raises, the SQL reads correctly by eye, and the damage is
+found later by whatever reads the column.
+
+So gemi reads the cast. Where a parameter carries one, the placeholder is retyped through `text` —
+`$1::text::jsonb` — and the value is serialised to match, which is what Prisma did implicitly and
+what a `Json` *column* has always compiled to. Recognised: `::jsonb`, `::json`, `::text::jsonb`,
+`cast(… as jsonb)`, in any case and with whitespace anywhere Postgres allows it.
+
+At such a parameter, **a string is JSON text** — `${'{"a":1}'}::jsonb` stores the object — where a
+`Json` column takes the same string as a JSON string value. That is not an inconsistency to
+work around: it is which of the two Prisma does on each path. Pass the serialisation you mean:
+
+```ts
+sql`… = ${JSON.stringify(patch)}::jsonb`               // the object
+sql`… = ${JSON.stringify(JSON.stringify(patch))}::jsonb`  // the jsonb string, if you want that
+```
+
+Everything else follows from "the parameter is JSON text": an object or array is serialised for you,
+so `${patch}::jsonb` works too; a number and a boolean become JSON numbers and booleans; `null` stays
+SQL NULL, and `DbNull` / `JsonNull` mean what they mean on a column. A `bigint` has no JSON form and
+raises rather than binding something wrong.
+
+**What is not covered, and why that is the right line:** a bare `$1` into a `jsonb` column has the
+same fault and there is nothing to read — no cast, no column type. It is also the shape a Prisma port
+cannot be carrying, because Prisma *refuses* it (`column "payload" is of type jsonb but expression is
+of type text`); write the cast. Schema-qualified spellings (`$1::pg_catalog.jsonb`) and `jsonb[]` are
+deliberately left alone — the second is an array of documents, and serialising the JS array into one
+would be wrong. `DB.sql`, Bun's own tagged template, is untouched by all of this: it binds through
+the driver directly, so `::text::jsonb` is yours to write there.
 
 ### The rowcount is a primitive, not a diagnostic
 
@@ -5126,6 +5184,11 @@ On Postgres the parameter is cast — `$1::text::jsonb` — and the value serial
 is what lets a bare number or boolean through. Binding it raw makes the driver send an `integer` to
 a `jsonb` column, and serialising *without* the cast stores the jsonb string `"42"` instead of the
 number, which is worse than refusing it. SQLite needs neither: it stores JSON as text.
+
+A raw statement gets the same cast from the one you write yourself — see
+[A `::jsonb` cast you write types the parameter as `text`](#a-jsonb-cast-you-write-types-the-parameter-as-text),
+which is also where the one difference between the two paths is spelled out: at a cast you wrote, a
+JS string is JSON *text* rather than a JSON string value.
 
 > **Upgrading:** `Json` values written by a *pre-release* build of this ORM on Postgres were stored
 > as JSON **strings** rather than as objects — `{ a: 1 }` landed as `"{\"a\":1}"`. Reads undid it,

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5028,6 +5028,16 @@ So gemi reads the cast. Where a parameter carries one, the placeholder is retype
 what a `Json` *column* has always compiled to. Recognised: `::jsonb`, `::json`, `::text::jsonb`,
 `cast(… as jsonb)`, in any case and with whitespace anywhere Postgres allows it.
 
+**On Postgres only, including the `cast(…)` spelling.** SQLite has no `jsonb` type and no `::`
+operator, so the mis-store cannot arise there — but `cast(x as json)` *does* parse and run on SQLite,
+where it means something else entirely: SQLite accepts any type name in a `CAST` and applies affinity
+rules, so `cast('{"a":1}' as json)` is `0`. gemi therefore leaves such a statement exactly as you
+wrote it on SQLite — retyping it would rewrite working SQL into a syntax error, and serialise for a
+cast that never meant JSON. There is no portable spelling to reach for: the two dialects do not share
+a JSON grammar at all, which is the same reason `path:` takes an array on Postgres and a `$.a.b`
+string on SQLite for the ORM's own filters. A raw statement that touches JSON is a per-dialect
+statement.
+
 At such a parameter, **a string is JSON text** — `${'{"a":1}'}::jsonb` stores the object — where a
 `Json` column takes the same string as a JSON string value. That is not an inconsistency to
 work around: it is which of the two Prisma does on each path. Pass the serialisation you mean:
@@ -5047,8 +5057,10 @@ same fault and there is nothing to read — no cast, no column type. It is also 
 cannot be carrying, because Prisma *refuses* it (`column "payload" is of type jsonb but expression is
 of type text`); write the cast. Schema-qualified spellings (`$1::pg_catalog.jsonb`) and `jsonb[]` are
 deliberately left alone — the second is an array of documents, and serialising the JS array into one
-would be wrong. `DB.sql`, Bun's own tagged template, is untouched by all of this: it binds through
-the driver directly, so `::text::jsonb` is yours to write there.
+would be wrong. A cast on an expression **around** the placeholder rather than on the placeholder
+itself is not read either — `(${'{"a":1}'})::jsonb` and `cast(coalesce(${v}) as jsonb)` still
+mis-store, so put the cast on the placeholder. `DB.sql`, Bun's own tagged template, is untouched by
+all of this: it binds through the driver directly, so `::text::jsonb` is yours to write there.
 
 ### The rowcount is a primitive, not a diagnostic
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -2045,6 +2045,16 @@ So gemi reads the cast. Where a parameter carries one, the placeholder is retype
 what a `Json` *column* has always compiled to. Recognised: `::jsonb`, `::json`, `::text::jsonb`,
 `cast(… as jsonb)`, in any case and with whitespace anywhere Postgres allows it.
 
+**On Postgres only, including the `cast(…)` spelling.** SQLite has no `jsonb` type and no `::`
+operator, so the mis-store cannot arise there — but `cast(x as json)` *does* parse and run on SQLite,
+where it means something else entirely: SQLite accepts any type name in a `CAST` and applies affinity
+rules, so `cast('{"a":1}' as json)` is `0`. gemi therefore leaves such a statement exactly as you
+wrote it on SQLite — retyping it would rewrite working SQL into a syntax error, and serialise for a
+cast that never meant JSON. There is no portable spelling to reach for: the two dialects do not share
+a JSON grammar at all, which is the same reason `path:` takes an array on Postgres and a `$.a.b`
+string on SQLite for the ORM's own filters. A raw statement that touches JSON is a per-dialect
+statement.
+
 At such a parameter, **a string is JSON text** — `${'{"a":1}'}::jsonb` stores the object — where a
 `Json` column takes the same string as a JSON string value. That is not an inconsistency to
 work around: it is which of the two Prisma does on each path. Pass the serialisation you mean:
@@ -2064,8 +2074,10 @@ same fault and there is nothing to read — no cast, no column type. It is also 
 cannot be carrying, because Prisma *refuses* it (`column "payload" is of type jsonb but expression is
 of type text`); write the cast. Schema-qualified spellings (`$1::pg_catalog.jsonb`) and `jsonb[]` are
 deliberately left alone — the second is an array of documents, and serialising the JS array into one
-would be wrong. `DB.sql`, Bun's own tagged template, is untouched by all of this: it binds through
-the driver directly, so `::text::jsonb` is yours to write there.
+would be wrong. A cast on an expression **around** the placeholder rather than on the placeholder
+itself is not read either — `(${'{"a":1}'})::jsonb` and `cast(coalesce(${v}) as jsonb)` still
+mis-store, so put the cast on the placeholder. `DB.sql`, Bun's own tagged template, is untouched by
+all of this: it binds through the driver directly, so `::text::jsonb` is yours to write there.
 
 ### The rowcount is a primitive, not a diagnostic
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1982,13 +1982,14 @@ stops at this door.
 
 Values are handed to the driver as they arrive, with two exceptions that exist so a fragment means
 the same thing on both dialects: a `Date` binds as milliseconds on SQLite — which is what the ORM
-stores — and a boolean as `0`/`1`.
+stores — and a boolean as `0`/`1`. A third applies only where the statement itself says the
+parameter is JSON — see [below](#a-jsonb-cast-you-write-types-the-parameter-as-text).
 
-A plain object is **not** JSON-encoded for you. The compiler only knows to do that because a field
-says `Json`, and guessing from the value would turn a mistyped parameter into a successfully-written
-string. What the driver then does with it differs: Bun binds an object into a Postgres `jsonb`
-column correctly, and on SQLite binds it to something no row matches. Stringify it yourself if the
-column is JSON and you want the same answer on both.
+A plain object is otherwise **not** JSON-encoded for you. The compiler only knows to do that because
+a field says `Json`, and guessing from the value would turn a mistyped parameter into a
+successfully-written string. What the driver then does with it differs: Bun binds an object into a
+Postgres `jsonb` column correctly, and on SQLite binds it to something no row matches. Stringify it
+yourself if the column is JSON and you want the same answer on both.
 
 **The separator `join` takes is written into the SQL**, so it is not a free string: whitespace,
 commas, or `and` / `or`, and nothing else. Anything more expressive is legitimate but has to say so
@@ -2008,6 +2009,63 @@ through, which has none of them and is still an injection.
 interpolation slot is bound — including an object that merely *looks* like a fragment, which is what
 a parsed request body can be made to contain. That check is membership, not shape, precisely so that
 `{"text": "…", "binders": []}` arriving from outside the program is a parameter and not a statement.
+
+### A `::jsonb` cast you write types the parameter as `text`
+
+**Read this before porting a raw statement off Prisma's `$executeRaw`.** On Postgres this is the one
+place a byte-identical statement used to change meaning, and it changed it silently.
+
+```ts
+// Merges the patch into the document, on both clients.
+await DB.execute(
+  sql`update "AsyncJob" set "payload" = "payload" || ${JSON.stringify(patch)}::jsonb
+      where "id" = ${id}`,
+)
+```
+
+The divergence is in the **parameter's** type, not the cast's. Prisma sends a JS string as `text` and
+lets Postgres parse it into the target type. Bun asks the server what the statement wants, is told
+`jsonb`, and JSON-encodes the string it was handed — so the document arrives as a jsonb *string*.
+Measured on Postgres 16, binding the JS string `'{"version":1}'`:
+
+| statement | Prisma | Bun, unassisted |
+| --- | --- | --- |
+| `values ($1)` | error: `jsonb` vs `text` | `"{\"version\":1}"` — a jsonb string |
+| `values ($1::jsonb)` | `{"version": 1}` | `"{\"version\":1}"` |
+| `values (cast($1 as jsonb))` | `{"version": 1}` | `"{\"version\":1}"` |
+| `values ($1::text::jsonb)` | `{"version": 1}` | `{"version": 1}` |
+
+The `||` case is the sharp end: concatenating an object with a jsonb *string* is **array
+concatenation, not a merge**, so a statement written to merge metadata appends the serialised text as
+a new element. The write succeeds, nothing raises, the SQL reads correctly by eye, and the damage is
+found later by whatever reads the column.
+
+So gemi reads the cast. Where a parameter carries one, the placeholder is retyped through `text` —
+`$1::text::jsonb` — and the value is serialised to match, which is what Prisma did implicitly and
+what a `Json` *column* has always compiled to. Recognised: `::jsonb`, `::json`, `::text::jsonb`,
+`cast(… as jsonb)`, in any case and with whitespace anywhere Postgres allows it.
+
+At such a parameter, **a string is JSON text** — `${'{"a":1}'}::jsonb` stores the object — where a
+`Json` column takes the same string as a JSON string value. That is not an inconsistency to
+work around: it is which of the two Prisma does on each path. Pass the serialisation you mean:
+
+```ts
+sql`… = ${JSON.stringify(patch)}::jsonb`               // the object
+sql`… = ${JSON.stringify(JSON.stringify(patch))}::jsonb`  // the jsonb string, if you want that
+```
+
+Everything else follows from "the parameter is JSON text": an object or array is serialised for you,
+so `${patch}::jsonb` works too; a number and a boolean become JSON numbers and booleans; `null` stays
+SQL NULL, and `DbNull` / `JsonNull` mean what they mean on a column. A `bigint` has no JSON form and
+raises rather than binding something wrong.
+
+**What is not covered, and why that is the right line:** a bare `$1` into a `jsonb` column has the
+same fault and there is nothing to read — no cast, no column type. It is also the shape a Prisma port
+cannot be carrying, because Prisma *refuses* it (`column "payload" is of type jsonb but expression is
+of type text`); write the cast. Schema-qualified spellings (`$1::pg_catalog.jsonb`) and `jsonb[]` are
+deliberately left alone — the second is an array of documents, and serialising the JS array into one
+would be wrong. `DB.sql`, Bun's own tagged template, is untouched by all of this: it binds through
+the driver directly, so `::text::jsonb` is yours to write there.
 
 ### The rowcount is a primitive, not a diagnostic
 
@@ -2143,6 +2201,11 @@ On Postgres the parameter is cast — `$1::text::jsonb` — and the value serial
 is what lets a bare number or boolean through. Binding it raw makes the driver send an `integer` to
 a `jsonb` column, and serialising *without* the cast stores the jsonb string `"42"` instead of the
 number, which is worse than refusing it. SQLite needs neither: it stores JSON as text.
+
+A raw statement gets the same cast from the one you write yourself — see
+[A `::jsonb` cast you write types the parameter as `text`](#a-jsonb-cast-you-write-types-the-parameter-as-text),
+which is also where the one difference between the two paths is spelled out: at a cast you wrote, a
+JS string is JSON *text* rather than a JSON string value.
 
 > **Upgrading:** `Json` values written by a *pre-release* build of this ORM on Postgres were stored
 > as JSON **strings** rather than as objects — `{ a: 1 }` landed as `"{\"a\":1}"`. Reads undid it,

--- a/packages/gemi/orm/compile/fragment.ts
+++ b/packages/gemi/orm/compile/fragment.ts
@@ -96,6 +96,34 @@ export function param(binder: Binder, cast = ""): Fragment {
   return { text: PARAM_MARKER + cast, binders: [binder] };
 }
 
+/**
+ * A fragment's text cut at every parameter: `segments[i]` is the text that
+ * precedes parameter `i`, and `segments[i + 1]` the text that follows it. The
+ * inverse is `fromParamSegments`.
+ *
+ * It exists so that one caller — `renderFragment` — can read *what the author
+ * wrote next to a parameter* before placeholders are assigned. A `::jsonb` a
+ * caller wrote onto their own placeholder is the only thing that says a raw
+ * parameter is JSON, and it is only readable here, in the marker's own
+ * coordinates; after `render` the text holds `$1` and the segment boundaries
+ * are gone.
+ *
+ * Nothing in the compiler uses this. A plan's casts come from the dialect and
+ * are already correct, and re-deriving them from text would be a second,
+ * weaker source for something the schema already answers.
+ */
+export function paramSegments(fragment: Fragment): string[] {
+  return fragment.text.split(PARAM_MARKER);
+}
+
+/** `paramSegments` reversed: the segments woven back around the markers. */
+export function fromParamSegments(
+  segments: readonly string[],
+  binders: Binder[],
+): Fragment {
+  return { text: segments.join(PARAM_MARKER), binders };
+}
+
 export function concat(...parts: Fragment[]): Fragment {
   return joinFragments(parts, "");
 }

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -85,6 +85,36 @@ export interface SqlDialect {
    */
   readonly maxBoundParameters: number;
 
+  /**
+   * Whether the **statement** decides a parameter's type, so a cast the caller
+   * wrote onto their own placeholder changes how the driver encodes the value.
+   *
+   * True on Postgres: the server describes the statement, the client is told
+   * the parameter is `jsonb`, and Bun then JSON-*encodes* whatever JS value it
+   * was handed. That is the whole of #376 — the reason `json-param.ts` retypes
+   * such a parameter through `text` and serialises it to match.
+   *
+   * False on SQLite, and not merely because the correction is unnecessary
+   * there: it would be **wrong**, and it would not parse. A parameter's type is
+   * the bound value's, and `cast(x as json)` is not a JSON cast at all — SQLite
+   * takes any type name and applies affinity rules, and a name containing none
+   * of INT/CHAR/CLOB/TEXT/BLOB/REAL/FLOA/DOUB gets NUMERIC affinity, so
+   * `cast('{"a":1}' as json)` is `0`. Measured through `bun:sqlite` (Bun
+   * 1.3.14):
+   *
+   *   select cast(? as jsonb)                            -> 0        (runs)
+   *   select json_set('{"a":1}','$.b', cast(? as json))   -> {"a":1,"b":2}
+   *   select cast(? as text)::json                        -> ERROR unrecognized token: ":"
+   *
+   * So the retyping's rewrite — `cast(? as text)::json` — turns a statement
+   * that runs on SQLite today into a syntax error. `::` genuinely cannot fire
+   * there (it does not parse), but `cast(… as …)` is not Postgres-only syntax,
+   * and "SQLite has no jsonb type" is a claim about semantics rather than about
+   * what the parser accepts. Asking here rather than matching on `name` is what
+   * makes that a fact `tsc` and a test can hold.
+   */
+  readonly typesParametersFromStatement: boolean;
+
   /** Quote a table or column name. Only ever called with names from the schema. */
   quoteIdent(name: string): string;
 

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -134,6 +134,11 @@ export interface SqlDialect {
    * plain object is *not* JSON-encoded here: the compiler only knows to do that
    * because a field says `Json`, and guessing from the value would turn a
    * mistyped parameter into a successfully-written string.
+   *
+   * The exception is a parameter the *caller* cast to `json`/`jsonb`, which is
+   * a declared type by another route and does not reach this at all — see
+   * `json-param.ts`. It is still not a guess from the value: the statement says
+   * so.
    */
   encodeUntyped(value: unknown): unknown;
 

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -494,6 +494,13 @@ export class PostgresDialect implements SqlDialect {
     // about. Keeping the two together in `fieldParam` means a site nobody
     // converted still binds raw and still fails loudly.
     //
+    // **The second row is also what a raw statement hits**, and there the cast
+    // is the caller's rather than the dialect's: `payload || $1::jsonb` is a
+    // Prisma port's spelling, and under Bun it appends the serialised text to an
+    // array instead of merging. `json-param.ts` retypes it, on the same
+    // reasoning and with the cast and the serialisation kept together for the
+    // same reason.
+    //
     return value;
   }
 
@@ -502,6 +509,9 @@ export class PostgresDialect implements SqlDialect {
   // declared type to be legitimate. `Date`, `boolean`, `bigint` and arrays all
   // bind natively, which is why a raw fragment is portable across the two
   // dialects even though only SQLite has to normalise anything.
+  //
+  // A parameter the caller cast to `json`/`jsonb` never arrives here: it has a
+  // declared type after all, and `renderFragment` binds it as JSON text.
   encodeUntyped(value: unknown): unknown {
     return value;
   }

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -34,6 +34,11 @@ export class PostgresDialect implements SqlDialect {
   // it the driver's error names neither the model nor the cause.
   readonly maxBoundParameters = 65535;
 
+  // The server describes the statement and Bun encodes to the type it is told,
+  // which is why a `::jsonb` on the placeholder changes what a JS string means.
+  // See `json-param.ts`.
+  readonly typesParametersFromStatement = true;
+
   quoteIdent(name: string): string {
     // See the SQLite implementation: NUL is the parameter sentinel in
     // compile/fragment.ts, so it is the one character that could shift a

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -74,6 +74,13 @@ export class SqliteDialect implements SqlDialect {
   // safe, which is the direction that matters for a guard.
   readonly maxBoundParameters = 32766;
 
+  // A parameter's type is the bound value's, and `cast(x as json)` is NUMERIC
+  // affinity rather than a JSON cast — `cast('{"a":1}' as json)` is `0`. So
+  // there is no #376 mis-store to correct here, and correcting one anyway would
+  // emit `cast(? as text)::json`, which SQLite refuses to parse. Measured with
+  // `bun:sqlite`; the table is on `SqlDialect.typesParametersFromStatement`.
+  readonly typesParametersFromStatement = false;
+
   quoteIdent(name: string): string {
     // NUL is the parameter sentinel in compile/fragment.ts, so it is the one
     // character that could shift a placeholder's position rather than merely

--- a/packages/gemi/orm/json-param.ts
+++ b/packages/gemi/orm/json-param.ts
@@ -1,0 +1,243 @@
+import {
+  type Fragment,
+  fromParamSegments,
+  paramSegments,
+} from "./compile/fragment";
+import { InvalidArgumentError } from "./errors";
+import { jsonNullKind } from "./json-null";
+
+/**
+ * A raw parameter the caller cast to `json`/`jsonb` carries **JSON text**.
+ *
+ * ## The statement that changes meaning between the two clients
+ *
+ * ```sql
+ * update "AsyncJob" set payload = payload || $1::jsonb where id = $2
+ * ```
+ *
+ * Byte-identical under Prisma's `$executeRaw` and under `DB.execute`, and it
+ * did two different things. Measured on Postgres 16 through Bun 1.3.14 and a
+ * generated `@prisma/client` 6.19.2, binding the JS string
+ * `'{"version":1}'` into a `jsonb` column:
+ *
+ *   form                      prisma                       bun
+ *   $1                        error: jsonb vs text         "{\"version\":1}"   (a jsonb string)
+ *   $1::jsonb                 {"version": 1}               "{\"version\":1}"
+ *   cast($1 as jsonb)         {"version": 1}               "{\"version\":1}"
+ *   $1::text::jsonb           {"version": 1}               {"version": 1}
+ *
+ * The mechanism is the parameter's *type*, not the cast's. Prisma sends a JS
+ * string as `text` and lets Postgres parse it into the target type; Bun asks
+ * the server what the statement wants, is told `jsonb`, and JSON-encodes the
+ * string it was handed — so the string becomes a jsonb **string** rather than
+ * the object it spells. `::text::jsonb` pins the parameter back to `text`,
+ * which is what Prisma did implicitly and what `compile/cast.ts` already emits
+ * for a typed `Json` column (#209).
+ *
+ * **The `||` case is the sharp end.** Concatenating an object with a jsonb
+ * *string* is array concatenation, not a merge:
+ *
+ *   payload || $1::jsonb        [{"attribution": …}, "{\"version\":1}"]
+ *   payload || $1::text::jsonb  {"attribution": …, "version": 1}
+ *
+ * A statement written to merge metadata into a document appends the serialised
+ * text as a new array element instead. The write succeeds, nothing raises, the
+ * SQL reads correctly by eye, and the corruption is found by whatever reads the
+ * column next.
+ *
+ * ## So the cast is read, and the parameter retyped
+ *
+ * A `::json`/`::jsonb` the caller wrote onto their own placeholder is the one
+ * thing in a raw statement that says "this parameter is JSON" — there is no
+ * field to ask, which is the whole difference between this and `fieldParam`.
+ * When it is there, the placeholder is rewritten to cast through `text` and the
+ * value is serialised to match, so the Prisma-shaped statement does the Prisma
+ * thing.
+ *
+ * **Rewriting a caller's SQL text needs a reason, and this is it:** the cast is
+ * preserved exactly — `::text::jsonb` and `::jsonb` denote the same type and
+ * the expression's result is unchanged — while the *parameter's* type, which is
+ * the thing that differs from Prisma and the thing no caller can otherwise
+ * reach, is set to what Prisma set it to. The raw path was never
+ * byte-preserving in any case: it is what turns a marker into `$1` or `?`.
+ *
+ * ## A string passes through, unlike the typed path — and Prisma agrees twice
+ *
+ * `fieldParam` serialises *every* value, so a `Json` column set to the JS string
+ * `"42"` stores the jsonb string `"42"`. Here a string is handed over as it
+ * arrived, so `${'{"a":1}'}::jsonb` stores the object. That is not an
+ * inconsistency to be tidied away: it is which of the two Prisma does, on each
+ * path, and both were measured against 6.19.2.
+ *
+ *   prisma.doc.create({ data: { payload: '{"version":1}' } })  -> jsonb string
+ *   prisma.$executeRaw`… values (${'{"version":1}'}::jsonb)`   -> jsonb object
+ *
+ * The distinction that explains both: with a field, nobody wrote a cast and the
+ * value is a JSON *value*; with a caller-written cast, the caller has said the
+ * parameter is JSON *text* being cast. Somebody who wants the jsonb string
+ * writes the serialisation they mean — `${JSON.stringify(v)}::jsonb`.
+ *
+ * ## What is left, and why the remainder is the right remainder
+ *
+ * A bare `$1` into a `jsonb` column is the same fault and is not detectable
+ * here: no cast, no field, nothing to read. It is also the shape a Prisma port
+ * cannot contain — Prisma *refuses* it (`column "payload" is of type jsonb but
+ * expression is of type text`), so a statement that ran under Prisma with a
+ * string operand had a cast on it. An object there works on both clients and is
+ * untouched. `docs/orm.md` carries the residue; this covers what a port can
+ * actually be carrying.
+ *
+ * Schema-qualified spellings (`$1::pg_catalog.jsonb`) and `jsonb[]` are
+ * deliberately not matched. The first is not what anyone writes and the second
+ * is a different operand — an array of documents, where serialising the JS
+ * array to one JSON text would be wrong.
+ */
+
+/**
+ * `::jsonb` / `::json` applied to the placeholder that precedes it.
+ *
+ * Whitespace is allowed on both sides of the operator because Postgres allows
+ * it and `$1 :: jsonb` mis-stores identically — measured, not assumed. The
+ * lookahead keeps `::jsonb[]` out: that operand is an array of documents, and
+ * the serialisation this triggers would flatten it into one.
+ *
+ * **`::text::jsonb` matches too**, and is then rewritten to itself. The cast is
+ * already right there — it is the spelling this whole note recommends, and the
+ * one a caller who has already been bitten will have written — but the *value*
+ * still has to be serialised, or an object bound to it reaches Postgres as
+ * `[object Object]`. Matching both spellings is what makes them mean the same
+ * thing, which is the only defensible relationship between them.
+ */
+const OPERATOR_CAST = /^\s*::\s*(?:text\s*::\s*)?(jsonb|json)\b(?!\s*\[)/i;
+
+/** The same cast written as a function: `cast($1 as jsonb)`. */
+const FUNCTION_CAST = /^\s*as\s+(jsonb|json)\s*\)/i;
+
+/**
+ * ...which is only that when a `cast(` opened immediately before the
+ * placeholder. Without this, `select ${x} as jsonb)` — nonsense, but nonsense
+ * the caller wrote — would have its parameter serialised on the strength of two
+ * keywords that mean nothing here.
+ */
+const CAST_OPEN = /\bcast\s*\(\s*$/i;
+
+/**
+ * The fragment with every JSON-cast parameter retyped through `text`, and the
+ * positions of the parameters that were.
+ *
+ * Returns the fragment unchanged, and an empty set, when there is no such cast
+ * — which is every statement in the compiler and nearly every raw one.
+ */
+export function retypeJsonParameters(fragment: Fragment): {
+  fragment: Fragment;
+  jsonParameters: ReadonlySet<number>;
+} {
+  const segments = paramSegments(fragment);
+  const jsonParameters = new Set<number>();
+  let rewritten: string[] | undefined;
+
+  // `segments[i]` is the text before parameter `i` and `segments[i + 1]` the
+  // text after it, so the last segment trails the final parameter and has no
+  // parameter of its own.
+  for (let index = 0; index < segments.length - 1; index++) {
+    const after = segments[index + 1];
+
+    const operator = OPERATOR_CAST.exec(after);
+    if (operator) {
+      rewritten ??= [...segments];
+      rewritten[index + 1] =
+        `::text::${operator[1]}${after.slice(operator[0].length)}`;
+      jsonParameters.add(index);
+      continue;
+    }
+
+    const fn = FUNCTION_CAST.exec(after);
+    // The preceding segment is read from the rewrite when there is one: a
+    // previous parameter's rewrite replaces the head of this segment and leaves
+    // its tail — the `cast(` this is looking for — where it was, but reading the
+    // live array is what keeps that a fact rather than an assumption.
+    if (fn && CAST_OPEN.test((rewritten ?? segments)[index])) {
+      rewritten ??= [...segments];
+      rewritten[index + 1] = ` as text)::${fn[1]}${after.slice(fn[0].length)}`;
+      jsonParameters.add(index);
+    }
+  }
+
+  if (!rewritten) return { fragment, jsonParameters };
+  return {
+    fragment: fromParamSegments(rewritten, fragment.binders),
+    jsonParameters,
+  };
+}
+
+/**
+ * The value for one such parameter: JSON text, or SQL NULL.
+ *
+ * `dialect.encodeUntyped` deliberately does not run on these. Its two
+ * conversions are for a value being compared against a column the ORM wrote — a
+ * `Date` as milliseconds, a boolean as `0`/`1` — and neither is JSON. A `Date`
+ * here becomes the ISO string `JSON.stringify` gives it, because that is what
+ * putting a `Date` in a JSON document means.
+ */
+export function jsonTextParameter(value: unknown, operation: string): unknown {
+  // SQL NULL rather than the JSON value `null`, the same reading `fieldParam`
+  // takes for a nullable `Json` column: an absent value is not a stored null.
+  // Prisma binds a JS `null` at `$1::jsonb` to SQL NULL too — measured.
+  if (value === null || value === undefined) return null;
+
+  // Prisma's null sentinels, which `JSON.stringify` turns into `{}` — #259's
+  // mis-store arrived at by a third route. `DbNull` is the column being NULL and
+  // `JsonNull` is the JSON value, exactly as in `compile/cast.ts`.
+  const nullKind = jsonNullKind(value);
+  if (nullKind === "db") return null;
+  if (nullKind === "json") return "null";
+  if (nullKind === "any") {
+    throw new InvalidArgumentError(
+      operation,
+      "DB",
+      operation,
+      `Prisma.AnyNull is a filter operand — it asks for a SQL NULL *or* a JSON ` +
+        `null — so it has no single value to bind. Write the one you mean: ` +
+        `Prisma.DbNull for the column being NULL, Prisma.JsonNull for the JSON ` +
+        `value.`,
+    );
+  }
+
+  // Already JSON text. See the header: at a cast the caller wrote, a string is
+  // the document rather than a JSON string value, which is Prisma's reading of
+  // the same parameter.
+  if (typeof value === "string") return value;
+
+  let text: string | undefined;
+  try {
+    text = JSON.stringify(value);
+  } catch (cause) {
+    // A `bigint` and a circular structure are the two that get here. Prisma
+    // fails on the first as well (`cannot cast type bigint to jsonb`), and this
+    // says which parameter rather than which JSON.stringify.
+    throw new InvalidArgumentError(
+      operation,
+      "DB",
+      operation,
+      `A parameter cast to json could not be serialised: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}. ` +
+        `Bind text you have serialised yourself if the value is not JSON — a ` +
+        `bigint has no JSON form, and neither does a cycle.`,
+    );
+  }
+
+  // `undefined` back from `JSON.stringify` means the value has no JSON form at
+  // all — a function, a symbol. Binding it would be SQL NULL, which is a
+  // successfully-written wrong answer.
+  if (text === undefined) {
+    throw new InvalidArgumentError(
+      operation,
+      "DB",
+      operation,
+      `A ${typeof value} was bound to a parameter cast to json, and has no ` +
+        `JSON form. Bind the value it stands for.`,
+    );
+  }
+
+  return text;
+}

--- a/packages/gemi/orm/json-param.ts
+++ b/packages/gemi/orm/json-param.ts
@@ -3,6 +3,7 @@ import {
   fromParamSegments,
   paramSegments,
 } from "./compile/fragment";
+import type { SqlDialect } from "./dialect";
 import { InvalidArgumentError } from "./errors";
 import { jsonNullKind } from "./json-null";
 
@@ -90,7 +91,34 @@ import { jsonNullKind } from "./json-null";
  * Schema-qualified spellings (`$1::pg_catalog.jsonb`) and `jsonb[]` are
  * deliberately not matched. The first is not what anyone writes and the second
  * is a different operand — an array of documents, where serialising the JS
- * array to one JSON text would be wrong.
+ * array to one JSON text would be wrong. Nor is a cast on an *expression
+ * around* the placeholder: `(${v})::jsonb` and `cast(coalesce(${v}) as jsonb)`
+ * read as an untyped parameter and still mis-store. Detection is textual, and
+ * parsing parentheses to reach a spelling nobody writes buys less than it
+ * costs; `docs/orm.md` says so where a reader looking for the covered set will
+ * find it.
+ *
+ * ## Postgres only, and that is a dialect capability rather than a regex's luck
+ *
+ * The first version of this ran on both dialects, on the argument that `::` is
+ * not SQLite syntax and SQLite has no `jsonb`, so nothing could match a
+ * statement SQLite could run. **The first half of that is true and the second
+ * is not.** SQLite's `CAST` accepts an arbitrary type name, so `cast(? as
+ * json)` parses and runs there — and means something else entirely, since a
+ * type name matching none of INT/CHAR/CLOB/TEXT/BLOB/REAL/FLOA/DOUB gets
+ * NUMERIC affinity:
+ *
+ *   select cast(? as jsonb)                           -> 0
+ *   select json_set('{"a":1}','$.b', cast(? as json))  -> {"a":1,"b":2}   (the cast
+ *                                                        is what makes it the number
+ *                                                        2 rather than the string)
+ *   select cast(? as text)::json                       -> unrecognized token: ":"
+ *
+ * So the rewrite would have turned a working SQLite statement into a syntax
+ * error. The gate is {@link SqlDialect.typesParametersFromStatement}, asked
+ * rather than matched on `dialect.name`, because "cannot fire" was exactly the
+ * kind of claim that should have been a capability someone can typecheck
+ * instead of a property of two regular expressions.
  */
 
 /**
@@ -110,7 +138,19 @@ import { jsonNullKind } from "./json-null";
  */
 const OPERATOR_CAST = /^\s*::\s*(?:text\s*::\s*)?(jsonb|json)\b(?!\s*\[)/i;
 
-/** The same cast written as a function: `cast($1 as jsonb)`. */
+/**
+ * The same cast written as a function: `cast($1 as jsonb)`.
+ *
+ * **This is the branch that is reachable on SQLite, and the reason the whole
+ * function is gated on a dialect capability rather than on the shape of these
+ * two patterns.** `::` is Postgres-only *syntax* — SQLite's parser rejects it,
+ * so `OPERATOR_CAST` genuinely cannot fire on a statement SQLite could run.
+ * `cast(… as …)` is not: SQLite takes any type name there, `cast(? as json)`
+ * parses and runs, and the rewrite this pairs with emits `as text)::json`,
+ * which SQLite refuses. "SQLite has no jsonb type" is a claim about semantics;
+ * what matters here is what the parser accepts. See
+ * {@link SqlDialect.typesParametersFromStatement}.
+ */
 const FUNCTION_CAST = /^\s*as\s+(jsonb|json)\s*\)/i;
 
 /**
@@ -121,17 +161,30 @@ const FUNCTION_CAST = /^\s*as\s+(jsonb|json)\s*\)/i;
  */
 const CAST_OPEN = /\bcast\s*\(\s*$/i;
 
+/** The answer on a dialect that is gated out, before any set is built. */
+const EMPTY: ReadonlySet<number> = new Set<number>();
+
 /**
  * The fragment with every JSON-cast parameter retyped through `text`, and the
  * positions of the parameters that were.
  *
  * Returns the fragment unchanged, and an empty set, when there is no such cast
- * — which is every statement in the compiler and nearly every raw one.
+ * — which is every statement in the compiler and nearly every raw one — and on
+ * any dialect that does not type a parameter from the statement, which today is
+ * SQLite. See the header: there the correction is unnecessary, the cast means
+ * NUMERIC affinity rather than JSON, and the rewrite does not parse.
  */
-export function retypeJsonParameters(fragment: Fragment): {
+export function retypeJsonParameters(
+  fragment: Fragment,
+  dialect: SqlDialect,
+): {
   fragment: Fragment;
   jsonParameters: ReadonlySet<number>;
 } {
+  if (!dialect.typesParametersFromStatement) {
+    return { fragment, jsonParameters: EMPTY };
+  }
+
   const segments = paramSegments(fragment);
   const jsonParameters = new Set<number>();
   let rewritten: string[] | undefined;
@@ -182,7 +235,10 @@ export function retypeJsonParameters(fragment: Fragment): {
 export function jsonTextParameter(value: unknown, operation: string): unknown {
   // SQL NULL rather than the JSON value `null`, the same reading `fieldParam`
   // takes for a nullable `Json` column: an absent value is not a stored null.
-  // Prisma binds a JS `null` at `$1::jsonb` to SQL NULL too — measured.
+  // Prisma binds a JS `null` at `$1::jsonb` to SQL NULL too — which follows
+  // from the parameter being declared `text` (the `values ($1)` error text in
+  // the table above is what shows that it is), since `NULL::text::jsonb` is SQL
+  // NULL. Reasoned, not measured: it is the one row of that table nobody ran.
   if (value === null || value === undefined) return null;
 
   // Prisma's null sentinels, which `JSON.stringify` turns into `{}` — #259's

--- a/packages/gemi/orm/known-divergences.test.ts
+++ b/packages/gemi/orm/known-divergences.test.ts
@@ -87,4 +87,40 @@ describe("divergences the source knows about are documented", () => {
 
     expect(sources.some((source) => source.includes("KNOWN DIVERGENCE"))).toBe(true);
   });
+
+  /**
+   * The third of the kind, and the only one gemi *fixed* rather than recorded —
+   * which is exactly why the page still has to say it.
+   *
+   * `$1::jsonb` bound a JS string as a jsonb **string** under Bun where Prisma
+   * bound the parsed document, so a byte-identical raw statement changed meaning
+   * on a port. `json-param.ts` retypes the parameter through `text`, and a
+   * reader who does not know that will write `${JSON.stringify(v)}::jsonb`
+   * against `DB.sql` — Bun's own tag, which this does not reach — or read the
+   * two paths' treatment of a string as a bug. The fix is not self-describing
+   * from the call site, so the page carries it.
+   */
+  test("the page tells a porter what a raw ::jsonb parameter does", () => {
+    expect(DOC).toMatch(/###\s+A `::jsonb` cast you write types the parameter as `text`/);
+
+    const section = DOC.slice(DOC.indexOf("### A `::jsonb` cast you write"));
+    // The three things a porter cannot recover from the call site: the spelling
+    // that fixes it, the operator whose meaning silently changed, and the one
+    // shape left uncovered.
+    expect(section).toMatch(/\$1::text::jsonb/);
+    expect(section).toMatch(/array\s*\n?\s*concatenation, not a merge/);
+    expect(section).toMatch(/bare `\$1`/);
+  });
+
+  test("the source the section is derived from is still there", () => {
+    const source = readFileSync(
+      join(ROOT, "packages/gemi/orm/json-param.ts"),
+      "utf8",
+    );
+
+    // The measurement, not the prose: if the table goes, the page above is
+    // describing driver behaviour that nothing in the repository records.
+    expect(source).toMatch(/prisma\s+bun/i);
+    expect(source).toMatch(/\$1::text::jsonb/);
+  });
 });

--- a/packages/gemi/orm/sql.test.ts
+++ b/packages/gemi/orm/sql.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { PostgresDialect } from "./dialect/postgres";
 import { SqliteDialect } from "./dialect/sqlite";
 import { ParameterLimitError, UnsupportedQueryError } from "./errors";
+import { AnyNull, DbNull, JsonNull } from "./json-null";
 import { empty, join, renderFragment, sql, unsafeSql } from "./sql";
 
 /**
@@ -288,6 +289,177 @@ describe("values with no column type behind them", () => {
   test("undefined becomes null rather than reaching the driver", () => {
     expect(render(sql`${undefined}`, sqlite).values).toEqual([null]);
     expect(render(sql`${undefined}`, postgres).values).toEqual([null]);
+  });
+});
+
+/**
+ * ...with the one exception: a cast the caller wrote is a declared type.
+ *
+ * The statement that made this necessary is byte-identical under Prisma's
+ * `$executeRaw` and under `DB.execute`, and did two different things — Prisma
+ * sends a string parameter as `text` and lets Postgres parse it, while Bun is
+ * told the parameter is `jsonb` and JSON-encodes the string, so the document is
+ * stored as a jsonb *string*. `payload || $1::jsonb` then appends it as an array
+ * element instead of merging. `json-param.ts` carries the measurements; these
+ * pin the emitted statement, which is where the fix lives.
+ */
+describe("a parameter the caller cast to json", () => {
+  const document = `{"version":1}`;
+
+  test("the placeholder is retyped through text, on both dialects", () => {
+    const fragment = sql`update "Job" set "payload" = "payload" || ${document}::jsonb where "id" = ${7}`;
+
+    expect(render(fragment, postgres).text).toBe(
+      `update "Job" set "payload" = "payload" || $1::text::jsonb where "id" = $2`,
+    );
+    expect(render(fragment, sqlite).text).toBe(
+      `update "Job" set "payload" = "payload" || ?::text::jsonb where "id" = ?`,
+    );
+  });
+
+  /**
+   * The half a text assertion cannot see. `::text::jsonb` alone would still
+   * mis-store an object — Bun sends `[object Object]` for one bound to a `text`
+   * parameter — so the cast and the serialisation are one change, exactly as
+   * `fieldParam` treats them.
+   */
+  test.each([
+    ["a string is already JSON text", `{"a":1}`, `{"a":1}`],
+    ["an object is serialised", { a: 1 }, `{"a":1}`],
+    ["an array is serialised", [1, 2], `[1,2]`],
+    ["a number is serialised", 42, `42`],
+    ["a boolean is serialised", true, `true`],
+    ["null stays SQL NULL", null, null],
+    ["undefined stays SQL NULL", undefined, null],
+  ])("%s", (_label, value, expected) => {
+    expect(render(sql`${value}::jsonb`, postgres).values).toEqual([expected]);
+    expect(render(sql`${value}::jsonb`, sqlite).values).toEqual([expected]);
+  });
+
+  /**
+   * A string is handed over as it arrived, where `fieldParam` serialises one —
+   * and that is which of the two Prisma does on each path, measured against
+   * 6.19.2 rather than reasoned about:
+   *
+   *   create({ data: { payload: '{"a":1}' } })      -> the jsonb string
+   *   $executeRaw`… values (${'{"a":1}'}::jsonb)`   -> the jsonb object
+   *
+   * The caller who wants the string writes the serialisation they mean.
+   */
+  test("a caller who wants the jsonb string serialises it themselves", () => {
+    expect(render(sql`${JSON.stringify(document)}::jsonb`).values).toEqual([
+      `"{\\"version\\":1}"`,
+    ]);
+  });
+
+  test.each([
+    ["spaces around the operator", sql`${document} :: jsonb`, `$1::text::jsonb`],
+    ["the type in capitals", sql`${document}::JSONB`, `$1::text::JSONB`],
+    ["json rather than jsonb", sql`${document}::json`, `$1::text::json`],
+    [
+      "the function spelling",
+      sql`cast(${document} as jsonb)`,
+      `cast($1 as text)::jsonb`,
+    ],
+    [
+      "the spelling that was already right",
+      sql`${document}::text::jsonb`,
+      `$1::text::jsonb`,
+    ],
+  ])("%s is recognised", (_label, fragment, text) => {
+    const rendered = render(fragment);
+    expect(rendered.text).toBe(text);
+    expect(rendered.values).toEqual([document]);
+  });
+
+  /**
+   * The `::text::jsonb` row above is the one worth stating twice: the cast is
+   * already correct and is left alone, but the *value* is still serialised, so
+   * the two spellings mean the same thing rather than one of them being a
+   * second trap.
+   */
+  test("an object at the already-correct spelling is serialised too", () => {
+    expect(render(sql`${{ a: 1 }}::text::jsonb`).values).toEqual([`{"a":1}`]);
+  });
+
+  test.each([
+    ["a cast to something else", sql`${document}::text`, [document]],
+    ["an array of documents", sql`${[document]}::jsonb[]`, [[document]]],
+    ["a jsonpath operand", sql`${document}::jsonpath`, [document]],
+    [
+      "`as jsonb)` with no cast( opening it",
+      sql`select ${document} as jsonb)`,
+      [document],
+    ],
+  ])("%s is left alone", (_label, fragment, values) => {
+    expect(render(fragment).values).toEqual(values);
+  });
+
+  test("only the cast parameter is affected", () => {
+    const at = new Date(1_700_000_000_000);
+    const { text, values } = render(
+      sql`update "Job" set "payload" = ${{ a: 1 }}::jsonb where "at" > ${at}`,
+      sqlite,
+    );
+
+    expect(text).toBe(`update "Job" set "payload" = ?::text::jsonb where "at" > ?`);
+    // The second parameter still goes through `encodeUntyped`.
+    expect(values).toEqual([`{"a":1}`, at.getTime()]);
+  });
+
+  /**
+   * The cast is written by whoever assembles the *outer* statement, and the
+   * value comes from a fragment built somewhere else — so this cannot be
+   * decided where the value is interpolated. It is decided at render, over the
+   * assembled text, which is the only place both halves exist.
+   */
+  test("a nested fragment's parameter is retyped by the outer cast", () => {
+    const patch = sql`${{ a: 1 }}`;
+    const { text, values } = render(
+      sql`update "Job" set "payload" = "payload" || ${patch}::jsonb`,
+    );
+
+    expect(text).toBe(
+      `update "Job" set "payload" = "payload" || $1::text::jsonb`,
+    );
+    expect(values).toEqual([`{"a":1}`]);
+  });
+
+  test("two of them in one statement, each retyped", () => {
+    const { text, values } = render(
+      sql`select cast(${{ a: 1 }} as jsonb) || ${{ b: 2 }}::jsonb`,
+    );
+
+    expect(text).toBe(`select cast($1 as text)::jsonb || $2::text::jsonb`);
+    expect(values).toEqual([`{"a":1}`, `{"b":2}`]);
+  });
+
+  test.each([
+    ["a bigint, which has no JSON form", 1n],
+    ["a function", () => 1],
+    ["a symbol", Symbol("x")],
+  ])("%s is refused rather than bound", (_label, value) => {
+    expect(() => render(sql`${value}::jsonb`)).toThrow(UnsupportedQueryError);
+  });
+
+  test("a circular structure names the parameter rather than JSON.stringify", () => {
+    const cycle: any = {};
+    cycle.self = cycle;
+
+    expect(() => renderFragment(sql`${cycle}::jsonb`, postgres, "execute")).toThrow(
+      /DB\.execute/,
+    );
+  });
+
+  /**
+   * Prisma's null sentinels, which `JSON.stringify` turns into `{}` — the same
+   * mis-store `compile/cast.ts` handles for a typed column, reachable a second
+   * way now that a raw parameter can be JSON.
+   */
+  test("the null sentinels mean what they mean on a typed column", () => {
+    expect(render(sql`${DbNull}::jsonb`).values).toEqual([null]);
+    expect(render(sql`${JsonNull}::jsonb`).values).toEqual(["null"]);
+    expect(() => render(sql`${AnyNull}::jsonb`)).toThrow(UnsupportedQueryError);
   });
 });
 

--- a/packages/gemi/orm/sql.test.ts
+++ b/packages/gemi/orm/sql.test.ts
@@ -306,14 +306,11 @@ describe("values with no column type behind them", () => {
 describe("a parameter the caller cast to json", () => {
   const document = `{"version":1}`;
 
-  test("the placeholder is retyped through text, on both dialects", () => {
+  test("the placeholder is retyped through text", () => {
     const fragment = sql`update "Job" set "payload" = "payload" || ${document}::jsonb where "id" = ${7}`;
 
     expect(render(fragment, postgres).text).toBe(
       `update "Job" set "payload" = "payload" || $1::text::jsonb where "id" = $2`,
-    );
-    expect(render(fragment, sqlite).text).toBe(
-      `update "Job" set "payload" = "payload" || ?::text::jsonb where "id" = ?`,
     );
   });
 
@@ -333,7 +330,6 @@ describe("a parameter the caller cast to json", () => {
     ["undefined stays SQL NULL", undefined, null],
   ])("%s", (_label, value, expected) => {
     expect(render(sql`${value}::jsonb`, postgres).values).toEqual([expected]);
-    expect(render(sql`${value}::jsonb`, sqlite).values).toEqual([expected]);
   });
 
   /**
@@ -395,16 +391,64 @@ describe("a parameter the caller cast to json", () => {
     expect(render(fragment).values).toEqual(values);
   });
 
+  /**
+   * **Postgres only, and the function spelling is why that had to become a
+   * dialect capability rather than a property of the patterns.**
+   *
+   * The first version of this ran on both dialects, arguing that `::` is not
+   * SQLite syntax and SQLite has no `jsonb`, so nothing could match a statement
+   * SQLite could run. Half right. `::` really does not parse there — which is
+   * why the `::jsonb` row below costs nothing either way and could never have
+   * caught this. But SQLite's `CAST` accepts an *arbitrary* type name, so
+   * `cast(? as json)` parses, runs, and means NUMERIC affinity; measured
+   * through `bun:sqlite` (Bun 1.3.14):
+   *
+   *   select cast(? as jsonb)                            -> 0
+   *   select json_set('{"a":1}','$.b', cast(? as json))   -> {"a":1,"b":2}
+   *   select cast(? as text)::json                        -> unrecognized token: ":"
+   *
+   * So the rewrite turned a working SQLite statement into a syntax error. The
+   * function-cast row is the one that pins the gate; `raw-sql.test.ts` runs the
+   * same statement against a real SQLite database, because what a parser
+   * accepts is not a claim emitted text can settle.
+   */
+  test.each([
+    ["the function spelling", sql`cast(${document} as jsonb)`, `cast(? as jsonb)`],
+    ["the operator spelling", sql`${document}::jsonb`, `?::jsonb`],
+    ["json rather than jsonb", sql`cast(${document} as json)`, `cast(? as json)`],
+  ])("%s is emitted unchanged on sqlite", (_label, fragment, text) => {
+    expect(render(fragment, sqlite).text).toBe(text);
+  });
+
+  /**
+   * ...and the value is not serialised either, which is the half a text
+   * assertion cannot see. `cast(x as json)` on SQLite is a numeric coercion,
+   * not a JSON parse, so serialising for it would be a wrong answer rather than
+   * a redundant one.
+   */
+  test("the value is not serialised on sqlite", () => {
+    expect(render(sql`cast(${document} as jsonb)`, sqlite).values).toEqual([
+      document,
+    ]);
+    expect(render(sql`${42}::jsonb`, sqlite).values).toEqual([42]);
+  });
+
+  /**
+   * The neighbour is the assertion: a `Date` still reaches `encodeUntyped`,
+   * which passes one through on Postgres. Were its index in the json set it
+   * would arrive as the ISO string `JSON.stringify` gives a `Date`, so the row
+   * distinguishes "only the cast parameter" from "every parameter".
+   */
   test("only the cast parameter is affected", () => {
     const at = new Date(1_700_000_000_000);
     const { text, values } = render(
       sql`update "Job" set "payload" = ${{ a: 1 }}::jsonb where "at" > ${at}`,
-      sqlite,
     );
 
-    expect(text).toBe(`update "Job" set "payload" = ?::text::jsonb where "at" > ?`);
-    // The second parameter still goes through `encodeUntyped`.
-    expect(values).toEqual([`{"a":1}`, at.getTime()]);
+    expect(text).toBe(
+      `update "Job" set "payload" = $1::text::jsonb where "at" > $2`,
+    );
+    expect(values).toEqual([`{"a":1}`, at]);
   });
 
   /**

--- a/packages/gemi/orm/sql.ts
+++ b/packages/gemi/orm/sql.ts
@@ -12,6 +12,7 @@ import {
   render,
   sql as text,
 } from "./compile/fragment";
+import { jsonTextParameter, retypeJsonParameters } from "./json-param";
 
 /**
  * SQL fragments as first-class values: `sql`, `join`, `empty`, and one door out.
@@ -119,6 +120,18 @@ function isFragment(value: unknown): value is Fragment {
  * Postgres's `= any($1)` wants, and it is the only reading that does not depend
  * on the dialect. For a comma-separated list of placeholders, say so with
  * `join`.
+ *
+ * A value at a `::jsonb` cast the caller wrote is the one parameter with a type
+ * behind it, and it is bound as **JSON text** so that the statement means what
+ * the same statement meant under Prisma's `$executeRaw`:
+ *
+ * ```ts
+ * sql`… set payload = payload || ${JSON.stringify(patch)}::jsonb`  // merges
+ * ```
+ *
+ * Without that the driver would JSON-encode the string and the column would
+ * hold the document as a jsonb *string* — which `||` appends as an array
+ * element rather than merging. `json-param.ts` has the measurements.
  */
 export function sql(
   strings: TemplateStringsArray,
@@ -344,7 +357,16 @@ export function renderFragment(
     );
   }
 
-  const rendered = render(fragment, dialect, { model: "DB", operation });
+  // The one thing a raw parameter can be *told* about its type: a `::jsonb` the
+  // caller wrote onto their own placeholder. Where there is one, the parameter
+  // is retyped through `text` and its value serialised, because Bun otherwise
+  // JSON-encodes a string bound to a `jsonb` parameter and stores the document
+  // as a jsonb *string* where Prisma stored the object. See `json-param.ts` —
+  // the mechanism, the measurements, and why a string is not serialised here
+  // while `fieldParam` serialises one.
+  const json = retypeJsonParameters(fragment);
+
+  const rendered = render(json.fragment, dialect, { model: "DB", operation });
   return {
     text: rendered.text,
     // `encodeUntyped` and not `encode`: there is no field here to ask, which is
@@ -352,10 +374,12 @@ export function renderFragment(
     // plan's. It normalises the two JavaScript types whose SQL form the ORM has
     // already decided — a `Date` and a boolean — so a raw statement compares
     // against ORM-written rows on both dialects rather than only on Postgres.
-    values: bindValues(rendered.binders)(undefined).map((value) =>
-      value === null || value === undefined
-        ? (value ?? null)
-        : dialect.encodeUntyped(value),
+    values: bindValues(rendered.binders)(undefined).map((value, index) =>
+      json.jsonParameters.has(index)
+        ? jsonTextParameter(value, operation)
+        : value === null || value === undefined
+          ? (value ?? null)
+          : dialect.encodeUntyped(value),
     ),
   };
 }

--- a/packages/gemi/orm/sql.ts
+++ b/packages/gemi/orm/sql.ts
@@ -364,7 +364,13 @@ export function renderFragment(
   // as a jsonb *string* where Prisma stored the object. See `json-param.ts` —
   // the mechanism, the measurements, and why a string is not serialised here
   // while `fieldParam` serialises one.
-  const json = retypeJsonParameters(fragment);
+  //
+  // The dialect is passed because this is not universal, and the reason is
+  // narrower than it looks: `::` is Postgres-only syntax, but `cast(? as json)`
+  // *parses and runs* on SQLite, where it means NUMERIC affinity — so retyping
+  // it would rewrite a working statement into `cast(? as text)::json`, which
+  // SQLite cannot parse. `typesParametersFromStatement` is false there.
+  const json = retypeJsonParameters(fragment, dialect);
 
   const rendered = render(json.fragment, dialect, { model: "DB", operation });
   return {

--- a/templates/saas-starter/app/models/raw-sql.test.ts
+++ b/templates/saas-starter/app/models/raw-sql.test.ts
@@ -295,6 +295,152 @@ function suite(label: string, url?: string) {
       expect(await emails()).toHaveLength(4);
     });
 
+    // --- a jsonb parameter -------------------------------------------------
+
+    /**
+     * **A `::jsonb` cast in a raw statement, which is where a Prisma port goes
+     * wrong silently.** Postgres only: SQLite has no `jsonb` type and no `::`
+     * operator, so these statements are not expressible there at all.
+     *
+     * The divergence is the parameter's type rather than the cast's. Prisma's
+     * `$executeRaw` sends a JS string as `text` and lets Postgres parse it; Bun
+     * asks the server what the statement wants, is told `jsonb`, and
+     * JSON-encodes the string — so the document is stored as a jsonb *string*.
+     * `renderFragment` now retypes such a parameter through `text`.
+     *
+     * `jsonb_typeof` is asserted rather than the value alone, for the reason
+     * `writes.coercion.test.ts` gives about the same mis-store: the wrong answer
+     * *reads back correctly through this ORM* and wrongly through everything
+     * else, so equality cannot tell the two apart.
+     */
+    const metadataOf = async (email: string) => {
+      const rows: any = await raw.unsafe(
+        `SELECT jsonb_typeof("metadata") AS kind, "metadata" AS value
+           FROM "User" WHERE "email" = $1`,
+        [email],
+      );
+      return [...rows][0];
+    };
+
+    test("a document at a ::jsonb cast is stored as the document — postgres", async () => {
+      if (!url) return;
+
+      const document = { version: 1, tags: ["a", "b"] };
+
+      expect(
+        await DB.execute(
+          sql`update "User" set "metadata" = ${JSON.stringify(document)}::jsonb
+              where "email" = ${"ada@x.test"}`,
+        ),
+      ).toBe(1);
+
+      const stored = await metadataOf("ada@x.test");
+      expect(stored.kind).toBe("object");
+      expect(stored.value).toEqual(document);
+    });
+
+    /**
+     * The sharp end, and the reason this is worth a fix rather than a caveat.
+     * `||` between an object and a jsonb *string* is array concatenation, not a
+     * merge: the statement below appended the serialised text as a new element
+     * and the column stopped being an object at all. Downstream code that
+     * expects an object gets an array, or drops the row when a guard fails.
+     */
+    test("|| merges into the document rather than appending to it — postgres", async () => {
+      if (!url) return;
+
+      await DB.execute(
+        sql`update "User" set "metadata" = ${JSON.stringify({ attribution: "x" })}::jsonb
+            where "email" = ${"ada@x.test"}`,
+      );
+
+      await DB.execute(
+        sql`update "User" set "metadata" = "metadata" || ${JSON.stringify({ version: 1 })}::jsonb
+            where "email" = ${"ada@x.test"}`,
+      );
+
+      const stored = await metadataOf("ada@x.test");
+      expect(stored.kind).toBe("object");
+      expect(stored.value).toEqual({ attribution: "x", version: 1 });
+    });
+
+    /**
+     * The claim about the *driver* that the fix rests on, pinned at the level it
+     * is true. Nothing in the ORM would notice Bun changing this, and if a later
+     * version binds it differently the retyping is solving a problem that no
+     * longer exists — which this failing is the only way to find out.
+     */
+    test("the same statement unretyped stores a jsonb string — postgres", async () => {
+      if (!url) return;
+
+      const document = JSON.stringify({ version: 1 });
+      await raw.unsafe(
+        `UPDATE "User" SET "metadata" = $1::jsonb WHERE "email" = $2`,
+        [document, "ada@x.test"],
+      );
+
+      const stored = await metadataOf("ada@x.test");
+      expect(stored.kind).toBe("string");
+      expect(stored.value).toBe(document);
+
+      // ...and the `||` above, on the same binding: an array, not a merge.
+      await raw.unsafe(
+        `UPDATE "User" SET "metadata" = '{"attribution":"x"}'::jsonb || $1::jsonb
+           WHERE "email" = $2`,
+        [document, "ada@x.test"],
+      );
+      expect((await metadataOf("ada@x.test")).kind).toBe("array");
+    });
+
+    /**
+     * Every shape, through the cast, and the function spelling of it — which is
+     * the other form a port can be carrying (`CAST($1 AS jsonb)`), and which
+     * mis-stores identically without the retyping.
+     */
+    test.each([
+      ["an object", { a: 1 }, "object"],
+      ["an array", [1, 2], "array"],
+      ["a document as text", `{"a":1}`, "object"],
+      ["a number", 42, "number"],
+      ["a boolean", true, "boolean"],
+    ])("%s survives both cast spellings — postgres", async (_label, value, kind) => {
+      if (!url) return;
+
+      for (const fragment of [
+        sql`update "User" set "metadata" = ${value}::jsonb where "email" = ${"ada@x.test"}`,
+        sql`update "User" set "metadata" = cast(${value} as jsonb) where "email" = ${"ada@x.test"}`,
+      ]) {
+        await DB.execute(fragment);
+        expect((await metadataOf("ada@x.test")).kind).toBe(kind);
+      }
+    });
+
+    /**
+     * The two paths agree about what a `Json` column holds — which is the
+     * property that makes raw SQL an escape hatch rather than a second
+     * representation. The ORM writes the column through `fieldParam`'s
+     * `::text::jsonb`; the raw filter finds that row through the same cast, now
+     * that the caller's `::jsonb` means the same thing.
+     */
+    test("a raw jsonb filter matches a row the ORM wrote — postgres", async () => {
+      if (!url) return;
+
+      const document = { version: 1, tags: ["a"] };
+      await Model.asSystem(async () => {
+        await User.update({
+          where: { email: "ada@x.test" },
+          data: { metadata: document },
+        });
+      });
+
+      const rows = await DB.query<{ email: string }>(
+        sql`select "email" from "User"
+            where "metadata" = ${JSON.stringify(document)}::jsonb`,
+      );
+
+      expect(rows.map((row) => row.email)).toEqual(["ada@x.test"]);
+    });
+
     // --- the ambient transaction -----------------------------------------
 
     /**

--- a/templates/saas-starter/app/models/raw-sql.test.ts
+++ b/templates/saas-starter/app/models/raw-sql.test.ts
@@ -299,8 +299,15 @@ function suite(label: string, url?: string) {
 
     /**
      * **A `::jsonb` cast in a raw statement, which is where a Prisma port goes
-     * wrong silently.** Postgres only: SQLite has no `jsonb` type and no `::`
-     * operator, so these statements are not expressible there at all.
+     * wrong silently.** Postgres only — but for a narrower reason than "SQLite
+     * cannot say this". `::` is Postgres-only *syntax* and SQLite's parser
+     * rejects it; `cast(x as jsonb)`, which the `test.each` below also
+     * exercises, parses and runs on SQLite perfectly well and simply means
+     * something else there (any type name is accepted, and one matching none of
+     * INT/CHAR/CLOB/TEXT/BLOB/REAL/FLOA/DOUB gets NUMERIC affinity, so
+     * `cast('{"a":1}' as json)` is `0`). The retyping is therefore gated on
+     * `SqlDialect.typesParametersFromStatement` rather than left to the
+     * patterns; the SQLite half of that is pinned below, in this same suite.
      *
      * The divergence is the parameter's type rather than the cast's. Prisma's
      * `$executeRaw` sends a JS string as `text` and lets Postgres parse it; Bun
@@ -439,6 +446,45 @@ function suite(label: string, url?: string) {
       );
 
       expect(rows.map((row) => row.email)).toEqual(["ada@x.test"]);
+    });
+
+    /**
+     * **The other side of the gate, and the reason there is one.** The first
+     * version of the retyping ran on every dialect, on the argument that
+     * nothing it matches could appear in a statement SQLite can run. That is
+     * true of `::` and false of `cast(… as …)`: SQLite accepts any type name
+     * there, so this statement runs today — and the rewrite would have emitted
+     * `cast(? as text)::jsonb`, which SQLite answers with *unrecognized token:
+     * ":"*. A working raw statement would have become a syntax error.
+     *
+     * The returned values are the second half, and they are why leaving it
+     * alone is right rather than merely harmless. A type name matching none of
+     * INT/CHAR/CLOB/TEXT/BLOB/REAL/FLOA/DOUB gets NUMERIC affinity, so this is
+     * a numeric coercion and not a JSON parse at all: `"2"` becomes the number
+     * `2` and a whole document becomes `0`. There is no mis-store here to
+     * correct, and serialising for it would invent one.
+     *
+     * Run against a real SQLite database rather than asserted as emitted text,
+     * because the claim is about what SQLite's *parser* accepts — and the
+     * emitted text is exactly what the first version got wrong.
+     */
+    test("cast( ... as jsonb) still runs, untouched — sqlite", async () => {
+      if (url) return;
+
+      expect(
+        (await DB.query<{ v: unknown }>(sql`select cast(${"2"} as jsonb) as v`))[0]
+          ?.v,
+      ).toBe(2);
+
+      // NUMERIC affinity, not a JSON parse. Retyping this would have been a
+      // wrong answer even if `::` had parsed here.
+      expect(
+        (
+          await DB.query<{ v: unknown }>(
+            sql`select cast(${`{"a":1}`} as json) as v`,
+          )
+        )[0]?.v,
+      ).toBe(0);
     });
 
     // --- the ambient transaction -----------------------------------------


### PR DESCRIPTION
The migration trap #376 reports, reproduced and closed at the choke point. A raw statement that Prisma ran as a merge ran as an append under `DB.execute`, with no error, no type complaint, and SQL text that reads correctly by eye.

## What is actually different, measured

Not the cast — the **parameter's type**. Prisma sends a JS string as `text` and lets Postgres parse it into whatever the expression wants. Bun describes the statement, is told the parameter is `jsonb`, and JSON-encodes the string it was handed. So the document arrives as a jsonb *string*.

Postgres 16 in a throwaway container, Bun 1.3.14, and a generated `@prisma/client` 6.19.2 against the same database with `log: [{ emit: "event", level: "query" }]`. Binding the JS string `'{"version":1}'` into a `jsonb` column, then reading `jsonb_typeof` and `payload::text` back:

| statement | prisma | bun |
| --- | --- | --- |
| `values ($1)` | **error** — `column "payload" is of type jsonb but expression is of type text` | `"{\"version\":1}"` — jsonb_typeof `string` |
| `values ($1::jsonb)` | `{"version": 1}` | `"{\"version\":1}"` |
| `values ($1 :: jsonb)` | — | `"{\"version\":1}"` |
| `values ($1::JSONB)` | — | `"{\"version\":1}"` |
| `values (cast($1 as jsonb))` | `{"version": 1}` | `"{\"version\":1}"` |
| `values ($1::pg_catalog.jsonb)` | — | `"{\"version\":1}"` |
| `values ($1::text::jsonb)` | `{"version": 1}` | `{"version": 1}` |

And the sharp end, the same two clients on `'{"attribution":"x"}'::jsonb || $1`:

```
prisma  $1::jsonb        {"attribution": "x", "version": 1}
bun     $1::jsonb        [{"attribution": "x"}, "{\"version\":1}"]     jsonb_typeof -> array
bun     $1::text::jsonb  {"attribution": "x", "version": 1}
```

Three rows of that table changed the shape of the fix:

- **The bare `$1` row.** Prisma *refuses* it with a string operand. So a statement that ran under Prisma with a string carried a cast — which makes "read the cast" cover exactly what a port can be carrying, rather than being a partial answer to a general problem. With an *object* operand a bare `$1` works on both clients and is untouched here.
- **The `cast(… as jsonb)` row.** It mis-stores identically, so handling only `::` would have left a second door open with the first one shut.
- **Prisma's own two paths disagree about a string**, which is what settled the rule below.

## The change

`renderFragment` — the single choke point every `DB.query` / `DB.execute` fragment passes through — reads the text that follows each parameter marker, before placeholders are assigned. Where the caller cast their own placeholder to `json`/`jsonb`, the placeholder is rewritten to cast through `text` and the value is bound as JSON text:

```
sql`… "payload" || ${JSON.stringify(patch)}::jsonb …`
  ->  … "payload" || $1::text::jsonb …
```

That is the pair `compile/cast.ts` already established for a typed `Json` column at #209 — the cast and the serialisation travel together, and neither is correct alone. The raw path had no field to ask, which is the whole reason it was missing; the cast the caller wrote is the declared type by another route.

**Rewriting a caller's SQL wants a justification.** The cast is preserved exactly — `::text::jsonb` and `::jsonb` denote the same type and the expression's value is unchanged — while the *parameter's* type, which is the thing that differs from Prisma and the thing no caller can otherwise reach through the driver, is set to what Prisma set it to. The raw path was never byte-preserving anyway: it is what turns a marker into `$1` or `?`.

### A string passes through, where `fieldParam` serialises one

The one place the two paths differ, and it is deliberate — **it is which of the two Prisma does on each path**:

```
prisma.doc.create({ data: { payload: '{"version":1}' } })      -> jsonb string
prisma.$executeRaw`… values (${'{"version":1}'}::jsonb)`       -> jsonb object
```

With a field, nobody wrote a cast and the value is a JSON *value*. With a caller-written cast, the caller has said the parameter is JSON *text* being cast, which is the only reading under which `${JSON.stringify(patch)}::jsonb` — the spelling a port contains — means what it meant. Somebody who wants the jsonb string writes the serialisation they mean.

Everything else follows from that one rule: an object or array is serialised (so `${patch}::jsonb`, which worked before because Bun serialises it, still works), a number and a boolean become JSON numbers and booleans where Prisma answers `cannot cast type bigint to jsonb` — gemi is more permissive there, and consistent with its own typed `Json` column, which is the more useful of the two to agree with. `null` stays SQL NULL rather than becoming a JSON null, matching both Prisma and `fieldParam`. `DbNull` / `JsonNull` mean what they mean on a column, because `JSON.stringify` turns them into `{}` — #259's mis-store reachable by a third route. A `bigint`, a function and a cycle raise `InvalidArgumentError` naming the operation rather than dying inside `JSON.stringify`.

### What is left alone, on purpose

`$1::pg_catalog.jsonb` (not what anyone writes), `$1::jsonb[]` (an array of documents — serialising the JS array into one JSON text would be wrong), `as jsonb)` with no `cast(` opening it, and a bare `$1`, whose residue is argued above and written down in the docs. `DB.sql` — Bun's own tag — does not pass through `renderFragment` and is untouched; the docs say so.

SQLite needs no branch: `::` is not SQLite syntax and there is no `jsonb` type, so the match cannot fire on a statement SQLite could run. It is still asserted on both dialects, because "cannot fire" is a claim.

## Tests

**Compile-level** (`orm/sql.test.ts`, 70 → 97): the emitted text and the bound values together, on both dialects — the five recognised spellings, the four left alone, a nested fragment retyped by the *outer* statement's cast (which is why this cannot be decided where the value is interpolated), two casts in one statement, the neighbouring parameter still going through `encodeUntyped`, and the refusals. The 70 that were there are unchanged and still pass; no existing expectation moved.

**Live Postgres** (`templates/saas-starter/app/models/raw-sql.test.ts`, 9 new, named `— postgres` so CI's `-t postgres` job runs them): `DB.execute` against `User.metadata`, read back through Bun with `jsonb_typeof` — the document stored as a document, `||` merging, every shape through both cast spellings, and a raw `where "metadata" = ${…}::jsonb` matching a row the *ORM* wrote, which is the property that makes raw SQL an escape hatch rather than a second representation.

Also there: **the driver behaviour the fix rests on, pinned**. `raw.unsafe` with `$1::jsonb` still stores the jsonb string and `||` still yields an array. Nothing in the ORM would notice Bun changing that, and if it does change, the retyping is solving a problem that no longer exists — this failing is the only way anyone finds out.

Reversed to check they bite: with the retyping disabled, 6 of the 9 new Postgres tests fail (`expected 'string' to be 'object'`, `expected 'array' to be 'object'`, and the filter matching nothing). The object and array cases pass either way, which is the measurement above showing through.

```
packages/gemi        3145 passed | 1 skipped        typecheck clean, oxlint orm --deny-warnings clean
template  sqlite      801 passed | 133 skipped
template  postgres    891 passed | 788 skipped      via app/models/postgres.sh app/models -t postgres
```

## Docs

`docs/orm.md` gains **`### A `::jsonb` cast you write types the parameter as `text`** in the Raw SQL section, with the measured table, the `||` consequence, the string rule, and the uncovered residue; mirrored into `llms-full.txt`, cross-linked from `## `Json` columns`. The paragraph that said "stringify it yourself if the column is JSON" is corrected — followed literally on Postgres, that advice *was* the bug.

`known-divergences.test.ts` pins the section and the source it derives from, the way it already pins the `TZ=UTC` one: the failure mode this whole issue describes is a fix nobody can see from the call site, so a page that stops describing it is a regression.

Closes #376.
