### PR TITLE
fix(i18n): stop gating the locale switch on an awaited cookie write

### DIFF
--- a/packages/gemi/client/useLocale.test.tsx
+++ b/packages/gemi/client/useLocale.test.tsx
@@ -1,0 +1,124 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { ClientRouterContext } from "./ClientRouterContext";
+import { I18nContext } from "./I18nContext";
+import { RouteStateProvider, type PageData, type RouteState } from "./RouteStateContext";
+import { useLocale } from "./useLocale";
+
+/**
+ * The switch has to survive a cookie write that never answers — that is the
+ * whole failure: `cookieStore.set()` staying unsettled on iOS Safari left the
+ * navigation behind a `.then()` that never ran, so changing the language did
+ * nothing at all and raised nothing to report it.
+ */
+function renderSetLocale(state: Partial<RouteState & PageData> = {}) {
+  const replaced: Array<[string, any]> = [];
+  const cookieAtNavigation: string[] = [];
+  const history = {
+    replace: (path: string, options?: any) => {
+      cookieAtNavigation.push(document.cookie);
+      replaced.push([path, options]);
+    },
+    push: () => {},
+  };
+
+  let setLocale!: (locale: string) => Promise<void>;
+  function Probe() {
+    const [, set] = useLocale();
+    setLocale = set;
+    return null;
+  }
+
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(
+        ClientRouterContext.Provider,
+        { value: { history, setNavigationAbortController: () => {} } as any },
+        createElement(
+          I18nContext.Provider,
+          { value: { defaultLocale: "en-US" } as any },
+          createElement(
+            RouteStateProvider,
+            {
+              state: {
+                pathname: "/pricing",
+                search: "",
+                hash: "",
+                params: {},
+                locale: "tr-TR",
+                i18n: { currentLocale: "tr-TR" },
+                ...state,
+              } as RouteState & PageData,
+            },
+            createElement(Probe),
+          ),
+        ),
+      ),
+    );
+  });
+
+  return {
+    setLocale: (locale: string) => setLocale(locale),
+    replaced,
+    cookieAtNavigation,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.cookie = "i18n-locale=; Max-Age=0; Path=/";
+});
+
+describe("useLocale().setLocale", () => {
+  test("navigates even though the cookie request never settles", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
+
+    const { setLocale, replaced } = renderSetLocale();
+    await act(async () => {
+      await setLocale("en-US");
+    });
+
+    expect(replaced).toHaveLength(1);
+    expect(replaced[0][0]).toBe("/pricing");
+  });
+
+  test("navigates even though the cookie request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("offline"))),
+    );
+
+    const { setLocale, replaced } = renderSetLocale();
+    await act(async () => {
+      await setLocale("en-US");
+    });
+
+    expect(replaced).toHaveLength(1);
+  });
+
+  test("writes the locale cookie before navigating", async () => {
+    // Switching *to* the default locale produces a URL with no locale segment,
+    // so the route-data request is resolved by the cookie alone — write it late
+    // and the server redirects the switch straight back to the old locale.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
+
+    const { setLocale, cookieAtNavigation } = renderSetLocale();
+    await act(async () => {
+      await setLocale("en-US");
+    });
+
+    expect(cookieAtNavigation[0]).toContain("i18n-locale=en-US");
+  });
+});

--- a/packages/gemi/client/useLocale.ts
+++ b/packages/gemi/client/useLocale.ts
@@ -3,15 +3,40 @@ import { useNavigate } from "./useNavigate";
 import { useParams } from "./useParams";
 import { useRouteData } from "./useRouteData";
 
