### PR TITLE
Close #301: the corpus walks JSON path filters, and depth stops minting plan entries

### DIFF
--- a/packages/gemi/orm/binding.invariants.test.ts
+++ b/packages/gemi/orm/binding.invariants.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { compileAggregate } from "./compile/aggregate";
 import { createBindContext } from "./compile/fragment";
@@ -119,6 +119,119 @@ describe("no value reaches the SQL text", () => {
   });
 
   /**
+   * **...and a plan compiled from one call's values binds the *next* call's.**
+   *
+   * The property above compiles each shape twice and compares the two texts,
+   * which is blind to a whole class: a compiler that reads a value at compile
+   * time and closes over it emits byte-identical text for both, keys
+   * identically, and is still wrong the moment the plan is reused. And it is
+   * reused — that is what `getOrCompile` is for, so this is the live path
+   * rather than a hypothetical one.
+   *
+   * Found while covering JSON path filters (#301), because a path is where the
+   * mistake is easiest to make: it is the one argument whose value decides part
+   * of an expression's *meaning*, so building the fragment from it reads as
+   * natural. Written over the whole corpus rather than over `path` alone,
+   * since nothing about the failure is specific to it — `where: { name: "a" }`
+   * compiled with a captured `"a"` fails the same way and was equally
+   * unasserted.
+   *
+   * `bind` rather than `text` is the whole point: compile from `args`, bind
+   * `twin`, and require the same array the plan compiled *for* `twin` produces.
+   */
+  test.each(DIALECTS)("a plan compiled for one call binds the next call's values — %s", (_name, dialect) => {
+    /**
+     * Two bound values are *supposed* to differ between two calls of one plan:
+     * `@default(now())` / `@updatedAt`, and `@default(cuid())`. Both are
+     * generated at bind time, which is the whole reason they are generated
+     * there rather than compiled in, so neither can be compared as-is.
+     *
+     * The clock is **frozen** rather than masked, because masking it cannot be
+     * done in a dialect-agnostic way: `encode` turns a `Date` into a number on
+     * SQLite and passes it through on Postgres, so a `value instanceof Date`
+     * mask covers one dialect and silently drops the other — and then flakes
+     * on whichever millisecond boundary falls between two binds. Freezing
+     * removes the difference instead of hiding it, and leaves a genuinely stale
+     * timestamp visible.
+     *
+     * `cuid` has no clock to freeze — it is random by construction — so it is
+     * masked, by kind rather than by position so it stays right if the column
+     * order moves.
+     */
+    const CUID = /^c[a-z0-9]{20,}$/;
+    const masked = (bound: unknown[]) =>
+      bound.map((value) =>
+        typeof value === "string" && CUID.test(value) ? "<generated cuid>" : value,
+      );
+
+    const stale: string[] = [];
+    let checked = 0;
+
+    vi.useFakeTimers();
+    try {
+      for (const [op, args] of entries) {
+        const twin = vary(args);
+        if (JSON.stringify(twin) === JSON.stringify(args)) continue;
+
+        let reused: unknown[];
+        let fresh: unknown[];
+        try {
+          // The cache hit, spelled out: a plan compiled for `args`, handed
+          // `twin`. `getOrCompile` does exactly this whenever two calls share a
+          // key, which every pair here does by construction.
+          reused = masked(compileAny(op, args, dialect).bind(twin, createBindContext()));
+          fresh = masked(compileAny(op, twin, dialect).bind(twin, createBindContext()));
+        } catch {
+          continue; // Refusals are `plan-key.invariants.test.ts`'s subject.
+        }
+
+        checked++;
+        if (JSON.stringify(reused) !== JSON.stringify(fresh)) {
+          stale.push(
+            `${op} ${JSON.stringify(args)}\n  reused ${JSON.stringify(reused)}\n  fresh  ${JSON.stringify(fresh)}`,
+          );
+        }
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(stale, stale.join("\n\n")).toEqual([]);
+    expect(checked).toBeGreaterThan(40);
+  });
+
+  /**
+   * A JSON path, in each dialect's own grammar — appended to the cases below
+   * because it is the value hardest to keep bound.
+   *
+   * The path is the one argument whose *value* decides what an expression
+   * means, and `compile/where.ts` says so at the branch. That makes "read it at
+   * compile time and build the fragment from it" the natural mistake, and it is
+   * invisible to the two properties above: such a compiler emits byte-identical
+   * text for two different paths and keys them identically. What it does not do
+   * is put the path in the binding, which is what this asks.
+   *
+   * Dialect-keyed rather than shared, because the grammars are not
+   * interchangeable: Postgres refuses `"$.a"` and SQLite refuses `["a"]`.
+   */
+  const JSON_BINDING_CASES: Record<string, [string, unknown, unknown[]][]> = {
+    sqlite: [
+      [
+        "findMany",
+        { where: { metadata: { path: "$.needlePath", equals: "needleValue" } } },
+        ["$.needlePath", "needleValue"],
+      ],
+    ],
+    postgres: [
+      [
+        "findMany",
+        { where: { metadata: { path: ["needlePath"], equals: "needleValue" } } },
+        ["needlePath", "needleValue"],
+      ],
+    ],
+  };
+
+  /**
    * ...and the values are **actually bound**, not dropped.
    *
    * Without this the property above is satisfiable by a compiler that throws
@@ -126,13 +239,14 @@ describe("no value reaches the SQL text", () => {
    * anything. Same vacuity trap that made `plan-key.invariants.test.ts` pass
    * against a reintroduced #92 on its first run.
    */
-  test.each(DIALECTS)("...and every value is present in the binding — %s", (_name, dialect) => {
+  test.each(DIALECTS)("...and every value is present in the binding — %s", (name, dialect) => {
     const cases: [string, unknown, unknown[]][] = [
       ["findMany", { where: { name: "needle" } }, ["needle"]],
       ["findMany", { where: { name: { contains: "needle" } } }, ["%needle%"]],
       ["findMany", { where: { id: { in: [11, 22, 33] } } }, [11, 22, 33]],
       ["update", { where: { id: 7 }, data: { name: "needle" } }, ["needle", 7]],
       ["deleteMany", { where: { name: "needle" } }, ["needle"]],
+      ...JSON_BINDING_CASES[name],
     ];
 
     for (const [op, args, expected] of cases) {

--- a/packages/gemi/orm/corpus.ts
+++ b/packages/gemi/orm/corpus.ts
@@ -71,27 +71,39 @@ export const READS: unknown[] = [
   // and a refused entry covers nothing. `userWithProfile` grew `metadata` for
   // this; see the note there for why that cost nothing.
   //
-  // **Every entry below is refused on exactly one dialect, by name, and that is
-  // the point rather than a nuisance.** `path` is the only argument in this
-  // corpus whose *grammar* is dialect-specific: Postgres takes
-  // `path: ["a", "b"]` and refuses a string, SQLite takes `path: "$.a.b"` and
-  // refuses an array. That is Prisma's own split, measured against a generated
-  // client on both, so writing one spelling would leave the other dialect's
-  // half of the feature unwalked. `plan-key.invariants.test.ts` lists both
-  // messages in `EXPECTED_REFUSALS` and asserts each still fires, so a dialect
-  // that quietly started accepting the other form fails there.
+  // **Every entry in the two *grammar* blocks below is refused on exactly one
+  // dialect, by name, and that is the point rather than a nuisance.** `path` is
+  // the only argument in this corpus whose *grammar* is dialect-specific:
+  // Postgres takes `path: ["a", "b"]` and refuses a string, SQLite takes
+  // `path: "$.a.b"` and refuses an array. That is Prisma's own split, measured
+  // against a generated client on both, so writing one spelling would leave the
+  // other dialect's half of the feature unwalked.
+  // `plan-key.invariants.test.ts` lists both messages in `EXPECTED_REFUSALS` and
+  // asserts each still fires, so a dialect that quietly started accepting the
+  // other form fails there.
+  //
+  // It is **not** true of the refusal block at the end, and the earlier draft of
+  // this note claimed it of the whole section: an empty path, a `path` on a
+  // String column, a malformed segment and `path: 5` are refused on *both*
+  // dialects. Which ones split and which do not is spelled out at the block
+  // itself, because it is exactly the thing that decides whether an entry needs
+  // writing twice.
 
-  // The Postgres grammar. The first four are the shape #301 opened to measure:
-  // three depths and a numeric segment, all compiling to the *same* statement —
-  // `("metadata" #>> $1) = $2` — because `#>` takes the whole path as one
-  // `text[]` parameter. Recording them element-wise minted four cache entries
-  // holding one statement, keyed by a depth that is as request-derived as an
-  // `in` list's length; `path` is in `LIST_KEYS` now, and this is what measures
-  // it.
+  // The Postgres grammar. The first three are the shape #301 opened to measure:
+  // three depths compiling to the *same* statement — `("metadata" #>> $1) = $2`
+  // — because `#>` takes the whole path as one `text[]` parameter. Recording
+  // them element-wise minted three cache entries holding one statement, keyed by
+  // a depth that is as request-derived as an `in` list's length; `path` is in
+  // `LIST_KEYS` now, and this is what measures it.
   { where: { metadata: { path: ["a"], equals: "x" } } },
   { where: { metadata: { path: ["a", "b"], equals: "x" } } },
   { where: { metadata: { path: ["a", "b", "c"], equals: "x" } } },
-  { where: { metadata: { path: ["a", 0], equals: "x" } } },
+  // An array *index*, spelled as a string. `#>` takes a `text[]` and reaches the
+  // same element either way, and the string spelling is the one #380 keeps when
+  // it narrows `JsonPath` to `readonly string[]` — this entry sits among the
+  // reads expected to compile, so a numeric segment here would report itself as
+  // an unexpected refusal the moment that lands.
+  { where: { metadata: { path: ["a", "0"], equals: "x" } } },
   { where: { metadata: { path: ["a"], not: "x" } } },
   { where: { metadata: { path: ["a"], string_contains: "x" } } },
   { where: { metadata: { path: ["a"], string_starts_with: "x" } } },
@@ -121,19 +133,45 @@ export const READS: unknown[] = [
   { where: { metadata: { path: "$.a", gt: 1 } } },
   { where: { metadata: { path: "$.a", array_contains: "x" } } },
 
-  // The refusals #299 owns, each written in **both** grammars so the message
-  // fires on the dialect that would otherwise reject the spelling first — the
-  // grammar check runs before all of them.
+  // The refusals #299 owns. Every one is written in **both** grammars, but for
+  // two different reasons, and the distinction was got wrong here first time —
+  // measured by compiling each entry on both dialects.
+  //
+  // **The first two pairs genuinely need both spellings.** `assertPathShape`
+  // runs before the bare-path and unknown-filter checks, so the array form
+  // reaches them on Postgres and is swallowed by the grammar message on SQLite,
+  // and the string form does the mirror of that. One spelling would leave one
+  // dialect's copy of the message unwalked.
   { where: { metadata: { path: ["a"] } } },
   { where: { metadata: { path: "$.a" } } },
   { where: { metadata: { path: ["a"], nonsense: "x" } } },
   { where: { metadata: { path: "$.a", nonsense: "x" } } },
+  // **The next two pairs do not**, and saying otherwise was the error. The empty
+  // check sits *above* the grammar branch inside `assertPathShape`, and the
+  // `field.type !== "Json"` throw sits above `assertPathShape` altogether, so
+  // each of these fires the same message on both dialects from either spelling.
+  // They are kept because they are the pairs whose redundancy depends on that
+  // ordering — the ordering the four entries above rely on being the other way
+  // round — so if a refactor ever hoists the grammar check to the top of
+  // `compileJsonFilter`, these are what keep both dialects covered instead of
+  // half of each. `[]` and `""` are distinct inputs in their own right besides.
   { where: { metadata: { path: [] } } },
   { where: { metadata: { path: "" } } },
   { where: { name: { path: ["a"], equals: "x" } } },
   { where: { name: { path: "$.a", equals: "x" } } },
-  // Neither grammar, which is its own branch of the shape check.
+  // Neither grammar. Not its own branch — `got` is `"other"`, which falls
+  // through to the same `got !== wanted` throw and the same message as the
+  // wrong-grammar entries above — but a distinct input class, and the one a
+  // caller reaches by forgetting to split a dotted string.
   { where: { metadata: { path: 5, equals: "x" } } },
+  // An array whose *segments* are malformed, which is the case the `LIST_KEYS`
+  // collapse has to keep out of a valid path's cache entry: refused cold on both
+  // dialects — the array grammar's own message on Postgres, the wrong-grammar
+  // one on SQLite — where `["a"]` beside it compiles. `plan-key.invariants` owns
+  // the assertion that the two do not share a key; a refused entry can never
+  // reach the same-key-implies-same-SQL property, so the corpus alone would not
+  // have caught it.
+  { where: { metadata: { path: ["a", null], equals: "x" } } },
 ];
 
 export const WRITES: [string, unknown][] = [

--- a/packages/gemi/orm/corpus.ts
+++ b/packages/gemi/orm/corpus.ts
@@ -62,6 +62,78 @@ export const READS: unknown[] = [
   { take: 5 },
   { skip: 1 },
   { skip: 1, take: 2 },
+
+  // ---------------------------------------------------------------------
+  // JSON path filters (#299), and the reason they arrived late (#301).
+  //
+  // They need a `Json` column, and the schema both invariant suites compile
+  // against did not have one — a `path` on a String column is refused outright,
+  // and a refused entry covers nothing. `userWithProfile` grew `metadata` for
+  // this; see the note there for why that cost nothing.
+  //
+  // **Every entry below is refused on exactly one dialect, by name, and that is
+  // the point rather than a nuisance.** `path` is the only argument in this
+  // corpus whose *grammar* is dialect-specific: Postgres takes
+  // `path: ["a", "b"]` and refuses a string, SQLite takes `path: "$.a.b"` and
+  // refuses an array. That is Prisma's own split, measured against a generated
+  // client on both, so writing one spelling would leave the other dialect's
+  // half of the feature unwalked. `plan-key.invariants.test.ts` lists both
+  // messages in `EXPECTED_REFUSALS` and asserts each still fires, so a dialect
+  // that quietly started accepting the other form fails there.
+
+  // The Postgres grammar. The first four are the shape #301 opened to measure:
+  // three depths and a numeric segment, all compiling to the *same* statement —
+  // `("metadata" #>> $1) = $2` — because `#>` takes the whole path as one
+  // `text[]` parameter. Recording them element-wise minted four cache entries
+  // holding one statement, keyed by a depth that is as request-derived as an
+  // `in` list's length; `path` is in `LIST_KEYS` now, and this is what measures
+  // it.
+  { where: { metadata: { path: ["a"], equals: "x" } } },
+  { where: { metadata: { path: ["a", "b"], equals: "x" } } },
+  { where: { metadata: { path: ["a", "b", "c"], equals: "x" } } },
+  { where: { metadata: { path: ["a", 0], equals: "x" } } },
+  { where: { metadata: { path: ["a"], not: "x" } } },
+  { where: { metadata: { path: ["a"], string_contains: "x" } } },
+  { where: { metadata: { path: ["a"], string_starts_with: "x" } } },
+  { where: { metadata: { path: ["a"], string_ends_with: "x" } } },
+  // The four Postgres-only filters, which SQLite's `jsonFilters` withholds
+  // because Prisma refuses them there with "Unknown argument".
+  { where: { metadata: { path: ["a"], array_contains: "x" } } },
+  { where: { metadata: { path: ["a"], gt: 1 } } },
+  { where: { metadata: { path: ["a"], gte: 1 } } },
+  { where: { metadata: { path: ["a"], lt: 1 } } },
+  { where: { metadata: { path: ["a"], lte: 1 } } },
+  // Two filters on one path — the `and`-grouped branch, and the only shape that
+  // extracts the same path twice in one statement.
+  { where: { metadata: { path: ["a"], gt: 1, lt: 9 } } },
+
+  // The SQLite grammar, same filters minus the ones the dialect declines.
+  { where: { metadata: { path: "$.a", equals: "x" } } },
+  { where: { metadata: { path: "$.a.b", equals: "x" } } },
+  { where: { metadata: { path: "$.a", not: "x" } } },
+  { where: { metadata: { path: "$.a", string_contains: "x" } } },
+  { where: { metadata: { path: "$.a", string_starts_with: "x" } } },
+  { where: { metadata: { path: "$.a", string_ends_with: "x" } } },
+  { where: { metadata: { path: "$.a", equals: "x", not: "y" } } },
+  // Refused on SQLite for the *filter* rather than for the grammar, which is a
+  // different message and the one that would fall silent if `jsonFilters` were
+  // ever widened there to match Postgres.
+  { where: { metadata: { path: "$.a", gt: 1 } } },
+  { where: { metadata: { path: "$.a", array_contains: "x" } } },
+
+  // The refusals #299 owns, each written in **both** grammars so the message
+  // fires on the dialect that would otherwise reject the spelling first — the
+  // grammar check runs before all of them.
+  { where: { metadata: { path: ["a"] } } },
+  { where: { metadata: { path: "$.a" } } },
+  { where: { metadata: { path: ["a"], nonsense: "x" } } },
+  { where: { metadata: { path: "$.a", nonsense: "x" } } },
+  { where: { metadata: { path: [] } } },
+  { where: { metadata: { path: "" } } },
+  { where: { name: { path: ["a"], equals: "x" } } },
+  { where: { name: { path: "$.a", equals: "x" } } },
+  // Neither grammar, which is its own branch of the shape check.
+  { where: { metadata: { path: 5, equals: "x" } } },
 ];
 
 export const WRITES: [string, unknown][] = [
@@ -115,6 +187,12 @@ export const WRITES: [string, unknown][] = [
   ["update", { where: { id: 1 }, data: { profile: { connect: { userId: 1 } } } }],
   ["updateMany", { where: { id: 1 }, data: { name: "x" } }],
   ["updateMany", { data: { name: "x" } }],
+  // A JSON path filter in a *write's* `where`, both grammars. The predicate
+  // compiler is shared, but its entry point is not — `compileWrite` builds its
+  // own `WhereContext` — and a `path` binder that located against the read's
+  // argument tree would only show up from here.
+  ["updateMany", { where: { metadata: { path: ["a"], equals: "x" } }, data: { name: "x" } }],
+  ["updateMany", { where: { metadata: { path: "$.a", equals: "x" } }, data: { name: "x" } }],
   ["delete", { where: { id: 1 } }],
   ["delete", { where: { id: 1 }, select: { id: true } }],
   // The conflict target has to be set by `create`, or `Model.upsert` runs it as

--- a/packages/gemi/orm/fixtures.ts
+++ b/packages/gemi/orm/fixtures.ts
@@ -833,9 +833,35 @@ export const profile: ModelSchema = {
  * `user`, plus the far side of {@link profile} — `kind: "one"` with empty
  * `from`/`to`, which is how the foreign side of any relation is spelled: the
  * link is resolved through the child's opposing relation, not stated here.
+ *
+ * **...and `metadata Json?`, which is the schema `corpus.ts` is compiled
+ * against.** A `where: { … : { path: …, equals: … } }` entry needs a Json
+ * column: aimed at anything else it is refused — *"A 'path' filter reads inside
+ * a JSON document, and 'name' is a String column"* — and the invariant suites
+ * track refusals rather than swallowing them, so the corpus could not carry a
+ * JSON path filter at all until some fixture grew one (#301). That refusal is
+ * itself a corpus entry now; what it could not be was the only one.
+ *
+ * Here rather than on `user` for the reason the `profile` relation is here:
+ * `user` is a faithful copy of the template's `User` *as the read tests assert
+ * it*, and {@link USER_COLUMNS} is spelled out in several of them. The template
+ * schema does declare `metadata Json?` on `User`, so this is the fixture moving
+ * *toward* the real model rather than away from it — `user` is the one that has
+ * drifted, and re-baselining it is not this change's business.
  */
 export const userWithProfile: ModelSchema = {
   ...user,
+  fields: {
+    ...user.fields,
+    metadata: {
+      name: "metadata",
+      column: "metadata",
+      type: "Json",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
   relations: {
     ...user.relations,
     profile: {

--- a/packages/gemi/orm/plan-key.invariants.test.ts
+++ b/packages/gemi/orm/plan-key.invariants.test.ts
@@ -119,17 +119,52 @@ describe("the plan key", () => {
   const EXPECTED_REFUSALS: Record<string, RegExp[]> = {
     // Postgres has ILIKE; SQLite has no case-insensitive LIKE for non-ASCII,
     // and Prisma refuses `mode` there too.
-    sqlite: [/mode: "insensitive"/],
-    postgres: [],
+    sqlite: [
+      /mode: "insensitive"/,
+      // The **array** path grammar, which is Postgres's. Prisma refuses it here
+      // too — the split is the client's, not this ORM's — so every array-form
+      // corpus entry is refused on this dialect and every JSONPath-string one
+      // is refused on the other. Both lists exist so that a dialect quietly
+      // accepting the form it should not fails here rather than silently
+      // gaining coverage.
+      /a JSON path is a JSONPath string/,
+      // ...and the filters `jsonFilters` withholds on SQLite — `gt` and
+      // `array_contains` in the corpus. Prisma answers "Unknown argument" for
+      // both, so this refusal is parity rather than a gap.
+      /is not available on sqlite/,
+    ],
+    postgres: [
+      // The JSONPath-**string** grammar, which is SQLite's. The mirror of the
+      // entry above.
+      /a JSON path is an array of keys/,
+    ],
   };
+
+  /**
+   * Refusals both dialects produce, kept apart from the per-dialect lists so
+   * that "this is a dialect split" and "this is refused everywhere" do not read
+   * alike.
+   */
+  const SHARED_REFUSALS = [
+    // A per-parent `take` inside a to-many needs the lateral strategy, and
+    // these compile with the default (batched) on both dialects — so it is
+    // refused everywhere here, not only on SQLite.
+    /accounts\.take/,
+    // The four JSON path refusals that are about the *argument* rather than
+    // about the database. Each is in the corpus in both grammars, because the
+    // grammar check runs before all of them — written in one spelling only,
+    // each would fire on one dialect and be swallowed by the grammar message on
+    // the other.
+    /is a String column/,
+    /A JSON path cannot be empty/,
+    /A 'path' needs a filter beside it/,
+    /A JSON path filter takes/,
+  ];
 
   test.each(DIALECTS)("every corpus entry compiles, or is refused by name — %s", (name, dialect) => {
     const { out, refused } = compiled(dialect);
 
-    // A per-parent `take` inside a to-many needs the lateral strategy, and
-    // these compile with the default (batched) on both dialects — so it is
-    // refused everywhere here, not only on SQLite.
-    const expected = [/accounts\.take/, ...EXPECTED_REFUSALS[name]];
+    const expected = [...SHARED_REFUSALS, ...EXPECTED_REFUSALS[name]];
     const unexpected = refused.filter(
       (message) => !expected.some((pattern) => pattern.test(message)),
     );
@@ -240,5 +275,58 @@ describe("the plan key", () => {
     // ...and present-versus-absent still differs, since that changes the text.
     expect(key({ take: 1 })).not.toBe(key({}));
     expect(key({ skip: 1, take: 2 })).not.toBe(key({ take: 2 }));
+  });
+
+  /**
+   * A JSON path's **depth** is bound too, which is the case #301 opened to
+   * measure rather than to reason about.
+   *
+   * Same shape as `take`/`skip` above and the opposite of the intuition: a
+   * deeper path plainly selects something else, so it looks structural. It is
+   * not. Postgres's `#>` takes the whole path as one `text[]` parameter, so
+   * `["a"]` and `["a", "b", "c"]` compile to the same `("metadata" #>> $1)`,
+   * and SQLite's path is a string, where depth was never in the shape at all.
+   *
+   * Left alone, `canonicalShape` records an array element-wise, so on Postgres
+   * every distinct depth minted its own entry holding a statement identical to
+   * its neighbours' — and a path built from a request (`?field=address.city`)
+   * varies with the data the way an `in` list's length does. `path` is in
+   * `LIST_KEYS` for that reason; this is what would notice it leaving.
+   *
+   * The SQL is asserted alongside the key deliberately. "One entry" is only
+   * correct while it is also "one statement" — assert the key on its own and a
+   * collapse that started serving the wrong text would still pass.
+   */
+  const JSON_PATHS: Record<string, unknown[]> = {
+    sqlite: ["$.a", "$.a.b", "$.a.b.c"],
+    postgres: [["a"], ["a", "b"], ["a", "b", "c"], ["a", 0]],
+  };
+
+  test.each(DIALECTS)("a JSON path's depth is bound, not compiled in — %s", (name, dialect) => {
+    const shapes = JSON_PATHS[name].map((path) => ({
+      where: { metadata: { path, equals: "x" } },
+    }));
+
+    const texts = new Set(
+      shapes.map(
+        (args) =>
+          compileRead(userWithProfile, "findMany" as never, args as never, dialect as never).text,
+      ),
+    );
+    const keys = new Set(
+      shapes.map((args) => planKey(dialect as never, "User", "findMany" as never, args)),
+    );
+
+    expect(texts.size, [...texts].join("\n")).toBe(1);
+    expect(keys.size, [...keys].join("\n")).toBe(1);
+
+    // ...and the *filter* beside the path still discriminates, which is the
+    // direction a too-eager collapse would break: these are two statements.
+    const filterKey = (filter: Record<string, unknown>) =>
+      planKey(dialect as never, "User", "findMany" as never, {
+        where: { metadata: { path: JSON_PATHS[name][0], ...filter } },
+      });
+    expect(filterKey({ equals: "x" })).not.toBe(filterKey({ not: "x" }));
+    expect(filterKey({ equals: "x" })).not.toBe(filterKey({ string_contains: "x" }));
   });
 });

--- a/packages/gemi/orm/plan-key.invariants.test.ts
+++ b/packages/gemi/orm/plan-key.invariants.test.ts
@@ -16,7 +16,7 @@ import {
   userWithProfile,
 } from "./fixtures";
 import { AGGREGATES, GROUPS, READS, vary, WRITES } from "./corpus";
-import { planKey } from "./plan";
+import { clearPlanCache, getOrCompile, planCacheStats, planKey } from "./plan";
 import * as registry from "./registry";
 
 const sqlite = new SqliteDialect();
@@ -151,10 +151,18 @@ describe("the plan key", () => {
     // refused everywhere here, not only on SQLite.
     /accounts\.take/,
     // The four JSON path refusals that are about the *argument* rather than
-    // about the database. Each is in the corpus in both grammars, because the
-    // grammar check runs before all of them — written in one spelling only,
-    // each would fire on one dialect and be swallowed by the grammar message on
-    // the other.
+    // about the database.
+    //
+    // Two of them need both grammars in the corpus and two do not, which is
+    // worth stating precisely because the first draft here claimed the first
+    // reason for all four. `assertPathShape` runs before the bare-path and
+    // unknown-filter checks, so those two are reached by the array form on
+    // Postgres and by the string form on SQLite — one spelling would leave one
+    // dialect's copy unwalked. The other two are reached from either spelling on
+    // either dialect: the `field.type !== "Json"` throw is above
+    // `assertPathShape` entirely, and the empty check is above the grammar
+    // branch inside it. Both spellings are in the corpus regardless; see the
+    // note there for why.
     /is a String column/,
     /A JSON path cannot be empty/,
     /A 'path' needs a filter beside it/,
@@ -299,7 +307,10 @@ describe("the plan key", () => {
    */
   const JSON_PATHS: Record<string, unknown[]> = {
     sqlite: ["$.a", "$.a.b", "$.a.b.c"],
-    postgres: [["a"], ["a", "b"], ["a", "b", "c"], ["a", 0]],
+    // The last is an array *index*, spelled as a string — `#>` takes a `text[]`
+    // and reaches the same element either way, and it is the spelling #380
+    // leaves standing when it narrows `JsonPath` to `readonly string[]`.
+    postgres: [["a"], ["a", "b"], ["a", "b", "c"], ["a", "0"]],
   };
 
   test.each(DIALECTS)("a JSON path's depth is bound, not compiled in — %s", (name, dialect) => {
@@ -329,4 +340,71 @@ describe("the plan key", () => {
     expect(filterKey({ equals: "x" })).not.toBe(filterKey({ not: "x" }));
     expect(filterKey({ equals: "x" })).not.toBe(filterKey({ string_contains: "x" }));
   });
+
+  /**
+   * ...and the other half of that collapse, which the first revision of #301
+   * got wrong: **a shape may only be collapsed if every argument it now covers
+   * would still be accepted by a cold compile.**
+   *
+   * `collapsedList` erases the array's elements along with its length, so `[*]`
+   * says nothing about what is *in* the path — while `assertPathShape` refuses
+   * an array whose segments are not scalars. Collapsed unconditionally, a plan
+   * compiled for `["a"]` answered `["a", null]`, `[["a"]]` and `[{ k: 1 }]` off
+   * the cache without recompiling, and the refusal never re-ran. `[["a"]]` is
+   * the one that matters: it flattens into `{"a"}` and returns the rows for
+   * `["a"]`, so the failure is wrong rows rather than a wrong error. It is the
+   * `disconnect: true`/`false` trap `plan.ts` documents, arriving from the
+   * direction where the *values* are checked rather than the structure.
+   *
+   * Asserted against `getOrCompile` rather than against `planKey` alone, because
+   * a distinct key is the mechanism and "the refusal still fires on a warm
+   * cache" is the property. Both are checked: the key comparison says why, the
+   * cache run says what.
+   */
+  const MALFORMED_PATHS: unknown[] = [
+    ["a", null],
+    ["a", undefined],
+    ["a", true],
+    [["a"]],
+    [{ k: 1 }],
+  ];
+
+  test.each(DIALECTS)(
+    "a path a cold compile refuses is not served by a warm plan — %s",
+    (name, dialect) => {
+      const args = (path: unknown) => ({
+        where: { metadata: { path, equals: "x" } },
+      });
+      const good = JSON_PATHS[name][0];
+      const goodKey = planKey(dialect as never, "User", "findMany" as never, args(good));
+
+      for (const bad of MALFORMED_PATHS) {
+        const label = JSON.stringify(bad);
+        // The premise: a cold compile refuses every one of these. Without this
+        // the rest of the test would pass vacuously the day the compiler
+        // started accepting them.
+        expect(
+          () =>
+            compileRead(userWithProfile, "findMany" as never, args(bad) as never, dialect as never),
+          label,
+        ).toThrow();
+        expect(
+          planKey(dialect as never, "User", "findMany" as never, args(bad)),
+          label,
+        ).not.toBe(goodKey);
+      }
+
+      clearPlanCache();
+      getOrCompile(userWithProfile, "findMany" as never, args(good), dialect as never);
+      for (const bad of MALFORMED_PATHS) {
+        expect(() =>
+          getOrCompile(userWithProfile, "findMany" as never, args(bad), dialect as never),
+          JSON.stringify(bad),
+        ).toThrow(/does not support/);
+      }
+      // None of them reached the warm entry at all — a hit here would mean the
+      // plan was returned rather than the argument refused.
+      expect(planCacheStats().hits).toBe(0);
+    },
+  );
 });

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -339,13 +339,37 @@ export function canonicalShape(
  * a different direction (#301).** `where: { metadata: { path: ["a", "b"],
  * equals: … } }` binds the whole path as one `text[]` through `#>`, so every
  * depth compiles to the identical `("metadata" #>> $1) = $2`. Measured over the
- * corpus: `["a"]`, `["a","b"]`, `["a","b","c"]` and `["a", 0]` were four cache
- * entries holding one statement, and a path depth taken off a request is as
- * ordinary as a list length taken off one.
+ * corpus: `["a"]`, `["a","b"]` and `["a","b","c"]` were three cache entries
+ * holding one statement, and a path depth taken off a request is as ordinary as
+ * a list length taken off one.
  *
  * SQLite needs nothing here and gets nothing: a path is a *string* there
  * (`"$.a.b"`), so depth was never in the shape to begin with, and
  * `collapseLists` is false on that dialect anyway.
+ *
+ * **`path` collapses only when every segment is a `string`, and that narrowing
+ * is the whole safety argument rather than a fussy detail.** `collapsedList`
+ * erases the elements as well as the count, so `[*]` says nothing about what is
+ * *in* the array — while `assertPathShape` (`compile/where.ts`) refuses an
+ * array whose segments are not each a string or a number. Collapse the two
+ * together and the refusal stops being reachable on a cache hit, the `disconnect:
+ * true`/`false` failure this file describes a few lines below, arriving from the
+ * other side: a plan compiled for `["a"]` served `["a", null]`, `[["a"]]` and
+ * `[{ k: 1 }]` without recompiling, and `[["a"]]` is the bad one — it flattens
+ * to `{"a"}` and answers as if the caller had written `["a"]`. Wrong rows, no
+ * error. Measured through `getOrCompile` + `bind` on Postgres, and it is a
+ * regression this collapse would have introduced: on `main` those three key
+ * apart from `["a"]` element-wise, so each is refused on every call.
+ *
+ * The predicate has to stay a **subset** of what `assertPathShape` accepts, not
+ * an equal — a collapsed shape must never cover an argument the compiler would
+ * refuse, but leaving an accepted one uncollapsed costs a cache entry and
+ * nothing else. `string` is that subset today (`assertPathShape` also takes a
+ * `number`, so a numeric segment simply keeps its element-wise shape) and it
+ * stays one under #380, which narrows `JsonPath` to `readonly string[]`. It is
+ * duplicated knowledge either way — `plan.ts` holds no dependency on the
+ * compiler, deliberately — so `plan-key.invariants.test.ts` asserts the
+ * subset relation directly, over the malformed shapes above.
  *
  * **The gate is `collapseLists` — that is `bindsListAsOneParameter`, a property
  * about `in` lists rather than about paths — and the conflation deserves
@@ -357,7 +381,9 @@ export function canonicalShape(
  * placeholders, the trap this comment already describes for SQLite's `in` — and
  * would need a flag of its own. None exists to hang one on today that is not
  * speculative, and `plan-key.invariants.test.ts` walks both grammars on both
- * dialects asserting same-key-implies-same-SQL, so that is what would fail.
+ * dialects asserting same-key-implies-same-SQL, so that is what would fail —
+ * conditional on the new dialect being added to `DIALECTS` there, which is the
+ * same condition every other property in that file already carries.
  *
  * **A *column* named `path` is the other collision, and it is harmless —
  * measured rather than assumed**, since `LIST_KEYS` matches by name at any
@@ -464,8 +490,17 @@ function shapeOfMember(
   // one plan entry per page. The root's `skip` never had the problem, which is
   // exactly why it went unnoticed until a node could carry one.
   if (key === "skip" && typeof value === "number") return "number";
+  // `path` is the one member of `LIST_KEYS` whose *elements* are checked by the
+  // compiler, so it is the one that cannot be collapsed unconditionally: `[*]`
+  // erases the segment kinds, and `assertPathShape` refuses a segment that is
+  // neither a string nor a number. A malformed path therefore keeps its
+  // element-wise shape, keys apart from every valid one, and is refused on every
+  // call rather than served by a plan compiled for a path it does not resemble.
+  // See {@link LIST_KEYS}.
   if (collapseLists && LIST_KEYS.has(key) && Array.isArray(value)) {
-    return collapsedList(value);
+    if (key !== "path" || value.every((segment) => typeof segment === "string")) {
+      return collapsedList(value);
+    }
   }
   /**
    * A composite `in`'s tuple list collapses on exactly the dialects where its

--- a/packages/gemi/orm/plan.ts
+++ b/packages/gemi/orm/plan.ts
@@ -312,7 +312,8 @@ export function canonicalShape(
 }
 
 /**
- * The operators whose operand is a list of values rather than a structure.
+ * The keys whose operand is an array that binds as **one** parameter, so its
+ * length never reaches the SQL text and must not reach the cache key either.
  *
  * `in` / `notIn` bind as one `= any($1)` on Postgres. So do a scalar list's
  * `hasEvery`, `hasSome` and `push` (#300) — `col @> $1`, `col && $1` and
@@ -331,8 +332,42 @@ export function canonicalShape(
  * the note above warns about for `OR`. Checked in `compile/nested-writes.ts`
  * rather than assumed from the name.
  *
- * The three below carry no such second meaning: `grep` finds them only in the
+ * Those three carry no such second meaning: `grep` finds them only in the
  * scalar-list filter set and the list write operators.
+ *
+ * **`path` is not a list of values at all, and reaches the same arithmetic from
+ * a different direction (#301).** `where: { metadata: { path: ["a", "b"],
+ * equals: … } }` binds the whole path as one `text[]` through `#>`, so every
+ * depth compiles to the identical `("metadata" #>> $1) = $2`. Measured over the
+ * corpus: `["a"]`, `["a","b"]`, `["a","b","c"]` and `["a", 0]` were four cache
+ * entries holding one statement, and a path depth taken off a request is as
+ * ordinary as a list length taken off one.
+ *
+ * SQLite needs nothing here and gets nothing: a path is a *string* there
+ * (`"$.a.b"`), so depth was never in the shape to begin with, and
+ * `collapseLists` is false on that dialect anyway.
+ *
+ * **The gate is `collapseLists` — that is `bindsListAsOneParameter`, a property
+ * about `in` lists rather than about paths — and the conflation deserves
+ * stating.** It is the right condition on both implemented dialects because the
+ * array path *grammar* exists only where `jsonPathSyntax` is `"array"`, and the
+ * one dialect with that grammar binds the array whole. A dialect that spelled a
+ * path as an array but emitted one parameter per segment would make this wrong
+ * in the dangerous direction — a plan reached with the wrong number of
+ * placeholders, the trap this comment already describes for SQLite's `in` — and
+ * would need a flag of its own. None exists to hang one on today that is not
+ * speculative, and `plan-key.invariants.test.ts` walks both grammars on both
+ * dialects asserting same-key-implies-same-SQL, so that is what would fail.
+ *
+ * **A *column* named `path` is the other collision, and it is harmless —
+ * measured rather than assumed**, since `LIST_KEYS` matches by name at any
+ * depth. Every position where a bare array can sit directly under such a key
+ * binds as one parameter on Postgres: `where: { path: [...] }` on a Json column
+ * is `"path" = $1::text::jsonb`, `equals: [...]` on a scalar list is
+ * `"path" = $1`, and `data: { path: [...] }` is one `values` placeholder for
+ * either. A bare-array *filter* on a scalar list is refused outright. So the
+ * collapse is correct there rather than merely unreachable, which incidentally
+ * closes a sliver of the case named next.
  *
  * **One case is still uncollapsed and needs a schema to fix.** A bare array as
  * a *write* value — `data: { tags: ["a", "b"] }` — is keyed by the **field
@@ -343,7 +378,14 @@ export function canonicalShape(
  * collapse is a wrong statement. The filter side — which is where a
  * user-sized list actually arrives — is covered.
  */
-const LIST_KEYS = new Set(["in", "notIn", "hasEvery", "hasSome", "push"]);
+const LIST_KEYS = new Set([
+  "in",
+  "notIn",
+  "hasEvery",
+  "hasSome",
+  "push",
+  "path",
+]);
 
 /**
  * The internal composite-`in` key — see `compile/where.ts`, which owns it.

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -1697,6 +1697,75 @@ function suite(label: string, url?: string) {
       ).rejects.toThrow(/only one of them/);
     });
 
+    // --- the plan cache -------------------------------------------------
+
+    /**
+     * Two JSON paths of **different depth** are one plan, and the second call
+     * still reads its own path (#301).
+     *
+     * The path binds whole — a `text[]` through `#>` on Postgres, a string
+     * through `json_extract` on SQLite — so depth never reaches the SQL text,
+     * and `plan.ts` collapses it out of the cache key rather than minting an
+     * entry per depth. That collapse is only safe if a warm plan binds the
+     * *new* call's path, and nothing above can show it: `expectSame` calls
+     * `clearPlanCache()` per case, so every JSON path case in `CASES` compiles
+     * fresh and a plan serving a stale path would leave all of them green.
+     *
+     * So the two calls run back to back through one warm cache, which is what
+     * an application does. The pair is chosen to be **discriminating rather
+     * than merely equal**: the shallow path matches Ada and the deep one
+     * matches nobody, so a plan that answered the second with the first's path
+     * would return a row instead of none. Run in both orders, because "the
+     * first shape compiled decides for the second" is directional.
+     *
+     * Prisma is still the oracle for both answers — `expectSame` pins them
+     * first, and the warm-cache rows are then required to equal those.
+     */
+    test("a JSON path is one plan whatever its depth is", async () => {
+      const { clearPlanCache, planCacheStats } = await import("gemi/orm");
+
+      // Prisma refuses the other dialect's grammar, so the spelling is the
+      // dialect's. `url` is set only for the Postgres suite.
+      const shallow = url ? ["plan"] : "$.plan";
+      const deep = url ? ["limits", "plan"] : "$.limits.plan";
+      const args = (path: unknown) => ({
+        where: { metadata: { path, equals: "pro" } },
+        orderBy: { id: "asc" as const },
+      });
+
+      const fromPrismaShallow = (await differential.expectSame(
+        "User",
+        "findMany",
+        args(shallow),
+      )) as any[];
+      const fromPrismaDeep = (await differential.expectSame(
+        "User",
+        "findMany",
+        args(deep),
+      )) as any[];
+
+      // The fixture has to discriminate, or everything below passes vacuously.
+      expect(fromPrismaShallow).toHaveLength(1);
+      expect(fromPrismaDeep).toHaveLength(0);
+
+      for (const [first, second, firstRows, secondRows] of [
+        [shallow, deep, fromPrismaShallow, fromPrismaDeep],
+        [deep, shallow, fromPrismaDeep, fromPrismaShallow],
+      ] as const) {
+        clearPlanCache();
+        const a = (await UserModel.findMany(args(first) as never)) as any[];
+        const b = (await UserModel.findMany(args(second) as never)) as any[];
+
+        // One statement, so one compile — and the second call is a *hit*, which
+        // is the arrangement the assertions below are about.
+        expect(planCacheStats().compiles).toBe(1);
+        expect(planCacheStats().hits).toBe(1);
+
+        expect(a.map((row) => row.id)).toEqual(firstRows.map((row) => row.id));
+        expect(b.map((row) => row.id)).toEqual(secondRows.map((row) => row.id));
+      }
+    });
+
     // A guard on the harness itself: if `expectSame` compared nothing, every
     // case above would pass vacuously.
     test("the harness actually compares rows", async () => {


### PR DESCRIPTION
`corpus.ts` says in its own header that it is the thing to extend when a new argument is implemented. #299 implemented `where: { metadata: { path: …, equals: … } }` and could not extend it, because both invariant suites compile the corpus against `userWithProfile` and a `path` on a non-Json column is refused outright — a refused entry covers nothing, and refusals are tracked rather than swallowed, so adding one without the column would have made the suite *report a hole* rather than fill it.

## The cost #299 and #301 both assumed, measured

> Adding a `Json` column to `userWithProfile` is not a one-line change either: it is a shared fixture, and every suite that reads all columns has its expected SQL text in it. That is a re-baseline, which is why #299 left it.

**That is not true today, and it is the reason this PR is small.** `USER_COLUMNS` is spelled against `user`, not against `userWithProfile`, and `grep` finds four other files touching `userWithProfile` — `compile/refusals.test.ts`, `compile/write.test.ts`, `plan.writes.discrimination.test.ts` and the two invariant suites — none of which asserts a full column list against it. Adding the column and running the package:

```
Test Files  64 passed (64)          <- orm only, before and after
     Tests  2421 passed (2421)
```

One test failed, and it was mine: `architecture.test.ts` objecting to a `USER_WITH_PROFILE_COLUMNS` export nothing used. It is not in the diff.

The column is `metadata Json?`, which is what the template's real `User` model declares. `user` — the fixture whose docblock claims to be a faithful copy of it — has neither `metadata` nor `avatar`, so it has drifted; this moves `userWithProfile` toward the real model rather than away from it. Re-baselining `user` is a different change and is not here.

## What the corpus gained

33 read shapes and 2 writes. `path` is the only argument in the corpus whose **grammar** is dialect-specific — Postgres takes `path: ["a", "b"]` and refuses a string, SQLite takes `path: "$.a.b"` and refuses an array, which is Prisma's own split — so **every entry is refused on exactly one dialect**, and both spellings are present so neither half goes unwalked.

That makes the refusal bookkeeping load-bearing rather than incidental. `EXPECTED_REFUSALS` now names, per dialect:

| dialect | pattern | what would make it stop firing |
| --- | --- | --- |
| sqlite | `a JSON path is a JSONPath string` | SQLite accepting the array grammar |
| sqlite | `is not available on sqlite` | `jsonFilters` widening to Postgres's set |
| postgres | `a JSON path is an array of keys` | Postgres accepting the JSONPath grammar |

and four that fire on **both**, split out into a `SHARED_REFUSALS` list so "this is a dialect split" and "this is refused everywhere" no longer read alike: `is a String column`, `A JSON path cannot be empty`, `A 'path' needs a filter beside it`, `A JSON path filter takes`. Each of those four is in the corpus in *both* grammars — the grammar check runs before all of them, so a single spelling would fire on one dialect and be swallowed on the other. The suite asserts every listed pattern still fires, so none of this can go stale silently.

## The decision the issue asked for: `path` joins `LIST_KEYS`

The issue's third question was whether `path` belongs in `LIST_KEYS` on a dialect whose `jsonPathSyntax` is `"array"`. It does. Measured through `compileRead` + `planKey` on both dialects:

```
postgres
  { path: ["a"],           equals } -> where ("metadata" #>> $1) = $2   key ...path:[string]
  { path: ["a","b"],       equals } -> where ("metadata" #>> $1) = $2   key ...path:[string,string]
  { path: ["a","b","c"],   equals } -> where ("metadata" #>> $1) = $2   key ...path:[string,string,string]

sqlite
  { path: "$.a",     equals } -> where (json_extract("metadata", ?)) = ?   key ...path:string
  { path: "$.a.b",   equals } -> where (json_extract("metadata", ?)) = ?   key ...path:string
```

Three cache entries, one statement. SQLite was never affected — a path is a *string* there, so depth was never in the shape — which is why this is Postgres-only in effect and dialect-conditional in a way `in` is not.

> **Review round 1.** This table originally carried a fourth row, `{ path: ["a", 0] }`. #380 makes `assertPathShape` refuse a numeric segment and narrows `JsonPath` to `readonly string[]`, so that row stops compiling the moment the two land together — the cross-PR review measured it as two failures on a clean merge. Every numeric segment in this branch is now spelled `"0"`; `#>` takes a `text[]` and reaches the same element either way. The count above is what it now is, re-measured, not what it was.

### The gate, stated rather than hidden

The collapse is gated on `collapseLists`, which is `bindsListAsOneParameter` — a property about `in` lists, not about paths. It is the right condition on both implemented dialects because the array path *grammar* exists only where `jsonPathSyntax` is `"array"`, and the one dialect with that grammar binds the array whole. A dialect that spelled a path as an array but emitted one parameter per segment would make it wrong in the dangerous direction. There is no non-speculative seam to hang a flag on today; `plan-key.invariants.test.ts` walks both grammars on both dialects asserting same-key-implies-same-SQL, so that is what fails if one appears. Written out at the line.

### The name collision, measured rather than assumed

`LIST_KEYS` matches by name at any depth, so a *column* named `path` is in scope. Compiled against a scratch schema carrying `path` as a Json column and as a `String[]`:

```
postgres
  where: { path: ["a"] }        Json  ->  "path" = $1::text::jsonb      (1 and 2 elements alike)
  where: { path: { equals: [] } } list ->  "path" = $1
  data:  { path: ["a","b"] }    both  ->  values ($1, $2)
  where: { path: ["a","b"] }    list  ->  refused — "a bare array is not a filter on one"
sqlite   collapseLists is false; the branch is unreachable
```

Every position binds as one parameter, so the collapse is *correct* there rather than merely harmless — it closes a sliver of the bare-array-in-`data` churn `LIST_KEYS`' own comment leaves open.

## The hole the collapse opened, and the two tests that close it

A collapsed key is only safe if a warm plan binds the **new** call's path. Nothing in the repository could show that, and the reason is worth stating: `expectSame` calls `clearPlanCache()` at the top of every case, so all eleven Postgres JSON path differential cases compile fresh and a plan serving a stale path leaves every one of them green.

The compile-level suites were blind to it too, and provably: a compiler that reads `filter.path` at compile time and closes over it emits **byte-identical text** for two different paths and keys them identically, so both existing invariants pass. Mutating `compile/where.ts`

```diff
-  const path: Binder = (args) => locate(args)?.path;
+  const compiledIn = filter.path;
+  const path: Binder = () => compiledIn;
```

was caught by nothing on the base branch and by nothing in the first revision of this PR either.

**1. A corpus-wide property, in `binding.invariants.test.ts`:** compile from `args`, bind `twin`, and require the array the plan compiled *for* `twin` produces. Written over the whole corpus rather than over `path` alone, because nothing about the failure is specific to paths — `where: { name: "a" }` compiled with a captured `"a"` fails the same way and was equally unasserted.

The clock is frozen (`vi.useFakeTimers`) rather than the timestamps masked, and that is not tidiness: `encode` turns a `Date` into a number on SQLite and passes it through on Postgres, so a `value instanceof Date` mask covers one dialect, silently drops the other, and then flakes on whichever millisecond boundary falls between two binds — which it did, on the first run. `cuid` has no clock to freeze and is masked by kind.

**2. A live-database case, in `differential.test.ts`,** running two depths back to back through one warm cache. The pair is chosen to discriminate rather than merely agree: the shallow path matches Ada and the deep one matches nobody, so a plan answering the second with the first's path returns a row instead of none. Run in both orders, because "the first shape compiled decides for the second" is directional, and Prisma is still the oracle — `expectSame` pins both answers first.

### Mutation results

Every new assertion was checked by reverting the thing it covers.

| mutation | what fails |
| --- | --- |
| `path` out of `LIST_KEYS` | `a JSON path's depth is bound, not compiled in — postgres`: `expected 3 to be 1`, printing three keys over one statement |
| the segment-kind gate reverted to an unconditional `collapsedList` | `a path a cold compile refuses is not served by a warm plan — postgres`: `["a",null]` keys the same as `["a"]` (round 1) |
| `path` out of `LIST_KEYS`, on live Postgres | `a JSON path is one plan whatever its depth is`: `expected 2 to be 1` compiles |
| path captured at compile time | `a plan compiled for one call binds the next call's values` — **both** dialects, showing `reused ["$.a","ZZZZ"]` against `fresh ["ZZZZ","ZZZZ"]` |
| path captured at compile time, on live Postgres | the same case, `expected [ 1 ] to deeply equal []` — the deep path answered with the shallow path's row |
| a JSON refusal pattern removed from `EXPECTED_REFUSALS` | `every corpus entry compiles, or is refused by name` |

The two live-Postgres mutations are the ones worth reading: they are the wrong-rows failure the collapse makes reachable, demonstrated against a real server rather than argued.

## Verification

```
packages/gemi     Test Files  120 passed (120)
                       Tests  3116 passed | 1 skipped (3117)      (base 3110)

saas-starter      Test Files   20 passed | 3 skipped (23)
   sqlite              Tests  793 passed | 133 skipped (926)      (base 792)
                  type tests  116 passed, no errors
```

**Postgres**, brought up through `app/models/postgres.sh` (postgres:16 in Docker, `prisma db push`, `@prisma/client` 6.19.2 regenerated for the provider), run with CI's `-t postgres` filter:

```
Test Files  14 passed | 9 skipped (23)
     Tests  874 passed | 789 skipped (1663)      (base 873)
```

An unfiltered Postgres run is `2 failed | 21 passed`, both failures being the SQLite halves of the differential suites failing loudly by design under a Postgres-generated client — the shape CI's filter exists for, and the same numbers #375 recorded.

`tsc --noEmit` clean on `packages/gemi` and on `tsconfig.generated.json`. `oxlint orm --deny-warnings`: 0 warnings, 0 errors. `bun run lint`: 79 warnings, 0 errors — unchanged. Schema restored to `sqlite`, container removed, `git status` clean.

## Review round 1 (80f99a8)

**The collapse erased the segment *kinds*, not only the depth — blocking, fixed.** `collapsedList` maps any non-empty array to `[*]`, so `["a", null]`, `["a", undefined]`, `[["a"]]` and `[{ k: 1 }]` all keyed identically to `["a"]` while a cold compile refused every one of them. `[["a"]]` is the bad one: it flattens to `{"a"}` and returns the rows for `["a"]` — wrong rows, no error. A regression this branch introduced; on `main` those shapes key element-wise and are refused on every call.

`path` now collapses **only when every segment is a `string`**:

```ts
if (key !== "path" || value.every((segment) => typeof segment === "string")) {
  return collapsedList(value);
}
```

The reviewer proposed `string | number`, which is exactly today's accepted set. The predicate has to stay a *subset* of what `assertPathShape` accepts rather than an equal — a collapsed shape covering a refused argument is a correctness bug, an accepted argument left uncollapsed costs one cache entry — and #380 narrows `JsonPath` to `readonly string[]`, which would make `string | number` wider than the accepted set and re-open this hole for `["a", 0]`. `string` is right before and after.

New property, `a path a cold compile refuses is not served by a warm plan — %s`: five malformed shapes per dialect, each asserted refused cold (so the test cannot go vacuous), each keyed apart from the valid path, and each still throwing after `getOrCompile` has been warmed with `["a"]`, with `planCacheStats().hits === 0`. `{ path: ["a", null] }` is in the corpus too — it needs no `EXPECTED_REFUSALS` change, since it fires the array-grammar message on Postgres and the wrong-grammar one on SQLite.

**#380 × #385, done here.** `["a", 0]` respelled `["a", "0"]` in `corpus.ts`, `plan-key.invariants.test.ts` and the `plan.ts` docblock, per the cross-PR review's assignment. The measurement above is restated as three depths / three entries, which is what it now is.

**Three comment-accuracy corrections**, each verified by compiling every JSON corpus entry on both dialects rather than by reading. "The grammar check runs before all of them" is right for the bare-path and unknown-filter pairs and wrong for the String-column and empty-path pairs; "every entry below is refused on exactly one dialect" is true of the two grammar blocks and false of the refusal block; `path: 5` reaches the same throw and the same message as the wrong-grammar entries rather than a branch of its own. Entries kept, reasons rewritten.

**Not done here.** The `childField` → `childFields` rename from #386 — #386 is not on `main`, so this branch cannot reference the new names; it is merge-time work for whoever lands #386 last. The `connectOrCreate` hit-branch short-circuit belongs to #378 by the cross-PR review's own assignment.

## Noted, not fixed

- **The `user` fixture has drifted from the template's `User`.** Its docblock claims same fields, same order, same types; the template declares `metadata Json?` and `avatar Bytes?` and the fixture has neither. Fixing it is the re-baseline this PR found it did not need, and belongs to whoever wants the Bytes coverage too.
- **`expectSame` clears the plan cache per case**, so *no* differential case exercises a cache hit. That is right for a differential — it compares answers, not caching — but it means the plan cache's live behaviour is covered only by the handful of bespoke tests that ask for it explicitly. There is one for `create` in `writes.differential.test.ts` and now one for JSON paths; everything else is compile-level.

Closes #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

