### PR TITLE
Add `gemi/testing`: a `<Page>` that mounts a view with its inputs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Data Fetching](./data-fetching.md)** — `useQuery`, the mutation hooks, the `Query` prefetch facade, and the type-safe `gemi.d.ts` layer.
 - **[Forms](./forms.md)** — the `Form` component, surfacing validation errors, form status hooks.
 - **[Navigation](./navigation.md)** — `Link`, `useNavigate`, `useParams`, `useSearchParams`, and the `Redirect` component vs. facade.
+- **[Testing Views](./testing.md)** — `<Page>` from `gemi/testing`: mounting a view with route params, dictionaries, prefetched query data and a signed-in user.
 
 ### Data
 - **[ORM](./orm.md)** — the Prisma-typed, gemi-executed query layer: models, relations, ambient transactions, named connections, policies, soft deletes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -105,6 +105,7 @@
         <a class="card" href="data-fetching.md"><span class="t">Data Fetching</span><span class="d">useQuery, mutations, Query prefetch, gemi.d.ts types.</span></a>
         <a class="card" href="forms.md"><span class="t">Forms</span><span class="d">The Form component, validation errors, status hooks.</span></a>
         <a class="card" href="navigation.md"><span class="t">Navigation</span><span class="d">Link, useNavigate, params, search, Redirect.</span></a>
+        <a class="card" href="testing.md"><span class="t">Testing Views</span><span class="d">Page from gemi/testing: params, dictionaries, query data, user.</span></a>
       </div>
 
       <h2>Data</h2>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -45,6 +45,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Data Fetching](./data-fetching.md)** — `useQuery`, the mutation hooks, the `Query` prefetch facade, and the type-safe `gemi.d.ts` layer.
 - **[Forms](./forms.md)** — the `Form` component, surfacing validation errors, form status hooks.
 - **[Navigation](./navigation.md)** — `Link`, `useNavigate`, `useParams`, `useSearchParams`, and the `Redirect` component vs. facade.
+- **[Testing Views](./testing.md)** — `<Page>` from `gemi/testing`: mounting a view with route params, dictionaries, prefetched query data and a signed-in user.
 
 ### Data
 - **[ORM](./orm.md)** — the Prisma-typed, gemi-executed query layer: models, relations, ambient transactions, named connections, policies, soft deletes.
@@ -8988,3 +8989,140 @@ See [Email](./email.md) for building and sending emails.
 - [Configuration](./configuration.md) — the `translation` config slice.
 - [Email](./email.md) — localized emails.
 
+
+---
+
+## Testing Views
+
+A view is a plain React component, so any renderer can mount one — but what it renders comes from inputs the framework normally supplies: route params, the current locale and its dictionaries, data `Query.prefetch` put on the page, the signed-in user. Without those a component test can only assert the empty state.
+
+`gemi/testing` exports one component, `<Page>`, that supplies them.
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { Page } from "gemi/testing";
+
+import OrgChat from "@/app/views/OrgChat";
+import dictionaries from "@/app/i18n";
+
+test("renders the organisation's messages", () => {
+  render(
+    <Page
+      pathname="/app/:orgId/chat"
+      params={{ orgId: "abc" }}
+      queryData={{ "/organizations/:orgId/messages": [{ id: 1, body: "hi" }] }}
+      dictionaries={[dictionaries.Chat]}
+      user={{ id: 1, name: "Ada" }}
+    >
+      <OrgChat />
+    </Page>,
+  );
+
+  expect(screen.getByText("hi")).toBeDefined();
+});
+```
+
+`<Page>` is a plain component and imports no test runner, so it works with `@testing-library/react`, `renderToString`, or anything else that renders React.
+
+## Props
+
+| Prop | Default | What it seeds |
+| --- | --- | --- |
+| `pathname` | `"/"` | The URL the component is mounted at — `useLocation()`, `useRoute()`, and a `Link`'s `data-active`. A template (`/app/:orgId/chat`) is resolved against `params`. |
+| `params` | `{}` | `useParams()`, and the params `useQuery` / `Form` / `Link` apply when a call site omits its own. |
+| `searchParams` | `""` | `useSearchParams()`. Accepts `"?tab=recent"`, `"tab=recent"` or `{ tab: "recent" }`. |
+| `hash` | `""` | `useLocation().hash`. |
+| `locale` | `"en-US"` | `useLocale()`, and which locale `useTranslator` reads translations from. |
+| `defaultLocale` | same as `locale` | The locale that gets no URL segment. Set it to render a page being viewed in a non-default locale — links then carry the `/tr-TR` prefix. |
+| `supportedLocales` | the two above | `Lang`-style locale lists on the client. |
+| `dictionaries` | `[]` | `useTranslator("Name")`. Pass the app's real dictionaries. |
+| `queryData` | `{}` | The query cache — see below. |
+| `queryConfig` | — | App-wide `useQuery` defaults, as `createRoot` threads them. |
+| `user` | `null` | `useUser()`. |
+| `breadcrumbs` | `[]` | `useBreadcrumbs()`, in order. |
+| `fallback` | `null` | The `Suspense` fallback wrapped around the children, standing in for the view's own `Loading` export. |
+| `errorFallback` | — | Rendered in place of the children when one throws, standing in for the view's `Error` export. |
+| `onNavigate` | — | Called with `(href, "push" \| "replace")` when something navigates. |
+
+## Seeding queries
+
+`queryData` is keyed by the path passed to `useQuery` — **without** the `/api` prefix, which the client adds only when it fetches:
+
+```tsx
+<Page queryData={{ "/todos": [{ id: 1 }, { id: 2 }] }}>
+```
+
+A key may carry `:params`, resolved against the page's `params`, and a query string, which seeds one search variant:
+
+```tsx
+<Page
+  pathname="/orgs/:orgId/lists"
+  params={{ orgId: "abc" }}
+  queryData={{
+    // Read by useQuery("/orgs/:orgId/lists") — the route's params apply.
+    "/orgs/:orgId/lists": [{ id: 1 }],
+    // Read by useQuery("/lists", { search: { page: "2" } }).
+    "/lists?page=2": [{ id: 9 }],
+  }}
+>
+```
+
+A seeded query renders its data on the first pass and issues no request. A query with no seed behaves exactly as it does in the browser: under the default `suspense: true` it suspends into `fallback` and fetches, so intercepting `fetch` (MSW, `vi.stubGlobal`) covers the loading-to-loaded path.
+
+> **Seeded at mount only.** A component that calls `mutate()` or `refetch()` owns the cache from then on, and re-rendering `<Page>` with a different `queryData` deliberately does not overwrite it. To assert a second state, render a second `<Page>`.
+
+`useUser()` resolves from `user` — `null` by default, an anonymous visitor — and never reaches `/auth/me`, so a layout that greets the current user does not have to be mocked out of a test that is about something else.
+
+## Translations
+
+Pass the dictionaries the components under test translate against, exactly as `app/config/translation.ts` prefetches them per route:
+
+```tsx
+import dictionaries from "@/app/i18n";
+
+render(
+  <Page dictionaries={[dictionaries.About]} locale="tr-TR" defaultLocale="en-US">
+    <About />
+  </Page>,
+);
+```
+
+`useTranslator("About")` then resolves keys against `tr-TR`, interpolation and `t.jsx` included. Without a matching dictionary the hook returns the key itself and logs `Unresolved translation` — which is the signal that the dictionary name in the test does not match the one the component asks for.
+
+## Navigation
+
+`<Page>` renders one route. It has no view tree and no route manifest behind it, so a navigation is *reported* rather than performed:
+
+```tsx
+const onNavigate = vi.fn();
+
+render(
+  <Page pathname="/app/abc/chat" onNavigate={onNavigate}>
+    <Nav />
+  </Page>,
+);
+
+screen.getByText("Settings").click();
+expect(onNavigate).toHaveBeenCalledWith("/app/abc/settings", "push");
+```
+
+`useLocation()` keeps reporting the pathname the page was given. To assert what the destination renders, render it in its own `<Page>`.
+
+## Runner setup
+
+The components need a DOM. Under vitest that is a per-file pragma (or `environment: "jsdom"` in `vitest.config.ts`):
+
+```tsx
+/** @vitest-environment jsdom */
+```
+
+Under `bun test`, preload `happy-dom` — no gemi-specific configuration is required either way. React 19 lifecycles, `@testing-library/user-event` and MSW's fetch interception all work against `gemi/client` components as they do against any other React tree.
+
+> **Gotcha:** a view test runs in a browser-shaped environment, so anything it imports has to be loadable there. Importing a controller or a model from a test file pulls the server runtime in behind it (`import { RedisClient } from "bun"`, the database drivers) and the file fails to collect before it renders anything. Import views, components and dictionaries; keep server modules to server tests.
+
+## Related
+
+- [Views & Layouts](./views-and-layouts.md) — what a view receives from its route.
+- [Data Fetching](./data-fetching.md) — `useQuery`, prefetching, and the variant keys `queryData` mirrors.
+- [Internationalization](./i18n.md) — dictionaries and `useTranslator`.
+- [Navigation](./navigation.md) — `Link`, `useNavigate`, `useParams`.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9022,7 +9022,7 @@ test("renders the organisation's messages", () => {
 });
 ```
 
