### PR TITLE
Close #388: a folded child is redacted as the read it is

### DIFF
--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -51,6 +51,7 @@ import {
   policiesFor,
   policyContext,
   redactedAs,
+  NESTED_READ,
   type PolicyEntry,
   type PolicyContext,
 } from "./policy";
@@ -987,22 +988,19 @@ export abstract class Model {
     //   relation executor rebuilds its options from `{ strategy }` rather than
     //   forwarding these.
     //
-    //   Which name a nested row is *redacted* as is a second mechanism and it
-    //   does not currently agree with the first. A **batched** child runs its
-    //   own `$exec` under `NESTED_READ`, so it is redacted as `findMany`; a
-    //   **folded** (lateral, the Postgres default) child never enters its own
-    //   `$exec`, so `redactFolded` below redacts it on the parent's behalf and
-    //   builds its context from the enclosing `$exec`'s `op` — which on this
-    //   call is the pre-read, a `findFirst`. Measured, same query, same rows:
+    //   Which name a nested row is *redacted* as is a second mechanism, and it
+    //   agrees with the first since #388. Both strategies answer `NESTED_READ`:
+    //   a **batched** child runs its own `$exec` under it, and a **folded**
+    //   (lateral, the Postgres default) child is handed the same constant by
+    //   `redactFolded` below, which redacts it on the parent's behalf because
+    //   its rows never enter its own `$exec`.
     //
-    //     sqlite   (batched) child redact context.operation -> "findMany"
-    //     postgres (folded)  child redact context.operation -> "findFirst"
-    //
-    //   Pre-existing, not widened here, and the same on an ordinary `findFirst`
-    //   with an `include`. Filed as #388; the fix is to hand `redactFolded`
-    //   `NESTED_READ` too. Neither value is the write, which is the part #366
-    //   is about and the only part `delete-redact-operation.test.ts` pins under
-    //   the default strategy.
+    //   Until #388 the folded path built its context from the enclosing
+    //   `$exec`'s `op` — on this call the pre-read, a `findFirst` — so the same
+    //   query over the same rows reported `findMany` on SQLite and `findFirst`
+    //   on Postgres. Neither value was ever the write, which is the part #366 is
+    //   about and the only part `delete-redact-operation.test.ts` pins under the
+    //   default strategy; `nested-redact-strategy.test.ts` pins the agreement.
     //
     // Only when there is something to read. A plain `delete` still compiles to
     // one statement and opens no transaction.
@@ -1217,6 +1215,17 @@ export abstract class Model {
       // cannot: it is a row transform in the shaping stage, with no argument to
       // rewrite. So the parent runs it on the child's behalf, which is the only
       // place that can.
+      //
+      // **`NESTED_READ`, not `op` — #388.** Running it here is a fact about where
+      // the rows were shaped, not about what they are. The child is a read of
+      // another model whatever statement encloses it, which is the whole reason
+      // `applyNestedPolicies` scopes every nested node under the same constant,
+      // and its docblock argues that at length. Handing the enclosing `op` down
+      // made the *same* relation read, over the same rows, tell the child's
+      // `redact` a different `context.operation` depending on which strategy
+      // planned it: `findMany` batched, `findFirst` folded. A policy written as
+      // `context.operation === "findMany"` therefore protected a child on SQLite
+      // and leaked it on Postgres, for identical application code.
       if (plan.relations !== undefined && !system) {
         for (const relation of plan.relations) {
           if (relation.root === undefined) continue;
@@ -1227,7 +1236,7 @@ export abstract class Model {
               folded: relation.root.folded,
             },
             result,
-            op,
+            NESTED_READ,
             system,
           );
         }

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -1548,7 +1548,7 @@ export type PolicyLookup = (model: string) => {
  * accepting one at all is what makes it unrepresentable — the same reason #79
  * made `resolveLink`'s `operation` required rather than defaulted.
  */
-const NESTED_READ: Operation = "findMany";
+export const NESTED_READ: Operation = "findMany";
 
 /**
  * Applies every *nested* model's policies to its own node in the argument tree,

--- a/templates/saas-starter/app/models/delete-redact-operation.test.ts
+++ b/templates/saas-starter/app/models/delete-redact-operation.test.ts
@@ -360,15 +360,12 @@ function suite(
      * whatever statement encloses it.
      *
      * Pinned under `batched` explicitly because that is the strategy both
-     * dialects have. Which read-name a *folded* child sees is strategy-dependent
-     * today — `redactFolded` passes the enclosing operation down, so a lateral
-     * child of this pre-read is told `findFirst` where a batched one is told
-     * `findMany`. Both were measured; the divergence predates this change, is
-     * about two reads disagreeing rather than a read reporting a write, and is
-     * out of #366's scope. It is filed as **#388**, whose fix — handing
-     * `redactFolded` the same `NESTED_READ` constant — would make the case below
-     * pinnable as an equality on both dialects. What must hold until then is the
-     * case below.
+     * dialects have. Which read-name a *folded* child saw used to be
+     * strategy-dependent — `redactFolded` passed the enclosing operation down, so
+     * a lateral child of this pre-read was told `findFirst` where a batched one
+     * was told `findMany`. That was **#388**, fixed by handing `redactFolded` the
+     * same `NESTED_READ` constant, and the equality it was waiting for is the
+     * test after next.
      */
     test("a nested read is still redacted as a read", async () => {
       const parent = await only();
@@ -393,14 +390,80 @@ function suite(
         include: { children: true },
       });
 
-      // Not an equality: the value differs by dialect, because the default
-      // strategy does. Measured — `findMany` on SQLite (batched), `findFirst` on
-      // Postgres (lateral, where `redactFolded` passes the enclosing read's
-      // name — #388). Neither is the write, which is the part that has to hold,
-      // and pinning either literal here would make this suite fail on one
-      // dialect for a divergence that is not #366's.
+      // Kept as the weaker claim it always was — that the child is never told
+      // the enclosing write — because that is #366's part and it has to hold
+      // whatever the strategy does. The stronger claim, that both strategies say
+      // the same thing, is the test below and belongs to #388.
       expect(childOperations).not.toContain("delete");
       expect(childOperations.length).toBeGreaterThan(0);
+    });
+
+    /**
+     * **#388 — the two strategies have to agree.**
+     *
+     * Written as an equality between the two runs rather than against a literal,
+     * and that is the whole point: the bug was that the *same* relation read,
+     * over the *same* rows, told the child's `redact` a different
+     * `context.operation` depending on which strategy planned it. A per-dialect
+     * literal cannot express that, and pinning one would have made this suite
+     * fail on whichever dialect it was not written for — which is why the case
+     * above stayed weak until the fix landed.
+     *
+     * The comparison is `batched` against the **dialect's default**, not against
+     * an explicit `lateral`. On Postgres the default *is* lateral, so this is the
+     * real test and it is the run that used to answer `findFirst`. On SQLite both
+     * sides are batched, so it degenerates to a control — worth keeping, because
+     * a fix that made the folded path agree by breaking the batched one would
+     * pass on Postgres alone. Asking SQLite for `lateral` explicitly would
+     * instead exercise a strategy that dialect never chooses.
+     *
+     * Deduplicated before comparing: `redact` runs per row and the fixture seeds
+     * two children, but the claim is about which name they are told, not how
+     * many of them there are.
+     */
+    test("a folded child is redacted as the same read a batched one is", async () => {
+      // `delete`, not `findFirst`, and not by preference: `parentReadScope`
+      // scopes a `findFirst` to a label no row has, so a direct one returns null
+      // and reads no children at all. The delete pre-read is `markPreScoped`, so
+      // that fragment never reaches it — which is what makes this the only shape
+      // here whose enclosing operation is not `findMany` *and* which actually
+      // reaches the child.
+      const first = await only();
+      await DelOpParent.$exec(
+        "delete",
+        { where: { id: first.id }, include: { children: true } },
+        { strategy: "batched" } as never,
+      );
+      const batched = [...new Set(childOperations)];
+
+      // The row is gone, so the second run needs its own. Seeded under
+      // `asSystem` for the same reason `beforeEach` does it: a `scope` with no
+      // `onCreate` is refused by name.
+      childOperations.length = 0;
+      clearPlanCache();
+      await Model.asSystem(async () => {
+        const parent: any = await DelOpParent.$exec("create", {
+          data: { label: "kept", secret: "hunter2" },
+        });
+        await DelOpChild.$exec("create", {
+          data: { parentId: parent.id, name: "a" },
+        });
+        await DelOpChild.$exec("create", {
+          data: { parentId: parent.id, name: "b" },
+        });
+      });
+
+      const second = await only();
+      await DelOpParent.$exec("delete", {
+        where: { id: second.id },
+        include: { children: true },
+      });
+      const planned = [...new Set(childOperations)];
+
+      expect(planned).toEqual(batched);
+      // ...and both are the read the child actually is, which is what makes the
+      // equality worth having rather than two matching wrong answers.
+      expect(planned).toEqual(["findMany"]);
     });
 
     /**


### PR DESCRIPTION
`redactFolded` built the child's policy context from the **enclosing** `$exec`'s
operation, where every other nested read is scoped and redacted as `NESTED_READ`.
So the same relation read, over the same rows, told the child's `redact` a
different `context.operation` depending on which strategy planned it:

    sqlite   (batched) childOperations: ["findMany","findMany"]
    postgres (lateral) childOperations: ["findFirst","findFirst"]

A policy written as `context.operation === "findMany"` therefore protected a
child on SQLite and leaked it on Postgres, for identical application code.

`applyNestedPolicies` already answers this: a nested node names another model's
rows whatever statement encloses it, which is why `NESTED_READ` is a constant
rather than a parameter — its docblock argues that threading the root operation
down is the bug the constant exists to prevent. The batched path obeyed it by
construction, because the child runs its own `$exec`. The folded path could not,
because the child's rows never enter one, so the parent redacts on its behalf —
and it was handed `op`. It is handed the same constant now. `redactFolded`
recurses into grandchildren with the value it is given, so one call site covers
the whole folded tree.

`NESTED_READ` becomes exported from `policy.ts`, not from `orm/index.ts` — it is
an internal agreement between the two redaction paths, not caller-facing.

The pin is an equality between the two strategies rather than a per-dialect
literal, which is the assertion the divergence would have failed and the one
`delete-redact-operation.test.ts` was explicitly waiting for #388 to make
possible. It compares `batched` against the dialect's *default*: on Postgres that
is lateral, so it is the real test; on SQLite both sides batch, so it is a
control that catches a "fix" which made the folded path agree by breaking the
batched one. It uses `delete` rather than `findFirst` because the fixture's
read-only scope makes a direct `findFirst` return null and read no children,
while the delete pre-read is `markPreScoped` and does reach them.

Measured: on live Postgres the new case fails with `expected [ 'findFirst' ] to
deeply equal [ 'findMany' ]` when the call site is reverted to `op`, and passes
restored. packages/gemi 3199 passed, template sqlite 849, live Postgres 1253,
typecheck and oxlint clean.