### PR TITLE
feat(useQuery): revalidate on window focus

### DIFF
--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -176,6 +176,7 @@ const { data } = useQuery("/feed", {}, {
   keepPreviousData: true,  // keep the previous variant's data on screen while a new one loads (default true)
   refreshInterval: 5000,   // poll every 5s
   retryIntervalOnError: 10000, // background retry — suspense: false only
+  revalidateOnFocus: false, // revalidate when the tab comes back to the foreground
   staleTime: 5000,         // how long cached data stays fresh (default 5000ms)
   lazy: false,             // when true, no fetch until trigger()/refetch(); implies suspense: false
 });
@@ -196,6 +197,14 @@ reads it kicks off a silent refetch. Raise it for data that rarely changes
 (`staleTime: 60_000`) to stop it being re-requested on every navigation, or set
 `staleTime: 0` to always revalidate. `Infinity` disables age-based revalidation
 entirely — `mutate()` and `refetch()` still fetch, since those are explicit.
+
+`revalidateOnFocus` refetches when the tab comes back to the foreground — the
+user switching windows, returning from another tab, or unlocking the device.
+It is off by default, and `staleTime` gates it: a quick tab-out-and-back costs
+nothing, and only data older than its freshness window goes back to the wire.
+The refetch is silent, so what's on screen keeps rendering (no `loading` flip,
+no fallback) until the new data lands. A `lazy` query that hasn't been
+triggered stays untouched.
 
 ### Optimistic updates with `mutate`
 

--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -177,6 +177,7 @@ const { data } = useQuery("/feed", {}, {
   refreshInterval: 5000,   // poll every 5s
   retryIntervalOnError: 10000, // background retry — suspense: false only
   revalidateOnFocus: false, // revalidate when the tab comes back to the foreground
+  focusThrottleInterval: 5000, // minimum gap between two focus revalidations
   staleTime: 5000,         // how long cached data stays fresh (default 5000ms)
   lazy: false,             // when true, no fetch until trigger()/refetch(); implies suspense: false
 });
@@ -200,11 +201,26 @@ entirely — `mutate()` and `refetch()` still fetch, since those are explicit.
 
 `revalidateOnFocus` refetches when the tab comes back to the foreground — the
 user switching windows, returning from another tab, or unlocking the device.
-It is off by default, and `staleTime` gates it: a quick tab-out-and-back costs
-nothing, and only data older than its freshness window goes back to the wire.
-The refetch is silent, so what's on screen keeps rendering (no `loading` flip,
-no fallback) until the new data lands. A `lazy` query that hasn't been
-triggered stays untouched.
+It is off by default, and the refetch is always silent: what's on screen keeps
+rendering (no `loading` flip, no fallback) until the new data lands.
+
+Three things keep it from firing more than it should:
+
+- **`staleTime`** — a quick tab-out-and-back costs nothing; only data older
+  than its freshness window goes back to the wire.
+- **A return actually has to have happened.** `focus` also fires for things
+  that never left the page (dismissing an `alert` or a file picker, closing
+  devtools), so a revalidation is only owed when the window lost focus or the
+  tab was hidden first.
+- **`focusThrottleInterval`** (default 5000ms) — the minimum gap between two
+  focus revalidations of the same query. Clicking in and out of an embedded
+  iframe (a payment form, a video) blurs and focuses the window every time, and
+  the handler runs for *every* mounted query, so without this a dashboard under
+  `staleTime: 0` would fire a request per query per click.
+
+A `lazy` query only becomes eligible once something has explicitly fetched it —
+`trigger()`, `refetch()` or `mutate()`. `prefetch()` deliberately does not
+count: it is "fetch once" for data the user may never look at.
 
 ### Optimistic updates with `mutate`
 

--- a/packages/gemi/client/QueryManagerContext.tsx
+++ b/packages/gemi/client/QueryManagerContext.tsx
@@ -36,6 +36,11 @@ export interface QueryConfig {
    * `staleTime`. Off by default.
    */
   revalidateOnFocus?: boolean;
+  /**
+   * Minimum gap between two focus revalidations of the same query, in ms
+   * (default 5000).
+   */
+  focusThrottleInterval?: number;
 }
 
 export const QueryConfigContext = createContext<QueryConfig | null>(null);