-`<Page>` is a plain component and imports no test runner, so it works with `@testing-library/react`, `renderToString`, or anything else that renders React.
+`<Page>` is a plain component and imports no test runner, so it works with `@testing-library/react`, `react-test-renderer`, or `renderToString` (with [one caveat](#server-rendering)).
 
 ## Props
 
@@ -9034,15 +9034,16 @@ test("renders the organisation's messages", () => {
 | `hash` | `""` | `useLocation().hash`. |
 | `locale` | `"en-US"` | `useLocale()`, and which locale `useTranslator` reads translations from. |
 | `defaultLocale` | same as `locale` | The locale that gets no URL segment. Set it to render a page being viewed in a non-default locale — links then carry the `/tr-TR` prefix. |
-| `supportedLocales` | the two above | `Lang`-style locale lists on the client. |
+| `supportedLocales` | the two above | The app's locale list, verbatim — a switcher maps over it, so the order is yours. `defaultLocale` and `locale` are appended if absent. |
 | `dictionaries` | `[]` | `useTranslator("Name")`. Pass the app's real dictionaries, or literals of the same `{ name, dictionary }` shape. |
 | `translations` | `{}` | The same thing already resolved for `locale` — `{ Chat: { greeting: "Hello" } }`. Merged over `dictionaries`. |
 | `queryData` | `{}` | The query cache — see below. |
 | `queryConfig` | — | App-wide `useQuery` defaults, as `createRoot` threads them. |
 | `user` | `null` | `useUser()`. |
 | `breadcrumbs` | `[]` | `useBreadcrumbs()`, in order. |
+| `theme` | stored, else `"light"` | `useTheme()`. A test has no browser session to have chosen one in; `setTheme` still works from whatever this seeds. |
 | `fallback` | `null` | The `Suspense` fallback wrapped around the children, standing in for the view's own `Loading` export. |
-| `errorFallback` | — | Rendered in place of the children when one throws, standing in for the view's `Error` export. |
+| `errorFallback` | — | Rendered in place of the children when one throws, standing in for the view's `Error` export. Its `resetErrorBoundary` clears query errors, so the retry path works as it does in the app. |
 | `onNavigate` | — | Called with `(href, "push" \| "replace")` when something navigates. |
 
 ## Seeding queries
@@ -9053,7 +9054,7 @@ test("renders the organisation's messages", () => {
 <Page queryData={{ "/todos": [{ id: 1 }, { id: 2 }] }}>
 ```
 
-A key may carry `:params`, resolved against the page's `params`, and a query string, which seeds one search variant:
+A key may carry a query string, which seeds one search variant, and `:params`, which resolve against the page's:
 
 ```tsx
 <Page
@@ -9067,6 +9068,14 @@ A key may carry `:params`, resolved against the page's `params`, and a query str
   }}
 >
 ```
+
+The cache is keyed by the **resolved** path, so a `:param` the page does not carry fails the render with an error naming the key. That is deliberate: a query's params often come from the call site rather than the route —
+
+```tsx
+const { data } = useQuery("/orgs/:orgId/lists", { params: { orgId } }); // orgId is state
+```
+
+— and the seed for that is the resolved path, `"/orgs/abc/lists"`, not the template.
 
 A seeded query renders its data on the first pass and issues no request. A query with no seed behaves exactly as it does in the browser: under the default `suspense: true` it suspends into `fallback` and fetches, so intercepting `fetch` (MSW, `vi.stubGlobal`) covers the loading-to-loaded path.
 
@@ -9124,6 +9133,16 @@ expect(onNavigate).toHaveBeenCalledWith("/app/abc/settings", "push");
 ```
 
 `useLocation()` keeps reporting the pathname the page was given. To assert what the destination renders, render it in its own `<Page>`.
+
+A navigation issued from a mount effect — `<Redirect>`, or an auth guard that pushes on render — is reported too.
+
+## Server rendering
+
+`renderToString(<Page …>…</Page>)` works, and a **seeded** query renders its data there exactly as it does in the browser. An **unseeded** one does not suspend: it renders the server's no-data branch and logs the framework's "rendered on the server without data … add `Query.prefetch(…)`" warning.
+
+That is the real SSR contract rather than a gap in the harness. Suspending on the server is the streaming renderer's job: `createRoot` threads the request's query store through `ServerQueryContext`, and that store is what runs the route handler and produces the data to wait on. A harness has no request and no handler, so there is nothing to suspend on — the same thing happens to a real route whose view handler declares no `Query.prefetch`.
+
+So: assert seeded output under `renderToString`, and use a DOM renderer for the suspend-then-resolve path.
 
 ## Runner setup
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9035,7 +9035,8 @@ test("renders the organisation's messages", () => {
 | `locale` | `"en-US"` | `useLocale()`, and which locale `useTranslator` reads translations from. |
 | `defaultLocale` | same as `locale` | The locale that gets no URL segment. Set it to render a page being viewed in a non-default locale — links then carry the `/tr-TR` prefix. |
 | `supportedLocales` | the two above | `Lang`-style locale lists on the client. |
-| `dictionaries` | `[]` | `useTranslator("Name")`. Pass the app's real dictionaries. |
+| `dictionaries` | `[]` | `useTranslator("Name")`. Pass the app's real dictionaries, or literals of the same `{ name, dictionary }` shape. |
+| `translations` | `{}` | The same thing already resolved for `locale` — `{ Chat: { greeting: "Hello" } }`. Merged over `dictionaries`. |
 | `queryData` | `{}` | The query cache — see below. |
 | `queryConfig` | — | App-wide `useQuery` defaults, as `createRoot` threads them. |
 | `user` | `null` | `useUser()`. |
@@ -9089,6 +9090,22 @@ render(
 
 `useTranslator("About")` then resolves keys against `tr-TR`, interpolation and `t.jsx` included. Without a matching dictionary the hook returns the key itself and logs `Unresolved translation` — which is the signal that the dictionary name in the test does not match the one the component asks for.
 
+### Dictionaries are server-side; `translations` is not
+
+A `Dictionary` is a server artifact. The browser never sees one: the server resolves the route's dictionaries for the active locale and serializes them onto the page, and `useTranslator` reads *that*. `<Page>` mirrors it — it takes the `name` and `dictionary` data off whatever you pass and builds the same payload. It never calls `Dictionary`'s server-only methods (`render` and `reference` throw once `window` is defined, as they do in a real browser), and `gemi/testing` does not import `gemi/i18n` at all.
+
+What is server-side is the *import*. `app/i18n/index.ts` imports `gemi/i18n`, so a test file that reads the app's dictionaries pulls the container and `node:async_hooks` into its module graph. Nothing there executes, so it is fine under any runner with Node builtins available — vitest, `bun test` — and not under one that renders in a real browser (vitest browser mode, Playwright component tests).
+
+For those, seed the client's own shape directly. It imports nothing:
+
+```tsx
+<Page translations={{ About: { title: "About {{version:[hi]}}" } }}>
+  <About />
+</Page>
+```
+
+`translations` is `{ dictionary name: { key: string } }` for the current locale — exactly what the server puts on the page. It is merged over `dictionaries`, so the two compose: seed from the app's real dictionary and override the one key a test is about.
+
 ## Navigation
 
 `<Page>` renders one route. It has no view tree and no route manifest behind it, so a navigation is *reported* rather than performed:
@@ -9118,7 +9135,7 @@ The components need a DOM. Under vitest that is a per-file pragma (or `environme
 
 Under `bun test`, preload `happy-dom` — no gemi-specific configuration is required either way. React 19 lifecycles, `@testing-library/user-event` and MSW's fetch interception all work against `gemi/client` components as they do against any other React tree.
 
-> **Gotcha:** a view test runs in a browser-shaped environment, so anything it imports has to be loadable there. Importing a controller or a model from a test file pulls the server runtime in behind it (`import { RedisClient } from "bun"`, the database drivers) and the file fails to collect before it renders anything. Import views, components and dictionaries; keep server modules to server tests.
+> **Gotcha:** the environment is browser-*shaped*, but it is still Node or Bun — a test file can import a server module and it will load. What it must not do is *run* one: a controller reaches the container, a model reaches the database, and neither has been booted. Import views, components and dictionaries (see [above](#dictionaries-are-server-side-translations-is-not) for what a dictionary import costs); leave the rest to server tests.
 
 ## Related
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -25,6 +25,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Data Fetching](https://nstfkc.github.io/gemi/data-fetching.md): the useQuery hook, mutation hooks, the Query prefetch facade, and the generated gemi.d.ts type layer.
 - [Forms](https://nstfkc.github.io/gemi/forms.md): the Form component, surfacing validation errors, form-status hooks.
 - [Navigation](https://nstfkc.github.io/gemi/navigation.md): Link, useNavigate, useParams, useSearchParams, and the Redirect component vs facade.
+- [Testing Views](https://nstfkc.github.io/gemi/testing.md): the Page component from gemi/testing — mounting a view with seeded route params, dictionaries, prefetched useQuery data and a signed-in user.
 
 ## Data
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,134 @@
+# Testing Views
+
+A view is a plain React component, so any renderer can mount one — but what it renders comes from inputs the framework normally supplies: route params, the current locale and its dictionaries, data `Query.prefetch` put on the page, the signed-in user. Without those a component test can only assert the empty state.
+
+`gemi/testing` exports one component, `<Page>`, that supplies them.
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { Page } from "gemi/testing";
+
+import OrgChat from "@/app/views/OrgChat";
+import dictionaries from "@/app/i18n";
+
+test("renders the organisation's messages", () => {
+  render(
+    <Page
+      pathname="/app/:orgId/chat"
+      params={{ orgId: "abc" }}
+      queryData={{ "/organizations/:orgId/messages": [{ id: 1, body: "hi" }] }}
+      dictionaries={[dictionaries.Chat]}
+      user={{ id: 1, name: "Ada" }}
+    >
+      <OrgChat />
+    </Page>,
+  );
+
+  expect(screen.getByText("hi")).toBeDefined();
+});
+```
+
+`<Page>` is a plain component and imports no test runner, so it works with `@testing-library/react`, `renderToString`, or anything else that renders React.
+
+## Props
+
+| Prop | Default | What it seeds |
+| --- | --- | --- |
+| `pathname` | `"/"` | The URL the component is mounted at — `useLocation()`, `useRoute()`, and a `Link`'s `data-active`. A template (`/app/:orgId/chat`) is resolved against `params`. |
+| `params` | `{}` | `useParams()`, and the params `useQuery` / `Form` / `Link` apply when a call site omits its own. |
+| `searchParams` | `""` | `useSearchParams()`. Accepts `"?tab=recent"`, `"tab=recent"` or `{ tab: "recent" }`. |
+| `hash` | `""` | `useLocation().hash`. |
+| `locale` | `"en-US"` | `useLocale()`, and which locale `useTranslator` reads translations from. |
+| `defaultLocale` | same as `locale` | The locale that gets no URL segment. Set it to render a page being viewed in a non-default locale — links then carry the `/tr-TR` prefix. |
+| `supportedLocales` | the two above | `Lang`-style locale lists on the client. |
+| `dictionaries` | `[]` | `useTranslator("Name")`. Pass the app's real dictionaries. |
+| `queryData` | `{}` | The query cache — see below. |
+| `queryConfig` | — | App-wide `useQuery` defaults, as `createRoot` threads them. |
+| `user` | `null` | `useUser()`. |
+| `breadcrumbs` | `[]` | `useBreadcrumbs()`, in order. |
+| `fallback` | `null` | The `Suspense` fallback wrapped around the children, standing in for the view's own `Loading` export. |
+| `errorFallback` | — | Rendered in place of the children when one throws, standing in for the view's `Error` export. |
+| `onNavigate` | — | Called with `(href, "push" \| "replace")` when something navigates. |
+
+## Seeding queries
+
+`queryData` is keyed by the path passed to `useQuery` — **without** the `/api` prefix, which the client adds only when it fetches:
+
+```tsx
+<Page queryData={{ "/todos": [{ id: 1 }, { id: 2 }] }}>
+```
+
+A key may carry `:params`, resolved against the page's `params`, and a query string, which seeds one search variant:
+
+```tsx
+<Page
+  pathname="/orgs/:orgId/lists"
+  params={{ orgId: "abc" }}
+  queryData={{
+    // Read by useQuery("/orgs/:orgId/lists") — the route's params apply.
+    "/orgs/:orgId/lists": [{ id: 1 }],
+    // Read by useQuery("/lists", { search: { page: "2" } }).
+    "/lists?page=2": [{ id: 9 }],
+  }}
+>
+```
+
+A seeded query renders its data on the first pass and issues no request. A query with no seed behaves exactly as it does in the browser: under the default `suspense: true` it suspends into `fallback` and fetches, so intercepting `fetch` (MSW, `vi.stubGlobal`) covers the loading-to-loaded path.
+
+> **Seeded at mount only.** A component that calls `mutate()` or `refetch()` owns the cache from then on, and re-rendering `<Page>` with a different `queryData` deliberately does not overwrite it. To assert a second state, render a second `<Page>`.
+
+`useUser()` resolves from `user` — `null` by default, an anonymous visitor — and never reaches `/auth/me`, so a layout that greets the current user does not have to be mocked out of a test that is about something else.
+
+## Translations
+
+Pass the dictionaries the components under test translate against, exactly as `app/config/translation.ts` prefetches them per route:
+
+```tsx
+import dictionaries from "@/app/i18n";
+
+render(
+  <Page dictionaries={[dictionaries.About]} locale="tr-TR" defaultLocale="en-US">
+    <About />
+  </Page>,
+);
+```
+
+`useTranslator("About")` then resolves keys against `tr-TR`, interpolation and `t.jsx` included. Without a matching dictionary the hook returns the key itself and logs `Unresolved translation` — which is the signal that the dictionary name in the test does not match the one the component asks for.
+
+## Navigation
+
+`<Page>` renders one route. It has no view tree and no route manifest behind it, so a navigation is *reported* rather than performed:
+
+```tsx
+const onNavigate = vi.fn();
+
+render(
+  <Page pathname="/app/abc/chat" onNavigate={onNavigate}>
+    <Nav />
+  </Page>,
+);
+
+screen.getByText("Settings").click();
+expect(onNavigate).toHaveBeenCalledWith("/app/abc/settings", "push");
+```
+
+`useLocation()` keeps reporting the pathname the page was given. To assert what the destination renders, render it in its own `<Page>`.
+
+## Runner setup
+
+The components need a DOM. Under vitest that is a per-file pragma (or `environment: "jsdom"` in `vitest.config.ts`):
+
+```tsx
+/** @vitest-environment jsdom */
+```
+
+Under `bun test`, preload `happy-dom` — no gemi-specific configuration is required either way. React 19 lifecycles, `@testing-library/user-event` and MSW's fetch interception all work against `gemi/client` components as they do against any other React tree.
+
+> **Gotcha:** a view test runs in a browser-shaped environment, so anything it imports has to be loadable there. Importing a controller or a model from a test file pulls the server runtime in behind it (`import { RedisClient } from "bun"`, the database drivers) and the file fails to collect before it renders anything. Import views, components and dictionaries; keep server modules to server tests.
+
+## Related
+
+- [Views & Layouts](./views-and-layouts.md) — what a view receives from its route.
+- [Data Fetching](./data-fetching.md) — `useQuery`, prefetching, and the variant keys `queryData` mirrors.
+- [Internationalization](./i18n.md) — dictionaries and `useTranslator`.
+- [Navigation](./navigation.md) — `Link`, `useNavigate`, `useParams`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,7 +28,7 @@ test("renders the organisation's messages", () => {
 });
 ```
 
-`<Page>` is a plain component and imports no test runner, so it works with `@testing-library/react`, `renderToString`, or anything else that renders React.
+`<Page>` is a plain component and imports no test runner, so it works with `@testing-library/react`, `react-test-renderer`, or `renderToString` (with [one caveat](#server-rendering)).
 
 ## Props
 
@@ -40,15 +40,16 @@ test("renders the organisation's messages", () => {
 | `hash` | `""` | `useLocation().hash`. |
 | `locale` | `"en-US"` | `useLocale()`, and which locale `useTranslator` reads translations from. |
 | `defaultLocale` | same as `locale` | The locale that gets no URL segment. Set it to render a page being viewed in a non-default locale — links then carry the `/tr-TR` prefix. |
-| `supportedLocales` | the two above | `Lang`-style locale lists on the client. |
+| `supportedLocales` | the two above | The app's locale list, verbatim — a switcher maps over it, so the order is yours. `defaultLocale` and `locale` are appended if absent. |
 | `dictionaries` | `[]` | `useTranslator("Name")`. Pass the app's real dictionaries, or literals of the same `{ name, dictionary }` shape. |
 | `translations` | `{}` | The same thing already resolved for `locale` — `{ Chat: { greeting: "Hello" } }`. Merged over `dictionaries`. |
 | `queryData` | `{}` | The query cache — see below. |
 | `queryConfig` | — | App-wide `useQuery` defaults, as `createRoot` threads them. |
 | `user` | `null` | `useUser()`. |
 | `breadcrumbs` | `[]` | `useBreadcrumbs()`, in order. |
+| `theme` | stored, else `"light"` | `useTheme()`. A test has no browser session to have chosen one in; `setTheme` still works from whatever this seeds. |
 | `fallback` | `null` | The `Suspense` fallback wrapped around the children, standing in for the view's own `Loading` export. |
-| `errorFallback` | — | Rendered in place of the children when one throws, standing in for the view's `Error` export. |
+| `errorFallback` | — | Rendered in place of the children when one throws, standing in for the view's `Error` export. Its `resetErrorBoundary` clears query errors, so the retry path works as it does in the app. |
 | `onNavigate` | — | Called with `(href, "push" \| "replace")` when something navigates. |
 
 ## Seeding queries
@@ -59,7 +60,7 @@ test("renders the organisation's messages", () => {
 <Page queryData={{ "/todos": [{ id: 1 }, { id: 2 }] }}>
 ```
 
-A key may carry `:params`, resolved against the page's `params`, and a query string, which seeds one search variant:
+A key may carry a query string, which seeds one search variant, and `:params`, which resolve against the page's:
 
 ```tsx
 <Page
@@ -73,6 +74,14 @@ A key may carry `:params`, resolved against the page's `params`, and a query str
   }}
 >
 ```
+
+The cache is keyed by the **resolved** path, so a `:param` the page does not carry fails the render with an error naming the key. That is deliberate: a query's params often come from the call site rather than the route —
+
+```tsx
+const { data } = useQuery("/orgs/:orgId/lists", { params: { orgId } }); // orgId is state
+```
+
+— and the seed for that is the resolved path, `"/orgs/abc/lists"`, not the template.
 
 A seeded query renders its data on the first pass and issues no request. A query with no seed behaves exactly as it does in the browser: under the default `suspense: true` it suspends into `fallback` and fetches, so intercepting `fetch` (MSW, `vi.stubGlobal`) covers the loading-to-loaded path.
 
@@ -130,6 +139,16 @@ expect(onNavigate).toHaveBeenCalledWith("/app/abc/settings", "push");
 ```
 
 `useLocation()` keeps reporting the pathname the page was given. To assert what the destination renders, render it in its own `<Page>`.
+
+A navigation issued from a mount effect — `<Redirect>`, or an auth guard that pushes on render — is reported too.
+
+## Server rendering
+
+`renderToString(<Page …>…</Page>)` works, and a **seeded** query renders its data there exactly as it does in the browser. An **unseeded** one does not suspend: it renders the server's no-data branch and logs the framework's "rendered on the server without data … add `Query.prefetch(…)`" warning.
+
+That is the real SSR contract rather than a gap in the harness. Suspending on the server is the streaming renderer's job: `createRoot` threads the request's query store through `ServerQueryContext`, and that store is what runs the route handler and produces the data to wait on. A harness has no request and no handler, so there is nothing to suspend on — the same thing happens to a real route whose view handler declares no `Query.prefetch`.
+
+So: assert seeded output under `renderToString`, and use a DOM renderer for the suspend-then-resolve path.
 
 ## Runner setup
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,7 +41,8 @@ test("renders the organisation's messages", () => {
 | `locale` | `"en-US"` | `useLocale()`, and which locale `useTranslator` reads translations from. |
 | `defaultLocale` | same as `locale` | The locale that gets no URL segment. Set it to render a page being viewed in a non-default locale — links then carry the `/tr-TR` prefix. |
 | `supportedLocales` | the two above | `Lang`-style locale lists on the client. |
-| `dictionaries` | `[]` | `useTranslator("Name")`. Pass the app's real dictionaries. |
+| `dictionaries` | `[]` | `useTranslator("Name")`. Pass the app's real dictionaries, or literals of the same `{ name, dictionary }` shape. |
+| `translations` | `{}` | The same thing already resolved for `locale` — `{ Chat: { greeting: "Hello" } }`. Merged over `dictionaries`. |
 | `queryData` | `{}` | The query cache — see below. |
 | `queryConfig` | — | App-wide `useQuery` defaults, as `createRoot` threads them. |
 | `user` | `null` | `useUser()`. |
@@ -95,6 +96,22 @@ render(
 
 `useTranslator("About")` then resolves keys against `tr-TR`, interpolation and `t.jsx` included. Without a matching dictionary the hook returns the key itself and logs `Unresolved translation` — which is the signal that the dictionary name in the test does not match the one the component asks for.
 
+### Dictionaries are server-side; `translations` is not
+
+A `Dictionary` is a server artifact. The browser never sees one: the server resolves the route's dictionaries for the active locale and serializes them onto the page, and `useTranslator` reads *that*. `<Page>` mirrors it — it takes the `name` and `dictionary` data off whatever you pass and builds the same payload. It never calls `Dictionary`'s server-only methods (`render` and `reference` throw once `window` is defined, as they do in a real browser), and `gemi/testing` does not import `gemi/i18n` at all.
+
+What is server-side is the *import*. `app/i18n/index.ts` imports `gemi/i18n`, so a test file that reads the app's dictionaries pulls the container and `node:async_hooks` into its module graph. Nothing there executes, so it is fine under any runner with Node builtins available — vitest, `bun test` — and not under one that renders in a real browser (vitest browser mode, Playwright component tests).
+
+For those, seed the client's own shape directly. It imports nothing:
+
+```tsx
+<Page translations={{ About: { title: "About {{version:[hi]}}" } }}>
+  <About />
+</Page>
+```
+
+`translations` is `{ dictionary name: { key: string } }` for the current locale — exactly what the server puts on the page. It is merged over `dictionaries`, so the two compose: seed from the app's real dictionary and override the one key a test is about.
+
 ## Navigation
 
 `<Page>` renders one route. It has no view tree and no route manifest behind it, so a navigation is *reported* rather than performed:
@@ -124,7 +141,7 @@ The components need a DOM. Under vitest that is a per-file pragma (or `environme
 
 Under `bun test`, preload `happy-dom` — no gemi-specific configuration is required either way. React 19 lifecycles, `@testing-library/user-event` and MSW's fetch interception all work against `gemi/client` components as they do against any other React tree.
 
-> **Gotcha:** a view test runs in a browser-shaped environment, so anything it imports has to be loadable there. Importing a controller or a model from a test file pulls the server runtime in behind it (`import { RedisClient } from "bun"`, the database drivers) and the file fails to collect before it renders anything. Import views, components and dictionaries; keep server modules to server tests.
+> **Gotcha:** the environment is browser-*shaped*, but it is still Node or Bun — a test file can import a server module and it will load. What it must not do is *run* one: a controller reaches the container, a model reaches the database, and neither has been booted. Import views, components and dictionaries (see [above](#dictionaries-are-server-side-translations-is-not) for what a dictionary import costs); leave the rest to server tests.
 
 ## Related
 

--- a/packages/gemi/client/Mutation.tsx
+++ b/packages/gemi/client/Mutation.tsx
@@ -219,10 +219,14 @@ export function useFormData() {
 
   const { formDataSubject } = context;
 
+  // Unbound on purpose: `Subject` binds in its constructor, so these are
+  // stable across renders. The `.bind` calls that used to be here allocated a
+  // fresh `subscribe` every render, which made `useSyncExternalStore` drop and
+  // re-add this component's subscription on each pass.
   return useSyncExternalStore(
-    formDataSubject.current.subscribe.bind(formDataSubject.current),
-    formDataSubject.current.getValue.bind(formDataSubject.current),
-    formDataSubject.current.getValue.bind(formDataSubject.current),
+    formDataSubject.current.subscribe,
+    formDataSubject.current.getValue,
+    formDataSubject.current.getValue,
   );
 }
 

--- a/packages/gemi/client/ThemeProvider.tsx
+++ b/packages/gemi/client/ThemeProvider.tsx
@@ -21,8 +21,20 @@ function storeTheme(theme: string) {
   }
 }
 
-export const ThemeProvider = (props: { children: ReactNode }) => {
+export const ThemeProvider = (props: {
+  children: ReactNode;
+  /**
+   * The theme to start on, ahead of the stored one. The app leaves this unset —
+   * a visitor's choice lives in `localStorage` — but a test has no browser
+   * session to have made that choice in, so `gemi/testing`'s `<Page>` passes
+   * it through to render a component in a theme without writing to storage.
+   */
+  theme?: Theme;
+}) => {
   const [theme, setTheme] = useState(() => {
+    if (props.theme) {
+      return props.theme;
+    }
     if (typeof window === "undefined") {
       return "light"; // Default theme for server-side rendering
     }

--- a/packages/gemi/client/useIsNavigationPending.ts
+++ b/packages/gemi/client/useIsNavigationPending.ts
@@ -3,10 +3,15 @@ import { ClientRouterContext } from "./ClientRouterContext";
 
 export function useIsNavigationPending() {
   const { isNavigatingSubject } = useContext(ClientRouterContext);
+  // Bound, like `useFormData` binds its own subject's: `Subject`'s methods
+  // read `this`, and `useSyncExternalStore` calls whatever it is handed as a
+  // plain function — so the unbound references this used to pass threw
+  // `undefined is not an object (evaluating 'this.value')` on the first render
+  // of any component that called this hook.
   const isNavigating = useSyncExternalStore(
-    isNavigatingSubject.subscribe,
-    isNavigatingSubject.getValue,
-    isNavigatingSubject.getValue,
+    isNavigatingSubject.subscribe.bind(isNavigatingSubject),
+    isNavigatingSubject.getValue.bind(isNavigatingSubject),
+    isNavigatingSubject.getValue.bind(isNavigatingSubject),
   );
 
   return isNavigating;

--- a/packages/gemi/client/useIsNavigationPending.ts
+++ b/packages/gemi/client/useIsNavigationPending.ts
@@ -3,15 +3,16 @@ import { ClientRouterContext } from "./ClientRouterContext";
 
 export function useIsNavigationPending() {
   const { isNavigatingSubject } = useContext(ClientRouterContext);
-  // Bound, like `useFormData` binds its own subject's: `Subject`'s methods
-  // read `this`, and `useSyncExternalStore` calls whatever it is handed as a
-  // plain function — so the unbound references this used to pass threw
-  // `undefined is not an object (evaluating 'this.value')` on the first render
-  // of any component that called this hook.
+  // These read `this`, and `useSyncExternalStore` calls whatever it is handed
+  // as a plain function — which used to throw `undefined is not an object
+  // (evaluating 'this.value')` on the first render of any component calling
+  // this hook. `Subject` now binds in its constructor, so the references are
+  // both correct and stable across renders; binding here instead would hand
+  // uSES a new `subscribe` every render and churn the subscription.
   const isNavigating = useSyncExternalStore(
-    isNavigatingSubject.subscribe.bind(isNavigatingSubject),
-    isNavigatingSubject.getValue.bind(isNavigatingSubject),
-    isNavigatingSubject.getValue.bind(isNavigatingSubject),
+    isNavigatingSubject.subscribe,
+    isNavigatingSubject.getValue,
+    isNavigatingSubject.getValue,
   );
 
   return isNavigating;

--- a/packages/gemi/client/useMutate.ts
+++ b/packages/gemi/client/useMutate.ts
@@ -7,18 +7,15 @@ import type { RPC } from "./rpc";
 import { QueryManagerContext } from "./QueryManagerContext";
 import type { UrlParser } from "./types";
 import { applyParams } from "../utils/applyParams";
-import { omitNullishValues } from "../utils/omitNullishValues";
+import { toVariantKey } from "../utils/variantKey";
 type GetRPC = {
   [K in keyof RPC as K extends `GET:${infer P}` ? P : never]: RPC[K];
 };
 
-type Data<T extends keyof GetRPC> = GetRPC[T] extends ApiRouterHandler<
-  any,
-  infer Data,
-  any
->
-  ? UnwrapPromise<Data>
-  : never;
+type Data<T extends keyof GetRPC> =
+  GetRPC[T] extends ApiRouterHandler<any, infer Data, any>
+    ? UnwrapPromise<Data>
+    : never;
 
 export function useMutate() {
   const { getResource } = useContext(QueryManagerContext);
@@ -35,9 +32,7 @@ export function useMutate() {
     const { path, params = {}, search = {} } = options ?? {};
     const normalPath = applyParams(path, params);
     const resource = getResource(normalPath);
-    const searchParams = new URLSearchParams(omitNullishValues(search));
-    searchParams.sort();
-    const variantKey = searchParams.toString();
+    const variantKey = toVariantKey(search);
     return resource.mutate.call(resource, variantKey, (data: any) => {
       if (data === undefined || data === null) {
         console.warn("Mutate function called before the query.");

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -16,7 +16,7 @@ import { ServerQueryContext } from "./ServerQueryContext";
 import { DEFAULT_STALE_TIME } from "./QueryResource";
 import { applyParams } from "../utils/applyParams";
 import type { UrlParser } from "./types";
-import { omitNullishValues } from "../utils/omitNullishValues";
+import { toVariantKey } from "../utils/variantKey";
 import { useParams } from "./useParams";
 import { useRouteData } from "./useRouteData";
 import { isPlainObject } from "./isPlainObject";
@@ -213,9 +213,7 @@ export function useFrameworkQuery<T extends keyof GetRPC>(
   const { getResource } = useContext(QueryManagerContext);
   const serverQueries = useContext(ServerQueryContext);
   const currentPath = applyParams(url, params);
-  const searchParams = new URLSearchParams(omitNullishValues(search));
-  searchParams.sort();
-  const currentVariantKey = searchParams.toString();
+  const currentVariantKey = toVariantKey(search);
   // `keepPreviousData` under suspense: read through deferred keys so a
   // variant change never suspends the committed tree. The urgent render keeps
   // showing the previous variant's data; React re-renders in the background
@@ -354,7 +352,9 @@ export function useFrameworkQuery<T extends keyof GetRPC>(
     process.env.NODE_ENV !== "production"
   ) {
     const searchHint = variantKey
-      ? `, { search: ${JSON.stringify(Object.fromEntries(searchParams))} }`
+      ? `, { search: ${JSON.stringify(
+          Object.fromEntries(new URLSearchParams(variantKey)),
+        )} }`
       : "";
     console.warn(
       `[gemi] useQuery("${url}") rendered on the server without data. ` +

--- a/packages/gemi/docs-imports.test.ts
+++ b/packages/gemi/docs-imports.test.ts
@@ -163,6 +163,7 @@ describe("documented gemi imports resolve", () => {
       "gemi/server",
       "gemi/services",
       "gemi/support",
+      "gemi/testing",
     ]);
   });
 

--- a/packages/gemi/i18n/Dictionary.ts
+++ b/packages/gemi/i18n/Dictionary.ts
@@ -1,4 +1,12 @@
-import { Lang } from "../facades";
+// The module, not the `../facades` barrel. A dictionary is the one server-side
+// artifact a *component* test has to import — `<Page dictionaries={[…]}>` takes
+// the app's real `app/i18n/index.ts` — and the barrel drags the whole facade
+// set in behind it, including `Redis` and its `import { RedisClient } from
+// "bun"`. Under a browser-targeted runner (vitest/jsdom) that specifier does
+// not resolve, so importing the app's dictionaries failed to collect before it
+// rendered anything. `Lang` itself only needs the translator and the request
+// context.
+import { Lang } from "../facades/Lang";
 import { parseTranslation } from "../utils/parseTranslation";
 import type {
   ParseTranslationParams,

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -20,6 +20,7 @@
   "exports": {
     "./http": "./http/index.ts",
     "./client": "./client/index.ts",
+    "./testing": "./testing/index.ts",
     "./app": "./app/index.ts",
     "./facades": "./facades/index.ts",
     "./email": "./email/index.ts",

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -46,7 +46,7 @@
     "build": "NODE_ENV=production bun run build:core && bun run build:bin && bun run build:types && bun run build:client && bun run build:plugin && bun run build:client-types",
     "build:core": "bun ./scripts/build.ts",
     "build:bin": "bun build --outdir=./dist/bin --target=bun --external=vite --external=react-dom --external=react/jsx-runtime --external=bun --external=sharp --external=@azure/storage-blob --sourcemap ./bin/gemi.ts ./bin/orm-generator.ts && bun ./scripts/prepare-bin.ts",
-    "build:client": "vite build -c vite.client.config.mts",
+    "build:client": "rm -rf dist/client dist/testing dist/chunks && vite build -c vite.client.config.mts",
     "build:plugin": "vite build -c vite.plugin.config.mts",
     "build:types": "tsc",
     "build:client-types": "tsc -p tsconfig.browser.json",

--- a/packages/gemi/testing/Page.test.tsx
+++ b/packages/gemi/testing/Page.test.tsx
@@ -1,10 +1,21 @@
 /** @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { useContext } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import { I18nContext } from "../client/I18nContext";
 
 import { Page } from "./Page";
 import { Form } from "../client/Mutation";
 import { Link } from "../client/Link";
+import { Redirect } from "../client/Redirect";
+import { useTheme } from "../client/ThemeProvider";
 import { useBreadcrumbs } from "../client/useBreadcrumbs";
 import { useIsNavigationPending } from "../client/useIsNavigationPending";
 import { useLocation } from "../client/useLocation";
@@ -123,6 +134,64 @@ describe("<Page> route state", () => {
     screen.getByText("Settings").click();
 
     expect(onNavigate).toHaveBeenCalledWith("/app/abc/settings", "push");
+  });
+
+  test("catches a navigation issued from a child's mount effect", () => {
+    // `<Redirect>` pushes from its own effect, and React flushes child effects
+    // before the parent's — so a listener registered in `<Page>`'s effect
+    // would not exist yet, and the auth-guard views that redirect on mount
+    // would look like they do nothing.
+    const onNavigate = vi.fn();
+
+    render(
+      <Page pathname="/app" onNavigate={onNavigate}>
+        <Redirect href={"/login" as never} action="replace" />
+      </Page>,
+    );
+
+    expect(onNavigate).toHaveBeenCalledWith("/login", "replace");
+  });
+
+  test("keeps the caller's `supportedLocales` order", () => {
+    function View() {
+      const { supportedLocales } = useContext(I18nContext);
+      return <div>{supportedLocales.join(",")}</div>;
+    }
+
+    // A language switcher maps over this list, so the page's own locale must
+    // not be hoisted to the front of it.
+    render(
+      <Page
+        locale="de-DE"
+        defaultLocale="en-US"
+        supportedLocales={["en-US", "tr-TR", "de-DE"]}
+      >
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("en-US,tr-TR,de-DE")).toBeDefined();
+  });
+
+  test("seeds the theme, and `setTheme` still works from there", () => {
+    function View() {
+      const { theme, setTheme } = useTheme();
+      return (
+        <button type="button" onClick={() => setTheme("light")}>
+          {theme}
+        </button>
+      );
+    }
+
+    render(
+      <Page theme="dark">
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("dark")).toBeDefined();
+    fireEvent.click(screen.getByText("dark"));
+    expect(screen.getByText("light")).toBeDefined();
   });
 
   test("the navigation-state hooks read from the page's idle router", () => {
@@ -324,6 +393,38 @@ describe("<Page> query data", () => {
     expect(fetchSpy).toHaveBeenCalled();
   });
 
+  test("a key whose `:param` the page cannot fill fails naming the key", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // `useQuery("/orgs/:orgId/lists", { params: { orgId } })` with `orgId` in
+    // component state resolves to a path the page's params know nothing about.
+    // Left to `applyParams`, that throws `Missing parameter: orgId` under
+    // vitest and silently seeds `/orgs/undefined/lists` under `bun test` —
+    // two wrong behaviours for one mistake, neither naming the seed key.
+    expect(() =>
+      render(
+        <Page queryData={{ "/orgs/:orgId/lists": [] }}>
+          <div>never rendered</div>
+        </Page>,
+      ),
+    ).toThrow(/queryData key "\/orgs\/:orgId\/lists".*:orgId/s);
+  });
+
+  test("the /api-prefix warning fires once per key, not once per render", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ui = (
+      <Page queryData={{ "/api/todos": [] }}>
+        <div>rendered</div>
+      </Page>
+    );
+    const { rerender } = render(ui);
+    rerender(ui);
+    rerender(ui);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
   test("a throwing view renders `errorFallback` instead of failing the render", () => {
     function View(): never {
       throw new Error("boom");
@@ -338,6 +439,44 @@ describe("<Page> query data", () => {
     );
 
     expect(screen.getByText("caught:boom")).toBeDefined();
+  });
+
+  test("`resetErrorBoundary` clears the stored query error, so a retry recovers", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // The retry path a view's real `Error` export offers. Without
+    // `onReset={clearErrors}`, resetting re-renders the child, `useQuery`
+    // reads the failure still held on the resource and throws it straight
+    // back, and the fallback never goes away.
+    fetchSpy.mockImplementationOnce(
+      async () =>
+        new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+    );
+
+    function View() {
+      const { data } = useQuery("/todos" as never);
+      return <div>{`items:${(data as any as unknown[]).length}`}</div>;
+    }
+
+    render(
+      <Page
+        errorFallback={({ resetErrorBoundary }) => (
+          <button type="button" onClick={resetErrorBoundary}>
+            Try again
+          </button>
+        )}
+      >
+        <View />
+      </Page>,
+    );
+
+    await waitFor(() => expect(screen.getByText("Try again")).toBeDefined());
+
+    fetchSpy.mockImplementation(
+      async () => new Response(JSON.stringify([{ id: 1 }]), { status: 200 }),
+    );
+    screen.getByText("Try again").click();
+
+    await waitFor(() => expect(screen.getByText("items:1")).toBeDefined());
   });
 });
 

--- a/packages/gemi/testing/Page.test.tsx
+++ b/packages/gemi/testing/Page.test.tsx
@@ -202,6 +202,41 @@ describe("<Page> translations", () => {
     expect(screen.getByText("Merhaba Ada")).toBeDefined();
   });
 
+  test("`translations` seeds the client's own shape, for the current locale", () => {
+    function View() {
+      const t = useTranslator("Test" as never);
+      return <div>{t("greeting" as never, { name: "Ada" } as never)}</div>;
+    }
+
+    // No dictionary object anywhere — this is what the server serializes onto
+    // the page, so a test can seed it without importing anything of the app's.
+    render(
+      <Page translations={{ Test: { greeting: "Hi {{name}}" } }}>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("Hi Ada")).toBeDefined();
+  });
+
+  test("`translations` overrides a key the dictionary also defines", () => {
+    function View() {
+      const t = useTranslator("Test" as never);
+      return <div>{t("greeting" as never, { name: "Ada" } as never)}</div>;
+    }
+
+    render(
+      <Page
+        dictionaries={[Greeting]}
+        translations={{ Test: { greeting: "Yo {{name}}" } }}
+      >
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("Yo Ada")).toBeDefined();
+  });
+
   test("a non-default locale prefixes the links on the page", () => {
     render(
       <Page locale="tr-TR" defaultLocale="en-US">

--- a/packages/gemi/testing/Page.test.tsx
+++ b/packages/gemi/testing/Page.test.tsx
@@ -1,0 +1,362 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { Page } from "./Page";
+import { Form } from "../client/Mutation";
+import { Link } from "../client/Link";
+import { useBreadcrumbs } from "../client/useBreadcrumbs";
+import { useIsNavigationPending } from "../client/useIsNavigationPending";
+import { useLocation } from "../client/useLocation";
+import { useNavigationProgress } from "../client/useNavigationProgress";
+import { useParams } from "../client/useParams";
+import { useQuery } from "../client/useQuery";
+import { useSearchParams } from "../client/useSearchParams";
+import { useTranslator } from "../client/useTranslator";
+import { useUser } from "../client/auth/useUser";
+
+/**
+ * The seams a component test needs, asserted through the hooks an application
+ * actually calls — every one of these rendered its empty state before
+ * `gemi/testing` existed, with no supported way to seed the input behind it
+ * (#395).
+ */
+
+const Greeting = {
+  name: "Test",
+  dictionary: {
+    greeting: { "en-US": "Hello {{name}}", "tr-TR": "Merhaba {{name}}" },
+  },
+};
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  // Unstubbed, a query that misses the cache reaches the network: the point of
+  // seeding is that it does not, so the spy is both a stand-in and an
+  // assertion target.
+  fetchSpy = vi.fn(async () => new Response("null", { status: 200 }));
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("<Page> route state", () => {
+  test("seeds the params a view reads", () => {
+    function View() {
+      const { orgId } = useParams();
+      return <div>{`org:${orgId}`}</div>;
+    }
+
+    render(
+      <Page pathname="/app/:orgId/chat" params={{ orgId: "abc" }}>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("org:abc")).toBeDefined();
+  });
+
+  test("resolves the pathname template against those params", () => {
+    function View() {
+      const { pathname } = useLocation();
+      return <div>{pathname}</div>;
+    }
+
+    render(
+      <Page pathname="/app/:orgId/chat" params={{ orgId: "abc" }}>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("/app/abc/chat")).toBeDefined();
+  });
+
+  test("accepts search params as a string or an object", () => {
+    function View() {
+      const searchParams = useSearchParams();
+      return <div>{searchParams.get("tab") ?? "none"}</div>;
+    }
+
+    const { unmount } = render(
+      <Page searchParams="?tab=recent">
+        <View />
+      </Page>,
+    );
+    expect(screen.getByText("recent")).toBeDefined();
+    unmount();
+
+    render(
+      <Page searchParams={{ tab: "archived" }}>
+        <View />
+      </Page>,
+    );
+    expect(screen.getByText("archived")).toBeDefined();
+  });
+
+  test("a Link marks itself active against the page's own URL", () => {
+    render(
+      <Page pathname="/app/:orgId/chat" params={{ orgId: "abc" }}>
+        <Link href={"/app/:orgId/chat" as never}>Chat</Link>
+      </Page>,
+    );
+
+    const link = screen.getByText("Chat");
+    // `params` came from the page, so the template resolved to the same href.
+    expect(link.getAttribute("href")).toBe("/app/abc/chat");
+    expect(link.getAttribute("data-active")).toBe("true");
+  });
+
+  test("reports a navigation rather than performing one", () => {
+    const onNavigate = vi.fn();
+
+    render(
+      <Page pathname="/app/abc/chat" onNavigate={onNavigate}>
+        <Link href={"/app/abc/settings" as never}>Settings</Link>
+      </Page>,
+    );
+
+    screen.getByText("Settings").click();
+
+    expect(onNavigate).toHaveBeenCalledWith("/app/abc/settings", "push");
+  });
+
+  test("the navigation-state hooks read from the page's idle router", () => {
+    // Nothing here navigates, so the interesting part is that a view calling
+    // these renders at all: they read the router's subjects, which `<Page>`
+    // supplies rather than leaving as the empty default context.
+    function View() {
+      return (
+        <div>{`${useIsNavigationPending()}:${useNavigationProgress()}`}</div>
+      );
+    }
+
+    render(
+      <Page>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("false:100")).toBeDefined();
+  });
+
+  test("seeds the breadcrumbs, in order", () => {
+    function View() {
+      return (
+        <div>
+          {useBreadcrumbs()
+            .map((b) => b.label)
+            .join(" > ")}
+        </div>
+      );
+    }
+
+    render(
+      <Page
+        pathname="/app/abc/chat"
+        breadcrumbs={[
+          { label: "App", href: "/app" },
+          { label: "Chat", href: "/app/abc/chat" },
+        ]}
+      >
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("App > Chat")).toBeDefined();
+  });
+});
+
+describe("<Page> translations", () => {
+  test("resolves a dictionary key instead of echoing it back", () => {
+    function View() {
+      const t = useTranslator("Test" as never);
+      return <div>{t("greeting" as never, { name: "Ada" } as never)}</div>;
+    }
+
+    render(
+      <Page dictionaries={[Greeting]}>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("Hello Ada")).toBeDefined();
+  });
+
+  test("renders the locale the page was given", () => {
+    function View() {
+      const t = useTranslator("Test" as never);
+      return <div>{t("greeting" as never, { name: "Ada" } as never)}</div>;
+    }
+
+    render(
+      <Page locale="tr-TR" defaultLocale="en-US" dictionaries={[Greeting]}>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("Merhaba Ada")).toBeDefined();
+  });
+
+  test("a non-default locale prefixes the links on the page", () => {
+    render(
+      <Page locale="tr-TR" defaultLocale="en-US">
+        <Link href={"/about" as never}>About</Link>
+      </Page>,
+    );
+
+    expect(screen.getByText("About").getAttribute("href")).toBe("/tr-TR/about");
+  });
+});
+
+describe("<Page> query data", () => {
+  test("a seeded query renders its data and never fetches", () => {
+    function View() {
+      const { data } = useQuery("/todos" as never);
+      return <div>{`${(data as any as { id: number }[]).length} todos`}</div>;
+    }
+
+    render(
+      <Page queryData={{ "/todos": [{ id: 1 }, { id: 2 }] }}>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("2 todos")).toBeDefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("a `:param` in the key resolves against the page's params", () => {
+    function View() {
+      // No `params` at the call site: `useQuery` applies the route's, so the
+      // key the cache is read under is the resolved path.
+      const { data } = useQuery("/orgs/:orgId/lists" as never);
+      return <div>{(data as any as { title: string }).title}</div>;
+    }
+
+    render(
+      <Page
+        pathname="/orgs/:orgId/lists"
+        params={{ orgId: "abc" }}
+        queryData={{ "/orgs/:orgId/lists": { title: "Inbox" } }}
+      >
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("Inbox")).toBeDefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("a query string in the key seeds that search variant only", () => {
+    function View(props: { page: string }) {
+      const { data } = useQuery(
+        "/lists" as never,
+        {
+          search: { page: props.page },
+        } as never,
+      );
+      return <div>{(data as any as { label: string }).label}</div>;
+    }
+
+    render(
+      <Page queryData={{ "/lists?page=2": { label: "second page" } }}>
+        <View page="2" />
+      </Page>,
+    );
+
+    expect(screen.getByText("second page")).toBeDefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("an unseeded query suspends into the page's fallback", () => {
+    function View() {
+      useQuery("/unseeded" as never);
+      return <div>never rendered</div>;
+    }
+
+    render(
+      <Page fallback={<div>loading</div>}>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("loading")).toBeDefined();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  test("a throwing view renders `errorFallback` instead of failing the render", () => {
+    function View(): never {
+      throw new Error("boom");
+    }
+
+    render(
+      <Page
+        errorFallback={({ error }) => <div>{`caught:${error.message}`}</div>}
+      >
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("caught:boom")).toBeDefined();
+  });
+});
+
+describe("<Page> forms", () => {
+  test("a submitted Form posts to the endpoint, with the page's params applied", async () => {
+    render(
+      <Page pathname="/orgs/:orgId/todos" params={{ orgId: "abc" }}>
+        <Form action={"/orgs/:orgId/todos" as never} method="post">
+          <input name="title" defaultValue="write a test" />
+          <button type="submit">Save</button>
+        </Form>
+      </Page>,
+    );
+
+    screen.getByText("Save").click();
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    const [url, init] = (fetchSpy as any).mock.calls[0];
+    expect(url).toBe("/api/orgs/abc/todos");
+    expect(init.method).toBe("post");
+    expect((init.body as FormData).get("title")).toBe("write a test");
+  });
+});
+
+describe("<Page> auth", () => {
+  test("`useUser` reports the seeded user without a request", () => {
+    function View() {
+      const { user } = useUser();
+      return <div>{user ? `user:${user.id}` : "anonymous"}</div>;
+    }
+
+    render(
+      <Page user={{ id: 7, name: "Ada" }}>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("user:7")).toBeDefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("defaults to an anonymous visitor, and still does not fetch", () => {
+    function View() {
+      const { user } = useUser();
+      return <div>{user ? `user:${user.id}` : "anonymous"}</div>;
+    }
+
+    render(
+      <Page>
+        <View />
+      </Page>,
+    );
+
+    expect(screen.getByText("anonymous")).toBeDefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gemi/testing/Page.tsx
+++ b/packages/gemi/testing/Page.tsx
@@ -1,6 +1,7 @@
 import {
   Suspense,
-  useEffect,
+  useContext,
+  useMemo,
   useRef,
   useState,
   type ComponentType,
@@ -15,6 +16,7 @@ import { ClientRouterContext } from "../client/ClientRouterContext";
 import { I18nProvider } from "../client/I18nContext";
 import { ProgressManager } from "../client/ProgressManager";
 import {
+  QueryManagerContext,
   QueryManagerProvider,
   type QueryConfig,
 } from "../client/QueryManagerContext";
@@ -28,10 +30,12 @@ import {
   ServerDataContext,
   type ServerDataContextValue,
 } from "../client/ServerDataProvider";
+import { ThemeProvider } from "../client/ThemeProvider";
 import type { Breadcrumb } from "../client/useBreadcrumbs";
 import { WebSocketContext } from "../client/WebsocketContext";
 import { applyParams } from "../utils/applyParams";
 import { Subject } from "../utils/Subject";
+import { toVariantKey } from "../utils/variantKey";
 
 /**
  * A dictionary as `Dictionary.create` produces it: a name and a
@@ -100,8 +104,16 @@ export interface PageProps {
   /**
    * Data `useQuery` finds already cached, keyed by API path — the path passed
    * to `useQuery`, without the `/api` prefix the client adds when it fetches.
-   * Keys may carry a query string (`"/lists?page=2"`) to seed one search
-   * variant, and may use `:params`, which resolve against `params`.
+   * A key may carry a query string (`"/lists?page=2"`) to seed one search
+   * variant.
+   *
+   * The cache is keyed by the *resolved* path, so a key's `:params` are
+   * resolved against the page's `params` — and a key naming one the page does
+   * not carry is an error, naming the key. That case is common enough to be
+   * worth the loud failure: a query often takes its params from the call site
+   * rather than the route (`useQuery("/orgs/:orgId/lists", { params: { orgId } })`
+   * with `orgId` in component state), and the right seed for it is the resolved
+   * path, `"/orgs/abc/lists"`.
    *
    * Seeded at mount only: a component that mutates or refetches its data owns
    * the cache from then on.
@@ -116,6 +128,12 @@ export interface PageProps {
   user?: Partial<User> | null;
   /** What `useBreadcrumbs()` returns, in order. */
   breadcrumbs?: Breadcrumb[];
+  /**
+   * The theme `useTheme()` starts on. The app reads a visitor's stored choice
+   * out of `localStorage`; a test has no session to have made one in, so this
+   * seeds it without writing to storage. `setTheme` works from either.
+   */
+  theme?: "light" | "dark" | "system";
   /**
    * Fallback for the `Suspense` boundary wrapped around the children — the
    * stand-in for the view's own `Loading` export, which the real router
@@ -150,11 +168,61 @@ function toSearchString(search: PageProps["searchParams"]): string {
   return query ? `?${query}` : "";
 }
 
-/** The cache's variant key: sorted search params, empty when there are none. */
-function toVariantKey(search: string): string {
-  const searchParams = new URLSearchParams(search);
-  searchParams.sort();
-  return searchParams.toString();
+/**
+ * The `:params` a seed key needs supplied. Wildcards (`:rest*`) are excluded —
+ * `applyParams` drops those when missing, which is a resolution rather than a
+ * failure.
+ *
+ * Optional params (`:id?`) cannot reach here at all: a key is split at its
+ * first `?` to separate the search string, so `"/lists/:folderId?"` arrives as
+ * the path `/lists/:folderId`. Seed the resolved path for those.
+ */
+function requiredParamsOf(path: string): string[] {
+  return Array.from(path.matchAll(/:([^/]+)/g), ([, name]) => name).filter(
+    (name) => !name.endsWith("*"),
+  );
+}
+
+/**
+ * Fails a `queryData` key whose `:params` the page does not carry, saying so
+ * in terms of the key.
+ *
+ * Without this the two documented runners disagree, and neither is legible.
+ * `applyParams` throws `Missing parameter: orgId` under `import.meta.env.DEV`
+ * (vitest) — a router-utility stack trace out of `<Page>`'s render, before
+ * anything mounts, naming nothing that appears in the test. Under `bun test`
+ * that flag is falsy, so it logs and seeds the literal `/orgs/undefined/lists`
+ * instead: the seed misses, the query goes to the network, and the assertion
+ * runs against a loading state.
+ *
+ * The case is common because a query's params often come from the call site
+ * rather than the route — `useQuery("/orgs/:orgId/lists", { params: { orgId } })`
+ * with `orgId` in component state. The cache is keyed by the *resolved* path,
+ * so the way out is to seed that path directly.
+ */
+function resolveSeedPath(
+  key: string,
+  rawPath: string,
+  params: Record<string, string>,
+): string {
+  const missing = requiredParamsOf(rawPath).filter(
+    (name) => params[name] === undefined,
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `[gemi] <Page> cannot resolve the queryData key "${key}": no value for ` +
+        `${missing.map((name) => `:${name}`).join(", ")}. The query cache is ` +
+        `keyed by the resolved path, so either add ${missing
+          .map((name) => `\`${name}\``)
+          .join(", ")} to the page's \`params\`, or seed the resolved path ` +
+        `(e.g. "${applyParams(
+          rawPath,
+          Object.fromEntries(missing.map((name) => [name, "123"])),
+        )}") — which is what a query taking its params from component state ` +
+        `reads under.`,
+    );
+  }
+  return applyParams(rawPath, params);
 }
 
 /**
@@ -164,18 +232,22 @@ function toVariantKey(search: string): string {
 function toPrefetchedData(
   queryData: Record<string, unknown>,
   params: Record<string, string>,
+  warned: Set<string>,
 ) {
   const prefetchedData: Record<string, Record<string, unknown>> = {};
   for (const [key, data] of Object.entries(queryData)) {
     const [rawPath, rawSearch = ""] = key.split("?");
-    if (rawPath.startsWith("/api/")) {
+    // Once per key per page, not once per render: this runs again on every
+    // re-render, and a duplicated warning reads as a second mistake.
+    if (rawPath.startsWith("/api/") && !warned.has(key)) {
+      warned.add(key);
       console.warn(
         `[gemi] queryData key "${key}" starts with /api. useQuery is keyed by ` +
           `the path you pass it — the /api prefix is added when it fetches — ` +
           `so this entry seeds a path no query reads.`,
       );
     }
-    const path = applyParams(rawPath, params);
+    const path = resolveSeedPath(key, rawPath, params);
     prefetchedData[path] = {
       ...prefetchedData[path],
       [toVariantKey(rawSearch)]: data,
@@ -248,11 +320,22 @@ function toClientDictionary(
  * ```
  *
  * It is a plain component, so it composes with any renderer — Testing
- * Library's `render`, `renderToString`, `react-test-renderer`.
+ * Library's `render`, `react-test-renderer`, or `renderToString`.
  *
- * What it does not do is route. There is no view tree and no route manifest
- * behind it, so a navigation is reported through `onNavigate` rather than
- * resolved; to assert the page *after* a navigation, render a second `<Page>`.
+ * Two things it does not do.
+ *
+ * It does not route: there is no view tree and no route manifest behind it, so
+ * a navigation is reported through `onNavigate` rather than resolved. To
+ * assert the page *after* one, render a second `<Page>`.
+ *
+ * And under `renderToString` it renders the server's own no-data branch for an
+ * *unseeded* query rather than suspending — deliberately, because suspending
+ * there is the streaming server's job: `createRoot` threads the request's
+ * `ServerQueryStore` through `ServerQueryContext`, and that store is what runs
+ * the route handler. A harness has no request and no handler to run, so there
+ * is nothing to suspend on. Seeded queries render their data on the server
+ * exactly as they do in the browser; unseeded ones behave as a route with no
+ * `Query.prefetch` does, framework warning included.
  */
 export const Page = (props: PropsWithChildren<PageProps>) => {
   const {
@@ -269,41 +352,61 @@ export const Page = (props: PropsWithChildren<PageProps>) => {
     queryConfig,
     user = null,
     breadcrumbs = [],
+    theme,
     fallback = null,
     errorFallback,
     onNavigate,
   } = props;
 
-  const supportedLocales = Array.from(
-    new Set([defaultLocale, locale, ...(props.supportedLocales ?? [])]),
+  // The caller's list, in the caller's order — a language switcher maps over
+  // it, so hoisting the page's own locale to the front would reorder the
+  // rendered options. The defaults are appended, only to guarantee presence.
+  const supportedLocales = useMemo(
+    () =>
+      Array.from(
+        new Set([...(props.supportedLocales ?? []), defaultLocale, locale]),
+      ),
+    [props.supportedLocales, defaultLocale, locale],
   );
   const pathname = applyParams(routePath, params) || "/";
   const search = toSearchString(searchParams);
   // The URL's locale segment, which the default locale does not get.
   const urlLocaleSegment = locale === defaultLocale ? null : locale;
 
-  const dictionary = toClientDictionary(
-    dictionaries,
-    supportedLocales,
-    locale,
-    translations,
+  const dictionary = useMemo(
+    () =>
+      toClientDictionary(dictionaries, supportedLocales, locale, translations),
+    [dictionaries, supportedLocales, locale, translations],
   );
-  const prefetchedData = toPrefetchedData(queryData, params);
-  // `useUser` reads `/auth/me` like any other query. Seeding it — with `null`
-  // for the anonymous default — is what keeps a component test off the network
-  // for a hook nothing in the test asked for.
-  prefetchedData["/auth/me"] ??= { "": user ?? null };
+
+  // Keys that have already drawn a warning, so a re-render does not repeat it.
+  const warnedRef = useRef<Set<string>>(new Set());
+  const prefetchedData = useMemo(() => {
+    const seeded = toPrefetchedData(queryData, params, warnedRef.current);
+    // `useUser` reads `/auth/me` like any other query. Seeding it — with `null`
+    // for the anonymous default — is what keeps a component test off the
+    // network for a hook nothing in the test asked for.
+    seeded["/auth/me"] ??= { "": user ?? null };
+    return seeded;
+  }, [queryData, params, user]);
 
   // Keyed by `${view}:${pathname}` in the router's cache; the view names are
   // ours to choose here, and only their order reaches `useBreadcrumbs`.
-  const breadcrumbViews = breadcrumbs.map((_, index) => `breadcrumb-${index}`);
-  const breadcrumbsCache = new Map<string, Breadcrumb>(
-    breadcrumbs.map((breadcrumb, index) => [
-      `${breadcrumbViews[index]}:${pathname}`,
-      breadcrumb,
-    ]),
-  );
-  const breadcrumbsRecord = Object.fromEntries(breadcrumbsCache);
+  const { breadcrumbViews, breadcrumbsCache, breadcrumbsRecord } =
+    useMemo(() => {
+      const views = breadcrumbs.map((_, index) => `breadcrumb-${index}`);
+      const cache = new Map<string, Breadcrumb>(
+        breadcrumbs.map((breadcrumb, index) => [
+          `${views[index]}:${pathname}`,
+          breadcrumb,
+        ]),
+      );
+      return {
+        breadcrumbViews: views,
+        breadcrumbsCache: cache,
+        breadcrumbsRecord: Object.fromEntries(cache),
+      };
+    }, [breadcrumbs, pathname]);
 
   const [isNavigatingSubject] = useState(() => new Subject<boolean>(false));
   const [progressManager] = useState(
@@ -313,123 +416,216 @@ export const Page = (props: PropsWithChildren<PageProps>) => {
     createMemoryHistory({ initialEntries: [`${pathname}${search}${hash}`] }),
   );
 
-  const routeState: RouteState & PageData = {
-    views: [],
-    params,
-    search,
-    state: {},
-    pathname,
-    hash,
-    action: null,
-    routePath,
-    locale: urlLocaleSegment,
-    data: {},
-    i18n: { currentLocale: locale, dictionary, supportedLocales },
-    prefetchedData,
-    breadcrumbs: breadcrumbsRecord,
-    appId: "test",
-  };
+  const routeState: RouteState & PageData = useMemo(
+    () => ({
+      views: [],
+      params,
+      search,
+      state: {},
+      pathname,
+      hash,
+      action: null,
+      routePath,
+      locale: urlLocaleSegment,
+      data: {},
+      i18n: { currentLocale: locale, dictionary, supportedLocales },
+      prefetchedData,
+      breadcrumbs: breadcrumbsRecord,
+      appId: "test",
+    }),
+    [
+      params,
+      search,
+      pathname,
+      hash,
+      routePath,
+      urlLocaleSegment,
+      locale,
+      dictionary,
+      supportedLocales,
+      prefetchedData,
+      breadcrumbsRecord,
+    ],
+  );
 
   const [routerSubject] = useState(() => new Subject<RouteState>(routeState));
 
   const onNavigateRef = useRef(onNavigate);
   onNavigateRef.current = onNavigate;
-  useEffect(() => {
-    return history.listen(({ location, action }) => {
+  // Subscribed during render, not in an effect, because React flushes child
+  // effects before parent ones — and mount-time navigation is a real pattern:
+  // `<Redirect>` pushes from its own mount effect, as does any auth guard. A
+  // listener registered in `<Page>`'s effect is not there yet when those fire,
+  // so `onNavigate` would silently miss exactly the redirects a test most
+  // wants to assert. Ref-guarded, so React's double-invoke registers one.
+  //
+  // Nothing unsubscribes: this history is created per `<Page>` and reachable
+  // from nowhere else, so it is collected with the page it belongs to.
+  const listeningRef = useRef(false);
+  if (!listeningRef.current) {
+    listeningRef.current = true;
+    history.listen(({ location, action }) => {
       const href = `${location.pathname}${location.search}${location.hash}`;
       onNavigateRef.current?.(
         href,
         action === Action.Replace ? "replace" : "push",
       );
     });
-  }, [history]);
+  }
 
-  const serverData: ServerDataContextValue = {
-    routeManifest: {},
-    pageData: {},
-    breadcrumbs: breadcrumbsRecord,
-    prefetchedData,
-    router: {
+  const serverData: ServerDataContextValue = useMemo(
+    () => ({
+      routeManifest: {},
+      pageData: {},
+      breadcrumbs: breadcrumbsRecord,
+      prefetchedData,
+      router: {
+        pathname,
+        params,
+        currentPath: routePath,
+        is404: false,
+        searchParams: search,
+        urlLocaleSegment,
+      },
+      i18n: {
+        dictionary,
+        currentLocale: locale,
+        supportedLocales,
+        defaultLocale,
+      },
+      componentTree: [],
+      auth: { user: user as User },
+      __csrf: "test-csrf-token",
+      cssManifest: {},
+      modulePreloadManifest: {},
+      meta: {},
+      appId: "test",
+    }),
+    [
+      breadcrumbsRecord,
+      prefetchedData,
       pathname,
       params,
-      currentPath: routePath,
-      is404: false,
-      searchParams: search,
+      routePath,
+      search,
       urlLocaleSegment,
-    },
-    i18n: {
       dictionary,
-      currentLocale: locale,
+      locale,
       supportedLocales,
       defaultLocale,
-    },
-    componentTree: [],
-    auth: { user: user as User },
-    __csrf: "test-csrf-token",
-    cssManifest: {},
-    modulePreloadManifest: {},
-    meta: {},
-    appId: "test",
-  };
+      user,
+    ],
+  );
 
   // Everything the router hooks read, inert: nothing here fetches, preloads or
   // resolves a route, but every hook finds the shape it expects rather than an
   // empty context to crash on.
-  const routerContext = {
-    viewEntriesSubject: new Subject<string[]>([]),
-    history,
-    updatePageData: () => {},
-    getPageData: () => ({}),
-    getScrollPosition: () => 0,
-    getViewPathsFromPathname: () => breadcrumbViews,
-    getRoutePathnameFromHref: (href: string) => href,
-    isNavigatingSubject,
-    setNavigationAbortController: () => {},
-    progressManager,
-    fetchRouteCSS: async () => {},
-    preloadRouteModules: () => {},
-    prefetchRoute: async () => {},
-    takePrefetched: () => null,
-    clearPrefetchCache: () => {},
-    breadcrumbsCache,
-    routerSubject,
-    urlLocaleSegment,
-  };
+  const [viewEntriesSubject] = useState(() => new Subject<string[]>([]));
+  const routerContext = useMemo(
+    () => ({
+      viewEntriesSubject,
+      history,
+      updatePageData: () => {},
+      getPageData: () => ({}),
+      getScrollPosition: () => 0,
+      getViewPathsFromPathname: () => breadcrumbViews,
+      getRoutePathnameFromHref: (href: string) => href,
+      isNavigatingSubject,
+      setNavigationAbortController: () => {},
+      progressManager,
+      fetchRouteCSS: async () => {},
+      preloadRouteModules: () => {},
+      prefetchRoute: async () => {},
+      takePrefetched: () => null,
+      clearPrefetchCache: () => {},
+      breadcrumbsCache,
+      routerSubject,
+      urlLocaleSegment,
+    }),
+    [
+      viewEntriesSubject,
+      history,
+      breadcrumbViews,
+      isNavigatingSubject,
+      progressManager,
+      breadcrumbsCache,
+      routerSubject,
+      urlLocaleSegment,
+    ],
+  );
 
-  const websocket = {
+  const [websocket] = useState(() => ({
     subscribe: async () => {},
     unsubscribe: async () => {},
     broadcast: () => {},
-  };
-
-  const ErrorFallback = errorFallback;
-  const content = <Suspense fallback={fallback}>{children}</Suspense>;
+  }));
 
   return (
-    <ServerDataContext.Provider value={serverData}>
-      <I18nProvider>
-        <WebSocketContext.Provider value={websocket}>
-          <QueryManagerProvider queryConfig={queryConfig}>
-            <ClientRouterContext.Provider value={routerContext}>
-              <RouteTransitionProvider
-                isPending={false}
-                isFetching={false}
-                transitionPath={["", pathname]}
-              >
-                <RouteStateProvider state={routeState}>
-                  {ErrorFallback ? (
-                    <ErrorBoundary FallbackComponent={ErrorFallback}>
-                      {content}
-                    </ErrorBoundary>
-                  ) : (
-                    content
-                  )}
-                </RouteStateProvider>
-              </RouteTransitionProvider>
-            </ClientRouterContext.Provider>
-          </QueryManagerProvider>
-        </WebSocketContext.Provider>
-      </I18nProvider>
-    </ServerDataContext.Provider>
+    <ThemeProvider theme={theme}>
+      <ServerDataContext.Provider value={serverData}>
+        <I18nProvider>
+          <WebSocketContext.Provider value={websocket}>
+            <QueryManagerProvider queryConfig={queryConfig}>
+              <ClientRouterContext.Provider value={routerContext}>
+                <RouteTransitionProvider
+                  isPending={false}
+                  isFetching={false}
+                  transitionPath={["", pathname]}
+                >
+                  <RouteStateProvider state={routeState}>
+                    <Boundary
+                      errorFallback={errorFallback}
+                      fallback={fallback}
+                      resetKey={pathname}
+                    >
+                      {children}
+                    </Boundary>
+                  </RouteStateProvider>
+                </RouteTransitionProvider>
+              </ClientRouterContext.Provider>
+            </QueryManagerProvider>
+          </WebSocketContext.Provider>
+        </I18nProvider>
+      </ServerDataContext.Provider>
+    </ThemeProvider>
+  );
+};
+
+/**
+ * The `Suspense` boundary every view renders inside, and — when the test
+ * supplies a fallback for it — the error boundary too.
+ *
+ * `onReset={clearErrors}` is the part that has to be here rather than inline
+ * above: it needs `QueryManagerContext`, and it is what makes a view's real
+ * `Error` export testable. A fallback whose "Try again" calls
+ * `resetErrorBoundary()` re-renders the child, and `useQuery` reads the
+ * failure still stored on the `QueryResource` and throws it straight back —
+ * so without this the fallback never goes away and the retry path that works
+ * in the app cannot be exercised. `ClientRouter`'s own boundary wires exactly
+ * this pair.
+ */
+const Boundary = (
+  props: PropsWithChildren<{
+    errorFallback?: ComponentType<FallbackProps>;
+    fallback: ReactNode;
+    resetKey: string;
+  }>,
+) => {
+  const { errorFallback: ErrorFallback, fallback, resetKey, children } = props;
+  const { clearErrors } = useContext(QueryManagerContext);
+  const content = <Suspense fallback={fallback}>{children}</Suspense>;
+
+  if (!ErrorFallback) {
+    return content;
+  }
+
+  return (
+    <ErrorBoundary
+      FallbackComponent={ErrorFallback}
+      resetKeys={[resetKey]}
+      onReset={clearErrors}
+    >
+      {content}
+    </ErrorBoundary>
   );
 };

--- a/packages/gemi/testing/Page.tsx
+++ b/packages/gemi/testing/Page.tsx
@@ -34,9 +34,18 @@ import { applyParams } from "../utils/applyParams";
 import { Subject } from "../utils/Subject";
 
 /**
- * A dictionary as `Dictionary.create` produces it. Typed structurally rather
- * than as `Dictionary<T>` so this module never imports `gemi/i18n` — that entry
- * reaches the `Lang` facade and, through it, the server container.
+ * A dictionary as `Dictionary.create` produces it: a name and a
+ * `{ key: { locale: string } }` map.
+ *
+ * Typed structurally rather than as `Dictionary<T>` for two reasons. It keeps
+ * `gemi/testing` from importing `gemi/i18n` — a server entry, which reaches the
+ * `Lang` facade and through it the container. And it means an object literal of
+ * the same shape is accepted, so a test never *has* to import the app's
+ * dictionaries at all.
+ *
+ * Only `name` and `dictionary` are read — both plain data. `Dictionary`'s
+ * server-only methods (`render`, `reference`, which throw once `window` is
+ * defined) are never called from here.
  */
 export interface PageDictionary {
   name: string;
@@ -63,8 +72,31 @@ export interface PageProps {
    */
   defaultLocale?: string;
   supportedLocales?: string[];
-  /** Dictionaries the components under test translate against. */
+  /**
+   * Dictionaries the components under test translate against — the app's own,
+   * or literals of the same shape.
+   *
+   * Note what importing the app's costs: `app/i18n/index.ts` imports
+   * `gemi/i18n`, a server entry, so the test file pulls the container and
+   * `node:async_hooks` into its module graph. Nothing there runs (and nothing
+   * here calls it), so it is fine under any runner that has Node builtins —
+   * vitest, `bun test` — and not under one that renders in a real browser. Use
+   * `translations` there, which is the shape the client actually receives.
+   */
   dictionaries?: PageDictionary[];
+  /**
+   * Translations for the current locale, already resolved: dictionary name →
+   * key → string. This is the shape the server serializes onto the page, so it
+   * is what the client reads at runtime — and it imports nothing.
+   *
+   * ```tsx
+   * <Page translations={{ Chat: { greeting: "Hello {{name}}" } }}>
+   * ```
+   *
+   * Merged over `dictionaries`, so the two compose: seed from the app's real
+   * dictionary and override the one key a test is about.
+   */
+  translations?: Record<string, Record<string, string>>;
   /**
    * Data `useQuery` finds already cached, keyed by API path — the path passed
    * to `useQuery`, without the `/api` prefix the client adds when it fetches.
@@ -152,26 +184,41 @@ function toPrefetchedData(
   return prefetchedData;
 }
 
-/** `{ [locale]: { [dictionary]: { [key]: string } } }`, as the server ships it. */
+/**
+ * `{ [locale]: { [dictionary]: { [key]: string } } }` — the payload
+ * `Translator` serializes onto the page, which is the only form the client
+ * ever sees. `dictionaries` are transposed into it (they are keyed the other
+ * way round, by key then locale); `translations` is already in it and lands
+ * under `locale`, last, so it wins.
+ */
 function toClientDictionary(
   dictionaries: PageDictionary[],
   locales: string[],
+  locale: string,
+  translations: Record<string, Record<string, string>>,
 ): Record<string, Record<string, Record<string, string>>> {
   const clientDictionary: Record<
     string,
     Record<string, Record<string, string>>
   > = {};
-  for (const locale of locales) {
-    clientDictionary[locale] ??= {};
+  for (const supported of locales) {
+    clientDictionary[supported] ??= {};
   }
   for (const { name, dictionary } of dictionaries) {
     for (const [key, byLocale] of Object.entries(dictionary ?? {})) {
-      for (const [locale, translation] of Object.entries(byLocale ?? {})) {
-        clientDictionary[locale] ??= {};
-        clientDictionary[locale][name] ??= {};
-        clientDictionary[locale][name][key] = translation;
+      for (const [dictLocale, translation] of Object.entries(byLocale ?? {})) {
+        clientDictionary[dictLocale] ??= {};
+        clientDictionary[dictLocale][name] ??= {};
+        clientDictionary[dictLocale][name][key] = translation;
       }
     }
+  }
+  for (const [name, keys] of Object.entries(translations)) {
+    clientDictionary[locale] ??= {};
+    clientDictionary[locale][name] = {
+      ...clientDictionary[locale][name],
+      ...keys,
+    };
   }
   return clientDictionary;
 }
@@ -217,6 +264,7 @@ export const Page = (props: PropsWithChildren<PageProps>) => {
     locale = "en-US",
     defaultLocale = locale,
     dictionaries = [],
+    translations = {},
     queryData = {},
     queryConfig,
     user = null,
@@ -234,7 +282,12 @@ export const Page = (props: PropsWithChildren<PageProps>) => {
   // The URL's locale segment, which the default locale does not get.
   const urlLocaleSegment = locale === defaultLocale ? null : locale;
 
-  const dictionary = toClientDictionary(dictionaries, supportedLocales);
+  const dictionary = toClientDictionary(
+    dictionaries,
+    supportedLocales,
+    locale,
+    translations,
+  );
   const prefetchedData = toPrefetchedData(queryData, params);
   // `useUser` reads `/auth/me` like any other query. Seeding it — with `null`
   // for the anonymous default — is what keeps a component test off the network

--- a/packages/gemi/testing/Page.tsx
+++ b/packages/gemi/testing/Page.tsx
@@ -1,0 +1,382 @@
+import {
+  Suspense,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+  type PropsWithChildren,
+  type ReactNode,
+} from "react";
+import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
+import { Action, createMemoryHistory } from "history";
+
+import type { User } from "../auth/types";
+import { ClientRouterContext } from "../client/ClientRouterContext";
+import { I18nProvider } from "../client/I18nContext";
+import { ProgressManager } from "../client/ProgressManager";
+import {
+  QueryManagerProvider,
+  type QueryConfig,
+} from "../client/QueryManagerContext";
+import {
+  RouteStateProvider,
+  type PageData,
+  type RouteState,
+} from "../client/RouteStateContext";
+import { RouteTransitionProvider } from "../client/RouteTransitionProvider";
+import {
+  ServerDataContext,
+  type ServerDataContextValue,
+} from "../client/ServerDataProvider";
+import type { Breadcrumb } from "../client/useBreadcrumbs";
+import { WebSocketContext } from "../client/WebsocketContext";
+import { applyParams } from "../utils/applyParams";
+import { Subject } from "../utils/Subject";
+
+/**
+ * A dictionary as `Dictionary.create` produces it. Typed structurally rather
+ * than as `Dictionary<T>` so this module never imports `gemi/i18n` — that entry
+ * reaches the `Lang` facade and, through it, the server container.
+ */
+export interface PageDictionary {
+  name: string;
+  dictionary: Record<string, Record<string, string>>;
+}
+
+export interface PageProps {
+  /**
+   * The URL the view is mounted at. A template (`/app/:orgId/chat`) is resolved
+   * against `params`, so the same string can be pasted from the router.
+   */
+  pathname?: string;
+  /** Route params, as the router would have parsed them out of `pathname`. */
+  params?: Record<string, string>;
+  /** `"?tab=recent"`, `"tab=recent"`, or `{ tab: "recent" }`. */
+  searchParams?: string | Record<string, string | number | boolean>;
+  hash?: string;
+  /** The locale `useTranslator` and `useLocale` report. */
+  locale?: string;
+  /**
+   * The app's default locale. Links and `useNavigate` omit the locale segment
+   * for it, so leaving this equal to `locale` (the default) keeps hrefs
+   * unprefixed — set it to seed a page being viewed in a non-default locale.
+   */
+  defaultLocale?: string;
+  supportedLocales?: string[];
+  /** Dictionaries the components under test translate against. */
+  dictionaries?: PageDictionary[];
+  /**
+   * Data `useQuery` finds already cached, keyed by API path — the path passed
+   * to `useQuery`, without the `/api` prefix the client adds when it fetches.
+   * Keys may carry a query string (`"/lists?page=2"`) to seed one search
+   * variant, and may use `:params`, which resolve against `params`.
+   *
+   * Seeded at mount only: a component that mutates or refetches its data owns
+   * the cache from then on.
+   */
+  queryData?: Record<string, unknown>;
+  /** App-wide `useQuery` defaults, as `createRoot` threads them. */
+  queryConfig?: QueryConfig;
+  /**
+   * What `useUser()` reports. Defaults to `null` — an anonymous visitor — and
+   * either way the hook resolves from here without issuing a request.
+   */
+  user?: Partial<User> | null;
+  /** What `useBreadcrumbs()` returns, in order. */
+  breadcrumbs?: Breadcrumb[];
+  /**
+   * Fallback for the `Suspense` boundary wrapped around the children — the
+   * stand-in for the view's own `Loading` export, which the real router
+   * supplies. Defaults to `null`.
+   */
+  fallback?: ReactNode;
+  /**
+   * Renders in place of the children when one throws, mirroring a view's
+   * `Error` export. Without it a thrown render (an errored suspense query,
+   * say) propagates out of `render()` and fails the test, which is usually
+   * what you want.
+   */
+  errorFallback?: ComponentType<FallbackProps>;
+  /**
+   * Called when something navigates — a `Link` click, `useNavigate().push`.
+   * The navigation is reported, not performed: `<Page>` renders one route and
+   * does not re-resolve the tree, so `useLocation()` keeps reporting the
+   * pathname it was given.
+   */
+  onNavigate?: (href: string, action: "push" | "replace") => void;
+}
+
+/** `"?a=b"` (or `""`) from any of the shapes `searchParams` accepts. */
+function toSearchString(search: PageProps["searchParams"]): string {
+  if (!search) return "";
+  const query =
+    typeof search === "string"
+      ? search.replace(/^\?/, "")
+      : new URLSearchParams(
+          Object.entries(search).map(([key, value]) => [key, String(value)]),
+        ).toString();
+  return query ? `?${query}` : "";
+}
+
+/** The cache's variant key: sorted search params, empty when there are none. */
+function toVariantKey(search: string): string {
+  const searchParams = new URLSearchParams(search);
+  searchParams.sort();
+  return searchParams.toString();
+}
+
+/**
+ * `queryData` in the shape the query cache seeds from: `{ [path]: { [variant]:
+ * data } }`, the same payload `Query.prefetch` puts on a server-rendered page.
+ */
+function toPrefetchedData(
+  queryData: Record<string, unknown>,
+  params: Record<string, string>,
+) {
+  const prefetchedData: Record<string, Record<string, unknown>> = {};
+  for (const [key, data] of Object.entries(queryData)) {
+    const [rawPath, rawSearch = ""] = key.split("?");
+    if (rawPath.startsWith("/api/")) {
+      console.warn(
+        `[gemi] queryData key "${key}" starts with /api. useQuery is keyed by ` +
+          `the path you pass it — the /api prefix is added when it fetches — ` +
+          `so this entry seeds a path no query reads.`,
+      );
+    }
+    const path = applyParams(rawPath, params);
+    prefetchedData[path] = {
+      ...prefetchedData[path],
+      [toVariantKey(rawSearch)]: data,
+    };
+  }
+  return prefetchedData;
+}
+
+/** `{ [locale]: { [dictionary]: { [key]: string } } }`, as the server ships it. */
+function toClientDictionary(
+  dictionaries: PageDictionary[],
+  locales: string[],
+): Record<string, Record<string, Record<string, string>>> {
+  const clientDictionary: Record<
+    string,
+    Record<string, Record<string, string>>
+  > = {};
+  for (const locale of locales) {
+    clientDictionary[locale] ??= {};
+  }
+  for (const { name, dictionary } of dictionaries) {
+    for (const [key, byLocale] of Object.entries(dictionary ?? {})) {
+      for (const [locale, translation] of Object.entries(byLocale ?? {})) {
+        clientDictionary[locale] ??= {};
+        clientDictionary[locale][name] ??= {};
+        clientDictionary[locale][name][key] = translation;
+      }
+    }
+  }
+  return clientDictionary;
+}
+
+/**
+ * Mounts a component with the inputs a view normally arrives with — route
+ * params, the current locale and its dictionaries, prefetched query data, the
+ * signed-in user — so a unit test can assert what it renders rather than only
+ * its empty state.
+ *
+ * ```tsx
+ * import { render, screen } from "@testing-library/react";
+ * import { Page } from "gemi/testing";
+ *
+ * render(
+ *   <Page
+ *     pathname="/app/:orgId/chat"
+ *     params={{ orgId: "abc" }}
+ *     queryData={{ "/organizations/:orgId/messages": [{ id: 1, body: "hi" }] }}
+ *     dictionaries={[ChatDictionary]}
+ *   >
+ *     <OrgChat />
+ *   </Page>,
+ * );
+ *
+ * expect(screen.getByText("hi")).toBeDefined();
+ * ```
+ *
+ * It is a plain component, so it composes with any renderer — Testing
+ * Library's `render`, `renderToString`, `react-test-renderer`.
+ *
+ * What it does not do is route. There is no view tree and no route manifest
+ * behind it, so a navigation is reported through `onNavigate` rather than
+ * resolved; to assert the page *after* a navigation, render a second `<Page>`.
+ */
+export const Page = (props: PropsWithChildren<PageProps>) => {
+  const {
+    children,
+    pathname: routePath = "/",
+    params = {},
+    searchParams,
+    hash = "",
+    locale = "en-US",
+    defaultLocale = locale,
+    dictionaries = [],
+    queryData = {},
+    queryConfig,
+    user = null,
+    breadcrumbs = [],
+    fallback = null,
+    errorFallback,
+    onNavigate,
+  } = props;
+
+  const supportedLocales = Array.from(
+    new Set([defaultLocale, locale, ...(props.supportedLocales ?? [])]),
+  );
+  const pathname = applyParams(routePath, params) || "/";
+  const search = toSearchString(searchParams);
+  // The URL's locale segment, which the default locale does not get.
+  const urlLocaleSegment = locale === defaultLocale ? null : locale;
+
+  const dictionary = toClientDictionary(dictionaries, supportedLocales);
+  const prefetchedData = toPrefetchedData(queryData, params);
+  // `useUser` reads `/auth/me` like any other query. Seeding it — with `null`
+  // for the anonymous default — is what keeps a component test off the network
+  // for a hook nothing in the test asked for.
+  prefetchedData["/auth/me"] ??= { "": user ?? null };
+
+  // Keyed by `${view}:${pathname}` in the router's cache; the view names are
+  // ours to choose here, and only their order reaches `useBreadcrumbs`.
+  const breadcrumbViews = breadcrumbs.map((_, index) => `breadcrumb-${index}`);
+  const breadcrumbsCache = new Map<string, Breadcrumb>(
+    breadcrumbs.map((breadcrumb, index) => [
+      `${breadcrumbViews[index]}:${pathname}`,
+      breadcrumb,
+    ]),
+  );
+  const breadcrumbsRecord = Object.fromEntries(breadcrumbsCache);
+
+  const [isNavigatingSubject] = useState(() => new Subject<boolean>(false));
+  const [progressManager] = useState(
+    () => new ProgressManager(isNavigatingSubject),
+  );
+  const [history] = useState(() =>
+    createMemoryHistory({ initialEntries: [`${pathname}${search}${hash}`] }),
+  );
+
+  const routeState: RouteState & PageData = {
+    views: [],
+    params,
+    search,
+    state: {},
+    pathname,
+    hash,
+    action: null,
+    routePath,
+    locale: urlLocaleSegment,
+    data: {},
+    i18n: { currentLocale: locale, dictionary, supportedLocales },
+    prefetchedData,
+    breadcrumbs: breadcrumbsRecord,
+    appId: "test",
+  };
+
+  const [routerSubject] = useState(() => new Subject<RouteState>(routeState));
+
+  const onNavigateRef = useRef(onNavigate);
+  onNavigateRef.current = onNavigate;
+  useEffect(() => {
+    return history.listen(({ location, action }) => {
+      const href = `${location.pathname}${location.search}${location.hash}`;
+      onNavigateRef.current?.(
+        href,
+        action === Action.Replace ? "replace" : "push",
+      );
+    });
+  }, [history]);
+
+  const serverData: ServerDataContextValue = {
+    routeManifest: {},
+    pageData: {},
+    breadcrumbs: breadcrumbsRecord,
+    prefetchedData,
+    router: {
+      pathname,
+      params,
+      currentPath: routePath,
+      is404: false,
+      searchParams: search,
+      urlLocaleSegment,
+    },
+    i18n: {
+      dictionary,
+      currentLocale: locale,
+      supportedLocales,
+      defaultLocale,
+    },
+    componentTree: [],
+    auth: { user: user as User },
+    __csrf: "test-csrf-token",
+    cssManifest: {},
+    modulePreloadManifest: {},
+    meta: {},
+    appId: "test",
+  };
+
+  // Everything the router hooks read, inert: nothing here fetches, preloads or
+  // resolves a route, but every hook finds the shape it expects rather than an
+  // empty context to crash on.
+  const routerContext = {
+    viewEntriesSubject: new Subject<string[]>([]),
+    history,
+    updatePageData: () => {},
+    getPageData: () => ({}),
+    getScrollPosition: () => 0,
+    getViewPathsFromPathname: () => breadcrumbViews,
+    getRoutePathnameFromHref: (href: string) => href,
+    isNavigatingSubject,
+    setNavigationAbortController: () => {},
+    progressManager,
+    fetchRouteCSS: async () => {},
+    preloadRouteModules: () => {},
+    prefetchRoute: async () => {},
+    takePrefetched: () => null,
+    clearPrefetchCache: () => {},
+    breadcrumbsCache,
+    routerSubject,
+    urlLocaleSegment,
+  };
+
+  const websocket = {
+    subscribe: async () => {},
+    unsubscribe: async () => {},
+    broadcast: () => {},
+  };
+
+  const ErrorFallback = errorFallback;
+  const content = <Suspense fallback={fallback}>{children}</Suspense>;
+
+  return (
+    <ServerDataContext.Provider value={serverData}>
+      <I18nProvider>
+        <WebSocketContext.Provider value={websocket}>
+          <QueryManagerProvider queryConfig={queryConfig}>
+            <ClientRouterContext.Provider value={routerContext}>
+              <RouteTransitionProvider
+                isPending={false}
+                isFetching={false}
+                transitionPath={["", pathname]}
+              >
+                <RouteStateProvider state={routeState}>
+                  {ErrorFallback ? (
+                    <ErrorBoundary FallbackComponent={ErrorFallback}>
+                      {content}
+                    </ErrorBoundary>
+                  ) : (
+                    content
+                  )}
+                </RouteStateProvider>
+              </RouteTransitionProvider>
+            </ClientRouterContext.Provider>
+          </QueryManagerProvider>
+        </WebSocketContext.Provider>
+      </I18nProvider>
+    </ServerDataContext.Provider>
+  );
+};

--- a/packages/gemi/testing/index.ts
+++ b/packages/gemi/testing/index.ts
@@ -1,0 +1,2 @@
+export { Page } from "./Page";
+export type { PageProps, PageDictionary } from "./Page";

--- a/packages/gemi/tsconfig.browser.json
+++ b/packages/gemi/tsconfig.browser.json
@@ -24,7 +24,7 @@
     "types": ["vite/client", "bun"],
     "outDir": "dist"
   },
-  "include": ["client"],
+  "include": ["client", "testing"],
   "exclude": [
     "node_modules",
     "dist",

--- a/packages/gemi/tsconfig.json
+++ b/packages/gemi/tsconfig.json
@@ -39,6 +39,7 @@
     "console",
     "broadcasting",
     "client",
+    "testing",
     "i18n",
     "server",
     "container",

--- a/packages/gemi/utils/Subject.test.ts
+++ b/packages/gemi/utils/Subject.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+
+import { Subject } from "./Subject";
+
+/**
+ * `Subject`'s methods are read as plain functions — `useSyncExternalStore`
+ * takes `subject.subscribe` and `subject.getValue` and calls them with no
+ * receiver. Two properties follow, and both were broken in a way nothing
+ * caught: `useIsNavigationPending` threw `undefined is not an object
+ * (evaluating 'this.value')` on first render, and the call sites that had
+ * noticed were binding per render, which makes uSES drop and re-create the
+ * subscription on every pass.
+ */
+describe("Subject", () => {
+  test("methods work detached from the instance", () => {
+    const subject = new Subject(1);
+    const { getValue, next, subscribe } = subject;
+
+    expect(getValue()).toBe(1);
+
+    const seen: number[] = [];
+    subscribe((value) => seen.push(value));
+    next(2);
+
+    expect(getValue()).toBe(2);
+    expect(seen).toEqual([2]);
+  });
+
+  test("method identity is stable, so a subscription is not churned", () => {
+    const subject = new Subject(1);
+
+    expect(subject.subscribe).toBe(subject.subscribe);
+    expect(subject.getValue).toBe(subject.getValue);
+  });
+
+  test("each instance keeps its own binding", () => {
+    const a = new Subject("a");
+    const b = new Subject("b");
+
+    expect(a.getValue()).toBe("a");
+    expect(b.getValue()).toBe("b");
+    expect(a.subscribe).not.toBe(b.subscribe);
+  });
+});

--- a/packages/gemi/utils/Subject.ts
+++ b/packages/gemi/utils/Subject.ts
@@ -4,6 +4,22 @@ export class Subject<T> {
 
   constructor(initialValue: T) {
     this.value = initialValue;
+    // Bound once, per instance, because these are read as plain functions:
+    // `useSyncExternalStore(subject.subscribe, subject.getValue, …)` calls them
+    // with no receiver, and an unbound method throws on `this.value`.
+    //
+    // Here rather than at each call site, and that part matters. Binding in a
+    // hook body allocates a fresh function every render, and
+    // `useSyncExternalStore` tears down and re-creates its subscription
+    // whenever `subscribe` changes identity — so a component rendering a
+    // navigation spinner would churn its entry in `subscribers` on every pass.
+    // `next` iterates that set, and `Set.forEach` visits entries inserted
+    // during iteration, so a value landing mid-resubscribe could notify both
+    // the outgoing and the incoming subscriber. Binding here keeps the stable
+    // prototype-method identity the call sites used to rely on.
+    this.subscribe = this.subscribe.bind(this);
+    this.next = this.next.bind(this);
+    this.getValue = this.getValue.bind(this);
   }
 
   public subscribe(subscriber: (value: T) => void) {

--- a/packages/gemi/utils/variantKey.test.ts
+++ b/packages/gemi/utils/variantKey.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { toVariantKey } from "./variantKey";
+
+/**
+ * The one definition of a cache variant key, which used to be a copy each in
+ * `useQuery` (the read), `useMutate` (the write) and `<Page>` (the seed).
+ *
+ * These pin the two properties those copies had to agree on: order-independence
+ * and nullish omission. A divergence in either is silent — a write lands under
+ * a key no read looks at, or a seed misses and the query goes to the network —
+ * so the assertions are here rather than left implied by the call sites.
+ */
+describe("toVariantKey", () => {
+  test("sorts, so param order is not part of the identity", () => {
+    expect(toVariantKey({ b: "2", a: "1" })).toBe(
+      toVariantKey({ a: "1", b: "2" }),
+    );
+    expect(toVariantKey({ b: "2", a: "1" })).toBe("a=1&b=2");
+  });
+
+  test("drops nullish values rather than stringifying them", () => {
+    // An optional filter left unset is absent, not `"undefined"`.
+    expect(toVariantKey({ page: "2", q: undefined, tag: null })).toBe("page=2");
+  });
+
+  test("is empty when there are no params", () => {
+    expect(toVariantKey({})).toBe("");
+    expect(toVariantKey(undefined)).toBe("");
+    expect(toVariantKey("")).toBe("");
+  });
+
+  test("takes the query-string form a seed key carries, sorted the same way", () => {
+    expect(toVariantKey("b=2&a=1")).toBe("a=1&b=2");
+    expect(toVariantKey("b=2&a=1")).toBe(toVariantKey({ a: "1", b: "2" }));
+  });
+
+  test("coerces non-string values the way a URL would", () => {
+    expect(toVariantKey({ page: 2, archived: false })).toBe(
+      "archived=false&page=2",
+    );
+  });
+});

--- a/packages/gemi/utils/variantKey.ts
+++ b/packages/gemi/utils/variantKey.ts
@@ -1,0 +1,30 @@
+import { omitNullishValues } from "./omitNullishValues";
+
+/**
+ * The key one search-param combination is cached under, inside a query's
+ * resource: the params sorted and serialized, empty when there are none.
+ *
+ * Sorted because `?b=2&a=1` and `?a=1&b=2` are the same request, and a cache
+ * that keyed them separately would fetch twice and hydrate one of them from a
+ * payload the server produced for the other. Nullish values are dropped for
+ * the same reason: an optional filter left `undefined` is absent, not the
+ * string `"undefined"`.
+ *
+ * Every site that reads or writes the cache derives its key from here —
+ * `useQuery` (the read), `useMutate` (the write), and `gemi/testing`'s `<Page>`
+ * (the seed). They used to hold a copy each, which is the kind of duplication
+ * that fails quietly: a seed built by an old copy simply misses, and the test
+ * that should have read it fetches over the network and asserts an empty state
+ * with nothing pointing at the mismatch.
+ */
+export function toVariantKey(
+  search: string | Record<string, unknown> | null | undefined,
+): string {
+  const searchParams = new URLSearchParams(
+    typeof search === "string"
+      ? search
+      : (omitNullishValues(search ?? {}) as Record<string, string>),
+  );
+  searchParams.sort();
+  return searchParams.toString();
+}

--- a/packages/gemi/vite.client.config.mts
+++ b/packages/gemi/vite.client.config.mts
@@ -4,13 +4,27 @@ import { defineConfig } from "vite";
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(__dirname, "client/index.ts"),
+      // Two entries in ONE build, deliberately: `gemi/testing` supplies the
+      // contexts (`RouteStateContext`, `QueryManagerContext`, …) that the
+      // components under test read through `gemi/client`. Built separately,
+      // each bundle would carry its own copy of every context object — two
+      // distinct `createContext` results — and a seeded `<Page>` would provide
+      // values nothing consumes. Rollup emits the shared modules as a chunk
+      // both entries import, so there is one instance of each.
+      entry: {
+        "client/index": resolve(__dirname, "client/index.ts"),
+        "testing/index": resolve(__dirname, "testing/index.ts"),
+      },
       formats: ["es"],
-      fileName: () => `index.js`,
+      fileName: (_format, entryName) => `${entryName}.js`,
     },
     minify: false,
-    outDir: "dist/client",
+    outDir: "dist",
+    // `dist/` already holds the output of `build:core`, `build:bin` and
+    // `build:types` by the time this runs — this build adds to it.
+    emptyOutDir: false,
     rollupOptions: {
+      output: { chunkFileNames: "chunks/[name]-[hash].js" },
       // React & friends are peer deps the consuming app provides — they must
       // stay external so the app's single copy is used. A plain string array is
       // exact-match, which silently missed subpaths: `react-dom/client`

--- a/packages/gemi/vite.client.config.mts
+++ b/packages/gemi/vite.client.config.mts
@@ -22,6 +22,13 @@ export default defineConfig({
     outDir: "dist",
     // `dist/` already holds the output of `build:core`, `build:bin` and
     // `build:types` by the time this runs — this build adds to it.
+    //
+    // Which loses the sweep vite does for free on an outDir it owns, and that
+    // matters now the output is content-hashed: run `build:client` twice
+    // without a clean and the first run's `chunks/*-<oldhash>.js` stays on
+    // disk, `build-publish.ts` copies `dist/` wholesale, and `files:
+    // ["dist/**/*"]` ships the dead chunks. The `build:client` script removes
+    // exactly the three directories this config writes before invoking it.
     emptyOutDir: false,
     rollupOptions: {
       output: { chunkFileNames: "chunks/[name]-[hash].js" },


### PR DESCRIPTION
Closes #395.

Mounting a view in a unit test already worked — the contexts have defaults and nothing throws — but every input a view reads was unseedable from the public API, so the only state a component test could assert was the empty one. `useParams()` returned `{}` with no exported provider to change it; `useTranslator()` returned the key back because outside a view tree it does not know which dictionary it belongs to; `QueryManagerContext` carried the `hydrate` a test needs while `QueryManagerProvider` accepted only `queryConfig`.

## The API

`gemi/testing` exports one component. It assembles the tree `ClientRouter` builds at runtime and seeds it:

```tsx
import { render, screen } from "@testing-library/react";
import { Page } from "gemi/testing";

render(
  <Page
    pathname="/app/:orgId/chat"          // a template, resolved against params
    params={{ orgId: "abc" }}
    searchParams="?tab=recent"           // or { tab: "recent" }
    locale="tr-TR" defaultLocale="en-US" // links then carry the /tr-TR prefix
    dictionaries={[dictionaries.Chat]}   // the app's real dictionaries
    queryData={{ "/orgs/:orgId/messages": [{ id: 1, body: "hi" }] }}
    user={{ id: 1 }}
  >
    <OrgChat />
  </Page>,
);

expect(screen.getByText("hi")).toBeDefined();
```

Also seedable: `breadcrumbs`, `queryConfig`, `hash`, `supportedLocales`, a `fallback` (the `Suspense` boundary standing in for a view's `Loading` export), an `errorFallback` (its `Error` export) and `onNavigate`. It is a plain component with no runner dependency, so it composes with Testing Library, `renderToString`, or anything else that renders React.

## Three choices worth reviewing

- **`queryData` keys are `useQuery` paths, without `/api`.** The prefix is added when the client fetches, so keying by it (as the issue's example does) seeds a path no query reads — silent, and looks like the harness not working. A key starting with `/api/` warns. `:params` resolve against the page's params, and a `?query` targets one search variant, matching how the cache is keyed.
- **Seeded at mount only.** Re-rendering with a new `queryData` would clobber whatever the component's own `mutate()`/`refetch()` had put in the cache, so it deliberately does not re-hydrate. To assert a second state, render a second `<Page>`.
- **No routing.** There is no view tree or route manifest behind it, so a navigation is reported through `onNavigate` rather than resolved; `useLocation()` keeps reporting the pathname it was given.

`useUser()` resolves from `user` (default `null`, an anonymous visitor) without reaching `/auth/me`, so a layout that greets the current user does not have to be mocked out of a test that is about something else.

## Build

`client` and `testing` are now two entries in **one** vite pass. Built separately, each bundle would carry its own copy of every `createContext` result — two distinct context objects — and a seeded `<Page>` would provide values the app's `gemi/client` components never read. The failure would be silent seeding, in the published package only. Verified the emitted bundles share one chunk.

## Two adjacent fixes, both load-bearing for the above

- **`Dictionary` imported the `../facades` barrel**, which drags in `Redis` and its `import { RedisClient } from "bun"`. A dictionary is the one server-side artifact a component test has to import, and under a browser-targeted runner that specifier does not resolve — so importing the app's own `app/i18n` failed to collect before rendering anything. Narrowed to `../facades/Lang`.
- **`useIsNavigationPending` handed unbound `Subject` methods to `useSyncExternalStore`**, which calls them as plain functions: `this.value` threw on the first render of any component calling the hook, in the browser as much as in a test. `useFormData` already binds its own; this now does too.

## Verification

- 18 new tests in `packages/gemi/testing/Page.test.tsx`, asserting through the hooks an application actually calls (`useParams`, `useSearchParams`, `useTranslator`, `useQuery`, `useUser`, `useBreadcrumbs`, `Link`, `Form`), including that a seeded query issues no request and an unseeded one still suspends and fetches.
- Full package suite green (3371 passed, 1 skipped), `typecheck` clean, `oxlint` unchanged at 79 warnings / 0 errors.
- `build:client` and `build:client-types` emit `dist/testing/index.{js,d.ts}`; the publish-shape check in `build-publish.ts` covers the new export.
- Checked end-to-end against a real app: `templates/saas-starter`'s `About.tsx`, imported through the package's `exports` map, rendered its seeded query variant and its real dictionary (`t.jsx` interpolation included) with zero fetches. Done on a scratch branch and reverted — landing it would mean adding `jsdom` and `@testing-library/react` to the scaffold every new app is generated from.

Docs: `docs/testing.md`, indexed in `README.md`, `llms.txt`, `llms-full.txt` and `index.html`.

## Not done, deliberately

- **An example test in the template.** It would also give CI a consumer-side check of `gemi/testing`, which nothing covers today — the "Template tests" step runs `app/models` only. Costs two devDependencies in the scaffold.
- **Simulating navigation** so `useLocation()` updates after a `Link` click. Without a route manifest the new route's params cannot be re-derived, and carrying stale ones forward would be a lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
