### PR TITLE
Close #271: a nested write contributes every joined field

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3918,17 +3918,32 @@ await List.create({
 | `upsert` | Finds the row **among this parent's**, updates it, or creates it. A to-one has no `where` to require — the link already names the row. |
 
 **A relation may join on more than one field.** `@relation(fields: [tenantId, orderId], references:
-[tenantId, id])` is the tenant-scoped composite-key style, and every read surface handles it: an
-`include` under either strategy, a relation filter, a `_count`, and an `orderBy` through the
-relation. The correlation becomes one equality per field; the batched strategy filters its children
-with an `OR` of `AND`s rather than a tuple `in`, because that is one shape both dialects already
-compile.
+[tenantId, id])` is the tenant-scoped composite-key style, and every surface handles it — reads and
+nested writes alike. On the read side: an `include` under either strategy, a relation filter, a
+`_count`, and an `orderBy` through the relation. The correlation becomes one equality per field; the
+batched strategy filters its children with an `OR` of `AND`s rather than a tuple `in`, because that
+is one shape both dialects already compile.
 
-Two consequences worth knowing. A composite join uses one placeholder *per field per parent*, so
-SQLite's parameter ceiling arrives proportionally sooner on a wide `include` — `ParameterLimitError`
-still names it rather than letting the driver fail. And a **nested write** through a composite
-relation is refused: it would have to contribute that many foreign-key columns to the insert, which
-is not implemented. Write the child separately with its keys set.
+**A nested write through one contributes every column**, in every operand that writes a key —
+`connect`, `create`, `connectOrCreate`, `createMany`, `set`, `disconnect`, `update`, `upsert`,
+`delete` and the two `*Many` — and on both sides of the relation. Three details follow from the key
+having more than one column, and they are the ones worth knowing:
+
+- **`connect` names the row in Prisma's compound form**, `connect: { tenantId_code: { tenantId: 1,
+  code: "a" } }`, because that is what a multi-column unique key is called. Unlike the single-field
+  case there is no zero-query shortcut — the operand does not carry the referenced values directly —
+  so it costs one lookup, which is what Prisma issues anyway.
+- **A key with any column `null` links nothing.** That is SQL's rule, not a choice: `(tenantId,
+  orderId) = (1, NULL)` is unknown, so the join finds no row. A `disconnect` clears every column
+  together, and an `update` through a half-written key reports the row as missing rather than
+  matching on the half that is set.
+- **A composite one-to-one displaces**, the same way a single-column one does — the discriminator is
+  a `@@unique` covering *exactly* the relation's own fields. `@@unique([tenantId, orderId, kind])`
+  covers them and something else, so it does not make the relation exclusive and does not displace.
+
+One consequence of the join itself: a composite `include` uses one placeholder *per field per
+parent*, so SQLite's parameter ceiling arrives proportionally sooner on a wide one —
+`ParameterLimitError` still names it rather than letting the driver fail.
 
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
@@ -5194,12 +5209,6 @@ Stated so you can plan around them rather than discover them:
   an identity map is worse than none.
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
   touched.
-- **No multi-field relations in a nested write.** `@relation(fields: [a, b], references: [c, d])`
-  now works everywhere a relation is *read* — `include` under either strategy, a relation filter,
-  `_count`, and an `orderBy` through a relation all correlate on every field. What is still refused
-  is reaching one from a nested write, and the error names the fields on both sides and the
-  operation it came from, rather than joining on the first field and writing plausible wrong rows.
-  Pending rather than declined.
 - **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
 - **No `distinct`, and this one is deliberate rather than pending.** Prisma applies it **in
   memory** — its query log shows no `DISTINCT` at all, so `take` neither reduces the rows pulled

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3924,10 +3924,15 @@ nested writes alike. On the read side: an `include` under either strategy, a rel
 batched strategy filters its children with an `OR` of `AND`s rather than a tuple `in`, because that
 is one shape both dialects already compile.
 
-**A nested write through one contributes every column**, in every operand that writes a key —
-`connect`, `create`, `connectOrCreate`, `createMany`, `set`, `disconnect`, `update`, `upsert`,
-`delete` and the two `*Many` — and on both sides of the relation. Three details follow from the key
-having more than one column, and they are the ones worth knowing:
+**A nested write through one contributes every column**, on both sides of the relation, in every
+operand that side offers. Which operands those are is unchanged by the width of the key: the
+**foreign** side — where the children hold it — takes all of `connect`, `create`, `connectOrCreate`,
+`createMany`, `set`, `disconnect`, `update`, `upsert`, `delete` and the two `*Many`; the **owning**
+side takes `connect`, `create`, `connectOrCreate`, `disconnect` and `update`, and refuses
+`createMany`, `set`, `delete`, `upsert` and the two `*Many` by name, because this row holds one
+foreign key and there is nothing there to write many of. A composite relation is refused in exactly
+the same places a single-field one is, and nowhere else. Four details follow from the key having
+more than one column, and they are the ones worth knowing:
 
 - **`connect` names the row in Prisma's compound form**, `connect: { tenantId_code: { tenantId: 1,
   code: "a" } }`, because that is what a multi-column unique key is called. Unlike the single-field
@@ -3940,6 +3945,13 @@ having more than one column, and they are the ones worth knowing:
 - **A composite one-to-one displaces**, the same way a single-column one does — the discriminator is
   a `@@unique` covering *exactly* the relation's own fields. `@@unique([tenantId, orderId, kind])`
   covers them and something else, so it does not make the relation exclusive and does not displace.
+- **Two relations that share a column cannot both be written in one call.** Nothing stops a model
+  from carrying `@relation(fields: [tenantId, orderId], …)` beside `@relation(fields: [tenantId,
+  noteId], …)` — Prisma accepts it — and then a single `data` writing through both says `tenantId`
+  twice. Prisma lets the *last* key in your `data` object win, which makes the row depend on a key
+  order gemi deliberately does not preserve: two argument objects differing only in key order have
+  to compile to one cached plan. So this is refused, naming the column and both relations. Write one
+  of them through the relation and set the other's own columns directly.
 
 One consequence of the join itself: a composite `include` uses one placeholder *per field per
 parent*, so SQLite's parameter ceiling arrives proportionally sooner on a wide one —
@@ -5226,7 +5238,7 @@ Stated so you can plan around them rather than discover them:
   column at schema validation. They are otherwise fully supported — see
   [Scalar lists](#scalar-lists-postgres-only).
 
-Both of the last two throw `UnsupportedByDesignError`, which says *"and this is a decision rather
+`distinct` and `cursor` throw `UnsupportedByDesignError`, which says *"and this is a decision rather
 than a gap"* rather than *"yet"* — so a refusal you can plan around reads differently from one that
 might lift next release.
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -935,17 +935,32 @@ await List.create({
 | `upsert` | Finds the row **among this parent's**, updates it, or creates it. A to-one has no `where` to require — the link already names the row. |
 
 **A relation may join on more than one field.** `@relation(fields: [tenantId, orderId], references:
-[tenantId, id])` is the tenant-scoped composite-key style, and every read surface handles it: an
-`include` under either strategy, a relation filter, a `_count`, and an `orderBy` through the
-relation. The correlation becomes one equality per field; the batched strategy filters its children
-with an `OR` of `AND`s rather than a tuple `in`, because that is one shape both dialects already
-compile.
+[tenantId, id])` is the tenant-scoped composite-key style, and every surface handles it — reads and
+nested writes alike. On the read side: an `include` under either strategy, a relation filter, a
+`_count`, and an `orderBy` through the relation. The correlation becomes one equality per field; the
+batched strategy filters its children with an `OR` of `AND`s rather than a tuple `in`, because that
+is one shape both dialects already compile.
 
-Two consequences worth knowing. A composite join uses one placeholder *per field per parent*, so
-SQLite's parameter ceiling arrives proportionally sooner on a wide `include` — `ParameterLimitError`
-still names it rather than letting the driver fail. And a **nested write** through a composite
-relation is refused: it would have to contribute that many foreign-key columns to the insert, which
-is not implemented. Write the child separately with its keys set.
+**A nested write through one contributes every column**, in every operand that writes a key —
+`connect`, `create`, `connectOrCreate`, `createMany`, `set`, `disconnect`, `update`, `upsert`,
+`delete` and the two `*Many` — and on both sides of the relation. Three details follow from the key
+having more than one column, and they are the ones worth knowing:
+
+- **`connect` names the row in Prisma's compound form**, `connect: { tenantId_code: { tenantId: 1,
+  code: "a" } }`, because that is what a multi-column unique key is called. Unlike the single-field
+  case there is no zero-query shortcut — the operand does not carry the referenced values directly —
+  so it costs one lookup, which is what Prisma issues anyway.
+- **A key with any column `null` links nothing.** That is SQL's rule, not a choice: `(tenantId,
+  orderId) = (1, NULL)` is unknown, so the join finds no row. A `disconnect` clears every column
+  together, and an `update` through a half-written key reports the row as missing rather than
+  matching on the half that is set.
+- **A composite one-to-one displaces**, the same way a single-column one does — the discriminator is
+  a `@@unique` covering *exactly* the relation's own fields. `@@unique([tenantId, orderId, kind])`
+  covers them and something else, so it does not make the relation exclusive and does not displace.
+
+One consequence of the join itself: a composite `include` uses one placeholder *per field per
+parent*, so SQLite's parameter ceiling arrives proportionally sooner on a wide one —
+`ParameterLimitError` still names it rather than letting the driver fail.
 
 Which direction a nested write runs in is decided by **who holds the foreign key**. When this model
 holds it, the far row is resolved or created *first* and collapses into one more column. When the
@@ -2211,12 +2226,6 @@ Stated so you can plan around them rather than discover them:
   an identity map is worse than none.
 - **No lazy loading.** A relation you did not `include` is absent, not a proxy that queries when
   touched.
-- **No multi-field relations in a nested write.** `@relation(fields: [a, b], references: [c, d])`
-  now works everywhere a relation is *read* — `include` under either strategy, a relation filter,
-  `_count`, and an `orderBy` through a relation all correlate on every field. What is still refused
-  is reaching one from a nested write, and the error names the fields on both sides and the
-  operation it came from, rather than joining on the first field and writing plausible wrong rows.
-  Pending rather than declined.
 - **No migrations, no schema DSL.** Prisma owns both, and gemi must not shadow the Prisma CLI.
 - **No `distinct`, and this one is deliberate rather than pending.** Prisma applies it **in
   memory** — its query log shows no `DISTINCT` at all, so `take` neither reduces the rows pulled

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -941,10 +941,15 @@ nested writes alike. On the read side: an `include` under either strategy, a rel
 batched strategy filters its children with an `OR` of `AND`s rather than a tuple `in`, because that
 is one shape both dialects already compile.
 
-**A nested write through one contributes every column**, in every operand that writes a key —
-`connect`, `create`, `connectOrCreate`, `createMany`, `set`, `disconnect`, `update`, `upsert`,
-`delete` and the two `*Many` — and on both sides of the relation. Three details follow from the key
-having more than one column, and they are the ones worth knowing:
+**A nested write through one contributes every column**, on both sides of the relation, in every
+operand that side offers. Which operands those are is unchanged by the width of the key: the
+**foreign** side — where the children hold it — takes all of `connect`, `create`, `connectOrCreate`,
+`createMany`, `set`, `disconnect`, `update`, `upsert`, `delete` and the two `*Many`; the **owning**
+side takes `connect`, `create`, `connectOrCreate`, `disconnect` and `update`, and refuses
+`createMany`, `set`, `delete`, `upsert` and the two `*Many` by name, because this row holds one
+foreign key and there is nothing there to write many of. A composite relation is refused in exactly
+the same places a single-field one is, and nowhere else. Four details follow from the key having
+more than one column, and they are the ones worth knowing:
 
 - **`connect` names the row in Prisma's compound form**, `connect: { tenantId_code: { tenantId: 1,
   code: "a" } }`, because that is what a multi-column unique key is called. Unlike the single-field
@@ -957,6 +962,13 @@ having more than one column, and they are the ones worth knowing:
 - **A composite one-to-one displaces**, the same way a single-column one does — the discriminator is
   a `@@unique` covering *exactly* the relation's own fields. `@@unique([tenantId, orderId, kind])`
   covers them and something else, so it does not make the relation exclusive and does not displace.
+- **Two relations that share a column cannot both be written in one call.** Nothing stops a model
+  from carrying `@relation(fields: [tenantId, orderId], …)` beside `@relation(fields: [tenantId,
+  noteId], …)` — Prisma accepts it — and then a single `data` writing through both says `tenantId`
+  twice. Prisma lets the *last* key in your `data` object win, which makes the row depend on a key
+  order gemi deliberately does not preserve: two argument objects differing only in key order have
+  to compile to one cached plan. So this is refused, naming the column and both relations. Write one
+  of them through the relation and set the other's own columns directly.
 
 One consequence of the join itself: a composite `include` uses one placeholder *per field per
 parent*, so SQLite's parameter ceiling arrives proportionally sooner on a wide one —
@@ -2243,7 +2255,7 @@ Stated so you can plan around them rather than discover them:
   column at schema validation. They are otherwise fully supported — see
   [Scalar lists](#scalar-lists-postgres-only).
 
-Both of the last two throw `UnsupportedByDesignError`, which says *"and this is a decision rather
+`distinct` and `cursor` throw `UnsupportedByDesignError`, which says *"and this is a decision rather
 than a gap"* rather than *"yet"* — so a refusal you can plan around reads differently from one that
 might lift next release.
 

--- a/packages/gemi/orm/compile/composite-relations.test.ts
+++ b/packages/gemi/orm/compile/composite-relations.test.ts
@@ -5,9 +5,12 @@ import { SqliteDialect } from "../dialect/sqlite";
 import { RecordNotFoundError, UnknownFieldError } from "../errors";
 import {
   ledger,
+  ledgerCrossEntry,
   ledgerEntry,
   ledgerNote,
   ledgerSeal,
+  ledgerSealMixed,
+  ledgerWithMixed,
   ledgerWithOptional,
 } from "../fixtures";
 import * as registry from "../registry";
@@ -846,6 +849,251 @@ describe("a nested write contributes every joined field", () => {
 
     const cleared = calls.find((call) => call.op === "updateMany")!;
     expect(cleared.args.data).toEqual({ tenantId: null, ledgerCode: null });
+    expect(calls[calls.length - 1].args.data).toEqual({
+      seal: "s",
+      tenantId: 1,
+      ledgerCode: "a",
+    });
+  });
+});
+
+/**
+ * **Two composite relations on one model, sharing a foreign-key column.**
+ *
+ * Reachable only because #271 stopped refusing composite relations by width.
+ * `prisma validate` accepts the schema on 6.19.2:
+ *
+ *     ledger Ledger @relation("L", fields: [tenantId, ledgerCode], references: [tenantId, code])
+ *     note   Ledger @relation("N", fields: [tenantId, noteCode],   references: [tenantId, code])
+ *
+ * Prisma resolves the operands in reverse key order and lets the first resolved
+ * win, so the caller's **last** `data` key decides `tenantId` — measured on
+ * 6.19.2 with query events on. gemi sorts its relation keys, because the plan
+ * cache needs two argument objects differing only in key order to be one plan,
+ * so it cannot reproduce that without giving up the canonical order. It refuses
+ * instead, which keeps the property the width refusal was buying: no plausible
+ * wrong row.
+ */
+describe("two relations that share a foreign-key column", () => {
+  beforeEach(() => {
+    registry.clearRegistry();
+    registry.register("Ledger", class { static $schema = ledgerWithMixed });
+    registry.register("LedgerEntry", class { static $schema = ledgerEntry });
+    registry.register("LedgerNote", class { static $schema = ledgerNote });
+    registry.register("LedgerSeal", class { static $schema = ledgerSeal });
+    registry.register(
+      "LedgerSealMixed",
+      class {
+        static $schema = ledgerSealMixed;
+      },
+    );
+    registry.register(
+      "LedgerCrossEntry",
+      class {
+        static $schema = ledgerCrossEntry;
+      },
+    );
+  });
+
+  /** The refusal names the column and both relations that write it. */
+  test("writing through both at once is refused by column", () => {
+    expect(() =>
+      compileWrite(
+        ledgerCrossEntry,
+        "create",
+        {
+          data: {
+            amount: 1,
+            ledger: { connect: { tenantId_code: { tenantId: 1, code: "a" } } },
+            note: { connect: { tenantId_code: { tenantId: 2, code: "b" } } },
+          },
+        },
+        sqlite,
+      ),
+    ).toThrow(/'tenantId' is written by both the 'ledger' and 'note' relations/);
+  });
+
+  /**
+   * ...and it is refused in either spelling.
+   *
+   * This is the whole point: the two orders are *different rows* under Prisma
+   * and one plan under gemi. A refusal that fired for one order and not the
+   * other would be the divergence wearing a different hat.
+   */
+  test("the caller's key order does not change the answer", () => {
+    const data = {
+      note: { connect: { tenantId_code: { tenantId: 2, code: "b" } } },
+      ledger: { connect: { tenantId_code: { tenantId: 1, code: "a" } } },
+      amount: 1,
+    };
+
+    expect(() =>
+      compileWrite(ledgerCrossEntry, "create", { data }, sqlite),
+    ).toThrow(/'tenantId' is written by both/);
+  });
+
+  /**
+   * The guard is over the *pair*, not over composite relations as such — one
+   * of them alone still contributes its whole key.
+   */
+  test("either relation on its own still writes every column it joins on", () => {
+    const args = {
+      where: { id: 1 },
+      data: { note: { connect: { tenantId_code: { tenantId: 2, code: "b" } } } },
+    };
+    const plan = compileWrite(ledgerCrossEntry, "update", args, sqlite);
+
+    expect(plan.text).toContain(`"tenantId" = ?`);
+    expect(plan.text).toContain(`"noteCode" = ?`);
+    // The column the *other* relation joins on is untouched — it appears in
+    // `returning`, never in `set`.
+    expect(plan.text).not.toContain(`"ledgerCode" = ?`);
+  });
+
+  /**
+   * ...and two operands on the *same* relation are not a collision either.
+   *
+   * They contribute the same columns twice by construction — that is what a
+   * `connect` beside a `create` on one to-one has always done, and folding them
+   * is `insertColumns`' existing behaviour rather than something this guard is
+   * entitled to change. Pinned so a later tightening has to notice it is
+   * tightening.
+   */
+  test("one relation contributing twice is not a collision", () => {
+    expect(() =>
+      compileWrite(
+        ledgerEntry,
+        "create",
+        {
+          data: {
+            amount: 1,
+            ledger: {
+              connect: { tenantId_code: { tenantId: 1, code: "a" } },
+              create: { tenantId: 9, code: "z", title: "t" },
+            },
+          },
+        },
+        sqlite,
+      ),
+    ).not.toThrow(/is written by both/);
+  });
+});
+
+/**
+ * **The three "every column is nullable" predicates**, pinned on the one shape
+ * that can tell them from `fields[0]`.
+ *
+ * `planOwningSide`'s `displaces`, `planForeignSide`'s `displaces` and
+ * `assertDisconnectable` each generalised from *"this column is nullable"* to
+ * *"every column is"*, and the first review of #271 measured that all three stay
+ * green when crippled back — because Prisma makes a composite relation optional
+ * or required as a whole, so no schema it validates distinguishes them.
+ *
+ * {@link ledgerSealMixed} is the hand-built `ModelSchema` that does: `tenantId`
+ * nullable, `ledgerCode` required, **in that order**, so `fields[0]` answers
+ * *"detachable"* where the tuple answers *"not"*. Each case below flips if any
+ * one of the three is narrowed.
+ */
+describe("a composite key whose columns disagree about being optional", () => {
+  interface Call {
+    model: string;
+    op: string;
+    args: any;
+  }
+
+  const recorder = (returns: Record<string, unknown[]> = {}) => {
+    const calls: Call[] = [];
+    const executor = {
+      async exec(model: string, op: string, args: unknown) {
+        calls.push({ model, op, args });
+        const queue = returns[`${model}.${op}`];
+        return queue && queue.length > 0 ? queue.shift() : null;
+      },
+    };
+    return { calls, executor: executor as never };
+  };
+
+  beforeEach(() => {
+    registry.clearRegistry();
+    registry.register("Ledger", class { static $schema = ledgerWithMixed });
+    registry.register("LedgerEntry", class { static $schema = ledgerEntry });
+    registry.register("LedgerNote", class { static $schema = ledgerNote });
+    registry.register("LedgerSeal", class { static $schema = ledgerSeal });
+    registry.register(
+      "LedgerSealMixed",
+      class {
+        static $schema = ledgerSealMixed;
+      },
+    );
+  });
+
+  /**
+   * `assertDisconnectable` names the required column, and the required one is
+   * *second*.
+   *
+   * Its docblock makes this claim outright — a mixed key "is refused here rather
+   * than nulling half a key" — and until this case nothing measured it.
+   */
+  test("disconnect is refused, naming the column that is not nullable", () => {
+    expect(() =>
+      compileWrite(
+        ledgerSealMixed,
+        "update",
+        { where: { id: 1 }, data: { ledger: { disconnect: true } } },
+        sqlite,
+      ),
+    ).toThrow(/'LedgerSealMixed\.ledgerCode' is required/);
+  });
+
+  /**
+   * The owning side does not displace, though the index and the back-relation
+   * both say one-to-one.
+   *
+   * `LedgerSealMixed` carries `@@unique([tenantId, ledgerCode])` and `Ledger`
+   * carries a non-list `sealMixed` — so the two halves of `displaces` that are
+   * *not* about nullability are both satisfied, and the nullability of the whole
+   * tuple is the only thing left deciding. Half a detach would leave the
+   * incumbent holding a key that joins nowhere while still occupying the index.
+   */
+  test("the owning side does not clear an incumbent it cannot fully detach", async () => {
+    const args = {
+      where: { id: 1 },
+      data: {
+        ledger: { connect: { tenantId_code: { tenantId: 1, code: "a" } } },
+      },
+    };
+    const plan = compileWrite(ledgerSealMixed, "update", args, sqlite);
+
+    const { calls, executor } = recorder({
+      "Ledger.findUniqueOrThrow": [{ tenantId: 1, code: "a" }],
+      "LedgerSealMixed.findFirst": [{ tenantId: 1, ledgerCode: "b" }],
+      "LedgerSealMixed.findMany": [[{ id: 2, tenantId: 1, ledgerCode: "a" }]],
+    });
+    const context = createBindContext();
+    await plan.before![0].run(args, context, executor, []);
+
+    // The lookup happens; the sibling is never read and never nulled.
+    expect(context.resolved).toEqual({ tenantId: 1, ledgerCode: "a" });
+    expect(calls.map((call) => call.op)).toEqual(["findUniqueOrThrow"]);
+  });
+
+  /** The foreign side reaches the same answer from the other end of the key. */
+  test("the foreign side does not clear an incumbent it cannot fully detach", async () => {
+    const args = {
+      where: { tenantId_code: { tenantId: 1, code: "a" } },
+      data: { sealMixed: { create: { seal: "s" } } },
+    };
+    const plan = compileWrite(ledgerWithMixed, "update", args, sqlite);
+
+    const { calls, executor } = recorder({
+      "LedgerSealMixed.findMany": [[{ id: 2, tenantId: 1, ledgerCode: "a" }]],
+    });
+    await plan.after![0].run(args, createBindContext(), executor, [
+      { tenantId: 1, code: "a" } as never,
+    ]);
+
+    expect(calls.some((call) => call.op === "updateMany")).toBe(false);
+    // ...and the new row is still stamped with the whole key.
     expect(calls[calls.length - 1].args.data).toEqual({
       seal: "s",
       tenantId: 1,

--- a/packages/gemi/orm/compile/composite-relations.test.ts
+++ b/packages/gemi/orm/compile/composite-relations.test.ts
@@ -2,9 +2,16 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import { PostgresDialect } from "../dialect/postgres";
 import { SqliteDialect } from "../dialect/sqlite";
-import { UnknownFieldError, UnsupportedQueryError } from "../errors";
-import { ledger, ledgerEntry } from "../fixtures";
+import { RecordNotFoundError, UnknownFieldError } from "../errors";
+import {
+  ledger,
+  ledgerEntry,
+  ledgerNote,
+  ledgerSeal,
+  ledgerWithOptional,
+} from "../fixtures";
 import * as registry from "../registry";
+import { createBindContext } from "./fragment";
 import { lateralStrategy } from "./lateral";
 import { compileRead } from "./read";
 import { compileWrite } from "./write";
@@ -13,23 +20,26 @@ import { plannerCompositeIn } from "./where";
 /**
  * Multi-field relations — `@relation(fields: [a, b], references: [c, d])`.
  *
- * **This file has inverted, exactly as it said it would.** It used to assert
- * that seven surfaces refuse a composite relation, on the reasoning that a
- * one-field assumption reached by any path would join on the first field and
- * silently return the wrong rows. #67 implements six of the seven, so those six
- * now assert the SQL — *every* joined field appears in the correlation, which is
- * the same property from the other side.
+ * **This file has inverted twice, exactly as it said it would.** It used to
+ * assert that seven surfaces refuse a composite relation, on the reasoning that
+ * a one-field assumption reached by any path would join on the first field and
+ * silently return the wrong rows. #67 implemented six of the seven, so those six
+ * assert the SQL instead — *every* joined field appears in the correlation,
+ * which is the same property from the other side.
  *
- * The seventh is a nested write, and it still refuses: reading across a
- * composite relation is a wider correlation, writing through one would have to
- * contribute that many foreign-key columns to an insert. The refusal is now a
- * `singleFieldLink` call rather than a shared resolver, so the narrowing is a
- * function nobody can reach past — there is no single-field property on `Link`
- * to index into.
+ * The seventh was a nested write, refused on the argument that reading across a
+ * composite relation is a wider correlation where writing through one has to
+ * contribute that many foreign-key columns to an insert. #271 does that, and the
+ * last section of this file asserts it the same way: not with SQL, which a write
+ * has none of for a link, but by running the planned steps and reading the
+ * arguments they hand the child's own operations.
  *
- * What has *not* changed is the reason the list is exhaustive: all seven still
- * resolve their link through one function, so a new surface inherits composite
- * support rather than having to grow it.
+ * `singleFieldLink` survives with one caller — the implicit many-to-many join
+ * table, where one column a side is Prisma's own shape rather than a limit here.
+ *
+ * What has *not* changed is the reason the list is exhaustive: all seven resolve
+ * their link through one function, so a new surface inherits composite support
+ * rather than having to grow it.
  */
 
 const sqlite = new SqliteDialect();
@@ -375,30 +385,472 @@ describe("the composite-in key is the planner's alone", () => {
   });
 });
 
-describe("a nested write still refuses, and says why", () => {
-  const run = () =>
-    compileWrite(
-      ledger,
+/**
+ * **The seventh surface, which used to be the refusal** (#271).
+ *
+ * A nested write does not correlate — it *writes* — so there is no SQL fragment
+ * to assert. What it produces is a list of foreign-key contributions folded
+ * into the caller's own statement, and a list of steps that read and write the
+ * child through the child's own `$exec`. Both are checked here by running them:
+ * the steps are driven with a recording executor, and the arguments they hand
+ * it are the thing that has to name every joined field.
+ *
+ * The property is the same one the read surfaces assert, transposed. A `where`
+ * naming one field of two matches every row in the tenant; a `data` naming one
+ * field of two writes half a link, which joins to nothing and leaves the other
+ * column holding whatever it held before. Both *succeed*, which is why they are
+ * asserted rather than left to a smoke test.
+ *
+ * Four shapes are needed and the fixtures carry all four:
+ *
+ *     ledgerEntry.ledger    owning side, required     connect / create / update
+ *     ledgerSeal.ledger     owning side, one-to-one   disconnect, displacement
+ *     ledger.entries        foreign side, to-many     the list operands
+ *     ledgerWithOptional.*  foreign side, optional    set, disconnect, displace
+ */
+describe("a nested write contributes every joined field", () => {
+  /** Every `exec` a step made, in order, with the arguments it passed. */
+  interface Call {
+    model: string;
+    op: string;
+    args: any;
+    ormAuthored?: readonly string[];
+  }
+
+  /**
+   * A `RelationExecutor` that records instead of running.
+   *
+   * `returns` answers the reads a step makes — a `connect` looks the far row
+   * up, a `set` reads what is linked — keyed by `<model>.<op>` and consumed in
+   * order, so a step that reads twice can be given two different answers.
+   */
+  const recorder = (returns: Record<string, unknown[]> = {}) => {
+    const calls: Call[] = [];
+    const executor = {
+      async exec(
+        model: string,
+        op: string,
+        args: unknown,
+        _preScoped: boolean,
+        ormAuthored?: readonly string[],
+      ) {
+        calls.push({ model, op, args, ormAuthored });
+        const queue = returns[`${model}.${op}`];
+        return queue && queue.length > 0 ? queue.shift() : null;
+      },
+    };
+    return { calls, executor: executor as never };
+  };
+
+  beforeEach(() => {
+    registry.clearRegistry();
+    registry.register("Ledger", class { static $schema = ledgerWithOptional });
+    registry.register("LedgerEntry", class { static $schema = ledgerEntry });
+    registry.register("LedgerNote", class { static $schema = ledgerNote });
+    registry.register("LedgerSeal", class { static $schema = ledgerSeal });
+  });
+
+  // --- the owning side -----------------------------------------------------
+
+  /**
+   * `connect` takes the lookup on a composite relation, deliberately.
+   *
+   * The single-field shortcut reads the referenced value straight out of the
+   * operand, and Prisma spells a multi-column unique key in its compound form —
+   * `{ tenantId_code: { … } }` — so there is no key here whose value is a
+   * referenced column. One statement, which is what Prisma issues for every
+   * `connect` on either shape.
+   */
+  test("connect resolves both referenced columns through one lookup", async () => {
+    const args = {
+      data: {
+        amount: 1,
+        ledger: { connect: { tenantId_code: { tenantId: 1, code: "a" } } },
+      },
+    };
+    const plan = compileWrite(ledgerEntry, "create", args, sqlite);
+
+    expect(plan.before).toHaveLength(1);
+
+    const { calls, executor } = recorder({
+      "Ledger.findUniqueOrThrow": [{ tenantId: 1, code: "a" }],
+    });
+    const context = createBindContext();
+    await plan.before![0].run(args, context, executor, []);
+
+    // Both columns read back, or the second contribution binds `undefined`.
+    expect(calls[0].args.select).toEqual({ tenantId: true, code: true });
+    expect(context.resolved).toEqual({ tenantId: 1, ledgerCode: "a" });
+
+    // ...and both are columns of the insert, under the *child's* names.
+    expect(plan.text).toContain(`"tenantId"`);
+    expect(plan.text).toContain(`"ledgerCode"`);
+    expect(plan.bind(args, context)).toEqual(expect.arrayContaining([1, "a"]));
+  });
+
+  /** A nested `create` reads the new row's whole key back before binding it. */
+  test("create resolves both referenced columns from the new row", async () => {
+    const args = {
+      data: {
+        amount: 1,
+        ledger: { create: { tenantId: 9, code: "z", title: "t" } },
+      },
+    };
+    const plan = compileWrite(ledgerEntry, "create", args, sqlite);
+
+    const { calls, executor } = recorder({
+      "Ledger.create": [{ tenantId: 9, code: "z" }],
+    });
+    const context = createBindContext();
+    await plan.before![0].run(args, context, executor, []);
+
+    expect(calls[0].args.select).toEqual({ tenantId: true, code: true });
+    expect(context.resolved).toEqual({ tenantId: 9, ledgerCode: "z" });
+  });
+
+  /**
+   * A nested `update` through the owning side needs the *current* key, which
+   * only the parent statement can supply — so both columns go into `RETURNING`,
+   * and the child is then found by both.
+   */
+  test("update returns both key columns and filters the child on both", async () => {
+    const args = {
+      where: { id: 1 },
+      data: { amount: 2, ledger: { update: { title: "renamed" } } },
+      select: { amount: true },
+    };
+    const plan = compileWrite(ledgerEntry, "update", args, sqlite);
+
+    expect(plan.text).toContain(`returning "tenantId", "ledgerCode", "amount"`);
+    expect(plan.hidden).toEqual(["tenantId", "ledgerCode"]);
+
+    const { calls, executor } = recorder();
+    await plan.after![0].run(args, createBindContext(), executor, [
+      { tenantId: 1, ledgerCode: "a", amount: 2 } as never,
+    ]);
+
+    expect(calls[0].op).toBe("updateMany");
+    // The child's own column names, paired positionally with the parent's.
+    expect(calls[0].args.where).toEqual({ tenantId: 1, code: "a" });
+  });
+
+  /**
+   * **A half-written composite key names no row**, so an `update` through it is
+   * the *absent* case rather than a lookup that finds nothing later.
+   *
+   * Unreachable through `ledgerEntry`, whose columns are required — which is
+   * why it is asserted on the optional pair.
+   */
+  test("update through a partially-null key raises rather than filtering", async () => {
+    const args = {
+      where: { id: 1 },
+      data: { ledger: { update: { title: "x" } } },
+    };
+    const plan = compileWrite(ledgerSeal, "update", args, sqlite);
+
+    const { calls, executor } = recorder();
+    await expect(
+      plan.after![0].run(args, createBindContext(), executor, [
+        { tenantId: 1, ledgerCode: null } as never,
+      ]),
+    ).rejects.toThrow(RecordNotFoundError);
+
+    // Nothing read and nothing written on a key that joins nowhere.
+    expect(calls).toEqual([]);
+  });
+
+  /** A required composite relation cannot be detached, and the message says which column. */
+  test("disconnect on a required composite relation is refused by column", () => {
+    expect(() =>
+      compileWrite(
+        ledgerEntry,
+        "update",
+        { where: { id: 1 }, data: { ledger: { disconnect: true } } },
+        sqlite,
+      ),
+    ).toThrow(/'LedgerEntry.tenantId' is required/);
+  });
+
+  /** `disconnect: true` clears the whole key, in the caller's own statement. */
+  test("disconnect true binds every column to null", () => {
+    const args = { where: { id: 1 }, data: { ledger: { disconnect: true } } };
+    const plan = compileWrite(ledgerSeal, "update", args, sqlite);
+
+    expect(plan.before).toBeUndefined();
+    expect(plan.text).toContain(`"tenantId" = ?`);
+    expect(plan.text).toContain(`"ledgerCode" = ?`);
+    expect(plan.bind(args, createBindContext())).toEqual([null, null, 1]);
+  });
+
+  /**
+   * The filter arm reads the linked row through *both* columns, and detaches
+   * both or neither.
+   */
+  test("disconnect by filter correlates on both columns", async () => {
+    const args = {
+      where: { id: 1 },
+      data: { ledger: { disconnect: { title: "one-a" } } },
+    };
+    const plan = compileWrite(ledgerSeal, "update", args, sqlite);
+
+    const { calls, executor } = recorder({
+      "LedgerSeal.findFirst": [{ tenantId: 1, ledgerCode: "a" }],
+      "Ledger.findFirst": [{ tenantId: 1, code: "a" }],
+    });
+    const context = createBindContext();
+    await plan.before![0].run(args, context, executor, []);
+
+    expect(calls[0].args.select).toEqual({ tenantId: true, ledgerCode: true });
+    expect(calls[1].args.where).toEqual({
+      AND: [{ title: "one-a" }, { tenantId: 1, code: "a" }],
+    });
+    expect(context.resolved).toEqual({ tenantId: null, ledgerCode: null });
+  });
+
+  /**
+   * **The composite one-to-one displaces**, which is the branch whose
+   * discriminator stops being a single-column index.
+   *
+   * `LedgerSeal` carries `@@unique([tenantId, ledgerCode])` — covering exactly
+   * the relation's fields — beside a non-list back-relation, and that is a
+   * schema `prisma validate` accepts on 6.19.2. The clear has to name both
+   * columns: nulling one leaves the sibling holding half a key that still
+   * occupies the index.
+   */
+  test("a one-to-one connect clears the incumbent's whole key", async () => {
+    const args = {
+      where: { id: 1 },
+      data: {
+        ledger: { connect: { tenantId_code: { tenantId: 1, code: "a" } } },
+      },
+    };
+    const plan = compileWrite(ledgerSeal, "update", args, sqlite);
+
+    const { calls, executor } = recorder({
+      "Ledger.findUniqueOrThrow": [{ tenantId: 1, code: "a" }],
+      // The row being written holds a *different* ledger, so the skip does not
+      // apply and the incumbent is cleared.
+      "LedgerSeal.findFirst": [{ tenantId: 1, ledgerCode: "b" }],
+      "LedgerSeal.findMany": [[{ tenantId: 1, ledgerCode: "a" }]],
+    });
+    await plan.before![0].run(args, createBindContext(), executor, []);
+
+    const cleared = calls.find((call) => call.op === "updateMany")!;
+    expect(cleared.args.where).toEqual({ tenantId: 1, ledgerCode: "a" });
+    expect(cleared.args.data).toEqual({ tenantId: null, ledgerCode: null });
+    expect(cleared.ormAuthored).toEqual(["tenantId", "ledgerCode"]);
+  });
+
+  /**
+   * ...and the skip that suppresses it compares the *whole* tuple.
+   *
+   * "Some column matches" would skip the clear for a sibling holding
+   * `(1, "b")` while this row takes `(1, "a")`, and the repoint would then
+   * collide on an index the caller cannot see.
+   */
+  test("the displacement skip compares every column", async () => {
+    const args = {
+      where: { id: 1 },
+      data: {
+        ledger: { connect: { tenantId_code: { tenantId: 1, code: "a" } } },
+      },
+    };
+    const plan = compileWrite(ledgerSeal, "update", args, sqlite);
+
+    const { calls, executor } = recorder({
+      "Ledger.findUniqueOrThrow": [{ tenantId: 1, code: "a" }],
+      // Same tenant, different code: one column agrees and the row is not
+      // already linked, so the clear must still be attempted.
+      "LedgerSeal.findFirst": [{ tenantId: 1, ledgerCode: "b" }],
+      "LedgerSeal.findMany": [[]],
+    });
+    await plan.before![0].run(args, createBindContext(), executor, []);
+
+    expect(calls.some((call) => call.op === "findMany")).toBe(true);
+  });
+
+  // --- the foreign side ----------------------------------------------------
+
+  /** Every parent key column goes into `RETURNING`, or the stamp is half a key. */
+  test("a foreign-side step returns every parent key column", () => {
+    const plan = compileWrite(
+      ledgerWithOptional,
       "create",
       {
         data: {
           tenantId: 1,
           code: "a",
           title: "t",
-          entries: { create: { amount: 1 } },
+          entries: { create: [{ amount: 1 }] },
         },
+        select: { title: true },
       },
       sqlite,
     );
 
-  test("it names the field count and the reason", () => {
-    expect(run).toThrow(UnsupportedQueryError);
-    expect(run).toThrow(/joins on 2 fields/);
-    expect(run).toThrow(/Reading across a composite relation works/);
+    expect(plan.after).toHaveLength(1);
+    expect(plan.text).toContain(`returning "tenantId", "code", "title"`);
+    expect(plan.hidden).toEqual(["tenantId", "code"]);
   });
 
-  /** #61's rule: a refusal that misnames its origin sends the reader astray. */
-  test("it names its own operation", () => {
-    expect(run).toThrow("(Ledger.create)");
+  /**
+   * `[label, operand, what to read off the child's call, what it has to be]`.
+   *
+   * One parent row, `(tenantId: 1, code: "a")`, and the child's link columns
+   * are `(tenantId, ledgerCode)` — so a correct stamp is
+   * `{ tenantId: 1, ledgerCode: "a" }`. The failure modes are either half of
+   * it, or `{ tenantId: 1, ledgerCode: 1 }` from a positional pairing that
+   * slipped, and every one of them writes rows rather than raising.
+   */
+  const FOREIGN: [string, unknown, (call: Call) => unknown, unknown][] = [
+    [
+      "create stamps the whole key onto the new row",
+      { create: [{ amount: 1 }] },
+      (call) => call.args.data,
+      { amount: 1, tenantId: 1, ledgerCode: "a" },
+    ],
+    [
+      "createMany stamps it onto every row",
+      { createMany: { data: [{ amount: 1 }, { amount: 2 }] } },
+      (call) => call.args.data,
+      [
+        { amount: 1, tenantId: 1, ledgerCode: "a" },
+        { amount: 2, tenantId: 1, ledgerCode: "a" },
+      ],
+    ],
+    [
+      "connect repoints the child on both columns",
+      { connect: [{ id: 7 }] },
+      (call) => call.args.data,
+      { tenantId: 1, ledgerCode: "a" },
+    ],
+    [
+      "updateMany conjoins the whole key rather than spreading it",
+      { updateMany: { where: { amount: 1 }, data: { memo: "m" } } },
+      (call) => call.args.where,
+      { AND: [{ amount: 1 }, { tenantId: 1, ledgerCode: "a" }] },
+    ],
+    [
+      "deleteMany conjoins it too",
+      { deleteMany: { amount: 1 } },
+      (call) => call.args.where,
+      { AND: [{ amount: 1 }, { tenantId: 1, ledgerCode: "a" }] },
+    ],
+  ];
+
+  test.each(FOREIGN)("%s", async (_label, operand, read, expected) => {
+    const args = {
+      where: { tenantId_code: { tenantId: 1, code: "a" } },
+      data: { title: "t", entries: operand },
+    };
+    const plan = compileWrite(ledgerWithOptional, "update", args, sqlite);
+
+    const { calls, executor } = recorder();
+    await plan.after![0].run(args, createBindContext(), executor, [
+      { tenantId: 1, code: "a" } as never,
+    ]);
+
+    expect(read(calls[calls.length - 1])).toEqual(expected);
+  });
+
+  /** `connect` names both columns as the ORM's own, for the scope-escape guard. */
+  test("connect declares every stamped column as ORM-authored", async () => {
+    const args = {
+      where: { tenantId_code: { tenantId: 1, code: "a" } },
+      data: { title: "t", entries: { connect: [{ id: 7 }] } },
+    };
+    const plan = compileWrite(ledgerWithOptional, "update", args, sqlite);
+
+    const { calls, executor } = recorder();
+    await plan.after![0].run(args, createBindContext(), executor, [
+      { tenantId: 1, code: "a" } as never,
+    ]);
+
+    expect(calls[0].ormAuthored).toEqual(["tenantId", "ledgerCode"]);
+  });
+
+  /** `set` is refused where the child's columns are required, by column name. */
+  test("set on a required composite child is refused", () => {
+    expect(() =>
+      compileWrite(
+        ledgerWithOptional,
+        "update",
+        {
+          where: { tenantId_code: { tenantId: 1, code: "a" } },
+          data: { entries: { set: [{ id: 1 }] } },
+        },
+        sqlite,
+      ),
+    ).toThrow(/'LedgerEntry.tenantId' is required/);
+  });
+
+  /** ...and clears and re-links both columns where they are not. */
+  test("set clears every column and re-links every column", async () => {
+    const args = {
+      where: { tenantId_code: { tenantId: 1, code: "a" } },
+      data: { notes: { set: [{ id: 3 }] } },
+    };
+    const plan = compileWrite(ledgerWithOptional, "update", args, sqlite);
+
+    const { calls, executor } = recorder({
+      "LedgerNote.findMany": [[{ tenantId: 1, ledgerCode: "a" }]],
+    });
+    await plan.after![0].run(args, createBindContext(), executor, [
+      { tenantId: 1, code: "a" } as never,
+    ]);
+
+    const [read, clear, link] = calls;
+    expect(read.args.where).toEqual({ tenantId: 1, ledgerCode: "a" });
+    expect(clear.args.data).toEqual({ tenantId: null, ledgerCode: null });
+    expect(clear.ormAuthored).toEqual(["tenantId", "ledgerCode"]);
+    expect(link.args.data).toEqual({ tenantId: 1, ledgerCode: "a" });
+  });
+
+  /** `disconnect` nulls the whole key on the rows it names. */
+  test("disconnect nulls every column of the link", async () => {
+    const args = {
+      where: { tenantId_code: { tenantId: 1, code: "a" } },
+      data: { notes: { disconnect: [{ id: 3 }] } },
+    };
+    const plan = compileWrite(ledgerWithOptional, "update", args, sqlite);
+
+    const { calls, executor } = recorder();
+    await plan.after![0].run(args, createBindContext(), executor, [
+      { tenantId: 1, code: "a" } as never,
+    ]);
+
+    expect(calls[0].args.where).toEqual({
+      AND: [{ id: 3 }, { tenantId: 1, ledgerCode: "a" }],
+    });
+    expect(calls[0].args.data).toEqual({ tenantId: null, ledgerCode: null });
+    expect(calls[0].ormAuthored).toEqual(["tenantId", "ledgerCode"]);
+  });
+
+  /**
+   * The foreign side of a composite one-to-one displaces on `create`, and the
+   * clear names both columns — the mirror of the owning-side case above.
+   */
+  test("a foreign-side one-to-one create clears the incumbent's whole key", async () => {
+    const args = {
+      where: { tenantId_code: { tenantId: 1, code: "a" } },
+      data: { seal: { create: { seal: "s" } } },
+    };
+    const plan = compileWrite(ledgerWithOptional, "update", args, sqlite);
+
+    const { calls, executor } = recorder({
+      "LedgerSeal.findMany": [[{ tenantId: 1, ledgerCode: "a" }]],
+    });
+    await plan.after![0].run(args, createBindContext(), executor, [
+      { tenantId: 1, code: "a" } as never,
+    ]);
+
+    const cleared = calls.find((call) => call.op === "updateMany")!;
+    expect(cleared.args.data).toEqual({ tenantId: null, ledgerCode: null });
+    expect(calls[calls.length - 1].args.data).toEqual({
+      seal: "s",
+      tenantId: 1,
+      ledgerCode: "a",
+    });
   });
 });