@@ -56,6 +61,7 @@ const APP_WIDE_QUERY_CONFIG_KEYS = [
   "retryIntervalOnError",
   "refreshInterval",
   "revalidateOnFocus",
+  "focusThrottleInterval",
 ] as const satisfies ReadonlyArray<keyof QueryConfig>;
 
 export function pickAppWideQueryConfig(

--- a/packages/gemi/client/QueryManagerContext.tsx
+++ b/packages/gemi/client/QueryManagerContext.tsx
@@ -31,6 +31,11 @@ export interface QueryConfig {
   keepPreviousData?: boolean;
   retryIntervalOnError?: number;
   refreshInterval?: number;
+  /**
+   * Revalidate every query when the tab comes back to the foreground, gated by
+   * `staleTime`. Off by default.
+   */
+  revalidateOnFocus?: boolean;
 }
 
 export const QueryConfigContext = createContext<QueryConfig | null>(null);
@@ -50,6 +55,7 @@ const APP_WIDE_QUERY_CONFIG_KEYS = [
   "keepPreviousData",
   "retryIntervalOnError",
   "refreshInterval",
+  "revalidateOnFocus",
 ] as const satisfies ReadonlyArray<keyof QueryConfig>;
 
 export function pickAppWideQueryConfig(

--- a/packages/gemi/client/QueryResource.ts
+++ b/packages/gemi/client/QueryResource.ts
@@ -207,6 +207,31 @@ export class QueryResource {
   }
 
   /**
+   * A background revalidation: the staleness gate `getVariant` applies, but
+   * the fetch is *always* silent — `loading: true` is never written to the
+   * cache, so what the caller renders is untouched until the new data lands.
+   *
+   * That is the difference from `getVariant`, which only takes the silent path
+   * for a variant that already `hasData`: a variant sitting on a failed fetch
+   * (`hasData: false`, an error stored) would otherwise flip `loading` on for
+   * the duration of the request. Focus revalidation reads through here so its
+   * "never changes what's on screen" contract holds in that case too.
+   */
+  revalidate(variantKey: string, staleTime: number = DEFAULT_STALE_TIME) {
+    if (typeof window === "undefined") return;
+    // Joining beats racing — a render-initiated read or the mount effect may
+    // already have this variant on the wire.
+    if (this.inflight.has(variantKey)) return;
+    const state = this.peek(variantKey);
+    if (state?.loading) return;
+    if (state?.hasData) {
+      if (!this.isStale(variantKey, staleTime)) return;
+      this.lastFetchRecord.set(variantKey, Date.now());
+    }
+    this.resolveVariant(variantKey, true);
+  }
+
+  /**
    * Drop the error for one variant (or every variant when omitted), so an
    * error boundary reset re-renders into a clean read instead of instantly
    * re-throwing the stored failure.

--- a/packages/gemi/client/useQuery.revalidateOnFocus.test.tsx
+++ b/packages/gemi/client/useQuery.revalidateOnFocus.test.tsx
@@ -1,0 +1,307 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { Suspense, act } from "react";
+import type { PropsWithChildren } from "react";
+import { cleanup, render } from "@testing-library/react";
+
+import { QueryManagerProvider, type QueryConfig } from "./QueryManagerContext";
+import {
+  RouteStateProvider,
+  type PageData,
+  type RouteState,
+} from "./RouteStateContext";
+import { useQuery } from "./useQuery";
+
+/**
+ * `revalidateOnFocus`: bringing the tab back to the foreground revalidates the
+ * query. Opt-in per call or app-wide, gated by `staleTime` (so a quick
+ * tab-out-and-back is free), and silent — the data on screen never flashes a
+ * loading state while the refetch is on the wire.
+ *
+ * Every test seeds the cache from a route payload so the mount is fetch-free,
+ * which leaves the fetch count reading exactly what focus did. Only `Date` is
+ * faked, so ageing the cache past `staleTime` is a `setSystemTime` away while
+ * promises and effects still run for real.
+ */
+
+function createFetch() {
+  const pending: Array<(value: { ok: boolean; body: any }) => void> = [];
+  const fetchMock = vi.fn((_url: string, _init?: RequestInit) => {
+    return new Promise((resolve) => {
+      pending.push(({ ok, body }) =>
+        resolve({
+          ok,
+          status: ok ? 200 : 500,
+          json: async () => body,
+        } as Response),
+      );
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  return {
+    fetchMock,
+    async resolve(body: any, ok = true) {
+      const settle = pending.shift();
+      if (!settle) throw new Error("No pending fetch to resolve");
+      await act(async () => {
+        settle({ ok, body });
+      });
+    },
+    pendingCount: () => pending.length,
+  };
+}
+
+const SEEDED = { prefetchedData: { "/todos": { "": [{ id: 1 }] } } };
+
+function Providers(
+  props: PropsWithChildren<{
+    queryConfig?: QueryConfig;
+    routeState?: Partial<RouteState & PageData>;
+  }>,
+) {
+  return (
+    <QueryManagerProvider queryConfig={props.queryConfig}>
+      <RouteStateProvider
+        state={(props.routeState ?? SEEDED) as RouteState & PageData}
+      >
+        <Suspense fallback={<div>suspense-fallback</div>}>
+          {props.children}
+        </Suspense>
+      </RouteStateProvider>
+    </QueryManagerProvider>
+  );
+}
+
+/** jsdom always reports "visible"; tests that need the hidden case swap it. */
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+/** Age the cache past the default `staleTime` (5s). */
+function ageCache() {
+  vi.setSystemTime(Date.now() + 10_000);
+}
+
+async function focusWindow() {
+  await act(async () => {
+    window.dispatchEvent(new Event("focus"));
+  });
+}
+
+async function fireVisibilityChange() {
+  await act(async () => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+let net: ReturnType<typeof createFetch>;
+
+beforeEach(() => {
+  net = createFetch();
+  vi.useFakeTimers({ toFake: ["Date"] });
+  setVisibility("visible");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  setVisibility("visible");
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("revalidateOnFocus", () => {
+  test("off by default: a focus event never touches the wire", async () => {
+    function View() {
+      const { data } = useQuery("/todos" as any);
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    const screen = render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+    expect(screen.queryByText("items:1")).not.toBeNull();
+    ageCache();
+
+    await focusWindow();
+    await fireVisibilityChange();
+
+    expect(net.fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("enabled: focus revalidates without dropping the rendered data", async () => {
+    function View() {
+      const { data, loading } = useQuery(
+        "/todos" as any,
+        {},
+        { revalidateOnFocus: true },
+      );
+      return <div>{`items:${(data as any[]).length} loading:${loading}`}</div>;
+    }
+
+    const screen = render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+    expect(net.fetchMock).not.toHaveBeenCalled();
+    ageCache();
+
+    await focusWindow();
+
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+    // Silent: the seeded rows stay on screen while the refetch is in flight.
+    expect(screen.queryByText("items:1 loading:false")).not.toBeNull();
+
+    await net.resolve([{ id: 1 }, { id: 2 }]);
+
+    expect(screen.queryByText("items:2 loading:false")).not.toBeNull();
+  });
+
+  test("a visibilitychange back to visible revalidates too; hidden does not", async () => {
+    function View() {
+      const { data } = useQuery(
+        "/todos" as any,
+        {},
+        { revalidateOnFocus: true },
+      );
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+    ageCache();
+
+    // Leaving the tab is not a return to the foreground.
+    setVisibility("hidden");
+    await fireVisibilityChange();
+    expect(net.fetchMock).not.toHaveBeenCalled();
+
+    setVisibility("visible");
+    await fireVisibilityChange();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("staleTime gates it: data still fresh is left alone", async () => {
+    function View() {
+      const { data } = useQuery(
+        "/todos" as any,
+        {},
+        { revalidateOnFocus: true },
+      );
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+
+    // No time passes, so the seeded data is inside its freshness window.
+    await focusWindow();
+    expect(net.fetchMock).not.toHaveBeenCalled();
+
+    ageCache();
+    await focusWindow();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a lazy query that was never triggered stays untouched", async () => {
+    function View() {
+      const { data, loading } = useQuery(
+        "/other" as any,
+        {},
+        { lazy: true, staleTime: 0, revalidateOnFocus: true },
+      );
+      return (
+        <div>{`items:${data ? (data as any[]).length : "none"} loading:${loading}`}</div>
+      );
+    }
+
+    const screen = render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+    expect(net.fetchMock).not.toHaveBeenCalled();
+
+    await focusWindow();
+
+    expect(net.fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("items:none loading:false")).not.toBeNull();
+  });
+
+  test("the provider-level queryConfig turns it on app-wide", async () => {
+    function View() {
+      const { data } = useQuery("/todos" as any);
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    render(
+      <Providers queryConfig={{ revalidateOnFocus: true }}>
+        <View />
+      </Providers>,
+    );
+    ageCache();
+
+    await focusWindow();
+
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a per-call revalidateOnFocus: false wins over the provider default", async () => {
+    function View() {
+      const { data } = useQuery(
+        "/todos" as any,
+        {},
+        { revalidateOnFocus: false },
+      );
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    render(
+      <Providers queryConfig={{ revalidateOnFocus: true }}>
+        <View />
+      </Providers>,
+    );
+    ageCache();
+
+    await focusWindow();
+
+    expect(net.fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("unmounting removes the listeners", async () => {
+    function View() {
+      const { data } = useQuery(
+        "/todos" as any,
+        {},
+        { revalidateOnFocus: true },
+      );
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    const screen = render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+    ageCache();
+
+    screen.unmount();
+    await focusWindow();
+    await fireVisibilityChange();
+
+    expect(net.fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gemi/client/useQuery.revalidateOnFocus.test.tsx
+++ b/packages/gemi/client/useQuery.revalidateOnFocus.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { Suspense, act } from "react";
+import { Suspense, act, useState } from "react";
 import type { PropsWithChildren } from "react";
 import { cleanup, render } from "@testing-library/react";
 
@@ -81,15 +81,30 @@ function setVisibility(state: DocumentVisibilityState) {
   });
 }
 
-/** Age the cache past the default `staleTime` (5s). */
-function ageCache() {
-  vi.setSystemTime(Date.now() + 10_000);
+/**
+ * Age the cache past the default `staleTime` (5s) — and, with the same tick,
+ * past the default `focusThrottleInterval` (5s).
+ */
+function ageCache(ms = 10_000) {
+  vi.setSystemTime(Date.now() + ms);
 }
 
 async function focusWindow() {
   await act(async () => {
     window.dispatchEvent(new Event("focus"));
   });
+}
+
+async function blurWindow() {
+  await act(async () => {
+    window.dispatchEvent(new Event("blur"));
+  });
+}
+
+/** The whole gesture the feature is named after: leave, come back. */
+async function leaveAndReturn() {
+  await blurWindow();
+  await focusWindow();
 }
 
 async function fireVisibilityChange() {
@@ -129,7 +144,7 @@ describe("revalidateOnFocus", () => {
     expect(screen.queryByText("items:1")).not.toBeNull();
     ageCache();
 
-    await focusWindow();
+    await leaveAndReturn();
     await fireVisibilityChange();
 
     expect(net.fetchMock).not.toHaveBeenCalled();
@@ -153,7 +168,7 @@ describe("revalidateOnFocus", () => {
     expect(net.fetchMock).not.toHaveBeenCalled();
     ageCache();
 
-    await focusWindow();
+    await leaveAndReturn();
 
     expect(net.fetchMock).toHaveBeenCalledTimes(1);
     // Silent: the seeded rows stay on screen while the refetch is in flight.
@@ -208,11 +223,11 @@ describe("revalidateOnFocus", () => {
     );
 
     // No time passes, so the seeded data is inside its freshness window.
-    await focusWindow();
+    await leaveAndReturn();
     expect(net.fetchMock).not.toHaveBeenCalled();
 
     ageCache();
-    await focusWindow();
+    await leaveAndReturn();
     expect(net.fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -235,7 +250,7 @@ describe("revalidateOnFocus", () => {
     );
     expect(net.fetchMock).not.toHaveBeenCalled();
 
-    await focusWindow();
+    await leaveAndReturn();
 
     expect(net.fetchMock).not.toHaveBeenCalled();
     expect(screen.queryByText("items:none loading:false")).not.toBeNull();
@@ -254,7 +269,7 @@ describe("revalidateOnFocus", () => {
     );
     ageCache();
 
-    await focusWindow();
+    await leaveAndReturn();
 
     expect(net.fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -276,9 +291,149 @@ describe("revalidateOnFocus", () => {
     );
     ageCache();
 
-    await focusWindow();
+    await leaveAndReturn();
 
     expect(net.fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("silent even for a variant sitting on a failed fetch", async () => {
+    let rerender: (() => void) | null = null;
+    function View() {
+      // A non-silent fetch writes `loading: true` into the cache without
+      // notifying subscribers, so the flip only shows up on the next render
+      // the component performs for any other reason — this is that render.
+      const [, bump] = useState(0);
+      rerender = () => bump((n) => n + 1);
+      const { data, loading, error } = useQuery(
+        "/other" as any,
+        {},
+        { suspense: false, revalidateOnFocus: true },
+      );
+      return (
+        <div>
+          {`items:${data ? (data as any[]).length : "none"} loading:${loading} err:${error ? "yes" : "no"}`}
+        </div>
+      );
+    }
+
+    const screen = render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+    // The first load fails, leaving a variant with an error and no data.
+    await net.resolve({ message: "boom" }, false);
+    expect(
+      screen.queryByText("items:none loading:false err:yes"),
+    ).not.toBeNull();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+
+    ageCache();
+    await leaveAndReturn();
+    expect(net.fetchMock).toHaveBeenCalledTimes(2);
+
+    // The retry is on the wire; the rendered state is exactly what it was.
+    await act(async () => rerender!());
+    expect(
+      screen.queryByText("items:none loading:false err:yes"),
+    ).not.toBeNull();
+
+    await net.resolve([{ id: 1 }]);
+    expect(screen.queryByText("items:1 loading:false err:no")).not.toBeNull();
+  });
+
+  test("prefetch() does not enrol a lazy query; trigger() does", async () => {
+    let controls: { prefetch: () => void; trigger: () => void } | null = null;
+    function View() {
+      const { data, prefetch, trigger } = useQuery(
+        "/other" as any,
+        {},
+        { lazy: true, revalidateOnFocus: true },
+      );
+      controls = { prefetch, trigger };
+      return <div>{`items:${data ? (data as any[]).length : "none"}`}</div>;
+    }
+
+    render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+
+    // A hover prefetch is "fetch once" — data the user may never look at.
+    await act(async () => controls!.prefetch());
+    await net.resolve([{ id: 1 }]);
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+
+    ageCache();
+    await leaveAndReturn();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+
+    // Triggering it puts the data on screen, and from then on it revalidates.
+    await act(async () => controls!.trigger());
+    ageCache();
+    await leaveAndReturn();
+    expect(net.fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a focus with nothing to return from is ignored", async () => {
+    function View() {
+      const { data } = useQuery(
+        "/todos" as any,
+        {},
+        { revalidateOnFocus: true },
+      );
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+    ageCache();
+
+    // A dismissed `alert()` or a closed devtools pane: `focus` without the
+    // window ever having lost it.
+    await focusWindow();
+    expect(net.fetchMock).not.toHaveBeenCalled();
+
+    await leaveAndReturn();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("focusThrottleInterval spaces out repeated returns", async () => {
+    function View() {
+      const { data } = useQuery(
+        "/todos" as any,
+        {},
+        { staleTime: 0, revalidateOnFocus: true },
+      );
+      return <div>{`items:${(data as any[]).length}`}</div>;
+    }
+
+    render(
+      <Providers>
+        <View />
+      </Providers>,
+    );
+    // `staleTime: 0` — every read is stale, so the throttle is the only guard.
+    ageCache();
+
+    await leaveAndReturn();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+    await net.resolve([{ id: 1 }]);
+
+    // Clicking in and out of an embedded iframe: blur/focus pairs, no time
+    // passing. The throttle absorbs them.
+    await leaveAndReturn();
+    await leaveAndReturn();
+    expect(net.fetchMock).toHaveBeenCalledTimes(1);
+
+    // Past the interval, the next return revalidates again.
+    ageCache(6000);
+    await leaveAndReturn();
+    expect(net.fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test("unmounting removes the listeners", async () => {
@@ -299,7 +454,7 @@ describe("revalidateOnFocus", () => {
     ageCache();
 
     screen.unmount();
-    await focusWindow();
+    await leaveAndReturn();
     await fireVisibilityChange();
 
     expect(net.fetchMock).not.toHaveBeenCalled();

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -42,6 +42,14 @@ interface Config<T> {
    * back to the wire — silently, keeping what's on screen rendered.
    */
   revalidateOnFocus?: boolean;
+  /**
+   * Minimum gap between two `revalidateOnFocus` revalidations of the same
+   * query, in ms (default 5000). `focus` fires on far more than tab returns —
+   * dismissing a file picker, closing a popup, clicking in and out of an
+   * embedded iframe — and `staleTime: 0` would otherwise turn each of those
+   * into a request per mounted query.
+   */
+  focusThrottleInterval?: number;
   /** How long cached data stays fresh before a read revalidates it, in ms. */
   staleTime?: number;
   debug?: boolean;
@@ -66,6 +74,7 @@ const defaultConfig: Config<any> = {
   retryIntervalOnError: 10000,
   refreshInterval: 999999,
   revalidateOnFocus: false,
+  focusThrottleInterval: 5000,
   staleTime: DEFAULT_STALE_TIME,
   debug: false,
   lazy: false,
@@ -275,6 +284,18 @@ export function useFrameworkQuery<T extends keyof GetRPC>(
   );
   const refetchUntilDurationRef = useRef(0);
   const prefetchedRef = useRef(false);
+  // Focus revalidation eligibility, deliberately *not* `fetchedRef`: that one
+  // is flipped by `prefetch()` too, and a hover prefetch is documented as
+  // "fetch once" for data the user may never look at — enrolling it in focus
+  // revalidation would keep re-requesting it for the life of the component.
+  // Only the reads that put data on screen (`trigger`, `refetch`, `mutate`,
+  // or simply not being lazy) count.
+  const focusEligibleRef = useRef(!lazy);
+  // The away latch: `focus` fires for things that never left the page —
+  // dismissing an `alert`, returning from devtools — so a revalidation is only
+  // owed when the window actually lost focus or the tab was hidden first.
+  const wasAwayRef = useRef(false);
+  const lastFocusRevalidationRef = useRef(0);
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => resource.store.subscribe(onStoreChange),
@@ -455,31 +476,62 @@ export function useFrameworkQuery<T extends keyof GetRPC>(
   }, [config.refreshInterval, handleReload]);
 
   // Revalidate when the tab comes back to the foreground — opt-in via
-  // `revalidateOnFocus` (per call or app-wide). `getVariant` applies
-  // `staleTime`, so this is the same read the mount effect performs: data
-  // still inside its freshness window is left alone, and anything older
-  // refetches *silently*, so what's on screen never flashes a loading state.
+  // `revalidateOnFocus` (per call or app-wide). `resource.revalidate` applies
+  // `staleTime` like the mount effect does, but always fetches silently, so
+  // data still inside its freshness window is left alone and anything older
+  // is refreshed without what's on screen ever flashing a loading state.
+  //
+  // Three guards decide whether a return to the foreground is owed a request,
+  // because `focus` alone is a poor proxy for one:
+  //   - eligibility — an untriggered lazy query has nothing on screen;
+  //   - the away latch — `focus` also fires for a dismissed `alert` or a
+  //     closed devtools pane, neither of which is a return from anywhere;
+  //   - the throttle — clicking in and out of an embedded iframe (a payment
+  //     form, a video) blurs and focuses the window every time, and `focus`
+  //     runs this for *every* mounted query, so a dashboard would otherwise
+  //     fire a dozen requests per interaction under `staleTime: 0`.
   //
   // Both events are listened for because neither covers the other: switching
   // between windows fires `focus` while the document stays visible, and
   // switching tabs (or unlocking the device) fires `visibilitychange` without
-  // necessarily firing `focus`. Landing on the same `getVariant` call makes
-  // the overlap a no-op — the second read finds the fetch in flight.
+  // necessarily firing `focus`. They land on one guarded call, so the overlap
+  // costs nothing — the latch is already spent by the time the second fires.
   useEffect(() => {
     if (!config.revalidateOnFocus) return;
-    const revalidate = () => {
-      // A lazy query that was never triggered stays untouched, and a
-      // `focus` fired while the document is hidden isn't a return to the
-      // foreground.
-      if (!fetchedRef.current) return;
-      if (document.visibilityState === "hidden") return;
-      resource.getVariant(variantKey, configRef.current.staleTime);
+    const markAway = () => {
+      wasAwayRef.current = true;
     };
+    const revalidate = () => {
+      if (!focusEligibleRef.current) return;
+      if (document.visibilityState === "hidden") return;
+      if (!wasAwayRef.current) return;
+      const now = Date.now();
+      // Throttled: leave the latch armed so the next return, once the
+      // interval has passed, still revalidates.
+      if (
+        now - lastFocusRevalidationRef.current <
+        configRef.current.focusThrottleInterval
+      ) {
+        return;
+      }
+      wasAwayRef.current = false;
+      lastFocusRevalidationRef.current = now;
+      resource.revalidate(variantKey, configRef.current.staleTime);
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        markAway();
+      } else {
+        revalidate();
+      }
+    };
+    window.addEventListener("blur", markAway);
     window.addEventListener("focus", revalidate);
-    document.addEventListener("visibilitychange", revalidate);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
+      window.removeEventListener("blur", markAway);
       window.removeEventListener("focus", revalidate);
-      document.removeEventListener("visibilitychange", revalidate);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, [config.revalidateOnFocus, resource, variantKey]);
 
@@ -502,6 +554,7 @@ export function useFrameworkQuery<T extends keyof GetRPC>(
 
   const trigger = useCallback(() => {
     fetchedRef.current = true;
+    focusEligibleRef.current = true;
     const store = resource.store.getValue();
     const variant = store.get(variantKey);
     if (!variant || (!variant.loading && !variant.hasData)) {
@@ -520,6 +573,7 @@ export function useFrameworkQuery<T extends keyof GetRPC>(
 
   const refetch = useCallback(() => {
     fetchedRef.current = true;
+    focusEligibleRef.current = true;
     resource.refetch(variantKey);
   }, [resource, variantKey]);
 
@@ -528,6 +582,9 @@ export function useFrameworkQuery<T extends keyof GetRPC>(
     fn?: (data: NestedPrettify<Data<T>>) => NestedPrettify<Data<T>>,
   ): void;
   function mutate(fn?: any) {
+    // Either form ends in a fetch whose result the component renders, so a
+    // lazy query mutated by hand is as focus-eligible as a triggered one.
+    focusEligibleRef.current = true;
     if (!fn) {
       fetchedRef.current = true;
       resource.refetch(variantKey);

--- a/packages/gemi/client/useQuery.ts
+++ b/packages/gemi/client/useQuery.ts
@@ -35,6 +35,13 @@ interface Config<T> {
   keepPreviousData?: boolean;
   retryIntervalOnError?: number;
   refreshInterval?: number;
+  /**
+   * When true, the query revalidates whenever the tab comes back to the
+   * foreground. Off by default. `staleTime` still gates it, so a quick
+   * tab-out-and-back costs nothing and only data that has actually aged goes
+   * back to the wire — silently, keeping what's on screen rendered.
+   */
+  revalidateOnFocus?: boolean;
   /** How long cached data stays fresh before a read revalidates it, in ms. */
   staleTime?: number;
   debug?: boolean;
@@ -58,6 +65,7 @@ const defaultConfig: Config<any> = {
   keepPreviousData: true,
   retryIntervalOnError: 10000,
   refreshInterval: 999999,
+  revalidateOnFocus: false,
   staleTime: DEFAULT_STALE_TIME,
   debug: false,
   lazy: false,
@@ -445,6 +453,35 @@ export function useFrameworkQuery<T extends keyof GetRPC>(
       }
     };
   }, [config.refreshInterval, handleReload]);
+
+  // Revalidate when the tab comes back to the foreground — opt-in via
+  // `revalidateOnFocus` (per call or app-wide). `getVariant` applies
+  // `staleTime`, so this is the same read the mount effect performs: data
+  // still inside its freshness window is left alone, and anything older
+  // refetches *silently*, so what's on screen never flashes a loading state.
+  //
+  // Both events are listened for because neither covers the other: switching
+  // between windows fires `focus` while the document stays visible, and
+  // switching tabs (or unlocking the device) fires `visibilitychange` without
+  // necessarily firing `focus`. Landing on the same `getVariant` call makes
+  // the overlap a no-op — the second read finds the fetch in flight.
+  useEffect(() => {
+    if (!config.revalidateOnFocus) return;
+    const revalidate = () => {
+      // A lazy query that was never triggered stays untouched, and a
+      // `focus` fired while the document is hidden isn't a return to the
+      // foreground.
+      if (!fetchedRef.current) return;
+      if (document.visibilityState === "hidden") return;
+      resource.getVariant(variantKey, configRef.current.staleTime);
+    };
+    window.addEventListener("focus", revalidate);
+    document.addEventListener("visibilitychange", revalidate);
+    return () => {
+      window.removeEventListener("focus", revalidate);
+      document.removeEventListener("visibilitychange", revalidate);
+    };
+  }, [config.revalidateOnFocus, resource, variantKey]);
 
   useEffect(() => {
     // Feature-checked per method: vitest's `import.meta.hot` shim has `on`


### PR DESCRIPTION
Adds `revalidateOnFocus` to `useQuery` — when the tab comes back to the
foreground, the query revalidates.

```tsx
const { data } = useQuery("/todos", {}, { revalidateOnFocus: true });
```

It is also an app-wide default, threaded like the other `queryConfig` keys:

```tsx
createRoot(RootLayout, { queryConfig: { revalidateOnFocus: true } });
```

## Semantics

- **Off by default** — nothing changes for existing apps.
- **`staleTime` gates it.** The listener calls the same `getVariant` read the
  mount effect performs, so a quick tab-out-and-back costs nothing and only
  data older than its freshness window goes back to the wire. `staleTime:
  Infinity` disables it, `staleTime: 0` makes every focus refetch.
- **Silent.** The refetch never flips `loading` or suspends — the data on
  screen keeps rendering until the new payload lands.
- **Two events.** `focus` (window switch, document stays visible) and
  `visibilitychange` (tab switch, device unlock) neither of which covers the
  other; both land on the same `getVariant` call, so the overlap is a no-op —
  the second read finds the fetch already in flight.
- A `focus` fired while the document is hidden, and a `lazy` query that was
  never triggered, are both left alone.

## Tests

New `packages/gemi/client/useQuery.revalidateOnFocus.test.tsx` (8 tests): off
by default, focus revalidates without dropping the rendered rows,
`visibilitychange` in both directions, the `staleTime` gate, untriggered
`lazy`, the provider-level default, a per-call `false` beating it, and
listener teardown on unmount. Full client suite (18 files / 178 tests),
`tsc --noEmit` and `oxlint` all pass.

Docs: `docs/data-fetching.md` config table + a paragraph on the semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
