### PR TITLE
Close #366: the row a delete returns is redacted as a delete

### DIFF
--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -828,8 +828,12 @@ export abstract class Model {
       // `applyRedaction`. Reading the marker unconditionally would leave a
       // shape — a future non-pre-scoped caller — where a `before` or a `scope`
       // could be handed an operation the statement is not, and `SCOPABLE` is
-      // keyed on exactly that. The guard makes that shape unrepresentable
-      // rather than merely absent.
+      // keyed on exactly that. The guard does not make that shape
+      // unconstructible — `markRedactedAs(options, "delete")` on its own is
+      // still a value anyone can build — it makes it *unread*, so the
+      // consequence is absent rather than the shape. That is the whole of what
+      // is claimed, and it is enough: the marker changes nothing on any call
+      // that policies still rewrite.
       policy = policyContext(
         schema.name,
         (preScoped ? redactedAs(options) : undefined) ?? op,
@@ -976,11 +980,29 @@ export abstract class Model {
     //   `"delete"`, and its row is thrown away, so nothing observable came of
     //   that half.
     //
-    //   The marker covers the returned row and nothing else. Nested reads keep
-    //   seeing `findMany` — `NESTED_READ` in `policy.ts` is a constant on
-    //   purpose, because a read of another model is a read whatever statement
-    //   encloses it, and that is also what a batched relation read has always
-    //   reported here.
+    //   The marker covers the returned row and nothing else. Nested reads are
+    //   *scoped* as `findMany` on both strategies — `NESTED_READ` in `policy.ts`
+    //   is a constant on purpose, because a read of another model is a read
+    //   whatever statement encloses it — and the marker does not reach them: the
+    //   relation executor rebuilds its options from `{ strategy }` rather than
+    //   forwarding these.
+    //
+    //   Which name a nested row is *redacted* as is a second mechanism and it
+    //   does not currently agree with the first. A **batched** child runs its
+    //   own `$exec` under `NESTED_READ`, so it is redacted as `findMany`; a
+    //   **folded** (lateral, the Postgres default) child never enters its own
+    //   `$exec`, so `redactFolded` below redacts it on the parent's behalf and
+    //   builds its context from the enclosing `$exec`'s `op` — which on this
+    //   call is the pre-read, a `findFirst`. Measured, same query, same rows:
+    //
+    //     sqlite   (batched) child redact context.operation -> "findMany"
+    //     postgres (folded)  child redact context.operation -> "findFirst"
+    //
+    //   Pre-existing, not widened here, and the same on an ordinary `findFirst`
+    //   with an `include`. Filed as #388; the fix is to hand `redactFolded`
+    //   `NESTED_READ` too. Neither value is the write, which is the part #366
+    //   is about and the only part `delete-redact-operation.test.ts` pins under
+    //   the default strategy.
     //
     // Only when there is something to read. A plain `delete` still compiles to
     // one statement and opens no transaction.

--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -46,9 +46,11 @@ import {
   isPreScoped,
   markOrmAuthored,
   markPreScoped,
+  markRedactedAs,
   ormAuthoredFields,
   policiesFor,
   policyContext,
+  redactedAs,
   type PolicyEntry,
   type PolicyContext,
 } from "./policy";
@@ -812,7 +814,28 @@ export abstract class Model {
       // policy that never consults the user — a soft-delete scope, say — has
       // nothing to deny and must keep working with no request in sight. See
       // `policyContext`.
-      policy = policyContext(schema.name, op, currentUser(), system);
+      //
+      // `redactedAs` is the one thing that can make `context.operation` differ
+      // from `op`, and it exists to *remove* a difference the caller can see: a
+      // `delete` that has to read before it writes runs its pre-read as a
+      // `findFirst` and hands that row back, so without this a `redact` keyed on
+      // `"delete"` stopped firing the moment the call also carried an `include`
+      // (#366). The row is the delete's return value; it is redacted as one.
+      //
+      // **Only on a pre-scoped call, which is what keeps it a redaction
+      // concern.** `applyPolicies` below is skipped when `preScoped`, so on the
+      // one call that sets this marker the context reaches nothing but
+      // `applyRedaction`. Reading the marker unconditionally would leave a
+      // shape — a future non-pre-scoped caller — where a `before` or a `scope`
+      // could be handed an operation the statement is not, and `SCOPABLE` is
+      // keyed on exactly that. The guard makes that shape unrepresentable
+      // rather than merely absent.
+      policy = policyContext(
+        schema.name,
+        (preScoped ? redactedAs(options) : undefined) ?? op,
+        currentUser(),
+        system,
+      );
 
       // **The context is built even when pre-scoped; only the rewrite is
       // skipped.** `preScoped` means "the scope is already in these args" — not
@@ -939,9 +962,25 @@ export abstract class Model {
     //   model's policies once already; re-applying them would `AND` the same
     //   predicate twice — same rows, different plan key.
     // - **The read is scoped as the delete was**, including its nested policies.
-    //   A policy that varies by `context.operation` therefore sees "delete" for
-    //   the children of a row being deleted, which is the conservative reading:
-    //   these are the rows the delete is about to remove.
+    //   `effective` was rewritten by `applyPolicies` and `applyNestedPolicies`
+    //   under operation `"delete"`, and `markPreScoped` stops the pre-read
+    //   redoing either — so the `where` the `findFirst` runs is the delete's,
+    //   predicate for predicate.
+    // - **`markRedactedAs`, so the row is redacted as the delete it belongs
+    //   to.** This bullet used to claim `context.operation` was already
+    //   `"delete"` here. It was not, and the row it was most wrong about was the
+    //   root one — the one returned. The pre-read is a `findFirst`, so
+    //   `policyContext` was built with `"findFirst"` and a `redact` keyed on
+    //   `"delete"` silently stopped firing as soon as the same call carried an
+    //   `include` (#366). The `delete` statement below *does* run under
+    //   `"delete"`, and its row is thrown away, so nothing observable came of
+    //   that half.
+    //
+    //   The marker covers the returned row and nothing else. Nested reads keep
+    //   seeing `findMany` — `NESTED_READ` in `policy.ts` is a constant on
+    //   purpose, because a read of another model is a read whatever statement
+    //   encloses it, and that is also what a batched relation read has always
+    //   reported here.
     //
     // Only when there is something to read. A plain `delete` still compiles to
     // one statement and opens no transaction.
@@ -998,7 +1037,14 @@ export abstract class Model {
         const before = await this.$exec(
           "findFirst",
           { where, ...projection },
-          markPreScoped({ strategy: options?.strategy }) as never,
+          // `op` rather than the literal `"delete"`: the branch is guarded on
+          // it, so they are the same string, and taking it from the variable
+          // keeps the two from drifting if the guard ever admits a second
+          // operation that has to read before it writes.
+          markRedactedAs(
+            markPreScoped({ strategy: options?.strategy }),
+            op,
+          ) as never,
         );
 
         // `findFirst` shapes a miss to `null`; the caller asked for a delete, so

--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -12,9 +12,11 @@ import {
   applyNestedPolicies,
   applyPolicies,
   applyRedaction,
+  markRedactedAs,
   policiesFor,
   policyContext,
   redactNullable,
+  redactedAs,
   type ModelPolicy,
   type PolicyContext,
 } from "./policy";
@@ -1903,5 +1905,57 @@ describe("a malformed $policies entry", () => {
     Owner.$policies = [{ scopes: () => ({}) }] as unknown as ModelPolicy[];
 
     expect(() => policiesFor(Owner)).toThrow(InvalidPolicyEntryError);
+  });
+});
+
+/**
+ * The marker that lets a read-first `delete` say which operation the row it is
+ * about to return belongs to — #366.
+ *
+ * The behaviour it produces needs a database, and lives in
+ * `templates/saas-starter/app/models/delete-redact-operation.test.ts`. What is
+ * checkable here is the property that makes it safe to have at all: the key is a
+ * module-private `Symbol`, so it cannot be spelled from outside this module and
+ * cannot become a way for an application to make a query claim to be an
+ * operation it is not — the same door `PRE_SCOPED` and `ORM_AUTHORED` are shut
+ * the same way.
+ */
+describe("the operation a returned row is redacted as", () => {
+  test("survives being carried on an options object", () => {
+    expect(redactedAs(markRedactedAs({ strategy: "batched" }, "delete"))).toBe(
+      "delete",
+    );
+  });
+
+  test("does not disturb the options it rides on", () => {
+    const marked = markRedactedAs({ strategy: "batched" }, "delete") as {
+      strategy?: string;
+    };
+
+    expect(marked.strategy).toBe("batched");
+    // Named keys only. `toEqual` compares symbol keys too, and the point here is
+    // that the strategy the caller asked for still reaches the pre-read — which
+    // is what carries a `{ strategy: "lateral" }` down from `$exec`'s options.
+    expect(Object.keys(marked)).toEqual(["strategy"]);
+  });
+
+  test("is absent from options that were never marked", () => {
+    expect(redactedAs({ strategy: "batched" })).toBeUndefined();
+    expect(redactedAs(undefined)).toBeUndefined();
+    expect(redactedAs(null)).toBeUndefined();
+  });
+
+  /**
+   * The forgery attempt, written out rather than argued: a string key is not the
+   * key, and neither is a symbol of the caller's own carrying the same
+   * description — `Symbol()` mints a fresh identity every call.
+   */
+  test("cannot be spelled from outside the module", () => {
+    expect(redactedAs({ redactedAs: "delete" })).toBeUndefined();
+    expect(
+      redactedAs({
+        [Symbol("gemi.orm.operationTheRowIsReturnedFor")]: "delete",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/gemi/orm/policy.test.ts
+++ b/packages/gemi/orm/policy.test.ts
@@ -12,6 +12,8 @@ import {
   applyNestedPolicies,
   applyPolicies,
   applyRedaction,
+  isPreScoped,
+  markPreScoped,
   markRedactedAs,
   policiesFor,
   policyContext,
@@ -1937,6 +1939,29 @@ describe("the operation a returned row is redacted as", () => {
     // that the strategy the caller asked for still reaches the pre-read — which
     // is what carries a `{ strategy: "lateral" }` down from `$exec`'s options.
     expect(Object.keys(marked)).toEqual(["strategy"]);
+  });
+
+  /**
+   * The property the one call site actually rests on, which the `strategy` case
+   * above does *not* cover: the spread inside `markRedactedAs` has to carry the
+   * `PRE_SCOPED` **symbol** it is wrapping.
+   *
+   * `markRedactedAs(markPreScoped({ strategy }), op)` is the only construction
+   * in the codebase, and it is load-bearing twice over. If that spread ever
+   * stopped carrying symbol keys the pre-read would be scoped a second time —
+   * and `redactedAs` is read only when `preScoped`, so the marker would go
+   * unread as well, silently restoring #366. Both failures are caught today, but
+   * only by the live-database suite and only as a `RecordNotFoundError` a long
+   * way from its cause. One line pins it where the mechanism is.
+   */
+  test("carries the pre-scoped marker it wraps", () => {
+    const marked = markRedactedAs(
+      markPreScoped({ strategy: "batched" }),
+      "delete",
+    );
+
+    expect(isPreScoped(marked)).toBe(true);
+    expect(redactedAs(marked)).toBe("delete");
   });
 
   test("is absent from options that were never marked", () => {

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -1449,6 +1449,52 @@ export function ormAuthoredFields(options: unknown): readonly string[] {
 
 const EMPTY_FIELDS: readonly string[] = [];
 
+/**
+ * The operation whose *return value* this `$exec` is producing, when that is not
+ * the operation it runs.
+ *
+ * There is exactly one such call: the pre-read a read-first `delete` performs.
+ * `delete({ where, include })` cannot be one statement — the children have to be
+ * read before the row goes away — so `$exec` runs a `findFirst` inside a
+ * transaction and hands **that** row to the caller, discarding what the `delete`
+ * statement returned. Every other consequence of the split was already made
+ * invisible: the read is scoped as the delete was, a miss raises
+ * `RecordNotFoundError` naming `delete`, and #364 taught it to carry the `omit`.
+ * `context.operation` was the last one left visible, and it was visible in the
+ * worst direction — a `redact` keyed on `"delete"` stopped firing on the row the
+ * caller got back, the moment an `include` was added (#366).
+ *
+ * **Redaction only, which is why it is named for redaction.** By the time this
+ * is read the pre-read is already `markPreScoped`, so `applyPolicies` does not
+ * run on it at all — no `before`, no `scope`, no `onCreate` / `onUpdate` sees
+ * this value, and a scope written for reads cannot be turned off by it. The
+ * remaining reader of the context is `applyRedaction`, over the one row that is
+ * about to be returned.
+ *
+ * **Not the nested reads.** A relation read underneath is scoped and redacted as
+ * `findMany` — see {@link NESTED_READ}, which is a constant for the reason this
+ * is narrow: a nested read is a read of another model, whatever statement
+ * encloses it. This marker travels no further than the row it names.
+ *
+ * A module-private `Symbol`, for the same reason `PRE_SCOPED` and `ORM_AUTHORED`
+ * are: it is not exported from `orm/index.ts`, so an application cannot forge it
+ * and cannot use it to make a query claim to be an operation it is not.
+ */
+const REDACTED_AS = Symbol("gemi.orm.operationTheRowIsReturnedFor");
+
+export function markRedactedAs(
+  options: object | undefined,
+  operation: Operation,
+): object {
+  return { ...options, [REDACTED_AS]: operation };
+}
+
+export function redactedAs(options: unknown): Operation | undefined {
+  if (typeof options !== "object" || options === null) return undefined;
+  const operation = (options as Record<symbol, unknown>)[REDACTED_AS];
+  return typeof operation === "string" ? (operation as Operation) : undefined;
+}
+
 /** Resolves a model name to its policies, so this file need not import the registry. */
 export type PolicyLookup = (model: string) => {
   policies: readonly ModelPolicy[];

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -1471,10 +1471,33 @@ const EMPTY_FIELDS: readonly string[] = [];
  * remaining reader of the context is `applyRedaction`, over the one row that is
  * about to be returned.
  *
- * **Not the nested reads.** A relation read underneath is scoped and redacted as
- * `findMany` — see {@link NESTED_READ}, which is a constant for the reason this
- * is narrow: a nested read is a read of another model, whatever statement
- * encloses it. This marker travels no further than the row it names.
+ * **Not the nested reads.** A relation read underneath is *scoped* as `findMany`
+ * — see {@link NESTED_READ}, which is a constant for the reason this marker is
+ * narrow: a nested read is a read of another model, whatever statement encloses
+ * it. This marker travels no further than the row it names, and the relation
+ * executor rebuilds its options from `{ strategy }` rather than forwarding
+ * these, so it cannot travel even by accident.
+ *
+ * *Redaction* of a nested row is the same answer only when the child went
+ * through its own `$exec`. Scoping and redaction are two mechanisms here and
+ * they do not currently agree:
+ *
+ * - **batched** — the child runs its own `$exec` under `NESTED_READ`, so its
+ *   `redact` is handed `findMany`. True on both dialects.
+ * - **folded** (lateral, the Postgres default) — the child's rows never enter
+ *   its own `$exec`, so the parent redacts them on its behalf via
+ *   `redactFolded`, which builds its context from the **enclosing** `$exec`'s
+ *   operation rather than from `NESTED_READ`. Under this marker's one call site
+ *   that enclosing operation is the pre-read, so a folded child of a
+ *   `delete({ where, include })` is redacted as `findFirst`. Measured on
+ *   postgres:16.
+ *
+ * That divergence predates this marker and is not widened by it — it is two
+ * reads disagreeing by strategy, not a read reporting a write, and it is the
+ * same on an ordinary `findFirst`. It is filed as #388. It is also the reason
+ * `REDACTED_AS` must **not** be widened to nested rows: doing so would hand a
+ * child's policy the enclosing *write*'s name on one strategy and not the other,
+ * which is strictly worse than two read names disagreeing.
  *
  * A module-private `Symbol`, for the same reason `PRE_SCOPED` and `ORM_AUTHORED`
  * are: it is not exported from `orm/index.ts`, so an application cannot forge it

--- a/templates/saas-starter/app/models/delete-redact-operation.test.ts
+++ b/templates/saas-starter/app/models/delete-redact-operation.test.ts
@@ -1,0 +1,442 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SQL } from "bun";
+
+import { DatabaseManager } from "gemi/database";
+import { Application } from "gemi/foundation";
+import {
+  Model,
+  clearPlanCache,
+  register,
+  type ModelPolicy,
+  type ModelSchema,
+} from "gemi/orm";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+
+import { POSTGRES_URL } from "./scratch";
+
+/**
+ * What `context.operation` says on the row a `delete` hands back — #366.
+ *
+ * A `delete` that carries an `include` or a `_count` cannot be one statement:
+ * the children have to be read before the row goes away. So `$exec` reads with
+ * `findFirst` inside a transaction, deletes, and returns **the row it read** —
+ * the `delete` statement's own row is discarded. Every other consequence of that
+ * split had already been made invisible to the caller: the read is scoped as the
+ * delete was, a miss raises `RecordNotFoundError` naming `delete`, and #364
+ * taught the pre-read to carry the `omit`. `context.operation` was the last one
+ * left showing, and it showed in the worst direction — a `redact` keyed on
+ * `"delete"` stopped firing on the returned row the moment an `include` was
+ * added beside it.
+ *
+ * This is a gemi feature with no Prisma counterpart, so there is no differential
+ * oracle for it; the authority is internal consistency, and the shape of that
+ * claim is *one operation must not answer two ways depending on whether it could
+ * be compiled to one statement*. Hence the plain `delete` case sitting beside
+ * the two read-first ones: it is the control, and it passed all along.
+ *
+ * ```prisma
+ * model DelOpParent { id Int @id  label String  secret String?  children DelOpChild[] }
+ * model DelOpChild  { id Int @id  parentId Int  name String
+ *                     parent DelOpParent @relation(fields: [parentId], references: [id]) }
+ * ```
+ */
+
+const SQLITE_DDL = [
+  `DROP TABLE IF EXISTS "DelOpChild"`,
+  `DROP TABLE IF EXISTS "DelOpParent"`,
+  `CREATE TABLE "DelOpParent" (
+     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+     "label" TEXT NOT NULL,
+     "secret" TEXT
+   )`,
+  `CREATE TABLE "DelOpChild" (
+     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+     "parentId" INTEGER NOT NULL,
+     "name" TEXT NOT NULL,
+     CONSTRAINT "DelOpChild_parentId_fkey" FOREIGN KEY ("parentId")
+       REFERENCES "DelOpParent" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+   )`,
+];
+
+const POSTGRES_DDL = [
+  `DROP TABLE IF EXISTS "DelOpChild"`,
+  `DROP TABLE IF EXISTS "DelOpParent"`,
+  `CREATE TABLE "DelOpParent" (
+     "id" SERIAL NOT NULL PRIMARY KEY,
+     "label" TEXT NOT NULL,
+     "secret" TEXT
+   )`,
+  `CREATE TABLE "DelOpChild" (
+     "id" SERIAL NOT NULL PRIMARY KEY,
+     "parentId" INTEGER NOT NULL,
+     "name" TEXT NOT NULL,
+     CONSTRAINT "DelOpChild_parentId_fkey" FOREIGN KEY ("parentId")
+       REFERENCES "DelOpParent" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+   )`,
+];
+
+function field(name: string, type: any, extra: Record<string, unknown> = {}) {
+  return {
+    name,
+    column: name,
+    type,
+    nullable: false,
+    isId: false,
+    isUpdatedAt: false,
+    ...extra,
+  } as any;
+}
+
+const parentSchema: ModelSchema = {
+  name: "DelOpParent",
+  table: "DelOpParent",
+  fields: {
+    id: field("id", "Int", { isId: true, default: { kind: "autoincrement" } }),
+    label: field("label", "String"),
+    secret: field("secret", "String", { nullable: true }),
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    children: {
+      name: "children",
+      model: "DelOpChild",
+      kind: "many",
+      relationName: "DelOpChildToDelOpParent",
+      from: [],
+      to: [],
+      nullable: false,
+    },
+  },
+};
+
+const childSchema: ModelSchema = {
+  name: "DelOpChild",
+  table: "DelOpChild",
+  fields: {
+    id: field("id", "Int", { isId: true, default: { kind: "autoincrement" } }),
+    parentId: field("parentId", "Int"),
+    name: field("name", "String"),
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    parent: {
+      name: "parent",
+      model: "DelOpParent",
+      kind: "one",
+      relationName: "DelOpChildToDelOpParent",
+      from: ["parentId"],
+      to: ["id"],
+      nullable: false,
+    },
+  },
+};
+
+/** Every operation the parent's `redact` was handed, in order, for one case. */
+const parentOperations: string[] = [];
+
+/** The same for the child model, so the boundary can be asserted rather than assumed. */
+const childOperations: string[] = [];
+
+/**
+ * Two branches in one hook, so a single returned row pins both directions.
+ *
+ * A test that only checks "`delete` redacts" would pass on an implementation
+ * that redacts unconditionally. The `findFirst` branch is what makes the
+ * assertion about the *operation* rather than about redaction happening at all:
+ * on the returned row of a `delete`, `secret` must be gone and `label` must not
+ * be, and before the fix it was exactly the other way round.
+ */
+const parentRedact: ModelPolicy = {
+  redact(context, row: any) {
+    parentOperations.push(context.operation);
+    if (context.operation === "delete") row.secret = null;
+    if (context.operation === "findFirst") row.label = null;
+  },
+};
+
+/**
+ * A scope that only exists for reads, which is how the pre-read's *scoping* is
+ * pinned separately from its redaction.
+ *
+ * The pre-read is `markPreScoped`, so `applyPolicies` never runs on it a second
+ * time — this fragment cannot reach it, and the `where` the `findFirst` executes
+ * is the delete's, predicate for predicate. That is worth an assertion because
+ * it is the half of #366 that was *already* right, and the fix must not disturb
+ * it: reporting the operation as `delete` for redaction and re-scoping the read
+ * as a read are two different changes, and only one of them is wanted.
+ */
+const parentReadScope: ModelPolicy = {
+  scope: (context) =>
+    context.operation === "findFirst" ? { label: "no-such-label" } : undefined,
+};
+
+class DelOpParent extends Model {
+  static $schema = parentSchema;
+  static $policies = [parentRedact, parentReadScope];
+}
+
+class DelOpChild extends Model {
+  static $schema = childSchema;
+  static $policies: ModelPolicy[] = [
+    {
+      redact(context) {
+        childOperations.push(context.operation);
+      },
+    },
+  ];
+}
+
+function suite(label: string, resolve: () => string, ddl: string[]) {
+  describe(label, () => {
+    let database: DatabaseManager;
+    let raw: SQL;
+    let previous: Application | undefined;
+
+    beforeAll(async () => {
+      const url = resolve();
+      database = new DatabaseManager({ url });
+      raw = new SQL(url);
+      for (const statement of ddl) await raw.unsafe(statement);
+      if (label.includes("sqlite")) {
+        await raw.unsafe(`PRAGMA foreign_keys = ON`);
+        await database.sql.unsafe(`PRAGMA foreign_keys = ON`);
+      }
+
+      previous = Application.getInstance();
+      const application = new Application();
+      application.instance(DatabaseManager, database as never);
+      Application.setInstance(application);
+
+      register("DelOpParent", DelOpParent);
+      register("DelOpChild", DelOpChild);
+    }, 120_000);
+
+    afterAll(async () => {
+      await raw?.unsafe(`DROP TABLE IF EXISTS "DelOpChild"`).catch(() => {});
+      await raw?.unsafe(`DROP TABLE IF EXISTS "DelOpParent"`).catch(() => {});
+      await raw?.close();
+      await database?.close();
+      if (previous) Application.setInstance(previous);
+      if (workspace) rmSync(workspace, { recursive: true, force: true });
+    });
+
+    beforeEach(async () => {
+      clearPlanCache();
+      parentOperations.length = 0;
+      childOperations.length = 0;
+      await raw.unsafe(`DELETE FROM "DelOpChild"`);
+      await raw.unsafe(`DELETE FROM "DelOpParent"`);
+
+      // Seeded under `asSystem`, which suspends policies entirely — so the
+      // `scope` above never meets a `create`, where a scope with no `onCreate`
+      // is refused by name.
+      await Model.asSystem(async () => {
+        const parent: any = await DelOpParent.$exec("create", {
+          data: { label: "kept", secret: "hunter2" },
+        });
+        await DelOpChild.$exec("create", {
+          data: { parentId: parent.id, name: "a" },
+        });
+        await DelOpChild.$exec("create", {
+          data: { parentId: parent.id, name: "b" },
+        });
+      });
+    });
+
+    async function only(): Promise<any> {
+      const rows = (await Model.asSystem(() =>
+        DelOpParent.$exec("findMany", {}),
+      )) as any[];
+      return rows[0];
+    }
+
+    /**
+     * The control. One statement, no pre-read, and it has always reported
+     * `delete` — which is what makes the two below a divergence within one
+     * operation rather than an open question about what `delete` should mean.
+     */
+    test("a plain delete redacts under delete", async () => {
+      const parent = await only();
+
+      const deleted: any = await DelOpParent.$exec("delete", {
+        where: { id: parent.id },
+      });
+
+      expect(deleted.secret).toBe(null);
+      expect(deleted.label).toBe("kept");
+      expect(parentOperations).toEqual(["delete"]);
+    });
+
+    /** #366: the same call, plus an `include`, used to come back unredacted. */
+    test("a delete with an include redacts under delete", async () => {
+      const parent = await only();
+
+      const deleted: any = await DelOpParent.$exec("delete", {
+        where: { id: parent.id },
+        include: { children: true },
+      });
+
+      expect(deleted.secret).toBe(null);
+      expect(deleted.label).toBe("kept");
+      expect(deleted.children).toHaveLength(2);
+    });
+
+    /**
+     * The other half of the branch's condition. A `_count` has no relation plan
+     * behind it, so `plan.counts` is what routes this one — a separate way in,
+     * and therefore a separate case.
+     */
+    test("a delete with a _count redacts under delete", async () => {
+      const parent = await only();
+
+      const deleted: any = await DelOpParent.$exec("delete", {
+        where: { id: parent.id },
+        include: { _count: { select: { children: true } } },
+      });
+
+      expect(deleted.secret).toBe(null);
+      expect(deleted.label).toBe("kept");
+      expect(deleted._count).toEqual({ children: 2 });
+    });
+
+    /**
+     * The row is redacted once, as one operation — not once as a read and again
+     * as a write. The second entry belongs to the inner `delete` statement,
+     * whose row is discarded; the returned row is the first.
+     */
+    test("neither invocation reports the read it was compiled as", async () => {
+      const parent = await only();
+
+      await DelOpParent.$exec("delete", {
+        where: { id: parent.id },
+        include: { children: true },
+      });
+
+      expect(parentOperations).toEqual(["delete", "delete"]);
+    });
+
+    /**
+     * The marker travels with one call and no further: an ordinary read still
+     * reports itself as one, so nothing outside the read-first `delete` can
+     * start claiming to be a write.
+     */
+    test("an ordinary read still reports its own operation", async () => {
+      await DelOpParent.$exec("findMany", { include: { children: true } });
+
+      expect(parentOperations).toEqual(["findMany"]);
+    });
+
+    /**
+     * The boundary. A relation read underneath is a read of another model, and
+     * `NESTED_READ` in `policy.ts` is a constant precisely so it stays one
+     * whatever statement encloses it.
+     *
+     * Pinned under `batched` explicitly because that is the strategy both
+     * dialects have. Which read-name a *folded* child sees is strategy-dependent
+     * today — `redactFolded` passes the enclosing operation down, so a lateral
+     * child of this pre-read is told `findFirst` where a batched one is told
+     * `findMany`. Both were measured; the divergence predates this change, is
+     * about two reads disagreeing rather than a read reporting a write, and is
+     * out of #366's scope. What must hold under either is the case below.
+     */
+    test("a nested read is still redacted as a read", async () => {
+      const parent = await only();
+
+      await DelOpParent.$exec(
+        "delete",
+        { where: { id: parent.id }, include: { children: true } },
+        { strategy: "batched" } as never,
+      );
+
+      // Deduplicated: `redact` runs per row, and the fixture seeds two children.
+      // The claim is about which operation they are told, not how many of them
+      // there are.
+      expect([...new Set(childOperations)]).toEqual(["findMany"]);
+    });
+
+    test("and never as the delete that encloses it, under the default strategy", async () => {
+      const parent = await only();
+
+      await DelOpParent.$exec("delete", {
+        where: { id: parent.id },
+        include: { children: true },
+      });
+
+      // Not an equality: the value differs by dialect, because the default
+      // strategy does. Measured — `findMany` on SQLite (batched), `findFirst` on
+      // Postgres (lateral, where `redactFolded` passes the enclosing read's
+      // name). Neither is the write, which is the part that has to hold, and
+      // pinning either literal here would make this suite fail on one dialect
+      // for a divergence that is not #366's.
+      expect(childOperations).not.toContain("delete");
+      expect(childOperations.length).toBeGreaterThan(0);
+    });
+
+    /**
+     * The scope keyed on `findFirst` is real — this is the assertion that gives
+     * the next one its teeth.
+     */
+    test("a read-only scope applies to a read", async () => {
+      const parent = await only();
+
+      expect(
+        await DelOpParent.$exec("findFirst", { where: { id: parent.id } }),
+      ).toBe(null);
+    });
+
+    /**
+     * …and does not apply to the pre-read, which is not a second read: its args
+     * arrive already scoped as the delete's, and `markPreScoped` is what stops
+     * them being scoped again. Redacting the returned row as a `delete` did not
+     * change that, and it must not.
+     */
+    test("but not to the pre-read of a delete", async () => {
+      const parent = await only();
+
+      const deleted: any = await DelOpParent.$exec("delete", {
+        where: { id: parent.id },
+        include: { children: true },
+      });
+
+      expect(deleted.id).toBe(parent.id);
+      expect(await Model.asSystem(() => DelOpParent.$exec("count", {}))).toBe(
+        0,
+      );
+    });
+  });
+}
+
+let workspace: string | undefined;
+
+suite(
+  "delete redaction operation — sqlite",
+  () => {
+    workspace = mkdtempSync(join(tmpdir(), "gemi-orm-delete-redact-"));
+    return `sqlite://${join(workspace, "delete-redact.db")}`;
+  },
+  SQLITE_DDL,
+);
+
+if (POSTGRES_URL) {
+  suite(
+    "delete redaction operation — postgres",
+    () => POSTGRES_URL,
+    POSTGRES_DDL,
+  );
+} else {
+  describe.skip("delete redaction operation — postgres", () => {
+    test("skipped", () => {});
+  });
+}

--- a/templates/saas-starter/app/models/delete-redact-operation.test.ts
+++ b/templates/saas-starter/app/models/delete-redact-operation.test.ts
@@ -198,14 +198,30 @@ class DelOpChild extends Model {
   ];
 }
 
-function suite(label: string, resolve: () => string, ddl: string[]) {
+/**
+ * `resolve` owns whatever it had to create to produce a URL, and hands back the
+ * teardown for it. The alternative — a module-level `workspace` the SQLite
+ * resolver sets and both `afterAll`s read — is cross-suite mutable state: the
+ * Postgres suite would try to remove the SQLite suite's temp directory. Harmless
+ * while describes run in order in one worker and `force: true` swallows the
+ * second call, but it is exactly the kind of shared handle that stops being
+ * harmless the day the two dialects run in separate workers.
+ */
+function suite(
+  label: string,
+  resolve: () => { url: string; cleanup?: () => void },
+  ddl: string[],
+) {
   describe(label, () => {
     let database: DatabaseManager;
     let raw: SQL;
     let previous: Application | undefined;
+    let cleanup: (() => void) | undefined;
 
     beforeAll(async () => {
-      const url = resolve();
+      const resolved = resolve();
+      const url = resolved.url;
+      cleanup = resolved.cleanup;
       database = new DatabaseManager({ url });
       raw = new SQL(url);
       for (const statement of ddl) await raw.unsafe(statement);
@@ -229,7 +245,7 @@ function suite(label: string, resolve: () => string, ddl: string[]) {
       await raw?.close();
       await database?.close();
       if (previous) Application.setInstance(previous);
-      if (workspace) rmSync(workspace, { recursive: true, force: true });
+      cleanup?.();
     });
 
     beforeEach(async () => {
@@ -349,7 +365,10 @@ function suite(label: string, resolve: () => string, ddl: string[]) {
      * child of this pre-read is told `findFirst` where a batched one is told
      * `findMany`. Both were measured; the divergence predates this change, is
      * about two reads disagreeing rather than a read reporting a write, and is
-     * out of #366's scope. What must hold under either is the case below.
+     * out of #366's scope. It is filed as **#388**, whose fix — handing
+     * `redactFolded` the same `NESTED_READ` constant — would make the case below
+     * pinnable as an equality on both dialects. What must hold until then is the
+     * case below.
      */
     test("a nested read is still redacted as a read", async () => {
       const parent = await only();
@@ -377,9 +396,9 @@ function suite(label: string, resolve: () => string, ddl: string[]) {
       // Not an equality: the value differs by dialect, because the default
       // strategy does. Measured — `findMany` on SQLite (batched), `findFirst` on
       // Postgres (lateral, where `redactFolded` passes the enclosing read's
-      // name). Neither is the write, which is the part that has to hold, and
-      // pinning either literal here would make this suite fail on one dialect
-      // for a divergence that is not #366's.
+      // name — #388). Neither is the write, which is the part that has to hold,
+      // and pinning either literal here would make this suite fail on one
+      // dialect for a divergence that is not #366's.
       expect(childOperations).not.toContain("delete");
       expect(childOperations.length).toBeGreaterThan(0);
     });
@@ -418,21 +437,24 @@ function suite(label: string, resolve: () => string, ddl: string[]) {
   });
 }
 
-let workspace: string | undefined;
-
 suite(
   "delete redaction operation — sqlite",
   () => {
-    workspace = mkdtempSync(join(tmpdir(), "gemi-orm-delete-redact-"));
-    return `sqlite://${join(workspace, "delete-redact.db")}`;
+    const workspace = mkdtempSync(join(tmpdir(), "gemi-orm-delete-redact-"));
+    return {
+      url: `sqlite://${join(workspace, "delete-redact.db")}`,
+      cleanup: () => rmSync(workspace, { recursive: true, force: true }),
+    };
   },
   SQLITE_DDL,
 );
 
 if (POSTGRES_URL) {
+  // No `cleanup`: the database is the caller's, and the tables are dropped by
+  // the shared `afterAll` either way.
   suite(
     "delete redaction operation — postgres",
-    () => POSTGRES_URL,
+    () => ({ url: POSTGRES_URL }),
     POSTGRES_DDL,
   );
 } else {


### PR DESCRIPTION
Closes #366.

`Model.$exec` sends a `delete` down a read-first path as soon as there is a relation or a `_count` to read: read the row inside a transaction, delete it, hand the caller **what was read**. The `delete` statement's own row is thrown away. Every other consequence of that split had already been made invisible to the caller — the read is scoped as the delete was, a miss raises `RecordNotFoundError` naming `delete`, and #364 taught the pre-read to carry the `omit`. `context.operation` was the last one still showing.

| call | today | after |
| --- | --- | --- |
| `delete({ where })` | redacted under `"delete"` | unchanged — one statement, no pre-read |
| `delete({ where, include })` | **redacted under `"findFirst"`** | `"delete"` |
| `delete({ where, include: { _count } })` | **redacted under `"findFirst"`** | `"delete"` |
| a nested read under either | `"findMany"` / `"findFirst"` | unchanged |

So a policy carrying `redact: (ctx, row) => { if (ctx.operation === "delete") row.secret = null }` protected the row until somebody added an `include` to the call, at which point the column came back. The plain `delete` beside it was always right, which is what makes this a divergence *within one operation* rather than an open question about what `delete` should mean.

## Measured

There is no Prisma oracle here — policies are gemi's, and the differential harness deliberately compares against the **pre-redaction** payload. The authority is internal consistency, so the evidence is the live-DB template suite rather than a generated client. Instrumenting the policy to record every `context.operation` it is handed, on the fixture in `delete-redact-operation.test.ts`:

```
delete({ where })                      -> { secret: null, label: "kept" }   CTXOP: delete
delete({ where, include: { children } })  -> { secret: "hunter2", … }       CTXOP: findFirst, delete
delete({ where, include: { _count } })    -> { secret: "hunter2", … }       CTXOP: findFirst, delete
```

Two invocations, and **the one that redacts the returned row is the first**. The second is the inner `delete` statement, running under `"delete"` correctly and having its row discarded — which is why nothing observable came of that half, and why the divergence is silent.

## The fix

`markRedactedAs` / `redactedAs` in `policy.ts`: a module-private `Symbol` on the options object, the third of its kind after `PRE_SCOPED` and `ORM_AUTHORED` and shut the same way — not exported from `orm/index.ts`, so an application cannot forge one and cannot make a query claim to be an operation it is not. The read-first branch marks its pre-read with `op` (not the literal `"delete"`; the branch is guarded on `op`, and taking it from the variable keeps the two from drifting if the guard ever admits a second read-before-write operation).

**Read only on a pre-scoped call**, and that guard is the whole reason this is a two-line change rather than a design question:

```ts
policy = policyContext(
  schema.name,
  (preScoped ? redactedAs(options) : undefined) ?? op,
  …
);
```

The issue asked whether the pre-read "needs to run its scope under `findFirst` while redacting under `delete`". It turns out there is nothing to arbitrate: the pre-read is `markPreScoped`, so `applyPolicies` **does not run on it at all** — no `before`, no `scope`, no `onCreate`/`onUpdate` sees this value. The `where` the `findFirst` executes is the delete's, predicate for predicate, rewritten once at the outer call. The only remaining reader of the context is `applyRedaction`, over the one row about to be returned. The `preScoped` guard makes that structural instead of merely true today: without it, a future non-pre-scoped caller could hand a `scope` an operation the statement is not, and `SCOPABLE` is keyed on exactly that.

That is also pinned rather than asserted. `delete-redact-operation.test.ts` carries a policy whose `scope` fires only for `findFirst`; a real `findFirst` returns `null`, and the `delete`'s pre-read is untouched by it.

## The comment that contradicted the code

The issue is right that `Model.ts:940-943` asserted one answer while the code did the other, and the comment was wrong in **both** halves rather than one:

> A policy that varies by `context.operation` therefore sees "delete" for the children of a row being deleted…

- The **root** row saw `findFirst`. That is #366 and it is fixed.
- The **children** never saw `delete` either. `applyNestedPolicies` scopes every nested node as `NESTED_READ`, a constant that is `findMany` — deliberately a constant, per its own docblock, because threading the root operation down is what produced an earlier bug. Measured: a batched child's `redact` is handed `findMany`; a folded (lateral, Postgres) child is handed `findFirst`, because `redactFolded` passes the enclosing read's name.

The fix does **not** extend the marker to the children, and the comment now says what is true. A nested read is a read of another model whatever statement encloses it, and telling a child's policy `"delete"` would deepen the batched/lateral disagreement rather than settle it.

**Loose end, deliberately left:** those two read names still differ by strategy — `findMany` batched, `findFirst` folded — for the *same* query on the *same* rows. That predates this change, is two reads disagreeing rather than a read reporting a write, and belongs to `redactFolded` rather than to #366. Both values are measured and written down at the test that skirts them; it asserts only that a child never reports the enclosing write, so it holds on either dialect.

## Pinned

`templates/saas-starter/app/models/delete-redact-operation.test.ts`, nine cases per dialect, on a `DelOpParent`/`DelOpChild` fixture of its own — the sibling `delete-include.test.ts` models carry no policies and giving them one would change every case in that file.

The policy branches on two operations in one hook, which is what makes the assertion about the *operation* rather than about redaction happening at all: on the returned row `secret` must be gone and `label` must **not** be, and before this change it was exactly the other way round. A test that only checked "`delete` redacts" would pass on an implementation that redacts unconditionally.

With the `Model.ts`/`policy.ts` hunks stashed, three of the nine fail together — the `include` case, the `_count` case, and the operation list, which reports `["findFirst", "delete"]` where it should report `["delete", "delete"]`.

`policy.test.ts` gets the marker's own contract, which is checkable with no database: it round-trips, it leaves the `strategy` the caller asked for alone, it is absent from unmarked options, and it cannot be spelled from outside the module — neither by a string key nor by a symbol of the caller's own carrying the same description.

## Verification

```
packages/gemi            bun --bun vitest run
  Test Files  120 passed (120)
       Tests  3115 passed | 1 skipped (3116)

packages/gemi            bun run typecheck                       clean
packages/gemi            bunx tsc --noEmit -p tsconfig.generated.json   clean
repo                     bun run lint      1 successful, 0 errors (79 pre-existing warnings)

templates/saas-starter   bun --bun vitest run app/models          (sqlite)
  Test Files  21 passed | 3 skipped (24)
       Tests  801 passed | 134 skipped (935)

templates/saas-starter   app/models/postgres.sh app/models/       (postgres 16, docker)
  Test Files  2 failed | 22 passed (24)
       Tests  1192 passed | 487 skipped (1679)
```

The two Postgres-run failures are `differential.test.ts` and `writes.differential.test.ts` refusing their **sqlite** halves by name — "This suite needs @prisma/client generated for the 'sqlite' provider… Only one dialect's suite can run at a time, which is why the other one is failing rather than skipping." That is the harness's own designed behaviour, not a result. Both files pass in the SQLite run above.

A worktree needs `bun install`, `bun run build:bin` in `packages/gemi`, the `gemi-orm-generator` link, and `bunx prisma generate --schema templates/saas-starter/prisma/differential.prisma` **from the repository root** before any of this is honest; without them `generated.test.ts` fails and the three differential files do not collect at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