+

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -244,34 +244,42 @@ function planOne(
 
   const child = relatedSchema(schema, relation);
 
-  // **Narrowed to one field, deliberately.** Reading across a composite
-  // relation works (#67); writing through one would have to contribute that
-  // many foreign-key columns to this insert, which is a different piece of
-  // work — so it is refused here by name rather than silently writing the
-  // first field. The narrowing is a function call rather than an index, so
-  // there is no single-field property on `Link` to reach for by accident.
+  // **Every joined field, not the first one** (#271).
   //
-  // Safe to do before the join-table branch below: an implicit many-to-many
-  // links parent and child by their primary keys, one field each side, so the
-  // narrowing never refuses one — and it carries `join` through untouched.
-  const link = singleFieldLink(
-    resolveLink(schema, child, relation, operation),
-    schema,
-    relation,
-    operation,
-  );
+  // This used to be `singleFieldLink(resolveLink(…))`: reading across
+  // `@relation(fields: [tenantId, orderId], references: [tenantId, id])` was
+  // implemented by #67 on all six read surfaces, and the write surface refused
+  // it by name rather than joining on the first field and writing plausible
+  // wrong rows. The refusal was honest and it was the only thing left on that
+  // list, so the narrowing is gone and what follows contributes *n* foreign-key
+  // columns wherever it used to contribute one.
+  //
+  // Nothing here branches on how many there are. The two sides read the link
+  // through {@link childLink}, {@link keySelect} and {@link nullKey}, which are
+  // the same three shapes for one field as for four — so a relation joining on
+  // one field compiles to exactly the arguments it did before, and there is no
+  // single-field path left to diverge from the composite one.
+  const link = resolveLink(schema, child, relation, operation);
 
   // An implicit many-to-many is *neither* side: the keys live in a third table
   // with no model, so both directions are the same work and the operand set is
   // wider — `disconnect` and `set` are a delete against the join table, which
   // needs no schema to compile.
   if (link.join) {
+    // **The one caller that still cannot take more than one field**, and it is
+    // an invariant rather than a gap: Prisma's implicit many-to-many links
+    // parent and child by their *primary keys*, one column each side, into a
+    // two-column join table there is no schema to widen. `singleFieldLink`
+    // states that rather than letting `planJoinTable` index into `[0]` and be
+    // silently wrong if it ever stopped holding.
+    const pair = singleFieldLink(link, schema, relation, operation);
+
     for (const key of keys) {
       planJoinTable(
         schema,
         relation,
         child,
-        link,
+        pair,
         key,
         (node as Record<string, unknown>)[key],
         operation,
@@ -345,23 +353,55 @@ function planOne(
 
 /**
  * This model holds the foreign key, so the far row must exist — or be created —
- * before the insert can bind, and the whole thing collapses to one extra column.
+ * before the insert can bind, and the whole thing collapses to *n* extra
+ * columns — one, in the ordinary schema; as many as the relation joins on in a
+ * tenant-scoped one (#271).
+ *
+ * **The columns are contributed to the statement the caller already asked for,
+ * which is what makes a composite key here atomic without arranging anything.**
+ * `contributions` is a list keyed by field, and `insertColumns` /
+ * `updateAssignments` fold every entry into the single `INSERT` or `UPDATE`
+ * this operation compiles to — so "some keys written, some not" is not a state
+ * this side can reach: the `before` step either resolves the whole tuple or
+ * throws, and the statement either runs or does not. The partial-write hazard
+ * is real on the *foreign* side, where each linked row is its own statement,
+ * and it is answered there by the transaction every plan carrying steps opens.
  */
 function planOwningSide(
   schema: ModelSchema,
   relation: RelationSchema,
   child: ModelSchema,
-  link: { parentField: string; childField: string },
+  link: Link,
   key: string,
   operand: unknown,
   operation: string,
   at: (args: any) => any,
   out: NestedWritePlanning,
 ): void {
-  // `link.parentField` is the FK on this model; `link.childField` is what it
-  // references on the other one.
-  const fkField = link.parentField;
-  const referenced = link.childField;
+  // `parentFields` are the FK columns on this model; `childFields` are what
+  // they reference on the other one, paired positionally.
+  const fkFields = link.parentFields;
+  const referencedFields = link.childFields;
+
+  /** Assign the resolved key onto the statement — one contribution per column. */
+  const contributeResolved = () => {
+    for (const field of fkFields) {
+      out.contributions.push({
+        field,
+        value: (_args, context) => context.resolved[field],
+      });
+    }
+  };
+
+  /** Record a whole key on the plan's per-call scratch space. */
+  const resolveKey = (
+    context: { resolved: Record<string, unknown> },
+    values: readonly unknown[],
+  ) => {
+    for (let index = 0; index < fkFields.length; index++) {
+      context.resolved[fkFields[index]] = values[index] ?? null;
+    }
+  };
 
   /**
    * **Whether linking through this relation has to displace a sibling** — the
@@ -428,14 +468,38 @@ function planOwningSide(
    * the foreign side: it would refuse the whole operand, including the
    * empty-far-row case that has always worked.
    *
-   * A single-column index only, which is what `singleFieldLink` has already
-   * narrowed this whole function to. A composite `@@unique` covering the key
-   * *and something else* does not make the relation one-to-one — Prisma wants
-   * the relation's own `fields` unique — and reading it as one would clear rows
-   * the schema never said were exclusive. A foreign key that is also the `@id`
-   * would not be found in `uniques`, which records `@unique` and `@@unique`
-   * rather than the primary key; it is out of reach anyway, since `@id` implies
-   * `NOT NULL` and the nullable guard has already excluded it.
+   * **An index over exactly the relation's own fields**, which is what the
+   * single-field test used to say and reads differently now that there may be
+   * several (#271). Prisma's rule is on the relation: *"A one-to-one relation
+   * must use unique fields on the defining side"*, meaning `fields` — so
+   * `@@unique([tenantId, ownerId])` beside `@relation(fields: [tenantId,
+   * ownerId], …)` is the composite one-to-one, and it is the same fact the
+   * single-column form was stating.
+   *
+   * **Both halves of that rule are Prisma's, measured on 6.19.2 rather than
+   * inferred**, because between them they are the whole discriminator:
+   *
+   *     @@unique([tenantId, ledgerCode])         accepted — the one-to-one
+   *     @@unique([tenantId, ledgerCode, seal])   P1012, "Either add an
+   *                                              `@@unique([tenantId,
+   *                                              ledgerCode])` attribute"
+   *     @@unique([ledgerCode, tenantId])         the identical P1012
+   *
+   * So a wider group does *not* make the relation one-to-one — reading it as
+   * one would clear rows the schema never said were exclusive — and the order
+   * has to match the relation's `fields` as well.
+   *
+   * Written as set equality all the same, and the second row is why that is not
+   * laxity: the length check is what carries the weight, and a positional loop
+   * would read as though order were a thing this had decided, when on any
+   * schema Prisma accepted the two lists are already identical. It also keeps a
+   * hand-built `ModelSchema` — a fixture, or a generator that reorders — out of
+   * the branch where the index is not recognised at all.
+   *
+   * A foreign key that is also the `@id` would not be found in `uniques`, which
+   * records `@unique` and `@@unique` rather than the primary key; it is out of
+   * reach anyway, since `@id` implies `NOT NULL` and the nullable guard has
+   * already excluded it.
    */
   const backRelations = Object.values(child.relations).filter(
     (candidate) =>
@@ -447,10 +511,13 @@ function planOwningSide(
       !(child.name === schema.name && candidate.name === relation.name),
   );
 
+  const keyed = new Set(fkFields);
+
   const displaces =
-    schema.fields[fkField]?.nullable === true &&
+    fkFields.every((field) => schema.fields[field]?.nullable === true) &&
     schema.uniques.some(
-      (unique) => unique.length === 1 && unique[0] === fkField,
+      (unique) =>
+        unique.length === keyed.size && unique.every((name) => keyed.has(name)),
     ) &&
     backRelations.length === 1 &&
     backRelations[0].kind !== "many";
@@ -490,19 +557,16 @@ function planOwningSide(
         const created = (await executor.exec(
           relation.model,
           "create",
-          { data: at(args), select: { [referenced]: true } },
+          { data: at(args), select: keySelect(referencedFields) },
           // NOT pre-scoped. Nothing walks `data.<relation>.create`, so the
           // child's own `onCreate` is the only thing that can scope this row.
           false,
         )) as Record<string, unknown> | null;
 
-        context.resolved[fkField] = created?.[referenced] ?? null;
+        resolveKey(context, valuesOf(created, referencedFields));
       },
     });
-    out.contributions.push({
-      field: fkField,
-      value: (_args, context) => context.resolved[fkField],
-    });
+    contributeResolved();
     return;
   }
 
@@ -566,7 +630,7 @@ function planOwningSide(
     // out of the input type entirely when the relation is required, so
     // `disconnect: false` there is *"Unknown argument `disconnect`"* rather
     // than an accepted no-op. Measured on `SocialAccount.user`.
-    assertDisconnectable(schema, relation, fkField, {
+    assertDisconnectable(schema, relation, fkFields, {
       model: schema.name,
       operation,
       argument: `data.${relation.name}.disconnect`,
@@ -591,13 +655,15 @@ function planOwningSide(
     if (filter === null || filter === undefined) return;
 
     /**
-     * `true` — one bound column set to `null`, exactly as `connect`'s direct
-     * form is one bound column set to a value. No step, nothing on the child
-     * read or written, and so no scoping question: the row being changed is
-     * the one the statement already names.
+     * `true` — the link's columns bound to `null`, exactly as `connect`'s
+     * direct form binds them to a value. No step, nothing on the child read or
+     * written, and so no scoping question: the row being changed is the one the
+     * statement already names.
      */
     if (operand === true) {
-      out.contributions.push({ field: fkField, value: () => null });
+      for (const field of fkFields) {
+        out.contributions.push({ field, value: () => null });
+      }
       return;
     }
 
@@ -630,48 +696,51 @@ function planOwningSide(
       relation: relation.name,
       operation: "disconnect",
       async run(args, context, executor) {
-        // Default to the value that is already there, so a filter that matches
-        // nothing writes the column back unchanged. The contribution is in the
-        // SET list either way — the statement's text cannot depend on a value
-        // read at bind time — so "nothing happens" has to be spelled as an
-        // assignment that changes nothing rather than as an absent one.
-        context.resolved[fkField] = null;
+        // Default to the values that are already there, so a filter that
+        // matches nothing writes the columns back unchanged. The contributions
+        // are in the SET list either way — the statement's text cannot depend
+        // on a value read at bind time — so "nothing happens" has to be spelled
+        // as assignments that change nothing rather than as absent ones.
+        resolveKey(context, nullsFor(fkFields));
 
         const parent = (await executor.exec(
           schema.name,
           "findFirst",
-          { where: args?.where, select: { [fkField]: true } },
+          { where: args?.where, select: keySelect(fkFields) },
           true,
         )) as Record<string, unknown> | null;
 
-        const linked = parent?.[fkField];
+        const linked = valuesOf(parent, fkFields);
         // Nothing linked: no row for the filter to match, and Prisma is silent
-        // about it. `null` is already what the column holds.
-        if (linked === null || linked === undefined) return;
+        // about it. `null` is already what the columns hold. A *partially*
+        // written composite key lands here too, and that is the right answer —
+        // it joins to no row, so no filter can match through it.
+        if (!isLinked(linked)) return;
 
-        context.resolved[fkField] = linked;
+        resolveKey(context, linked);
 
         const matched = await executor.exec(
           relation.model,
           "findFirst",
           {
-            // `AND`, not a spread: a filter naming the referenced column itself
+            // `AND`, not a spread: a filter naming a referenced column itself
             // must narrow rather than replace the restriction that keeps this
             // on the linked row. Same rule as everywhere else here.
-            where: conjoin(at(args), { [referenced]: linked }),
-            select: { [referenced]: true },
+            // `link` reads the same way on this side: its `parentFields` are
+            // this row's foreign key and its `childFields` are what they
+            // reference, so `childLink` yields the far row's own columns bound
+            // to the values just read off this one.
+            where: conjoin(at(args), childLink(link, parent as Record<string, unknown>)),
+            select: keySelect(referencedFields),
           },
           false,
         );
 
-        if (matched) context.resolved[fkField] = null;
+        if (matched) resolveKey(context, nullsFor(fkFields));
       },
     });
 
-    out.contributions.push({
-      field: fkField,
-      value: (_args, context) => context.resolved[fkField],
-    });
+    contributeResolved();
     return;
   }
 
@@ -701,7 +770,7 @@ function planOwningSide(
    * nothing returned at all.
    */
   if (key === "update") {
-    out.keyFields.push(fkField);
+    out.keyFields.push(...fkFields);
 
     // The same check the foreign side runs, on the same operand grammar. Both
     // sides accept `{ where?, data }` and both must refuse an unknown key
@@ -717,8 +786,10 @@ function planOwningSide(
         const parent = rows[0];
         if (!parent) return;
 
-        const linked = parent[fkField];
-        if (linked === null || linked === undefined) {
+        // A composite key with any column null names no row — see
+        // {@link isLinked} — so a half-written link is the *absent* case here
+        // rather than a lookup that finds nothing later.
+        if (!isLinked(valuesOf(parent, fkFields))) {
           // The same error as the foreign side's miss, and for the same reason
           // — this is one condition with two spellings, not two conditions.
           // Measured rather than inferred: Prisma answers P2025 here too,
@@ -763,13 +834,13 @@ function planOwningSide(
         // is shape-stable — `canonicalShape` records a `where` key's presence —
         // so the common `update: { … }` spelling still costs one statement.
         const filter = wrapped ? record!.where : undefined;
-        const where = conjoin(filter, { [referenced]: linked });
+        const where = conjoin(filter, childLink(link, parent));
 
         if (filter !== undefined) {
           const found = (await executor.exec(
             relation.model,
             "findFirst",
-            { where, select: { [referenced]: true } },
+            { where, select: keySelect(referencedFields) },
             false,
           )) as Record<string, unknown> | null;
 
@@ -861,7 +932,7 @@ function planOwningSide(
         const found = (await executor.exec(
           relation.model,
           "findUnique",
-          { where, select: { [referenced]: true } },
+          { where, select: keySelect(referencedFields) },
           // NOT pre-scoped, for the reason `connect` is not: this reads another
           // model's rows to decide what to attach, so that model's policies say
           // which rows exist. Scoped away, a hit becomes a miss and the row is
@@ -871,7 +942,7 @@ function planOwningSide(
         )) as Record<string, unknown> | null;
 
         if (found) {
-          const value = found[referenced] ?? null;
+          const values = valuesOf(found, referencedFields);
           // A hit **is** a connect, so it displaces where the miss below cannot
           // — measured on both sides, and the reason `displaces` is consulted
           // per *branch* rather than per operand. `planForeignSide`'s table
@@ -879,21 +950,21 @@ function planOwningSide(
           if (displaces) {
             await displaceSibling(
               schema,
-              fkField,
-              value,
+              fkFields,
+              values,
               args?.where,
               existing,
               executor,
             );
           }
-          context.resolved[fkField] = value;
+          resolveKey(context, values);
           return;
         }
 
         const created = (await executor.exec(
           relation.model,
           "create",
-          { data: at(args)?.create, select: { [referenced]: true } },
+          { data: at(args)?.create, select: keySelect(referencedFields) },
           // NOT pre-scoped — the child's own `onCreate` scopes the new row.
           false,
         )) as Record<string, unknown> | null;
@@ -902,14 +973,11 @@ function planOwningSide(
         // row was minted a line ago, so nothing can already be pointing at it.
         // Prisma agrees by construction rather than by rule — its miss branch
         // logs the insert and the repoint and no incumbent lookup at all.
-        context.resolved[fkField] = created?.[referenced] ?? null;
+        resolveKey(context, valuesOf(created, referencedFields));
       },
     });
 
-    out.contributions.push({
-      field: fkField,
-      value: (_args, context) => context.resolved[fkField],
-    });
+    contributeResolved();
     return;
   }
 
@@ -933,13 +1001,44 @@ function planOwningSide(
     );
   }
 
+  /**
+   * **Single-field only, and a composite `connect` takes the lookup** (#271).
+   *
+   * The optimisation is "the caller already handed us the value the column
+   * needs", and on a composite relation they did not: Prisma spells a
+   * multi-column unique key in its *compound* form —
+   * `connect: { tenantId_code: { tenantId: 1, code: "a" } }`, one argument key
+   * named after the index — so there is no key here whose value is a referenced
+   * column. Reading one out would mean reproducing the generator's `_`-joined
+   * naming rule inside the planner, and then assuming the caller reached for
+   * the group the relation *references* rather than any other unique key on the
+   * child, which `connect` explicitly allows.
+   *
+   * So the composite case pays one `findUniqueOrThrow`, and that costs parity
+   * nothing: Prisma issues the same lookup. Measured on 6.19.2 with query
+   * events on, `LedgerEntry.create({ data: { amount: 1, ledger: { connect:
+   * { tenantId_code: { tenantId: 1, code: "ab" } } } } })` logs
+   *
+   *     BEGIN IMMEDIATE
+   *     select Ledger.tenantId, Ledger.code where tenantId = ? and code = ?
+   *     insert into LedgerEntry (tenantId, ledgerCode, amount) values (?,?,?)
+   *     select the row back
+   *     COMMIT
+   *
+   * — the resolve is a statement there too. The zero-query path was always a
+   * gemi-only shortcut over the shape where the operand *is* the value.
+   */
   const direct =
-    (operand as Record<string, unknown>)[referenced] !== undefined &&
+    referencedFields.length === 1 &&
+    (operand as Record<string, unknown>)[referencedFields[0]] !== undefined &&
     Object.keys(operand as Record<string, unknown>).filter(
       (name) => (operand as Record<string, unknown>)[name] !== undefined,
     ).length === 1;
 
   if (direct) {
+    const referenced = referencedFields[0];
+    const fkField = fkFields[0];
+
     /**
      * **The direct form still costs a step when it has an incumbent to
      * displace**, and only then.
@@ -961,8 +1060,8 @@ function planOwningSide(
         async run(args, _context, executor) {
           await displaceSibling(
             schema,
-            fkField,
-            at(args)?.[referenced],
+            [fkField],
+            [at(args)?.[referenced]],
             args?.where,
             existing,
             executor,
@@ -995,14 +1094,14 @@ function planOwningSide(
       const found = (await executor.exec(
         relation.model,
         "findUniqueOrThrow",
-        { where: at(args), select: { [referenced]: true } },
+        { where: at(args), select: keySelect(referencedFields) },
         // NOT pre-scoped. This lookup reads another model's rows to decide what
         // to attach, so it is that model's policies that say which rows exist —
         // otherwise a `connect` by any unique key reaches every tenant's.
         false,
       )) as Record<string, unknown> | null;
 
-      const value = found?.[referenced] ?? null;
+      const values = valuesOf(found, referencedFields);
 
       // After the lookup, which is the ordering #363 asked how to get: the
       // clear cannot be written until the referenced value is known, and
@@ -1014,43 +1113,49 @@ function planOwningSide(
       if (displaces) {
         await displaceSibling(
           schema,
-          fkField,
-          value,
+          fkFields,
+          values,
           args?.where,
           existing,
           executor,
         );
       }
 
-      context.resolved[fkField] = value;
+      resolveKey(context, values);
     },
   });
-  out.contributions.push({
-    field: fkField,
-    value: (_args, context) => context.resolved[fkField],
-  });
+  contributeResolved();
 }
 
 /**
  * The *child* holds the foreign key, so nothing can be written until this row
  * exists and its key is known. Both forms are therefore `after` steps, and both
- * need the key in the statement's `RETURNING` list.
+ * need the key in the statement's `RETURNING` list — **every column of it**,
+ * since a composite link is only usable once the whole tuple is known (#271).
+ *
+ * **This is the side the partial-write hazard is real on**, and it is answered
+ * rather than avoided. The owning side folds its columns into one statement;
+ * here each linked row is its own `update` or `create`, so a composite key
+ * whose second statement fails leaves the first row repointed. `$exec` opens a
+ * transaction for any plan carrying steps — iteration 5 — so the failure rolls
+ * the parent row back with it, which is the same guarantee that already covers
+ * a `connect` of three rows where the third does not exist.
  */
 function planForeignSide(
   schema: ModelSchema,
   relation: RelationSchema,
   child: ModelSchema,
-  link: { parentField: string; childField: string },
+  link: Link,
   key: string,
   operand: unknown,
   operation: string,
   at: (args: any) => any,
   out: NestedWritePlanning,
 ): void {
-  const parentField = link.parentField;
-  const childField = link.childField;
+  const parentFields = link.parentFields;
+  const childFields = link.childFields;
 
-  out.keyFields.push(parentField);
+  out.keyFields.push(...parentFields);
 
   /**
    * **Whether linking through this relation has to displace what is linked
@@ -1103,9 +1208,16 @@ function planForeignSide(
    * the relation for its `kind` and uses `uniques` only to narrow. From the
    * owning side `relation.kind` is still unreadable — it says `"one"` for a
    * many-to-one and a one-to-one alike, because both point at a single far row.
+   *
+   * **Every column has to be nullable, not the first one** (#271). Prisma makes
+   * a composite relation optional or required as a whole and refuses a mixture,
+   * so on a schema it accepted the columns agree — but the test is over all of
+   * them because half a detach is worse than none: the incumbent would keep a
+   * key that still joins nowhere while the unique index still holds it.
    */
   const displaces =
-    relation.kind !== "many" && child.fields[childField]?.nullable === true;
+    relation.kind !== "many" &&
+    childFields.every((field) => child.fields[field]?.nullable === true);
 
   /**
    * **A to-one whose key is on the child**, which this function otherwise plans
@@ -1404,14 +1516,12 @@ function planForeignSide(
         if (!parent) return;
 
         for (const entry of listOf(at(args)) as Record<string, unknown>[]) {
-          const where = conjoin(entry.where, {
-            [childField]: parent[parentField],
-          });
+          const where = conjoin(entry.where, childLink(link, parent));
 
           const hit = (await executor.exec(
             relation.model,
             "findFirst",
-            { where, select: { [childField]: true } },
+            { where, select: keySelect(childFields) },
             false,
           )) as Record<string, unknown> | null;
 
@@ -1432,11 +1542,8 @@ function planForeignSide(
             "create",
             {
               // The foreign key is ours, as it is for every create here.
-              data: {
-                ...(entry.create as object),
-                [childField]: parent[parentField],
-              },
-              select: { [childField]: true },
+              data: { ...(entry.create as object), ...childLink(link, parent) },
+              select: keySelect(childFields),
             },
             false,
           );
@@ -1474,7 +1581,7 @@ function planForeignSide(
         // Conjoining also keeps the parent restriction *unforgeable* while
         // letting the caller's predicate narrow, which is exactly what
         // `withScope` does for a policy fragment and for the same reason.
-        const where = conjoin(filter, { [childField]: parent[parentField] });
+        const where = conjoin(filter, childLink(link, parent));
 
         await executor.exec(
           relation.model,
@@ -1492,7 +1599,7 @@ function planForeignSide(
 
   if (key === "set") {
     assertNamedRows(schema, relation, child, operand, "set", operation);
-    assertDisconnectable(child, relation, childField, {
+    assertDisconnectable(child, relation, childFields, {
       model: schema.name,
       operation,
       argument: `data.${relation.name}.set`,
@@ -1505,15 +1612,20 @@ function planForeignSide(
         const parent = rows[0];
         if (!parent) return;
 
-        const parentKey = parent[parentField];
+        const attach = childLink(link, parent);
 
-        await clearLinks(relation.model, childField, parentKey, executor);
+        await clearLinks(
+          relation.model,
+          childFields,
+          valuesOf(parent, parentFields),
+          executor,
+        );
 
         for (const entry of listOf(at(args))) {
           await executor.exec(
             relation.model,
             "updateMany",
-            { where: entry as object, data: { [childField]: parentKey } },
+            { where: entry as object, data: attach },
             false,
           );
         }
@@ -1548,14 +1660,12 @@ function planForeignSide(
           // and it does the same two jobs. `AND` rather than a spread for the
           // reason `updateMany` documents: a key naming the foreign column
           // itself would otherwise be overwritten rather than honoured.
-          const where = conjoin(entry.where, {
-            [childField]: parent[parentField],
-          });
+          const where = conjoin(entry.where, childLink(link, parent));
 
           const found = (await executor.exec(
             relation.model,
             "findFirst",
-            { where, select: { [childField]: true } },
+            { where, select: keySelect(childFields) },
             false,
           )) as Record<string, unknown> | null;
 
@@ -1607,7 +1717,7 @@ function planForeignSide(
       // `connect`?"*, with the available options listed as create /
       // connectOrCreate / upsert / connect / update. The refusal is on the
       // **key**, not on the value, and this one already reads only the schema.
-      assertDisconnectable(child, relation, childField, {
+      assertDisconnectable(child, relation, childFields, {
         model: schema.name,
         operation,
         argument: `data.${relation.name}.disconnect`,
@@ -1650,23 +1760,22 @@ function planForeignSide(
           // The caller's key *and* the link, so neither operand can reach a row
           // attached to a different parent. `AND` rather than a spread — see
           // `updateMany`.
-          const where = conjoin(list[index], {
-            [childField]: parent[parentField],
-          });
+          const where = conjoin(list[index], childLink(link, parent));
 
           if (!deleting) {
             await executor.exec(
               relation.model,
               "updateMany",
-              { where, data: { [childField]: null } },
+              { where, data: nullKey(childFields) },
               // NOT pre-scoped: clearing a foreign key is a write to the child,
               // so the child's scope decides which rows are reachable.
               false,
-              // ...but the column is *ours*: the caller wrote `disconnect: { id }`
-              // and the ORM chose to null the key. Without this a child scoped
-              // on its own foreign key is refused for a write it never made —
-              // the same case as `connect`, see #98 and `ormAuthoredFields`.
-              [childField],
+              // ...but the columns are *ours*: the caller wrote `disconnect:
+              // { id }` and the ORM chose to null the key. Without this a child
+              // scoped on its own foreign key is refused for a write it never
+              // made — the same case as `connect`, see #98 and
+              // `ormAuthoredFields`.
+              childFields,
             );
             continue;
           }
@@ -1674,7 +1783,7 @@ function planForeignSide(
           const found = (await executor.exec(
             relation.model,
             "findFirst",
-            { where, select: { [childField]: true } },
+            { where, select: keySelect(childFields) },
             false,
           )) as Record<string, unknown> | null;
 
@@ -1784,7 +1893,12 @@ function planForeignSide(
         // the kind that holds until someone reads it. One read, on a path that
         // already runs several.
         if (displaces) {
-          await clearLinks(relation.model, childField, parent[parentField], executor);
+          await clearLinks(
+            relation.model,
+            childFields,
+            valuesOf(parent, parentFields),
+            executor,
+          );
         }
 
         for (const item of listOf(at(args))) {
@@ -1794,10 +1908,10 @@ function planForeignSide(
             {
               // The foreign key is set by us, not by the caller: a nested create
               // that also named it would be describing two different parents.
-              data: { ...(item as object), [childField]: parent[parentField] },
+              data: { ...(item as object), ...childLink(link, parent) },
               // Nothing reads the result, and the narrowest select keeps the
               // returned payload from growing with the child's column count.
-              select: { [childField]: true },
+              select: keySelect(childFields),
             },
             // NOT pre-scoped — the child's `onCreate` is what scopes this row.
             false,
@@ -1850,7 +1964,7 @@ function planForeignSide(
           // nested input type entirely, so a row naming it is describing a
           // different parent than the call is.
           ...(item as object),
-          [childField]: parent[parentField],
+          ...childLink(link, parent),
         }));
 
         // **No short-circuit on an empty list**, and that is worth the round
@@ -1929,7 +2043,7 @@ function planForeignSide(
           const found = (await executor.exec(
             relation.model,
             "findUnique",
-            { where: item.where, select: { [childField]: true } },
+            { where: item.where, select: keySelect(childFields) },
             false,
           )) as Record<string, unknown> | null;
 
@@ -1941,7 +2055,12 @@ function planForeignSide(
             // a row orphans the incumbent and takes the link, while the same
             // call missing collides on the child's unique key. See `displaces`.
             if (displaces) {
-              await clearLinks(relation.model, childField, parent[parentField], executor);
+              await clearLinks(
+                relation.model,
+                childFields,
+                valuesOf(parent, parentFields),
+                executor,
+              );
             }
 
             await executor.exec(
@@ -1949,8 +2068,8 @@ function planForeignSide(
               "update",
               {
                 where: item.where,
-                data: { [childField]: parent[parentField] },
-                select: { [childField]: true },
+                data: childLink(link, parent),
+                select: keySelect(childFields),
               },
               false,
             );
@@ -1964,11 +2083,8 @@ function planForeignSide(
               // The foreign key is ours, not the caller's — the same rule the
               // nested `create` above follows, and Prisma leaves it out of the
               // nested input type entirely.
-              data: {
-                ...(item.create as object),
-                [childField]: parent[parentField],
-              },
-              select: { [childField]: true },
+              data: { ...(item.create as object), ...childLink(link, parent) },
+              select: keySelect(childFields),
             },
             false,
           );
@@ -2023,7 +2139,12 @@ function planForeignSide(
       if (!parent) return;
 
       if (displaces) {
-        await clearLinks(relation.model, childField, parent[parentField], executor);
+        await clearLinks(
+          relation.model,
+          childFields,
+          valuesOf(parent, parentFields),
+          executor,
+        );
       }
 
       for (const item of listOf(at(args))) {
@@ -2032,17 +2153,18 @@ function planForeignSide(
           "update",
           {
             where: item,
-            data: { [childField]: parent[parentField] },
-            select: { [childField]: true },
+            data: childLink(link, parent),
+            select: keySelect(childFields),
           },
           // NOT pre-scoped. Repointing an existing row at this parent is a write
           // to the child, and the child's scope decides which rows are reachable
           // — otherwise `connect` re-parents another tenant's row.
           false,
-          // ...and the column being written is *ours*, not the caller's. Without
-          // this, a child whose policy scopes on its foreign key is refused for
-          // a write it never made — see #98 and `ormAuthoredFields`.
-          [childField],
+          // ...and the columns being written are *ours*, not the caller's.
+          // Without this, a child whose policy scopes on its foreign key is
+          // refused for a write it never made — see #98 and
+          // `ormAuthoredFields`.
+          childFields,
         );
       }
     },
@@ -2531,7 +2653,95 @@ function conjoin(
 }
 
 /**
- * Null one foreign-key column on every row that currently holds `value` **and
+ * The three shapes a link takes in an argument object, and the two questions
+ * asked about its *values* — written once so that a relation joining on four
+ * fields goes down the same path as one joining on one (#271).
+ *
+ * Before these, every site spelled the link as `{ [childField]: parent[
+ * parentField] }` or `select: { [childField]: true }` by hand, in about forty
+ * places across the two sides. Generalising each of them separately is how a
+ * composite relation ends up correlating on every field in nine operands and on
+ * the first field in the tenth — a silent wrong write, which is precisely what
+ * the refusal these replace was protecting against. One function per shape
+ * means the count of fields is invisible to the callers, so there is no
+ * single-field spelling left for a new operand to copy.
+ */
+
+/**
+ * `{ <childField>: row[<parentField>], … }` — the far side's columns bound to
+ * the values this row holds.
+ *
+ * On the foreign side that reads as "belonging to this parent": the child's
+ * foreign key set to the parent's key. On the owning side the same call reads
+ * as "the row this one points at": `link.parentFields` are this row's foreign
+ * key and `link.childFields` are what they reference, so the object is the far
+ * row's own columns. One function, because the arithmetic is identical and the
+ * two sides differ only in which table the result is applied to.
+ *
+ * An object with several keys is a conjunction in every `where` this ORM
+ * compiles, and several assignments in every `data`, so the same shape serves
+ * both — which is why `create`, `connect`, `update`, `delete` and the two
+ * `*Many` operands can all take it unchanged.
+ */
+function childLink(
+  link: { parentFields: string[]; childFields: string[] },
+  parent: Record<string, unknown>,
+): Record<string, unknown> {
+  const key: Record<string, unknown> = {};
+  for (let index = 0; index < link.childFields.length; index++) {
+    key[link.childFields[index]] = parent[link.parentFields[index]];
+  }
+  return key;
+}
+
+/** `{ <field>: true, … }` — the narrowest select that reads a whole link back. */
+function keySelect(fields: readonly string[]): Record<string, true> {
+  const select: Record<string, true> = {};
+  for (const field of fields) select[field] = true;
+  return select;
+}
+
+/** `{ <field>: null, … }` — a detach, which has to clear *every* column. */
+function nullKey(fields: readonly string[]): Record<string, null> {
+  const cleared: Record<string, null> = {};
+  for (const field of fields) cleared[field] = null;
+  return cleared;
+}
+
+/** The same detach spelled as *values* rather than as a `data` object. */
+function nullsFor(fields: readonly string[]): null[] {
+  return fields.map(() => null);
+}
+
+/** The values of `fields` on `row`, positionally. */
+function valuesOf(
+  row: Record<string, unknown> | null | undefined,
+  fields: readonly string[],
+): unknown[] {
+  return fields.map((field) => row?.[field]);
+}
+
+/**
+ * Whether a link's columns actually name a row.
+ *
+ * **A partially-null composite key links nothing**, which is SQL's rule and not
+ * a choice made here: `(tenantId, orderId) = (1, NULL)` is `UNKNOWN`, so the
+ * join finds no row however many other columns match. Prisma agrees at the
+ * type level — an optional relation over composite fields makes *all* of them
+ * optional together, and `include` on a row holding `(1, NULL)` returns `null`.
+ *
+ * So every place that used to test one value for `null` — "is anything linked
+ * here" — tests the whole key through this, and a half-written key reads as
+ * *absent* rather than as a link to a row that does not exist. Getting this
+ * backwards is what would make `clearLinks` null the key of every unlinked row
+ * in the table, and `disconnect`'s filter arm read a child by a `NULL` key.
+ */
+function isLinked(values: readonly unknown[]): boolean {
+  return values.every((value) => value !== null && value !== undefined);
+}
+
+/**
+ * Null the foreign-key columns of every row that currently holds `values` **and
  * that the caller can see** — the clearing half of `set`, the half a nested
  * `create` on an occupied to-one needs before it can insert (#360), and the
  * half the owning side's `connect` needs before it can repoint (#363).
@@ -2558,22 +2768,41 @@ function conjoin(
  * case — nothing linked — costs a select rather than an update, and that the
  * scope is consulted through a read before anything is written.
  *
- * `[field]` is ORM-authored: the caller named a row to `set`, or a payload to
- * `create`, or a row to `connect`, and the ORM chose to null this column.
- * Without it a model scoped on that same foreign key is refused by the
- * scope-escape guard for a write it never made — #98, and the reason
- * `disconnect` one operand over passes the same list.
+ * `fields` is ORM-authored: the caller named a row to `set`, or a payload to
+ * `create`, or a row to `connect`, and the ORM chose to null these columns.
+ * Without it a model scoped on one of them is refused by the scope-escape guard
+ * for a write it never made — #98, and the reason `disconnect` one operand over
+ * passes the same list. **Every** column of the link goes in it, because a
+ * composite key is cleared by writing null to all of them and each one is as
+ * much the ORM's as the first.
+ *
+ * **A key with a null component clears nothing** (#271), and the guard is not
+ * defensive tidying. `where: { tenantId: 1, orderId: null }` matches every row
+ * whose order is unset in that tenant — rows linked to *nothing*, which is the
+ * opposite of the set this is asked for — and the `updateMany` behind it would
+ * then write null over null across all of them. See {@link isLinked}. Nothing
+ * reaches here with a null today (`displaceSibling` returns first, and the
+ * foreign side reads its values out of a primary key), so this buys no
+ * behaviour; it means a caller that one day does cannot silently rewrite the
+ * table.
  */
 async function clearLinks(
   model: string,
-  field: string,
-  value: unknown,
+  fields: readonly string[],
+  values: readonly unknown[],
   executor: RelationExecutor,
 ): Promise<void> {
+  if (!isLinked(values)) return;
+
+  const where: Record<string, unknown> = {};
+  for (let index = 0; index < fields.length; index++) {
+    where[fields[index]] = values[index];
+  }
+
   const linked = (await executor.exec(
     model,
     "findMany",
-    { where: { [field]: value }, select: { [field]: true } },
+    { where, select: keySelect(fields) },
     false,
   )) as Record<string, unknown>[];
 
@@ -2582,9 +2811,9 @@ async function clearLinks(
   await executor.exec(
     model,
     "updateMany",
-    { where: { [field]: value }, data: { [field]: null } },
+    { where, data: nullKey(fields) },
     false,
-    [field],
+    fields,
   );
 }
 
@@ -2663,9 +2892,17 @@ async function clearLinks(
  */
 async function displaceSibling(
   schema: ModelSchema,
-  fkField: string,
-  /** The value about to be written into this row's foreign key. */
-  value: unknown,
+  fkFields: readonly string[],
+  /**
+   * The values about to be written into this row's foreign key, positionally
+   * paired with `fkFields`.
+   *
+   * **A key with a null component displaces nothing**, which is the composite
+   * generalisation of the `value === null` return this has always had rather
+   * than a new rule: the row is being *un*linked, and there is no incumbent for
+   * a link that is not being made. See {@link isLinked}.
+   */
+  values: readonly unknown[],
   /**
    * This statement's own `where`, **already through this model's policies** —
    * so the read below is pre-scoped, exactly as the `disconnect` filter arm's
@@ -2677,21 +2914,29 @@ async function displaceSibling(
   existing: boolean,
   executor: RelationExecutor,
 ): Promise<void> {
-  if (value === null || value === undefined) return;
+  if (!isLinked(values)) return;
 
   if (existing) {
     const self = (await executor.exec(
       schema.name,
       "findFirst",
-      { where, select: { [fkField]: true } },
+      { where, select: keySelect(fkFields) },
       true,
     )) as Record<string, unknown> | null;
 
     if (self === null || self === undefined) return;
-    if (sameKey(self[fkField], value)) return;
+    // **Every column, not the first that differs** — the skip is "this row
+    // already points at that row", and on a composite key that is only true
+    // when the whole tuple matches. Reading it as "some column matches" would
+    // skip the clear for a sibling holding `(1, "b")` while this row takes
+    // `(1, "a")`, and the repoint would then collide on the unique index the
+    // caller cannot see.
+    if (fkFields.every((field, index) => sameKey(self[field], values[index]))) {
+      return;
+    }
   }
 
-  await clearLinks(schema.name, fkField, value, executor);
+  await clearLinks(schema.name, fkFields, values, executor);
 }
 
 /**
@@ -3063,21 +3308,30 @@ function assertToOneWriteOperand(
  * *structured* model is always the caller's. Passing `owner` for both meant a
  * `User.update` reported `model = "Account"` on the foreign side while the
  * owning side reported `User`, from the same function (#112).
+ *
+ * **Every column of the link, and the first required one is named** (#271).
+ * Prisma makes a composite relation optional or required as a whole — it
+ * refuses a mixture, *"The fields of a relation must either all be optional or
+ * all be required"* — so on a schema Prisma accepted the columns agree and any
+ * one of them answers. Checking all of them anyway costs nothing and means the
+ * refusal does not depend on a validation rule enforced in another program:
+ * a hand-built `ModelSchema` with `tenantId` required beside a nullable
+ * `orderId` is refused here rather than nulling half a key.
  */
 function assertDisconnectable(
   owner: ModelSchema,
   relation: RelationSchema,
-  fieldName: string,
+  fieldNames: readonly string[],
   caller: RefusalOrigin,
 ): void {
-  const field = owner.fields[fieldName];
-  if (field && field.nullable) return;
+  const required = fieldNames.find((name) => !owner.fields[name]?.nullable);
+  if (required === undefined) return;
 
   throw new UnsupportedQueryError(
     caller.argument,
     caller.model,
     caller.operation,
-    `'${owner.name}.${fieldName}' is required, so there is no value to leave ` +
+    `'${owner.name}.${required}' is required, so there is no value to leave ` +
       `behind — a disconnected row would have to be deleted or repointed ` +
       `instead. Prisma does not offer 'disconnect' on a required relation ` +
       `either.`,

--- a/packages/gemi/orm/compile/nested-writes.ts
+++ b/packages/gemi/orm/compile/nested-writes.ts
@@ -192,12 +192,62 @@ export function planNestedWrites(
     keyFields: [],
   };
 
+  /** Which relation contributed each foreign-key column, for the guard below. */
+  const contributedBy = new Map<string, string>();
+
   for (const key of entries) {
     const relation = schema.relations[key];
     const node = (data as Record<string, unknown>)[key];
     const locate = (args: any) => locateData(args)?.[key];
+    const before = planning.contributions.length;
 
     planOne(schema, relation, node, operation, locate, planning, dialect);
+
+    // **Two relations that share a foreign-key column are refused by name**
+    // (#271). A composite relation joins on *n* columns and nothing stops two
+    // of them from sharing one — it is the tenant-scoped shape this whole
+    // change is about:
+    //
+    //     ledger Ledger @relation(fields: [tenantId, ledgerCode], …)
+    //     note   Ledger @relation(fields: [tenantId, noteCode],   …)
+    //
+    // `prisma validate` accepts that on 6.19.2, and before #271 both relations
+    // were refused here for their width, so writing through both at once was
+    // unreachable. It is reachable now, and the two `tenantId` contributions
+    // collide: `insertColumns` folds contributions through a `Map` keyed by
+    // field, so the later one wins, and `entries` above is sorted, so the
+    // winner is whichever relation sorts last.
+    //
+    // **Prisma resolves the operands in the opposite direction and lets the
+    // first resolved win, so the caller's last `data` key decides the shared
+    // column** — measured on 6.19.2 with query events on: writing
+    // `{ note: connect(2,"b"), ledger: connect(1,"a") }` stores `tenantId=1`
+    // where `{ ledger: …, note: … }` stores `2`. gemi stores `2` either way.
+    //
+    // Matching that would mean giving up the sorted key order, which the plan
+    // cache needs — two argument objects differing only in key order have to
+    // be one plan. So this refuses instead, which is what the width refusal
+    // this change replaced was buying: no plausible wrong row. A caller who
+    // wants both links connects through one relation — which writes the shared
+    // column — and sets the other relation's remaining columns directly, since
+    // `insertColumns` only refuses a column that is written *both* ways.
+    for (let index = before; index < planning.contributions.length; index++) {
+      const field = planning.contributions[index].field;
+      const owner = contributedBy.get(field);
+      if (owner !== undefined && owner !== key) {
+        throw new UnsupportedQueryError(
+          `data.${key}`,
+          schema.name,
+          operation,
+          `'${field}' is written by both the '${owner}' and '${key}' relations, ` +
+            `which join on it in common. Prisma lets the last key in 'data' win; ` +
+            `gemi plans relations in a fixed order and will not guess which row ` +
+            `you meant. Write one of them through the relation and set the ` +
+            `other's own columns directly.`,
+        );
+      }
+      contributedBy.set(field, key);
+    }
   }
 
   return planning;
@@ -3315,8 +3365,16 @@ function assertToOneWriteOperand(
  * all be required"* — so on a schema Prisma accepted the columns agree and any
  * one of them answers. Checking all of them anyway costs nothing and means the
  * refusal does not depend on a validation rule enforced in another program:
- * a hand-built `ModelSchema` with `tenantId` required beside a nullable
- * `orderId` is refused here rather than nulling half a key.
+ * a hand-built `ModelSchema` with a nullable `tenantId` beside a required
+ * `ledgerCode` is refused here rather than nulling half a key.
+ *
+ * That is a claim about behaviour, so it is measured rather than asserted —
+ * `ledgerSealMixed` in `fixtures.ts` is exactly that schema, and
+ * `composite-relations.test.ts` names the column this refuses on. **The
+ * nullable column is first there deliberately**: `[fieldNames[0]]` is what this
+ * collapses to if the generalisation is undone, and over `(nullable, required)`
+ * that answers *"detachable"*. The same fixture pins the two `displaces`
+ * predicates, which generalised the same way and were equally unpinned.
  */
 function assertDisconnectable(
   owner: ModelSchema,

--- a/packages/gemi/orm/compile/plan-relations.ts
+++ b/packages/gemi/orm/compile/plan-relations.ts
@@ -716,10 +716,13 @@ export interface Link {
    * guarantees the two sides are the same length, which `resolveLink` checks
    * rather than assumes.
    *
-   * Singular access is a *narrowing* and has to be justified: nested writes
-   * still take one field at a time, so they go through {@link singleFieldLink},
-   * which refuses a composite relation by name. That is a type-level guard
-   * rather than a convention — there is no `parentField` to reach for.
+   * Singular access is a *narrowing* and has to be justified. Nested writes
+   * needed one until #271 and went through {@link singleFieldLink}, which
+   * refused a composite relation by name; they contribute every column now, so
+   * the only caller left is the implicit many-to-many join table, where one
+   * field a side is an invariant of Prisma's own schema rather than a limit
+   * here. That is still a type-level guard rather than a convention — there is
+   * no `parentField` to reach for.
    */
   parentFields: string[];
   /** Fields on the child holding the matching values. */
@@ -729,12 +732,21 @@ export interface Link {
 }
 
 /**
- * The one-field view of a link, for the callers that genuinely cannot take more.
+ * The one-field view of a link, for the caller that genuinely cannot take more.
  *
- * A nested write contributes a *column* to an insert, so a composite relation
- * would be several — a different piece of work from reading across one, and
- * refused here rather than silently writing the first field. #67's acceptance
- * list is the read surfaces; this keeps the write side honest about the gap.
+ * **That is now exactly one: the implicit many-to-many join table.** Prisma
+ * builds it from the two models' *primary keys*, one column each side, into a
+ * table with no schema of its own — so "one field" there is a property of the
+ * shape rather than a limit of this compiler, and it can never be widened
+ * without Prisma changing what an implicit m-n is.
+ *
+ * It used to serve nested writes as well, refusing a composite relation by name
+ * on the argument that contributing *n* foreign-key columns to an insert is a
+ * different piece of work from reading across one. #271 did that work, so the
+ * refusal below is unreachable from an ordinary relation: `planOne` resolves
+ * the full link and only narrows on the join-table branch. Kept as an assertion
+ * of the invariant — the alternative is `link.parentFields[0]` at the call
+ * site, which is the same narrowing with nothing checking it.
  */
 export function singleFieldLink(
   link: Link,
@@ -748,10 +760,9 @@ export function singleFieldLink(
       parent.name,
       operation,
       `${relation.name} joins on ${link.parentFields.length} fields ` +
-        `(${link.parentFields.join(", ")}). Reading across a composite ` +
-        `relation works; writing through one would have to contribute that ` +
-        `many foreign-key columns to this insert, which is not implemented. ` +
-        `Write the child separately with its keys set.`,
+        `(${link.parentFields.join(", ")}), and it is planned through a join ` +
+        `table, which links two models by a single primary key each side. ` +
+        `Prisma does not build an implicit many-to-many over a composite key.`,
     );
   }
   return {

--- a/packages/gemi/orm/composite-surfaces.test.ts
+++ b/packages/gemi/orm/composite-surfaces.test.ts
@@ -5,7 +5,6 @@ import { compileRead } from "./compile/read";
 import { compileWrite } from "./compile/write";
 import { PostgresDialect } from "./dialect/postgres";
 import { SqliteDialect } from "./dialect/sqlite";
-import { UnsupportedQueryError } from "./errors";
 import { ledger, ledgerEntry } from "./fixtures";
 import * as registry from "./registry";
 
@@ -19,7 +18,9 @@ const postgres = new PostgresDialect();
  * wherever a relation is correlated — `include` under either strategy, a
  * relation filter, `_count`, an `orderBy` through a relation, and nested
  * writes". Four of those five stopped being true when #95 and #100 landed, and
- * the entry did not move with them.
+ * the entry did not move with them. The fifth stopped being true at #271, and
+ * the entry is gone: there is nothing left on that list for a reader to plan
+ * around.
  *
  * That is the direction #145 was about: a *Not in scope* list is written so a
  * reader can plan around it, and one that names something already implemented
@@ -108,30 +109,43 @@ describe("a relation that joins on two fields", () => {
   });
 
   /**
-   * The one still refused, and the reason the docs entry is narrowed rather
-   * than deleted. When this starts compiling, this test fails — which is the
-   * prompt to move the entry again.
+   * The sixth, which used to be the one refused (#271).
+   *
+   * This test previously asserted the refusal and said *"when this starts
+   * compiling, this test fails — which is the prompt to move the entry again"*.
+   * It started compiling; the entry moved; this asserts the property the
+   * refusal was standing in for.
+   *
+   * **The parent's `RETURNING` is what makes it the same property.** A nested
+   * write on this side repoints the child by the parent's key, so the columns
+   * the statement returns are the columns the repoint can correlate on — return
+   * one of two and the `update` below writes `tenantId` and leaves `ledgerCode`
+   * holding whatever it held, which is the *first-field join* the refusal
+   * existed to prevent, one layer down.
    */
-  test("a nested write is still refused, by name", () => {
-    let error: UnsupportedQueryError | null = null;
-    try {
-      compileWrite(
-        ledger,
-        "update",
-        {
-          where: { tenantId_code: { tenantId: 1, code: "x" } },
-          data: { entries: { connect: { id: 1 } } },
-        } as never,
-        sqlite,
-      );
-    } catch (raised) {
-      error = raised as UnsupportedQueryError;
-    }
+  test("a nested write returns every key field to correlate on", () => {
+    const plan = compileWrite(
+      ledger,
+      "update",
+      {
+        where: { tenantId_code: { tenantId: 1, code: "x" } },
+        data: { title: "t", entries: { connect: { id: 1 } } },
+        // Narrow, so the key columns below are in the statement *only* because
+        // the nested step asked for them. Without this they would be there
+        // anyway — they are the primary key — and the assertion would hold
+        // whether or not the planner had asked.
+        select: { title: true },
+      } as never,
+      sqlite,
+    );
 
-    expect(error).toBeInstanceOf(UnsupportedQueryError);
-    // The message names the count and the fields, which is what makes it
-    // actionable rather than a shrug.
-    expect(error!.message).toMatch(/joins on 2 fields/);
-    expect(error!.message).toContain("tenantId");
+    expect(plan.after).toHaveLength(1);
+    expect(plan.after?.[0].operation).toBe("connect");
+    expect(plan.text).toContain(`returning "tenantId", "code", "title"`);
+    // Both fetched to stitch with, neither asked for — so both are stripped
+    // from the row the caller sees. One here would mean the repoint writes half
+    // a key: `tenantId` set and `ledgerCode` left holding whatever it held,
+    // which is the first-field join this file's refusal existed to prevent.
+    expect(plan.hidden).toEqual(["tenantId", "code"]);
   });
 });

--- a/packages/gemi/orm/fixtures.ts
+++ b/packages/gemi/orm/fixtures.ts
@@ -521,6 +521,162 @@ export const ledgerEntry: ModelSchema = {
 };
 
 /**
+ * The **optional** composite key — the same two columns as {@link ledgerEntry},
+ * nullable (#271).
+ *
+ * `ledgerEntry`'s is required, which is the ordinary tenant-scoped shape, and
+ * Prisma leaves `disconnect` out of a required relation's nested input type
+ * entirely. So every operand that *detaches* a composite link — `disconnect`,
+ * `set`, and the branches of `connect` / `create` / `connectOrCreate` that
+ * displace an incumbent — was unreachable from these fixtures, in the same way
+ * the foreign side of a to-one was unreachable before {@link profile}.
+ *
+ * Both columns are optional together, which is Prisma's rule rather than a
+ * choice here: *"The fields of a relation must either all be optional or all be
+ * required"*. `assertDisconnectable` and the two `displaces` predicates test
+ * every column and expect one answer, and this is the shape that gives it.
+ */
+export const ledgerNote: ModelSchema = {
+  name: "LedgerNote",
+  table: "LedgerNote",
+  fields: {
+    id: {
+      name: "id",
+      column: "id",
+      type: "Int",
+      nullable: false,
+      isId: true,
+      isUpdatedAt: false,
+      default: { kind: "autoincrement" },
+    },
+    tenantId: {
+      name: "tenantId",
+      column: "tenantId",
+      type: "Int",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    ledgerCode: {
+      name: "ledgerCode",
+      column: "ledgerCode",
+      type: "String",
+      nullable: true,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    body: {
+      name: "body",
+      column: "body",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    ledger: {
+      name: "ledger",
+      model: "Ledger",
+      kind: "one",
+      relationName: "LedgerToLedgerNote",
+      from: ["tenantId", "ledgerCode"],
+      to: ["tenantId", "code"],
+      nullable: true,
+    },
+  },
+};
+
+/**
+ * A composite **one-to-one** — {@link ledgerNote}'s columns plus the
+ * `@@unique` covering exactly them, which is what makes the far row hold one
+ * partner.
+ *
+ * {@link profile} is the single-field version of this shape. Over one column
+ * *"the index covers exactly the relation's fields"* and *"the index is one
+ * column"* are the same sentence; here they are not, which is the whole reason
+ * this fixture exists.
+ *
+ * `uniques: [["tenantId", "ledgerCode"]]` is the group Prisma requires — and
+ * the only one it accepts, measured on 6.19.2: both a wider
+ * `@@unique([tenantId, ledgerCode, seal])` and a reordered
+ * `@@unique([ledgerCode, tenantId])` are refused at parse time with P1012,
+ * *"Either add an `@@unique([tenantId, ledgerCode])` attribute to the model, or
+ * change the relation to one-to-many"*.
+ */
+export const ledgerSeal: ModelSchema = {
+  name: "LedgerSeal",
+  table: "LedgerSeal",
+  fields: {
+    id: ledgerNote.fields.id,
+    tenantId: ledgerNote.fields.tenantId,
+    ledgerCode: ledgerNote.fields.ledgerCode,
+    seal: {
+      name: "seal",
+      column: "seal",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+  },
+  primaryKey: ["id"],
+  uniques: [["tenantId", "ledgerCode"]],
+  relations: {
+    ledger: {
+      name: "ledger",
+      model: "Ledger",
+      kind: "one",
+      relationName: "LedgerToLedgerSeal",
+      from: ["tenantId", "ledgerCode"],
+      to: ["tenantId", "code"],
+      nullable: true,
+    },
+  },
+};
+
+/**
+ * `ledger`, plus the far sides of {@link ledgerNote} and {@link ledgerSeal}.
+ *
+ * A separate export rather than an edit to `ledger` for the reason
+ * {@link userWithProfile} is: the read suites count that model's relations, and
+ * a fixture that grew two would change what they assert without saying so.
+ *
+ * `seal` is `kind: "one"`, which is the *foreign* side's whole displacement
+ * discriminator — P1012 gives that a non-list back-relation implies the child's
+ * key is unique, and that implication holds over a composite `@@unique` exactly
+ * as it does over a single-column one. Measured on 6.19.2 rather than assumed:
+ * `prisma validate` accepts `LedgerSeal.@@unique([tenantId, ledgerCode])`
+ * beside `Ledger.seal LedgerSeal?`.
+ */
+export const ledgerWithOptional: ModelSchema = {
+  ...ledger,
+  relations: {
+    ...ledger.relations,
+    notes: {
+      name: "notes",
+      model: "LedgerNote",
+      kind: "many",
+      relationName: "LedgerToLedgerNote",
+      from: [],
+      to: [],
+      nullable: false,
+    },
+    seal: {
+      name: "seal",
+      model: "LedgerSeal",
+      kind: "one",
+      relationName: "LedgerToLedgerSeal",
+      from: [],
+      to: [],
+      nullable: true,
+    },
+  },
+};
+
+/**
  * A self-relation — the one topology where the parent and the child are the same
  * table, which the template's schema has no example of.
  *

--- a/packages/gemi/orm/fixtures.ts
+++ b/packages/gemi/orm/fixtures.ts
@@ -677,6 +677,155 @@ export const ledgerWithOptional: ModelSchema = {
 };
 
 /**
+ * **A composite key whose columns disagree about being optional** — `tenantId`
+ * nullable beside a required `ledgerCode` (#271).
+ *
+ * Prisma cannot produce this: *"The fields of a relation must either all be
+ * optional or all be required"*, so every schema it validates has columns that
+ * agree and the first one answers for all of them. That is exactly why the
+ * three "every column" *nullability* tests — `planOwningSide`'s `displaces`,
+ * `planForeignSide`'s `displaces`, and `assertDisconnectable` — had no case
+ * that could tell them from their single-field spellings, and the first review
+ * of #271 said so.
+ *
+ * A hand-built `ModelSchema` is the one thing that can, and this is where a
+ * hand-built `ModelSchema` lives. **The nullable column is deliberately
+ * first**: `[fields[0]]` is the mutation these three predicates collapse to,
+ * and over `(nullable, required)` that mutation answers *"detachable"* where
+ * the whole tuple answers *"not"* — so a test written against this fixture goes
+ * red when any of the three is narrowed, and green only on the real thing.
+ *
+ * `uniques` covers exactly the relation's fields, so the *index* half of the
+ * owning side's `displaces` is satisfied and the nullability half is the only
+ * thing left deciding — otherwise the case would pass for the wrong reason.
+ */
+export const ledgerSealMixed: ModelSchema = {
+  name: "LedgerSealMixed",
+  table: "LedgerSealMixed",
+  fields: {
+    id: ledgerNote.fields.id,
+    tenantId: ledgerNote.fields.tenantId,
+    ledgerCode: { ...ledgerNote.fields.ledgerCode, nullable: false },
+    seal: ledgerSeal.fields.seal,
+  },
+  primaryKey: ["id"],
+  uniques: [["tenantId", "ledgerCode"]],
+  relations: {
+    ledger: {
+      name: "ledger",
+      model: "Ledger",
+      kind: "one",
+      relationName: "LedgerToLedgerSealMixed",
+      from: ["tenantId", "ledgerCode"],
+      to: ["tenantId", "code"],
+      nullable: true,
+    },
+  },
+};
+
+/**
+ * **Two composite relations that share a foreign-key column** — the shape #271
+ * makes reachable and the first review of it caught (#386).
+ *
+ * `prisma validate` accepts this on 6.19.2. Before #271 both relations were
+ * refused by name for their width, so no call could write through both at
+ * once; now both compile, both contribute a `tenantId`, and `insertColumns`
+ * folds contributions through a `Map` keyed by field — so without the guard in
+ * `planNestedWrites` the alphabetically-last relation would silently decide the
+ * shared column, where Prisma lets the caller's last `data` key decide it.
+ *
+ * `ledgerCode` and `noteCode` are the columns the two relations do *not* share,
+ * which is what makes the divergence a wrong row rather than a wrong error:
+ * both links are plausible, and only one of the two `tenantId`s is right.
+ */
+export const ledgerCrossEntry: ModelSchema = {
+  name: "LedgerCrossEntry",
+  table: "LedgerCrossEntry",
+  fields: {
+    id: ledgerEntry.fields.id,
+    tenantId: ledgerEntry.fields.tenantId,
+    ledgerCode: ledgerEntry.fields.ledgerCode,
+    noteCode: {
+      name: "noteCode",
+      column: "noteCode",
+      type: "String",
+      nullable: false,
+      isId: false,
+      isUpdatedAt: false,
+    },
+    amount: ledgerEntry.fields.amount,
+  },
+  primaryKey: ["id"],
+  uniques: [],
+  relations: {
+    ledger: {
+      name: "ledger",
+      model: "Ledger",
+      kind: "one",
+      relationName: "LedgerToCrossEntry",
+      from: ["tenantId", "ledgerCode"],
+      to: ["tenantId", "code"],
+      nullable: false,
+    },
+    note: {
+      name: "note",
+      model: "Ledger",
+      kind: "one",
+      relationName: "NoteToCrossEntry",
+      from: ["tenantId", "noteCode"],
+      to: ["tenantId", "code"],
+      nullable: false,
+    },
+  },
+};
+
+/**
+ * `ledgerWithOptional`, plus the far sides of {@link ledgerSealMixed} and
+ * {@link ledgerCrossEntry}.
+ *
+ * A third variant rather than an edit, for the reason {@link ledgerWithOptional}
+ * is a second one: the suites that count a fixture's relations should not have
+ * to move every time a case needs one more back-reference.
+ *
+ * `sealMixed` is `kind: "one"` so that the *foreign* side's `displaces` reaches
+ * its nullability test — with `kind: "many"` the predicate short-circuits and
+ * the column check is never evaluated, which would pin nothing.
+ */
+export const ledgerWithMixed: ModelSchema = {
+  ...ledgerWithOptional,
+  relations: {
+    ...ledgerWithOptional.relations,
+    sealMixed: {
+      name: "sealMixed",
+      model: "LedgerSealMixed",
+      kind: "one",
+      relationName: "LedgerToLedgerSealMixed",
+      from: [],
+      to: [],
+      nullable: true,
+    },
+    crossEntries: {
+      name: "crossEntries",
+      model: "LedgerCrossEntry",
+      kind: "many",
+      relationName: "LedgerToCrossEntry",
+      from: [],
+      to: [],
+      nullable: false,
+    },
+    crossNotes: {
+      name: "crossNotes",
+      model: "LedgerCrossEntry",
+      kind: "many",
+      relationName: "NoteToCrossEntry",
+      from: [],
+      to: [],
+      nullable: false,
+    },
+  },
+};
+
+/**
  * A self-relation — the one topology where the parent and the child are the same
  * table, which the template's schema has no example of.
  *

--- a/templates/saas-starter/app/models/differential.ts
+++ b/templates/saas-starter/app/models/differential.ts
@@ -405,11 +405,18 @@ export async function createDifferential(options: {
     "User",
     "OrganizationInvitation",
     "Organization",
-    // The composite-relation pair (#67). Adding a model to the schema without
-    // adding it here is a *silent* omission on SQLite, where every run gets a
-    // fresh temp database, and a loud one on Postgres, where the second run's
-    // seed collides with the first's rows — which is exactly how this was
+    // The composite-relation family (#67, #271). Adding a model to the schema
+    // without adding it here is a *silent* omission on SQLite, where every run
+    // gets a fresh temp database, and a loud one on Postgres, where the second
+    // run's seed collides with the first's rows — which is exactly how this was
     // found, and the second time in this suite's history.
+    //
+    // Children before the parent, as everywhere in this list. All three hold a
+    // composite foreign key into `Ledger`; `LedgerNote` and `LedgerSeal` hold a
+    // nullable one, so the wrong order would detach rather than raise — the
+    // same silent shape `Profile` is ordered for above.
+    "LedgerSeal",
+    "LedgerNote",
     "LedgerEntry",
     "Ledger",
   ];
@@ -451,6 +458,17 @@ export async function createDifferential(options: {
     await prisma.user.deleteMany({});
     await prisma.organizationInvitation.deleteMany({});
     await prisma.organization.deleteMany({});
+
+    // The composite family, children first — the same order and the same reason
+    // as `TABLES` above. It was absent here while present there, which cost
+    // nothing while the only composite cases were reads against a temp database
+    // that is fresh per file. A write comparison resets between the two runs,
+    // so a table this does not clear carries the first client's rows into the
+    // second's and fails every case for a reason that is not the code's.
+    await prisma.ledgerSeal.deleteMany({});
+    await prisma.ledgerNote.deleteMany({});
+    await prisma.ledgerEntry.deleteMany({});
+    await prisma.ledger.deleteMany({});
 
     // SQLite keeps the high-water mark for an AUTOINCREMENT column in this
     // table, and clearing it is the only way to make ids start from 1 again.

--- a/templates/saas-starter/app/models/generated/index.ts
+++ b/templates/saas-starter/app/models/generated/index.ts
@@ -10,6 +10,8 @@ import {
   AccountModel,
   LedgerModel,
   LedgerEntryModel,
+  LedgerNoteModel,
+  LedgerSealModel,
   MagicLinkTokenModel,
   MembershipModel,
   OrganizationModel,
@@ -31,6 +33,8 @@ assertSchemaArtifactVersion(ARTIFACT_VERSION);
 register("Account", AccountModel);
 register("Ledger", LedgerModel);
 register("LedgerEntry", LedgerEntryModel);
+register("LedgerNote", LedgerNoteModel);
+register("LedgerSeal", LedgerSealModel);
 register("MagicLinkToken", MagicLinkTokenModel);
 register("Membership", MembershipModel);
 register("Organization", OrganizationModel);

--- a/templates/saas-starter/app/models/generated/models.ts
+++ b/templates/saas-starter/app/models/generated/models.ts
@@ -265,6 +265,8 @@ export type LedgerCreateScalars = {
 
 export type LedgerRelations = {
   entries: { kind: "many"; nullable: false; target: LedgerEntryTypes };
+  notes: { kind: "many"; nullable: false; target: LedgerNoteTypes };
+  seal: { kind: "one"; nullable: true; target: LedgerSealTypes };
 };
 
 export type LedgerUnique = { tenantId_code: { tenantId: number; code: string } };
@@ -632,6 +634,394 @@ export class LedgerEntryModel extends Model {
   }
 
   static wrap<C extends { prototype: unknown }, R extends LedgerEntryScalars>(
+    this: C,
+    row: R,
+  ): C["prototype"] & R {
+    return (Model.wrap as (row: object) => any).call(this, row);
+  }
+}
+
+export type LedgerNoteScalars = {
+  id: number;
+  tenantId: number | null;
+  ledgerCode: string | null;
+  body: string;
+};
+
+export type LedgerNoteCreateScalars = {
+  id?: number;
+  tenantId?: number | null;
+  ledgerCode?: string | null;
+  body: string;
+};
+
+export type LedgerNoteRelations = {
+  ledger: { kind: "one"; nullable: true; target: LedgerTypes };
+};
+
+export type LedgerNoteUnique = { id: number };
+
+export interface LedgerNoteTypes extends ModelTypeInfo {
+  scalars: LedgerNoteScalars;
+  relations: LedgerNoteRelations;
+  unique: LedgerNoteUnique;
+  create: LedgerNoteCreateScalars;
+}
+
+// Merges the row's columns into the instance type, so a method on a subclass can
+// read `this.email`. No runtime output.
+//
+// oxlint flags class/interface merging because TypeScript does not check the
+// merged properties are initialised — a directly constructed instance would type
+// as carrying every column while holding none. That hazard is closed rather than
+// accepted: `Model`'s constructor is `protected`, so the only way to get an
+// instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
+export interface LedgerNoteModel extends LedgerNoteScalars {}
+
+export type LedgerNotePolicy = ModelPolicy<
+  WhereInput<LedgerNoteTypes>,
+  CreateInput<LedgerNoteTypes>,
+  LedgerNoteScalars
+>;
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class LedgerNoteScopedPolicy extends ScopedPolicy<
+  WhereInput<LedgerNoteTypes>,
+  CreateInput<LedgerNoteTypes>,
+  LedgerNoteScalars
+> {}
+
+export class LedgerNoteModel extends Model {
+  static $schema = schema.LedgerNote;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    WhereInput<LedgerNoteTypes>,
+    CreateInput<LedgerNoteTypes>,
+    LedgerNoteScalars
+  >[];
+
+  static findMany<T extends FindManyArgs<LedgerNoteTypes>>(
+    args?: Subset<T, FindManyArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T>[]> {
+    return this.$exec("findMany", args, options) as Promise<Payload<LedgerNoteTypes, T>[]>;
+  }
+
+  static findFirst<T extends FindFirstArgs<LedgerNoteTypes>>(
+    args?: Subset<T, FindFirstArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T> | null> {
+    return this.$exec("findFirst", args, options) as Promise<Payload<LedgerNoteTypes, T> | null>;
+  }
+
+  static findFirstOrThrow<T extends FindFirstOrThrowArgs<LedgerNoteTypes>>(
+    args?: Subset<T, FindFirstOrThrowArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T>> {
+    return this.$exec("findFirstOrThrow", args, options) as Promise<Payload<LedgerNoteTypes, T>>;
+  }
+
+  static findUnique<T extends FindUniqueArgs<LedgerNoteTypes>>(
+    args: Subset<T, FindUniqueArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T> | null> {
+    return this.$exec("findUnique", args, options) as Promise<Payload<LedgerNoteTypes, T> | null>;
+  }
+
+  static findUniqueOrThrow<T extends FindUniqueOrThrowArgs<LedgerNoteTypes>>(
+    args: Subset<T, FindUniqueOrThrowArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T>> {
+    return this.$exec("findUniqueOrThrow", args, options) as Promise<Payload<LedgerNoteTypes, T>>;
+  }
+
+  static count(args?: Omit<CountArgs<LedgerNoteTypes>, "select">): Promise<number>;
+  static count<T extends CountArgs<LedgerNoteTypes>>(
+    args: SelectSubset<T, CountArgs<LedgerNoteTypes>> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<CountPayload<T["select"]>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends AggregateArgs<LedgerNoteTypes>>(
+    args: Subset<T, AggregateArgs<LedgerNoteTypes>>,
+  ): Promise<AggregatePayload<LedgerNoteTypes, T>> {
+    return this.$exec("aggregate", args) as Promise<
+      AggregatePayload<LedgerNoteTypes, T>
+    >;
+  }
+
+  static groupBy<T extends GroupByArgs<LedgerNoteTypes>>(
+    args: Subset<T, GroupByArgs<LedgerNoteTypes>>,
+  ): Promise<GroupByPayload<LedgerNoteTypes, T>> {
+    return this.$exec("groupBy", args) as Promise<
+      GroupByPayload<LedgerNoteTypes, T>
+    >;
+  }
+
+  static create<T extends CreateArgs<LedgerNoteTypes>>(
+    args: Subset<T, CreateArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T>> {
+    return this.$exec("create", args, options) as Promise<Payload<LedgerNoteTypes, T>>;
+  }
+
+  static update<T extends UpdateArgs<LedgerNoteTypes>>(
+    args: Subset<T, UpdateArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T>> {
+    return this.$exec("update", args, options) as Promise<Payload<LedgerNoteTypes, T>>;
+  }
+
+  static delete<T extends DeleteArgs<LedgerNoteTypes>>(
+    args: Subset<T, DeleteArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T>> {
+    return this.$exec("delete", args, options) as Promise<Payload<LedgerNoteTypes, T>>;
+  }
+
+  static upsert<T extends UpsertArgs<LedgerNoteTypes>>(
+    args: Subset<T, UpsertArgs<LedgerNoteTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerNoteTypes, T>> {
+    return this.$exec("upsert", args, options) as Promise<Payload<LedgerNoteTypes, T>>;
+  }
+
+  static createMany(
+    args?: CreateManyArgs<LedgerNoteTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: UpdateManyArgs<LedgerNoteTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: DeleteManyArgs<LedgerNoteTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
+
+  static wrap<C extends { prototype: unknown }, R extends LedgerNoteScalars>(
+    this: C,
+    row: R,
+  ): C["prototype"] & R {
+    return (Model.wrap as (row: object) => any).call(this, row);
+  }
+}
+
+export type LedgerSealScalars = {
+  id: number;
+  tenantId: number | null;
+  ledgerCode: string | null;
+  seal: string;
+};
+
+export type LedgerSealCreateScalars = {
+  id?: number;
+  tenantId?: number | null;
+  ledgerCode?: string | null;
+  seal: string;
+};
+
+export type LedgerSealRelations = {
+  ledger: { kind: "one"; nullable: true; target: LedgerTypes };
+};
+
+export type LedgerSealUnique = { id: number } | { tenantId_ledgerCode: { tenantId: number; ledgerCode: string } };
+
+export interface LedgerSealTypes extends ModelTypeInfo {
+  scalars: LedgerSealScalars;
+  relations: LedgerSealRelations;
+  unique: LedgerSealUnique;
+  create: LedgerSealCreateScalars;
+}
+
+// Merges the row's columns into the instance type, so a method on a subclass can
+// read `this.email`. No runtime output.
+//
+// oxlint flags class/interface merging because TypeScript does not check the
+// merged properties are initialised — a directly constructed instance would type
+// as carrying every column while holding none. That hazard is closed rather than
+// accepted: `Model`'s constructor is `protected`, so the only way to get an
+// instance is `wrap`, which assigns a complete row. See bin/orm/emit.ts.
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
+export interface LedgerSealModel extends LedgerSealScalars {}
+
+export type LedgerSealPolicy = ModelPolicy<
+  WhereInput<LedgerSealTypes>,
+  CreateInput<LedgerSealTypes>,
+  LedgerSealScalars
+>;
+
+// The same shape with `scope`, `onCreate` and `onUpdate` abstract, so a policy
+// that scopes cannot omit the write halves. The runtime refuses those
+// combinations too — this makes it `TS2515` at the class declaration instead of
+// an error on the first write that reaches production.
+export abstract class LedgerSealScopedPolicy extends ScopedPolicy<
+  WhereInput<LedgerSealTypes>,
+  CreateInput<LedgerSealTypes>,
+  LedgerSealScalars
+> {}
+
+export class LedgerSealModel extends Model {
+  static $schema = schema.LedgerSeal;
+
+  // Says this class came out of the generator, so `registerModels` can prefer
+  // the application's subclass over it without having to *infer* which is which.
+  // It reads own-vs-inherited, and a subclass inherits this rather than
+  // declaring it — so the mark is on exactly one class per model. See
+  // `isGeneratedBase`.
+  //
+  // `readonly` so the initialiser keeps the literal type. `Model` declares this
+  // `?: true`, and a mutable `= true` widens to `boolean` — which is not
+  // assignable to it, so every class in this file was a TS2417 until a reviewer
+  // regenerating a 79-model schema found 79 of them. `tsconfig.generated.json`
+  // is the check that now says so here rather than in an app.
+  static readonly $generated = true;
+
+  // Narrowed from `Model`'s `PolicyEntry[]` to this model's own, so a policy
+  // written for another model is a type error here rather than a scope compiled
+  // against columns that do not exist.
+  static $policies?: readonly PolicyEntry<
+    WhereInput<LedgerSealTypes>,
+    CreateInput<LedgerSealTypes>,
+    LedgerSealScalars
+  >[];
+
+  static findMany<T extends FindManyArgs<LedgerSealTypes>>(
+    args?: Subset<T, FindManyArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T>[]> {
+    return this.$exec("findMany", args, options) as Promise<Payload<LedgerSealTypes, T>[]>;
+  }
+
+  static findFirst<T extends FindFirstArgs<LedgerSealTypes>>(
+    args?: Subset<T, FindFirstArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T> | null> {
+    return this.$exec("findFirst", args, options) as Promise<Payload<LedgerSealTypes, T> | null>;
+  }
+
+  static findFirstOrThrow<T extends FindFirstOrThrowArgs<LedgerSealTypes>>(
+    args?: Subset<T, FindFirstOrThrowArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T>> {
+    return this.$exec("findFirstOrThrow", args, options) as Promise<Payload<LedgerSealTypes, T>>;
+  }
+
+  static findUnique<T extends FindUniqueArgs<LedgerSealTypes>>(
+    args: Subset<T, FindUniqueArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T> | null> {
+    return this.$exec("findUnique", args, options) as Promise<Payload<LedgerSealTypes, T> | null>;
+  }
+
+  static findUniqueOrThrow<T extends FindUniqueOrThrowArgs<LedgerSealTypes>>(
+    args: Subset<T, FindUniqueOrThrowArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T>> {
+    return this.$exec("findUniqueOrThrow", args, options) as Promise<Payload<LedgerSealTypes, T>>;
+  }
+
+  static count(args?: Omit<CountArgs<LedgerSealTypes>, "select">): Promise<number>;
+  static count<T extends CountArgs<LedgerSealTypes>>(
+    args: SelectSubset<T, CountArgs<LedgerSealTypes>> & {
+      select: NonNullable<T["select"]>;
+    },
+  ): Promise<CountPayload<T["select"]>>;
+  static count(args?: unknown): Promise<unknown> {
+    return this.$exec("count", args as never);
+  }
+
+  static aggregate<T extends AggregateArgs<LedgerSealTypes>>(
+    args: Subset<T, AggregateArgs<LedgerSealTypes>>,
+  ): Promise<AggregatePayload<LedgerSealTypes, T>> {
+    return this.$exec("aggregate", args) as Promise<
+      AggregatePayload<LedgerSealTypes, T>
+    >;
+  }
+
+  static groupBy<T extends GroupByArgs<LedgerSealTypes>>(
+    args: Subset<T, GroupByArgs<LedgerSealTypes>>,
+  ): Promise<GroupByPayload<LedgerSealTypes, T>> {
+    return this.$exec("groupBy", args) as Promise<
+      GroupByPayload<LedgerSealTypes, T>
+    >;
+  }
+
+  static create<T extends CreateArgs<LedgerSealTypes>>(
+    args: Subset<T, CreateArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T>> {
+    return this.$exec("create", args, options) as Promise<Payload<LedgerSealTypes, T>>;
+  }
+
+  static update<T extends UpdateArgs<LedgerSealTypes>>(
+    args: Subset<T, UpdateArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T>> {
+    return this.$exec("update", args, options) as Promise<Payload<LedgerSealTypes, T>>;
+  }
+
+  static delete<T extends DeleteArgs<LedgerSealTypes>>(
+    args: Subset<T, DeleteArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T>> {
+    return this.$exec("delete", args, options) as Promise<Payload<LedgerSealTypes, T>>;
+  }
+
+  static upsert<T extends UpsertArgs<LedgerSealTypes>>(
+    args: Subset<T, UpsertArgs<LedgerSealTypes>>,
+    options?: ExecOptions,
+  ): Promise<Payload<LedgerSealTypes, T>> {
+    return this.$exec("upsert", args, options) as Promise<Payload<LedgerSealTypes, T>>;
+  }
+
+  static createMany(
+    args?: CreateManyArgs<LedgerSealTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("createMany", args) as Promise<{ count: number }>;
+  }
+
+  static updateMany(
+    args?: UpdateManyArgs<LedgerSealTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("updateMany", args) as Promise<{ count: number }>;
+  }
+
+  static deleteMany(
+    args?: DeleteManyArgs<LedgerSealTypes>,
+  ): Promise<{ count: number }> {
+    return this.$exec("deleteMany", args) as Promise<{ count: number }>;
+  }
+
+  static wrap<C extends { prototype: unknown }, R extends LedgerSealScalars>(
     this: C,
     row: R,
   ): C["prototype"] & R {

--- a/templates/saas-starter/app/models/generated/schema.ts
+++ b/templates/saas-starter/app/models/generated/schema.ts
@@ -189,6 +189,24 @@ export const Ledger = {
       "from": [],
       "to": [],
       "nullable": false
+    },
+    "notes": {
+      "name": "notes",
+      "model": "LedgerNote",
+      "kind": "many",
+      "relationName": "LedgerToLedgerNote",
+      "from": [],
+      "to": [],
+      "nullable": false
+    },
+    "seal": {
+      "name": "seal",
+      "model": "LedgerSeal",
+      "kind": "one",
+      "relationName": "LedgerToLedgerSeal",
+      "from": [],
+      "to": [],
+      "nullable": true
     }
   }
 } satisfies ModelSchema;
@@ -260,6 +278,137 @@ export const LedgerEntry = {
         "code"
       ],
       "nullable": false
+    }
+  }
+} satisfies ModelSchema;
+
+export const LedgerNote = {
+  "name": "LedgerNote",
+  "table": "LedgerNote",
+  "fields": {
+    "id": {
+      "name": "id",
+      "column": "id",
+      "type": "Int",
+      "nullable": false,
+      "isId": true,
+      "isUpdatedAt": false,
+      "default": {
+        "kind": "autoincrement"
+      }
+    },
+    "tenantId": {
+      "name": "tenantId",
+      "column": "tenantId",
+      "type": "Int",
+      "nullable": true,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "ledgerCode": {
+      "name": "ledgerCode",
+      "column": "ledgerCode",
+      "type": "String",
+      "nullable": true,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "body": {
+      "name": "body",
+      "column": "body",
+      "type": "String",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    }
+  },
+  "primaryKey": [
+    "id"
+  ],
+  "uniques": [],
+  "relations": {
+    "ledger": {
+      "name": "ledger",
+      "model": "Ledger",
+      "kind": "one",
+      "relationName": "LedgerToLedgerNote",
+      "from": [
+        "tenantId",
+        "ledgerCode"
+      ],
+      "to": [
+        "tenantId",
+        "code"
+      ],
+      "nullable": true
+    }
+  }
+} satisfies ModelSchema;
+
+export const LedgerSeal = {
+  "name": "LedgerSeal",
+  "table": "LedgerSeal",
+  "fields": {
+    "id": {
+      "name": "id",
+      "column": "id",
+      "type": "Int",
+      "nullable": false,
+      "isId": true,
+      "isUpdatedAt": false,
+      "default": {
+        "kind": "autoincrement"
+      }
+    },
+    "tenantId": {
+      "name": "tenantId",
+      "column": "tenantId",
+      "type": "Int",
+      "nullable": true,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "ledgerCode": {
+      "name": "ledgerCode",
+      "column": "ledgerCode",
+      "type": "String",
+      "nullable": true,
+      "isId": false,
+      "isUpdatedAt": false
+    },
+    "seal": {
+      "name": "seal",
+      "column": "seal",
+      "type": "String",
+      "nullable": false,
+      "isId": false,
+      "isUpdatedAt": false
+    }
+  },
+  "primaryKey": [
+    "id"
+  ],
+  "uniques": [
+    [
+      "tenantId",
+      "ledgerCode"
+    ]
+  ],
+  "relations": {
+    "ledger": {
+      "name": "ledger",
+      "model": "Ledger",
+      "kind": "one",
+      "relationName": "LedgerToLedgerSeal",
+      "from": [
+        "tenantId",
+        "ledgerCode"
+      ],
+      "to": [
+        "tenantId",
+        "code"
+      ],
+      "nullable": true
     }
   }
 } satisfies ModelSchema;

--- a/templates/saas-starter/app/models/writes.differential.test.ts
+++ b/templates/saas-starter/app/models/writes.differential.test.ts
@@ -9,6 +9,10 @@ import {
 } from "./differential";
 import {
   AccountModel,
+  LedgerEntryModel,
+  LedgerModel,
+  LedgerNoteModel,
+  LedgerSealModel,
   MembershipModel,
   OrganizationModel,
   PasswordResetTokenModel,
@@ -140,6 +144,60 @@ async function seed(prisma: PrismaClient) {
   // `Profile.userId`'s unique index (P2002). Both are pinned below.
   await prisma.profile.createMany({
     data: [{ bio: "seed", userId: users[0].id }, { bio: "loose" }],
+  });
+
+  /**
+   * The composite-relation family (#271) — a relation joining on **two**
+   * fields, written through rather than read across.
+   *
+   * The tenant scoping is what makes a partial join *wrong* rather than empty,
+   * and it is arranged the same way `differential.test.ts`'s read seed is: the
+   * code `"a"` exists in both tenants, and tenant 1 also has `"ab"`, whose code
+   * has `"a"` as a prefix. So a nested write that stamped only `tenantId` would
+   * attach to two ledgers, one that stamped only `ledgerCode` would reach
+   * across tenants, and a stitch that concatenated the columns would confuse
+   * `(1, "ab")` with `(1, "a") + "b"`. Every one of those *writes rows*, which
+   * is why these are compared against Prisma rather than counted.
+   *
+   * `LedgerNote` and `LedgerSeal` carry the same two columns nullable, which is
+   * what makes `disconnect`, `set` and the displacement branches reachable at
+   * all — Prisma leaves `disconnect` out of a required relation's nested input
+   * type entirely, and `LedgerEntry.ledger` is required.
+   *
+   * The split inside each is the one `Profile` established: a row attached to
+   * `(1, "a")` and a row attached to nothing, so a miss branch is reachable and
+   * `connect` has something loose to attach. `LedgerSeal` gets the same split
+   * across two *ledgers* instead — the relation holds one row per ledger, so
+   * the second seal is what an occupied displacement has to displace.
+   */
+  await prisma.ledger.createMany({
+    data: [
+      { tenantId: 1, code: "a", title: "one-a" },
+      { tenantId: 1, code: "ab", title: "one-ab" },
+      { tenantId: 2, code: "a", title: "two-a" },
+    ],
+  });
+  await prisma.ledgerEntry.createMany({
+    data: [
+      { tenantId: 1, ledgerCode: "a", amount: 10, memo: "first" },
+      { tenantId: 1, ledgerCode: "a", amount: 20, memo: null },
+      { tenantId: 1, ledgerCode: "ab", amount: 30, memo: "ab only" },
+      { tenantId: 2, ledgerCode: "a", amount: 40, memo: "other tenant" },
+    ],
+  });
+  await prisma.ledgerNote.createMany({
+    data: [
+      { tenantId: 1, ledgerCode: "a", body: "mine" },
+      { tenantId: 1, ledgerCode: "ab", body: "sibling" },
+      { tenantId: 2, ledgerCode: "a", body: "other tenant" },
+      { body: "loose" },
+    ],
+  });
+  await prisma.ledgerSeal.createMany({
+    data: [
+      { tenantId: 1, ledgerCode: "a", seal: "mine" },
+      { tenantId: 1, ledgerCode: "ab", seal: "sibling" },
+    ],
   });
 }
 
@@ -990,6 +1048,13 @@ function suite(label: string, url?: string) {
           // listed here is not a missing convenience — it throws.
           Profile: ProfileModel as never,
           PasswordResetToken: PasswordResetTokenModel as never,
+          // The composite family (#271). Registered even where only the parent
+          // is written through, because `readTables` reads `$schema.primaryKey`
+          // off the class to order its comparison read.
+          Ledger: LedgerModel as never,
+          LedgerEntry: LedgerEntryModel as never,
+          LedgerNote: LedgerNoteModel as never,
+          LedgerSeal: LedgerSealModel as never,
         },
         seed,
         url,
@@ -1148,6 +1213,512 @@ function suite(label: string, url?: string) {
           },
           { tables: ["Post", "Tag"] },
         );
+      });
+    });
+
+    /**
+     * **Nested writes through a relation joining on two fields** (#271).
+     *
+     * This was the last entry on `docs/orm.md`'s *Not in scope* list that said
+     * *"pending"* rather than *"declined"*: every read surface correlated on
+     * every field from #67, and a nested write refused by name because it would
+     * have to contribute that many foreign-key columns to an insert.
+     *
+     * Compared against Prisma rather than asserted, and the table contents are
+     * read back on every case, because the failure mode here does not raise. A
+     * stamp that wrote `tenantId` and left `ledgerCode` alone attaches the row
+     * to *no* ledger while returning a perfectly plausible payload; a filter
+     * that conjoined only `tenantId` reaches the sibling ledger's children and
+     * updates them. Both are green tests against a client that only checks what
+     * came back.
+     *
+     * `tables` names both ends on every case for that reason: the parent's own
+     * row is rarely the interesting half.
+     */
+    describe("a composite relation", () => {
+      /** Prisma's spelling of `Ledger`'s two-column `@@id`. */
+      const ledgerKey = (tenantId: number, code: string) => ({
+        tenantId_code: { tenantId, code },
+      });
+
+      /**
+       * The **owning** side: `LedgerEntry` holds `(tenantId, ledgerCode)`, so
+       * every operand here resolves the far row and folds two columns into the
+       * entry's own statement.
+       */
+      describe("the owning side", () => {
+        test("connect by the compound key", async () => {
+          await differential.expectSameWrite(
+            "LedgerEntry",
+            "create",
+            {
+              data: { amount: 1, ledger: { connect: ledgerKey(1, "ab") } },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerEntry", "Ledger"] },
+          );
+        });
+
+        /**
+         * Connecting into the *other tenant*, which is the case a
+         * first-field-only stamp cannot distinguish from the one above: both
+         * ledgers have code `"a"`, so the row lands in tenant 1 or tenant 2
+         * depending on whether `tenantId` was written.
+         */
+        test("connect across tenants keeps both columns", async () => {
+          await differential.expectSameWrite(
+            "LedgerEntry",
+            "create",
+            {
+              data: { amount: 2, ledger: { connect: ledgerKey(2, "a") } },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerEntry", "Ledger"] },
+          );
+        });
+
+        test("connect naming no row", async () => {
+          await differential.expectSameWrite(
+            "LedgerEntry",
+            "create",
+            { data: { amount: 3, ledger: { connect: ledgerKey(9, "nope") } } },
+            { tables: ["LedgerEntry", "Ledger"] },
+          );
+        });
+
+        test("create writes the parent and binds its whole key", async () => {
+          await differential.expectSameWrite(
+            "LedgerEntry",
+            "create",
+            {
+              data: {
+                amount: 4,
+                ledger: { create: { tenantId: 3, code: "new", title: "three" } },
+              },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerEntry", "Ledger"] },
+          );
+        });
+
+        test("connectOrCreate hitting an existing ledger", async () => {
+          await differential.expectSameWrite(
+            "LedgerEntry",
+            "create",
+            {
+              data: {
+                amount: 5,
+                ledger: {
+                  connectOrCreate: {
+                    where: ledgerKey(1, "a"),
+                    // Ignored on a hit — it is connect-or-create, not upsert —
+                    // and a different title makes that observable.
+                    create: { tenantId: 1, code: "a", title: "would-be" },
+                  },
+                },
+              },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerEntry", "Ledger"] },
+          );
+        });
+
+        test("connectOrCreate missing and creating", async () => {
+          await differential.expectSameWrite(
+            "LedgerEntry",
+            "create",
+            {
+              data: {
+                amount: 6,
+                ledger: {
+                  connectOrCreate: {
+                    where: ledgerKey(4, "fresh"),
+                    create: { tenantId: 4, code: "fresh", title: "four" },
+                  },
+                },
+              },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerEntry", "Ledger"] },
+          );
+        });
+
+        /**
+         * `update` through the owning side finds the far row by *this* row's
+         * key, which the arguments do not carry — so both columns come back in
+         * the statement's `RETURNING` and both go into the child's filter.
+         * Entry 1 is in `(1, "a")`, whose sibling `(1, "ab")` must not move.
+         */
+        test("update the far row through the link", async () => {
+          await differential.expectSameWrite(
+            "LedgerEntry",
+            "update",
+            { where: { id: 1 }, data: { ledger: { update: { title: "renamed" } } } },
+            { tables: ["LedgerEntry", "Ledger"] },
+          );
+        });
+
+        test("update through the link with a filter that matches nothing", async () => {
+          await differential.expectSameWrite(
+            "LedgerEntry",
+            "update",
+            {
+              where: { id: 1 },
+              data: {
+                ledger: { update: { where: { title: "nope" }, data: { title: "x" } } },
+              },
+            },
+            { tables: ["LedgerEntry", "Ledger"] },
+          );
+        });
+
+        /**
+         * A **required** composite relation cannot be detached, and Prisma
+         * refuses it on the key rather than the value — the operand is not in
+         * the input type at all.
+         */
+        test("disconnect on the required side is refused", async () => {
+          await expect(
+            LedgerEntryModel.update({
+              where: { id: 1 },
+              data: { ledger: { disconnect: true } },
+            } as never),
+          ).rejects.toThrow(/is required/);
+        });
+
+        /** ...and on the optional one it clears both columns together. */
+        test("disconnect clears the whole key", async () => {
+          await differential.expectSameWrite(
+            "LedgerSeal",
+            "update",
+            {
+              where: { id: 1 },
+              data: { ledger: { disconnect: true } },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerSeal", "Ledger"] },
+          );
+        });
+
+        /**
+         * The filter arm: detach only if the linked row matches. Both arms are
+         * compared because a filter that correlated on one column would match
+         * the sibling ledger and detach a link the caller guarded.
+         */
+        test.each([
+          ["matching", "one-a"],
+          ["not matching", "one-ab"],
+        ])("disconnect by a filter, %s", async (_label, title) => {
+          await differential.expectSameWrite(
+            "LedgerSeal",
+            "update",
+            {
+              where: { id: 1 },
+              data: { ledger: { disconnect: { title } } },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerSeal", "Ledger"] },
+          );
+        });
+
+        /**
+         * **The composite one-to-one displaces**, and the incumbent is
+         * *orphaned* rather than deleted — the answer #360 and #363 measured
+         * over one column, asked again over two.
+         *
+         * Seal 1 holds `(1, "a")` and seal 2 holds `(1, "ab")`; pointing seal 2
+         * at `(1, "a")` collides on `@@unique([tenantId, ledgerCode])` unless
+         * seal 1 is detached first, and detaching it means nulling *both* of
+         * its columns.
+         */
+        test("connect onto an occupied composite one-to-one", async () => {
+          await differential.expectSameWrite(
+            "LedgerSeal",
+            "update",
+            {
+              where: { id: 2 },
+              data: { ledger: { connect: ledgerKey(1, "a") } },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerSeal", "Ledger"] },
+          );
+        });
+
+        /** Connecting the ledger it already holds writes nothing net. */
+        test("connect onto the ledger already held", async () => {
+          await differential.expectSameWrite(
+            "LedgerSeal",
+            "update",
+            {
+              where: { id: 1 },
+              data: { ledger: { connect: ledgerKey(1, "a") } },
+              include: { ledger: true },
+            },
+            { tables: ["LedgerSeal", "Ledger"] },
+          );
+        });
+      });
+
+      /**
+       * The **foreign** side: `Ledger` holds nothing, so every operand is an
+       * `after` step that stamps or filters by the two columns the parent's
+       * `RETURNING` supplied.
+       */
+      describe("the foreign side", () => {
+        const on = (tenantId: number, code: string) => ({
+          where: ledgerKey(tenantId, code),
+        });
+
+        test("create stamps both columns onto the new child", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: { entries: { create: [{ amount: 99 }] } },
+              include: { entries: { orderBy: { id: "asc" } } },
+            },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        test("createMany stamps them onto every row", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "ab"),
+              data: { entries: { createMany: { data: [{ amount: 1 }, { amount: 2 }] } } },
+              include: { entries: { orderBy: { id: "asc" } } },
+            },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        /**
+         * Repointing a child that belongs to the *other tenant*, which is where
+         * a half-written stamp is visible: entry 4 is in `(2, "a")`, and moving
+         * it to `(1, "ab")` has to change both of its columns.
+         */
+        test("connect repoints a child across the composite key", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "ab"),
+              data: { entries: { connect: [{ id: 4 }] } },
+              include: { entries: { orderBy: { id: "asc" } } },
+            },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        test("connectOrCreate, hit and miss", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "ab"),
+              data: {
+                entries: {
+                  connectOrCreate: [
+                    { where: { id: 4 }, create: { amount: 0 } },
+                    { where: { id: 99 }, create: { amount: 77 } },
+                  ],
+                },
+              },
+              include: { entries: { orderBy: { id: "asc" } } },
+            },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        /**
+         * The parent restriction is a conjunction rather than a spread, and
+         * over two columns that matters twice: `(1, "a")` and `(2, "a")` share
+         * a code, `(1, "a")` and `(1, "ab")` share a tenant. A filter conjoined
+         * on one of the two reaches one of those neighbours.
+         */
+        test("updateMany writes only this ledger's entries", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: { entries: { updateMany: { where: {}, data: { memo: "touched" } } } },
+            },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        test("deleteMany deletes only this ledger's entries", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            { ...on(1, "a"), data: { entries: { deleteMany: {} } } },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        test("update names a row and cannot reach another ledger's", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: { entries: { update: [{ where: { id: 1 }, data: { amount: 11 } }] } },
+            },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        /** Entry 3 belongs to `(1, "ab")`, so this is the "not connected" arm. */
+        test("update naming another ledger's row raises", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: { entries: { update: [{ where: { id: 3 }, data: { amount: 0 } }] } },
+            },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        test("delete a connected row", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            { ...on(1, "a"), data: { entries: { delete: [{ id: 1 }] } } },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        test("upsert, both branches", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: {
+                entries: {
+                  upsert: [
+                    { where: { id: 1 }, update: { amount: 111 }, create: { amount: 0 } },
+                    { where: { id: 98 }, update: { amount: 0 }, create: { amount: 222 } },
+                  ],
+                },
+              },
+              include: { entries: { orderBy: { id: "asc" } } },
+            },
+            { tables: ["Ledger", "LedgerEntry"] },
+          );
+        });
+
+        /** `set` needs the child's columns nullable, so it goes through notes. */
+        test("set replaces the whole set", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              // Note 4 is loose and note 3 belongs to the other tenant, so this
+              // detaches one, attaches two, and has to write both columns in
+              // both directions.
+              data: { notes: { set: [{ id: 3 }, { id: 4 }] } },
+              include: { notes: { orderBy: { id: "asc" } } },
+            },
+            { tables: ["Ledger", "LedgerNote"] },
+          );
+        });
+
+        test("set to nothing detaches every note", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: { notes: { set: [] } },
+              include: { notes: true },
+            },
+            { tables: ["Ledger", "LedgerNote"] },
+          );
+        });
+
+        test("disconnect nulls both columns of the named row", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: { notes: { disconnect: [{ id: 1 }] } },
+              include: { notes: true },
+            },
+            { tables: ["Ledger", "LedgerNote"] },
+          );
+        });
+
+        /**
+         * The foreign side of the composite one-to-one: creating a seal where
+         * one is linked orphans the incumbent rather than deleting it, and
+         * orphaning it means clearing both of its columns.
+         */
+        test("create onto an occupied composite one-to-one", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: { seal: { create: { seal: "second" } } },
+              include: { seal: true },
+            },
+            { tables: ["Ledger", "LedgerSeal"] },
+          );
+        });
+
+        /** ...and `connect` onto an occupied one does the same. */
+        test("connect onto an occupied composite one-to-one", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "update",
+            {
+              ...on(1, "a"),
+              data: { seal: { connect: { id: 2 } } },
+              include: { seal: true },
+            },
+            { tables: ["Ledger", "LedgerSeal"] },
+          );
+        });
+
+        /**
+         * A parent `create` reaching every operand at once, which is the shape
+         * the ordering argument is about: the parent's composite key does not
+         * exist until its own statement runs, so every stamp below depends on
+         * a `RETURNING` that has to carry both columns.
+         */
+        test("a parent create with children of every kind", async () => {
+          await differential.expectSameWrite(
+            "Ledger",
+            "create",
+            {
+              data: {
+                tenantId: 5,
+                code: "mixed",
+                title: "five",
+                entries: {
+                  create: [{ amount: 1 }],
+                  createMany: { data: [{ amount: 2 }] },
+                  connect: [{ id: 4 }],
+                },
+                notes: { create: [{ body: "fresh" }] },
+              },
+              include: {
+                entries: { orderBy: { id: "asc" } },
+                notes: { orderBy: { id: "asc" } },
+              },
+            },
+            { tables: ["Ledger", "LedgerEntry", "LedgerNote"] },
+          );
+        });
       });
     });
 

--- a/templates/saas-starter/prisma/differential.prisma
+++ b/templates/saas-starter/prisma/differential.prisma
@@ -254,6 +254,8 @@ model Ledger {
   title    String
 
   entries LedgerEntry[]
+  notes   LedgerNote[]
+  seal    LedgerSeal?
 
   @@id([tenantId, code])
 }
@@ -268,6 +270,60 @@ model LedgerEntry {
   ledger Ledger @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])
 
   @@index([tenantId, ledgerCode])
+}
+
+/// The **optional** half of the composite relation, and the reason it is a
+/// second model rather than a change to `LedgerEntry` (#271).
+///
+/// `LedgerEntry.ledger` is required, which is the ordinary tenant-scoped shape
+/// and the one the read surfaces are measured on. Prisma leaves `disconnect`
+/// out of a required relation's nested input type entirely — so every operand
+/// that *detaches* a composite link was unreachable from this schema, in the
+/// same way the foreign side of a to-one was unreachable before `Profile`
+/// (#358). `set` and `disconnect` need the columns nullable; nothing else here
+/// does.
+///
+/// Both columns are optional together, which is Prisma's rule rather than a
+/// choice: *"The fields of a relation must either all be optional or all be
+/// required"*. It is also the rule the ORM's `assertDisconnectable` and its two
+/// `displaces` predicates lean on when they test every column and expect one
+/// answer.
+model LedgerNote {
+  id         Int     @id @default(autoincrement())
+  tenantId   Int?
+  ledgerCode String?
+  body       String
+
+  ledger Ledger? @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])
+
+  @@index([tenantId, ledgerCode])
+}
+
+/// A composite **one-to-one** — the displacing shape, over two columns.
+///
+/// `Profile` is the single-field version of this (#358, #360, #361, #363), and
+/// displacement is the one branch whose discriminator reads the relation's own
+/// fields as a unique index. Over one column "the index covers exactly the
+/// relation's fields" and "the index is one column" are the same sentence, and
+/// they stop being the same sentence here.
+///
+/// The `@@unique` below covers exactly the relation, which is what Prisma
+/// requires of a one-to-one and what it *only* accepts — measured on 6.19.2,
+/// both directions: `@@unique([tenantId, ledgerCode, seal])` and
+/// `@@unique([ledgerCode, tenantId])` are each refused at parse time with
+/// P1012, *"Either add an `@@unique([tenantId, ledgerCode])` attribute to the
+/// model, or change the relation to one-to-many"*. Without a model of this
+/// shape the harness cannot ask Prisma what a composite one-to-one does with
+/// an occupied link.
+model LedgerSeal {
+  id         Int     @id @default(autoincrement())
+  tenantId   Int?
+  ledgerCode String?
+  seal       String
+
+  ledger Ledger? @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])
+
+  @@unique([tenantId, ledgerCode])
 }
 
 enum OrganizationPlan {

--- a/templates/saas-starter/prisma/migrations/20260809000000_composite_optional_and_one_to_one/migration.sql
+++ b/templates/saas-starter/prisma/migrations/20260809000000_composite_optional_and_one_to_one/migration.sql
@@ -1,0 +1,48 @@
+-- The two composite relations a nested write can *detach* through, so the
+-- differential harness can reach the operands #271 implements. `LedgerEntry`
+-- has a required composite key, and Prisma leaves `disconnect` out of a
+-- required relation's nested input type entirely — so `disconnect`, `set` and
+-- the displacement branches were unreachable from this schema in the same way
+-- the foreign side of a to-one was before `Profile`.
+--
+-- Not hand-written: verbatim what
+--
+--     prisma migrate diff --from-schema-datamodel <the schema before these> \
+--                         --to-schema-datamodel prisma/schema.prisma --script
+--
+-- emits for SQLite on prisma 6.19.2. Two details are the ones a hand-written
+-- version gets wrong, and both are load-bearing for what is being tested. The
+-- foreign key is a **two-column** constraint referencing a two-column primary
+-- key, `("tenantId", "ledgerCode") REFERENCES "Ledger" ("tenantId", "code")` —
+-- one constraint, not two. And `ON DELETE SET NULL` follows from the columns
+-- being nullable, which is exactly the property that makes a detach expressible
+-- at all.
+--
+-- `LedgerSeal`'s `@@unique` becomes a two-column unique index rather than a
+-- pair of single-column ones. That index *is* the composite one-to-one: it is
+-- what makes a second link a collision, and what `planOwningSide`'s `displaces`
+-- has to recognise as covering exactly the relation's own fields.
+
+-- CreateTable
+CREATE TABLE "LedgerNote" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "tenantId" INTEGER,
+    "ledgerCode" TEXT,
+    "body" TEXT NOT NULL,
+    CONSTRAINT "LedgerNote_tenantId_ledgerCode_fkey" FOREIGN KEY ("tenantId", "ledgerCode") REFERENCES "Ledger" ("tenantId", "code") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "LedgerSeal" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "tenantId" INTEGER,
+    "ledgerCode" TEXT,
+    "seal" TEXT NOT NULL,
+    CONSTRAINT "LedgerSeal_tenantId_ledgerCode_fkey" FOREIGN KEY ("tenantId", "ledgerCode") REFERENCES "Ledger" ("tenantId", "code") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "LedgerNote_tenantId_ledgerCode_idx" ON "LedgerNote"("tenantId", "ledgerCode");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LedgerSeal_tenantId_ledgerCode_key" ON "LedgerSeal"("tenantId", "ledgerCode");

--- a/templates/saas-starter/prisma/schema.prisma
+++ b/templates/saas-starter/prisma/schema.prisma
@@ -256,6 +256,8 @@ model Ledger {
   title    String
 
   entries LedgerEntry[]
+  notes   LedgerNote[]
+  seal    LedgerSeal?
 
   @@id([tenantId, code])
 }
@@ -270,6 +272,60 @@ model LedgerEntry {
   ledger Ledger @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])
 
   @@index([tenantId, ledgerCode])
+}
+
+/// The **optional** half of the composite relation, and the reason it is a
+/// second model rather than a change to `LedgerEntry` (#271).
+///
+/// `LedgerEntry.ledger` is required, which is the ordinary tenant-scoped shape
+/// and the one the read surfaces are measured on. Prisma leaves `disconnect`
+/// out of a required relation's nested input type entirely — so every operand
+/// that *detaches* a composite link was unreachable from this schema, in the
+/// same way the foreign side of a to-one was unreachable before `Profile`
+/// (#358). `set` and `disconnect` need the columns nullable; nothing else here
+/// does.
+///
+/// Both columns are optional together, which is Prisma's rule rather than a
+/// choice: *"The fields of a relation must either all be optional or all be
+/// required"*. It is also the rule the ORM's `assertDisconnectable` and its two
+/// `displaces` predicates lean on when they test every column and expect one
+/// answer.
+model LedgerNote {
+  id         Int     @id @default(autoincrement())
+  tenantId   Int?
+  ledgerCode String?
+  body       String
+
+  ledger Ledger? @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])
+
+  @@index([tenantId, ledgerCode])
+}
+
+/// A composite **one-to-one** — the displacing shape, over two columns.
+///
+/// `Profile` is the single-field version of this (#358, #360, #361, #363), and
+/// displacement is the one branch whose discriminator reads the relation's own
+/// fields as a unique index. Over one column "the index covers exactly the
+/// relation's fields" and "the index is one column" are the same sentence, and
+/// they stop being the same sentence here.
+///
+/// The `@@unique` below covers exactly the relation, which is what Prisma
+/// requires of a one-to-one and what it *only* accepts — measured on 6.19.2,
+/// both directions: `@@unique([tenantId, ledgerCode, seal])` and
+/// `@@unique([ledgerCode, tenantId])` are each refused at parse time with
+/// P1012, *"Either add an `@@unique([tenantId, ledgerCode])` attribute to the
+/// model, or change the relation to one-to-many"*. Without a model of this
+/// shape the harness cannot ask Prisma what a composite one-to-one does with
+/// an occupied link.
+model LedgerSeal {
+  id         Int     @id @default(autoincrement())
+  tenantId   Int?
+  ledgerCode String?
+  seal       String
+
+  ledger Ledger? @relation(fields: [tenantId, ledgerCode], references: [tenantId, code])
+
+  @@unique([tenantId, ledgerCode])
 }
 
 enum OrganizationPlan {


### PR DESCRIPTION
Closes #271

The last **pending** entry on `docs/orm.md`'s *Not in scope* list. `@relation(fields: [tenantId, orderId], references: [tenantId, id])` worked everywhere a relation is *read* — `include` under either strategy, a relation filter, `_count`, an `orderBy` through a relation, and #97's Postgres `unnest` form — and was refused wherever one is *written*. `planNestedWrites` narrowed the link through `singleFieldLink`, which raised by name rather than joining on the first field and writing plausible wrong rows.

The refusal was honest and it was the only thing left on that list. It is gone.

## What Prisma actually does, and how that was established

The template's schema grew two models (below), `prisma db push` to a throwaway SQLite file, a generated 6.19.2 client, `log: [{ emit: "event", level: "query" }]`, and the table read back after each call.

**`connect` by the compound key** — `LedgerEntry.create({ data: { amount: 1, ledger: { connect: { tenantId_code: { tenantId: 1, code: "ab" } } } } })`:

```
BEGIN IMMEDIATE
select Ledger.tenantId, Ledger.code    where tenantId = ? and code = ?     [1, "ab"]
insert into LedgerEntry (tenantId, ledgerCode, amount) values (?,?,?)      [1, "ab", 1]
select the row back
COMMIT
```

**`connect` onto an occupied composite one-to-one** — seal 2 holds `(1, "ab")`, seal 1 holds `(1, "a")`, and seal 2 is pointed at `(1, "a")`:

```
BEGIN IMMEDIATE
select Ledger.tenantId, Ledger.code                    resolve the operand
select LedgerSeal.* where id = 2                       the row being written
select Ledger.*     where (tenantId, code) in ((1,"ab"))   what it holds now
select LedgerSeal.id, tenantId, ledgerCode
       where (tenantId, ledgerCode) in ((1,"a"))       the incumbent
update LedgerSeal set tenantId = ?, ledgerCode = ? where id in (1)   [null, null]
update LedgerSeal set tenantId = ?, ledgerCode = ? where id in (2)   [1, "a"]
COMMIT
```

…and the table afterwards:

```
{ id: 1, tenantId: null, ledgerCode: null, seal: "mine"    }   orphaned, not deleted
{ id: 2, tenantId: 1,    ledgerCode: "a",  seal: "sibling" }
```

**Foreign-side `create` onto an occupied one** is the same shape from the other end: the incumbent's `UPDATE` sets **both** columns to null, then the new row is inserted with both set.

Three things follow, and each is a decision in the diff:

| measured | decision |
| --- | --- |
| Prisma issues the resolving `select` for a compound `connect` | the composite `connect` takes the lookup; the zero-query shortcut stays single-field and parity is unchanged |
| the detach writes `set tenantId = null, ledgerCode = null` | `clearLinks` nulls **every** column, and names all of them as ORM-authored for #98 |
| `@@unique([tenantId, ledgerCode, seal])` and `@@unique([ledgerCode, tenantId])` are each **P1012** — *"Either add an `@@unique([tenantId, ledgerCode])` attribute to the model, or change the relation to one-to-many"* | `displaces` requires an index covering **exactly** the relation's fields |

## The diff

`planOne` resolves the full `Link` and no longer narrows. Both planners take it, and forty hand-spelled `{ [childField]: parent[parentField] }` / `select: { [childField]: true }` literals become four helpers:

```
childLink(link, row)   { <childField>: row[<parentField>], … }
keySelect(fields)      { <field>: true, … }
nullKey(fields)        { <field>: null, … }
isLinked(values)       whether the tuple names a row at all
```

Generalising each of the forty separately is how a composite relation ends up correlating on every field in nine operands and on the first field in the tenth — a silent wrong write, which is precisely what the refusal was protecting against. One function per shape means the count of fields is invisible to the callers, and there is no single-field spelling left for a new operand to copy.

`childLink` serves both sides with the same arithmetic. On the foreign side it reads as *"belonging to this parent"*; on the owning side `link.parentFields` are this row's foreign key and `link.childFields` are what they reference, so the identical call yields the far row's own columns.

**`singleFieldLink` survives with exactly one caller**: the implicit many-to-many join table. Prisma builds that from the two models' *primary keys*, one column each side, into a table with no schema — so "one field" there is an invariant of the shape rather than a limit of this compiler, and the function states it rather than letting `planJoinTable` index into `[0]` with nothing checking it. Its message and docblock say that now instead of announcing a gap.

### A null column means "not linked"

`(tenantId, orderId) = (1, NULL)` is `UNKNOWN`, so a partial key joins to no row. Every place that used to test one value for null — *is anything linked here* — goes through `isLinked`:

- `displaceSibling` returns (the composite generalisation of the `value === null` return it already had);
- `clearLinks` refuses to run, because `where: { tenantId: 1, orderId: null }` matches every *unlinked* row in the tenant and the `updateMany` behind it would write null over null across all of them;
- the owning side's `update` reports the row missing rather than filtering on the half that is set;
- `disconnect`'s filter arm treats it as nothing-linked, which is silent, as Prisma is.

Nothing reaches `clearLinks` with a null today, so that one buys no behaviour; it means a caller that one day does cannot silently rewrite the table.

### The two `displaces` predicates

Both generalise, and neither changes shape. The foreign side already read `relation.kind` and now requires **every** child column nullable. The owning side (#363) still takes both halves — the far side's `kind` *and* the index — and the index test moves from `unique.length === 1 && unique[0] === fkField` to set equality against the relation's fields.

Written as set equality even though Prisma requires the order to match (measured above), because the length check is what carries the weight and a positional loop would read as though order were a thing this had decided.

### Where a partial write could live

The owning side folds its columns into the caller's own `INSERT`/`UPDATE` — `contributions` is keyed by field and `insertColumns`/`updateAssignments` fold every entry into one statement — so "some keys written, some not" is not a state it can reach. The hazard is real on the **foreign** side, where each linked row is its own statement; `$exec` opens a transaction for any plan carrying steps, which is the same guarantee that already covers a `connect` of three rows where the third does not exist.

### `assertDisconnectable`

Takes the whole key and names the first required column. Prisma refuses a mixture of optional and required relation fields, so on a schema it accepted the columns agree and any one of them answers — checking all of them costs nothing and means the refusal does not depend on a rule enforced in another program.

## The template

`LedgerEntry.ledger` is **required**, which is the ordinary tenant-scoped shape and the one #67's read surfaces are measured on. Prisma leaves `disconnect` out of a required relation's nested input type entirely, so every operand that *detaches* a composite link was unreachable from this schema — the same "the harness cannot get there" problem `Profile` fixed one shape down (#358).

So two models, and a migration that is verbatim `prisma migrate diff` output:

- **`LedgerNote`** — the same two columns, nullable. Reaches `set` and `disconnect`.
- **`LedgerSeal`** — those columns plus `@@unique([tenantId, ledgerCode])` beside a non-list back-relation, which is the composite one-to-one. Reaches displacement on both sides.

`differential.ts`'s SQLite `clearAll` did not clear the Ledger tables at all — present in the Postgres `TABLES` list, absent from the `deleteMany` branch. That cost nothing while the only composite cases were reads against a temp database that is fresh per file; a write comparison resets *between* the two runs, so it had to be fixed before any of this could pass.

## Tests

**Compile level** (`composite-relations.test.ts`, +26 cases). Nested writes have no SQL to assert for a link, so the planned steps are driven with a recording `RelationExecutor` and the arguments they hand the child's own operations are what is checked. Covers all four shapes: owning/required, owning/one-to-one, foreign/to-many, foreign/optional.

Mutation-checked rather than assumed — each helper crippled to its first field in turn:

| mutation | compile suite | differential suite |
| --- | --- | --- |
| `childLink` first field only | 10 failed | 14 failed |
| `keySelect` first field only | 3 failed | — |
| `nullKey` first field only | 4 failed | — |
| owning-side contributions, first field only | — | 8 failed |

**Differential** (`writes.differential.test.ts`, +30 cases, both dialects). The failure mode here does not raise: a stamp that wrote `tenantId` and left `ledgerCode` alone attaches the row to *no* ledger while returning a plausible payload, and a filter conjoined on one column reaches the sibling ledger's children. Both are green against a client that only checks what came back, which is why every case names both tables and reads them back.

The seed is arranged so a partial join is *wrong* rather than empty: code `"a"` exists in two tenants, tenant 1 also has `"ab"` (so a concatenating stitch confuses `(1,"ab")` with `(1,"a")+"b"`), and each child model has a row attached elsewhere and a row attached to nothing.

`composite-surfaces.test.ts`'s *"a nested write is still refused, by name"* said *"when this starts compiling, this test fails — which is the prompt to move the entry again"*. It compiled; the entry moved; the test now asserts that the parent statement returns **both** key columns and hides both — return one and the repoint writes half a key, which is the first-field join one layer down.

## Verification

- `packages/gemi`: typecheck, `tsc -p tsconfig.generated.json`, 3128 tests, `oxlint orm --deny-warnings` at zero.
- `templates/saas-starter`, SQLite: 822 tests, `test:types`, `gemi check models` (16 registered).
- `templates/saas-starter`, **Postgres 16** in a container, following the CI job exactly — provider flipped, schema re-derived, client regenerated, `db push` — `vitest run app/models --no-file-parallelism -t postgres`: 803 passed, all 30 composite cases among them.

## Not done here

`upsert` on the *owning* side is still refused by name, on both single-field and composite relations, for the reason it always was: an absent far row would have to be created and then written back to a row that has already been inserted. Unchanged and unrelated to the key's width.


---

## Review round 1

**Two relations that share a foreign-key column are now refused by name.** A composite relation joins on *n* columns and nothing stops two of them from sharing one — `prisma validate` accepts `ledger Ledger @relation(fields: [tenantId, ledgerCode], …)` beside `note Ledger @relation(fields: [tenantId, noteCode], …)` on 6.19.2. Before this PR both were refused for their width, so writing through both at once was unreachable; it is reachable now, and both contribute a `tenantId`. `insertColumns` folds contributions through a `Map` keyed by field and `planNestedWrites` sorts its relation keys, so the alphabetically-last relation decided the shared column. Prisma resolves the operands in the opposite direction and lets the *first resolved* win, so the caller's **last** `data` key decides it — a different `Ledger`, no error either side.

Reproducing that means giving up the sorted key order, which the plan cache needs (two argument objects differing only in key order have to be one plan). So `planNestedWrites` records which relation contributed each column and refuses the second, which is what the width refusal was buying: no plausible wrong row.

**The three "every column is nullable" predicates are pinned.** `planOwningSide`'s `displaces`, `planForeignSide`'s `displaces` and `assertDisconnectable` all stayed green when crippled to `fields[0]`, because Prisma makes a composite relation optional or required as a whole and no schema it validates distinguishes them. `ledgerSealMixed` is the hand-built `ModelSchema` that does — `tenantId` nullable, `ledgerCode` required, the nullable one deliberately first — and each of the three goes red under its own mutation now.

**`docs/orm.md`'s operand list was wider than the code.** The owning side refuses `createMany`, `set`, `delete`, `upsert` and the two `*Many` by name, unchanged by this PR, so the paragraph names the two sides separately rather than claiming "both sides" of a single list. The shared-column refusal is documented as a fourth bullet. Also fixed in passing, and pre-existing: *"Both of the last two throw `UnsupportedByDesignError`"* now names `distinct` and `cursor`, which is what `PERMANENTLY_REFUSED` actually holds.

Verification, on top of the above: `packages/gemi` typecheck clean, **3135 passed** / 1 skipped over 120 files, `oxlint orm --deny-warnings` 0/0; template SQLite **822 passed** / 133 skipped, `test:types` 116 with no type errors; both `prisma generate` runs leave `git status` clean. Each new test mutation-checked — the guard disabled fails 2, and the three nullability narrowings fail 1 each.
