### PR TITLE
fix(i18n): let the client own the locale cookie outright

### DIFF
--- a/packages/gemi/client/useLocale.test.tsx
+++ b/packages/gemi/client/useLocale.test.tsx
@@ -105,6 +105,41 @@ describe("useLocale().setLocale", () => {
     expect(replaced).toHaveLength(1);
   });
 
+  test("navigates on a runtime with no fetch at all", async () => {
+    // Old WebViews. An unguarded call throws *synchronously*, which would skip
+    // the navigation the same way the awaited cookie write used to.
+    vi.stubGlobal("fetch", undefined);
+
+    const { setLocale, replaced } = renderSetLocale();
+    await act(async () => {
+      await setLocale("en-US");
+    });
+
+    expect(replaced).toHaveLength(1);
+  });
+
+  test("keeps a malformed locale inside the cookie value", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise(() => {})),
+    );
+
+    const { setLocale } = renderSetLocale();
+    await act(async () => {
+      await setLocale("en-US; Domain=.example.com");
+    });
+
+    // The `;` has to stay inside the value. Written raw it would terminate it
+    // and the rest would be parsed as a `Domain` attribute, leaving `en-US`
+    // behind as the stored locale.
+    const value = document.cookie
+      .split("; ")
+      .find((pair) => pair.startsWith("i18n-locale="))
+      ?.slice("i18n-locale=".length);
+
+    expect(decodeURIComponent(value ?? "")).toBe("en-US; Domain=.example.com");
+  });
+
   test("writes the locale cookie before navigating", async () => {
     // Switching *to* the default locale produces a URL with no locale segment,
     // so the route-data request is resolved by the cookie alone — write it late

--- a/packages/gemi/client/useLocale.ts
+++ b/packages/gemi/client/useLocale.ts
@@ -26,7 +26,11 @@ function persistLocale(locale: string) {
   }
   try {
     document.cookie = [
-      `${LOCALE_COOKIE}=${locale}`,
+      // Encoded, not interpolated: `cookieStore.set()` rejected malformed
+      // values, a raw string write does not. A locale carrying `;` would
+      // otherwise write cookie *attributes* — `Domain`, `Path` — from whatever
+      // the app happens to feed the switcher.
+      `${LOCALE_COOKIE}=${encodeURIComponent(locale)}`,
       `Max-Age=${LOCALE_COOKIE_MAX_AGE}`,
       "SameSite=Strict",
       "Path=/",
@@ -38,6 +42,24 @@ function persistLocale(locale: string) {
   }
 }
 
+/**
+ * `onLocaleChange` is a server-side hook, so it takes a request to fire it. The
+ * switch must not wait on that round trip, nor be cancelled by one that fails —
+ * including one that fails *synchronously*: `fetch` is absent in some old
+ * WebViews, and an unguarded call would throw before the navigation ran, which
+ * is the same silent no-op this hook exists to prevent through another door.
+ */
+function notifyLocaleChange(locale: string) {
+  try {
+    void fetch(
+      `/api/__gemi__/services/i18n/set-locale/${encodeURIComponent(locale)}`,
+    ).catch(() => {});
+  } catch {
+    // `fetch` itself is unavailable. The locale is already persisted and the
+    // navigation still runs; only the server-side hook misses this switch.
+  }
+}
+
 export function useLocale() {
   const { i18n } = useRouteData();
   const { pathname, search } = useLocation();
@@ -46,14 +68,7 @@ export function useLocale() {
 
   const setLocale = async (locale: string) => {
     persistLocale(locale);
-
-    // `onLocaleChange` is a server-side hook, so it needs a request to fire —
-    // but the language switch must not wait on a round trip, nor be cancelled
-    // by one that fails. Fire and forget: the route re-sets the same cookie,
-    // which is already correct locally either way.
-    void fetch(`/api/__gemi__/services/i18n/set-locale/${locale}`).catch(
-      () => {},
-    );
+    notifyLocaleChange(locale);
 
     const urlSearchParams = new URLSearchParams(search);
     await replace(pathname, {

--- a/packages/gemi/i18n/I18nRouter.ts
+++ b/packages/gemi/i18n/I18nRouter.ts
@@ -5,11 +5,16 @@ import { Translator } from "./Translator";
 export class I18nRouter extends ApiRouter {
   middlewares = ["cache:private,0,no-store"];
   routes = {
+    // Fires `onLocaleChange` and nothing else. The `i18n-locale` cookie is
+    // written by the client before it navigates (`useLocale`), because the
+    // navigation's own route-data request already has to carry it. Setting it
+    // here as well could only ever undo that: this response would replace the
+    // client's year-long cookie with a session one, and two switches in quick
+    // succession put two responses in flight, where the later-landing one wins
+    // regardless of which locale the user actually stopped on.
     "/set-locale/:locale": this.get(async () => {
       const req = new HttpRequest<any, any>();
       const locale = req.params.locale;
-      console.log(`Setting locale to ${locale}`);
-      req.ctx().setCookie("i18n-locale", locale);
       await app(Translator).onLocaleChange(locale);
       return { locale };
     }),


### PR DESCRIPTION
Follow-up to #398. These are the four review findings from that PR — they were pushed as `6290ad4` seven minutes after the squash-merge landed, so the merge captured only the first commit and none of the fixes. Everything below is currently live on `main`.

## What was wrong on main

**medium — `/set-locale` undoes the client's cookie seconds after it is written.** The route sets `i18n-locale` with no `maxAge`/`expires`, over the same name and `Path=/` the client just wrote with a year on it, so the response replaces a persistent cookie with a session one. Pick Türkçe, quit the browser, relaunch → the cookie is gone and `detectLocale` falls back to `accept-language`. Nothing restores the year in practice: the only route that sets an expiry is `/translations/:locale`, and `fetchTranslations` has no callers outside its own definition. Before #398 the request only fired on browsers without `cookieStore`; now every switch takes the downgrade.

**low — rapid switching can leave the cookie naming a stale locale.** Two `/set-locale` requests per double-click, responding out of order; the loser's `Set-Cookie` wins. Click TR then EN quickly and the URL settles on `en-US` while the cookie ends up `tr-TR`, so the next reload 302s back to `/tr-TR/…`.

**low — a synchronous throw skips the navigation.** `fetch` is called before `replace` and outside any `try`. Where `globalThis.fetch` is missing (old WebViews) the call throws synchronously and `replace` never runs — the same silent no-op #398 fixed, through another door.

**low — `locale` interpolated raw into `document.cookie`.** `cookieStore.set()` rejected malformed values; a raw string write does not. An app wiring the switcher to untrusted input (`setLocale(searchParams.get("lang"))`) can write cookie *attributes* through it.

## The fix

`/set-locale` no longer sets the cookie — the client already has to write it before it navigates (the default-locale redirect forces that), so a write on the response could only ever race the first one. Adding `expires` would have fixed the persistence and left the ordering bug intact; dropping the write fixes both and settles ownership. The route keeps firing `onLocaleChange`, which is now its whole job. Its per-request `console.log` goes with it.

`Lang.setLocale` still sets the cookie with a year, and validates against `supportedLocales` — that server-side path is untouched.

The request is wrapped in a `notifyLocaleChange` helper with its own `try`, and the locale is encoded into both the cookie value and the URL path.

## Tests

Two added to `packages/gemi/client/useLocale.test.tsx`, both verified failing against `4bcd600`:

- navigates on a runtime with no `fetch` at all
- keeps a malformed locale inside the cookie value (`en-US; Domain=.example.com` round-trips intact instead of truncating at the `;`)

5/5 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126d5QL4Z7DzQgfYSpmUvVw