### PR TITLE
Application commands and `gemi run`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,39 @@ jobs:
         env:
           TZ: UTC
 
+      # `gemi run`, against the one real project in this repository.
+      #
+      # `console/runner.test.ts` covers the runner over fixture projects, so what
+      # is left is what a fixture cannot do. Its command files import
+      # `defineCommand` by absolute path, which makes the class identity hold by
+      # construction; a real project imports it from its *installed* gemi, while
+      # the CLI runs from `dist/bin/gemi.js` with a bundled copy of its own.
+      # Discovery decides what is a command by walking the prototype chain, so
+      # if `gemi run` ever stops spawning a process and resolving the runner out
+      # of the app's own `node_modules`, every command in every project becomes
+      # invisible — and every unit test still passes.
+      #
+      # The template ships no commands, so this asserts the empty-directory
+      # listing: enough to prove the spawn, both preloads, the app's Kernel and
+      # the config slice all lined up. Add a command to `app/commands/` here and
+      # this becomes an end-to-end assertion.
+      #
+      # `timeout 60` because the second failure this covers is a command that
+      # finishes its work and then sits there — an open database pool, a Redis
+      # client or a cron handle holding the loop open. Without the bound that is
+      # a six-hour job rather than a red step.
+      - name: Run the console command runner
+        run: |
+          output=$(timeout 60 bunx gemi run)
+          echo "$output"
+          echo "$output" | grep -q 'app/commands'
+          if timeout 60 bunx gemi run no-such-command; then
+            echo "expected a non-zero exit for an unknown command"; exit 1
+          fi
+        working-directory: templates/saas-starter
+        env:
+          TZ: UTC
+
       # `.test-d.ts` files do not match vitest's default `include`, so the step
       # above collects none of them: 15 type assertions in `wrap.test-d.ts` and
       # `aggregate.test-d.ts` ran nowhere, locally or here. They are the only

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Email](./email.md)** — the `Email` class, jsx-email templates, the Resend driver, localization and scheduling.
 - **[Jobs & Queues](./jobs-and-queues.md)** — defining and dispatching background `Job`s.
 - **[Cron](./cron.md)** — scheduling recurring `CronJob`s.
+- **[Commands](./commands.md)** — one-off application commands run with `gemi run`.
 - **[Broadcasting](./broadcasting.md)** — websocket channels, the `Broadcast` facade, `useSubscription` / `useBroadcast`.
 - **[Internationalization](./i18n.md)** — component-scoped dictionaries, `useTranslator`, `useLocale`, locale detection.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ bun run build
 bun run start
 ```
 
-> **Note:** Apart from `gemi migrate --dry-run` and `gemi check models`, the commands take no flags or options — each is a bare subcommand. gemi discovers your project from the current working directory (it expects `app/` and, for tooling commands, `app/kernel/Kernel.ts`).
+> **Note:** Apart from `gemi run`, `gemi migrate --dry-run` and `gemi check models`, the commands take no flags or options — each is a bare subcommand. gemi discovers your project from the current working directory (it expects `app/` and, for tooling commands, `app/kernel/Kernel.ts`).
 
 ## `gemi dev`
 
@@ -58,6 +58,26 @@ gemi start
 It launches `dist/server/server.mjs` in a fresh Bun process with `NODE_ENV=production`, registering the same runtime preloads as `dev` (`gemi/bun/preload`, then `app/preload.ts` if present). The fresh process is required so Bun starts with the production JSX runtime and production React DOM export conditions.
 
 > **Gotcha:** `start` requires a completed [`gemi build`](#gemi-build) — it does not build for you. In deployments you'll typically run migrations first, e.g. `bunx prisma migrate deploy && gemi start`.
+
+## `gemi run`
+
+Runs one of your application's [commands](./commands.md) — a seeder, a backfill, a report — inside your booted app.
+
+```bash
+gemi run                                    # list every command
+gemi run backfill-avatars 2024-01-01 --dry-run
+gemi run backfill-avatars --help            # that command's usage
+```
+
+Commands are the classes under `app/commands/`, written as `defineCommand(...)` chains. `gemi run` with no name lists them; an unrecognised name prints a suggestion and the list and exits `1`. The handler's return value is the exit code — see [Commands](./commands.md#exit-codes) for the full table.
+
+Like `dev` and `start`, it launches a fresh Bun process with the same two runtime preloads (`gemi/bun/preload`, then `app/preload.ts` if present) and boots the application fully, so a command reaches models, facades and the container exactly as a request handler does.
+
+> **Gotcha:** everything after the command's name belongs to the command. `gemi run send-digest --queue` forwards `--queue` untouched rather than treating it as a `gemi run` option, and `gemi run send-digest --help` prints the command's usage — `gemi run --help`, with no name, is the one that describes `gemi run` itself. Use `--` (`gemi run x -- --weird`) if a tail ever needs escaping; it is never required.
+
+> **Gotcha:** the cron scheduler does not start under `gemi run`, so a long-running command cannot fire your whole schedule in a process nobody is watching. Jobs are still discovered and `app(Scheduler).jobs` still answers honestly. The command sets `GEMI_NO_SCHEDULE=1` on the process it spawns, which also works as a general "boot this app but do not schedule anything" switch.
+
+> **Gotcha:** `NODE_ENV` is inherited rather than forced, unlike `dev` (development) and `start` (production), which each are one mode by definition. Run `NODE_ENV=production gemi run <name>` for production semantics.
 
 ## `gemi migrate`
 
@@ -152,6 +172,7 @@ Like `app:component-tree`, it loads the app from the kernel and prints the resol
 
 ## Related
 
+- [Commands](./commands.md) — writing the application commands `gemi run` runs.
 - [Getting Started](./getting-started.md) — installing gemi and running your first commands.
 - [Configuration](./configuration.md) — `.env`, `preload.ts`, and `gemi.config.ts` that these commands consume.
 - [Project Structure & the Kernel](./project-structure.md) — `server.ts`, the kernel, and how the app boots.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,296 @@
+# Commands
+
+Commands are one-off pieces of application code you run by hand: a seeder, a backfill, a tenant repair, a report. You define each one as a `defineCommand(...)` chain (from `gemi/services`) in a file under `app/commands/`, and run it with `gemi run <name>`. The command runs inside your booted application, so it reaches models, facades, mail and everything else exactly as a request handler does.
+
+```bash
+gemi run backfill-avatars 2024-01-01 --dry-run
+```
+
+## Defining a command
+
+A command needs a name and a handler. Everything between them is optional.
+
+```typescript
+// app/commands/BackfillAvatars.ts
+import { defineCommand } from "gemi/services";
+import { User } from "@/app/models/User";
+
+export default defineCommand("backfill-avatars")
+  .describe("Regenerate avatar URLs for users created before the CDN move")
+  .arg("since", { required: true, description: "ISO date to backfill from" })
+  .option("dryRun", {
+    type: "boolean",
+    description: "Print the plan, write nothing",
+  })
+  .option("limit", {
+    type: "number",
+    default: 500,
+    description: "Stop after N users",
+  })
+  .handle(async ({ args, options, line }) => {
+    const users = await User.findMany({
+      where: { createdAt: { gte: args.since } },
+      take: options.limit,
+    });
+
+    line(`${users.length} users to backfill`);
+    if (options.dryRun) return;
+
+    // ...do the work...
+  });
+```
+
+That file is the whole registration — there is no list to add it to. **Registering commands**, below, covers how the directory is read and how to take registration over yourself.
+
+`args.since` is a `string`, `options.limit` is a `number`, and `options.dryRun` is a `boolean` — inferred from the chain, with nothing written by hand.
+
+### Why it is a chain and not a class
+
+Every other extension point in gemi is a class: `Job`, `CronJob`, `Controller`, `Middleware`. A command is not, and the reason is that a class cannot type its own handler.
+
+TypeScript does not contextually type an overriding method's parameters from the base-class method it overrides. So a class declaring its schema as statics gets nothing from it:
+
+```typescript
+// the shape this replaces — it does not type-check
+class BackfillAvatars extends Command {
+  static args = [{ name: "since", required: true }];
+
+  async run(ctx) {} // implicit any — `ctx.args.since` is unchecked
+}
+```
+
+The only way out of that is to restate the type by hand in every command, which is the ceremony the schema was supposed to remove — and which nothing enforces, so a wrong restatement compiles. A **function expression passed as an argument** _is_ contextually typed, which is why `.handle(fn)` is the shape.
+
+`.handle()` returns a `Command` subclass, so nothing else changes: discovery finds it by walking the prototype chain, exactly as it finds a `Job` or a `CronJob`. You can subclass `Command` by hand if you need to, and you give up the typing when you do.
+
+## Arguments — `.arg()`
+
+Positional values, in the order they are declared and the order they are typed.
+
+```typescript
+.arg("tenant", { required: true })
+.arg("environment", { default: "staging" })
+.arg("extra", { variadic: true })
+```
+
+| Key           | Type      | Description                                                 |
+| ------------- | --------- | ----------------------------------------------------------- |
+| `description` | `string`  | Shown in `--help`.                                          |
+| `required`    | `boolean` | Omitting it is a usage error rather than an `undefined`.    |
+| `default`     | `string`  | Supplied when the argument is absent.                       |
+| `variadic`    | `boolean` | Collects every remaining positional. Must be declared last. |
+
+What each combination gives the handler:
+
+| Declaration                     | Type in `args`                      |
+| ------------------------------- | ----------------------------------- |
+| `.arg("x")`                     | `string \| undefined`               |
+| `.arg("x", { required: true })` | `string`                            |
+| `.arg("x", { default: "…" })`   | `string`                            |
+| `.arg("x", { variadic: true })` | `string[]` — `[]` when it took none |
+
+`required` and `default` together are refused: an argument that is supplied when absent cannot also be absent. So is anything declared after a variadic argument, which would collect everything and leave the one after it permanently empty.
+
+## Options — `.option()`
+
+Flags. Declared in camelCase and typed on the command line in kebab-case, so `.option("dryRun", …)` is `--dry-run` for whoever runs it and `options.dryRun` in the handler.
+
+```typescript
+.option("dryRun", { type: "boolean" })
+.option("limit", { type: "number", default: 500 })
+.option("tag", { type: "string", alias: "t", required: true })
+```
+
+| Key           | Type                                | Description                                                          |
+| ------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| `type`        | `"boolean" \| "string" \| "number"` | Required. Decides how the value is parsed and what the handler sees. |
+| `description` | `string`                            | Shown in `--help`.                                                   |
+| `alias`       | `string`                            | A single character, without the dash: `-t`.                          |
+| `default`     | matching `type`                     | Applied only when the flag is absent, never over a supplied value.   |
+| `required`    | `boolean`                           | Omitting it is a usage error. Not available on booleans.             |
+
+`type` is required rather than defaulting to `"string"` because a `--dry-run` declared without one would arrive as the empty string, and every `if (options.dryRun)` over it would be wrong in the one direction nobody tests.
+
+A `number` option that is not a number is a usage error, not a `NaN` in your handler:
+
+```
+$ gemi run backfill-avatars 2024-01-01 --limit abc
+Option --limit expects a number, but got "abc".
+```
+
+All the usual spellings work: `--limit 5`, `--limit=5`, `-l 5`, `-l5`, `-l=5`, and clustered flags like `-dl 5`. A boolean can be turned off with `--no-dry-run`. Everything after a bare `--` is positional, however it is spelled — the escape hatch for an argument that looks like a flag.
+
+## The handler
+
+`.handle(fn)` receives one argument holding everything the command has.
+
+| Member                 | Type                                        | Description                                                     |
+| ---------------------- | ------------------------------------------- | --------------------------------------------------------------- |
+| `args`                 | inferred                                    | The positional arguments, by the names `.arg()` declared.       |
+| `options`              | inferred                                    | The flags, by the names `.option()` declared.                   |
+| `argv`                 | `readonly string[]`                         | Everything after the command name, unparsed.                    |
+| `line(message?)`       | `(message?: string) => void`                | The command's answer, on **stdout**.                            |
+| `error(message)`       | `(message: string) => void`                 | A diagnostic, on **stderr**. Does not end the command.          |
+| `fail(message, code?)` | `(message: string, code?: number) => never` | Ends the command with a message and an exit code, and no stack. |
+
+The `line`/`error` split is the one thing worth being deliberate about. A diagnostic printed to stdout is what breaks `TOTAL=$(gemi run count-users)` and what makes a CI grep match a progress line instead of the answer — and it stays invisible until somebody pipes the command somewhere.
+
+There is no `info`, `success`, `warn`, table or progress bar. Colour is your application's business, and a console formatting library is a project rather than a feature.
+
+### Exit codes
+
+| The handler                  | Exit code                                                   |
+| ---------------------------- | ----------------------------------------------------------- |
+| returns nothing              | `0`                                                         |
+| returns an integer `0`–`255` | that number                                                 |
+| returns anything else        | `1`, and says the value was not an exit code                |
+| calls `fail(message, code)`  | `code` (default `1`), with `message` on stderr and no stack |
+| throws                       | `1`, with the stack                                         |
+
+Returning something that is not an exit code is reported rather than coerced. `return users.length` is an easy thing to write, and coercing it would turn 300 backfilled users into exit status 44 — which reads as a failure to everything downstream, for a command that succeeded.
+
+```typescript
+export default defineCommand("verify-invoices").handle(
+  async ({ line, fail }) => {
+    const broken = await findBrokenInvoices();
+
+    if (broken.length > 0) {
+      fail(`${broken.length} invoices failed verification`, 2);
+    }
+
+    line("all invoices verified");
+  },
+);
+```
+
+## Running one — `gemi run`
+
+```bash
+gemi run                       # list every command, with its description
+gemi run backfill-avatars      # run one
+gemi run backfill-avatars --help
+```
+
+Everything after the name belongs to the command, including its flags — `gemi run send-digest --queue` forwards `--queue` untouched, and `gemi run send-digest --help` prints that command's usage rather than `gemi run`'s. A `--` is available for a genuinely hostile tail (`gemi run x -- --weird`) but is never required.
+
+An unrecognised name prints a suggestion and the list, and exits `1`:
+
+```
+$ gemi run db:sed
+No command named `db:sed`. Did you mean `db:seed`?
+
+Commands in app/commands:
+
+  db:seed      Seed the development database
+  send-digest  Send the weekly digest to every subscribed user
+```
+
+> **Gotcha:** `gemi run` starts a **fresh Bun process**, the same way `gemi dev` and `gemi start` do, registering `gemi/bun/preload` and your `app/preload.ts` before any application code loads. It has to: those preloads can only be installed at process start, and a command that touches a controller needs the first while your models generally need the second.
+>
+> One consequence is worth knowing. `NODE_ENV` is passed through rather than forced, so `gemi run backfill` inherits whatever the shell has and `NODE_ENV=production gemi run backfill` is how you run against production semantics. That works precisely because the mode is fixed at the child's own startup.
+
+### What a command may reach
+
+Running a command boots the application fully — both phases — so a handler resolves services exactly as a request handler does:
+
+```typescript
+import { defineCommand } from "gemi/services";
+import { app } from "gemi/foundation";
+import { MailManager } from "gemi/services";
+
+export default defineCommand("send-digest").handle(async ({ line }) => {
+  app(MailManager); // typed, no cast
+  line("sent");
+});
+```
+
+Resolve services _inside_ the handler rather than at the top of the file. A command module is imported by discovery before the container has finished booting, and a service captured at module load is captured from a container that is not ready.
+
+> **Gotcha:** the cron scheduler does **not** start under `gemi run`. Booting the application is how a command reaches the container, and starting the schedule is a side effect of that which nobody asked for — a backfill that runs for four minutes would otherwise fire your whole cron schedule in a process no one is watching, and the `Bun.cron` handles would hold it open besides. Your jobs are still discovered and `app(Scheduler).jobs` still answers honestly; nothing is scheduled. `gemi run` sets `GEMI_NO_SCHEDULE=1` on the process it spawns, and that variable works anywhere — it is also how a deploy runs one cron dyno beside several web ones.
+
+> **Gotcha:** the queue is in-process, so a command that calls `Job.dispatch(...)` and then returns may exit before the job runs. Do the work in the command, or wait for it yourself. See [Jobs & Queues](./jobs-and-queues.md).
+
+## Registering commands — `app/commands/`
+
+Commands are discovered. Every class under `app/commands` that extends `Command` — which is what a finished `defineCommand` chain produces — is available to `gemi run`, so writing the file is all it takes.
+
+Unlike [cron jobs](./cron.md#registering-jobs--appcron) and [queued jobs](./jobs-and-queues.md), this directory is **not** read at boot. A command registry has one consumer — `gemi run` — and reading it during boot would import every file under `app/commands` into every dev server, every production start and every deployed process, for code no request will ever reach. The walk happens when you run a command, and nowhere else.
+
+### The chain must reach `.handle()`
+
+A `defineCommand` chain that never calls `.handle()` is a plain object rather than a class, so nothing would find it. That is refused by name rather than passed over:
+
+```
+app/commands/Backfill.ts exports a command builder that never called `.handle()`,
+so there is no command to run. `.handle()` is what turns the chain into a command
+```
+
+Without that check the command would simply be missing from `gemi run`, with nothing raised — the author sees a listing holding every command except the one they just wrote.
+
+### Two commands, one name
+
+A name is how a command is run, so only one can hold it. Two claiming the same name is refused outright, naming both classes — unlike the queue and the scheduler, which keep the first and warn. Those have a server to keep booting; here there is no boot to protect and a person is waiting, and running the wrong one of two commands called `db:seed` is worse than running neither.
+
+### What the walk costs
+
+A class does not exist until its module has run, so **every `.ts`/`.tsx` file under `app/commands` is imported** when you run a command, and a file that _does something_ on import does it then. The walk skips what certainly is not a declaration: `.d.ts` files, tests, type tests and benchmarks by their filename suffix, dot-directories, `node_modules`, and anything under a directory carrying its own `package.json`. Nothing else is guessed at.
+
+A file that cannot be imported at all fails naming itself, rather than being quietly left out.
+
+### Listing them explicitly — `app/config/command.ts`
+
+Declaring `commands` in the `command` config slice turns discovery off and uses your list verbatim. Reach for it when the commands live somewhere the walk cannot reach, when you want a deliberate subset, or when the deploy ships only the build output.
+
+```typescript
+// app/config/command.ts
+import { defineCommandConfig } from "gemi/services";
+import BackfillAvatars from "@/app/commands/BackfillAvatars";
+
+export default defineCommandConfig({
+  commands: [BackfillAvatars],
+});
+```
+
+**A present `commands` wins, and `commands: []` is present.** An empty array means an application with no commands and is honoured as such; it does not mean "go and find some". Leaving the key out — or leaving the slice out entirely — is what asks for discovery.
+
+The file is wired into the kernel by name:
+
+```typescript
+// app/kernel/Kernel.ts
+import { Kernel } from "gemi/kernel";
+import command from "../config/command";
+
+export default class extends Kernel {
+  config = { command /* , ...other slices */ };
+}
+```
+
+| Config key | Field         | Type             | Default          | Description                                                        |
+| ---------- | ------------- | ---------------- | ---------------- | ------------------------------------------------------------------ |
+| `command`  | `commands`    | `CommandClass[]` | _discovered_     | The command classes. Omit to discover them from `commandsDir`.     |
+| `command`  | `commandsDir` | `string`         | `"app/commands"` | Where to discover them. Relative to the project root, or absolute. |
+
+> The slice is called `command`, not `console`, for a small and annoying reason: a file named `app/config/console.ts` arrives in your kernel as `import console from "../config/console"`, which shadows the global `console` for the rest of that module.
+
+### Asking what an application has
+
+`discoverCommands()` walks `app/commands` (or a directory you name) and returns the classes it finds, without an application around it:
+
+```typescript
+import { discoverCommands } from "gemi/services";
+
+const commands = await discoverCommands();
+```
+
+It imports every file it walks, the same as `discoverJobs()` and `discoverCronJobs()`.
+
+## Commands vs. cron jobs vs. queued jobs
+
+Use a **command** for work a person starts, by hand, once. Use a [**cron job**](./cron.md) for time-based recurring work. Use a [**queued job**](./jobs-and-queues.md) for work a request triggers and does not want to wait for. They compose: a command often dispatches jobs, and a cron `callback` often does the same thing a command does on demand.
+
+## Related
+
+- [CLI](./cli.md) — `gemi run` and every other command.
+- [Cron](./cron.md) — recurring scheduled work.
+- [Jobs & Queues](./jobs-and-queues.md) — background work triggered on demand.
+- [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -73,23 +73,28 @@ Positional values, in the order they are declared and the order they are typed.
 .arg("extra", { variadic: true })
 ```
 
-| Key           | Type      | Description                                                 |
-| ------------- | --------- | ----------------------------------------------------------- |
-| `description` | `string`  | Shown in `--help`.                                          |
-| `required`    | `boolean` | Omitting it is a usage error rather than an `undefined`.    |
-| `default`     | `string`  | Supplied when the argument is absent.                       |
-| `variadic`    | `boolean` | Collects every remaining positional. Must be declared last. |
+| Key           | Type      | Description                                                                                 |
+| ------------- | --------- | ------------------------------------------------------------------------------------------- |
+| `description` | `string`  | Shown in `--help`.                                                                          |
+| `required`    | `boolean` | Omitting it is a usage error rather than an `undefined`. On a variadic, means at least one. |
+| `default`     | `string`  | Supplied when the argument is absent.                                                       |
+| `variadic`    | `boolean` | Collects every remaining positional. Must be declared last.                                 |
 
 What each combination gives the handler:
 
-| Declaration                     | Type in `args`                      |
-| ------------------------------- | ----------------------------------- |
-| `.arg("x")`                     | `string \| undefined`               |
-| `.arg("x", { required: true })` | `string`                            |
-| `.arg("x", { default: "…" })`   | `string`                            |
-| `.arg("x", { variadic: true })` | `string[]` — `[]` when it took none |
+| Declaration                                     | Type in `args`                        |
+| ----------------------------------------------- | ------------------------------------- |
+| `.arg("x")`                                     | `string \| undefined`                 |
+| `.arg("x", { required: true })`                 | `string`                              |
+| `.arg("x", { default: "…" })`                   | `string`                              |
+| `.arg("x", { variadic: true })`                 | `string[]` — `[]` when it took none   |
+| `.arg("x", { variadic: true, required: true })` | `string[]` — a usage error when empty |
 
-`required` and `default` together are refused: an argument that is supplied when absent cannot also be absent. So is anything declared after a variadic argument, which would collect everything and leave the one after it permanently empty.
+Declarations that contradict themselves are refused where you wrote them rather than surfacing later as a confusing usage error:
+
+- `required` with `default` — an argument that is supplied when absent cannot also be absent.
+- Anything declared after a `variadic` one, which would collect everything and leave the next permanently empty.
+- `variadic` with `default` — a variadic is an empty list when it takes nothing, so the default could never apply.
 
 ## Options — `.option()`
 
@@ -120,6 +125,16 @@ Option --limit expects a number, but got "abc".
 
 All the usual spellings work: `--limit 5`, `--limit=5`, `-l 5`, `-l5`, `-l=5`, and clustered flags like `-dl 5`. A boolean can be turned off with `--no-dry-run`. Everything after a bare `--` is positional, however it is spelled — the escape hatch for an argument that looks like a flag.
 
+An option that takes a value will not swallow the next flag as that value:
+
+```
+$ gemi run notify --message --dry-run
+Option --message needs a value, but the next token is "--dry-run", which is
+another option. If that really is the value, write --message=--dry-run.
+```
+
+Without this, `--message --dry-run` would set the message to the literal `"--dry-run"` and leave `dryRun` false — the dry run executes for real, and nothing says so. Use `=` when a value really does begin with a dash. Negative numbers (`--limit -5`) and a bare `-` are values, not flags, and need no escaping.
+
 ## The handler
 
 `.handle(fn)` receives one argument holding everything the command has.
@@ -147,7 +162,7 @@ There is no `info`, `success`, `warn`, table or progress bar. Colour is your app
 | calls `fail(message, code)`  | `code` (default `1`), with `message` on stderr and no stack |
 | throws                       | `1`, with the stack                                         |
 
-Returning something that is not an exit code is reported rather than coerced. `return users.length` is an easy thing to write, and coercing it would turn 300 backfilled users into exit status 44 — which reads as a failure to everything downstream, for a command that succeeded.
+An exit status is one byte, and both ways of naming one go through the same check. Anything outside `0`–`255` is reported rather than coerced, because coercion here is silent and inverts the answer: `return users.length` after 300 backfilled users would exit `44`, and ``fail(`${bad.length} rows failed`, bad.length)`` with 256 bad rows would exit **`0`** — a failure the `&&` chain or CI step waiting on it reads as a success.
 
 ```typescript
 export default defineCommand("verify-invoices").handle(
@@ -172,6 +187,8 @@ gemi run backfill-avatars --help
 ```
 
 Everything after the name belongs to the command, including its flags — `gemi run send-digest --queue` forwards `--queue` untouched, and `gemi run send-digest --help` prints that command's usage rather than `gemi run`'s. A `--` is available for a genuinely hostile tail (`gemi run x -- --weird`) but is never required.
+
+`--help` is offered in whichever spellings your command has left free: declare an option called `help` and `--help` is yours, declare a `-h` alias and `-h` is yours, and each is decided on its own — a `.option("host", { alias: "h" })` keeps the long `--help` it never claimed. The usage screen lists only the spellings that actually work.
 
 An unrecognised name prints a suggestion and the list, and exits `1`:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -126,6 +126,7 @@
         <a class="card" href="email.md"><span class="t">Email</span><span class="d">Email class, jsx-email templates, Resend, scheduling.</span></a>
         <a class="card" href="jobs-and-queues.md"><span class="t">Jobs &amp; Queues</span><span class="d">Background Jobs through the in-process queue.</span></a>
         <a class="card" href="cron.md"><span class="t">Cron</span><span class="d">Recurring CronJobs with Bun.cron.</span></a>
+        <a class="card" href="commands.md"><span class="t">Commands</span><span class="d">One-off application commands run with gemi run.</span></a>
         <a class="card" href="broadcasting.md"><span class="t">Broadcasting</span><span class="d">Websocket channels, Broadcast, useSubscription.</span></a>
         <a class="card" href="i18n.md"><span class="t">Internationalization</span><span class="d">Component-scoped dictionaries, useTranslator, useLocale.</span></a>
       </div>

--- a/docs/jobs-and-queues.md
+++ b/docs/jobs-and-queues.md
@@ -182,6 +182,7 @@ For work that must happen on a **schedule** (nightly reports, hourly cleanups) r
 
 ## Related
 