-const setCookie = async (locale: string) => {
-  try {
-    return await globalThis.cookieStore.set("i18n-locale", locale);
-  } catch (err) {
-    return await fetch(`/api/__gemi__/services/i18n/set-locale/${locale}`);
-    // TODO: show unsuported browser error
-    // console.log(err);
+const LOCALE_COOKIE = "i18n-locale";
+const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+/**
+ * The active locale lives in two places: the URL segment `setLocale` navigates
+ * to, and the `i18n-locale` cookie the server falls back to when the URL has no
+ * segment — which is exactly the case for the default locale. Both have to be in
+ * place *before* the navigation asks for route data, or `Translator.detectLocale`
+ * answers the request with a redirect back to the locale the cookie still names.
+ *
+ * Hence a synchronous `document.cookie` write rather than an awaited one. The
+ * previous implementation awaited `cookieStore.set()` and hung the navigation off
+ * its `.then()`; that promise is reported to never settle on iOS Safari, so the
+ * `.then()` never ran and changing the language became a silent no-op — no
+ * rejection, nothing for an error reporter to pick up. A synchronous write cannot
+ * hang and cannot fail asynchronously, so nothing is left to gate navigation on.
+ */
+function persistLocale(locale: string) {
+  if (typeof document === "undefined") {
+    return;
   }
-};
+  try {
+    document.cookie = [
+      `${LOCALE_COOKIE}=${locale}`,
+      `Max-Age=${LOCALE_COOKIE_MAX_AGE}`,
+      "SameSite=Strict",
+      "Path=/",
+    ].join("; ");
+  } catch {
+    // A sandboxed iframe with no storage access throws here. The navigation
+    // still carries the locale in its URL, so it is better to switch without
+    // remembering the choice than to not switch at all.
+  }
+}
 
 export function useLocale() {
   const { i18n } = useRouteData();
@@ -20,16 +45,24 @@ export function useLocale() {
   const params = useParams();
 
   const setLocale = async (locale: string) => {
+    persistLocale(locale);
+
+    // `onLocaleChange` is a server-side hook, so it needs a request to fire —
+    // but the language switch must not wait on a round trip, nor be cancelled
+    // by one that fails. Fire and forget: the route re-sets the same cookie,
+    // which is already correct locally either way.
+    void fetch(`/api/__gemi__/services/i18n/set-locale/${locale}`).catch(
+      () => {},
+    );
+
     const urlSearchParams = new URLSearchParams(search);
-    setCookie(locale).then(() => {
-      replace(pathname, {
-        locale,
-        // TODO: fix: this conversion is wrong, because there can be multiple
-        // search params with the same name
-        search: Object.fromEntries(urlSearchParams.entries()),
-        params,
-      } as any);
-    });
+    await replace(pathname, {
+      locale,
+      // TODO: fix: this conversion is wrong, because there can be multiple
+      // search params with the same name
+      search: Object.fromEntries(urlSearchParams.entries()),
+      params,
+    } as any);
   };
 
   return [i18n.currentLocale, setLocale] as const;


### PR DESCRIPTION
## The bug

`useLocale().setLocale` gated the navigation on the cookie write:

```ts
setCookie(locale).then(() => {
  replace(pathname, { locale, ... });
});
```

If that promise never settles, `.then()` never runs, `replace()` never happens, and changing the language is a **silent no-op** — no exception, so nothing reaches an error reporter. This matches the reported iOS Safari symptom: Safari ships the Cookie Store API from 18.4, so `globalThis.cookieStore.set()` is reached rather than throwing into the `fetch` fallback (pre-18.4 it throws synchronously and the fallback works).

The same shape breaks from the other end too, on any browser: the fallback's `return await fetch(...)` rethrows out of `setCookie`, and there is no `.catch()` on the chain — an offline user gets no navigation plus an unhandled rejection. And on the happy path the switch waits on a full round trip with no timeout.

## The fix

Write the cookie synchronously with `document.cookie`. It can't hang and can't fail asynchronously, so nothing is left to gate the navigation on.

The write stays **before** the navigation deliberately. Switching *to* the default locale produces a URL with no locale segment, and `ViewRouteDispatcher.handleViewRequest` resolves those through `detectLocale` and 302s back to the cookie's locale — `.json` route-data requests included (only `.og` is exempt). So "navigate anyway and let the URL win" is only true for non-default locales; the cookie has to be correct before the route-data request goes out.

The `/set-locale` request is kept, now fire-and-forget, so the documented `onLocaleChange` server hook fires on **every** switch instead of only in browsers without `cookieStore`.

## Tests

`packages/gemi/client/useLocale.test.tsx` — all three fail against the old implementation, pass with the fix:

- navigates even though the cookie request never settles (the iOS shape)
- navigates even though the cookie request fails (offline)
- writes the locale cookie before navigating (default-locale switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126d5QL4Z7DzQgfYSpmUvVw