+- [Commands](./commands.md) — one-off work a person starts by hand, which often dispatches jobs.
 - [Cron](./cron.md) — scheduled, recurring background work.
 - [Controllers](./controllers.md) — dispatching jobs from request handlers.
 - [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -275,6 +275,7 @@ app/
   email/                 # email templates (jsx-email)
   cron/                  # CronJob classes — scheduled by being here
   jobs/                  # Job classes — registered by being here
+  commands/              # Command chains — available to `gemi run` by being here
   i18n/                  # translation dictionaries
   database/
     prisma.ts            # the Prisma client instance
@@ -323,11 +324,15 @@ If present, `app/preload.ts` runs once, before the server starts, for both `gemi
 - **`i18n/`** — translation dictionaries created with `Dictionary.create` from `gemi/i18n`, exported as a single default object.
 - **`database/prisma.ts`** — your Prisma client instance, imported wherever you query the database.
 
-### `cron/` and `jobs/` — the two discovered directories
+### `cron/`, `jobs/` and `commands/` — the three discovered directories
 
-These two directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, and every class under `app/jobs` extending `Job` is registered at boot, with nothing anywhere naming them — writing the file is the registration. The `schedule` and `queue` slices can still declare `jobs` explicitly, which turns the walk off and uses the declared list verbatim; `jobs: []` is a declaration too, and means an app with none.
+These directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, every class under `app/jobs` extending `Job` is registered at boot, and every command under `app/commands` is available to `gemi run` — with nothing anywhere naming them. Writing the file is the registration. The `schedule`, `queue` and `command` slices can still declare their list explicitly, which turns the walk off and uses the declared list verbatim; an empty array is a declaration too, and means an app with none.
 
-Discovery imports every `.ts`/`.tsx` file it walks, because a class does not exist until its module has run — so a file in either directory that does work when imported does that work at boot. Keep them to declarations. See [Cron](./cron.md) and [Jobs & Queues](./jobs-and-queues.md) for the walk's skip rules and the reasons for reading a directory at all.
+Discovery imports every `.ts`/`.tsx` file it walks, because a class does not exist until its module has run — so a file in one of these directories that does work when imported does that work when the directory is read. Keep them to declarations.
+
+`app/commands` differs in **when** it is read: cron and queue discovery happen during boot, because a tick or a dispatch can arrive at any moment afterwards, while commands are walked only by `gemi run`. A registry no request consults has no reason to cost every production process an import of every file under it.
+
+See [Cron](./cron.md), [Jobs & Queues](./jobs-and-queues.md) and [Commands](./commands.md) for the walk's skip rules and the reasons for reading a directory at all.
 
 ## The Kernel
 
@@ -957,7 +962,7 @@ bun run build
 bun run start
 ```
 
-> **Note:** Apart from `gemi migrate --dry-run` and `gemi check models`, the commands take no flags or options — each is a bare subcommand. gemi discovers your project from the current working directory (it expects `app/` and, for tooling commands, `app/kernel/Kernel.ts`).
+> **Note:** Apart from `gemi run`, `gemi migrate --dry-run` and `gemi check models`, the commands take no flags or options — each is a bare subcommand. gemi discovers your project from the current working directory (it expects `app/` and, for tooling commands, `app/kernel/Kernel.ts`).
 
 ## `gemi dev`
 
@@ -1003,6 +1008,26 @@ gemi start
 It launches `dist/server/server.mjs` in a fresh Bun process with `NODE_ENV=production`, registering the same runtime preloads as `dev` (`gemi/bun/preload`, then `app/preload.ts` if present). The fresh process is required so Bun starts with the production JSX runtime and production React DOM export conditions.
 
 > **Gotcha:** `start` requires a completed [`gemi build`](#gemi-build) — it does not build for you. In deployments you'll typically run migrations first, e.g. `bunx prisma migrate deploy && gemi start`.
+
+## `gemi run`
+
+Runs one of your application's [commands](./commands.md) — a seeder, a backfill, a report — inside your booted app.
+
+```bash
+gemi run                                    # list every command
+gemi run backfill-avatars 2024-01-01 --dry-run
+gemi run backfill-avatars --help            # that command's usage
+```
+
+Commands are the classes under `app/commands/`, written as `defineCommand(...)` chains. `gemi run` with no name lists them; an unrecognised name prints a suggestion and the list and exits `1`. The handler's return value is the exit code — see [Commands](./commands.md#exit-codes) for the full table.
+
+Like `dev` and `start`, it launches a fresh Bun process with the same two runtime preloads (`gemi/bun/preload`, then `app/preload.ts` if present) and boots the application fully, so a command reaches models, facades and the container exactly as a request handler does.
+
+> **Gotcha:** everything after the command's name belongs to the command. `gemi run send-digest --queue` forwards `--queue` untouched rather than treating it as a `gemi run` option, and `gemi run send-digest --help` prints the command's usage — `gemi run --help`, with no name, is the one that describes `gemi run` itself. Use `--` (`gemi run x -- --weird`) if a tail ever needs escaping; it is never required.
+
+> **Gotcha:** the cron scheduler does not start under `gemi run`, so a long-running command cannot fire your whole schedule in a process nobody is watching. Jobs are still discovered and `app(Scheduler).jobs` still answers honestly. The command sets `GEMI_NO_SCHEDULE=1` on the process it spawns, which also works as a general "boot this app but do not schedule anything" switch.
+
+> **Gotcha:** `NODE_ENV` is inherited rather than forced, unlike `dev` (development) and `start` (production), which each are one mode by definition. Run `NODE_ENV=production gemi run <name>` for production semantics.
 
 ## `gemi migrate`
 
@@ -1097,6 +1122,7 @@ Like `app:component-tree`, it loads the app from the kernel and prints the resol
 
 ## Related
 
+- [Commands](./commands.md) — writing the application commands `gemi run` runs.
 - [Getting Started](./getting-started.md) — installing gemi and running your first commands.
 - [Configuration](./configuration.md) — `.env`, `preload.ts`, and `gemi.config.ts` that these commands consume.
 - [Project Structure & the Kernel](./project-structure.md) — `server.ts`, the kernel, and how the app boots.
@@ -7996,6 +8022,306 @@ Use a **cron job** for time-based, recurring work that runs on its own schedule.
 - [Jobs & Queues](./jobs-and-queues.md) — background work triggered on demand.
 - [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.
 - [Configuration](./configuration.md) — environment setup.
+
+
+---
+
+## Commands
+
+Commands are one-off pieces of application code you run by hand: a seeder, a backfill, a tenant repair, a report. You define each one as a `defineCommand(...)` chain (from `gemi/services`) in a file under `app/commands/`, and run it with `gemi run <name>`. The command runs inside your booted application, so it reaches models, facades, mail and everything else exactly as a request handler does.
+
+```bash
+gemi run backfill-avatars 2024-01-01 --dry-run
+```
+
+## Defining a command
+
+A command needs a name and a handler. Everything between them is optional.
+
+```typescript
+// app/commands/BackfillAvatars.ts
+import { defineCommand } from "gemi/services";
+import { User } from "@/app/models/User";
+
+export default defineCommand("backfill-avatars")
+  .describe("Regenerate avatar URLs for users created before the CDN move")
+  .arg("since", { required: true, description: "ISO date to backfill from" })
+  .option("dryRun", {
+    type: "boolean",
+    description: "Print the plan, write nothing",
+  })
+  .option("limit", {
+    type: "number",
+    default: 500,
+    description: "Stop after N users",
+  })
+  .handle(async ({ args, options, line }) => {
+    const users = await User.findMany({
+      where: { createdAt: { gte: args.since } },
+      take: options.limit,
+    });
+
+    line(`${users.length} users to backfill`);
+    if (options.dryRun) return;
+
+    // ...do the work...
+  });
+```
+
+That file is the whole registration — there is no list to add it to. **Registering commands**, below, covers how the directory is read and how to take registration over yourself.
+
+`args.since` is a `string`, `options.limit` is a `number`, and `options.dryRun` is a `boolean` — inferred from the chain, with nothing written by hand.
+
+### Why it is a chain and not a class
+
+Every other extension point in gemi is a class: `Job`, `CronJob`, `Controller`, `Middleware`. A command is not, and the reason is that a class cannot type its own handler.
+
+TypeScript does not contextually type an overriding method's parameters from the base-class method it overrides. So a class declaring its schema as statics gets nothing from it:
+
+```typescript
+// the shape this replaces — it does not type-check
+class BackfillAvatars extends Command {
+  static args = [{ name: "since", required: true }];
+
+  async run(ctx) {} // implicit any — `ctx.args.since` is unchecked
+}
+```
+
+The only way out of that is to restate the type by hand in every command, which is the ceremony the schema was supposed to remove — and which nothing enforces, so a wrong restatement compiles. A **function expression passed as an argument** _is_ contextually typed, which is why `.handle(fn)` is the shape.
+
+`.handle()` returns a `Command` subclass, so nothing else changes: discovery finds it by walking the prototype chain, exactly as it finds a `Job` or a `CronJob`. You can subclass `Command` by hand if you need to, and you give up the typing when you do.
+
+## Arguments — `.arg()`
+
+Positional values, in the order they are declared and the order they are typed.
+
+```typescript
+.arg("tenant", { required: true })
+.arg("environment", { default: "staging" })
+.arg("extra", { variadic: true })
+```
+
+| Key           | Type      | Description                                                 |
+| ------------- | --------- | ----------------------------------------------------------- |
+| `description` | `string`  | Shown in `--help`.                                          |
+| `required`    | `boolean` | Omitting it is a usage error rather than an `undefined`.    |
+| `default`     | `string`  | Supplied when the argument is absent.                       |
+| `variadic`    | `boolean` | Collects every remaining positional. Must be declared last. |
+
+What each combination gives the handler:
+
+| Declaration                     | Type in `args`                      |
+| ------------------------------- | ----------------------------------- |
+| `.arg("x")`                     | `string \| undefined`               |
+| `.arg("x", { required: true })` | `string`                            |
+| `.arg("x", { default: "…" })`   | `string`                            |
+| `.arg("x", { variadic: true })` | `string[]` — `[]` when it took none |
+
+`required` and `default` together are refused: an argument that is supplied when absent cannot also be absent. So is anything declared after a variadic argument, which would collect everything and leave the one after it permanently empty.
+
+## Options — `.option()`
+
+Flags. Declared in camelCase and typed on the command line in kebab-case, so `.option("dryRun", …)` is `--dry-run` for whoever runs it and `options.dryRun` in the handler.
+
+```typescript
+.option("dryRun", { type: "boolean" })
+.option("limit", { type: "number", default: 500 })
+.option("tag", { type: "string", alias: "t", required: true })
+```
+
+| Key           | Type                                | Description                                                          |
+| ------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| `type`        | `"boolean" \| "string" \| "number"` | Required. Decides how the value is parsed and what the handler sees. |
+| `description` | `string`                            | Shown in `--help`.                                                   |
+| `alias`       | `string`                            | A single character, without the dash: `-t`.                          |
+| `default`     | matching `type`                     | Applied only when the flag is absent, never over a supplied value.   |
+| `required`    | `boolean`                           | Omitting it is a usage error. Not available on booleans.             |
+
+`type` is required rather than defaulting to `"string"` because a `--dry-run` declared without one would arrive as the empty string, and every `if (options.dryRun)` over it would be wrong in the one direction nobody tests.
+
+A `number` option that is not a number is a usage error, not a `NaN` in your handler:
+
+```
+$ gemi run backfill-avatars 2024-01-01 --limit abc
+Option --limit expects a number, but got "abc".
+```
+
+All the usual spellings work: `--limit 5`, `--limit=5`, `-l 5`, `-l5`, `-l=5`, and clustered flags like `-dl 5`. A boolean can be turned off with `--no-dry-run`. Everything after a bare `--` is positional, however it is spelled — the escape hatch for an argument that looks like a flag.
+
+## The handler
+
+`.handle(fn)` receives one argument holding everything the command has.
+
+| Member                 | Type                                        | Description                                                     |
+| ---------------------- | ------------------------------------------- | --------------------------------------------------------------- |
+| `args`                 | inferred                                    | The positional arguments, by the names `.arg()` declared.       |
+| `options`              | inferred                                    | The flags, by the names `.option()` declared.                   |
+| `argv`                 | `readonly string[]`                         | Everything after the command name, unparsed.                    |
+| `line(message?)`       | `(message?: string) => void`                | The command's answer, on **stdout**.                            |
+| `error(message)`       | `(message: string) => void`                 | A diagnostic, on **stderr**. Does not end the command.          |
+| `fail(message, code?)` | `(message: string, code?: number) => never` | Ends the command with a message and an exit code, and no stack. |
+
+The `line`/`error` split is the one thing worth being deliberate about. A diagnostic printed to stdout is what breaks `TOTAL=$(gemi run count-users)` and what makes a CI grep match a progress line instead of the answer — and it stays invisible until somebody pipes the command somewhere.
+
+There is no `info`, `success`, `warn`, table or progress bar. Colour is your application's business, and a console formatting library is a project rather than a feature.
+
+### Exit codes
+
+| The handler                  | Exit code                                                   |
+| ---------------------------- | ----------------------------------------------------------- |
+| returns nothing              | `0`                                                         |
+| returns an integer `0`–`255` | that number                                                 |
+| returns anything else        | `1`, and says the value was not an exit code                |
+| calls `fail(message, code)`  | `code` (default `1`), with `message` on stderr and no stack |
+| throws                       | `1`, with the stack                                         |
+
+Returning something that is not an exit code is reported rather than coerced. `return users.length` is an easy thing to write, and coercing it would turn 300 backfilled users into exit status 44 — which reads as a failure to everything downstream, for a command that succeeded.
+
+```typescript
+export default defineCommand("verify-invoices").handle(
+  async ({ line, fail }) => {
+    const broken = await findBrokenInvoices();
+
+    if (broken.length > 0) {
+      fail(`${broken.length} invoices failed verification`, 2);
+    }
+
+    line("all invoices verified");
+  },
+);
+```
+
+## Running one — `gemi run`
+
+```bash
+gemi run                       # list every command, with its description
+gemi run backfill-avatars      # run one
+gemi run backfill-avatars --help
+```
+
+Everything after the name belongs to the command, including its flags — `gemi run send-digest --queue` forwards `--queue` untouched, and `gemi run send-digest --help` prints that command's usage rather than `gemi run`'s. A `--` is available for a genuinely hostile tail (`gemi run x -- --weird`) but is never required.
+
+An unrecognised name prints a suggestion and the list, and exits `1`:
+
+```
+$ gemi run db:sed
+No command named `db:sed`. Did you mean `db:seed`?
+
+Commands in app/commands:
+
+  db:seed      Seed the development database
+  send-digest  Send the weekly digest to every subscribed user
+```
+
+> **Gotcha:** `gemi run` starts a **fresh Bun process**, the same way `gemi dev` and `gemi start` do, registering `gemi/bun/preload` and your `app/preload.ts` before any application code loads. It has to: those preloads can only be installed at process start, and a command that touches a controller needs the first while your models generally need the second.
+>
+> One consequence is worth knowing. `NODE_ENV` is passed through rather than forced, so `gemi run backfill` inherits whatever the shell has and `NODE_ENV=production gemi run backfill` is how you run against production semantics. That works precisely because the mode is fixed at the child's own startup.
+
+### What a command may reach
+
+Running a command boots the application fully — both phases — so a handler resolves services exactly as a request handler does:
+
+```typescript
+import { defineCommand } from "gemi/services";
+import { app } from "gemi/foundation";
+import { MailManager } from "gemi/services";
+
+export default defineCommand("send-digest").handle(async ({ line }) => {
+  app(MailManager); // typed, no cast
+  line("sent");
+});
+```
+
+Resolve services _inside_ the handler rather than at the top of the file. A command module is imported by discovery before the container has finished booting, and a service captured at module load is captured from a container that is not ready.
+
+> **Gotcha:** the cron scheduler does **not** start under `gemi run`. Booting the application is how a command reaches the container, and starting the schedule is a side effect of that which nobody asked for — a backfill that runs for four minutes would otherwise fire your whole cron schedule in a process no one is watching, and the `Bun.cron` handles would hold it open besides. Your jobs are still discovered and `app(Scheduler).jobs` still answers honestly; nothing is scheduled. `gemi run` sets `GEMI_NO_SCHEDULE=1` on the process it spawns, and that variable works anywhere — it is also how a deploy runs one cron dyno beside several web ones.
+
+> **Gotcha:** the queue is in-process, so a command that calls `Job.dispatch(...)` and then returns may exit before the job runs. Do the work in the command, or wait for it yourself. See [Jobs & Queues](./jobs-and-queues.md).
+
+## Registering commands — `app/commands/`
+
+Commands are discovered. Every class under `app/commands` that extends `Command` — which is what a finished `defineCommand` chain produces — is available to `gemi run`, so writing the file is all it takes.
+
+Unlike [cron jobs](./cron.md#registering-jobs--appcron) and [queued jobs](./jobs-and-queues.md), this directory is **not** read at boot. A command registry has one consumer — `gemi run` — and reading it during boot would import every file under `app/commands` into every dev server, every production start and every deployed process, for code no request will ever reach. The walk happens when you run a command, and nowhere else.
+
+### The chain must reach `.handle()`
+
+A `defineCommand` chain that never calls `.handle()` is a plain object rather than a class, so nothing would find it. That is refused by name rather than passed over:
+
+```
+app/commands/Backfill.ts exports a command builder that never called `.handle()`,
+so there is no command to run. `.handle()` is what turns the chain into a command
+```
+
+Without that check the command would simply be missing from `gemi run`, with nothing raised — the author sees a listing holding every command except the one they just wrote.
+
+### Two commands, one name
+
+A name is how a command is run, so only one can hold it. Two claiming the same name is refused outright, naming both classes — unlike the queue and the scheduler, which keep the first and warn. Those have a server to keep booting; here there is no boot to protect and a person is waiting, and running the wrong one of two commands called `db:seed` is worse than running neither.
+
+### What the walk costs
+
+A class does not exist until its module has run, so **every `.ts`/`.tsx` file under `app/commands` is imported** when you run a command, and a file that _does something_ on import does it then. The walk skips what certainly is not a declaration: `.d.ts` files, tests, type tests and benchmarks by their filename suffix, dot-directories, `node_modules`, and anything under a directory carrying its own `package.json`. Nothing else is guessed at.
+
+A file that cannot be imported at all fails naming itself, rather than being quietly left out.
+
+### Listing them explicitly — `app/config/command.ts`
+
+Declaring `commands` in the `command` config slice turns discovery off and uses your list verbatim. Reach for it when the commands live somewhere the walk cannot reach, when you want a deliberate subset, or when the deploy ships only the build output.
+
+```typescript
+// app/config/command.ts
+import { defineCommandConfig } from "gemi/services";
+import BackfillAvatars from "@/app/commands/BackfillAvatars";
+
+export default defineCommandConfig({
+  commands: [BackfillAvatars],
+});
+```
+
+**A present `commands` wins, and `commands: []` is present.** An empty array means an application with no commands and is honoured as such; it does not mean "go and find some". Leaving the key out — or leaving the slice out entirely — is what asks for discovery.
+
+The file is wired into the kernel by name:
+
+```typescript
+// app/kernel/Kernel.ts
+import { Kernel } from "gemi/kernel";
+import command from "../config/command";
+
+export default class extends Kernel {
+  config = { command /* , ...other slices */ };
+}
+```
+
+| Config key | Field         | Type             | Default          | Description                                                        |
+| ---------- | ------------- | ---------------- | ---------------- | ------------------------------------------------------------------ |
+| `command`  | `commands`    | `CommandClass[]` | _discovered_     | The command classes. Omit to discover them from `commandsDir`.     |
+| `command`  | `commandsDir` | `string`         | `"app/commands"` | Where to discover them. Relative to the project root, or absolute. |
+
+> The slice is called `command`, not `console`, for a small and annoying reason: a file named `app/config/console.ts` arrives in your kernel as `import console from "../config/console"`, which shadows the global `console` for the rest of that module.
+
+### Asking what an application has
+
+`discoverCommands()` walks `app/commands` (or a directory you name) and returns the classes it finds, without an application around it:
+
+```typescript
+import { discoverCommands } from "gemi/services";
+
+const commands = await discoverCommands();
+```
+
+It imports every file it walks, the same as `discoverJobs()` and `discoverCronJobs()`.
+
+## Commands vs. cron jobs vs. queued jobs
+
+Use a **command** for work a person starts, by hand, once. Use a [**cron job**](./cron.md) for time-based recurring work. Use a [**queued job**](./jobs-and-queues.md) for work a request triggers and does not want to wait for. They compose: a command often dispatches jobs, and a cron `callback` often does the same thing a command does on demand.
+
+## Related
+
+- [CLI](./cli.md) — `gemi run` and every other command.
+- [Cron](./cron.md) — recurring scheduled work.
+- [Jobs & Queues](./jobs-and-queues.md) — background work triggered on demand.
+- [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.
 
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8101,23 +8101,28 @@ Positional values, in the order they are declared and the order they are typed.
 .arg("extra", { variadic: true })
 ```
 
-| Key           | Type      | Description                                                 |
-| ------------- | --------- | ----------------------------------------------------------- |
-| `description` | `string`  | Shown in `--help`.                                          |
-| `required`    | `boolean` | Omitting it is a usage error rather than an `undefined`.    |
-| `default`     | `string`  | Supplied when the argument is absent.                       |
-| `variadic`    | `boolean` | Collects every remaining positional. Must be declared last. |
+| Key           | Type      | Description                                                                                 |
+| ------------- | --------- | ------------------------------------------------------------------------------------------- |
+| `description` | `string`  | Shown in `--help`.                                                                          |
+| `required`    | `boolean` | Omitting it is a usage error rather than an `undefined`. On a variadic, means at least one. |
+| `default`     | `string`  | Supplied when the argument is absent.                                                       |
+| `variadic`    | `boolean` | Collects every remaining positional. Must be declared last.                                 |
 
 What each combination gives the handler:
 
-| Declaration                     | Type in `args`                      |
-| ------------------------------- | ----------------------------------- |
-| `.arg("x")`                     | `string \| undefined`               |
-| `.arg("x", { required: true })` | `string`                            |
-| `.arg("x", { default: "…" })`   | `string`                            |
-| `.arg("x", { variadic: true })` | `string[]` — `[]` when it took none |
+| Declaration                                     | Type in `args`                        |
+| ----------------------------------------------- | ------------------------------------- |
+| `.arg("x")`                                     | `string \| undefined`                 |
+| `.arg("x", { required: true })`                 | `string`                              |
+| `.arg("x", { default: "…" })`                   | `string`                              |
+| `.arg("x", { variadic: true })`                 | `string[]` — `[]` when it took none   |
+| `.arg("x", { variadic: true, required: true })` | `string[]` — a usage error when empty |
 
-`required` and `default` together are refused: an argument that is supplied when absent cannot also be absent. So is anything declared after a variadic argument, which would collect everything and leave the one after it permanently empty.
+Declarations that contradict themselves are refused where you wrote them rather than surfacing later as a confusing usage error:
+
+- `required` with `default` — an argument that is supplied when absent cannot also be absent.
+- Anything declared after a `variadic` one, which would collect everything and leave the next permanently empty.
+- `variadic` with `default` — a variadic is an empty list when it takes nothing, so the default could never apply.
 
 ## Options — `.option()`
 
@@ -8148,6 +8153,16 @@ Option --limit expects a number, but got "abc".
 
 All the usual spellings work: `--limit 5`, `--limit=5`, `-l 5`, `-l5`, `-l=5`, and clustered flags like `-dl 5`. A boolean can be turned off with `--no-dry-run`. Everything after a bare `--` is positional, however it is spelled — the escape hatch for an argument that looks like a flag.
 
+An option that takes a value will not swallow the next flag as that value:
+
+```
+$ gemi run notify --message --dry-run
+Option --message needs a value, but the next token is "--dry-run", which is
+another option. If that really is the value, write --message=--dry-run.
+```
+
+Without this, `--message --dry-run` would set the message to the literal `"--dry-run"` and leave `dryRun` false — the dry run executes for real, and nothing says so. Use `=` when a value really does begin with a dash. Negative numbers (`--limit -5`) and a bare `-` are values, not flags, and need no escaping.
+
 ## The handler
 
 `.handle(fn)` receives one argument holding everything the command has.
@@ -8175,7 +8190,7 @@ There is no `info`, `success`, `warn`, table or progress bar. Colour is your app
 | calls `fail(message, code)`  | `code` (default `1`), with `message` on stderr and no stack |
 | throws                       | `1`, with the stack                                         |
 
-Returning something that is not an exit code is reported rather than coerced. `return users.length` is an easy thing to write, and coercing it would turn 300 backfilled users into exit status 44 — which reads as a failure to everything downstream, for a command that succeeded.
+An exit status is one byte, and both ways of naming one go through the same check. Anything outside `0`–`255` is reported rather than coerced, because coercion here is silent and inverts the answer: `return users.length` after 300 backfilled users would exit `44`, and ``fail(`${bad.length} rows failed`, bad.length)`` with 256 bad rows would exit **`0`** — a failure the `&&` chain or CI step waiting on it reads as a success.
 
 ```typescript
 export default defineCommand("verify-invoices").handle(
@@ -8200,6 +8215,8 @@ gemi run backfill-avatars --help
 ```
 
 Everything after the name belongs to the command, including its flags — `gemi run send-digest --queue` forwards `--queue` untouched, and `gemi run send-digest --help` prints that command's usage rather than `gemi run`'s. A `--` is available for a genuinely hostile tail (`gemi run x -- --weird`) but is never required.
+
+`--help` is offered in whichever spellings your command has left free: declare an option called `help` and `--help` is yours, declare a `-h` alias and `-h` is yours, and each is decided on its own — a `.option("host", { alias: "h" })` keeps the long `--help` it never claimed. The usage screen lists only the spellings that actually work.
 
 An unrecognised name prints a suggestion and the list, and exits `1`:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Getting Started](https://nstfkc.github.io/gemi/getting-started.md): install, scaffold with create-gemi-app, dev/build/start, a first route + view.
 - [Project Structure & the Kernel](https://nstfkc.github.io/gemi/project-structure.md): the app/ layout, the Kernel, the container, app/config/*.ts, service providers, and app bootstrap.
 - [Configuration](https://nstfkc.github.io/gemi/configuration.md): gemi.config.ts (BUILD config, distinct from app/config/), .env handling, HTML compression, app/preload.ts, Vite config.
-- [CLI](https://nstfkc.github.io/gemi/cli.md): gemi dev/build/start, gemi migrate (the 0.42 -> config/container codemod, the retired-API TODOs, and the two annotate-only passes for a Prisma-to-ORM port), plus codegen and inspection commands.
+- [CLI](https://nstfkc.github.io/gemi/cli.md): gemi dev/build/start, gemi migrate (the 0.42 -> config/container codemod, the retired-API TODOs, and the two annotate-only passes for a Prisma-to-ORM port), gemi run for application commands, plus codegen and inspection commands.
 
 ## HTTP layer
 
@@ -43,11 +43,13 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Email](https://nstfkc.github.io/gemi/email.md): the Email class, jsx-email templates, the Resend driver, localization and scheduling.
 - [Jobs & Queues](https://nstfkc.github.io/gemi/jobs-and-queues.md): defining and dispatching background Jobs through the in-process queue.
 - [Cron](https://nstfkc.github.io/gemi/cron.md): scheduling recurring CronJobs with Bun.cron.
+- [Commands](https://nstfkc.github.io/gemi/commands.md): one-off application commands written with defineCommand and run with `gemi run <name>`.
 - [Broadcasting](https://nstfkc.github.io/gemi/broadcasting.md): websocket channels, the Broadcast facade, useSubscription/useBroadcast.
 - [Internationalization](https://nstfkc.github.io/gemi/i18n.md): component-scoped dictionaries, useTranslator, useLocale, locale detection.
 
 ## Notes
 
+- Application commands are `defineCommand(...).handle(...)` chains under `app/commands`, run with `gemi run <name>` — a chain, not a class, because a class body cannot type its own handler.
 - The client query hook is `useQuery` (not `useGet`).
 - The server-side `Redirect` facade works by throwing — never wrap it in try/catch.
 - Middleware is a string DSL (`auth`, `cache:...`, `rate-limit:N`); `-name` cancels an inherited middleware.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -36,6 +36,7 @@ app/
   email/                 # email templates (jsx-email)
   cron/                  # CronJob classes — scheduled by being here
   jobs/                  # Job classes — registered by being here
+  commands/              # Command chains — available to `gemi run` by being here
   i18n/                  # translation dictionaries
   database/
     prisma.ts            # the Prisma client instance
@@ -84,11 +85,15 @@ If present, `app/preload.ts` runs once, before the server starts, for both `gemi
 - **`i18n/`** — translation dictionaries created with `Dictionary.create` from `gemi/i18n`, exported as a single default object.
 - **`database/prisma.ts`** — your Prisma client instance, imported wherever you query the database.
 
-### `cron/` and `jobs/` — the two discovered directories
+### `cron/`, `jobs/` and `commands/` — the three discovered directories
 
-These two directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, and every class under `app/jobs` extending `Job` is registered at boot, with nothing anywhere naming them — writing the file is the registration. The `schedule` and `queue` slices can still declare `jobs` explicitly, which turns the walk off and uses the declared list verbatim; `jobs: []` is a declaration too, and means an app with none.
+These directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, every class under `app/jobs` extending `Job` is registered at boot, and every command under `app/commands` is available to `gemi run` — with nothing anywhere naming them. Writing the file is the registration. The `schedule`, `queue` and `command` slices can still declare their list explicitly, which turns the walk off and uses the declared list verbatim; an empty array is a declaration too, and means an app with none.
 
-Discovery imports every `.ts`/`.tsx` file it walks, because a class does not exist until its module has run — so a file in either directory that does work when imported does that work at boot. Keep them to declarations. See [Cron](./cron.md) and [Jobs & Queues](./jobs-and-queues.md) for the walk's skip rules and the reasons for reading a directory at all.
+Discovery imports every `.ts`/`.tsx` file it walks, because a class does not exist until its module has run — so a file in one of these directories that does work when imported does that work when the directory is read. Keep them to declarations.
+
+`app/commands` differs in **when** it is read: cron and queue discovery happen during boot, because a tick or a dispatch can arrive at any moment afterwards, while commands are walked only by `gemi run`. A registry no request consults has no reason to cost every production process an import of every file under it.
+
+See [Cron](./cron.md), [Jobs & Queues](./jobs-and-queues.md) and [Commands](./commands.md) for the walk's skip rules and the reasons for reading a directory at all.
 
 ## The Kernel
 

--- a/packages/gemi/bin/gemi.ts
+++ b/packages/gemi/bin/gemi.ts
@@ -174,6 +174,90 @@ program.command("start").action(async () => {
   await proc.exited;
 });
 
+// Everything after the command's name belongs to the command, including its
+// flags. Two commander settings do that, and both are load-bearing:
+//
+//   - `enablePositionalOptions()` on the program, so a subcommand may own the
+//     options that follow it. Program-level options must then precede the
+//     subcommand name; the program declares none, so nothing changes for the
+//     commands above.
+//   - `passThroughOptions()` here, so everything after the first operand is an
+//     operand — `gemi run send-email --queue` forwards `--queue` untouched, and
+//     `gemi run send-email --help` reaches the command rather than printing
+//     commander's help for `run` (`gemi run --help`, with no name, still does).
+//
+// NOT `allowUnknownOption()`, which was the first thing tried: commander
+// collects unknown options into a separate list and concatenates it *after* the
+// operands, so `gemi run job --flag value` arrives as `job value --flag`. Order
+// silently mangled is the worst failure available to an argument forwarder.
+//
+// For the same reason this subcommand declares no options of its own. Any it
+// declared would be shadowed after the first operand and would read as a
+// `gemi run` flag that mysteriously does nothing; a future one goes *before* the
+// name, as `gemi run --env=staging send-email`.
+program.enablePositionalOptions();
+
+program
+  .command("run")
+  .description(
+    "Run a Command from app/commands. Everything after the name is the " +
+      "command's own, including its flags. Omit the name to list them",
+  )
+  .argument("[name]", "The command's name")
+  .argument("[args...]", "Passed through to the command untouched")
+  .passThroughOptions()
+  .action(async (name: string | undefined, args: string[]) => {
+    const rootDir = path.resolve(process.cwd());
+    const appDir = path.join(rootDir, "app");
+
+    // Resolved from the *application's* gemi, never bundled into this binary.
+    // Discovery decides what is a command by walking the prototype chain, and
+    // the `Command` the app's files extend is the app's copy — a base bundled
+    // in here is a different class object and would match nothing, silently.
+    // `bin/check-models.ts` resolves `gemi/orm` the same way and for the same
+    // reason.
+    let entry: string;
+    try {
+      entry = Bun.resolveSync("gemi/console/run", rootDir);
+    } catch {
+      console.error(
+        `Could not resolve \`gemi/console/run\` from ${rootDir}. Run this from ` +
+          `the root of a gemi project, on a version of gemi that has console ` +
+          `commands.`,
+      );
+      process.exit(1);
+    }
+
+    const proc = Bun.spawn({
+      cmd: [
+        "bun",
+        // The same two preloads as `dev` and `start`, in the same order and for
+        // the same reasons: a command reaches controllers and models, so the
+        // custom-request transform and the app's own preload both have to be in
+        // place before any of it loads.
+        "--preload",
+        "gemi/bun/preload",
+        ...appPreloadArgs(appDir),
+        entry,
+        ...(name === undefined ? [] : [name]),
+        ...args,
+      ],
+      stdout: "inherit",
+      stderr: "inherit",
+      // Explicit: `Bun.spawn` ignores stdin by default, and a destructive
+      // command that asks for confirmation would read EOF and take the default.
+      stdin: "inherit",
+      // NODE_ENV is passed through unchanged rather than forced. `dev` and
+      // `start` each are one mode by definition; this is not, and spawning is
+      // what makes `NODE_ENV=production gemi run backfill` correct from the
+      // child's first line.
+      env: { ...process.env, GEMI_NO_SCHEDULE: "1" },
+    });
+
+    await proc.exited;
+    process.exit(proc.exitCode ?? 1);
+  });
+
 program
   .command("migrate")
   .description(
@@ -197,7 +281,9 @@ program
 // level (`gemi dev`, `gemi build`) and leaves room for `gemi check <other>`.
 const check = program
   .command("check")
-  .description("Checks that can be run in CI, on a project that is not running");
+  .description(
+    "Checks that can be run in CI, on a project that is not running",
+  );
 
 check
   .command("models")
@@ -219,7 +305,10 @@ check
       "cannot apply. Comma-separated, and repeatable",
     (value: string, previous: string[]) => [
       ...previous,
-      ...value.split(",").map((entry) => entry.trim()).filter(Boolean),
+      ...value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean),
     ],
     [] as string[],
   )
@@ -232,7 +321,10 @@ check
     // it took both.
     (value: string, previous: string[]) => [
       ...previous,
-      ...value.split(",").map((entry) => entry.trim()).filter(Boolean),
+      ...value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean),
     ],
     [] as string[],
   )

--- a/packages/gemi/console/Command.ts
+++ b/packages/gemi/console/Command.ts
@@ -1,0 +1,158 @@
+/**
+ * A command an operator runs by hand: `gemi run backfill-avatars --dry-run`.
+ *
+ * This file is the *runtime* shape — the base class discovery walks the
+ * prototype chain for, and the statics the runner reads. It is not the
+ * authoring surface. Applications write commands with `defineCommand` in
+ * `./builder`, which produces one of these; see that file for why the authoring
+ * surface is a builder and not a class body.
+ *
+ * ### Why the schema is descriptors and not a signature string
+ *
+ * Laravel spells this `protected $signature = 'mail:send {user} {--queue}'`, and
+ * the string is the whole schema. It reads beautifully and TypeScript cannot see
+ * a word of it: a brace in the wrong place is a parse error the first time
+ * somebody runs the command, months after it was written, and the parser is a
+ * piece of framework surface with its own failure modes. The descriptors below
+ * say the same thing in a shape the compiler checks — and, through the builder,
+ * in a shape that types the handler's own body.
+ *
+ * ### Why the name is declared and never falls back to the class name
+ *
+ * `Job` keys off `static name`, which shadows `Function.name`. That is the right
+ * trade there: a job's name *is* its class name, and the shadow is what makes it
+ * a string literal that survives minification. Here it is the wrong one twice
+ * over. A command's name is a CLI token (`backfill-avatars`, `db:seed`) with no
+ * relationship to the class name, so an implicit fallback would only ever be
+ * wrong; and shadowing `Function.name` costs the one error anybody will actually
+ * hit — "two commands claim `db:seed`" — the ability to say *which two*.
+ *
+ * ### The minification hazard does not reach here
+ *
+ * `services/discovery.ts` warns about a job that never declared `static name`,
+ * because two halves have to agree on one string across a bundler: the
+ * dispatcher, minified into `dist/server/server.mjs`, and discovery, reading the
+ * source. A command has one half — a human types the name and it is matched
+ * against discovery-on-source. Nothing in the server bundle names a command, and
+ * `gemi build` keeps `app/commands` out of the bundle anyway. So there is no
+ * `warnIfNameWillNotSurviveTheBuild` equivalent below, and adding one by analogy
+ * would be noise.
+ *
+ * If a `Command.call("db:seed")` reachable from a controller is ever added, that
+ * changes — and `commandName` being a declared string literal already covers it,
+ * which is one more reason not to fall back to the class binding.
+ */
+
+/** A positional argument. `variadic` collects the rest and must come last. */
+export interface ArgSpec {
+  description?: string;
+  /**
+   * Missing it is a usage error rather than an `undefined` in the handler.
+   * Mutually exclusive with `default` — an argument that is supplied when absent
+   * cannot also be absent, and declaring both is refused rather than silently
+   * resolved in one direction.
+   */
+  required?: boolean;
+  /** Collects every remaining positional. Only legal on the last argument. */
+  variadic?: boolean;
+  /** Supplied when the argument is absent, which makes it always present. */
+  default?: string;
+}
+
+/**
+ * A flag. The `type` decides both how the value is parsed and what the handler
+ * sees, which is why it is required rather than defaulted to `string`: a
+ * `--dry-run` declared without a type would arrive as the string `""`, and every
+ * `if (options.dryRun)` over it would be wrong in the one direction nobody
+ * tests.
+ */
+export type OptionSpec =
+  | {
+      type: "boolean";
+      description?: string;
+      /** Single character, without the dash. */
+      alias?: string;
+      default?: boolean;
+    }
+  | {
+      type: "string";
+      description?: string;
+      alias?: string;
+      default?: string;
+      required?: boolean;
+    }
+  | {
+      type: "number";
+      description?: string;
+      alias?: string;
+      default?: number;
+      required?: boolean;
+    };
+
+/** An argument as stored on the class: the spec, plus the name it was given. */
+export type CommandArgument = ArgSpec & { name: string };
+
+/** An option as stored on the class: the spec, plus the name it was given. */
+export type CommandOption = OptionSpec & { name: string };
+
+/** What a handler may return. `void` and `0` mean the same thing. */
+export type CommandResult = Promise<number | void> | number | void;
+
+/**
+ * A command that failed on purpose.
+ *
+ * The distinction `bin/check-models.ts` draws between `CheckModelsError` and
+ * everything else, in the one place an application can reach it: this is a
+ * sentence written for the terminal and is printed without a stack, while
+ * anything else that escapes a handler is a bug and keeps its stack.
+ */
+export class CommandFailed extends Error {
+  constructor(
+    message: string,
+    readonly code: number = 1,
+  ) {
+    super(message);
+    this.name = "CommandFailed";
+  }
+}
+
+/**
+ * The base class. Discovery finds subclasses of this; the runner reads the
+ * statics and calls `run`.
+ *
+ * Subclassing it by hand works and is what `defineCommand` does under the hood,
+ * but it gives up the typing that is the whole point of the builder — `run`'s
+ * parameter cannot be inferred from statics declared on the subclass, because
+ * TypeScript does not contextually type an overriding method's parameters. Write
+ * commands with `defineCommand`.
+ */
+export class Command {
+  /**
+   * The name typed on the command line. Mandatory: there is no sensible default
+   * and the class name is not one.
+   */
+  static commandName = "unset";
+
+  /** One line, printed by `gemi run` with no name and at the top of `--help`. */
+  static description = "";
+
+  /** Positional arguments, in order. A variadic one must be last. */
+  static args: CommandArgument[] = [];
+
+  /** Flags. Declared in camelCase; `dryRun` is spelled `--dry-run` on the CLI. */
+  static options: CommandOption[] = [];
+
+  /**
+   * The body.
+   *
+   * Runs inside `kernel.run()`, so `app(MailManager)` and a model read resolve
+   * exactly as they do in a request handler. Resolve services *here* rather than
+   * at module load: a command file is imported by discovery before the container
+   * has finished booting, and a service captured at the top of the file is
+   * captured from a container that is not ready.
+   */
+  run(_ctx: any): CommandResult {}
+}
+
+/** The type of a class `defineCommand(...).handle(...)` produces. */
+export type CommandClass = typeof Command;

--- a/packages/gemi/console/CommandRegistry.test.ts
+++ b/packages/gemi/console/CommandRegistry.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+
+import { Command } from "./Command";
+import { CommandRegistry } from "./CommandRegistry";
+import { defineCommand } from "./builder";
+
+/**
+ * The rules about what a command may be, and the seam a test asks "what did you
+ * actually take".
+ *
+ * The interesting decision recorded here is the duplicate-name one. `QueueManager
+ * .useJobs` and `Scheduler.start` both keep the first of two same-named classes
+ * and warn, because a server has to boot: running one of two identically-named
+ * jobs beats refusing to start. This refuses outright, because a CLI has no boot
+ * to protect and a person is waiting — running the wrong one of two commands
+ * called `db:seed` is strictly worse than running neither and being told why.
+ */
+
+const command = (name: string, description = "") =>
+  defineCommand(name)
+    .describe(description)
+    .handle(() => {});
+
+describe("what the registry took", () => {
+  test("is readable, and in declaration order", () => {
+    const registry = new CommandRegistry([
+      command("db:seed"),
+      command("send-digest"),
+    ]);
+
+    expect(registry.commands.map((entry) => entry.commandName)).toEqual([
+      "db:seed",
+      "send-digest",
+    ]);
+  });
+
+  test("looks up by the exact name, and misses cleanly", () => {
+    const registry = new CommandRegistry([command("db:seed")]);
+
+    expect(registry.get("db:seed")?.commandName).toBe("db:seed");
+    expect(registry.get("db:sed")).toBeUndefined();
+  });
+
+  test("an application with no commands is an ordinary state", () => {
+    expect(new CommandRegistry([]).commands).toEqual([]);
+  });
+});
+
+describe("commands that cannot be run", () => {
+  test("a class that never declared a name is refused, with the fix", () => {
+    class Nameless extends Command {}
+
+    expect(() => new CommandRegistry([Nameless])).toThrow(
+      /does not declare a command name/,
+    );
+    expect(() => new CommandRegistry([Nameless])).toThrow(/defineCommand/);
+  });
+
+  test("the refusal names the offending class", () => {
+    class Nameless extends Command {}
+
+    expect(() => new CommandRegistry([Nameless])).toThrow(/`Nameless`/);
+  });
+
+  /**
+   * The concrete payoff of keeping the name off `static name`. `Job` shadows
+   * `Function.name` to key its registry, which is right there; here it would
+   * cost this message the only two facts it has to convey.
+   */
+  test("two commands with one name are refused, naming both classes", () => {
+    const first = command("db:seed");
+    const second = command("db:seed");
+    Object.defineProperty(first, "name", { value: "SeedDatabase" });
+    Object.defineProperty(second, "name", { value: "SeedTenants" });
+
+    expect(() => new CommandRegistry([first, second])).toThrow(
+      /Two commands are named "db:seed"/,
+    );
+    expect(() => new CommandRegistry([first, second])).toThrow(/SeedDatabase/);
+    expect(() => new CommandRegistry([first, second])).toThrow(/SeedTenants/);
+  });
+});
+
+describe("suggesting a near miss", () => {
+  const registry = () =>
+    new CommandRegistry([
+      command("db:seed"),
+      command("db:reset"),
+      command("send-digest"),
+    ]);
+
+  test("a typo finds the name it meant", () => {
+    expect(registry().suggest("db:sed")).toContain("db:seed");
+    expect(registry().suggest("send-digset")).toContain("send-digest");
+  });
+
+  test("a prefix finds what it starts", () => {
+    expect(registry().suggest("send")).toEqual(["send-digest"]);
+  });
+
+  /**
+   * A typo inside the namespace is the common case, and the useful answer is
+   * every command in that namespace rather than the nearest single string.
+   */
+  test("a wrong name in a right namespace finds the namespace", () => {
+    expect(registry().suggest("db:truncate").sort()).toEqual([
+      "db:reset",
+      "db:seed",
+    ]);
+  });
+
+  test("something unrelated suggests nothing rather than reaching", () => {
+    expect(registry().suggest("completely-different")).toEqual([]);
+  });
+
+  test("at most three, so the message stays a message", () => {
+    const many = new CommandRegistry(
+      ["a:one", "a:two", "a:three", "a:four", "a:five"].map((name) =>
+        command(name),
+      ),
+    );
+
+    expect(many.suggest("a:six").length).toBeLessThanOrEqual(3);
+  });
+});

--- a/packages/gemi/console/CommandRegistry.ts
+++ b/packages/gemi/console/CommandRegistry.ts
@@ -1,0 +1,126 @@
+import type { CommandClass } from "./Command";
+
+/**
+ * The commands an application has, and the rules about what a command may be.
+ *
+ * A plain class, not a container service, and that is a decision rather than an
+ * omission. `QueueManager` and `Scheduler` are bound and populated during boot
+ * because the server needs them: a dispatch or a tick can arrive at any moment
+ * after boot finishes. A command registry has exactly one consumer — `gemi run`,
+ * which builds one, uses it, and exits. Making it a boot step would import every
+ * file under `app/commands` into every `gemi dev`, every `gemi start` and every
+ * deployed server process, on every start, for code no request will ever reach.
+ * That is the cost `bin/check-models.ts` argues against at length, and there is
+ * no benefit here to weigh against it.
+ *
+ * What the class is for is the rules below, and the `commands` getter — the same
+ * seam `QueueManager.registeredJobs` and `Scheduler.jobs` exist to give a test:
+ * what was actually taken, rather than what a walk would find if asked again.
+ */
+export class CommandRegistry {
+  private readonly byName = new Map<string, CommandClass>();
+
+  /**
+   * @throws Error naming the offending class for a command that cannot be run.
+   *
+   * Every refusal here is loud and immediate. There is a human at a terminal,
+   * and every one of these is a mistake in the application's own source that
+   * they are better off seeing now than after the command they meant to run
+   * silently did not exist.
+   */
+  constructor(commands: CommandClass[]) {
+    for (const command of commands) {
+      const name = command.commandName;
+
+      if (!name || name === "unset") {
+        throw new Error(
+          `${describe(command)} does not declare a command name, so there is ` +
+            `no name to run it by. Commands are written with \`defineCommand\`:` +
+            `\n\n    export default defineCommand("my-command")\n` +
+            `      .handle(async ({ line }) => { line("hello") })`,
+        );
+      }
+
+      const existing = this.byName.get(name);
+      if (existing) {
+        // Deliberately a hard error, where `QueueManager.useJobs` and
+        // `Scheduler.start` take the first and warn. Those two must keep a
+        // server booting, so running one of two identically-named jobs beats
+        // refusing to start at all. Here there is no boot to protect and a
+        // person is waiting: running the wrong one of two commands called
+        // `db:seed` is strictly worse than running neither and being told why.
+        throw new Error(
+          `Two commands are named "${name}": ${describe(existing)} and ` +
+            `${describe(command)}. A command name is how it is run, so one of ` +
+            `them could never be reached — rename one.`,
+        );
+      }
+
+      this.byName.set(name, command);
+    }
+  }
+
+  /** What was actually taken. */
+  get commands(): CommandClass[] {
+    return [...this.byName.values()];
+  }
+
+  get(name: string): CommandClass | undefined {
+    return this.byName.get(name);
+  }
+
+  /**
+   * The nearest names to something that did not match, for the "did you mean"
+   * line. Prefix matches first, then substring, then names sharing a namespace —
+   * `db:sed` should find `db:seed`, and a typo in a namespace is the common case.
+   */
+  suggest(name: string): string[] {
+    const needle = name.toLowerCase();
+    const namespace = needle.includes(":") ? needle.split(":")[0] : undefined;
+    const scored: Array<[number, string]> = [];
+
+    for (const candidate of this.byName.keys()) {
+      const haystack = candidate.toLowerCase();
+      if (haystack.startsWith(needle) || needle.startsWith(haystack)) {
+        scored.push([0, candidate]);
+      } else if (haystack.includes(needle) || needle.includes(haystack)) {
+        scored.push([1, candidate]);
+      } else if (namespace && haystack.startsWith(`${namespace}:`)) {
+        scored.push([2, candidate]);
+      } else if (editDistance(haystack, needle) <= 2) {
+        scored.push([3, candidate]);
+      }
+    }
+
+    return scored
+      .sort((a, b) => a[0] - b[0] || (a[1] < b[1] ? -1 : 1))
+      .slice(0, 3)
+      .map(([, candidate]) => candidate);
+  }
+}
+
+function describe(command: CommandClass): string {
+  return command.name ? `\`${command.name}\`` : "an anonymous command class";
+}
+
+/** Small enough that a dependency would cost more than it saves. */
+function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (Math.abs(a.length - b.length) > 2) return 99;
+
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+
+  for (let i = 1; i <= a.length; i += 1) {
+    const current = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      current[j] = Math.min(
+        previous[j]! + 1,
+        current[j - 1]! + 1,
+        previous[j - 1]! + (a[i - 1] === b[j - 1] ? 0 : 1),
+      );
+    }
+    previous = current;
+  }
+
+  return previous[b.length]!;
+}

--- a/packages/gemi/console/CommandRegistry.ts
+++ b/packages/gemi/console/CommandRegistry.ts
@@ -1,4 +1,5 @@
 import type { CommandClass } from "./Command";
+import { ConsoleError } from "./errors";
 
 /**
  * The commands an application has, and the rules about what a command may be.
@@ -21,19 +22,25 @@ export class CommandRegistry {
   private readonly byName = new Map<string, CommandClass>();
 
   /**
-   * @throws Error naming the offending class for a command that cannot be run.
+   * @throws ConsoleError naming the offending class for a command that cannot
+   * be run.
    *
    * Every refusal here is loud and immediate. There is a human at a terminal,
    * and every one of these is a mistake in the application's own source that
    * they are better off seeing now than after the command they meant to run
    * silently did not exist.
+   *
+   * `ConsoleError` rather than a plain `Error` so the runner prints the message
+   * alone. These are sentences with the fix named in them, and burying one under
+   * `at new CommandRegistry (…)` plus the runner's own frames points the reader
+   * at framework code when the mistake is in their `app/commands`.
    */
   constructor(commands: CommandClass[]) {
     for (const command of commands) {
       const name = command.commandName;
 
       if (!name || name === "unset") {
-        throw new Error(
+        throw new ConsoleError(
           `${describe(command)} does not declare a command name, so there is ` +
             `no name to run it by. Commands are written with \`defineCommand\`:` +
             `\n\n    export default defineCommand("my-command")\n` +
@@ -49,7 +56,7 @@ export class CommandRegistry {
         // refusing to start at all. Here there is no boot to protect and a
         // person is waiting: running the wrong one of two commands called
         // `db:seed` is strictly worse than running neither and being told why.
-        throw new Error(
+        throw new ConsoleError(
           `Two commands are named "${name}": ${describe(existing)} and ` +
             `${describe(command)}. A command name is how it is run, so one of ` +
             `them could never be reached — rename one.`,

--- a/packages/gemi/console/builder.test-d.ts
+++ b/packages/gemi/console/builder.test-d.ts
@@ -1,0 +1,169 @@
+import { describe, expectTypeOf, test } from "vitest";
+
+import { defineCommand } from "./builder";
+import type { CommandContext } from "./context";
+
+/**
+ * The builder's whole reason for existing, and the only file that can check it.
+ *
+ * A class body cannot type a command's own handler: TypeScript does not
+ * contextually type an overriding method's parameters from the base-class method
+ * it overrides, so `static args` next to `run(ctx)` leaves `ctx` an implicit
+ * `any` — and so does a configured base class returned by a `Command.define()`.
+ * A function expression passed as an argument *is* contextually typed, which is
+ * why `.handle(fn)` is the shape.
+ *
+ * None of that is observable at run time. A regression in the inference types —
+ * a `const` type parameter dropped, a conditional branch that stops firing —
+ * would leave every other test in this repository green while quietly handing
+ * every handler an `any`. Hence the last block: **asserting a property of `any`
+ * succeeds**, so a suite that only checked `toEqualTypeOf<string>()` would pass
+ * just as happily on a builder that had stopped inferring anything at all.
+ */
+
+describe("arguments", () => {
+  test("required is present, bare is optional", () => {
+    defineCommand("demo")
+      .arg("required", { required: true })
+      .arg("bare")
+      .handle(({ args }) => {
+        expectTypeOf(args.required).toEqualTypeOf<string>();
+        expectTypeOf(args.bare).toEqualTypeOf<string | undefined>();
+      });
+  });
+
+  test("a default makes an argument always present", () => {
+    defineCommand("demo")
+      .arg("env", { default: "staging" })
+      .handle(({ args }) => {
+        expectTypeOf(args.env).toEqualTypeOf<string>();
+      });
+  });
+
+  test("a variadic argument is a list, never undefined", () => {
+    defineCommand("demo")
+      .arg("rest", { variadic: true })
+      .handle(({ args }) => {
+        expectTypeOf(args.rest).toEqualTypeOf<string[]>();
+      });
+  });
+
+  test("a description alone does not make an argument present", () => {
+    defineCommand("demo")
+      .arg("who", { description: "Who to greet" })
+      .handle(({ args }) => {
+        expectTypeOf(args.who).toEqualTypeOf<string | undefined>();
+      });
+  });
+});
+
+describe("options", () => {
+  test("a boolean is always a boolean", () => {
+    defineCommand("demo")
+      .option("dryRun", { type: "boolean" })
+      .handle(({ options }) => {
+        expectTypeOf(options.dryRun).toEqualTypeOf<boolean>();
+      });
+  });
+
+  test("a number is optional until it has a default or is required", () => {
+    defineCommand("demo")
+      .option("bare", { type: "number" })
+      .option("defaulted", { type: "number", default: 50 })
+      .option("required", { type: "number", required: true })
+      .handle(({ options }) => {
+        expectTypeOf(options.bare).toEqualTypeOf<number | undefined>();
+        expectTypeOf(options.defaulted).toEqualTypeOf<number>();
+        expectTypeOf(options.required).toEqualTypeOf<number>();
+      });
+  });
+
+  test("a string behaves the same way, and stays a string", () => {
+    defineCommand("demo")
+      .option("bare", { type: "string" })
+      .option("defaulted", { type: "string", default: "x" })
+      .handle(({ options }) => {
+        expectTypeOf(options.bare).toEqualTypeOf<string | undefined>();
+        expectTypeOf(options.defaulted).toEqualTypeOf<string>();
+      });
+  });
+});
+
+describe("accumulation across the chain", () => {
+  test("every declaration survives, in any order, past describe()", () => {
+    defineCommand("demo")
+      .arg("one", { required: true })
+      .describe("interleaved on purpose")
+      .option("two", { type: "number", default: 1 })
+      .arg("three")
+      .option("four", { type: "boolean" })
+      .handle(({ args, options }) => {
+        expectTypeOf(args.one).toEqualTypeOf<string>();
+        expectTypeOf(args.three).toEqualTypeOf<string | undefined>();
+        expectTypeOf(options.two).toEqualTypeOf<number>();
+        expectTypeOf(options.four).toEqualTypeOf<boolean>();
+      });
+  });
+
+  test("a name that was never declared is an error", () => {
+    defineCommand("demo")
+      .arg("who", { required: true })
+      .handle(({ args, options }) => {
+        // Reading a name nothing declared is an error, and suppressing it gets
+        // you `any` — which is what the assertions below are asserting, and why
+        // they are written as bindings rather than as bare member reads.
+        // @ts-expect-error - `whom` was never declared
+        const missingArg = args.whom;
+        // @ts-expect-error - no options were declared at all
+        const missingOption = options.anything;
+
+        expectTypeOf(missingArg).toBeAny();
+        expectTypeOf(missingOption).toBeAny();
+      });
+  });
+});
+
+describe("the context itself", () => {
+  test("carries the writers and the raw tail", () => {
+    defineCommand("demo").handle((ctx) => {
+      expectTypeOf(ctx.line).toBeFunction();
+      expectTypeOf(ctx.error).toBeFunction();
+      expectTypeOf(ctx.argv).toEqualTypeOf<readonly string[]>();
+      expectTypeOf(ctx.fail).returns.toBeNever();
+    });
+  });
+
+  /**
+   * The assertion the rest of this file rests on.
+   *
+   * `expectTypeOf<any>().toEqualTypeOf<string>()` passes. So does every other
+   * check above, if the inference collapses and the handler starts receiving
+   * `any` — which is exactly what a class body does today and what this whole
+   * design exists to avoid. Without this, the suite cannot tell the two apart.
+   */
+  test("is never any — the failure every other assertion here would hide", () => {
+    defineCommand("demo")
+      .arg("who", { required: true })
+      .option("loud", { type: "boolean" })
+      .handle((ctx) => {
+        expectTypeOf(ctx).not.toBeAny();
+        expectTypeOf(ctx.args).not.toBeAny();
+        expectTypeOf(ctx.options).not.toBeAny();
+        expectTypeOf(ctx.args.who).not.toBeAny();
+        expectTypeOf(ctx.options.loud).not.toBeAny();
+        expectTypeOf(ctx).toMatchTypeOf<CommandContext>();
+      });
+  });
+});
+
+describe("the handler's return type", () => {
+  test("nothing, a number, or a promise of either", () => {
+    defineCommand("demo").handle(() => {});
+    defineCommand("demo").handle(() => 0);
+    defineCommand("demo").handle(async () => 3);
+    defineCommand("demo").handle(async () => {});
+
+    // @ts-expect-error - a string is not an exit code
+    defineCommand("demo").handle(() => "done");
+  });
+});

--- a/packages/gemi/console/builder.test.ts
+++ b/packages/gemi/console/builder.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "vitest";
+
+import { Command } from "./Command";
+import { defineCommand, isUnfinishedBuilder } from "./builder";
+
+/**
+ * The builder's run-time half: what it produces, and what it refuses.
+ *
+ * The type tests beside this file cover the inference, which is the reason the
+ * builder exists. What is left is the handful of declarations that are wrong in
+ * a way no type can express — a variadic argument with something after it, an
+ * argument that is both required and defaulted — and the shape of the class that
+ * comes out the other end, which everything downstream reads.
+ *
+ * Every refusal here throws at *declaration* time rather than when the command
+ * runs. That is deliberate: these are mistakes in the application's own source,
+ * and the author is looking at the file right now. Surfacing them later means
+ * showing a confusing usage error to an operator who cannot fix it.
+ */
+
+describe("what the builder produces", () => {
+  test("a Command subclass, which is what discovery looks for", () => {
+    const Produced = defineCommand("demo").handle(() => {});
+
+    expect(Object.prototype.isPrototypeOf.call(Command, Produced)).toBe(true);
+    expect(Produced).not.toBe(Command);
+  });
+
+  test("the statics the runner and the help renderer read", () => {
+    const Produced = defineCommand("send-digest")
+      .describe("Send the weekly digest")
+      .arg("segment", { required: true })
+      .option("dryRun", { type: "boolean" })
+      .handle(() => {});
+
+    expect(Produced.commandName).toBe("send-digest");
+    expect(Produced.description).toBe("Send the weekly digest");
+    expect(Produced.args).toEqual([{ name: "segment", required: true }]);
+    expect(Produced.options).toEqual([{ name: "dryRun", type: "boolean" }]);
+  });
+
+  /**
+   * An anonymous class expression reports `name === ""`, and the duplicate-name
+   * error's whole job is to say *which two*. Without this it would say neither.
+   */
+  test("carries the command name as its class name", () => {
+    expect(defineCommand("db:seed").handle(() => {}).name).toBe("db:seed");
+  });
+
+  test("runs the handler it was given, and passes the context through", () => {
+    const Produced = defineCommand("demo").handle(
+      (ctx: any) => `saw ${ctx.args.who}`,
+    );
+
+    expect(new Produced().run({ args: { who: "world" } })).toBe("saw world");
+  });
+
+  test("declaration order is preserved, which is what makes positionals work", () => {
+    const Produced = defineCommand("demo")
+      .arg("first")
+      .arg("second")
+      .arg("third")
+      .handle(() => {});
+
+    expect(Produced.args.map((arg) => arg.name)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+});
+
+describe("names that cannot be run", () => {
+  /**
+   * Aimed at one specific reader: somebody who knows Laravel and reaches for
+   * `defineCommand("mail:send {user} {--queue}")`. Without this they get a
+   * command registered under a name containing spaces, which can never be typed
+   * and so never runs, and no explanation of why.
+   */
+  test("a Laravel signature string is refused, pointing at .arg and .option", () => {
+    expect(() => defineCommand("mail:send {user} {--queue}")).toThrow(
+      /does not parse a signature string/,
+    );
+    expect(() => defineCommand("mail:send {user}")).toThrow(/\.arg\(\)/);
+  });
+
+  test("whitespace alone is enough to refuse", () => {
+    expect(() => defineCommand("send digest")).toThrow(/Invalid command name/);
+  });
+
+  test("an empty name is refused", () => {
+    expect(() => defineCommand("  ")).toThrow(/cannot be empty/);
+  });
+
+  test("the ordinary shapes are accepted", () => {
+    expect(defineCommand("send-digest").handle(() => {}).commandName).toBe(
+      "send-digest",
+    );
+    expect(defineCommand("db:seed").handle(() => {}).commandName).toBe(
+      "db:seed",
+    );
+  });
+});
+
+describe("declarations that contradict themselves", () => {
+  test("an argument cannot be both required and defaulted", () => {
+    expect(() =>
+      defineCommand("demo").arg("env", { required: true, default: "staging" }),
+    ).toThrow(/both required and has a default/);
+  });
+
+  /**
+   * A variadic argument collects everything that follows, so anything declared
+   * after it could never receive a value — the command would run, and one of its
+   * arguments would be permanently empty with nothing to say so.
+   */
+  test("nothing may be declared after a variadic argument", () => {
+    expect(() =>
+      defineCommand("demo").arg("rest", { variadic: true }).arg("after"),
+    ).toThrow(/must be declared last/);
+  });
+
+  test("a name declared twice is refused, for arguments and options alike", () => {
+    expect(() => defineCommand("demo").arg("who").arg("who")).toThrow(
+      /declares the argument "who" twice/,
+    );
+    expect(() =>
+      defineCommand("demo")
+        .option("loud", { type: "boolean" })
+        .option("loud", { type: "boolean" }),
+    ).toThrow(/declares the option "loud" twice/);
+  });
+
+  test("two options cannot share an alias", () => {
+    expect(() =>
+      defineCommand("demo")
+        .option("limit", { type: "number", alias: "l" })
+        .option("locale", { type: "string", alias: "l" }),
+    ).toThrow(/both use the alias "-l"/);
+  });
+});
+
+describe("recognising a chain that was never finished", () => {
+  /**
+   * The one silence the builder introduces. A builder that never called
+   * `.handle()` is a plain object rather than a class, so `discoverClasses`
+   * discards it along with every constant a command file happens to export — and
+   * the command disappears from `gemi run` with nothing raised.
+   *
+   * `discoverCommands` uses this to tell that case apart from an ordinary
+   * non-class export and refuse the file by name.
+   */
+  test("an unfinished builder is recognisable, and a finished one is not", () => {
+    expect(isUnfinishedBuilder(defineCommand("demo"))).toBe(true);
+    expect(isUnfinishedBuilder(defineCommand("demo").arg("who"))).toBe(true);
+    expect(isUnfinishedBuilder(defineCommand("demo").handle(() => {}))).toBe(
+      false,
+    );
+  });
+
+  test("the ordinary exports a command file carries are not mistaken for one", () => {
+    for (const value of [undefined, null, {}, [], "x", 42, () => {}, Command]) {
+      expect(isUnfinishedBuilder(value)).toBe(false);
+    }
+  });
+});

--- a/packages/gemi/console/builder.test.ts
+++ b/packages/gemi/console/builder.test.ts
@@ -47,6 +47,34 @@ describe("what the builder produces", () => {
     expect(defineCommand("db:seed").handle(() => {}).name).toBe("db:seed");
   });
 
+  /**
+   * The statics are a snapshot, not a window onto the builder.
+   *
+   * The builder goes on owning its `args`/`options` arrays and pushing to them,
+   * so storing the instances themselves let a chain reach back into a class it
+   * had already produced. Both `--help` and the parser read these statics, so a
+   * finished command's printed usage and accepted arguments could change
+   * afterwards.
+   */
+  test("copies the declarations, so a later .arg() cannot reach back in", () => {
+    const builder = defineCommand("demo").arg("first");
+    const Produced = builder.handle(() => {});
+
+    builder.arg("late").option("later", { type: "boolean" });
+
+    expect(Produced.args).toEqual([{ name: "first" }]);
+    expect(Produced.options).toEqual([]);
+  });
+
+  test("two commands off one builder do not share a schema", () => {
+    const builder = defineCommand("demo");
+    const First = builder.handle(() => {});
+    const Second = builder.arg("only-on-second").handle(() => {});
+
+    expect(First.args).toEqual([]);
+    expect(Second.args).toEqual([{ name: "only-on-second" }]);
+  });
+
   test("runs the handler it was given, and passes the context through", () => {
     const Produced = defineCommand("demo").handle(
       (ctx: any) => `saw ${ctx.args.who}`,
@@ -110,6 +138,19 @@ describe("declarations that contradict themselves", () => {
   });
 
   /**
+   * A variadic collects whatever is left and is an empty list when there is
+   * nothing, so there is no "absent" for a default to fill. Refused rather than
+   * ignored, because a declaration the parser silently drops reads — to whoever
+   * wrote it — exactly like one it honours. (`required` on a variadic *does*
+   * mean something, and `parse.ts` enforces it: at least one.)
+   */
+  test("a variadic argument cannot have a default", () => {
+    expect(() =>
+      defineCommand("demo").arg("files", { variadic: true, default: "x" }),
+    ).toThrow(/variadic and has a default/);
+  });
+
+  /**
    * A variadic argument collects everything that follows, so anything declared
    * after it could never receive a value — the command would run, and one of its
    * arguments would be permanently empty with nothing to say so.
@@ -162,5 +203,30 @@ describe("recognising a chain that was never finished", () => {
     for (const value of [undefined, null, {}, [], "x", 42, () => {}, Command]) {
       expect(isUnfinishedBuilder(value)).toBe(false);
     }
+  });
+
+  /**
+   * "Unfinished" has to mean *this chain produced nothing*, not *this export is
+   * still a builder object*. The two differ for the natural way to share
+   * declarations between commands:
+   *
+   *     export const base = defineCommand("reindex").option("verbose", …);
+   *     export default base.handle(async () => {});
+   *
+   * Both exports are visible to discovery, and `base` is a builder that did
+   * produce a command. Keying off the shape alone made that file throw — and
+   * because the throw happens before the registry is built, it took *every other
+   * command in the project* down with it, under a message that was untrue.
+   */
+  test("a chain that did reach .handle() is finished, however it was held", () => {
+    const base = defineCommand("reindex").option("verbose", {
+      type: "boolean",
+    });
+
+    expect(isUnfinishedBuilder(base)).toBe(true);
+
+    base.handle(() => {});
+
+    expect(isUnfinishedBuilder(base)).toBe(false);
   });
 });

--- a/packages/gemi/console/builder.ts
+++ b/packages/gemi/console/builder.ts
@@ -1,0 +1,270 @@
+import {
+  Command,
+  type ArgSpec,
+  type CommandArgument,
+  type CommandClass,
+  type CommandOption,
+  type CommandResult,
+  type OptionSpec,
+} from "./Command";
+import type { CommandContext } from "./context";
+
+/**
+ * Declaring a command, in the one shape that can type its own body.
+ *
+ * ### Why a builder and not a class
+ *
+ * The point of declaring arguments and options at all is that the handler then
+ * knows what it has. A class body cannot deliver that, and the reason is a hard
+ * TypeScript rule rather than a matter of arrangement: **TypeScript does not
+ * contextually type a method's parameters from the base-class method it
+ * overrides.** So both class-shaped designs fail in the same place:
+ *
+ * ```ts
+ * class Backfill extends Command {
+ *   static args = [{ name: "since", required: true }];
+ *   async run(ctx) {}                       // implicit any
+ * }
+ *
+ * class Backfill extends Command.define({ since: { required: true } }) {
+ *   async run(ctx) {}                       // still implicit any — the
+ * }                                         // configured base's signature does
+ *                                           // not flow into the override
+ * ```
+ *
+ * The author's only way out is to restate the type by hand, which is the
+ * ceremony the descriptors existed to remove — and which nothing enforces, so a
+ * wrong restatement compiles.
+ *
+ * A **function expression passed as an argument is contextually typed**. That is
+ * the entire mechanism here, and it is why this is a builder rather than sugar:
+ * `.handle(fn)` carries the accumulated argument and option types into `fn`'s
+ * parameter with nothing written by hand and nothing to keep in step.
+ *
+ * ### What it produces
+ *
+ * A `Command` subclass, so nothing downstream knows the difference: discovery
+ * finds it by prototype chain, and the registry, parser and `--help` read the
+ * same statics they would read off a hand-written class. The builder is an
+ * authoring surface over one runtime shape, not a second mechanism.
+ */
+
+/**
+ * Marks a builder that was never finished. `discoverCommands` looks for this on
+ * the exports it is about to discard — see the note on `handle` below.
+ */
+export const BUILDER_BRAND: unique symbol = Symbol.for("gemi.console.builder");
+
+/** Flattens an accumulated intersection so editor hovers stay readable. */
+type Simplify<T> = { [K in keyof T]: T[K] } & {};
+
+/**
+ * What the handler sees for one argument.
+ *
+ * The order matters: `variadic` first because it wins over everything, then the
+ * two ways an argument is guaranteed present. Anything else can be absent and
+ * says so.
+ */
+export type ArgValue<S> = S extends { variadic: true }
+  ? string[]
+  : S extends { required: true }
+    ? string
+    : S extends { default: string }
+      ? string
+      : string | undefined;
+
+/** What the handler sees for one option. */
+export type OptionValue<S> = S extends { type: "boolean" }
+  ? boolean
+  : S extends { type: "number" }
+    ? S extends { default: number }
+      ? number
+      : S extends { required: true }
+        ? number
+        : number | undefined
+    : S extends { default: string }
+      ? string
+      : S extends { required: true }
+        ? string
+        : string | undefined;
+
+export interface CommandBuilder<
+  A extends Record<string, unknown>,
+  O extends Record<string, unknown>,
+> {
+  /** One line, shown in the listing and at the top of `--help`. */
+  describe(text: string): CommandBuilder<A, O>;
+
+  /**
+   * A positional argument. Declared in the order it is read from the command
+   * line; a `variadic` one must be last.
+   */
+  arg<N extends string, const S extends ArgSpec = {}>(
+    name: N,
+    spec?: S,
+  ): CommandBuilder<A & { [K in N]: ArgValue<S> }, O>;
+
+  /**
+   * A flag. Declared in camelCase and spelled in kebab-case on the command line,
+   * so `.option("dryRun", …)` is `--dry-run` for the operator and
+   * `options.dryRun` in the handler — no string key nobody can autocomplete, and
+   * no CLI flag with a capital letter in it.
+   */
+  option<N extends string, const S extends OptionSpec>(
+    name: N,
+    spec: S,
+  ): CommandBuilder<A, O & { [K in N]: OptionValue<S> }>;
+
+  /**
+   * The body, and the terminal of the chain.
+   *
+   * A builder that never reaches here is not a class, so discovery would skip it
+   * and the command would simply vanish from `gemi run` with nothing raised —
+   * the silence #322 and #323 exist to remove, reintroduced by a new authoring
+   * surface. `discoverCommands` therefore looks for `BUILDER_BRAND` among the
+   * exports it discards and refuses the file by name.
+   */
+  handle(
+    fn: (ctx: CommandContext<Simplify<A>, Simplify<O>>) => CommandResult,
+  ): CommandClass;
+}
+
+/**
+ * Refused early, where the author is looking.
+ *
+ * The whitespace and brace checks are aimed at one specific reader: somebody who
+ * knows Laravel and reaches for `defineCommand("mail:send {user} {--queue}")`.
+ * Without this they get a command registered under a name containing a space,
+ * which can never be typed and never runs, and no explanation.
+ */
+function assertUsableName(name: string): void {
+  if (name.trim() === "") {
+    throw new Error("A command name cannot be empty.");
+  }
+
+  if (/[{}]/.test(name) || /\s/.test(name)) {
+    throw new Error(
+      `Invalid command name ${JSON.stringify(name)}. gemi does not parse a ` +
+        `signature string; the name is the whole of it. Declare arguments ` +
+        `with .arg() and flags with .option():\n\n` +
+        `    defineCommand("mail:send")\n` +
+        `      .arg("user", { required: true })\n` +
+        `      .option("queue", { type: "boolean" })\n` +
+        `      .handle(async ({ args, options }) => { ... })`,
+    );
+  }
+}
+
+export function defineCommand(name: string): CommandBuilder<{}, {}> {
+  assertUsableName(name);
+
+  const args: CommandArgument[] = [];
+  const options: CommandOption[] = [];
+  let description = "";
+
+  const builder = {
+    [BUILDER_BRAND]: name,
+
+    describe(text: string) {
+      description = text;
+      return builder;
+    },
+
+    arg(argName: string, spec: ArgSpec = {}) {
+      // Checked here rather than at parse time because both of these are
+      // mistakes in the declaration, and the declaration is what the author is
+      // looking at right now. At parse time they would surface as a confusing
+      // usage error in front of an operator who cannot fix them.
+      if (spec.required && spec.default !== undefined) {
+        throw new Error(
+          `Argument "${argName}" of command "${name}" is both required and has ` +
+            `a default. An argument that is supplied when absent cannot also be ` +
+            `absent — drop one.`,
+        );
+      }
+
+      const variadic = args.find((existing) => existing.variadic);
+      if (variadic) {
+        throw new Error(
+          `Argument "${argName}" of command "${name}" is declared after the ` +
+            `variadic argument "${variadic.name}", which collects everything ` +
+            `that follows, so "${argName}" could never receive a value. A ` +
+            `variadic argument must be declared last.`,
+        );
+      }
+
+      if (args.some((existing) => existing.name === argName)) {
+        throw new Error(
+          `Command "${name}" declares the argument "${argName}" twice.`,
+        );
+      }
+
+      args.push({ ...spec, name: argName });
+      return builder;
+    },
+
+    option(optionName: string, spec: OptionSpec) {
+      if (options.some((existing) => existing.name === optionName)) {
+        throw new Error(
+          `Command "${name}" declares the option "${optionName}" twice.`,
+        );
+      }
+
+      const alias = "alias" in spec ? spec.alias : undefined;
+      const clash =
+        alias === undefined
+          ? undefined
+          : options.find(
+              (existing) => "alias" in existing && existing.alias === alias,
+            );
+      if (clash) {
+        throw new Error(
+          `Options "${clash.name}" and "${optionName}" of command "${name}" ` +
+            `both use the alias "-${alias}".`,
+        );
+      }
+
+      options.push({ ...spec, name: optionName });
+      return builder;
+    },
+
+    handle(fn: (ctx: any) => CommandResult) {
+      const commandName = name;
+      const commandDescription = description;
+
+      const cls = class extends Command {
+        static commandName = commandName;
+        static description = commandDescription;
+        static args = args;
+        static options = options;
+
+        run(ctx: any) {
+          return fn(ctx);
+        }
+      };
+
+      // An anonymous class expression reports `name === ""`, and the duplicate-
+      // name error's whole job is to say *which two*. Give it the one name it
+      // has.
+      Object.defineProperty(cls, "name", {
+        value: commandName,
+        configurable: true,
+      });
+
+      return cls;
+    },
+  };
+
+  return builder as unknown as CommandBuilder<{}, {}>;
+}
+
+/** True for a builder that never called `.handle()`. */
+export function isUnfinishedBuilder(
+  value: unknown,
+): value is { [BUILDER_BRAND]: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<PropertyKey, unknown>)[BUILDER_BRAND] === "string"
+  );
+}

--- a/packages/gemi/console/builder.ts
+++ b/packages/gemi/console/builder.ts
@@ -183,6 +183,19 @@ export function defineCommand(name: string): CommandBuilder<{}, {}> {
         );
       }
 
+      // A variadic collects whatever is left, so there is no "absent" for a
+      // default to fill — the empty list is the answer. Refused rather than
+      // ignored, for the same reason as the pair above: a declaration the parser
+      // silently drops reads, to whoever wrote it, exactly like one it honours.
+      if (spec.variadic && spec.default !== undefined) {
+        throw new Error(
+          `Argument "${argName}" of command "${name}" is variadic and has a ` +
+            `default. A variadic argument collects the remaining values and is ` +
+            `an empty list when there are none, so the default could never ` +
+            `apply — drop it, or drop \`variadic\`.`,
+        );
+      }
+
       const variadic = args.find((existing) => existing.variadic);
       if (variadic) {
         throw new Error(
@@ -235,13 +248,32 @@ export function defineCommand(name: string): CommandBuilder<{}, {}> {
       const cls = class extends Command {
         static commandName = commandName;
         static description = commandDescription;
-        static args = args;
-        static options = options;
+        // Copied, not aliased. The builder goes on owning `args`/`options` and
+        // mutating them on every subsequent `.arg()`/`.option()`, so storing the
+        // instances themselves let a chain reach back into a class it had
+        // already produced — and `--help` and the parser both read these
+        // statics, so the printed usage and the accepted arguments would change
+        // under a command that was finished.
+        static args = [...args];
+        static options = [...options];
 
         run(ctx: any) {
           return fn(ctx);
         }
       };
+
+      // This chain produced a command, so it is no longer unfinished. The brand
+      // exists to catch a file that exports a builder and never calls `.handle()`
+      // — see `refuseUnfinishedBuilders` in `services/discovery.ts`. Leaving it
+      // set meant the natural way to share declarations,
+      //
+      //     export const base = defineCommand("reindex").option("verbose", ...);
+      //     export default base.handle(async () => {});
+      //
+      // left a branded object among the file's exports and aborted the whole of
+      // `gemi run` — every command in the project unrunnable, under a message
+      // that was untrue for that file.
+      delete (builder as Record<PropertyKey, unknown>)[BUILDER_BRAND];
 
       // An anonymous class expression reports `name === ""`, and the duplicate-
       // name error's whole job is to say *which two*. Give it the one name it

--- a/packages/gemi/console/config.ts
+++ b/packages/gemi/console/config.ts
@@ -1,0 +1,58 @@
+import type { CommandClass } from "./Command";
+
+// Config key: `command`. Consumed by `gemi run`, and by nothing at boot.
+//
+// Named `command` rather than `console` on purpose. An app declares its slices
+// by importing them into `app/kernel/Kernel.ts`, and a file called
+// `app/config/console.ts` arrives there as `import console from
+// "../config/console"` — which shadows the global `console` for the rest of that
+// module. Every application would inherit that, silently. `command` also matches
+// the singular slice names already in use: `route`, `queue`, `schedule`, `log`.
+export interface CommandConfig {
+  /**
+   * The `Command` classes this application can run, or nothing.
+   *
+   * ### The rule, exactly
+   *
+   * **Declared wins, and `[]` is declared.** A `commands` that is present is
+   * used verbatim and no directory is read — the escape hatch for an app whose
+   * commands live somewhere the walk cannot reach, and for a deploy that ships
+   * no source. An empty array means an app with no commands and says so; it does
+   * not mean "find some".
+   *
+   * **Absent or `undefined` discovers.** `undefined` counts as absent for the
+   * same reason `withDefaults` treats it that way everywhere else: a key spread
+   * in from an optional value is an omission, not an instruction.
+   *
+   * ### One way this differs from `queue` and `schedule`
+   *
+   * There, the cost of the list and the directory disagreeing is silence — a
+   * dispatch dropped with a line on stderr nobody reads, a report that stops
+   * arriving. Here it is a person typing `gemi run thing` and being told, in
+   * those words, that there is no command called `thing`. The rule is kept for
+   * consistency and for the source-less-deploy case, not because the stakes are
+   * the same.
+   */
+  commands?: CommandClass[];
+
+  /**
+   * Where to look when `commands` was not declared. Relative to the project
+   * root, or absolute.
+   *
+   * Every `.ts`/`.tsx` file underneath is imported when a command is run, so
+   * this wants to be a directory of command declarations rather than a directory
+   * that merely contains some.
+   */
+  commandsDir?: string;
+}
+
+export function defineCommandConfig(config: CommandConfig): CommandConfig {
+  return config;
+}
+
+export function commandConfigDefaults(): Required<CommandConfig> {
+  return {
+    commands: [],
+    commandsDir: "app/commands",
+  };
+}

--- a/packages/gemi/console/context.ts
+++ b/packages/gemi/console/context.ts
@@ -1,0 +1,95 @@
+import { CommandFailed } from "./Command";
+
+/**
+ * The single argument a command handler receives.
+ *
+ * ### Why the output helpers live here and not on `this`
+ *
+ * The authoring surface is a builder terminating in `.handle(fn)`, and `fn` is
+ * an arrow function with no useful `this`. That turns out to be the better
+ * arrangement rather than a cost to work around: the helpers are destructured on
+ * the first line of the handler, so a reader sees which streams a command writes
+ * to before reading any of it, and a test supplies its own writers by passing a
+ * context instead of subclassing.
+ *
+ * ### Why there are three of them
+ *
+ * The load-bearing thing a framework can own here is **stream discipline, not
+ * colour**. A diagnostic printed to stdout is what breaks
+ * `TOTAL=$(gemi run count-users)` and what makes a CI grep match a progress line
+ * instead of the answer, and that mistake is invisible until somebody pipes the
+ * command somewhere.
+ *
+ * So: `line` is the command's answer and goes to stdout, `error` is a diagnostic
+ * and goes to stderr, and `fail` ends the command. Deliberately absent are
+ * `info`/`success` (`line` with a colour, and colour is the application's
+ * business), `warn` (identical to `error`; two names for one stream is a coin
+ * flip at every call site), and tables or progress bars — a console formatting
+ * library is a project, not a feature.
+ */
+export interface CommandContext<
+  A = Record<string, unknown>,
+  O = Record<string, unknown>,
+> {
+  /** The positional arguments, by the names `.arg()` declared. */
+  args: A;
+
+  /** The flags, by the names `.option()` declared. */
+  options: O;
+
+  /**
+   * Everything after the command name, unparsed.
+   *
+   * The escape hatch, for a command that wants to forward its tail to something
+   * else. Present even when parsing succeeded, so a command never has to choose
+   * between the declared schema and the raw truth.
+   */
+  argv: readonly string[];
+
+  /** The command's answer, on stdout. */
+  line(message?: string): void;
+
+  /** A diagnostic, on stderr. Does not end the command. */
+  error(message: string): void;
+
+  /**
+   * Ends the command with a message and an exit code, and no stack.
+   *
+   * Throws rather than returning, so it type-checks as the last statement of any
+   * branch and a caller cannot forget to `return` after it.
+   */
+  fail(message: string, code?: number): never;
+}
+
+/** Where a context writes. Injectable so tests can capture without spawning. */
+export interface CommandWriters {
+  stdout: (chunk: string) => void;
+  stderr: (chunk: string) => void;
+}
+
+export function processWriters(): CommandWriters {
+  return {
+    stdout: (chunk) => process.stdout.write(chunk),
+    stderr: (chunk) => process.stderr.write(chunk),
+  };
+}
+
+export function createContext<A, O>(params: {
+  args: A;
+  options: O;
+  argv: readonly string[];
+  writers?: CommandWriters;
+}): CommandContext<A, O> {
+  const writers = params.writers ?? processWriters();
+
+  return {
+    args: params.args,
+    options: params.options,
+    argv: params.argv,
+    line: (message = "") => writers.stdout(`${message}\n`),
+    error: (message: string) => writers.stderr(`${message}\n`),
+    fail: (message: string, code = 1) => {
+      throw new CommandFailed(message, code);
+    },
+  };
+}

--- a/packages/gemi/console/context.ts
+++ b/packages/gemi/console/context.ts
@@ -67,10 +67,56 @@ export interface CommandWriters {
   stderr: (chunk: string) => void;
 }
 
-export function processWriters(): CommandWriters {
+/**
+ * Writers onto this process's streams, and the means to know they landed.
+ *
+ * ### Why `flush` exists
+ *
+ * `process.stdout.write` is asynchronous when stdout is a pipe, and `gemi run`
+ * ends in an explicit `process.exit` — which it must, or a command holding a
+ * database pool open would finish its work and then sit there. Those two facts
+ * together truncate output at the pipe buffer: measured on Bun 1.3.14, a
+ * 2,000,000-byte write followed immediately by `process.exit(0)` delivers
+ * exactly 65,536 bytes through a pipe, and exits 0 while doing it. So
+ * `gemi run export-users | gzip > out.gz` silently stores a fragment — the exact
+ * idiom the three-stream design above exists to protect.
+ *
+ * The fence is the *last* write's completion callback. Chunks are flushed in
+ * order, so awaiting the newest one awaits all of them. The obvious alternatives
+ * do not work here: a zero-length `write("", cb)` used as a fence delivered only
+ * 1,310,720 of those bytes, and `writableLength` reports 0 while data is still
+ * pending, so a drain loop exits immediately. Both were measured rather than
+ * assumed.
+ */
+export interface ProcessWriters extends CommandWriters {
+  /** Resolves once everything written so far has reached the OS. */
+  flush(): Promise<void>;
+}
+
+export function processWriters(): ProcessWriters {
+  // One per stream: the last write issued to it, resolved when that write (and
+  // therefore every write queued before it) has been handed over.
+  let stdout: Promise<void> = Promise.resolve();
+  let stderr: Promise<void> = Promise.resolve();
+
+  const write = (stream: NodeJS.WriteStream, chunk: string): Promise<void> =>
+    new Promise((resolve) => {
+      // Resolved on the callback rather than on the return value: `write`
+      // returning false means "buffered", not "failed", and an error here is
+      // still a completed attempt — a closed pipe must not hang the exit.
+      stream.write(chunk, () => resolve());
+    });
+
   return {
-    stdout: (chunk) => process.stdout.write(chunk),
-    stderr: (chunk) => process.stderr.write(chunk),
+    stdout: (chunk) => {
+      stdout = write(process.stdout, chunk);
+    },
+    stderr: (chunk) => {
+      stderr = write(process.stderr, chunk);
+    },
+    flush: async () => {
+      await Promise.all([stdout, stderr]);
+    },
   };
 }
 

--- a/packages/gemi/console/errors.ts
+++ b/packages/gemi/console/errors.ts
@@ -1,0 +1,19 @@
+/**
+ * The failures `gemi run` prints as sentences rather than stack traces.
+ *
+ * Its own file rather than a declaration in `runner.ts`, because the classes
+ * that *raise* these are the ones the runner imports — `CommandRegistry` most of
+ * all — and a registry importing the runner to reach its error type is a cycle
+ * for no reason.
+ *
+ * The split this exists to serve is the one `bin/gemi.ts` already draws around
+ * `CheckModelsError`: a message written for the operator standing at the
+ * terminal, with the fix named in it, is printed alone; anything else is a bug
+ * in the framework and keeps its stack so it can be reported.
+ */
+export class ConsoleError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "ConsoleError";
+  }
+}

--- a/packages/gemi/console/parse.test.ts
+++ b/packages/gemi/console/parse.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from "vitest";
+
+import type { CommandArgument, CommandOption } from "./Command";
+import { kebab, parseArgv, wantsHelp, type CommandSpec } from "./parse";
+
+/**
+ * What an operator typed, against what a command declared.
+ *
+ * Every off-by-one in argument handling lives here, which is why `parse.ts` is a
+ * pure function: none of this needs a project on disk, a spawned process or a
+ * booted container, so all of it can be cheap and there can be a lot of it.
+ *
+ * The cases worth having are the ones where a wrong answer still looks like an
+ * answer — `--times abc` arriving as `NaN`, a default overwriting a value the
+ * operator supplied, a flag after `--` being read as a flag. A parser that
+ * *throws* on bad input is easy to notice; one that quietly produces a plausible
+ * number is not.
+ */
+
+const spec = (
+  args: CommandArgument[] = [],
+  options: CommandOption[] = [],
+): CommandSpec => ({ commandName: "demo", args, options });
+
+const ok = (result: ReturnType<typeof parseArgv>) => {
+  if (!result.ok) throw new Error(`expected a parse, got: ${result.errors}`);
+  return result;
+};
+
+const errors = (result: ReturnType<typeof parseArgv>) => {
+  if (result.ok) throw new Error("expected usage errors, got a parse");
+  return result.errors;
+};
+
+describe("kebab", () => {
+  test("declared camelCase becomes the flag an operator types", () => {
+    expect(kebab("dryRun")).toBe("dry-run");
+    expect(kebab("limit")).toBe("limit");
+    expect(kebab("maxDBConnections")).toBe("max-db-connections");
+  });
+});
+
+describe("positional arguments", () => {
+  test("fill in declaration order", () => {
+    const result = ok(
+      parseArgv(spec([{ name: "from" }, { name: "to" }]), ["a", "b"]),
+    );
+
+    expect(result.args).toEqual({ from: "a", to: "b" });
+  });
+
+  test("a missing required argument is a usage error", () => {
+    expect(
+      errors(parseArgv(spec([{ name: "who", required: true }]), [])),
+    ).toEqual(["Missing required argument <who>."]);
+  });
+
+  test("a missing optional argument is undefined, not an error", () => {
+    expect(ok(parseArgv(spec([{ name: "who" }]), [])).args).toEqual({
+      who: undefined,
+    });
+  });
+
+  test("a default fills in for an absent argument", () => {
+    expect(
+      ok(parseArgv(spec([{ name: "env", default: "staging" }]), [])).args,
+    ).toEqual({ env: "staging" });
+  });
+
+  /**
+   * The direction that matters. A default that wins over a supplied value is
+   * the bug nobody reports, because the command runs and does something
+   * reasonable — just not the thing that was asked for.
+   */
+  test("a supplied value wins over the default", () => {
+    expect(
+      ok(parseArgv(spec([{ name: "env", default: "staging" }]), ["prod"])).args,
+    ).toEqual({ env: "prod" });
+  });
+
+  test("a variadic argument collects the tail, and is [] when it takes none", () => {
+    const declared = spec([
+      { name: "first" },
+      { name: "rest", variadic: true },
+    ]);
+
+    expect(ok(parseArgv(declared, ["a", "b", "c"])).args).toEqual({
+      first: "a",
+      rest: ["b", "c"],
+    });
+    expect(ok(parseArgv(declared, ["a"])).args).toEqual({
+      first: "a",
+      rest: [],
+    });
+  });
+
+  test("an argument the command never declared is reported, not ignored", () => {
+    expect(errors(parseArgv(spec([{ name: "who" }]), ["a", "b"]))).toEqual([
+      'Unexpected argument "b". Command "demo" takes 1 argument.',
+    ]);
+  });
+});
+
+describe("options", () => {
+  const flag: CommandOption = { name: "dryRun", type: "boolean" };
+  const limit: CommandOption = { name: "limit", type: "number", alias: "l" };
+  const tag: CommandOption = { name: "tag", type: "string", alias: "t" };
+
+  test("a boolean is false when absent and true when present", () => {
+    expect(ok(parseArgv(spec([], [flag]), [])).options).toEqual({
+      dryRun: false,
+    });
+    expect(ok(parseArgv(spec([], [flag]), ["--dry-run"])).options).toEqual({
+      dryRun: true,
+    });
+  });
+
+  test("both the kebab and the declared spelling resolve", () => {
+    expect(ok(parseArgv(spec([], [flag]), ["--dryRun"])).options).toEqual({
+      dryRun: true,
+    });
+  });
+
+  test("--no-<flag> turns a boolean off", () => {
+    expect(
+      ok(parseArgv(spec([], [{ ...flag, default: true }]), ["--no-dry-run"]))
+        .options,
+    ).toEqual({ dryRun: false });
+  });
+
+  test("a value can be attached or separate", () => {
+    expect(ok(parseArgv(spec([], [tag]), ["--tag=x"])).options).toEqual({
+      tag: "x",
+    });
+    expect(ok(parseArgv(spec([], [tag]), ["--tag", "x"])).options).toEqual({
+      tag: "x",
+    });
+  });
+
+  test("aliases work, attached, separate and clustered", () => {
+    expect(ok(parseArgv(spec([], [limit]), ["-l", "5"])).options.limit).toBe(5);
+    expect(ok(parseArgv(spec([], [limit]), ["-l5"])).options.limit).toBe(5);
+    expect(ok(parseArgv(spec([], [limit]), ["-l=5"])).options.limit).toBe(5);
+    expect(
+      ok(parseArgv(spec([], [{ ...flag, alias: "d" }, limit]), ["-dl", "5"]))
+        .options,
+    ).toEqual({ dryRun: true, limit: 5 });
+  });
+
+  /**
+   * `Number("")` is `0` and `Number(" ")` is `0`, which is how an empty value
+   * becomes a plausible-looking limit. A `NaN` reaching the handler is worse
+   * still: every comparison against it is false, so the command does nothing and
+   * reports success.
+   */
+  test("a number option that is not a number is a usage error", () => {
+    expect(errors(parseArgv(spec([], [limit]), ["--limit", "abc"]))).toEqual([
+      'Option --limit expects a number, but got "abc".',
+    ]);
+    expect(errors(parseArgv(spec([], [limit]), ["--limit", ""]))).toEqual([
+      'Option --limit expects a number, but got "".',
+    ]);
+  });
+
+  test("a number option keeps negatives and decimals", () => {
+    expect(
+      ok(parseArgv(spec([], [limit]), ["--limit=-2.5"])).options.limit,
+    ).toBe(-2.5);
+  });
+
+  test("an option with no value is reported rather than swallowing the next flag", () => {
+    expect(errors(parseArgv(spec([], [tag]), ["--tag"]))).toEqual([
+      "Option --tag needs a value.",
+    ]);
+  });
+
+  test("an unknown option names the command", () => {
+    expect(errors(parseArgv(spec([], [flag]), ["--bogus"]))).toEqual([
+      'Unknown option --bogus for command "demo".',
+    ]);
+  });
+
+  test("a missing required option is a usage error", () => {
+    expect(
+      errors(parseArgv(spec([], [{ ...tag, required: true }]), [])),
+    ).toEqual(["Missing required option --tag."]);
+  });
+
+  test("defaults apply only when absent", () => {
+    const declared = spec([], [{ ...limit, default: 50 }]);
+
+    expect(ok(parseArgv(declared, [])).options.limit).toBe(50);
+    expect(ok(parseArgv(declared, ["--limit", "7"])).options.limit).toBe(7);
+  });
+
+  test("a flag given a value is refused rather than quietly ignored", () => {
+    expect(errors(parseArgv(spec([], [flag]), ["--dry-run=maybe"]))).toEqual([
+      'Option --dry-run is a flag and takes no value, but got "maybe".',
+    ]);
+  });
+});
+
+describe("the -- escape", () => {
+  test("everything after it is positional, however it is spelled", () => {
+    const result = ok(
+      parseArgv(
+        spec(
+          [{ name: "rest", variadic: true }],
+          [{ name: "dryRun", type: "boolean" }],
+        ),
+        ["--", "--dry-run", "-l", "x"],
+      ),
+    );
+
+    expect(result.args).toEqual({ rest: ["--dry-run", "-l", "x"] });
+    expect(result.options).toEqual({ dryRun: false });
+  });
+});
+
+describe("wantsHelp", () => {
+  test("--help and -h ask for help", () => {
+    expect(wantsHelp(spec(), ["--help"])).toBe(true);
+    expect(wantsHelp(spec(), ["-h"])).toBe(true);
+    expect(wantsHelp(spec(), ["run"])).toBe(false);
+  });
+
+  test("a --help after -- is the command's argument, not a request for help", () => {
+    expect(wantsHelp(spec(), ["--", "--help"])).toBe(false);
+  });
+
+  /**
+   * The application's schema wins over the framework's convenience. A command
+   * that declares its own `--help` documents what it does, and a flag that
+   * silently does something else instead is worse than no help at all.
+   */
+  test("a command that declares its own help keeps it", () => {
+    expect(
+      wantsHelp(spec([], [{ name: "help", type: "boolean" }]), ["--help"]),
+    ).toBe(false);
+    expect(
+      wantsHelp(spec([], [{ name: "human", type: "boolean", alias: "h" }]), [
+        "-h",
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("several mistakes at once", () => {
+  test("are all reported, so a fix is one round trip", () => {
+    expect(
+      errors(
+        parseArgv(
+          spec(
+            [{ name: "who", required: true }],
+            [{ name: "limit", type: "number" }],
+          ),
+          ["--limit", "abc", "--bogus"],
+        ),
+      ),
+    ).toEqual([
+      'Unknown option --bogus for command "demo".',
+      "Missing required argument <who>.",
+      'Option --limit expects a number, but got "abc".',
+    ]);
+  });
+});

--- a/packages/gemi/console/parse.test.ts
+++ b/packages/gemi/console/parse.test.ts
@@ -94,6 +94,29 @@ describe("positional arguments", () => {
     });
   });
 
+  /**
+   * `usage.ts` prints `<files...>` for this declaration, which tells the
+   * operator it is mandatory. Ignoring `required` meant `gemi run import-files`
+   * with the paths forgotten booted the application, ran the handler over an
+   * empty list and exited 0 — a no-op that reads as a successful import.
+   */
+  test("a required variadic argument needs at least one value", () => {
+    const declared = spec([{ name: "files", required: true, variadic: true }]);
+
+    expect(errors(parseArgv(declared, []))).toEqual([
+      'Missing required argument <files...>. Command "demo" needs at least one.',
+    ]);
+    expect(ok(parseArgv(declared, ["a", "b"])).args).toEqual({
+      files: ["a", "b"],
+    });
+  });
+
+  test("an optional variadic argument is still happy with nothing", () => {
+    expect(
+      ok(parseArgv(spec([{ name: "files", variadic: true }]), [])).args,
+    ).toEqual({ files: [] });
+  });
+
   test("an argument the command never declared is reported, not ignored", () => {
     expect(errors(parseArgv(spec([{ name: "who" }]), ["a", "b"]))).toEqual([
       'Unexpected argument "b". Command "demo" takes 1 argument.',
@@ -174,6 +197,60 @@ describe("options", () => {
     ]);
   });
 
+  /**
+   * The worst shape a parser bug can take: `--tag --dry-run` setting `tag` to
+   * the literal `"--dry-run"` and leaving `dryRun` false means the operator's
+   * dry run executes for real, with a nonsense value, and nothing is printed.
+   */
+  describe("a value-taking option and an option-shaped token", () => {
+    const declared = spec([{ name: "rest", variadic: true }], [tag, flag]);
+
+    test("the next option is refused, not swallowed", () => {
+      expect(errors(parseArgv(declared, ["--tag", "--dry-run"]))).toEqual([
+        'Option --tag needs a value, but the next token is "--dry-run", which ' +
+          "is another option. If that really is the value, write --tag=--dry-run.",
+      ]);
+    });
+
+    test("a bare -- is refused too, so the escape hatch survives", () => {
+      expect(errors(parseArgv(declared, ["--tag", "--", "x"]))[0]).toContain(
+        "Option --tag needs a value",
+      );
+      // And the `--` still did its job rather than vanishing into the option.
+      expect(
+        ok(
+          parseArgv(spec([{ name: "rest", variadic: true }], [flag]), [
+            "--",
+            "--dry-run",
+          ]),
+        ).args,
+      ).toEqual({ rest: ["--dry-run"] });
+    });
+
+    test("an alias refuses it as well", () => {
+      expect(errors(parseArgv(declared, ["-t", "--dry-run"]))[0]).toContain(
+        "Option -t needs a value",
+      );
+    });
+
+    test("`=` is the way to say a value really does start with a dash", () => {
+      expect(ok(parseArgv(declared, ["--tag=--dry-run"])).options.tag).toBe(
+        "--dry-run",
+      );
+    });
+
+    /** Both of these are values, not options, and refusing them would be wrong. */
+    test("a negative number and a bare - are still values", () => {
+      expect(
+        ok(parseArgv(spec([], [limit]), ["--limit", "-5"])).options.limit,
+      ).toBe(-5);
+      expect(
+        ok(parseArgv(spec([], [limit]), ["--limit", "-2.5"])).options.limit,
+      ).toBe(-2.5);
+      expect(ok(parseArgv(declared, ["--tag", "-"])).options.tag).toBe("-");
+    });
+  });
+
   test("an unknown option names the command", () => {
     expect(errors(parseArgv(spec([], [flag]), ["--bogus"]))).toEqual([
       'Unknown option --bogus for command "demo".',
@@ -242,6 +319,80 @@ describe("wantsHelp", () => {
         "-h",
       ]),
     ).toBe(false);
+  });
+
+  /**
+   * The two yields are independent. A `-h` alias is a claim on `-h` and nothing
+   * else — treating it as a claim on `--help` too meant a command with a
+   * `-h, --host` lost the long spelling it never asked for, while `usage.ts`
+   * went on advertising `-h, --help` right beside the `-h, --host` that had
+   * taken it.
+   */
+  test("declaring a -h alias does not also surrender --help", () => {
+    const host = spec([], [{ name: "host", type: "string", alias: "h" }]);
+
+    expect(wantsHelp(host, ["--help"])).toBe(true);
+    expect(wantsHelp(host, ["-h", "example.com"])).toBe(false);
+  });
+
+  test("declaring a `help` option does not also surrender -h", () => {
+    const own = spec([], [{ name: "help", type: "boolean" }]);
+
+    expect(wantsHelp(own, ["--help"])).toBe(false);
+    expect(wantsHelp(own, ["-h"])).toBe(true);
+  });
+
+  /**
+   * A flat token scan cannot tell these apart, and got the second one wrong:
+   * `--message --help` printed usage and exited 0, so the notification was never
+   * sent and a wrapper branching on the exit code recorded a success.
+   *
+   * Now `--help` in *value* position is a value, and `--help` in option position
+   * is help even when the rest of the line is a usage error — which is exactly
+   * when somebody reaches for it.
+   */
+  describe("help against an option that takes a value", () => {
+    const notify = spec(
+      [{ name: "env", required: true }],
+      [{ name: "message", type: "string" }],
+    );
+
+    test("a --help attached as a value is the value", () => {
+      const result = ok(parseArgv(notify, ["--message=--help", "prod"]));
+
+      expect(result.help).toBe(false);
+      expect(result.options.message).toBe("--help");
+    });
+
+    test("a --help after -- is the command's argument", () => {
+      expect(parseArgv(notify, ["prod", "--", "--help"]).help).toBe(false);
+    });
+
+    /**
+     * The genuinely ambiguous one: the operator wanted usage, or they wanted to
+     * send the literal text `--help` and the shell ate their quotes. Guessing
+     * either way is silent, and guessing "help" is the worse of the two — usage
+     * printed, exit 0, nothing sent. So it is reported, with both readings and
+     * the fix named.
+     */
+    test("a --help refused as a value is reported, not answered", () => {
+      const result = parseArgv(notify, ["prod", "--message", "--help"]);
+
+      expect(result.help).toBe(false);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.errors[0]).toContain(
+        "write --message=--help",
+      );
+    });
+
+    test("--help still works when the invocation is otherwise unusable", () => {
+      // No `env`, so this is a usage error — and help has to win, or the flag
+      // is useless precisely when it is needed.
+      const result = parseArgv(notify, ["--help"]);
+
+      expect(result.help).toBe(true);
+      expect(result.ok).toBe(false);
+    });
   });
 });
 

--- a/packages/gemi/console/parse.ts
+++ b/packages/gemi/console/parse.ts
@@ -39,13 +39,30 @@ export interface CommandSpec {
   options: CommandOption[];
 }
 
-export type ParseResult =
+export type ParseResult = {
+  /**
+   * The invocation asked for help rather than for work.
+   *
+   * Reported by the parse rather than by a separate scan, because whether a
+   * `--help` is a request for help or the *value* of the option before it is a
+   * question only something tracking option arity can answer. A flat token scan
+   * reads `--message --help` as a request for help, prints usage and exits 0 —
+   * so the message is never sent and a cron wrapper branching on the exit code
+   * records a success for work that did not happen.
+   *
+   * Present on both branches, and the runner checks it first: `--help` has to
+   * work on an invocation that would otherwise be a usage error, which is
+   * precisely when somebody reaches for it.
+   */
+  help: boolean;
+} & (
   | {
       ok: true;
       args: Record<string, string | string[] | undefined>;
       options: Record<string, string | number | boolean | undefined>;
     }
-  | { ok: false; errors: string[] };
+  | { ok: false; errors: string[] }
+);
 
 function optionIndex(options: CommandOption[]) {
   const byName = new Map<string, CommandOption>();
@@ -66,21 +83,32 @@ function optionIndex(options: CommandOption[]) {
 /**
  * Whether this invocation is asking for help rather than running.
  *
- * A command that declares its own `help` option or `-h` alias keeps them — the
- * application's schema wins over the framework's convenience, because the
- * alternative is a flag that silently does something other than what the command
- * documents.
+ * A thin read of the parse, so the two cannot disagree about what counts as a
+ * `--help`. See `ParseResult["help"]` for why that question needs a parse at all.
  */
 export function wantsHelp(spec: CommandSpec, argv: readonly string[]): boolean {
-  const { byName, byAlias } = optionIndex(spec.options);
-  if (byName.has("help") || byAlias.has("h")) return false;
+  return parseArgv(spec, argv).help;
+}
 
-  for (const token of argv) {
-    if (token === "--") return false;
-    if (token === "--help" || token === "-h") return true;
-  }
-
-  return false;
+/**
+ * Whether a token is the next option rather than the previous one's value.
+ *
+ * `--message --dry-run` should not set `message` to the literal `"--dry-run"`
+ * and leave `dryRun` false — a dry run that executes for real is the worst shape
+ * a parser bug can take. So a value-taking option refuses an option-shaped
+ * token and says how to override it.
+ *
+ * The two exceptions are both real values that happen to start with a dash: a
+ * negative number, and a bare `-` (the long-standing spelling of "stdin"). For
+ * anything else `--opt=value` is the escape hatch, which is how every getopt
+ * since the 1980s has handled it.
+ */
+function looksLikeAnotherOption(token: string): boolean {
+  if (token === "--") return true;
+  if (!token.startsWith("-")) return false;
+  if (token === "-") return false;
+  if (/^-(\d|\.\d)/.test(token)) return false;
+  return true;
 }
 
 export function parseArgv(
@@ -92,8 +120,36 @@ export function parseArgv(
   const positionals: string[] = [];
   const raw = new Map<string, string | boolean>();
 
+  // Split, rather than one guard over both. A command that declares an option
+  // called `help` has claimed `--help`, and a command that declares a `-h` alias
+  // has claimed `-h` — but neither claims the other, and treating them as one
+  // switch means a `.option("host", { alias: "h" })` silently removes the long
+  // `--help` the command never asked for, while `usage.ts` goes on advertising
+  // it. The application's schema wins over the framework's convenience, exactly
+  // as far as the application actually reached.
+  const helpIsFree = !byName.has("help");
+  const shortHelpIsFree = !byAlias.has("h");
+  let requested = false;
+
+  // Set when the token refused as a value was itself a `--help`, which is the
+  // one case where "did they want help?" has no honest answer. See the note
+  // above the return.
+  let ambiguous = false;
+
   const unknown = (token: string) =>
     errors.push(`Unknown option ${token} for command "${spec.commandName}".`);
+
+  const needsValue = (label: string, next: string | undefined) => {
+    if (next === "--help" || next === "-h") ambiguous = true;
+
+    errors.push(
+      next === undefined
+        ? `Option ${label} needs a value.`
+        : `Option ${label} needs a value, but the next token is ` +
+            `${JSON.stringify(next)}, which is another option. If that really is ` +
+            `the value, write ${label}=${next}.`,
+    );
+  };
 
   let index = 0;
   while (index < argv.length) {
@@ -124,6 +180,13 @@ export function parseArgv(
         }
       }
 
+      // Only once the command's own options have had their chance at the name.
+      if (!option && key === "help" && helpIsFree) {
+        requested = true;
+        index += 1;
+        continue;
+      }
+
       if (!option) {
         unknown(`--${key}`);
         index += 1;
@@ -144,15 +207,21 @@ export function parseArgv(
         continue;
       }
 
-      const value = inline ?? argv[index + 1];
-      if (value === undefined) {
-        errors.push(`Option --${kebab(option.name)} needs a value.`);
+      if (inline !== undefined) {
+        raw.set(option.name, inline);
         index += 1;
         continue;
       }
 
-      raw.set(option.name, value);
-      index += inline === undefined ? 2 : 1;
+      const next = argv[index + 1];
+      if (next === undefined || looksLikeAnotherOption(next)) {
+        needsValue(`--${kebab(option.name)}`, next);
+        index += 1;
+        continue;
+      }
+
+      raw.set(option.name, next);
+      index += 2;
       continue;
     }
 
@@ -166,6 +235,10 @@ export function parseArgv(
       for (let position = 0; position < chars.length; position += 1) {
         const option = byAlias.get(chars[position]!);
         if (!option) {
+          if (chars[position] === "h" && shortHelpIsFree) {
+            requested = true;
+            continue;
+          }
           unknown(`-${chars[position]}`);
           break;
         }
@@ -179,12 +252,17 @@ export function parseArgv(
         const inline = rest.startsWith("=") ? rest.slice(1) : rest;
         if (inline !== "") {
           raw.set(option.name, inline);
-        } else if (argv[index + 1] !== undefined) {
-          raw.set(option.name, argv[index + 1]!);
-          consumedNext = true;
-        } else {
-          errors.push(`Option -${option.alias} needs a value.`);
+          break;
         }
+
+        const next = argv[index + 1];
+        if (next === undefined || looksLikeAnotherOption(next)) {
+          needsValue(`-${option.alias}`, next);
+          break;
+        }
+
+        raw.set(option.name, next);
+        consumedNext = true;
         break;
       }
 
@@ -201,8 +279,22 @@ export function parseArgv(
 
   for (const declared of spec.args) {
     if (declared.variadic) {
-      args[declared.name] = positionals.slice(cursor);
+      const collected = positionals.slice(cursor);
       cursor = positionals.length;
+      args[declared.name] = collected;
+
+      // `required` on a variadic means "at least one", and honouring it is the
+      // only reading that matches what the operator is shown: `usage.ts` prints
+      // `<files...>` for this declaration, which says mandatory. Ignoring it
+      // meant `gemi run import-files` with the paths forgotten booted the
+      // application, ran the handler over an empty list and exited 0 — a no-op
+      // that reads as a successful import.
+      if (declared.required && collected.length === 0) {
+        errors.push(
+          `Missing required argument <${declared.name}...>. Command ` +
+            `"${spec.commandName}" needs at least one.`,
+        );
+      }
       continue;
     }
 
@@ -282,6 +374,27 @@ export function parseArgv(
     options[declared.name] = value;
   }
 
-  if (errors.length > 0) return { ok: false, errors };
-  return { ok: true, args, options };
+  /**
+   * A `--help` refused as a value is not a request for help.
+   *
+   * `gemi run notify --message --help` has two readings and no way to tell them
+   * apart: the operator wanted the usage, or they wanted to send the literal
+   * text `--help` and the shell ate their quotes. Answering either one silently
+   * is how the reviewer's case goes wrong — showing usage and exiting 0 means
+   * the notification was never sent and the wrapper waiting on the status
+   * records a success.
+   *
+   * So the ambiguity is reported instead. `needsValue` has already written the
+   * sentence naming both readings and the fix (`--message=--help`), and
+   * suppressing the help request here is what lets the operator see it rather
+   * than a usage screen with no explanation.
+   *
+   * Help still wins over an ordinary usage error — `gemi run deploy --help`
+   * with `<env>` missing prints the usage, because that is the invocation
+   * somebody reaches for `--help` on.
+   */
+  const help = requested && !ambiguous;
+
+  if (errors.length > 0) return { ok: false, help, errors };
+  return { ok: true, help, args, options };
 }

--- a/packages/gemi/console/parse.ts
+++ b/packages/gemi/console/parse.ts
@@ -1,0 +1,287 @@
+import type { CommandArgument, CommandOption } from "./Command";
+
+/**
+ * Turning what an operator typed into what a handler declared it wanted.
+ *
+ * A pure function over `(spec, argv)`, deliberately: this is where every
+ * off-by-one in argument handling lives, and a pure function is one a test can
+ * exercise a hundred ways without a project on disk, a spawned process or a
+ * booted container. `runner.ts` does the parts that need those.
+ *
+ * ### Why gemi parses this itself instead of handing it to commander
+ *
+ * commander is a dependency of this package and would resolve here, and an
+ * earlier draft used it. Two things argued it back out. The schema is already
+ * declared — named options with a `type`, not commander's `"-t, --tries <n>"`
+ * flag strings — so using commander means translating one declaration into
+ * another and then translating its output back, with the type information lost
+ * in the middle. And commander is currently a *CLI-side* concern: `bin/gemi.ts`
+ * uses it, and nothing that runs inside an application does. Keeping it that way
+ * means a command's parsing has no dependency at all, which matters more here
+ * than it looks — this code runs in the application's process, next to the
+ * application's own module graph.
+ *
+ * `usage.ts` renders `--help` from the same spec this reads, so the help and the
+ * parser cannot drift.
+ */
+
+/** `dryRun` -> `dry-run`. What the operator types. */
+export function kebab(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+    .toLowerCase();
+}
+
+export interface CommandSpec {
+  commandName: string;
+  args: CommandArgument[];
+  options: CommandOption[];
+}
+
+export type ParseResult =
+  | {
+      ok: true;
+      args: Record<string, string | string[] | undefined>;
+      options: Record<string, string | number | boolean | undefined>;
+    }
+  | { ok: false; errors: string[] };
+
+function optionIndex(options: CommandOption[]) {
+  const byName = new Map<string, CommandOption>();
+  const byAlias = new Map<string, CommandOption>();
+
+  for (const option of options) {
+    // Both spellings resolve, so `--dryRun` works for anyone who typed the
+    // declared name out of habit. The kebab form is the documented one.
+    byName.set(kebab(option.name), option);
+    byName.set(option.name, option);
+    const alias = "alias" in option ? option.alias : undefined;
+    if (alias) byAlias.set(alias, option);
+  }
+
+  return { byName, byAlias };
+}
+
+/**
+ * Whether this invocation is asking for help rather than running.
+ *
+ * A command that declares its own `help` option or `-h` alias keeps them — the
+ * application's schema wins over the framework's convenience, because the
+ * alternative is a flag that silently does something other than what the command
+ * documents.
+ */
+export function wantsHelp(spec: CommandSpec, argv: readonly string[]): boolean {
+  const { byName, byAlias } = optionIndex(spec.options);
+  if (byName.has("help") || byAlias.has("h")) return false;
+
+  for (const token of argv) {
+    if (token === "--") return false;
+    if (token === "--help" || token === "-h") return true;
+  }
+
+  return false;
+}
+
+export function parseArgv(
+  spec: CommandSpec,
+  argv: readonly string[],
+): ParseResult {
+  const { byName, byAlias } = optionIndex(spec.options);
+  const errors: string[] = [];
+  const positionals: string[] = [];
+  const raw = new Map<string, string | boolean>();
+
+  const unknown = (token: string) =>
+    errors.push(`Unknown option ${token} for command "${spec.commandName}".`);
+
+  let index = 0;
+  while (index < argv.length) {
+    const token = argv[index]!;
+
+    // Everything after a bare `--` is positional, however it is spelled. This is
+    // the escape hatch for an argument that looks like a flag.
+    if (token === "--") {
+      positionals.push(...argv.slice(index + 1));
+      break;
+    }
+
+    if (token.startsWith("--")) {
+      const body = token.slice(2);
+      const equals = body.indexOf("=");
+      const key = equals === -1 ? body : body.slice(0, equals);
+      const inline = equals === -1 ? undefined : body.slice(equals + 1);
+
+      let option = byName.get(key);
+      let negated = false;
+
+      // `--no-dry-run` only when there is no option actually called that.
+      if (!option && key.startsWith("no-")) {
+        const positive = byName.get(key.slice(3));
+        if (positive && positive.type === "boolean") {
+          option = positive;
+          negated = true;
+        }
+      }
+
+      if (!option) {
+        unknown(`--${key}`);
+        index += 1;
+        continue;
+      }
+
+      if (option.type === "boolean") {
+        if (inline !== undefined && inline !== "true" && inline !== "false") {
+          errors.push(
+            `Option --${kebab(option.name)} is a flag and takes no value, ` +
+              `but got ${JSON.stringify(inline)}.`,
+          );
+        } else {
+          const value = inline === undefined ? true : inline === "true";
+          raw.set(option.name, negated ? !value : value);
+        }
+        index += 1;
+        continue;
+      }
+
+      const value = inline ?? argv[index + 1];
+      if (value === undefined) {
+        errors.push(`Option --${kebab(option.name)} needs a value.`);
+        index += 1;
+        continue;
+      }
+
+      raw.set(option.name, value);
+      index += inline === undefined ? 2 : 1;
+      continue;
+    }
+
+    if (token.startsWith("-") && token.length > 1) {
+      // A cluster: every character is an alias. All but the last must be flags,
+      // and the last may take the remainder of the token as its value (`-l50`,
+      // `-l=50`) or the next argument.
+      const chars = token.slice(1);
+      let consumedNext = false;
+
+      for (let position = 0; position < chars.length; position += 1) {
+        const option = byAlias.get(chars[position]!);
+        if (!option) {
+          unknown(`-${chars[position]}`);
+          break;
+        }
+
+        if (option.type === "boolean") {
+          raw.set(option.name, true);
+          continue;
+        }
+
+        const rest = chars.slice(position + 1);
+        const inline = rest.startsWith("=") ? rest.slice(1) : rest;
+        if (inline !== "") {
+          raw.set(option.name, inline);
+        } else if (argv[index + 1] !== undefined) {
+          raw.set(option.name, argv[index + 1]!);
+          consumedNext = true;
+        } else {
+          errors.push(`Option -${option.alias} needs a value.`);
+        }
+        break;
+      }
+
+      index += consumedNext ? 2 : 1;
+      continue;
+    }
+
+    positionals.push(token);
+    index += 1;
+  }
+
+  const args: Record<string, string | string[] | undefined> = {};
+  let cursor = 0;
+
+  for (const declared of spec.args) {
+    if (declared.variadic) {
+      args[declared.name] = positionals.slice(cursor);
+      cursor = positionals.length;
+      continue;
+    }
+
+    const value = positionals[cursor];
+    cursor += 1;
+
+    if (value !== undefined) {
+      args[declared.name] = value;
+      continue;
+    }
+
+    if (declared.default !== undefined) {
+      args[declared.name] = declared.default;
+      continue;
+    }
+
+    if (declared.required) {
+      errors.push(`Missing required argument <${declared.name}>.`);
+    }
+
+    args[declared.name] = undefined;
+  }
+
+  if (cursor < positionals.length) {
+    const extra = positionals.slice(cursor);
+    errors.push(
+      `Unexpected argument${extra.length === 1 ? "" : "s"} ` +
+        `${extra.map((value) => JSON.stringify(value)).join(", ")}. ` +
+        `Command "${spec.commandName}" takes ${spec.args.length} argument` +
+        `${spec.args.length === 1 ? "" : "s"}.`,
+    );
+  }
+
+  const options: Record<string, string | number | boolean | undefined> = {};
+
+  for (const declared of spec.options) {
+    const supplied = raw.get(declared.name);
+
+    if (declared.type === "boolean") {
+      options[declared.name] =
+        supplied === undefined
+          ? (declared.default ?? false)
+          : Boolean(supplied);
+      continue;
+    }
+
+    if (supplied === undefined) {
+      if (declared.default !== undefined) {
+        options[declared.name] = declared.default;
+      } else if (declared.required) {
+        errors.push(`Missing required option --${kebab(declared.name)}.`);
+        options[declared.name] = undefined;
+      } else {
+        options[declared.name] = undefined;
+      }
+      continue;
+    }
+
+    const value = String(supplied);
+
+    if (declared.type === "number") {
+      const parsed = Number(value);
+      // `Number("")` is 0 and `Number(" ")` is 0, which is how a typo becomes a
+      // plausible-looking number. Reject anything that was not written as one.
+      if (value.trim() === "" || !Number.isFinite(parsed)) {
+        errors.push(
+          `Option --${kebab(declared.name)} expects a number, but got ` +
+            `${JSON.stringify(value)}.`,
+        );
+        options[declared.name] = undefined;
+      } else {
+        options[declared.name] = parsed;
+      }
+      continue;
+    }
+
+    options[declared.name] = value;
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, args, options };
+}

--- a/packages/gemi/console/run.test.ts
+++ b/packages/gemi/console/run.test.ts
@@ -1,0 +1,151 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
+
+/**
+ * The two properties of `gemi run` that only exist in a real process.
+ *
+ * `runner.test.ts` calls `runConsole` directly, which is the right seam for
+ * almost everything — but it starts *after* argv handling and ends by returning
+ * an exit code instead of taking one. The two things `run.ts` does either side
+ * of that are invisible to it, and both were wrong:
+ *
+ *   - it consumed the `--` the escape hatch is made of, before the only code
+ *     that reads one; and
+ *   - it exited so promptly that piped stdout was truncated at the pipe buffer,
+ *     with status 0.
+ *
+ * Both need a spawn to observe, in the idiom `kernel/exit.test.ts` established:
+ * a synchronous one, so the process's own exit is what is being measured.
+ */
+
+const RUN = resolve(import.meta.dirname, "run.ts");
+const BUILDER = JSON.stringify(resolve(import.meta.dirname, "builder.ts"));
+const KERNEL = JSON.stringify(
+  resolve(import.meta.dirname, "../kernel/Kernel.ts"),
+);
+const HTTP = JSON.stringify(resolve(import.meta.dirname, "../http/index.ts"));
+
+const roots: string[] = [];
+
+/** An application whose single command is `body`. See `runner.test.ts`. */
+function project(name: string, body: string, chain = ""): string {
+  const root = mkdtempSync(join(tmpdir(), "gemi-run-"));
+  roots.push(root);
+
+  const files: Record<string, string> = {
+    "app/kernel/Kernel.ts": `import { Kernel } from ${KERNEL};
+import { ApiRouter, ViewRouter } from ${HTTP};
+class RootApi extends ApiRouter { routes = {}; }
+class RootView extends ViewRouter { routes = {}; }
+export default class extends Kernel {
+  config = {
+    command: {},
+    route: { api: { rootRouter: RootApi }, view: { rootRouter: RootView } },
+  };
+}`,
+    "app/commands/Cmd.ts": `import { defineCommand } from ${BUILDER};
+export default defineCommand(${JSON.stringify(name)})${chain}
+  .handle(async (ctx) => { ${body} });`,
+  };
+
+  for (const [path, source] of Object.entries(files)) {
+    mkdirSync(join(root, path, ".."), { recursive: true });
+    writeFileSync(join(root, path), source);
+  }
+
+  return root;
+}
+
+/** Spawns the real entry point against a fixture, over a pipe. */
+function run(root: string, argv: string[]) {
+  const result = spawnSync("bun", [RUN, ...argv], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 60_000,
+    // The default is 1 MB, which the truncation test would hit on its own and
+    // report as a failure of the thing it is measuring.
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, GEMI_NO_SCHEDULE: "1" },
+  });
+
+  // Checked first: a `bun` that is not on PATH sets `error` and leaves both
+  // `status` and `signal` null, which otherwise surfaces as a confusing
+  // assertion about stdout rather than as an environment problem.
+  expect(result.error, "could not spawn bun").toBeUndefined();
+  // A timeout kill shows up here, and is the shape a hang takes.
+  expect(result.signal, result.stderr).toBeNull();
+
+  return result;
+}
+
+afterAll(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+describe("the -- escape hatch", () => {
+  const fixture = () =>
+    project(
+      "echo",
+      `ctx.line(JSON.stringify(ctx.args.rest));`,
+      `.arg("rest", { variadic: true }).option("dryRun", { type: "boolean" })`,
+    );
+
+  /**
+   * commander hands a `--` through as a literal operand, and `parse.ts` already
+   * treats one as "everything after this is positional". Stripping it in between
+   * — which an earlier draft did — meant the documented escape hatch reported
+   * `Unknown option --dry-run`, and `-- --` typed twice was the only way through.
+   */
+  test("passes a flag-shaped value through as an argument", () => {
+    const result = run(fixture(), ["echo", "--", "--dry-run"]);
+
+    expect(result.stdout.trim(), result.stderr).toBe('["--dry-run"]');
+    expect(result.status).toBe(0);
+  });
+
+  test("without it, the same token is still read as the flag", () => {
+    const result = run(fixture(), ["echo", "--dry-run"]);
+
+    expect(result.stdout.trim()).toBe("[]");
+    expect(result.status).toBe(0);
+  });
+});
+
+describe("output that outgrows the pipe buffer", () => {
+  /**
+   * `process.stdout.write` is asynchronous on a pipe and `run.ts` ends in an
+   * explicit `process.exit`, so without a flush the two together truncate at the
+   * buffer — measured at exactly 65,536 bytes of a 2 MB write on Bun 1.3.14,
+   * while exiting 0. `gemi run export-users | gzip > out.gz` stored a fragment
+   * and reported success.
+   *
+   * A subprocess is the only way to see it: `spawnSync` captures stdout over a
+   * pipe, which is the affected path, and an in-process test with injected
+   * writers never touches a stream at all.
+   */
+  test("survives intact, and the command still exits on its own", () => {
+    const size = 2_000_000;
+    const root = project("dump", `ctx.line("x".repeat(${size}));`);
+
+    const result = run(root, ["dump"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    // The `\n` `line` adds. An assertion on the exact length rather than on
+    // `toContain`, because truncation is the failure and a prefix match cannot
+    // see it.
+    expect(result.stdout.length).toBe(size + 1);
+  }, 60_000);
+
+  test("stderr is flushed too, so a diagnostic is not lost to the exit", () => {
+    const size = 500_000;
+    const root = project("warn", `ctx.error("y".repeat(${size})); return 3;`);
+
+    const result = run(root, ["warn"]);
+
+    expect(result.status).toBe(3);
+    expect(result.stderr.length).toBe(size + 1);
+  }, 60_000);
+});

--- a/packages/gemi/console/run.ts
+++ b/packages/gemi/console/run.ts
@@ -1,0 +1,34 @@
+/**
+ * The entry point `gemi run` spawns.
+ *
+ * Exposed through the exports map as `gemi/console/run` and resolved by the CLI
+ * out of the *application's* `node_modules`, the same way `dev` and `start`
+ * resolve `gemi/bun/preload`. That indirection is the point: the runner has to
+ * be the application's copy of gemi, not the one bundled into `dist/bin/gemi.js`
+ * — see the note at the top of `runner.ts`.
+ *
+ * Nothing but argv handling lives here, so that everything worth testing lives
+ * in `runConsole`, which returns an exit code instead of taking one.
+ */
+import { runConsole } from "./runner";
+
+const [name, ...rest] = process.argv.slice(2);
+
+// commander forwards a `--` through as a literal operand, so `gemi run x --
+// --verbose` arrives here with it still attached. Dropping a leading one makes
+// the escape hatch mean what it looks like it means; a second `--` is the
+// command's own and `parse.ts` handles it.
+const argv = rest[0] === "--" ? rest.slice(1) : rest;
+
+// `.then` rather than a top-level `await`, so this file typechecks under the
+// package's inherited `module: NodeNext` — the same TS1309 that keeps `bun/` out
+// of tsconfig.json's `include`. Bun runs it as ESM either way; this just avoids
+// buying a nested tsconfig for two lines.
+runConsole({ rootDir: process.cwd(), name, argv }).then((code) => {
+  // Explicit, and not belt-and-braces. `kernel.destroy()` stops the scheduler,
+  // but an open database pool, a Redis client or an unref'd timer will happily
+  // hold the loop open after the work is done — a command that finishes and then
+  // sits there, which is the failure `kernel/exit.test.ts` exists for and the
+  // one `orm/context.test.ts` names by example.
+  process.exit(code);
+});

--- a/packages/gemi/console/run.ts
+++ b/packages/gemi/console/run.ts
@@ -10,25 +10,35 @@
  * Nothing but argv handling lives here, so that everything worth testing lives
  * in `runConsole`, which returns an exit code instead of taking one.
  */
+import { processWriters } from "./context";
 import { runConsole } from "./runner";
 
-const [name, ...rest] = process.argv.slice(2);
+// The tail is forwarded exactly as commander handed it over, `--` and all.
+// commander passes a `--` through as a literal operand (verified: `gemi run x --
+// --weird` arrives as `["--", "--weird"]`), and `parse.ts` already treats a `--`
+// as "everything after this is positional". Stripping it here — which an earlier
+// draft did — consumed the escape hatch before the only thing that reads it,
+// leaving `-- --weird` reported as an unknown option and `-- --` the only way to
+// pass a flag-shaped value.
+const [name, ...argv] = process.argv.slice(2);
 
-// commander forwards a `--` through as a literal operand, so `gemi run x --
-// --verbose` arrives here with it still attached. Dropping a leading one makes
-// the escape hatch mean what it looks like it means; a second `--` is the
-// command's own and `parse.ts` handles it.
-const argv = rest[0] === "--" ? rest.slice(1) : rest;
+const writers = processWriters();
 
 // `.then` rather than a top-level `await`, so this file typechecks under the
 // package's inherited `module: NodeNext` — the same TS1309 that keeps `bun/` out
 // of tsconfig.json's `include`. Bun runs it as ESM either way; this just avoids
 // buying a nested tsconfig for two lines.
-runConsole({ rootDir: process.cwd(), name, argv }).then((code) => {
-  // Explicit, and not belt-and-braces. `kernel.destroy()` stops the scheduler,
-  // but an open database pool, a Redis client or an unref'd timer will happily
-  // hold the loop open after the work is done — a command that finishes and then
-  // sits there, which is the failure `kernel/exit.test.ts` exists for and the
-  // one `orm/context.test.ts` names by example.
-  process.exit(code);
-});
+runConsole({ rootDir: process.cwd(), name, argv, writers }).then(
+  async (code) => {
+    // Everything written has to reach the OS before the exit below discards it —
+    // see `processWriters` for what that costs when it is skipped.
+    await writers.flush();
+
+    // Explicit, and not belt-and-braces. `kernel.destroy()` stops the scheduler,
+    // but an open database pool, a Redis client or an unref'd timer will happily
+    // hold the loop open after the work is done — a command that finishes and then
+    // sits there, which is the failure `kernel/exit.test.ts` exists for and the
+    // one `orm/context.test.ts` names by example.
+    process.exit(code);
+  },
+);

--- a/packages/gemi/console/runner.test.ts
+++ b/packages/gemi/console/runner.test.ts
@@ -1,0 +1,530 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import { Scheduler } from "../services/cron/Scheduler";
+import { runConsole } from "./runner";
+
+/**
+ * `gemi run`, over an application directory on disk.
+ *
+ * `parse.ts` and the registry are covered by their own files without any of
+ * this. What is left needs a real project: a Kernel that boots, a config slice
+ * read before defaults are applied, command files imported off the filesystem,
+ * and the ordering that decides which of those an invocation pays for.
+ *
+ * The fixtures import `defineCommand` by absolute path rather than from
+ * `gemi/services`, since a temp directory has no `node_modules` above it to
+ * resolve that through — the path lands on the very module this file imports
+ * from, so the class identity `discoverClasses` walks the prototype chain for
+ * holds. The real thing resolves it through the application's own gemi, which is
+ * exactly why `gemi run` spawns a process rather than doing this in the CLI, and
+ * is the one property this file cannot check. `bin/gemi.ts` and a real project
+ * are where that is observable.
+ */
+
+const BUILDER = JSON.stringify(resolve(import.meta.dirname, "builder.ts"));
+const KERNEL = JSON.stringify(
+  resolve(import.meta.dirname, "../kernel/Kernel.ts"),
+);
+const HTTP = JSON.stringify(resolve(import.meta.dirname, "../http/index.ts"));
+
+/**
+ * The smallest `route` slice `RouteServiceProvider.boot` will accept.
+ *
+ * It is here because running a command boots the application the way the server
+ * does, and that provider force-resolves both dispatchers rather than building
+ * them lazily — so an app with no root router cannot complete phase two. Every
+ * real application has `app/config/route.ts`; a fixture has to say so too, and
+ * the tests that never reach phase two prove they never reach it by passing
+ * without ever exercising this.
+ */
+const ROUTES = `import { ApiRouter, ViewRouter } from ${HTTP};
+class RootApi extends ApiRouter { routes = {}; }
+class RootView extends ViewRouter { routes = {}; }
+const route = { api: { rootRouter: RootApi }, view: { rootRouter: RootView } };`;
+
+const roots: string[] = [];
+
+/** An application tree in a temp directory. Keys are paths, values are source. */
+function project(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "gemi-console-"));
+  roots.push(root);
+  for (const [path, source] of Object.entries(files)) {
+    mkdirSync(join(root, path, ".."), { recursive: true });
+    writeFileSync(join(root, path), source);
+  }
+  return root;
+}
+
+/** A Kernel with nothing but the `command` slice the test is about. */
+const kernel = (slice = "{}") => `import { Kernel } from ${KERNEL};
+${ROUTES}
+export default class extends Kernel {
+  config = { command: ${slice}, route };
+  async waitForBoot() {
+    globalThis.__consoleBoots = (globalThis.__consoleBoots ?? 0) + 1;
+    await super.waitForBoot();
+  }
+}`;
+
+const command = (name: string, body = "", chain = "") =>
+  `import { defineCommand } from ${BUILDER};
+export default defineCommand(${JSON.stringify(name)})${chain}
+  .handle(async (ctx) => { ${body} });`;
+
+/** Runs the console against a fixture, capturing both streams separately. */
+async function run(
+  root: string,
+  name?: string,
+  argv: string[] = [],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  let stdout = "";
+  let stderr = "";
+
+  const code = await runConsole({
+    rootDir: root,
+    name,
+    argv,
+    writers: {
+      stdout: (chunk) => (stdout += chunk),
+      stderr: (chunk) => (stderr += chunk),
+    },
+  });
+
+  return { code, stdout, stderr };
+}
+
+const boots = () => (globalThis as any).__consoleBoots ?? 0;
+
+beforeAll(() => {
+  // What `gemi run` sets on the process it spawns. Without it every fixture that
+  // reaches phase two would register `Bun.cron` handles and leave them ticking
+  // into the next test file.
+  process.env.GEMI_NO_SCHEDULE = "1";
+});
+
+afterEach(() => {
+  (globalThis as any).__consoleBoots = 0;
+  for (const [name, handle] of globalThis.__gemiCronJobs ?? []) {
+    handle.stop();
+    globalThis.__gemiCronJobs?.delete(name);
+  }
+});
+
+afterAll(() => {
+  delete process.env.GEMI_NO_SCHEDULE;
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+describe("listing what an application has", () => {
+  test("no name prints the commands and their descriptions", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Seed.ts": command("db:seed", "", `.describe("Seed it")`),
+      "app/commands/Digest.ts": command(
+        "send-digest",
+        "",
+        `.describe("Send it")`,
+      ),
+    });
+
+    const { code, stdout } = await run(root);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("db:seed");
+    expect(stdout).toContain("Seed it");
+    expect(stdout).toContain("send-digest");
+  });
+
+  test("the listing is sorted, so it does not depend on the filesystem", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/A.ts": command("zebra"),
+      "app/commands/Z.ts": command("aardvark"),
+    });
+
+    const { stdout } = await run(root);
+
+    expect(stdout.indexOf("aardvark")).toBeLessThan(stdout.indexOf("zebra"));
+  });
+
+  test("an empty directory says where it looked and how to register one", async () => {
+    const root = project({ "app/kernel/Kernel.ts": kernel() });
+
+    const { code, stdout } = await run(root);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("No commands found");
+    expect(stdout).toContain("app/commands");
+  });
+});
+
+describe("the config slice", () => {
+  test("absent commands discovers the directory", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Seed.ts": command("db:seed"),
+    });
+
+    expect((await run(root)).stdout).toContain("db:seed");
+  });
+
+  /**
+   * Declared wins, and `[]` is declared. The slice has to be read before
+   * `withDefaults`, which collapses absent and `undefined` into the default `[]`
+   * — the same value an app writes when it means "none, and I mean it".
+   */
+  test("an empty declared list means none, and does not read the directory", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel("{ commands: [] }"),
+      "app/commands/Seed.ts": command("db:seed"),
+    });
+
+    const { stdout } = await run(root);
+
+    expect(stdout).not.toContain("db:seed");
+    expect(stdout).toContain("declares no commands");
+  });
+
+  test("a declared list is used verbatim, whatever the directory holds", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": `import { Kernel } from ${KERNEL};
+import Declared from "../commands/Declared.ts";
+${ROUTES}
+export default class extends Kernel {
+  config = { command: { commands: [Declared] }, route };
+}`,
+      "app/commands/Declared.ts": command("declared"),
+      "app/commands/Ignored.ts": command("ignored"),
+    });
+
+    const { stdout } = await run(root);
+
+    expect(stdout).toContain("declared");
+    expect(stdout).not.toContain("ignored");
+  });
+
+  test("commandsDir moves the walk", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(`{ commandsDir: "app/tasks" }`),
+      "app/tasks/Seed.ts": command("db:seed"),
+      "app/commands/Elsewhere.ts": command("elsewhere"),
+    });
+
+    const { stdout } = await run(root);
+
+    expect(stdout).toContain("db:seed");
+    expect(stdout).not.toContain("elsewhere");
+  });
+});
+
+describe("a name that does not match", () => {
+  test("is reported with a suggestion and the listing, and exits 1", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Seed.ts": command("db:seed"),
+    });
+
+    const { code, stdout, stderr } = await run(root, "db:sed");
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("No command named `db:sed`");
+    expect(stderr).toContain("Did you mean `db:seed`");
+    // The whole report is a diagnostic, so none of it lands on stdout.
+    expect(stdout).toBe("");
+  });
+});
+
+describe("help", () => {
+  test("renders the declared schema and exits 0", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Seed.ts": command(
+        "db:seed",
+        "",
+        `.describe("Seed it")
+  .arg("tenant", { required: true, description: "Which tenant" })
+  .option("dryRun", { type: "boolean", description: "Print the plan" })
+  .option("limit", { type: "number", default: 50 })`,
+      ),
+    });
+
+    const { code, stdout } = await run(root, "db:seed", ["--help"]);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("Usage: gemi run db:seed [options] <tenant>");
+    expect(stdout).toContain("Which tenant");
+    expect(stdout).toContain("--dry-run");
+    expect(stdout).toContain("--limit <number>");
+    expect(stdout).toContain("(default: 50)");
+  });
+});
+
+describe("running one", () => {
+  test("hands the handler its parsed arguments and options", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Echo.ts": command(
+        "echo",
+        `ctx.line(JSON.stringify({ args: ctx.args, options: ctx.options }));`,
+        `.arg("who", { required: true })
+  .arg("rest", { variadic: true })
+  .option("loud", { type: "boolean" })
+  .option("times", { type: "number", default: 1 })`,
+      ),
+    });
+
+    const { code, stdout } = await run(root, "echo", [
+      "world",
+      "a",
+      "b",
+      "--loud",
+      "--times=3",
+    ]);
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      args: { who: "world", rest: ["a", "b"] },
+      options: { loud: true, times: 3 },
+    });
+  });
+
+  test("a usage error prints the usage and exits 1 without running anything", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Echo.ts": command(
+        "echo",
+        `ctx.line("RAN");`,
+        `.arg("who", { required: true })`,
+      ),
+    });
+
+    const { code, stdout, stderr } = await run(root, "echo");
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("Missing required argument <who>.");
+    expect(stderr).toContain("Usage: gemi run echo");
+    expect(stdout).not.toContain("RAN");
+  });
+
+  /**
+   * The split a piped command depends on: `TOTAL=$(gemi run count)` has to
+   * capture the answer and nothing else.
+   */
+  test("line goes to stdout and error goes to stderr", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Both.ts": command(
+        "both",
+        `ctx.line("the answer"); ctx.error("a diagnostic");`,
+      ),
+    });
+
+    const { stdout, stderr } = await run(root, "both");
+
+    expect(stdout.trim()).toBe("the answer");
+    expect(stderr.trim()).toBe("a diagnostic");
+  });
+});
+
+describe("exit codes", () => {
+  const withReturn = (body: string) =>
+    project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Ret.ts": command("ret", body),
+    });
+
+  test("returning nothing succeeds", async () => {
+    expect((await run(withReturn(""), "ret")).code).toBe(0);
+  });
+
+  test("returning an integer is the exit code", async () => {
+    expect((await run(withReturn("return 3;"), "ret")).code).toBe(3);
+    expect((await run(withReturn("return 0;"), "ret")).code).toBe(0);
+  });
+
+  /**
+   * `return users.length` is an easy thing to write, and coercing it would turn
+   * 300 backfilled users into exit status 44 — which reads as a failure to
+   * everything downstream, for a command that succeeded.
+   */
+  test("returning something that is not an exit code says so and fails", async () => {
+    const { code, stderr } = await run(withReturn("return 300;"), "ret");
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("not an exit code");
+  });
+
+  test("fail() carries its message and code, with no stack", async () => {
+    const { code, stdout, stderr } = await run(
+      withReturn(`ctx.fail("nothing to do", 2);`),
+      "ret",
+    );
+
+    expect(code).toBe(2);
+    expect(stderr.trim()).toBe("nothing to do");
+    // A stack frame, not the letters — the sentences these commands print are
+    // English and "what turns" contains "at ".
+    expect(stderr).not.toMatch(/^\s+at /m);
+    expect(stdout).toBe("");
+  });
+
+  test("an unexpected throw keeps its stack, because it is a bug", async () => {
+    const { code, stderr } = await run(
+      withReturn(`throw new Error("boom");`),
+      "ret",
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("boom");
+    expect(stderr).toMatch(/^\s+at /m);
+  });
+});
+
+describe("what an invocation pays for", () => {
+  /**
+   * Listing, an unknown name and `--help` are the three things an operator does
+   * most often, and none of them needs anything from the application beyond its
+   * config. Booting for them would open a database connection to answer a
+   * question about a directory.
+   */
+  test("listing, a miss and help all resolve without booting", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Seed.ts": command("db:seed"),
+    });
+
+    await run(root);
+    await run(root, "nope");
+    await run(root, "db:seed", ["--help"]);
+    await run(root, "db:seed", ["--bogus"]);
+
+    expect(boots()).toBe(0);
+  });
+
+  test("running one does boot, so a command sees the container", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Seed.ts": command("db:seed"),
+    });
+
+    await run(root, "db:seed");
+
+    expect(boots()).toBe(1);
+  });
+
+  test("a command resolves services the way a request handler does", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Sched.ts": command(
+        "sched",
+        `const { app } = await import(${JSON.stringify(resolve(import.meta.dirname, "../foundation/app.ts"))});
+         const { Scheduler } = await import(${JSON.stringify(resolve(import.meta.dirname, "../services/cron/Scheduler.ts"))});
+         ctx.line(String(app(Scheduler) instanceof Scheduler));`,
+      ),
+    });
+
+    const { code, stdout } = await run(root, "sched");
+
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("true");
+  });
+
+  /**
+   * `gemi run` sets `GEMI_NO_SCHEDULE=1` on the process it spawns. Booting the
+   * application is how a command reaches the container; starting the schedule is
+   * a side effect of that which nobody asked for, and a long backfill would
+   * otherwise fire the whole schedule in a process no operator is watching.
+   */
+  test("booting for a command does not start the schedule", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Seed.ts": command("db:seed"),
+      "app/cron/Daily.ts": `import { CronJob } from ${JSON.stringify(resolve(import.meta.dirname, "../services/cron/CronJob.ts"))};
+export class Daily extends CronJob {
+  name = "Daily";
+  cron = "* * * * *";
+  async callback() {}
+}`,
+    });
+
+    await run(root, "db:seed");
+
+    expect(globalThis.__gemiCronJobs?.size ?? 0).toBe(0);
+  });
+});
+
+describe("an application that cannot be read", () => {
+  test("a missing Kernel is a sentence, not a stack", async () => {
+    const root = project({ "app/commands/Seed.ts": command("db:seed") });
+
+    const { code, stderr } = await run(root);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("Could not load");
+    expect(stderr).toContain("root of a gemi project");
+  });
+
+  test("a Kernel with no default export says so", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": `export const NotDefault = 1;`,
+    });
+
+    const { code, stderr } = await run(root);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("no default export");
+  });
+
+  /**
+   * The one silence the builder introduces: a chain that never reached
+   * `.handle()` is a plain object, so discovery discards it and the command
+   * disappears from the listing with nothing raised.
+   */
+  test("a builder that never called handle refuses by name", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Half.ts": `import { defineCommand } from ${BUILDER};
+export default defineCommand("half-written").arg("who");`,
+    });
+
+    const { code, stderr } = await run(root);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("Half.ts");
+    expect(stderr).toContain("never called `.handle()`");
+    expect(stderr).not.toMatch(/^\s+at /m);
+  });
+
+  test("two commands claiming one name refuse rather than picking", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/One.ts": command("db:seed"),
+      "app/commands/Two.ts": command("db:seed"),
+    });
+
+    const { code, stderr } = await run(root);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain('Two commands are named "db:seed"');
+  });
+});
+
+describe("teardown", () => {
+  test("the container is flushed even when the command threw", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Boom.ts": command("boom", `throw new Error("boom");`),
+    });
+
+    await run(root, "boom");
+
+    // `destroy()` clears the static instance and stops a resolved Scheduler.
+    // A command that threw must not leave either behind for the next process —
+    // or, here, the next test.
+    expect(globalThis.__gemiCronJobs?.size ?? 0).toBe(0);
+    expect(() => new Scheduler({ jobs: [] } as any)).not.toThrow();
+  });
+});

--- a/packages/gemi/console/runner.test.ts
+++ b/packages/gemi/console/runner.test.ts
@@ -25,6 +25,7 @@ import { runConsole } from "./runner";
  */
 
 const BUILDER = JSON.stringify(resolve(import.meta.dirname, "builder.ts"));
+const COMMAND = JSON.stringify(resolve(import.meta.dirname, "Command.ts"));
 const KERNEL = JSON.stringify(
   resolve(import.meta.dirname, "../kernel/Kernel.ts"),
 );
@@ -260,6 +261,78 @@ describe("help", () => {
     expect(stdout).toContain("--limit <number>");
     expect(stdout).toContain("(default: 50)");
   });
+
+  /**
+   * A `--help` in *value* position is a value. Deciding otherwise from a flat
+   * token scan meant `gemi run notify --message --help` printed usage and exited
+   * 0 — the notification never sent, and a cron wrapper branching on the exit
+   * code recording a success for work that did not happen.
+   */
+  test("a --help that is an option's value runs the command", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Notify.ts": command(
+        "notify",
+        `ctx.line("sent: " + ctx.options.message);`,
+        `.option("message", { type: "string" })`,
+      ),
+    });
+
+    const { code, stdout } = await run(root, "notify", ["--message=--help"]);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("sent: --help");
+    expect(stdout).not.toContain("Usage:");
+  });
+
+  /**
+   * The ambiguous spelling, which is the one the reviewer's case turned on:
+   * `--message "--help"` reaches the process as two tokens, indistinguishable
+   * from asking for help. Printing usage and exiting 0 meant the notification
+   * was never sent and the wrapper waiting on the status saw a success — so the
+   * ambiguity is reported instead, naming the fix.
+   */
+  test("a --help the shell stripped the quotes from is an error, not a success", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Notify.ts": command(
+        "notify",
+        `ctx.line("sent");`,
+        `.option("message", { type: "string" })`,
+      ),
+    });
+
+    const { code, stdout, stderr } = await run(root, "notify", [
+      "--message",
+      "--help",
+    ]);
+
+    expect(code).toBe(1);
+    expect(stdout).not.toContain("sent");
+    expect(stderr).toContain("write --message=--help");
+  });
+
+  /**
+   * The other direction, and the reason help is checked before the usage
+   * errors: the invocation somebody reaches for `--help` on is usually the one
+   * that is already wrong.
+   */
+  test("--help works on an invocation that is otherwise a usage error", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Seed.ts": command(
+        "db:seed",
+        "",
+        `.arg("tenant", { required: true })`,
+      ),
+    });
+
+    const { code, stdout, stderr } = await run(root, "db:seed", ["--help"]);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("Usage: gemi run db:seed <tenant>");
+    expect(stderr).toBe("");
+  });
 });
 
 describe("running one", () => {
@@ -381,6 +454,35 @@ describe("exit codes", () => {
     expect(stderr).toContain("boom");
     expect(stderr).toMatch(/^\s+at /m);
   });
+
+  /**
+   * The guard on `return` was worthless while `fail` had none, because both take
+   * the same kind of number from the same kind of expression:
+   *
+   *     ctx.fail(`${bad.length} rows failed`, bad.length)
+   *
+   * An exit status is one byte, so 256 reached `process.exit` and the shell read
+   * status **0** — a failed command reported as a success to the `&&` chain or
+   * CI step waiting on it. 300 arrives as 44; 512 is 0 again.
+   */
+  test("fail() with a number that is not an exit code cannot report success", async () => {
+    const { code, stderr } = await run(
+      withReturn(`ctx.fail("256 rows failed", 256);`),
+      "ret",
+    );
+
+    expect(code).not.toBe(0);
+    expect(code).toBe(1);
+    expect(stderr).toContain("256 rows failed");
+    expect(stderr).toContain("not an exit code");
+  });
+
+  test("fail() with a real exit code is untouched", async () => {
+    expect((await run(withReturn(`ctx.fail("no", 2);`), "ret")).code).toBe(2);
+    expect((await run(withReturn(`ctx.fail("no", 255);`), "ret")).code).toBe(
+      255,
+    );
+  });
 });
 
 describe("what an invocation pays for", () => {
@@ -498,6 +600,14 @@ export default defineCommand("half-written").arg("who");`,
     expect(stderr).not.toMatch(/^\s+at /m);
   });
 
+  /**
+   * The registry's refusals are sentences with the fix named in them, about a
+   * mistake in the application's own source — the same class of thing the
+   * `DiscoveryError` above is, and they have to print the same way. Raised as
+   * plain `Error`s they fell through to the bug branch, and the operator read
+   * the message buried under `at new CommandRegistry (…)` plus the runner's own
+   * frames, pointing them at framework code they cannot fix.
+   */
   test("two commands claiming one name refuse rather than picking", async () => {
     const root = project({
       "app/kernel/Kernel.ts": kernel(),
@@ -509,6 +619,49 @@ export default defineCommand("half-written").arg("who");`,
 
     expect(code).toBe(1);
     expect(stderr).toContain('Two commands are named "db:seed"');
+    expect(stderr).not.toMatch(/^\s+at /m);
+  });
+
+  test("a command with no name refuses, also without a stack", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Bare.ts": `import { Command } from ${COMMAND};
+export default class extends Command {}`,
+    });
+
+    const { code, stderr } = await run(root);
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("does not declare a command name");
+    expect(stderr).not.toMatch(/^\s+at /m);
+  });
+
+  /**
+   * The natural way to share option declarations between commands. `base` is a
+   * builder that *did* produce a command, so the file is fine — but the
+   * unfinished-builder check keyed off the export still being a builder object,
+   * so it threw before the registry existed and took every other command in the
+   * project down with it.
+   */
+  test("a builder held in a shared const does not abort the whole run", async () => {
+    const root = project({
+      "app/kernel/Kernel.ts": kernel(),
+      "app/commands/Shared.ts": `import { defineCommand } from ${BUILDER};
+export const base = defineCommand("reindex").option("verbose", { type: "boolean" });
+export default base.handle(async ({ line }) => { line("reindexed") });`,
+      "app/commands/Other.ts": command("db:seed"),
+    });
+
+    const listed = await run(root);
+
+    expect(listed.code).toBe(0);
+    expect(listed.stdout).toContain("reindex");
+    expect(listed.stdout).toContain("db:seed");
+
+    const ran = await run(root, "reindex");
+
+    expect(ran.code).toBe(0);
+    expect(ran.stdout).toContain("reindexed");
   });
 });
 

--- a/packages/gemi/console/runner.ts
+++ b/packages/gemi/console/runner.ts
@@ -1,0 +1,249 @@
+import path from "node:path";
+
+import type { Kernel } from "../kernel/Kernel";
+import { discoverCommands } from "../services/discovery";
+import { DiscoveryError } from "../support/discover";
+import { withDefaults } from "../support/withDefaults";
+import { CommandFailed, type CommandClass } from "./Command";
+import { CommandRegistry } from "./CommandRegistry";
+import { commandConfigDefaults, type CommandConfig } from "./config";
+import { createContext, processWriters, type CommandWriters } from "./context";
+import { parseArgv, wantsHelp } from "./parse";
+import { renderList, renderUsage } from "./usage";
+
+/**
+ * `gemi run`, from the inside.
+ *
+ * This runs in a Bun process the CLI spawned, not in the CLI. That is the whole
+ * reason the file exists, and it is worth stating here because everything below
+ * assumes it:
+ *
+ *   - `dist/bin/gemi.js` bundles its own copy of gemi, while the application's
+ *     Kernel resolves `gemi/*` to source. Discovery decides membership by
+ *     walking the prototype chain, so a `Command` base imported into the CLI
+ *     bundle is a *different class object* from the one `app/commands/*.ts`
+ *     extends — every command would be invisible, silently. In this process
+ *     there is one copy and the question does not arise.
+ *   - `--preload gemi/bun/preload` and the app's own `app/preload.ts` can only
+ *     be registered at process start, and a command that touches a controller
+ *     needs the first while the template's models need the second.
+ *   - Bun fixes its JSX transform and react-dom's export conditions from
+ *     `NODE_ENV` at startup, so a command that renders an email is only correct
+ *     in a process that began with the right one.
+ *
+ * ### Why the ordering below is the ordering
+ *
+ * Listing commands, reporting an unknown name and printing `--help` all resolve
+ * *before* `waitForBoot()`. Those are the three things an operator does most
+ * often and the three that need nothing from the application beyond its config,
+ * so none of them should open a database connection. Running a command needs the
+ * full boot and takes it.
+ */
+
+/** A failure with a sentence written for the terminal. Never printed with a stack. */
+export class ConsoleError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "ConsoleError";
+  }
+}
+
+export interface RunConsoleParams {
+  rootDir: string;
+  /** The command to run. Absent means "list what there is". */
+  name?: string;
+  /** Everything after the name, already stripped of a leading `--`. */
+  argv: readonly string[];
+  writers?: CommandWriters;
+}
+
+export async function runConsole(params: RunConsoleParams): Promise<number> {
+  const writers = params.writers ?? processWriters();
+  const out = (message: string) => writers.stdout(`${message}\n`);
+  const err = (message: string) => writers.stderr(`${message}\n`);
+
+  let kernel: Kernel | undefined;
+
+  try {
+    kernel = await loadKernel(params.rootDir);
+    kernel.boot();
+
+    const slice = kernel.app.config.get<CommandConfig>("command", {});
+    const dir = withDefaults(commandConfigDefaults(), slice).commandsDir;
+
+    // Resolved against `rootDir` rather than left for `discoverCommands` to hang
+    // off `projectRoot()`. In the spawned process the two are the same thing —
+    // the CLI spawns with no `cwd`, so the child inherits the project root — but
+    // "the same thing in production" is how a parameter quietly stops being one.
+    // This function already resolves the Kernel against `rootDir`, and a caller
+    // that passes a directory only for half of it to be honoured is the kind of
+    // thing tests find and nothing else does.
+    const commandsDir = path.isAbsolute(dir)
+      ? dir
+      : path.join(params.rootDir, dir);
+
+    // Declared wins, and `[]` is declared. Read before `withDefaults`, which
+    // collapses absent and `undefined` into the default `[]` — the same value an
+    // app writes when it means "none, and I mean it".
+    const declared = slice.commands !== undefined;
+    const commands = declared
+      ? slice.commands!
+      : await discoverCommands(commandsDir);
+
+    const registry = new CommandRegistry(commands);
+    const source = { declared, dir };
+
+    if (params.name === undefined) {
+      out(renderList(registry.commands, source));
+      return 0;
+    }
+
+    const command = registry.get(params.name);
+
+    if (!command) {
+      const suggestions = registry.suggest(params.name);
+      err(
+        `No command named \`${params.name}\`.` +
+          (suggestions.length > 0
+            ? ` Did you mean ${suggestions
+                .map((candidate) => `\`${candidate}\``)
+                .join(", or ")}?`
+            : ""),
+      );
+      err("");
+      err(renderList(registry.commands, source));
+      return 1;
+    }
+
+    const spec = {
+      commandName: command.commandName,
+      args: command.args,
+      options: command.options,
+    };
+
+    if (wantsHelp(spec, params.argv)) {
+      out(renderUsage(command));
+      return 0;
+    }
+
+    const parsed = parseArgv(spec, params.argv);
+
+    // `=== false` rather than `!parsed.ok`: the package compiles with
+    // `strictNullChecks` off, and under it a `!x.ok` test does not narrow a
+    // discriminated union while an explicit comparison does. The negation
+    // compiles to the same check and reads the same, which is exactly why it is
+    // worth a line — it fails as a type error here, but the same shape in an
+    // untypechecked file would just quietly be `any`.
+    if (parsed.ok === false) {
+      for (const message of parsed.errors) err(message);
+      err("");
+      err(renderUsage(command));
+      return 1;
+    }
+
+    // Only now. Everything above answered a question about the application's
+    // shape; this is the first line that needs the application itself.
+    await kernel.waitForBoot();
+
+    const context = createContext({
+      args: parsed.args,
+      options: parsed.options,
+      argv: params.argv,
+      writers,
+    });
+
+    const result = await kernel.run(() =>
+      Promise.resolve(
+        new (command as new () => { run(ctx: unknown): unknown })().run(
+          context,
+        ),
+      ),
+    );
+
+    return exitCodeFor(result, command, err);
+  } catch (error) {
+    // A `CommandFailed`, a `ConsoleError` or a `DiscoveryError` is a sentence
+    // written for this moment; anything else is a bug and keeps its stack. The
+    // same split `bin/gemi.ts` already applies to `CheckModelsError`.
+    //
+    // `DiscoveryError` belongs in this list rather than the other because every
+    // way of raising one — a command file that will not import, a builder chain
+    // that was never finished — is a mistake in the application's own source
+    // with the fix named in the message. A stack above it points at this
+    // runner's frames, which is not where anybody needs to look.
+    if (error instanceof CommandFailed) {
+      err(error.message);
+      return error.code;
+    }
+
+    if (error instanceof ConsoleError || error instanceof DiscoveryError) {
+      err(error.message);
+      return 1;
+    }
+
+    err(String((error as Error)?.stack ?? error));
+    return 1;
+  } finally {
+    // Stops the Scheduler if it was resolved, flushes the container, clears the
+    // static instance and disables the kernel context. The caller still exits
+    // explicitly — see `run.ts`.
+    kernel?.destroy();
+  }
+}
+
+async function loadKernel(rootDir: string): Promise<Kernel> {
+  const kernelPath = path.resolve(rootDir, "app/kernel/Kernel.ts");
+
+  let module: { default?: new () => Kernel };
+  try {
+    module = await import(kernelPath);
+  } catch (error) {
+    throw new ConsoleError(
+      `Could not load ${kernelPath}:\n    ${(error as Error).message}\n` +
+        `\`gemi run\` boots your application the way the server does, so it ` +
+        `needs the Kernel. Run it from the root of a gemi project.`,
+      { cause: error },
+    );
+  }
+
+  if (typeof module.default !== "function") {
+    throw new ConsoleError(
+      `${kernelPath} has no default export. gemi expects the Kernel subclass ` +
+        `to be the default export of that file.`,
+    );
+  }
+
+  return new module.default();
+}
+
+/**
+ * What the handler returned, as something a shell can branch on.
+ *
+ * A returned value that is not an exit code is reported rather than coerced:
+ * `return users.length` is an easy thing to write and would otherwise turn 300
+ * backfilled users into exit status 44 (300 & 255), which reads as a failure to
+ * everything downstream.
+ */
+function exitCodeFor(
+  result: unknown,
+  command: CommandClass,
+  err: (message: string) => void,
+): number {
+  if (result === undefined || result === null) return 0;
+
+  if (
+    typeof result === "number" &&
+    Number.isInteger(result) &&
+    result >= 0 &&
+    result <= 255
+  ) {
+    return result;
+  }
+
+  err(
+    `Command "${command.commandName}" returned ${JSON.stringify(result)}, ` +
+      `which is not an exit code. Return nothing for success, or an integer ` +
+      `from 0 to 255. Treating this as a failure.`,
+  );
+  return 1;
+}

--- a/packages/gemi/console/runner.ts
+++ b/packages/gemi/console/runner.ts
@@ -8,8 +8,11 @@ import { CommandFailed, type CommandClass } from "./Command";
 import { CommandRegistry } from "./CommandRegistry";
 import { commandConfigDefaults, type CommandConfig } from "./config";
 import { createContext, processWriters, type CommandWriters } from "./context";
-import { parseArgv, wantsHelp } from "./parse";
+import { ConsoleError } from "./errors";
+import { parseArgv } from "./parse";
 import { renderList, renderUsage } from "./usage";
+
+export { ConsoleError };
 
 /**
  * `gemi run`, from the inside.
@@ -40,19 +43,11 @@ import { renderList, renderUsage } from "./usage";
  * full boot and takes it.
  */
 
-/** A failure with a sentence written for the terminal. Never printed with a stack. */
-export class ConsoleError extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-    this.name = "ConsoleError";
-  }
-}
-
 export interface RunConsoleParams {
   rootDir: string;
   /** The command to run. Absent means "list what there is". */
   name?: string;
-  /** Everything after the name, already stripped of a leading `--`. */
+  /** Everything after the name, exactly as it was typed — including any `--`. */
   argv: readonly string[];
   writers?: CommandWriters;
 }
@@ -63,6 +58,8 @@ export async function runConsole(params: RunConsoleParams): Promise<number> {
   const err = (message: string) => writers.stderr(`${message}\n`);
 
   let kernel: Kernel | undefined;
+  // Hoisted only so the catch can name the command in an exit-code complaint.
+  let running: CommandClass | undefined;
 
   try {
     kernel = await loadKernel(params.rootDir);
@@ -99,6 +96,7 @@ export async function runConsole(params: RunConsoleParams): Promise<number> {
     }
 
     const command = registry.get(params.name);
+    running = command;
 
     if (!command) {
       const suggestions = registry.suggest(params.name);
@@ -121,12 +119,16 @@ export async function runConsole(params: RunConsoleParams): Promise<number> {
       options: command.options,
     };
 
-    if (wantsHelp(spec, params.argv)) {
+    const parsed = parseArgv(spec, params.argv);
+
+    // Before the error branch, so `--help` works on the invocation that most
+    // needs it: the one that is already a usage error. And *from the parse*
+    // rather than from a token scan, because only the parse knows that the
+    // `--help` in `--message --help` is a value — see `ParseResult["help"]`.
+    if (parsed.help) {
       out(renderUsage(command));
       return 0;
     }
-
-    const parsed = parseArgv(spec, params.argv);
 
     // `=== false` rather than `!parsed.ok`: the package compiles with
     // `strictNullChecks` off, and under it a `!x.ok` test does not narrow a
@@ -173,7 +175,14 @@ export async function runConsole(params: RunConsoleParams): Promise<number> {
     // runner's frames, which is not where anybody needs to look.
     if (error instanceof CommandFailed) {
       err(error.message);
-      return error.code;
+
+      // Through the same guard a returned value gets. `fail` takes the same
+      // kind of number and the same kind of expression produces it, so
+      // ``ctx.fail(`${bad.length} rows failed`, bad.length)`` with 256 bad rows
+      // handed 256 straight to `process.exit`, which the shell reports as
+      // status **0** — a failed command read as a success by the `&&` chain or
+      // CI step waiting on it. 300 arrives as 44; 512 is 0 again.
+      return exitCodeFor(error.code, running, err, "called fail() with");
     }
 
     if (error instanceof ConsoleError || error instanceof DiscoveryError) {
@@ -217,17 +226,23 @@ async function loadKernel(rootDir: string): Promise<Kernel> {
 }
 
 /**
- * What the handler returned, as something a shell can branch on.
+ * What the command asked the shell to see, if a shell can actually see it.
  *
- * A returned value that is not an exit code is reported rather than coerced:
- * `return users.length` is an easy thing to write and would otherwise turn 300
- * backfilled users into exit status 44 (300 & 255), which reads as a failure to
- * everything downstream.
+ * An exit status is one byte. Anything else a handler offers is reported rather
+ * than coerced, because coercion here is silent and inverts the answer: `return
+ * users.length` after 300 backfilled users would exit 44 (300 & 255), and 256
+ * would exit **0** — a failure indistinguishable from success to the `&&` chain,
+ * CI step or cron wrapper waiting on it.
+ *
+ * Both ways a command names its status come through here — `return n` and
+ * `ctx.fail(msg, n)` — because both take the same kind of number from the same
+ * kind of expression, and a guard on only one of them is a guard on neither.
  */
 function exitCodeFor(
   result: unknown,
-  command: CommandClass,
+  command: CommandClass | undefined,
   err: (message: string) => void,
+  source = "returned",
 ): number {
   if (result === undefined || result === null) return 0;
 
@@ -240,10 +255,12 @@ function exitCodeFor(
     return result;
   }
 
+  const subject = command ? `Command "${command.commandName}"` : "The command";
+
   err(
-    `Command "${command.commandName}" returned ${JSON.stringify(result)}, ` +
-      `which is not an exit code. Return nothing for success, or an integer ` +
-      `from 0 to 255. Treating this as a failure.`,
+    `${subject} ${source} ${JSON.stringify(result)}, which is not an exit ` +
+      `code — an exit code is an integer from 0 to 255. Treating this as a ` +
+      `failure.`,
   );
   return 1;
 }

--- a/packages/gemi/console/usage.test.ts
+++ b/packages/gemi/console/usage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+
+import { defineCommand } from "./builder";
+import { renderUsage } from "./usage";
+
+/**
+ * What `--help` prints, checked against what the parser actually accepts.
+ *
+ * The whole reason `usage.ts` renders from the declared statics rather than
+ * from hand-written strings is that help which describes a flag the parser
+ * rejects is worse than no help — it sends the reader to try something that
+ * cannot work. The `-h, --help` line was the one place that reasoning had a
+ * hole: it was printed unconditionally, including for commands that had taken
+ * one or both of those spellings for themselves.
+ */
+
+const usage = (build: (chain: any) => any) =>
+  renderUsage(build(defineCommand("demo")).handle(() => {}));
+
+describe("the help line", () => {
+  test("is offered in both spellings when the command claims neither", () => {
+    expect(usage((c: any) => c)).toContain("-h, --help");
+  });
+
+  test("drops the alias when the command took -h for something else", () => {
+    const rendered = usage((c: any) =>
+      c.option("host", { type: "string", alias: "h" }),
+    );
+
+    // `parse.ts` still answers `--help` here, so it is still advertised — but
+    // only in the spelling that works. Two contradictory `-h` entries, one of
+    // them dead, was the bug.
+    expect(rendered).toContain("--help");
+    expect(rendered).not.toContain("-h, --help");
+    expect(rendered).toContain("-h, --host");
+  });
+
+  test("falls back to the alias when the command took the long spelling", () => {
+    const rendered = usage((c: any) => c.option("help", { type: "boolean" }));
+
+    expect(rendered).toContain("-h ");
+    expect(rendered).not.toContain("-h, --help");
+  });
+
+  test("says nothing when the command claimed both", () => {
+    const rendered = usage((c: any) =>
+      c.option("help", { type: "boolean", alias: "h" }),
+    );
+
+    expect(rendered).not.toContain("Show this message");
+  });
+});
+
+describe("arguments", () => {
+  test("a required variadic reads as mandatory, which the parser now enforces", () => {
+    expect(
+      usage((c: any) => c.arg("files", { required: true, variadic: true })),
+    ).toContain("<files...>");
+  });
+
+  test("an optional one reads as optional", () => {
+    expect(usage((c: any) => c.arg("files", { variadic: true }))).toContain(
+      "[files...]",
+    );
+  });
+});

--- a/packages/gemi/console/usage.ts
+++ b/packages/gemi/console/usage.ts
@@ -27,6 +27,33 @@ function argSlot(arg: {
   return arg.required ? `<${inner}>` : `[${inner}]`;
 }
 
+/**
+ * The `--help` line, listed only in the spellings the command left free.
+ *
+ * `parse.ts` yields `--help` to a command that declares an option called `help`
+ * and `-h` to one that declares that alias, independently. Printing an
+ * unconditional `-h, --help` meant a command with a `-h, --host` was shown two
+ * contradictory `-h` entries, one of which did nothing — help that lies about
+ * the parser is worse than no help line at all.
+ */
+function helpEntry(command: CommandClass): Array<[string, string]> {
+  const claimed = (
+    predicate: (option: CommandClass["options"][number]) => boolean,
+  ) => command.options.some(predicate);
+
+  const longTaken = claimed(
+    (option) => option.name === "help" || kebab(option.name) === "help",
+  );
+  const shortTaken = claimed(
+    (option) => "alias" in option && option.alias === "h",
+  );
+
+  if (longTaken && shortTaken) return [];
+  if (longTaken) return [["-h", "Show this message"]];
+
+  return [[`${shortTaken ? "" : "-h, "}--help`, "Show this message"]];
+}
+
 export function renderUsage(command: CommandClass): string {
   const lines: string[] = [];
 
@@ -86,7 +113,7 @@ export function renderUsage(command: CommandClass): string {
           string,
         ];
       }),
-      ["-h, --help", "Show this message"],
+      ...helpEntry(command),
     ]),
   );
 

--- a/packages/gemi/console/usage.ts
+++ b/packages/gemi/console/usage.ts
@@ -1,0 +1,132 @@
+import type { CommandClass } from "./Command";
+import { kebab } from "./parse";
+
+/**
+ * Everything `gemi run` prints when it is not running a command.
+ *
+ * Rendered from the same statics `parse.ts` reads, so the help cannot describe a
+ * flag the parser does not accept. That is the only reason this is not a set of
+ * template literals next to the code that needs them.
+ */
+
+function pad(entries: Array<[string, string]>, indent = "  "): string[] {
+  const width = entries.reduce((max, [left]) => Math.max(max, left.length), 0);
+  return entries.map(([left, right]) =>
+    right === ""
+      ? `${indent}${left}`
+      : `${indent}${left.padEnd(width)}  ${right}`,
+  );
+}
+
+function argSlot(arg: {
+  name: string;
+  required?: boolean;
+  variadic?: boolean;
+}): string {
+  const inner = arg.variadic ? `${arg.name}...` : arg.name;
+  return arg.required ? `<${inner}>` : `[${inner}]`;
+}
+
+export function renderUsage(command: CommandClass): string {
+  const lines: string[] = [];
+
+  const slots = command.args.map(argSlot).join(" ");
+  const usage = [
+    "gemi run",
+    command.commandName,
+    command.options.length > 0 ? "[options]" : "",
+    slots,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  lines.push(`Usage: ${usage}`);
+
+  if (command.description) {
+    lines.push("", command.description);
+  }
+
+  if (command.args.length > 0) {
+    lines.push("", "Arguments:");
+    lines.push(
+      ...pad(
+        command.args.map((arg) => {
+          const notes = [
+            arg.description ?? "",
+            arg.default !== undefined
+              ? `(default: ${JSON.stringify(arg.default)})`
+              : "",
+          ]
+            .filter(Boolean)
+            .join(" ");
+          return [argSlot(arg), notes] as [string, string];
+        }),
+      ),
+    );
+  }
+
+  lines.push("", "Options:");
+  lines.push(
+    ...pad([
+      ...command.options.map((option) => {
+        const alias =
+          "alias" in option && option.alias ? `-${option.alias}, ` : "";
+        const value = option.type === "boolean" ? "" : ` <${option.type}>`;
+        const notes = [
+          option.description ?? "",
+          option.default !== undefined
+            ? `(default: ${JSON.stringify(option.default)})`
+            : "",
+          "required" in option && option.required ? "(required)" : "",
+        ]
+          .filter(Boolean)
+          .join(" ");
+        return [`${alias}--${kebab(option.name)}${value}`, notes] as [
+          string,
+          string,
+        ];
+      }),
+      ["-h, --help", "Show this message"],
+    ]),
+  );
+
+  return lines.join("\n");
+}
+
+export function renderList(
+  commands: CommandClass[],
+  source: { declared: boolean; dir: string },
+): string {
+  const heading = source.declared
+    ? `${commands.length} command${commands.length === 1 ? "" : "s"} declared in app/config/command.ts:`
+    : `Commands in ${source.dir}:`;
+
+  if (commands.length === 0) {
+    return source.declared
+      ? `app/config/command.ts declares no commands.\n\n` +
+          `Remove the \`commands\` key from that slice to discover the classes ` +
+          `under ${source.dir} instead — a declared list wins, and an empty one ` +
+          `means "none, and I mean it".`
+      : `No commands found in ${source.dir}.\n\n` +
+          `A command is registered by existing: write a file there that exports ` +
+          `a \`defineCommand(...).handle(...)\` chain and it will appear here.`;
+  }
+
+  const sorted = [...commands].sort((a, b) =>
+    a.commandName < b.commandName ? -1 : a.commandName > b.commandName ? 1 : 0,
+  );
+
+  return [
+    heading,
+    "",
+    ...pad(
+      sorted.map(
+        (command) =>
+          [command.commandName, command.description] as [string, string],
+      ),
+    ),
+    "",
+    "Run one with `gemi run <name>`, and see its arguments with " +
+      "`gemi run <name> --help`.",
+  ].join("\n");
+}

--- a/packages/gemi/exports-map.test.ts
+++ b/packages/gemi/exports-map.test.ts
@@ -44,9 +44,9 @@ const entries = Object.entries(PKG.exports).filter(
 describe("the package's exports map", () => {
   test("names at least the entrypoints the docs and templates import", () => {
     // Guards against an `exports` that parsed to something empty, which would
-    // make every assertion below vacuously true. Pinned just under the 19 the
+    // make every assertion below vacuously true. Pinned just under the 20 the
     // map currently holds, so losing a couple is noticed rather than absorbed.
-    expect(entries.length).toBeGreaterThanOrEqual(18);
+    expect(entries.length).toBeGreaterThanOrEqual(19);
   });
 
   test("every source target exists", () => {

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -35,6 +35,7 @@
     "./database": "./database/index.ts",
     "./orm": "./orm/index.ts",
     "./support": "./support/index.ts",
+    "./console/run": "./console/run.ts",
     "./bun/preload": "./bun/preload.ts",
     "./bun/plugin": "./bun/plugin.ts"
   },

--- a/packages/gemi/scripts/build.ts
+++ b/packages/gemi/scripts/build.ts
@@ -24,6 +24,13 @@ const result = await Bun.build({
     "./support/index.ts",
     "./database/index.ts",
     "./orm/index.ts",
+    // The entry `gemi run` spawns. It belongs in *this* build rather than one of
+    // its own: `splitting: true` is what puts the `Command` base class in a
+    // chunk shared with `dist/services/index.js`, so the published runner and
+    // the `gemi/services` an application imports from hold the same class
+    // object. Discovery decides what is a command by walking the prototype
+    // chain, so two copies would mean the runner finds nothing.
+    "./console/run.ts",
   ],
   outdir: "./dist",
   external: [

--- a/packages/gemi/services/cron/ScheduleServiceProvider.ts
+++ b/packages/gemi/services/cron/ScheduleServiceProvider.ts
@@ -51,6 +51,26 @@ export class ScheduleServiceProvider extends ServiceProvider {
       scheduler.useJobs(await discoverCronJobs(jobsDir));
     }
 
+    // Resolved, listed, and not started.
+    //
+    // `gemi run` sets this on the process it spawns. Booting the application is
+    // how a console command reaches the container, and starting the schedule is
+    // a side effect of that which nobody asked for: a `gemi run backfill` that
+    // takes four minutes would otherwise fire the application's whole cron
+    // schedule in a process no operator is watching, and `Bun.cron` handles hold
+    // the loop open besides.
+    //
+    // Deliberately above `start` and below `useJobs`, so `app(Scheduler).jobs`
+    // still answers honestly — a command that wants to fire a tick by hand can,
+    // and a test asking what this application schedules gets the same answer
+    // either way.
+    //
+    // An environment variable rather than a config field, because this is a
+    // property of *this process* and not of the application: the same variable
+    // is how a deploy runs one cron dyno beside several web ones, and a config
+    // slice would have to know which command started it.
+    if (process.env.GEMI_NO_SCHEDULE === "1") return;
+
     const app = this.app;
     scheduler.start((cb) => kernelContext.run(app, cb));
   }

--- a/packages/gemi/services/discovery.test.ts
+++ b/packages/gemi/services/discovery.test.ts
@@ -17,7 +17,7 @@ import type { ConfigItems } from "../support/Repository";
 import { Scheduler } from "./cron/Scheduler";
 import { ScheduleServiceProvider } from "./cron/ScheduleServiceProvider";
 import { CronJob } from "./cron/CronJob";
-import { discoverCronJobs, discoverJobs } from "./discovery";
+import { discoverCommands, discoverCronJobs, discoverJobs } from "./discovery";
 import { Job } from "./queue/Job";
 import { QueueManager } from "./queue/QueueManager";
 import { QueueServiceProvider } from "./queue/QueueServiceProvider";
@@ -370,6 +370,139 @@ describe("the schedule", () => {
     );
 
     expect(application.make(Scheduler).jobs).toEqual([]);
+  });
+
+  /**
+   * `GEMI_NO_SCHEDULE=1` is what `gemi run` sets on the process it spawns.
+   *
+   * Booting the application is how a console command reaches the container, and
+   * starting the schedule is a side effect of that which nobody asked for: a
+   * `gemi run backfill` that takes four minutes would otherwise fire the whole
+   * schedule in a process no operator is watching, and the `Bun.cron` handles
+   * hold the loop open besides.
+   *
+   * The half worth pinning is the *first* assertion. Suppressing the schedule by
+   * skipping discovery too would look identical from the outside — nothing ticks
+   * either way — and would quietly make `app(Scheduler).jobs` answer differently
+   * depending on which process asked, so a command that wanted to fire a tick by
+   * hand would find nothing to fire.
+   */
+  test("GEMI_NO_SCHEDULE resolves and lists the jobs, and starts none of them", async () => {
+    const root = project({
+      "app/cron/EveryMinute.ts": cron("EveryMinute", "* * * * *"),
+    });
+
+    const previous = process.env.GEMI_NO_SCHEDULE;
+    process.env.GEMI_NO_SCHEDULE = "1";
+
+    try {
+      const application = await boot(
+        { schedule: { jobsDir: join(root, "app/cron") } },
+        ScheduleServiceProvider,
+      );
+
+      expect(names(application.make(Scheduler).jobs)).toEqual(["EveryMinute"]);
+      expect(globalThis.__gemiCronJobs?.size ?? 0).toBe(0);
+    } finally {
+      if (previous === undefined) delete process.env.GEMI_NO_SCHEDULE;
+      else process.env.GEMI_NO_SCHEDULE = previous;
+    }
+  });
+
+  test("without it, the same schedule does start", async () => {
+    const root = project({
+      "app/cron/EveryMinute.ts": cron("EveryMinute", "* * * * *"),
+    });
+
+    const application = await boot(
+      { schedule: { jobsDir: join(root, "app/cron") } },
+      ScheduleServiceProvider,
+    );
+
+    expect(names(application.make(Scheduler).jobs)).toEqual(["EveryMinute"]);
+    expect(globalThis.__gemiCronJobs?.size ?? 0).toBe(1);
+  });
+});
+
+/**
+ * Commands, the third directory discovery reads.
+ *
+ * The walk is the same one, so the skip rules and the base-class exclusion are
+ * covered above and only spot-checked here. What is specific to commands is the
+ * failure the builder introduces: a chain that never reached `.handle()` is a
+ * plain object rather than a class, so the walk would discard it exactly as it
+ * discards a helper — and the command would vanish from `gemi run` with nothing
+ * raised, which is the silence this whole file exists to remove.
+ */
+describe("asking an application what commands it has", () => {
+  const BUILDER = JSON.stringify(
+    resolve(import.meta.dirname, "../console/builder.ts"),
+  );
+
+  const declaration = (name: string) =>
+    `import { defineCommand } from ${BUILDER};
+export default defineCommand(${JSON.stringify(name)}).handle(() => {});`;
+
+  test("finds every command under the directory, nested included", async () => {
+    const root = project({
+      "app/commands/Seed.ts": declaration("db:seed"),
+      "app/commands/tenants/Repair.ts": declaration("tenants:repair"),
+    });
+
+    const found = await discoverCommands(join(root, "app/commands"));
+
+    expect(found.map((command) => command.commandName)).toEqual([
+      "db:seed",
+      "tenants:repair",
+    ]);
+  });
+
+  test("never returns the base class, however it got re-exported", async () => {
+    const root = project({
+      "app/commands/Seed.ts": declaration("db:seed"),
+      "app/commands/base.ts": `export { Command } from ${JSON.stringify(
+        resolve(import.meta.dirname, "../console/Command.ts"),
+      )};`,
+    });
+
+    expect(
+      (await discoverCommands(join(root, "app/commands"))).map(
+        (command) => command.commandName,
+      ),
+    ).toEqual(["db:seed"]);
+  });
+
+  test("a directory that does not exist is an empty list, not a throw", async () => {
+    const root = project({ "app/config/command.ts": "" });
+
+    expect(await discoverCommands(join(root, "app/commands"))).toEqual([]);
+  });
+
+  test("an unfinished builder stops the walk and names the file", async () => {
+    const root = project({
+      "app/commands/Seed.ts": declaration("db:seed"),
+      "app/commands/Half.ts": `import { defineCommand } from ${BUILDER};
+export default defineCommand("half-written").arg("who");`,
+    });
+
+    await expect(
+      discoverCommands(join(root, "app/commands")),
+    ).rejects.toThrow(/never called `\.handle\(\)`/);
+  });
+
+  test("the ordinary things a command file exports are not mistaken for one", async () => {
+    const root = project({
+      "app/commands/Seed.ts": `${declaration("db:seed")}
+export const BATCH_SIZE = 100;
+export function helper() {}
+export const config = { retries: 3 };`,
+    });
+
+    expect(
+      (await discoverCommands(join(root, "app/commands"))).map(
+        (command) => command.commandName,
+      ),
+    ).toEqual(["db:seed"]);
   });
 });
 

--- a/packages/gemi/services/discovery.ts
+++ b/packages/gemi/services/discovery.ts
@@ -201,6 +201,17 @@ export async function discoverCommands(
  * A throw rather than a warning, because there is no reading of an unfinished
  * builder under which the author meant it: the chain builds a description of a
  * command and then discards it.
+ *
+ * "Unfinished" is decided by `.handle()` clearing the brand, not by the export
+ * still being a builder object. Those differ for the natural way to share
+ * declarations —
+ *
+ *     export const base = defineCommand("reindex").option("verbose", …);
+ *     export default base.handle(async () => {});
+ *
+ * — where `base` is a builder that *did* produce a command. Keying off the shape
+ * alone made that file abort the whole of `gemi run`, taking every other command
+ * in the project down with it, under a message that was untrue for it.
  */
 function refuseUnfinishedBuilders(files: string[]): void {
   if (files.length === 0) return;

--- a/packages/gemi/services/discovery.ts
+++ b/packages/gemi/services/discovery.ts
@@ -1,7 +1,14 @@
 import { existsSync } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 
-import { discoverClasses, projectRoot } from "../support/discover";
+import {
+  discoverClasses,
+  DiscoveryError,
+  projectRoot,
+} from "../support/discover";
+import { Command, type CommandClass } from "../console/Command";
+import { commandConfigDefaults } from "../console/config";
+import { isUnfinishedBuilder } from "../console/builder";
 import { CronJob } from "./cron/CronJob";
 import { scheduleConfigDefaults } from "./cron/config";
 import { Job } from "./queue/Job";
@@ -143,4 +150,71 @@ export async function discoverCronJobs(
   const resolved = resolveDir(dir);
   warnIfSourceIsMissing(resolved, "cron jobs", "schedule");
   return await discoverClasses(resolved, CronJob);
+}
+
+/**
+ * The `Command` subclasses under `dir`, defaulting to the config slice's
+ * `app/commands`.
+ *
+ * This is what a `commands`-less `command` slice resolves to, and what
+ * `gemi run` lists. Unlike the two above it is not called during boot — a
+ * command registry has one consumer, and importing every file under
+ * `app/commands` into every server process would be a cost paid on every start
+ * for code no request reaches.
+ *
+ * Every file underneath is imported, so calling this runs the app's command
+ * modules — the cost `discoverClasses` documents at length, paid once per call.
+ */
+export async function discoverCommands(
+  dir: string = commandConfigDefaults().commandsDir,
+): Promise<CommandClass[]> {
+  const resolved = resolveDir(dir);
+  warnIfSourceIsMissing(resolved, "commands", "command");
+
+  const unfinished: string[] = [];
+
+  const commands = await discoverClasses(
+    resolved,
+    Command,
+    [],
+    (value, file) => {
+      if (isUnfinishedBuilder(value)) unfinished.push(file);
+    },
+  );
+
+  refuseUnfinishedBuilders(unfinished);
+
+  return commands as CommandClass[];
+}
+
+/**
+ * Stops the walk for a builder chain that was never finished.
+ *
+ * This is the one silence the builder introduces, and it is the exact shape
+ * #322 and #323 exist to remove. `defineCommand(...).arg(...)` without a
+ * trailing `.handle(...)` is a plain object rather than a class, so
+ * `discoverClasses` discards it along with every constant and helper a command
+ * file happens to export — and the command disappears from `gemi run` with
+ * nothing raised. The author sees a listing containing every command except the
+ * one they just wrote.
+ *
+ * A throw rather than a warning, because there is no reading of an unfinished
+ * builder under which the author meant it: the chain builds a description of a
+ * command and then discards it.
+ */
+function refuseUnfinishedBuilders(files: string[]): void {
+  if (files.length === 0) return;
+
+  const subject =
+    files.length === 1
+      ? `${files[0]} exports a command builder that never called \`.handle()\``
+      : `${files.length} files export a command builder that never called ` +
+        `\`.handle()\`:\n    ${files.join("\n    ")}`;
+
+  throw new DiscoveryError(
+    `${subject}, so there is no command to run. \`.handle()\` is what turns ` +
+      `the chain into a command — finish it:\n\n` +
+      `    export default defineCommand("my-command")\n` +
+      `      .handle(async ({ line }) => { line("hello") })`,
+  );
 }

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -105,10 +105,28 @@ export { ScheduleServiceProvider } from "./cron/ScheduleServiceProvider";
 export { Scheduler } from "./cron/Scheduler";
 export { CronJob } from "./cron/CronJob";
 
+// Console commands. `defineCommand` is the authoring surface — the `Command`
+// base class below is what it produces and what discovery finds, and
+// subclassing it by hand gives up the typing that is the point (see
+// `console/builder.ts`).
+export { defineCommand } from "../console/builder";
+export type { CommandBuilder } from "../console/builder";
+export { Command, CommandFailed } from "../console/Command";
+export type {
+  ArgSpec,
+  OptionSpec,
+  CommandArgument,
+  CommandOption,
+  CommandClass,
+  CommandResult,
+} from "../console/Command";
+export type { CommandContext } from "../console/context";
+export { CommandRegistry } from "../console/CommandRegistry";
+
 // Discovery. What a `jobs`-less `queue` or `schedule` slice resolves to, and
 // the only way left to ask an application what it has: the config array a test
 // used to import may not exist any more.
-export { discoverJobs, discoverCronJobs } from "./discovery";
+export { discoverJobs, discoverCronJobs, discoverCommands } from "./discovery";
 
 // Redis
 export { RedisServiceProvider } from "./redis/RedisServiceProvider";
@@ -163,6 +181,11 @@ export {
   scheduleConfigDefaults,
   type ScheduleConfig,
 } from "./cron/config";
+export {
+  defineCommandConfig,
+  commandConfigDefaults,
+  type CommandConfig,
+} from "../console/config";
 export {
   defineRedisConfig,
   redisConfigDefaults,

--- a/packages/gemi/support/discover.ts
+++ b/packages/gemi/support/discover.ts
@@ -175,6 +175,14 @@ export class DiscoveryError extends Error {
  * where the caller is a scheduler and the alternative is a boot order that
  * depends on the filesystem.
  *
+ * `onSkipped` is handed every export that did *not* match, with the file it came
+ * from. Discovery's characteristic failure is a thing the author wrote and this
+ * walk cannot see, and by the time an export has been discarded here the
+ * information about why is gone — the caller is left holding "four classes"
+ * where the directory holds five. A caller that can recognise its own
+ * near-misses, as `discoverCommands` recognises a builder chain that was never
+ * finished, uses this to say so by name instead.
+ *
  * @throws DiscoveryError if a walked file cannot be imported. Not a skip: a file
  * that will not load is a class the caller was going to be told about and now is
  * not, which is the failure discovery exists to remove.
@@ -183,6 +191,7 @@ export async function discoverClasses<T extends ClassLike>(
   dir: string,
   base: T,
   ignore: string[] = [],
+  onSkipped?: (value: unknown, file: string) => void,
 ): Promise<T[]> {
   const found = new Set<T>();
 
@@ -202,9 +211,16 @@ export async function discoverClasses<T extends ClassLike>(
     }
 
     for (const value of Object.values(module)) {
-      if (typeof value !== "function" || value === base) continue;
-      if (!Object.prototype.isPrototypeOf.call(base, value)) continue;
-      found.add(value as unknown as T);
+      if (
+        typeof value === "function" &&
+        value !== base &&
+        Object.prototype.isPrototypeOf.call(base, value)
+      ) {
+        found.add(value as unknown as T);
+        continue;
+      }
+
+      onSkipped?.(value, path);
     }
   }
 

--- a/packages/gemi/tsconfig.json
+++ b/packages/gemi/tsconfig.json
@@ -36,6 +36,7 @@
     "facades",
     "email",
     "services",
+    "console",
     "broadcasting",
     "client",
     "i18n",


### PR DESCRIPTION
A one-off piece of application code — a seeder, a backfill, a tenant repair, a report — had nowhere to live. The two places that already boot the app outside a request (`bin/loadApp.ts`, `bin/check-models.ts`) each do it differently and each skip a phase, so the alternatives were a throwaway script that hand-rolls the boot or an HTTP route that shouldn't exist. `orm/context.test.ts` already carries a comment about the hypothetical `gemi db:seed` nobody could write.

Commands are `defineCommand(...)` chains under `app/commands`, run with `gemi run <name>`.

```ts
export default defineCommand("backfill-avatars")
  .describe("Regenerate avatar URLs for users created before the CDN move")
  .arg("since", { required: true, description: "ISO date to backfill from" })
  .option("dryRun", { type: "boolean" })
  .option("limit", { type: "number", default: 500 })
  .handle(async ({ args, options, line }) => {
    //  args.since   -> string   (required, so not `| undefined`)
    // options.limit -> number   (has a default, so not `| undefined`)
    // options.dryRun-> boolean
  });
```

```
$ gemi run                                  # list every command
$ gemi run backfill-avatars 2024-01-01 --dry-run
$ gemi run backfill-avatars --help          # usage, from the same spec the parser reads
```

## Why a chain and not a class

Every other extension point in gemi is a class — `Job`, `CronJob`, `Controller`, `Middleware` — and a class cannot type its own handler. TypeScript does not contextually type an overriding method's parameters from the base-class method it overrides, so `static args` beside `run(ctx)` leaves `ctx` an implicit `any`. So does a configured base class returned by a `Command.define()`, one indirection further away. The author's only way out is restating the type by hand in every command, which is the ceremony the schema was supposed to remove and which nothing enforces.

A **function expression passed as an argument is contextually typed**. That is the whole mechanism, and it is why `.handle(fn)` is the shape rather than sugar.

`.handle()` returns a `Command` subclass, so nothing downstream knows the difference: discovery finds it by prototype chain, and the registry, parser and `--help` read the same statics a hand-written class would carry.

`console/builder.test-d.ts` is the only place that inference is observable — a regression in it would leave every other test in the repo green. It includes an explicit `not.toBeAny()`, because `expectTypeOf<any>().toEqualTypeOf<string>()` passes and without it the suite couldn't tell a working builder from one that had stopped inferring. Verified by breaking the inference on purpose and watching the file go red.

## Why `gemi run` spawns a process

`dist/bin/gemi.js` bundles its own copy of gemi while the app's Kernel resolves `gemi/*` to source — the constraint `app/App.ts:23-32` documents. Discovery decides membership by walking the prototype chain, so a `Command` base imported into the CLI bundle is a *different class object* from the one `app/commands/*.ts` extends: every command would be invisible, silently. `--preload gemi/bun/preload` and the app's `app/preload.ts` can only be installed at process start besides.

So the CLI resolves `gemi/console/run` out of the app's own `node_modules` and spawns it, the way `dev` and `start` already do. That entrypoint goes in the **existing** `Bun.build` call rather than one of its own: `splitting: true` is what keeps `Command` in a chunk shared with `dist/services/index.js`, so the published runner and the `gemi/services` an app imports hold the same class object. Confirmed against a real build — one copy of the class in the whole `dist/`, reached by both entrypoints.

## Notable choices

- **Boots both phases**, so a command sees exactly what a request handler sees. But listing, an unknown name and `--help` all resolve *before* `waitForBoot()` — the three things an operator does most often shouldn't open a database connection to answer a question about a directory.
- **`GEMI_NO_SCHEDULE=1`** stops `ScheduleServiceProvider` starting the schedule while still discovering it, so a four-minute backfill can't fire the app's whole cron schedule in a process nobody is watching. `app(Scheduler).jobs` still answers honestly. An env var rather than a config field because it's a property of *this process* — it's also how a deploy runs one cron dyno beside several web ones.
- **`app/commands` is walked by `gemi run` and not at boot**, unlike `app/jobs` and `app/cron`. A registry no request consults shouldn't cost every dev server and every production start an import of every file under it.
- **Commander needs `enablePositionalOptions()` + `passThroughOptions()`.** Not `allowUnknownOption()`, which was the first thing tried: it collects unknown options into a separate list and concatenates them *after* the operands, so `gemi run job --flag value` arrives as `job value --flag`. Order silently mangled is the worst failure available to an argument forwarder.
- **An unfinished chain is refused by name.** A `defineCommand(...)` that never calls `.handle()` is a plain object, so discovery would drop it alongside every helper a command file exports and the command would vanish from the listing with nothing raised — the silence #322 and #323 exist to remove, reintroduced by a new authoring surface.
- **Two commands with one name is a hard error naming both**, where `QueueManager.useJobs` and `Scheduler.start` keep the first and warn. Those have a server to keep booting; here there's no boot to protect and a person is waiting, and running the wrong one of two `db:seed`s is worse than running neither.
- **The config slice is `command`, not `console`** — `app/config/console.ts` arrives in a Kernel as `import console from "../config/console"`, shadowing the global `console` for that module.
- **Three output helpers and no more.** `line` (stdout), `error` (stderr), `fail`. The load-bearing thing is stream discipline, not colour: a diagnostic on stdout is what breaks `TOTAL=$(gemi run count-users)`, and it stays invisible until someone pipes the command somewhere.

## Two things found on the way

- **`console/` was missing from `tsconfig.json`'s `include`**, which meant `tsc --noEmit` never looked at any of the new code and the type-test file was decorative. Adding it surfaced two real errors, including that this package compiles with `strictNullChecks: false` — under which `if (!parsed.ok)` does **not** narrow a discriminated union while `=== false` does.
- **`runConsole` was resolving the Kernel against `rootDir` but letting the commands directory fall back to `process.cwd()`.** Identical in the spawned process, which is exactly how a parameter quietly stops being one; the fixture tests caught it.

## Testing

- `console/parse.test.ts` (25) — the parser, pure. Aimed at the cases where a wrong answer still looks like an answer: `--limit abc` arriving as `NaN`, a default winning over a supplied value, a flag after `--` read as a flag.
- `console/builder.test-d.ts` (12) — the inference, plus `not.toBeAny()`.
- `console/builder.test.ts` (16) and `CommandRegistry.test.ts` (10) — declaration-time refusals and the duplicate-name message.
- `console/runner.test.ts` (26) — real fixture projects on disk: the config slice's declared-wins rule, exit codes, stream discipline, that cheap paths don't boot, and that cron doesn't start.
- `services/discovery.test.ts` — `discoverCommands` beside the job/cron cases, and the `GEMI_NO_SCHEDULE` behaviour both ways.
- Full suite green (3292), `tsc` clean, `oxlint` 0 errors and 0 warnings in `console/`, full `bun run build` + `build:publish` ("20 exports, all resolved").
- End-to-end by hand in `templates/saas-starter`: listing, `--help`, real ORM read, exit codes including `fail(msg, 3)`, and a DB-touching command exiting in 0.6s rather than hanging.

## One thing to decide

The template ships **no** example command, per an explicit call during planning. Worth knowing what that costs: the cross-copy class-identity failure this whole design is shaped around produces an empty command list, "not found" for everything, and **a fully green unit-test suite** — tmpdir fixtures can't catch it because they import `defineCommand` by absolute path, which makes the identity hold by construction. Only a real project with a real `node_modules` can, and `templates/saas-starter` is the only one here.

The CI step added therefore asserts the empty-directory listing plus a non-zero exit for an unknown name — enough to prove the spawn, both preloads, the Kernel and the config slice lined up, but not the identity. Dropping a command into `templates/saas-starter/app/commands/` would turn it into a real end-to-end assertion; happy to add one if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeYiZuQjPgdSNAqKG3L6CK
