### PR TITLE
feat(orm): answer the Json null sentinels at a path (#407)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3786,10 +3786,10 @@ await AsyncJob.findMany({
 ```
 
 A bare `null` is accepted under these two operators and reads as `JsonNull`, which is Prisma's own
-reading — the two spellings compile to identical SQL. That is the opposite of the rule on the
-*column*, where `null` is a type error and the sentinel is required. The difference is real: a
-column has two empty states and guessing between them is the whole reason the sentinels exist,
-while at a path Prisma simply reads `null` as the JSON value.
+reading — the two spellings compile to identical SQL. Note it means something *different* on the
+column, where `null` reads as `DbNull` and compiles to `is null`. The asymmetry is Prisma's, and
+it is why writing the sentinel you mean is worth the keystrokes even where a bare `null` is
+accepted: a column has two empty states, and at a path the JSON value is the one Prisma picks.
 
 **Under the other seven operators a sentinel is refused, and so is a bare `null`.** They compare an
 extracted value against a scalar, and "which kind of null is this" is not a scalar question. Prisma

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3751,20 +3751,56 @@ element; Prisma's generated `path` is `string[]` and its client refuses a number
 one too rather than answering a query the differential harness has no oracle for. On SQLite the
 index lives inside the JSONPath string, `"$.items[0]"`.
 
-Four things a path filter refuses, each because answering would be silently wrong rather than
-merely unsupported:
+#### The null sentinels at a path
 
-- **The null sentinels.** `{ path: […], equals: DbNull }` is refused. An extracted value
-  cannot tell an absent key from a JSON `null` — `#>>` yields SQL NULL for both — so the
-  distinction the sentinels exist to make is already gone by the time the comparison happens.
-  Filter the column itself: `{ metadata: { equals: DbNull } }`.
-- **A bare `null`, under every operator**, for the same reason and one more. `= NULL` is NULL
-  rather than true, so `{ path: […], equals: null }` would run and match nothing; and under
-  `array_contains`, `x @> NULL` is NULL as well. Prisma *does* answer this one — it extracts with
-  `#>` and compares as `jsonb`, so it reads `null` as the JSON value and returns the rows holding
-  one, the same answer as `equals: JsonNull`. gemi cannot follow it there without a second,
-  Postgres-only implementation of every operator, so it names the limitation instead. A `null`
-  *inside* an `array_contains` document is an ordinary value and still compiles.
+`equals` and `not` answer the three sentinels one level down, and they mean what they mean on the
+column — with one adjustment, because a *key* has a third way of being empty that a column does not:
+
+```ts
+// the value at metadata.plan is missing: an absent key, or a column with
+// nothing to index into (SQL NULL, or a JSON null)
+await User.findMany({ where: { metadata: { path: ["plan"], equals: DbNull } } })
+
+// the value at metadata.plan is the JSON value null
+await User.findMany({ where: { metadata: { path: ["plan"], equals: JsonNull } } })
+
+// either, which is usually what you want
+await User.findMany({ where: { metadata: { path: ["plan"], equals: AnyNull } } })
+```
+
+`not` negates each: `not: DbNull` is "there is something there", `not: AnyNull` is "there is
+something there and it is not a JSON null".
+
+This is what makes a `COALESCE`-style fallback expressible — a column read where the value moved
+into the payload and old rows still carry it beside:
+
+```ts
+await AsyncJob.findMany({
+  where: {
+    OR: [
+      { payload: { path: ["operation"], equals: op } },
+      { name: op, payload: { path: ["operation"], equals: AnyNull } },
+    ],
+  },
+})
+```
+
+A bare `null` is accepted under these two operators and reads as `JsonNull`, which is Prisma's own
+reading — the two spellings compile to identical SQL. That is the opposite of the rule on the
+*column*, where `null` is a type error and the sentinel is required. The difference is real: a
+column has two empty states and guessing between them is the whole reason the sentinels exist,
+while at a path Prisma simply reads `null` as the JSON value.
+
+**Under the other seven operators a sentinel is refused, and so is a bare `null`.** They compare an
+extracted value against a scalar, and "which kind of null is this" is not a scalar question. Prisma
+refuses them there too.
+
+Three things a path filter still refuses, each because answering would be silently wrong rather
+than merely unsupported:
+
+- **A bare `null` under `array_contains`.** The operand binds as SQL NULL rather than as the JSON
+  value, and `x @> NULL` is NULL rather than true — the query would run and match nothing. A `null`
+  *inside* the document is an ordinary value and still compiles.
 - **A non-string operand to `string_contains` / `string_starts_with` / `string_ends_with`**, for
   the same reason the scalar `contains` refuses one: the pattern would become `%null%`, which runs
   and returns the wrong rows.
@@ -3784,8 +3820,8 @@ compiling to a predicate no row can satisfy.
 **What the type checks, and what it leaves to run time.** The path filter is typed: `path` takes
 either dialect's grammar, the ten operators are the ones above, and their operand types are the
 ones the compiler will compile. A misspelled operator, a `path` that is not one, a numeric path
-segment, a non-string under `string_contains`, a sentinel at a path and a `null` at a path are all
-compile errors. The type carries no dialect — the generated artifact does not know which database
+segment, a non-string under `string_contains`, and a sentinel or a `null` under any operator but
+`equals` and `not` are all compile errors. The type carries no dialect — the generated artifact does not know which database
 it will be pointed at — so the table above is offered in full on both and the wrong half is refused
 at run time, naming the dialect. The empty path is refused at run time too.
 
@@ -5313,6 +5349,9 @@ Two things are worth knowing:
   an `OR` you assemble yourself. It is a question about rows rather than a value, so writing it
   raises `InvalidArgumentError`, and so does using it under any operator other than `equals` and
   `not`. Prisma refuses all three of those too.
+
+  All three also work one level down, on a value inside the document — see
+  [The null sentinels at a path](#the-null-sentinels-at-a-path).
 
 On Postgres the parameter is cast — `$1::text::jsonb` — and the value serialised to match, which
 is what lets a bare number or boolean through. Binding it raw makes the driver send an `integer` to

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3786,21 +3786,26 @@ await AsyncJob.findMany({
 ```
 
 A bare `null` is accepted under these two operators and reads as `JsonNull`, which is Prisma's own
-reading — the two spellings compile to identical SQL. Note it means something *different* on the
-column, where `null` reads as `DbNull` and compiles to `is null`. The asymmetry is Prisma's, and
-it is why writing the sentinel you mean is worth the keystrokes even where a bare `null` is
-accepted: a column has two empty states, and at a path the JSON value is the one Prisma picks.
+reading — the two spellings compile to identical SQL. It does *not* mean that on the column, where
+gemi reads a bare `null` as `DbNull`; see
+[A bare `null` on a `Json` column](#a-bare-null-on-a-json-column-means-dbnull-here-and-jsonnull-on-prisma)
+below, which is a divergence rather than a rule. Writing the sentinel you mean is what makes a
+filter say the same thing in both positions.
 
-**Under the other seven operators a sentinel is refused, and so is a bare `null`.** They compare an
-extracted value against a scalar, and "which kind of null is this" is not a scalar question. Prisma
-refuses them there too.
+**Under the other eight operators a sentinel is refused**, and so is a bare `null`. The string
+filters want a string, the numeric comparisons want a number, and `array_contains` wants a
+document; "which kind of null is this" is none of those. Prisma refuses a sentinel under all eight
+too, on both dialects.
 
 Three things a path filter still refuses, each because answering would be silently wrong rather
 than merely unsupported:
 
 - **A bare `null` under `array_contains`.** The operand binds as SQL NULL rather than as the JSON
-  value, and `x @> NULL` is NULL rather than true — the query would run and match nothing. A `null`
-  *inside* the document is an ordinary value and still compiles.
+  value, and `x @> NULL` is NULL rather than true — the query would run and match nothing. Prisma
+  does compile this one, to a containment test guarded by `jsonb_typeof(…) = 'array'`, and it
+  matches nothing there too — so this is gemi refusing where the oracle answers, which is the one
+  direction of divergence this ORM prefers to be loud about. A `null` *inside* the document is an
+  ordinary value and still compiles.
 - **A non-string operand to `string_contains` / `string_starts_with` / `string_ends_with`**, for
   the same reason the scalar `contains` refuses one: the pattern would become `%null%`, which runs
   and returns the wrong rows.
@@ -5368,6 +5373,32 @@ JS string is JSON *text* rather than a JSON string value.
 > so nothing looked wrong from inside the ORM, but the column was wrong for anything else that read
 > it. Those rows now read back as strings. Re-seed development databases; there is no released
 > version affected.
+
+## A bare `null` on a `Json` column means `DbNull` here and `JsonNull` on Prisma
+
+**A known divergence, and it returns disjoint row sets rather than raising.** On every other column
+type a bare `null` in a filter means `is null`, and that is Prisma's reading too. On a `Json`
+column it is not: Prisma reads a bare `null` as the JSON *value* `null`, the same thing it reads at
+a path.
+
+Measured on a generated 6.19.2 client against Postgres 16 and SQLite, on a table holding both empty
+states:
+
+| filter | gemi | Prisma |
+| --- | --- | --- |
+| `{ metadata: { equals: null } }` | `"metadata" is null` — the SQL-NULL rows | `"metadata"::jsonb = 'null'` — the JSON-null rows |
+| `{ metadata: { not: null } }` | `is not null` | `<> 'null'`, which also excludes the JSON-null rows |
+
+**Write the sentinel and there is no divergence.** `{ equals: DbNull }` and `{ equals: JsonNull }`
+compile to the same predicate on both libraries, which is what the sentinels are for:
+
+```ts
+await User.findMany({ where: { metadata: { equals: DbNull } } })   // the SQL NULLs, both libraries
+await User.findMany({ where: { metadata: { equals: JsonNull } } }) // the JSON nulls, both libraries
+```
+
+This is the *column*. At a **path** a bare `null` reads as `JsonNull` and agrees with Prisma
+exactly — see [The null sentinels at a path](#the-null-sentinels-at-a-path).
 
 ## Run Postgres deployments with `TZ=UTC`
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -776,10 +776,10 @@ await AsyncJob.findMany({
 ```
 
 A bare `null` is accepted under these two operators and reads as `JsonNull`, which is Prisma's own
-reading — the two spellings compile to identical SQL. That is the opposite of the rule on the
-*column*, where `null` is a type error and the sentinel is required. The difference is real: a
-column has two empty states and guessing between them is the whole reason the sentinels exist,
-while at a path Prisma simply reads `null` as the JSON value.
+reading — the two spellings compile to identical SQL. Note it means something *different* on the
+column, where `null` reads as `DbNull` and compiles to `is null`. The asymmetry is Prisma's, and
+it is why writing the sentinel you mean is worth the keystrokes even where a bare `null` is
+accepted: a column has two empty states, and at a path the JSON value is the one Prisma picks.
 
 **Under the other seven operators a sentinel is refused, and so is a bare `null`.** They compare an
 extracted value against a scalar, and "which kind of null is this" is not a scalar question. Prisma

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -776,21 +776,26 @@ await AsyncJob.findMany({
 ```
 
 A bare `null` is accepted under these two operators and reads as `JsonNull`, which is Prisma's own
-reading — the two spellings compile to identical SQL. Note it means something *different* on the
-column, where `null` reads as `DbNull` and compiles to `is null`. The asymmetry is Prisma's, and
-it is why writing the sentinel you mean is worth the keystrokes even where a bare `null` is
-accepted: a column has two empty states, and at a path the JSON value is the one Prisma picks.
+reading — the two spellings compile to identical SQL. It does *not* mean that on the column, where
+gemi reads a bare `null` as `DbNull`; see
+[A bare `null` on a `Json` column](#a-bare-null-on-a-json-column-means-dbnull-here-and-jsonnull-on-prisma)
+below, which is a divergence rather than a rule. Writing the sentinel you mean is what makes a
+filter say the same thing in both positions.
 
-**Under the other seven operators a sentinel is refused, and so is a bare `null`.** They compare an
-extracted value against a scalar, and "which kind of null is this" is not a scalar question. Prisma
-refuses them there too.
+**Under the other eight operators a sentinel is refused**, and so is a bare `null`. The string
+filters want a string, the numeric comparisons want a number, and `array_contains` wants a
+document; "which kind of null is this" is none of those. Prisma refuses a sentinel under all eight
+too, on both dialects.
 
 Three things a path filter still refuses, each because answering would be silently wrong rather
 than merely unsupported:
 
 - **A bare `null` under `array_contains`.** The operand binds as SQL NULL rather than as the JSON
-  value, and `x @> NULL` is NULL rather than true — the query would run and match nothing. A `null`
-  *inside* the document is an ordinary value and still compiles.
+  value, and `x @> NULL` is NULL rather than true — the query would run and match nothing. Prisma
+  does compile this one, to a containment test guarded by `jsonb_typeof(…) = 'array'`, and it
+  matches nothing there too — so this is gemi refusing where the oracle answers, which is the one
+  direction of divergence this ORM prefers to be loud about. A `null` *inside* the document is an
+  ordinary value and still compiles.
 - **A non-string operand to `string_contains` / `string_starts_with` / `string_ends_with`**, for
   the same reason the scalar `contains` refuses one: the pattern would become `%null%`, which runs
   and returns the wrong rows.
@@ -2358,6 +2363,32 @@ JS string is JSON *text* rather than a JSON string value.
 > so nothing looked wrong from inside the ORM, but the column was wrong for anything else that read
 > it. Those rows now read back as strings. Re-seed development databases; there is no released
 > version affected.
+
+## A bare `null` on a `Json` column means `DbNull` here and `JsonNull` on Prisma
+
+**A known divergence, and it returns disjoint row sets rather than raising.** On every other column
+type a bare `null` in a filter means `is null`, and that is Prisma's reading too. On a `Json`
+column it is not: Prisma reads a bare `null` as the JSON *value* `null`, the same thing it reads at
+a path.
+
+Measured on a generated 6.19.2 client against Postgres 16 and SQLite, on a table holding both empty
+states:
+
+| filter | gemi | Prisma |
+| --- | --- | --- |
+| `{ metadata: { equals: null } }` | `"metadata" is null` — the SQL-NULL rows | `"metadata"::jsonb = 'null'` — the JSON-null rows |
+| `{ metadata: { not: null } }` | `is not null` | `<> 'null'`, which also excludes the JSON-null rows |
+
+**Write the sentinel and there is no divergence.** `{ equals: DbNull }` and `{ equals: JsonNull }`
+compile to the same predicate on both libraries, which is what the sentinels are for:
+
+```ts
+await User.findMany({ where: { metadata: { equals: DbNull } } })   // the SQL NULLs, both libraries
+await User.findMany({ where: { metadata: { equals: JsonNull } } }) // the JSON nulls, both libraries
+```
+
+This is the *column*. At a **path** a bare `null` reads as `JsonNull` and agrees with Prisma
+exactly — see [The null sentinels at a path](#the-null-sentinels-at-a-path).
 
 ## Run Postgres deployments with `TZ=UTC`
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -741,20 +741,56 @@ element; Prisma's generated `path` is `string[]` and its client refuses a number
 one too rather than answering a query the differential harness has no oracle for. On SQLite the
 index lives inside the JSONPath string, `"$.items[0]"`.
 
-Four things a path filter refuses, each because answering would be silently wrong rather than
-merely unsupported:
+#### The null sentinels at a path
 
-- **The null sentinels.** `{ path: […], equals: DbNull }` is refused. An extracted value
-  cannot tell an absent key from a JSON `null` — `#>>` yields SQL NULL for both — so the
-  distinction the sentinels exist to make is already gone by the time the comparison happens.
-  Filter the column itself: `{ metadata: { equals: DbNull } }`.
-- **A bare `null`, under every operator**, for the same reason and one more. `= NULL` is NULL
-  rather than true, so `{ path: […], equals: null }` would run and match nothing; and under
-  `array_contains`, `x @> NULL` is NULL as well. Prisma *does* answer this one — it extracts with
-  `#>` and compares as `jsonb`, so it reads `null` as the JSON value and returns the rows holding
-  one, the same answer as `equals: JsonNull`. gemi cannot follow it there without a second,
-  Postgres-only implementation of every operator, so it names the limitation instead. A `null`
-  *inside* an `array_contains` document is an ordinary value and still compiles.
+`equals` and `not` answer the three sentinels one level down, and they mean what they mean on the
+column — with one adjustment, because a *key* has a third way of being empty that a column does not:
+
+```ts
+// the value at metadata.plan is missing: an absent key, or a column with
+// nothing to index into (SQL NULL, or a JSON null)
+await User.findMany({ where: { metadata: { path: ["plan"], equals: DbNull } } })
+
+// the value at metadata.plan is the JSON value null
+await User.findMany({ where: { metadata: { path: ["plan"], equals: JsonNull } } })
+
+// either, which is usually what you want
+await User.findMany({ where: { metadata: { path: ["plan"], equals: AnyNull } } })
+```
+
+`not` negates each: `not: DbNull` is "there is something there", `not: AnyNull` is "there is
+something there and it is not a JSON null".
+
+This is what makes a `COALESCE`-style fallback expressible — a column read where the value moved
+into the payload and old rows still carry it beside:
+
+```ts
+await AsyncJob.findMany({
+  where: {
+    OR: [
+      { payload: { path: ["operation"], equals: op } },
+      { name: op, payload: { path: ["operation"], equals: AnyNull } },
+    ],
+  },
+})
+```
+
+A bare `null` is accepted under these two operators and reads as `JsonNull`, which is Prisma's own
+reading — the two spellings compile to identical SQL. That is the opposite of the rule on the
+*column*, where `null` is a type error and the sentinel is required. The difference is real: a
+column has two empty states and guessing between them is the whole reason the sentinels exist,
+while at a path Prisma simply reads `null` as the JSON value.
+
+**Under the other seven operators a sentinel is refused, and so is a bare `null`.** They compare an
+extracted value against a scalar, and "which kind of null is this" is not a scalar question. Prisma
+refuses them there too.
+
+Three things a path filter still refuses, each because answering would be silently wrong rather
+than merely unsupported:
+
+- **A bare `null` under `array_contains`.** The operand binds as SQL NULL rather than as the JSON
+  value, and `x @> NULL` is NULL rather than true — the query would run and match nothing. A `null`
+  *inside* the document is an ordinary value and still compiles.
 - **A non-string operand to `string_contains` / `string_starts_with` / `string_ends_with`**, for
   the same reason the scalar `contains` refuses one: the pattern would become `%null%`, which runs
   and returns the wrong rows.
@@ -774,8 +810,8 @@ compiling to a predicate no row can satisfy.
 **What the type checks, and what it leaves to run time.** The path filter is typed: `path` takes
 either dialect's grammar, the ten operators are the ones above, and their operand types are the
 ones the compiler will compile. A misspelled operator, a `path` that is not one, a numeric path
-segment, a non-string under `string_contains`, a sentinel at a path and a `null` at a path are all
-compile errors. The type carries no dialect — the generated artifact does not know which database
+segment, a non-string under `string_contains`, and a sentinel or a `null` under any operator but
+`equals` and `not` are all compile errors. The type carries no dialect — the generated artifact does not know which database
 it will be pointed at — so the table above is offered in full on both and the wrong half is refused
 at run time, naming the dialect. The empty path is refused at run time too.
 
@@ -2303,6 +2339,9 @@ Two things are worth knowing:
   an `OR` you assemble yourself. It is a question about rows rather than a value, so writing it
   raises `InvalidArgumentError`, and so does using it under any operator other than `equals` and
   `not`. Prisma refuses all three of those too.
+
+  All three also work one level down, on a value inside the document — see
+  [The null sentinels at a path](#the-null-sentinels-at-a-path).
 
 On Postgres the parameter is cast — `$1::text::jsonb` — and the value serialised to match, which
 is what lets a bare number or boolean through. Binding it raw makes the driver send an `integer` to

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -1459,7 +1459,7 @@ describe("json path filters", () => {
     });
 
     /**
-     * The other seven operators still refuse all three, and so does Prisma —
+     * The other eight operators still refuse all three, and so does Prisma —
      * *"Invalid value provided. … provided Enum."*, measured. A sentinel asks
      * which kind of null a value is, and `gt` compares a number.
      */

--- a/packages/gemi/orm/compile/read.test.ts
+++ b/packages/gemi/orm/compile/read.test.ts
@@ -10,6 +10,7 @@ import {
   UnsupportedQueryError,
 } from "../errors";
 import { USER_COLUMNS, account, mapped, user } from "../fixtures";
+import { JsonNull } from "../json-null";
 import { compile } from "./index";
 import { compileRead } from "./read";
 import { compileWrite } from "./write";
@@ -1314,18 +1315,32 @@ describe("json path filters", () => {
   });
 
   /**
-   * The gap review found: `compileFieldFilter` refuses a bare sentinel *above*
-   * the `path` branch and refuses `AnyNull` under a non-`equals`/`not` operator
-   * *below* it, so a sentinel inside a JSON filter reached neither and went
-   * straight to the binder. Postgres compared against the literal text
-   * `Prisma.DbNull`; SQLite bound the sentinel object. Zero rows, no error —
-   * the class #259 and #266 exist to close.
+   * #407, and the history is worth keeping because the refusal it replaces was
+   * *right about its own mechanism* and wrong about the database.
    *
-   * Refused rather than mapped, because an extracted value cannot tell an
-   * absent key from a JSON null: `#>>` yields NULL for both, so there is no
-   * answer to give that is not silently wrong half the time.
+   * The gap review that produced it found: `compileFieldFilter` refuses a bare
+   * sentinel *above* the `path` branch and refuses `AnyNull` under a
+   * non-`equals`/`not` operator *below* it, so a sentinel inside a JSON filter
+   * reached neither and went straight to the binder. Postgres compared against
+   * the literal text `Prisma.DbNull`; SQLite bound the sentinel object. Zero
+   * rows, no error — the class #259 and #266 exist to close. It was closed by
+   * refusing, because an extracted value cannot tell an absent key from a JSON
+   * null: `#>>` yields NULL for both.
+   *
+   * All true, and all about `#>>`. `#>` keeps the distinction, and so does
+   * SQLite's `->` — `dialect.jsonValueAt` is that extraction — so the question
+   * is answerable at a path under the two operators that can ask it.
+   *
+   * **Measured against the oracle before it was implemented**, on a generated
+   * 6.19.2 client, both dialects, over rows covering an absent key, a JSON null
+   * at the key, a scalar at the key, a SQL-NULL column and a JSON-null column.
+   * The row sets are identical on the two databases and the SQL is the shape
+   * asserted below. This is what the issue asked for and it changed the answer:
+   * the SQLite half was an open question — keep refusing, or implement
+   * `json_type` — until the measurement showed Prisma answers there too, which
+   * made refusing a divergence rather than a dialect gap.
    */
-  describe("a Json null sentinel inside a path filter is refused", () => {
+  describe("a Json null sentinel inside a path filter compiles", () => {
     // A class, for the reason `json-null.test.ts` spells out: a method in an
     // object literal is enumerable, `for…in` walks it, and the recogniser would
     // reject the fake while accepting Prisma's real one.
@@ -1338,35 +1353,142 @@ describe("json path filters", () => {
       return new Sentinel();
     };
 
-    const sentinels = [
-      ["DbNull", sentinel("Prisma.DbNull")],
-      ["JsonNull", sentinel("Prisma.JsonNull")],
-      ["AnyNull", sentinel("Prisma.AnyNull")],
-    ] as const;
+    const DbNull = sentinel("Prisma.DbNull");
+    const JsonNull = sentinel("Prisma.JsonNull");
+    const AnyNull = sentinel("Prisma.AnyNull");
 
-    test.each(sentinels)("%s on sqlite", (_name, sentinel) => {
-      expect(() =>
-        sqliteText({ where: { metadata: { path: "$.a", equals: sentinel } } }),
-      ).toThrow(InvalidArgumentError);
+    /**
+     * Postgres, and the `::jsonb` cast on the left is not decoration: `#>` on a
+     * `@db.Json` column yields `json`, which has no equality operator at all.
+     * Prisma emits the same cast.
+     */
+    test.each([
+      ["equals", DbNull, `("metadata" #> $1)::jsonb is null`],
+      ["equals", JsonNull, `("metadata" #> $1)::jsonb = $2::text::jsonb`],
+      [
+        "equals",
+        AnyNull,
+        `(("metadata" #> $1)::jsonb = $2::text::jsonb or ("metadata" #> $3)::jsonb is null)`,
+      ],
+      ["not", DbNull, `("metadata" #> $1)::jsonb is not null`],
+      ["not", JsonNull, `("metadata" #> $1)::jsonb <> $2::text::jsonb`],
+      [
+        "not",
+        AnyNull,
+        `(("metadata" #> $1)::jsonb <> $2::text::jsonb and ("metadata" #> $3)::jsonb is not null)`,
+      ],
+    ] as [string, object, string][])(
+      "%s on postgres",
+      (key, operand, expected) => {
+        expect(
+          pgText({ where: { metadata: { path: ["a"], [key]: operand } } }),
+        ).toContain(expected);
+      },
+    );
+
+    /**
+     * SQLite, where the operator is `->` rather than `json_extract` — the whole
+     * reason this dialect can answer at all. `json_extract` returns a native
+     * value, so a JSON null comes back as SQL NULL and collapses into the
+     * absent case; `->` returns the JSON text and keeps them apart.
+     */
+    test.each([
+      ["equals", DbNull, `("metadata" -> ?) is null`],
+      ["equals", JsonNull, `("metadata" -> ?) = ?`],
+      [
+        "equals",
+        AnyNull,
+        `(("metadata" -> ?) = ? or ("metadata" -> ?) is null)`,
+      ],
+      ["not", DbNull, `("metadata" -> ?) is not null`],
+      ["not", JsonNull, `("metadata" -> ?) <> ?`],
+      [
+        "not",
+        AnyNull,
+        `(("metadata" -> ?) <> ? and ("metadata" -> ?) is not null)`,
+      ],
+    ] as [string, object, string][])(
+      "%s on sqlite",
+      (key, operand, expected) => {
+        expect(
+          sqliteText({ where: { metadata: { path: "$.a", [key]: operand } } }),
+        ).toContain(expected);
+      },
+    );
+
+    /**
+     * Nothing of the sentinel reaches the SQL — the original defect — and what
+     * *is* bound is the JSON null, spelled by each dialect's own encoder.
+     *
+     * The bound values are the half a text assertion cannot see. On Postgres
+     * the placeholder carries `::text::jsonb` and the value is the string
+     * `null`, which is `'null'::jsonb`; binding SQL NULL there would be `is
+     * null`'s question asked a second way and would match the wrong rows. On
+     * SQLite the value is the text `null`, which is what `->` yields for a JSON
+     * null — and it is *not* what `->` yields for the JSON string `"null"`,
+     * which is `"null"` with the quotes.
+     */
+    test("the JSON null is bound, and the sentinel never is", () => {
+      const pgArgs = {
+        where: { metadata: { path: ["a"], equals: JsonNull } },
+      };
+      const pg = compileRead(jsonUser, "findMany", pgArgs, postgres);
+      expect(pg.text).not.toContain("Prisma.");
+      expect(pg.bind(pgArgs)).toEqual([`{"a"}`, "null"]);
+
+      const sqliteArgs = {
+        where: { metadata: { path: "$.a", equals: JsonNull } },
+      };
+      const lite = compileRead(jsonUser, "findMany", sqliteArgs, sqlite);
+      expect(lite.text).not.toContain("Prisma.");
+      expect(lite.bind(sqliteArgs)).toEqual(["$.a", "null"]);
     });
 
-    test.each(sentinels)("%s on postgres", (_name, sentinel) => {
-      expect(() =>
-        pgText({ where: { metadata: { path: ["a"], equals: sentinel } } }),
-      ).toThrow(InvalidArgumentError);
+    /**
+     * `AnyNull` binds the path **twice**, once per half, which is what Prisma
+     * does too. Asserted because the alternative — sharing one placeholder —
+     * would be an invariant-2 violation dressed as an optimisation, and because
+     * a binder that silently produced three values for four placeholders is the
+     * failure this shape invites.
+     */
+    test("AnyNull binds the path once per half", () => {
+      const args = { where: { metadata: { path: ["a"], equals: AnyNull } } };
+      expect(
+        compileRead(jsonUser, "findMany", args, postgres).bind(args),
+      ).toEqual([`{"a"}`, "null", `{"a"}`]);
     });
 
-    /** Nothing of the sentinel reaches the SQL, which is the actual defect. */
-    test("it never becomes a bound literal", () => {
-      let text = "";
-      try {
-        text = pgText({
-          where: { metadata: { path: ["a"], equals: sentinel("Prisma.DbNull") } },
-        });
-      } catch {
-        // expected
-      }
-      expect(text).not.toContain("Prisma.DbNull");
+    /**
+     * The other seven operators still refuse all three, and so does Prisma —
+     * *"Invalid value provided. … provided Enum."*, measured. A sentinel asks
+     * which kind of null a value is, and `gt` compares a number.
+     */
+    test.each([
+      ["gt", DbNull],
+      ["lte", JsonNull],
+      ["array_contains", AnyNull],
+      ["string_contains", DbNull],
+    ] as [string, object][])(
+      "%s still refuses a sentinel on postgres",
+      (key, operand) => {
+        expect(() =>
+          pgText({ where: { metadata: { path: ["a"], [key]: operand } } }),
+        ).toThrow(InvalidArgumentError);
+      },
+    );
+
+    /**
+     * The one shape `carriesAnyNull` is still there for: a sentinel *inside* a
+     * document, where there is nothing for it to mean. `equals` and `not` never
+     * reach that check with an object operand — `assertJsonOperand` refuses one
+     * — so `array_contains` is the reachable case.
+     */
+    test("AnyNull inside an array_contains document is refused", () => {
+      expect(() =>
+        pgText({
+          where: { metadata: { path: ["a"], array_contains: [AnyNull] } },
+        }),
+      ).toThrow(/a question rather than a value/);
     });
   });
 
@@ -1434,27 +1556,52 @@ describe("json path filters", () => {
    * and `x @> NULL` is NULL. Prisma binds it as the JSON value and runs a real
    * containment test.
    */
-  describe("null at a path is refused", () => {
+  describe("null at a path", () => {
     /**
-     * **Each row asserts its message, not just `InvalidArgumentError`**, and
-     * that is what pins the two things the class alone cannot see.
+     * **Under `equals` and `not` it is answered, and it is `JsonNull`.**
      *
-     * The `string_*` rows already threw before this change, from the non-string
-     * guard, with the `'%null%'` reasoning — so a class assertion passes either
-     * way and leaves the new guard's *placement* unpinned. It sits deliberately
-     * **after** that guard so the better message survives; moving it above used
-     * to leave all 153 tests green while `string_contains: null` silently swapped
-     * its message for the generic one.
+     * That is not a reading gemi chose. Measured on 6.19.2 against both
+     * dialects: `{ path: […], equals: null }` and
+     * `{ path: […], equals: Prisma.JsonNull }` compile to byte-identical SQL
+     * and return identical rows. So the two spellings are one query, and this
+     * asserts they compile to one predicate rather than asserting the text
+     * twice — if they ever diverge, this is the test that says so.
+     */
+    test.each([
+      ["equals", "postgres"],
+      ["not", "postgres"],
+      ["equals", "sqlite"],
+      ["not", "sqlite"],
+    ] as const)("%s: null is equals: JsonNull, on %s", (key, dialect) => {
+      const path = dialect === "sqlite" ? "$.a" : ["a"];
+      const text = dialect === "sqlite" ? sqliteText : pgText;
+      expect(text({ where: { metadata: { path, [key]: null } } })).toBe(
+        text({ where: { metadata: { path, [key]: JsonNull } } }),
+      );
+    });
+
+    /**
+     * **The other operators still refuse it, and each keeps its own sentence.**
      *
-     * The `array_contains` row asserts the other sentence for the same kind of
-     * reason: that operator does not extract with `#>>`, so its refusal names
-     * the raw bind and `x @> NULL` instead of the text collapse.
+     * The `string_*` rows already threw before the `null` guard existed, from
+     * the non-string guard, with the `'%null%'` reasoning — so a class
+     * assertion passes either way and leaves the guard's *placement* unpinned.
+     * It sits deliberately **after** that guard so the better message survives;
+     * moving it above used to leave all 153 tests green while
+     * `string_contains: null` silently swapped its message for the generic one.
+     *
+     * The `array_contains` row asserts the third sentence for the same kind of
+     * reason: that operator does not compare an extracted scalar, so its
+     * refusal names the raw bind and `x @> NULL` instead.
+     *
+     * The numeric rows say *"Prisma refuses it here too"* and that is measured,
+     * not assumed: `{ path: ["a"], gt: null }` panics Prisma's query engine —
+     * "JSON target types only accept strings or numbers, found: null" — rather
+     * than compiling. The message used to promise gemi would answer it later.
      */
     const postgresOperators = [
-      ["equals", /null cannot be compared through a JSON path/],
-      ["not", /null cannot be compared through a JSON path/],
-      ["gt", /null cannot be compared through a JSON path/],
-      ["lte", /null cannot be compared through a JSON path/],
+      ["gt", /compares the extracted value as a number/],
+      ["lte", /compares the extracted value as a number/],
       ["string_contains", /'%null%', which runs and returns the wrong rows/],
       ["array_contains", /null cannot be tested for containment/],
     ] as const;
@@ -1468,21 +1615,19 @@ describe("json path filters", () => {
 
     // SQLite offers only the six its dialect answers; the other four raise the
     // dialect refusal first, which is a different message and already pinned.
-    test.each([
-      ["equals", /null cannot be compared through a JSON path/],
-      ["not", /null cannot be compared through a JSON path/],
-      ["string_ends_with", /'%null%', which runs and returns the wrong rows/],
-    ] as const)("%s on sqlite", (key, message) => {
+    test("string_ends_with on sqlite", () => {
       const compile = () =>
-        sqliteText({ where: { metadata: { path: "$.a", [key]: null } } });
+        sqliteText({
+          where: { metadata: { path: "$.a", string_ends_with: null } },
+        });
       expect(compile).toThrow(InvalidArgumentError);
-      expect(compile).toThrow(message);
+      expect(compile).toThrow(/'%null%', which runs and returns the wrong rows/);
     });
 
     /**
-     * The load-bearing negative: only the *bare* operand is refused. A `null`
-     * inside a document under `array_contains` is an ordinary JSON value, and
-     * containment against `[null]` is a question Postgres answers.
+     * The load-bearing negative: only the *bare* operand is refused under
+     * `array_contains`. A `null` inside a document is an ordinary JSON value,
+     * and containment against `[null]` is a question Postgres answers.
      */
     test("a null inside an array_contains document still compiles", () => {
       const args = { where: { metadata: { path: ["a"], array_contains: [null] } } };
@@ -1494,7 +1639,7 @@ describe("json path filters", () => {
     });
 
     /**
-     * Nothing of it reaches the SQL, which is the actual defect. The message is
+     * Under a refusing operator, nothing of it reaches the SQL. The message is
      * asserted alongside because a bare `text === ""` passes for *any* throw,
      * including one from an unrelated future guard — it would say "no SQL was
      * built" where it means "this guard built no SQL".
@@ -1503,11 +1648,11 @@ describe("json path filters", () => {
       let text = "";
       let message = "";
       try {
-        text = pgText({ where: { metadata: { path: ["a"], equals: null } } });
+        text = pgText({ where: { metadata: { path: ["a"], gt: null } } });
       } catch (error) {
         message = (error as Error).message;
       }
-      expect(message).toMatch(/null cannot be compared through a JSON path/);
+      expect(message).toMatch(/compares the extracted value as a number/);
       expect(text).toBe("");
     });
   });

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -1105,13 +1105,26 @@ function compileJsonFilter(
     }
 
     if (sentinel && operand !== null) {
+      // **The clause naming the mechanism branches for `array_contains`**, for
+      // the same reason `assertJsonOperand`'s `null` guard branches below: that
+      // operator does not compare an extracted scalar at all — it compiles to
+      // `#>` + `@>`, containment against a jsonb document — so telling its
+      // caller about a scalar comparison names a mechanism it does not have.
+      // Everything else here does compare one bound scalar against one
+      // extracted value.
+      const because =
+        key === "array_contains"
+          ? `'array_contains' tests containment against a document, and a ` +
+            `sentinel is not one`
+          : `'${key}' compares an extracted value against a scalar, and a ` +
+            `sentinel is not one`;
+
       throw new InvalidArgumentError(
         `where.${field.name}.${key}`,
         schema.name,
         context.operation,
         `${sentinelName(sentinel)} asks which kind of null a value is, which ` +
-          `only 'equals' and 'not' can express — '${key}' compares an ` +
-          `extracted value against a scalar, and a sentinel is not one. ` +
+          `only 'equals' and 'not' can express — ${because}. ` +
           `Prisma refuses it under this operator too. Write ` +
           `{ ${field.name}: { path: […], equals: ${sentinelName(sentinel)} } }, ` +
           `or filter the column itself — ` +
@@ -1281,8 +1294,8 @@ function assertJsonOperand(
     );
   }
 
-  // **`null` is refused under the operators that are left, and the oracle
-  // refuses it there too.**
+  // **`null` is refused under the operators that are left**, and the oracle
+  // agrees about the numeric four and not about `array_contains`.
   //
   // `equals` and `not` do not reach this — `compileJsonFilter` compiles them
   // as `JsonNull` before calling here, because Prisma reads a bare `null` at a
@@ -1300,14 +1313,22 @@ function assertJsonOperand(
   // and compiled to `cast(("metadata" #>> $1) as real) > $2` bound to NULL,
   // which is NULL rather than true: a query that runs and matches nothing.
   //
-  // `array_contains` is included rather than exempt, **and its mechanism is a
-  // different one**. It takes the `#>` form, so the text collapse above does
-  // not apply to it — but `jsonArrayContains` binds the operand raw, so `null`
-  // arrives as SQL NULL and `x @> NULL` is NULL too. The message below branches
-  // for that reason: telling an `array_contains` caller about an extracted
-  // scalar would name a mechanism this operator does not have, and pointing
-  // them at `{ equals: Prisma.JsonNull }` would answer a containment question
-  // with an equality.
+  // `array_contains` is included rather than exempt, **and it is the one place
+  // here that refuses something the oracle answers**. Its mechanism is its own:
+  // it takes the `#>` form, so the text collapse never applied to it, but
+  // `jsonArrayContains` binds the operand raw, so `null` arrives as SQL NULL
+  // and `x @> NULL` is NULL too — a query that runs and matches nothing.
+  //
+  // Prisma compiles it, measured: `(payload #> $1)::jsonb @> $2 AND
+  // JSONB_TYPEOF((payload #> $3)::jsonb) = 'array'`, which also returns no rows
+  // — so the refusal costs a caller nothing but an error where the oracle gave
+  // an empty set, and this comment says so rather than claiming parity it does
+  // not have. `docs/orm.md` records it in the same terms.
+  //
+  // The message below branches for the mechanism: telling an `array_contains`
+  // caller about an extracted scalar would name something this operator does
+  // not have, and pointing them at `{ equals: Prisma.JsonNull }` would answer a
+  // containment question with an equality.
   if (operand === null) {
     throw new InvalidArgumentError(
       `where.${field.name}.${key}`,
@@ -1784,6 +1805,29 @@ function equals(
   // below and compiled to `= ?` — matching nothing, whatever the table held.
   // Its sibling `JsonNull` is a genuine *value* comparison and belongs there:
   // the column holds the JSON `null`, and `= 'null'` is how you find it.
+  //
+  // **KNOWN DIVERGENCE — a bare `null` on a `Json` column.** For every other
+  // column type `operand === null` meaning `is null` *is* Prisma's reading. On
+  // a `Json` column it is not: Prisma reads a bare `null` as the JSON value
+  // `null` there, exactly as it does at a path. Measured on 6.19.2 against
+  // Postgres 16 and SQLite, over a table holding both empty states:
+  //
+  //   { equals: null }      prisma  "payload"::jsonb = $1   the JSON-null rows
+  //                         gemi    "payload" is null       the SQL-NULL rows
+  //   { not: null }         prisma  "payload"::jsonb <> $1
+  //                         gemi    "payload" is not null   (one row more)
+  //
+  // Disjoint row sets on identical data, and nothing raises. Left alone rather
+  // than fixed here: this is the *column* path, and #407 is about a value at a
+  // path — where a bare `null` now agrees with Prisma exactly, because
+  // `compileJsonFilter` reads it as `JsonNull`. Changing the column would be a
+  // behaviour change to released semantics for every `Json` filter, which wants
+  // its own change and its own differential cases.
+  //
+  // `{ equals: Prisma.DbNull }` is unambiguous and compiles to this same
+  // predicate on both libraries, so the divergence has a spelling that avoids
+  // it. `docs/orm.md` says so where a reader will look, and
+  // `known-divergences.test.ts` pins that it keeps saying so.
   if (operand === null || jsonNullKind(operand) === "db") {
     return sql(`${column} is null`);
   }

--- a/packages/gemi/orm/compile/where.ts
+++ b/packages/gemi/orm/compile/where.ts
@@ -1075,47 +1075,64 @@ function compileJsonFilter(
 
     const operand = filter[key];
 
-    // **The sentinels have to be refused here, and only here.**
+    // **`equals` and `not` answer the three sentinels; the other eight refuse
+    // them.** That split is Prisma's, measured on a generated 6.19.2 client
+    // against both databases rather than derived from the operators:
     //
-    // `compileFieldFilter` refuses a bare sentinel above this branch, and
-    // refuses `AnyNull` under a non-`equals`/`not` operator in the scalar key
-    // loop below it. A `path` filter sits between the two and reaches neither,
-    // so before this check a sentinel inside a JSON filter went straight to the
-    // binder: Postgres compared against the literal text `Prisma.DbNull` and
-    // SQLite bound the sentinel object. Zero rows, no error — the failure class
-    // #259 and #266 exist to close, arrived at from the one direction nothing
-    // was watching.
+    //   equals / not              compiled, and the SQL is in `jsonNullAtPath`
+    //   the other eight           "Invalid value provided. … provided Enum."
     //
-    // Refused rather than mapped. The scalar path *can* answer these because it
-    // compiles them against the column, where SQL NULL and the JSON value
-    // `null` are distinguishable. An extracted value has already lost that
-    // distinction — `#>>` yields NULL both for an absent key and for a JSON
-    // null — so answering here would mean picking one meaning and being
-    // silently wrong about the other.
-    const sentinel = jsonNullKind(operand);
-    if (sentinel) {
+    // The refusal below used to cover all ten, and its reason was true of the
+    // extraction it named rather than of the dialect: `#>>` does yield NULL for
+    // an absent key and for a JSON `null` alike, but `#>` does not, and neither
+    // does SQLite's `->`. `dialect.jsonValueAt` is that second extraction, so
+    // the distinction the sentinels exist to draw survives to the comparison
+    // and there is nothing left to refuse — #407.
+    //
+    // A bare `null` takes the same branch, as `JsonNull`. It is not a third
+    // reading: Prisma compiles `{ path: […], equals: null }` and
+    // `{ path: […], equals: Prisma.JsonNull }` to byte-identical SQL and
+    // returns identical rows on both dialects, measured. It was refused for the
+    // same `#>>` reason (#371's second item), and the same fix reaches it.
+    const sentinel: JsonNullKind | null =
+      operand === null ? "json" : jsonNullKind(operand);
+
+    if (sentinel && (key === "equals" || key === "not")) {
+      parts.push(
+        jsonNullAtPath(sentinel, column, path, field, dialect, key === "not"),
+      );
+      continue;
+    }
+
+    if (sentinel && operand !== null) {
       throw new InvalidArgumentError(
         `where.${field.name}.${key}`,
         schema.name,
         context.operation,
-        `${sentinelName(sentinel)} is not a filter on an extracted JSON ` +
-          `value: the extraction yields NULL for an absent key and for a JSON ` +
-          `null alike, so the distinction the sentinel exists to make is ` +
-          `already gone. Filter the column itself — ` +
-          `{ ${field.name}: { equals: ${sentinelName(sentinel)} } } — or test ` +
-          `the path against the value you mean.`,
+        `${sentinelName(sentinel)} asks which kind of null a value is, which ` +
+          `only 'equals' and 'not' can express — '${key}' compares an ` +
+          `extracted value against a scalar, and a sentinel is not one. ` +
+          `Prisma refuses it under this operator too. Write ` +
+          `{ ${field.name}: { path: […], equals: ${sentinelName(sentinel)} } }, ` +
+          `or filter the column itself — ` +
+          `{ ${field.name}: { equals: ${sentinelName(sentinel)} } }.`,
       );
     }
 
-    // The same shape one level down: `{ path: …, equals: { not: DbNull } }`.
+    // The same shape one level down — `{ path: …, array_contains: [AnyNull] }`.
+    // Still refused, and now for its own reason rather than by inheriting the
+    // extraction's: `AnyNull` is a *question*, not a value, so there is nothing
+    // to put inside a document. (`equals` and `not` never reach here with an
+    // object operand — `assertJsonOperand` refuses one below — so this is
+    // `array_contains`'s case in practice.)
     if (carriesAnyNull(operand)) {
       throw new InvalidArgumentError(
         `where.${field.name}.${key}`,
         schema.name,
         context.operation,
-        `Prisma.AnyNull cannot be reached through a JSON path, for the same ` +
-          `reason the other two cannot: the extracted value does not ` +
-          `distinguish an absent key from a JSON null.`,
+        `Prisma.AnyNull is a question rather than a value — 'either kind of ` +
+          `null' — so it cannot appear inside a document. Ask it directly: ` +
+          `{ ${field.name}: { path: […], equals: Prisma.AnyNull } }.`,
       );
     }
 
@@ -1131,6 +1148,75 @@ function compileJsonFilter(
   return parts.length === 1
     ? parts[0]
     : group(parts, " and ");
+}
+
+/**
+ * A null sentinel at a JSON path — `{ path: ["operation"], equals: AnyNull }`.
+ *
+ * **The two halves, and why neither is the other.** A `Json` column has two
+ * empty states and so does a *key inside* one, except the key's second state is
+ * "not there at all":
+ *
+ *   DbNull     the value at the path is missing — an absent key, or a column
+ *              that is SQL NULL, or one holding a JSON null (nothing to index)
+ *   JsonNull   the value at the path is the JSON value `null`
+ *   AnyNull    either, which is what `AnyNull` means everywhere else
+ *
+ * `dialect.jsonValueAt` is what keeps them apart; `jsonExtract` at `asText:
+ * true` does not, which is the collapse that had all three refused here before
+ * #407. So `DbNull` is `is null` on the extraction itself and `JsonNull` is an
+ * equality against the JSON null, bound the way {@link jsonNullComparison}
+ * binds it on the column path — through the dialect's own encoder, so `'null'`
+ * on SQLite and `'null'::text::jsonb` on Postgres stay that encoder's business.
+ *
+ * **`negated` is the direct form, not `not (…)`.** Prisma emits `IS NOT NULL`,
+ * `<>` and `(<> … AND IS NOT NULL)`, and the negation of the positive form
+ * agrees with all three under three-valued logic — `equals`'s own comment makes
+ * the same argument on the column path. The direct spelling is emitted because
+ * it is the one the oracle emits and it reads as what it means; the contract is
+ * equal results either way.
+ *
+ * Measured on 6.19.2 against Postgres 16 and SQLite, over rows covering an
+ * absent key, a JSON null at the key, a scalar at the key, a SQL-NULL column
+ * and a JSON-null column. Both dialects return the same five row sets, and this
+ * compiles to the same predicates:
+ *
+ *   equals: DbNull      absent key, SQL-NULL column, JSON-null column
+ *   equals: JsonNull    the key holding a JSON null
+ *   equals: AnyNull     all four of those
+ *   not: DbNull         the key holding a JSON null, and the key holding a scalar
+ *   not: JsonNull       the key holding a scalar
+ *   not: AnyNull        the key holding a scalar
+ */
+function jsonNullAtPath(
+  kind: JsonNullKind,
+  column: string,
+  path: Binder,
+  field: FieldSchema,
+  dialect: SqlDialect,
+  negated: boolean,
+): Fragment {
+  // `is null` on the extraction: nothing is there to compare.
+  const missing = (): Fragment =>
+    concat(
+      dialect.jsonValueAt(column, path),
+      sql(negated ? " is not null" : " is null"),
+    );
+
+  // ...and the JSON value `null`, which is a value and compares as one.
+  const jsonNull = (): Fragment =>
+    concat(
+      dialect.jsonValueAt(column, path),
+      sql(negated ? " <> " : " = "),
+      fieldParam(field, dialect, () => dialect.encode(JSON_NULL, field)),
+    );
+
+  if (kind === "db") return missing();
+  if (kind === "json") return jsonNull();
+
+  // The path is bound twice, once per half, which is what Prisma does too —
+  // it is a parameter, so there is nothing to share and nothing in the text.
+  return group([jsonNull(), missing()], negated ? " and " : " or ");
 }
 
 /**
@@ -1152,14 +1238,21 @@ function compileJsonFilter(
  *
  *   - **`null` fell between the two.** The string branch refuses a non-string
  *     and the object branch tests `operand !== null` first, so `equals: null`
- *     reached the binder and compiled to `= NULL` — see the guard below.
+ *     reached the binder and compiled to `= NULL` — see the guard below. Under
+ *     `equals` and `not` it is answered rather than refused now, and never
+ *     reaches this function: #407 gave those two the extraction that can tell a
+ *     JSON `null` from an absent key, and `equals: null` is `equals: JsonNull`
+ *     on the oracle. The guard below covers the operators that are left.
  *
- * The last two are a **refusal rather than an implementation**, deliberately.
- * Prisma does accept an object or an array there, and answering it properly
- * means the `#>` + `::jsonb` form `array_contains` already uses — which is
- * Postgres-only, so implementing it would give SQLite either a second wrong
- * answer or a silent divergence. Refusing names the limitation on both
- * dialects, which is what this file does everywhere else it cannot answer.
+ * The object operand is still a **refusal rather than an implementation**, and
+ * the reason has narrowed. It used to be that answering it needs the JSON-
+ * preserving extraction, which was Postgres-only here — so implementing it
+ * would give SQLite either a second wrong answer or a silent divergence. That
+ * is no longer true: `dialect.jsonValueAt` is that extraction and both dialects
+ * have it (#407). What is left is simply that nobody has compiled a document
+ * comparison against it — the operand would still bind through `jsonComparison`
+ * as a scalar — so this stays a named limitation rather than becoming a silent
+ * wrong answer, which is what this file does everywhere it cannot answer.
  * `array_contains` is exempt from the object rule because containment is
  * precisely the operator that takes a document — but not from the `null` one,
  * because a bound SQL NULL is not a JSON `null` on either side of `@>`.
@@ -1188,38 +1281,33 @@ function assertJsonOperand(
     );
   }
 
-  // **`null` is refused under every path operator, and it is a refusal rather
-  // than a gap.**
+  // **`null` is refused under the operators that are left, and the oracle
+  // refuses it there too.**
   //
-  // Measured on a generated 6.19.2 client against Postgres, with query-event
-  // logging and the rows read back: Prisma extracts with `#>` and compares as
-  // `jsonb`, so `{ path: ["a"], equals: null }` asks for the JSON value `null`
-  // and returns the rows that hold one — the same SQL and the same rows as
-  // `equals: Prisma.JsonNull`. gemi extracts with `#>>`, which yields *text*,
-  // and NULL for an absent key and for a JSON null alike. That collapse is
-  // exactly why the sentinels are refused a few lines above, and it leaves this
-  // operand nothing to mean.
+  // `equals` and `not` do not reach this — `compileJsonFilter` compiles them
+  // as `JsonNull` before calling here, because Prisma reads a bare `null` at a
+  // path as the JSON value `null` and returns the rows holding one: identical
+  // SQL and identical rows to `equals: Prisma.JsonNull`, measured on 6.19.2
+  // against both dialects. That was #371's second item, and it was refused for
+  // a reason that was true of `#>>` rather than of the database.
   //
-  // Left alone it reached the binder and compiled to `("metadata" #>> $1) = $2`
-  // bound to NULL — `= NULL` is NULL rather than true on both dialects, so the
-  // query ran, raised nothing, and matched no row where Prisma matched some.
-  // The `string_contains` guard above names that failure in this file's own
-  // words, "runs and returns the wrong rows"; only the arithmetic differs.
+  // The four numeric comparisons are a different answer, measured the same way:
+  // `{ path: ["a"], gt: null }` does not compile on Prisma either. Its query
+  // engine *panics* — "JSON target types only accept strings or numbers, found:
+  // null", from `sql-query-builder/src/filter/visitor.rs` — so refusing is
+  // matching the oracle rather than falling short of it, and this message says
+  // so instead of promising an answer later. Left alone it reached the binder
+  // and compiled to `cast(("metadata" #>> $1) as real) > $2` bound to NULL,
+  // which is NULL rather than true: a query that runs and matches nothing.
   //
   // `array_contains` is included rather than exempt, **and its mechanism is a
   // different one**. It takes the `#>` form, so the text collapse above does
   // not apply to it — but `jsonArrayContains` binds the operand raw, so `null`
-  // arrives as SQL NULL and `x @> NULL` is NULL too. Prisma binds it as the
-  // JSON value and runs a real containment test. The message below branches for
-  // that reason: telling an `array_contains` caller about `#>>` would name a
-  // mechanism this operator does not have, and pointing them at
-  // `{ equals: Prisma.JsonNull }` would answer a containment question with an
-  // equality on the column.
-  //
-  // Answering any of them properly means the `#> … ::jsonb` form on Postgres
-  // and `json_type` on SQLite, which is a second implementation of the same
-  // operator per dialect rather than a guard — the same reason the object
-  // operand below is refused instead of compiled.
+  // arrives as SQL NULL and `x @> NULL` is NULL too. The message below branches
+  // for that reason: telling an `array_contains` caller about an extracted
+  // scalar would name a mechanism this operator does not have, and pointing
+  // them at `{ equals: Prisma.JsonNull }` would answer a containment question
+  // with an equality.
   if (operand === null) {
     throw new InvalidArgumentError(
       `where.${field.name}.${key}`,
@@ -1229,17 +1317,15 @@ function assertJsonOperand(
         ? `null cannot be tested for containment through a JSON path: the ` +
           `operand binds as SQL NULL rather than as the JSON value, and ` +
           `'x @> NULL' is NULL rather than true — the query would run and ` +
-          `match nothing. Prisma binds it as the JSON value and runs a real ` +
-          `containment test; gemi does not yet. A null *inside* the document ` +
+          `match nothing. A null *inside* the document ` +
           `is an ordinary value and still compiles: ` +
           `{ ${field.name}: { path: […], array_contains: [null] } }.`
-        : `null cannot be compared through a JSON path: the extraction yields ` +
-          `SQL NULL for an absent key and for a JSON null alike, and the ` +
-          `comparison against it is NULL rather than true — the query would ` +
-          `run and match nothing. Prisma reads it as the JSON value null and ` +
-          `does answer it; gemi does not yet. Filter the column itself — ` +
-          `{ ${field.name}: { equals: Prisma.JsonNull } } — or test the path ` +
-          `against the value you mean.`,
+        : `null cannot be compared through a JSON path with '${key}', which ` +
+          `compares the extracted value as a number — the comparison against ` +
+          `NULL is NULL rather than true, so the query would run and match ` +
+          `nothing. Prisma refuses it here too. For "the value at this path ` +
+          `is a JSON null", use equals or not: ` +
+          `{ ${field.name}: { path: […], equals: null } }.`,
     );
   }
 

--- a/packages/gemi/orm/corpus.ts
+++ b/packages/gemi/orm/corpus.ts
@@ -1,3 +1,5 @@
+import { AnyNull, DbNull, JsonNull, jsonNullKind } from "./json-null";
+
 /**
  * A corpus of argument shapes, shared by the invariant suites.
  *
@@ -115,9 +117,41 @@ export const READS: unknown[] = [
   { where: { metadata: { path: ["a"], gte: 1 } } },
   { where: { metadata: { path: ["a"], lt: 1 } } },
   { where: { metadata: { path: ["a"], lte: 1 } } },
-  // Two filters on one path — the `and`-grouped branch, and the only shape that
-  // extracts the same path twice in one statement.
+  // Two filters on one path — the `and`-grouped branch, and one of the two
+  // shapes that extract the same path twice in one statement. The other is
+  // `equals: AnyNull` below, which does it inside a *single* filter.
   { where: { metadata: { path: ["a"], gt: 1, lt: 9 } } },
+  // **The null sentinels at a path (#407), which are why `vary` had to learn
+  // what a sentinel is.** Three shapes that compile to three different
+  // predicates and must therefore hold three different plan keys — the #266
+  // failure class, arrived at one level down from where it was closed.
+  //
+  // `AnyNull` is the shape worth having: it is the only argument in the ORM
+  // that binds one caller value at *two* placeholder positions in one
+  // predicate, so it is where the count of bound values stops being one per
+  // operator. Measured, so the claim is bounded rather than hopeful: removing
+  // the `vary` guard below makes "varying every bound value leaves the key
+  // alone" fail on both dialects *because of these entries*, and that is the
+  // property they add.
+  //
+  // What they do **not** catch, checked by mutation rather than assumed: a
+  // refactor that hoists the path out of the binder *consistently* — both the
+  // plan compiled for one call and the plan compiled for the next capture the
+  // same wrong value, so `binding.invariants`' reuse property compares equal.
+  // The differential suite is what covers that, since it reads rows.
+  { where: { metadata: { path: ["a"], equals: DbNull } } },
+  { where: { metadata: { path: ["a"], equals: JsonNull } } },
+  { where: { metadata: { path: ["a"], equals: AnyNull } } },
+  { where: { metadata: { path: ["a"], equals: null } } },
+  { where: { metadata: { path: ["a"], not: DbNull } } },
+  { where: { metadata: { path: ["a"], not: JsonNull } } },
+  { where: { metadata: { path: ["a"], not: AnyNull } } },
+  // A sentinel beside an ordinary operator, so the `and`-grouped branch carries
+  // one — three placeholders from one key and two from the other.
+  { where: { metadata: { path: ["a"], equals: AnyNull, not: "x" } } },
+  // ...and at depth, because the path is bound rather than interpolated and a
+  // two-segment one is where a shared-placeholder mistake would show.
+  { where: { metadata: { path: ["a", "b"], equals: AnyNull } } },
 
   // The SQLite grammar, same filters minus the ones the dialect declines.
   { where: { metadata: { path: "$.a", equals: "x" } } },
@@ -127,6 +161,15 @@ export const READS: unknown[] = [
   { where: { metadata: { path: "$.a", string_starts_with: "x" } } },
   { where: { metadata: { path: "$.a", string_ends_with: "x" } } },
   { where: { metadata: { path: "$.a", equals: "x", not: "y" } } },
+  // The sentinels in this grammar too. `equals` and `not` are in SQLite's
+  // `jsonFilters`, so these compile here rather than hitting the dialect
+  // refusal — on the `->` extraction rather than Postgres's `#>`, which is a
+  // different fragment reached through the same compiler branch.
+  { where: { metadata: { path: "$.a", equals: DbNull } } },
+  { where: { metadata: { path: "$.a", equals: JsonNull } } },
+  { where: { metadata: { path: "$.a", equals: AnyNull } } },
+  { where: { metadata: { path: "$.a", equals: null } } },
+  { where: { metadata: { path: "$.a", not: AnyNull } } },
   // Refused on SQLite for the *filter* rather than for the grammar, which is a
   // different message and the one that would fall silent if `jsonFilters` were
   // ever widened there to match Postgres.
@@ -299,6 +342,32 @@ const LITERAL = new Set([
 export function vary(node: unknown, bound = false): unknown {
   if (node === null || node === undefined) return node;
   if (Array.isArray(node)) return node.map((entry) => vary(entry, bound));
+
+  // **An object that is a *value* is not a container to walk into**, and
+  // rebuilding one from `Object.entries` destroys it: every value below has no
+  // enumerable own properties, so the walk returned `{}` and silently changed
+  // the argument's *shape* rather than its bound value.
+  //
+  // That is the opposite of what this function is for. `plan-key.invariants`
+  // asks "does varying a bound value leave the key alone", so a helper that
+  // alters the shape reports a leak that is its own; `binding.invariants` asks
+  // "does the same shape compile alike", and a `{}` twin either raises inside
+  // the compiler and is swallowed by that suite's `catch { continue }` — a case
+  // that looks covered and tests nothing — or compiles to different SQL.
+  //
+  // Reached the moment the corpus gained a Json null sentinel (#407), which is
+  // the first entry whose operand is such an object. `Date` and a typed array
+  // are the same shape of mistake and are guarded here rather than left for the
+  // next person to rediscover; `isFilterObject` in the where compiler and
+  // `canonicalShape` in `plan.ts` both already draw this exact line.
+  if (
+    node instanceof Date ||
+    ArrayBuffer.isView(node) ||
+    jsonNullKind(node) !== null
+  ) {
+    return node;
+  }
+
   if (typeof node === "object") {
     const out: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(node)) {

--- a/packages/gemi/orm/dialect/index.ts
+++ b/packages/gemi/orm/dialect/index.ts
@@ -337,12 +337,44 @@ export interface SqlDialect {
    * operator whose right-hand side is a document.
    *
    * SQLite ignores the flag: `json_extract` already yields a SQL value rather
-   * than a JSON document for a scalar at the path.
+   * than a JSON document for a scalar at the path. That is why the null
+   * sentinels need {@link jsonValueAt} instead of this — see there.
    */
   jsonExtract(column: string, path: Binder, asText: boolean): Fragment;
 
   /** `<extracted> @> <value>` — Postgres only; see `jsonFilters`. */
   jsonArrayContains(column: string, path: Binder, value: Binder): Fragment;
+
+  /**
+   * The value at `path` **as JSON**, in the form two JSON values compare in.
+   *
+   * The difference from {@link jsonExtract} is the whole of #407, and it is the
+   * distinction the null sentinels are made of. Both dialects have an
+   * extraction that collapses "the key is absent" into "the key holds the JSON
+   * value `null`", and both have one that does not:
+   *
+   * |          | collapses          | keeps the distinction |
+   * | ---      | ---                | ---                   |
+   * | postgres | `#>>` (text)       | `#>` (jsonb)          |
+   * | sqlite   | `json_extract`     | `->` (JSON text)      |
+   *
+   * `jsonExtract` is the left column at `asText: true`, which is what every
+   * scalar comparison wants — a value to compare, not a document. This is the
+   * right column, and it is what lets `equals: DbNull` compile to
+   * `<value at path> is null` while `equals: JsonNull` compiles to
+   * `<value at path> = <the JSON null>`. Refusing them because `#>>` cannot
+   * tell the two apart was true of `#>>` and not of the dialect.
+   *
+   * **Postgres casts and SQLite does not**, and the cast is not decoration:
+   * `#>` on a `json` column (a `@db.Json` field) yields `json`, which has no
+   * equality operator at all — *"operator does not exist: json = jsonb"*, a
+   * raised error rather than a wrong answer, but still one Prisma does not
+   * raise. Prisma emits `(…#>…)::jsonb` for exactly this reason and so does
+   * this. SQLite's `->` already yields the JSON text form.
+   *
+   * Bound, never interpolated, for the same reason `jsonExtract` is.
+   */
+  jsonValueAt(column: string, path: Binder): Fragment;
 
   /**
    * `limit`/`offset`. Both are values and therefore parameters — this is the

--- a/packages/gemi/orm/dialect/postgres.ts
+++ b/packages/gemi/orm/dialect/postgres.ts
@@ -285,6 +285,27 @@ export class PostgresDialect implements SqlDialect {
   }
 
   /**
+   * `("col" #> $1)::jsonb` — the JSON value at the path, comparable.
+   *
+   * The cast is load-bearing on a `@db.Json` column and a no-op on the `jsonb`
+   * one Prisma maps `Json` to by default. Measured against Postgres 16, on a
+   * `json` column:
+   *
+   *   (payload #> '{operation}')            = 'null'::jsonb   operator does not exist: json = jsonb
+   *   ((payload #> '{operation}')::jsonb)   = 'null'::jsonb   the row whose key holds a JSON null
+   *
+   * Prisma emits the same cast — `("Doc"."payload"#>ARRAY[$1]::text[])::jsonb`
+   * — which is where this one comes from rather than from the manual.
+   */
+  jsonValueAt(column: string, path: Binder): Fragment {
+    return concat(
+      sql("("),
+      this.jsonExtract(column, path, false),
+      sql(")::jsonb"),
+    );
+  }
+
+  /**
    * `("col" #> $1) @> $2` — containment, which is what Prisma's
    * `array_contains` compiles to and why it accepts both a scalar and a list:
    * `@>` asks whether the left document contains the right one, and a bare

--- a/packages/gemi/orm/dialect/sqlite.ts
+++ b/packages/gemi/orm/dialect/sqlite.ts
@@ -234,6 +234,40 @@ export class SqliteDialect implements SqlDialect {
     return concat(sql(`json_extract(${column}, `), param(path), sql(")"));
   }
 
+  /**
+   * `("col" -> ?)` — the JSON value at the path, as JSON text.
+   *
+   * **`->` rather than `json_extract`, and the difference is the whole point.**
+   * `json_extract` returns a *native* SQL value, so a JSON `null` comes back as
+   * SQL NULL and is then indistinguishable from an absent key — the collapse
+   * that had the sentinels refused here. `->` returns the JSON *text* of the
+   * subcomponent, which keeps them apart. Measured on SQLite 3.51 against
+   * `'$.operation'`:
+   *
+   *   {"operation":null}        ->: 'null'        json_extract: NULL
+   *   {"other":1}               ->: NULL          json_extract: NULL
+   *   {"operation":"sync"}      ->: '"sync"'      json_extract: 'sync'
+   *   {"operation":"null"}      ->: '"null"'      json_extract: 'null'
+   *
+   * The last row is why this is a real distinction rather than a spelling one:
+   * a JSON string `"null"` and a JSON null differ under `->` (the quotes are
+   * part of the text) and are the same under `json_extract`. So
+   * `equals: JsonNull` does not accidentally match a document holding the
+   * string.
+   *
+   * `json_type` would answer the same question and is the form #407 proposed;
+   * `->` is what Prisma emits here — `` `Doc`.`payload`->? IS NULL `` — and
+   * matching the oracle's operator costs nothing over inventing a second one.
+   * It needs SQLite 3.38 (2022); Bun ships 3.51.
+   *
+   * No cast, unlike Postgres: `->` already yields the text form both sides of
+   * the comparison are in, and `encode` spells a JSON null `'null'` for the
+   * bound side.
+   */
+  jsonValueAt(column: string, path: Binder): Fragment {
+    return concat(sql(`(${column} -> `), param(path), sql(")"));
+  }
+
   jsonArrayContains(): Fragment {
     // Unreachable: `jsonFilters` does not list it, so `where.ts` refuses first
     // with a message naming the dialect. Throwing here rather than returning

--- a/packages/gemi/orm/known-divergences.test.ts
+++ b/packages/gemi/orm/known-divergences.test.ts
@@ -123,4 +123,56 @@ describe("divergences the source knows about are documented", () => {
     expect(source).toMatch(/prisma\s+bun/i);
     expect(source).toMatch(/\$1::text::jsonb/);
   });
+
+  /**
+   * The fourth, found by reviewing #407 rather than by using the ORM — which is
+   * why it needs pinning hardest.
+   *
+   * A bare `null` in a filter means `is null` on every column type, and that is
+   * Prisma's reading on every column type *but* `Json`. There Prisma reads it
+   * as the JSON value `null` — the same thing it reads at a path — so
+   * `{ metadata: { equals: null } }` returns the SQL-NULL rows here and the
+   * JSON-null rows there. Disjoint sets, identical data, nothing raised.
+   *
+   * **It was nearly documented backwards.** #407 gave a bare `null` at a *path*
+   * the `JsonNull` reading, correctly and to match the oracle, and then
+   * explained the column/path difference as Prisma's own asymmetry. It is not:
+   * Prisma has no asymmetry, gemi has the divergence, and prose asserting the
+   * opposite would have told a reader the wrong row set was the right one. That
+   * is the failure this file exists to prevent, arriving through a comment
+   * rather than through silence.
+   *
+   * Not fixed, deliberately: the column path is released behaviour for every
+   * `Json` filter and wants its own change and its own differential cases.
+   * Recorded instead, in the three places a reader might start from.
+   */
+  test("the page documents the bare-null-on-a-Json-column divergence", () => {
+    expect(DOC).toMatch(
+      /##\s+A bare `null` on a `Json` column means `DbNull` here and `JsonNull` on Prisma/,
+    );
+
+    const section = DOC.slice(DOC.indexOf("## A bare `null` on a `Json` column"));
+    // The three things a reader cannot recover from the call site: which rows
+    // each side returns, that it is silent, and the spelling that avoids it.
+    expect(section).toMatch(/SQL-NULL rows/);
+    expect(section).toMatch(/JSON-null rows/);
+    expect(section).toMatch(/equals: DbNull/);
+    // ...and that the *path* is the case that agrees, so the section cannot be
+    // read as condemning the thing #407 added.
+    expect(section).toMatch(/agrees with Prisma/);
+  });
+
+  test("the compiler still carries the note that section is derived from", () => {
+    const source = readFileSync(
+      join(ROOT, "packages/gemi/orm/compile/where.ts"),
+      "utf8",
+    );
+
+    expect(source).toMatch(/KNOWN DIVERGENCE — a bare `null` on a `Json` column/);
+    // The measurement rather than the prose, for the reason the `json-param.ts`
+    // check above gives: if the two predicates go, the page is describing
+    // behaviour nothing in the repository records.
+    expect(source).toMatch(/"payload"::jsonb = \$1/);
+    expect(source).toMatch(/"payload" is null/);
+  });
 });

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -417,16 +417,29 @@ type ListFilter<E> = {
  * ({@link JsonPathNull}) and nowhere else: it asks "either kind of empty", which
  * is a question rather than a value, and the write paths refuse it.
  *
- * **`equals: null` is not refused, here or at run time, and it is read as
- * `DbNull`.** The type cannot exclude it — `JsonValue` minus `null` still
+ * **`equals: null` is not refused, here or at run time — and it is a KNOWN
+ * DIVERGENCE.** The type cannot exclude it: `JsonValue` minus `null` still
  * contains `{ [key: string]: JsonValue }`, and `{ equals: null }` is itself a
- * valid JSON object — and the compiler does not either: `equals` takes the
- * `operand === null` branch and compiles `"metadata" is null`, which is the
- * same predicate `equals: DbNull` gives. Measured against `compileRead` on both
- * dialects. So the column's two empty states are *not* forced apart by anything
- * except the convention of writing the sentinel, and Prisma has the same gap.
- * Stated rather than papered over: a comment claiming either layer rejects it
- * would be read as a guarantee, and this one used to.
+ * valid JSON object. Neither does the compiler — `equals` takes the
+ * `operand === null` branch and compiles `"metadata" is null`, the same
+ * predicate `equals: DbNull` gives.
+ *
+ * Prisma reads it as the other empty. Measured on 6.19.2 against Postgres 16
+ * and SQLite, over a table holding both states:
+ *
+ *   gemi    { metadata: { equals: null } }  ->  "metadata" is null    the SQL NULLs
+ *   prisma  { payload:  { equals: null } }  ->  "payload"::jsonb = $1 the JSON nulls
+ *
+ * Disjoint row sets on identical data, silently. So a bare `null` on the column
+ * is gemi's `DbNull` and Prisma's `JsonNull`, and the sentinel is the only
+ * spelling that means the same thing on both.
+ *
+ * Pre-existing and **not** #407's to fix — that change is about a value at a
+ * *path*, where gemi now agrees with Prisma exactly. Recorded here, in
+ * `where.ts` at `equals`, in `docs/orm.md` and in `known-divergences.test.ts`
+ * rather than left to be rediscovered, because this comment previously claimed
+ * first that the shape was refused and then that Prisma agreed, and both were
+ * read as guarantees.
  *
  * **This is the filter on the *column*, which is why `path` is excluded.** A
  * `path` sends the whole operand to `compileJsonFilter`, which answers the
@@ -516,7 +529,7 @@ type JsonPath = string | readonly string[];
  * offering a query only one dialect could answer.
  *
  * **The sentinels are not here, they are on {@link JsonPathNull}** — the arm
- * `equals` and `not` get and the other seven operators do not. They used to be
+ * `equals` and `not` get and the other eight operators do not. They used to be
  * on none of them, because `#>>` yields SQL NULL for an absent key and for a
  * JSON `null` alike and the distinction the sentinels draw was gone before the
  * comparison. `dialect.jsonValueAt` is the extraction that keeps it, so the
@@ -534,21 +547,29 @@ type JsonPathScalar = string | number | boolean;
  * `JsonNull` is "the value at this path is the JSON value `null`". `AnyNull` is
  * either, as everywhere else.
  *
- * **A bare `null` means different things here and on the column, and the split
- * is Prisma's.** On a `Json` *column* it is read as `DbNull` — the column is
- * SQL NULL — which is why {@link JsonInput} excludes it on the write side,
- * where the two empty states are both storable and guessing between them is the
- * failure the sentinels exist to prevent. (On the *read* side neither the type
- * nor the compiler excludes it; see {@link JsonFilter}.) At a *path* Prisma
- * reads it as the JSON value instead: `{ path: […], equals: null }` and
- * `{ path: […], equals: JsonNull }` compile to byte-identical SQL and return
- * identical rows, measured on 6.19.2 against Postgres 16 and SQLite. So the
- * two spellings are one query here, and refusing it would be gemi diverging
- * from the oracle rather than protecting anyone.
+ * **A bare `null` is admitted, and here it agrees with Prisma.** Prisma reads a
+ * bare `null` as the JSON value `null` wherever it appears, so at a path
+ * `{ path: […], equals: null }` and `{ path: […], equals: JsonNull }` compile to
+ * byte-identical SQL and return identical rows — measured on 6.19.2 against
+ * Postgres 16 and SQLite. Refusing it would be gemi diverging from the oracle
+ * rather than protecting anyone, which is why #371's second item is closed here
+ * rather than kept.
  *
- * The other seven operators keep refusing every member. `string_contains` and
- * friends want a string; the four numeric comparisons compare a number, and
- * Prisma's own query engine panics on `{ gt: null }` rather than answering it.
+ * It does **not** mean the same thing on the column, and that is gemi's
+ * divergence rather than Prisma's: there a bare `null` compiles to `is null`,
+ * i.e. `DbNull`, where Prisma still reads the JSON value. {@link JsonFilter}
+ * records it. Writing the sentinel you mean is what makes a filter say the same
+ * thing in both positions and on both libraries.
+ *
+ * ({@link JsonInput} excludes `null` on the *write* side, where the two empty
+ * states are both storable and guessing between them is the failure the
+ * sentinels exist to prevent. Nothing excludes it on the read side.)
+ *
+ * The other eight operators keep refusing every member — all eight, which is
+ * the count `JSON_FILTER_NAMES`'s ten minus these two gives. `string_contains`
+ * and friends want a string; `array_contains` wants a document; the four
+ * numeric comparisons compare a number, and Prisma's own query engine panics on
+ * `{ gt: null }` rather than answering it.
  */
 type JsonPathNull =
   | null
@@ -615,7 +636,7 @@ type JsonPathFilter = { path: JsonPath } & {
  * replaces; the narrowing lives on the arm here so the two do not resolve to
  * whichever side of the merge is taken.)
  *
- * **`equals` and `not` split off from the other five scalar operators** because
+ * **`equals` and `not` split off from the other four scalar operators** because
  * they are the two that can ask *which kind of null* a value is — see
  * {@link JsonPathNull}. The arm is placed above the default rather than folded
  * into it so the four numeric comparisons keep refusing a sentinel, which is

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -509,30 +509,44 @@ type JsonPath = string | readonly string[];
  * form, which is Postgres-only — so the type says the same thing rather than
  * offering a query only one dialect could answer.
  *
- * **The sentinels are absent, and their absence is the point.** `DbNull`,
- * `JsonNull` and `AnyNull` are refused at a path by `compileJsonFilter`, because
- * `#>>` yields SQL NULL for an absent key and for a JSON `null` alike — the
- * distinction the sentinels exist to draw is gone before the comparison
- * happens. They stay on `JsonFilter`, which compiles against the column, where
- * the distinction survives.
- *
- * **`null` is absent too, and the compiler now agrees — #371.** This comment
- * used to record it as the one place the type went further than the runtime:
- * `assertJsonOperand` let `null` through and `{ path: […], equals: null }`
- * compiled to `("metadata" #>> $1) = $2` bound to NULL, which is NULL rather
- * than true on both dialects — a predicate no row can satisfy. It is an
- * `InvalidArgumentError` now, so a `null` arriving dynamically is refused
- * rather than silently answered wrong.
- *
- * The refusal is a *divergence*, not a gap in the type. Prisma extracts with
- * `#>` and compares as `jsonb`, so it reads `equals: null` as the JSON value
- * `null` and returns the rows holding one — measured on 6.19.2, identical SQL
- * and identical rows to `equals: Prisma.JsonNull`. gemi extracts with `#>>`,
- * which yields SQL NULL for an absent key and a JSON null alike, so the
- * question cannot be asked at a path here at all — the same collapse that
- * keeps the sentinels off this type.
+ * **The sentinels are not here, they are on {@link JsonPathNull}** — the arm
+ * `equals` and `not` get and the other seven operators do not. They used to be
+ * on none of them, because `#>>` yields SQL NULL for an absent key and for a
+ * JSON `null` alike and the distinction the sentinels draw was gone before the
+ * comparison. `dialect.jsonValueAt` is the extraction that keeps it, so the
+ * question is answerable at a path now (#407) — under the two operators that
+ * can ask it, which is exactly where Prisma admits them too.
  */
 type JsonPathScalar = string | number | boolean;
+
+/**
+ * The null operands `equals` and `not` take at a path.
+ *
+ * The same four spellings `JsonFilter` offers on the column, and they mean the
+ * corresponding things one level down: `DbNull` is "there is no value at this
+ * path" — an absent key, or a column with nothing to index into — and
+ * `JsonNull` is "the value at this path is the JSON value `null`". `AnyNull` is
+ * either, as everywhere else.
+ *
+ * **A bare `null` is admitted here and refused on the column, and that
+ * asymmetry is Prisma's.** On a `Json` *column* the two empty states are both
+ * reachable and choosing between them is the whole reason the sentinels exist,
+ * so `null` is excluded from `JsonWriteValue` and from `JsonFilter` — guessing
+ * is the failure. At a *path* Prisma simply reads `null` as the JSON value:
+ * `{ path: […], equals: null }` and `{ path: […], equals: JsonNull }` compile
+ * to byte-identical SQL and return identical rows, measured on 6.19.2 against
+ * Postgres 16 and SQLite. So there is nothing to guess, and refusing it would
+ * be gemi diverging from the oracle rather than protecting anyone.
+ *
+ * The other seven operators keep refusing every member. `string_contains` and
+ * friends want a string; the four numeric comparisons compare a number, and
+ * Prisma's own query engine panics on `{ gt: null }` rather than answering it.
+ */
+type JsonPathNull =
+  | null
+  | DbNullValue
+  | JsonNullValue
+  | AnyNullValue;
 
 /**
  * `where: { metadata: { path: …, equals: … } }` — a filter on a value *inside*
@@ -592,12 +606,20 @@ type JsonPathFilter = { path: JsonPath } & {
  * narrows the same property on the hand-written literal this mapped type
  * replaces; the narrowing lives on the arm here so the two do not resolve to
  * whichever side of the merge is taken.)
+ *
+ * **`equals` and `not` split off from the other five scalar operators** because
+ * they are the two that can ask *which kind of null* a value is — see
+ * {@link JsonPathNull}. The arm is placed above the default rather than folded
+ * into it so the four numeric comparisons keep refusing a sentinel, which is
+ * what the compiler does and what Prisma does.
  */
 type JsonPathOperand<K extends JsonFilterName> = K extends "array_contains"
   ? Exclude<JsonValue, null>
   : K extends "string_contains" | "string_starts_with" | "string_ends_with"
     ? string
-    : JsonPathScalar;
+    : K extends "equals" | "not"
+      ? JsonPathScalar | JsonPathNull
+      : JsonPathScalar;
 
 /**
  * The bare-value half of a `Json` column's filter — **`JsonValue` with its

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -413,23 +413,29 @@ type ListFilter<E> = {
  * `Json` filters, which are a comparison against one of the column's empty
  * states as often as against a value.
  *
- * `AnyNull` is accepted here and nowhere else: it asks "either kind of empty",
- * which is a question rather than a value, and the write paths refuse it.
+ * `AnyNull` is accepted here and under `equals` / `not` at a path
+ * ({@link JsonPathNull}) and nowhere else: it asks "either kind of empty", which
+ * is a question rather than a value, and the write paths refuse it.
  *
- * **`equals: null` is refused at runtime and cannot be refused here.** A `Json`
- * column has two empty states and the filter has to say which, so the compiler
- * raises `InvalidArgumentError` naming the explicit form — but the type cannot
- * express it, because `JsonValue` minus `null` still contains
- * `{ [key: string]: JsonValue }`, and `{ equals: null }` is itself a valid JSON
- * object. Prisma has the same gap. Stated rather than papered over: a comment
- * claiming the type rejects it would be read as a guarantee.
+ * **`equals: null` is not refused, here or at run time, and it is read as
+ * `DbNull`.** The type cannot exclude it — `JsonValue` minus `null` still
+ * contains `{ [key: string]: JsonValue }`, and `{ equals: null }` is itself a
+ * valid JSON object — and the compiler does not either: `equals` takes the
+ * `operand === null` branch and compiles `"metadata" is null`, which is the
+ * same predicate `equals: DbNull` gives. Measured against `compileRead` on both
+ * dialects. So the column's two empty states are *not* forced apart by anything
+ * except the convention of writing the sentinel, and Prisma has the same gap.
+ * Stated rather than papered over: a comment claiming either layer rejects it
+ * would be read as a guarantee, and this one used to.
  *
  * **This is the filter on the *column*, which is why `path` is excluded.** A
- * `path` sends the whole operand to `compileJsonFilter`, where the sentinels are
- * refused — `#>>` cannot tell an absent key from a JSON `null`. Without the
- * `path?: never`, `{ path: […], equals: DbNull }` landed here instead of on
- * `JsonPathFilter`, because a union ignores a property one member declares and
- * excess-property checking counts it known if *any* member has it.
+ * `path` sends the whole operand to `compileJsonFilter`, which answers the
+ * sentinels under `equals` and `not` and refuses them under the other eight
+ * (#407) — a different grammar, reached through `dialect.jsonValueAt` rather
+ * than through the column. Without the `path?: never`,
+ * `{ path: […], equals: DbNull }` landed here instead of on `JsonPathFilter`,
+ * because a union ignores a property one member declares and excess-property
+ * checking counts it known if *any* member has it.
  *
  * **`equals` and `not` are asymmetric, and the compiler is what makes them so.**
  * `equals` binds its operand as a *value*, so an object under it is a document
@@ -528,15 +534,17 @@ type JsonPathScalar = string | number | boolean;
  * `JsonNull` is "the value at this path is the JSON value `null`". `AnyNull` is
  * either, as everywhere else.
  *
- * **A bare `null` is admitted here and refused on the column, and that
- * asymmetry is Prisma's.** On a `Json` *column* the two empty states are both
- * reachable and choosing between them is the whole reason the sentinels exist,
- * so `null` is excluded from `JsonWriteValue` and from `JsonFilter` — guessing
- * is the failure. At a *path* Prisma simply reads `null` as the JSON value:
- * `{ path: […], equals: null }` and `{ path: […], equals: JsonNull }` compile
- * to byte-identical SQL and return identical rows, measured on 6.19.2 against
- * Postgres 16 and SQLite. So there is nothing to guess, and refusing it would
- * be gemi diverging from the oracle rather than protecting anyone.
+ * **A bare `null` means different things here and on the column, and the split
+ * is Prisma's.** On a `Json` *column* it is read as `DbNull` — the column is
+ * SQL NULL — which is why {@link JsonInput} excludes it on the write side,
+ * where the two empty states are both storable and guessing between them is the
+ * failure the sentinels exist to prevent. (On the *read* side neither the type
+ * nor the compiler excludes it; see {@link JsonFilter}.) At a *path* Prisma
+ * reads it as the JSON value instead: `{ path: […], equals: null }` and
+ * `{ path: […], equals: JsonNull }` compile to byte-identical SQL and return
+ * identical rows, measured on 6.19.2 against Postgres 16 and SQLite. So the
+ * two spellings are one query here, and refusing it would be gemi diverging
+ * from the oracle rather than protecting anyone.
  *
  * The other seven operators keep refusing every member. `string_contains` and
  * friends want a string; the four numeric comparisons compare a number, and

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -1436,6 +1436,205 @@ function suite(label: string, url?: string) {
     );
 
     /**
+     * The same three sentinels **one level down**, at a JSON path — #407.
+     *
+     * They were refused here until now, and the refusal was right about the
+     * extraction it named: `#>>` yields SQL NULL for an absent key and for a
+     * JSON `null` alike, so there was nothing left to compare. `#>` keeps the
+     * distinction and so does SQLite's `->`, which is what `dialect.jsonValueAt`
+     * is, so the question is answerable on both dialects.
+     *
+     * **This suite is the reason the SQLite half went the way it did.** The
+     * issue offered two defensible answers — keep refusing on SQLite the way
+     * `array_contains` is dialect-gated, or implement `json_type` — and left the
+     * choice open. Measuring the oracle first, which is this repo's convention
+     * and what the issue asked for, settled it: Prisma answers all three at a
+     * path on SQLite too, and returns the *same rows* it returns on Postgres.
+     * Refusing there would have been a divergence from the oracle rather than a
+     * difference between the databases, which is the one thing the dialect gate
+     * is not for.
+     *
+     * ### The rows, and why four more of them
+     *
+     * Every case here compares gemi against Prisma, so **both agreeing on the
+     * empty set is a pass** — the trap the sentinel block above names, and it
+     * bites harder at a path because a path has three states rather than two.
+     * The seed discriminates two of them (`p1` holds a scalar at `plan`, `p2`
+     * holds `{}` so the key is absent, `p4` leaves the column SQL NULL) and not
+     * the third: no seeded row has a JSON `null` *at* a key, which is precisely
+     * what `JsonNull` asks for and precisely what separates it from `DbNull`.
+     * Without `p6` below, `equals: JsonNull` returns nothing from either client
+     * and an implementation that answered `DbNull`'s question instead would
+     * pass.
+     *
+     * `p7` covers the other half of that: a column holding a JSON `null` has
+     * nothing to index into, so the extraction is SQL NULL and the row is a
+     * `DbNull` match rather than a `JsonNull` one. It reads as a surprise and
+     * is what both databases do.
+     *
+     * `p8` is the JSON string `"null"`, and it is the case that catches an
+     * implementation reaching for the text extraction after all: under `#>>`
+     * and under SQLite's `json_extract` this row is indistinguishable from a
+     * JSON null, and under `#>` and `->` it is not.
+     *
+     * Added in a `beforeAll` rather than in `seed`, and taken back out in an
+     * `afterAll`, because the shared seed's row count and ordering are asserted
+     * by cases throughout this file.
+     */
+    describe("a Json null sentinel at a path", () => {
+      /** Postgres takes an array of keys, SQLite a JSONPath string. */
+      const path = url ? ["plan"] : "$.plan";
+
+      beforeAll(async () => {
+        await differential.prisma.user.createMany({
+          data: [
+            {
+              publicId: "p6",
+              email: "p6@example.dev",
+              globalRole: 2,
+              createdAt: new Date(EPOCH + 5000),
+              updatedAt: new Date(EPOCH + 5000),
+              // The JSON value `null` *at* the key — the state the seed had
+              // none of, and the only thing `JsonNull` matches here.
+              metadata: { plan: null },
+            },
+            {
+              publicId: "p7",
+              email: "p7@example.dev",
+              globalRole: 2,
+              createdAt: new Date(EPOCH + 6000),
+              updatedAt: new Date(EPOCH + 6000),
+              // The *column* is a JSON null, so there is nothing to index into
+              // and the extraction is SQL NULL — a `DbNull` row, not a
+              // `JsonNull` one.
+              metadata: PrismaNS.JsonNull,
+            },
+            {
+              publicId: "p8",
+              email: "p8@example.dev",
+              globalRole: 2,
+              createdAt: new Date(EPOCH + 7000),
+              updatedAt: new Date(EPOCH + 7000),
+              // The JSON *string* "null", which the text extraction cannot tell
+              // from a JSON null and the JSON one can.
+              metadata: { plan: "null" },
+            },
+          ],
+        });
+      });
+
+      afterAll(async () => {
+        await differential.reset();
+      });
+
+      test.each([
+        ["equals DbNull", { equals: PrismaNS.DbNull }],
+        ["equals JsonNull", { equals: PrismaNS.JsonNull }],
+        ["equals AnyNull", { equals: PrismaNS.AnyNull }],
+        ["not DbNull", { not: PrismaNS.DbNull }],
+        ["not JsonNull", { not: PrismaNS.JsonNull }],
+        ["not AnyNull", { not: PrismaNS.AnyNull }],
+        // A bare `null` reads as `JsonNull` at a path, which is Prisma's
+        // reading and the opposite of the rule on the column. #371's second
+        // item, closed by the same change.
+        ["equals null", { equals: null }],
+        ["not null", { not: null }],
+      ] as [string, object][])("%s", async (_label, filter) => {
+        await differential.expectSame("User", "findMany", {
+          where: { metadata: { path, ...filter } },
+          orderBy: { id: "asc" },
+        });
+      });
+
+      /**
+       * The folio predicate from #407 — `COALESCE(payload->>'x', name) = v`
+       * spelled in the grammar, and the read that could not leave Prisma.
+       *
+       * The second branch is the one that needed `AnyNull`: "the extracted
+       * value is not there, so fall back to the column". It is here rather than
+       * only in the compiler tests because the whole claim is about *rows*, and
+       * because it is the shape that exercises a sentinel inside an `OR` beside
+       * an ordinary column filter.
+       */
+      test("the fallback predicate the issue could not write", async () => {
+        // Both branches contribute: `p1` carries `plan: "pro"` in the payload,
+        // and `p3` is an "Ada" whose payload has no `plan` at all — which is
+        // the row the second branch exists for. A predicate that answered only
+        // the first branch would still return rows, so this discriminates.
+        const rows = (await differential.expectSame("User", "findMany", {
+          where: {
+            OR: [
+              { metadata: { path, equals: "pro" } },
+              { name: "Ada", metadata: { path, equals: PrismaNS.AnyNull } },
+            ],
+          },
+          orderBy: { id: "asc" },
+        })) as { publicId: string }[];
+
+        expect(rows.map((row) => row.publicId)).toEqual(["p1", "p3"]);
+      });
+
+      /**
+       * ...and the rows those cases run against discriminate.
+       *
+       * Asserted on what the comparison actually saw, for the reason the enum
+       * block below gives: every case above passes if both clients return
+       * nothing, so a seed that drifted would leave eight green tests checking
+       * nothing. These four numbers are the ones that make the eight
+       * meaningful — each sentinel has to select a *different*, non-empty set,
+       * and `JsonNull` in particular has to find exactly `p6` rather than
+       * agreeing with `DbNull`.
+       */
+      test("the three sentinels select three different non-empty sets", async () => {
+        const ids = async (filter: object) =>
+          (
+            (await differential.expectSame("User", "findMany", {
+              where: { metadata: { path, ...filter } },
+              orderBy: { id: "asc" },
+            })) as { publicId: string }[]
+          ).map((row) => row.publicId);
+
+        const db = await ids({ equals: PrismaNS.DbNull });
+        const json = await ids({ equals: PrismaNS.JsonNull });
+        const any = await ids({ equals: PrismaNS.AnyNull });
+
+        // Exactly the row holding a JSON null *at* the key — the assertion that
+        // does the work. Not `p8`, whose value is the JSON *string* `"null"`,
+        // and not any of `DbNull`'s rows.
+        expect(json).toEqual(["p6"]);
+
+        // "Nothing at this path": the key is absent on `p2` and `p3`, the
+        // column is a JSON scalar with no key to reach on `p5`, SQL NULL on
+        // `p4`, and a JSON null on `p7`.
+        expect(db.length).toBeGreaterThan(1);
+        expect(db).not.toContain("p6");
+        expect(db).not.toContain("p8");
+
+        // ...and `AnyNull` is exactly the two together, which is what makes it
+        // a third question rather than a spelling of one of the other two.
+        expect(any).toEqual([...db, ...json].sort());
+      });
+
+      /**
+       * The row that separates the JSON-preserving extraction from the text
+       * one, asserted on its own so a regression to `#>>` / `json_extract`
+       * names itself here instead of arriving as an off-by-one row count.
+       *
+       * `p8` holds the JSON string `"null"`. Under the text extraction it is
+       * the four characters `null`, indistinguishable from a JSON null; under
+       * `#>` and `->` it is `"null"` with its quotes and is an ordinary string.
+       */
+      test("the JSON string \"null\" is not a JSON null", async () => {
+        const rows = (await differential.expectSame("User", "findMany", {
+          where: { metadata: { path, equals: "null" } },
+          orderBy: { id: "asc" },
+        })) as { publicId: string }[];
+
+        expect(rows.map((row) => row.publicId)).toEqual(["p8"]);
+      });
+    });
+
+    /**
      * ...and the data those cases run against discriminates.
      *
      * Every case above compares gemi to Prisma, so both agreeing on nothing is

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -1535,8 +1535,10 @@ function suite(label: string, url?: string) {
         ["not JsonNull", { not: PrismaNS.JsonNull }],
         ["not AnyNull", { not: PrismaNS.AnyNull }],
         // A bare `null` reads as `JsonNull` at a path, which is Prisma's
-        // reading and the opposite of the rule on the column. #371's second
-        // item, closed by the same change.
+        // reading — so these two rows are the same query as the JsonNull ones
+        // above. #371's second item, closed by the same change. (On the
+        // *column* gemi reads a bare `null` as `DbNull` and Prisma does not;
+        // that divergence is recorded in `known-divergences.test.ts`.)
         ["equals null", { equals: null }],
         ["not null", { not: null }],
       ] as [string, object][])("%s", async (_label, filter) => {

--- a/templates/saas-starter/app/models/filters.test-d.ts
+++ b/templates/saas-starter/app/models/filters.test-d.ts
@@ -355,7 +355,7 @@ describe("Json path filters", () => {
   });
 
   /**
-   * ...and under the other seven it is still a compile error, which is what the
+   * ...and under the other eight it is still a compile error, which is what the
    * compiler does and what Prisma does — *"Invalid value provided. … provided
    * Enum."*, measured on 6.19.2. A sentinel asks which kind of null a value is;
    * `gt` compares a number and `string_contains` builds a pattern.
@@ -384,11 +384,22 @@ describe("Json path filters", () => {
    *
    * On the *column* a bare `null` is accepted too and means the other thing —
    * `DbNull`, compiling to `is null`. Neither the type nor the compiler refuses
-   * it there; `JsonFilter`'s docblock says why the type cannot. The two lines
-   * below pin that, because an earlier draft of this comment asserted the
-   * column form was a type error and nothing here would have caught it.
+   * it there; `JsonFilter`'s docblock says why the type cannot.
+   *
+   * **And that one is a known divergence rather than a rule.** Prisma reads a
+   * bare `null` as the JSON value on the column as well, so the two libraries
+   * return disjoint row sets for the same filter — measured, and recorded in
+   * `known-divergences.test.ts` and `docs/orm.md`. It is pre-existing and not
+   * #407's to fix; what #407 changed is the *path*, where the two now agree.
+   *
+   * The lines below pin only that the column form compiles, which is all a type
+   * test can see. Two earlier drafts of this comment got the surrounding claim
+   * wrong in opposite directions — first that the column form was a type error,
+   * then that Prisma agreed with it — and nothing here would have caught
+   * either, so the sentence is kept short and the row-level claim is left to
+   * the file that can measure it.
    */
-  test("a bare null on the column is accepted, and reads as DbNull", async () => {
+  test("a bare null on the column is accepted, and diverges from Prisma", async () => {
     await UserModel.findMany({ where: { metadata: { equals: null } } });
     await UserModel.findMany({ where: { metadata: { not: null } } });
   });

--- a/templates/saas-starter/app/models/filters.test-d.ts
+++ b/templates/saas-starter/app/models/filters.test-d.ts
@@ -330,39 +330,67 @@ describe("Json path filters", () => {
   });
 
   /**
-   * `compileJsonFilter` refuses the sentinels at a path, and refuses the same
-   * shape one level down — `{ equals: { not: DbNull } }` — because `#>>` yields
-   * SQL NULL for an absent key and a JSON `null` alike, so the distinction the
-   * sentinels exist to draw is gone before the comparison happens. Folio's
-   * `{ payload: { path: […], equals: AnyNull } }` is exactly this, and typing
-   * it as valid is what this pair prevents.
+   * **The sentinels type-check under `equals` and `not`, and nowhere else at a
+   * path — #407.** They used to be refused under all ten, because `#>>` yields
+   * SQL NULL for an absent key and a JSON `null` alike and the distinction the
+   * sentinels draw was gone before the comparison. `dialect.jsonValueAt` is the
+   * extraction that keeps it — `#>` on Postgres, `->` on SQLite — so the
+   * question is answerable, and the type has to admit it: folio's
+   * `{ payload: { path: […], equals: AnyNull } }` is a read that could not
+   * leave Prisma while this was a compile error.
    */
-  test("a sentinel at a path is refused, and so is one a level down", async () => {
-    // @ts-expect-error an extracted value cannot tell the two empties apart
+  test("a sentinel at a path type-checks under equals and not", async () => {
     await UserModel.findMany({ where: { metadata: { path: ["a"], equals: DbNull } } });
-    // @ts-expect-error nor can it under `not`
     await UserModel.findMany({ where: { metadata: { path: ["a"], not: JsonNull } } });
-    // @ts-expect-error and the nested operator object is refused with them
+    await UserModel.findMany({ where: { metadata: { path: ["a"], equals: AnyNull } } });
+    // The predicate #407 exists for: "the extracted value is not there".
+    await UserModel.findMany({
+      where: {
+        OR: [
+          { metadata: { path: ["operation"], equals: "video" } },
+          { name: "video", metadata: { path: ["operation"], equals: AnyNull } },
+        ],
+      },
+    });
+  });
+
+  /**
+   * ...and under the other seven it is still a compile error, which is what the
+   * compiler does and what Prisma does — *"Invalid value provided. … provided
+   * Enum."*, measured on 6.19.2. A sentinel asks which kind of null a value is;
+   * `gt` compares a number and `string_contains` builds a pattern.
+   *
+   * The nested shape goes with them: `{ equals: { not: DbNull } }` is an object
+   * operand, and an object under `equals` is refused for its own reason.
+   */
+  test("a sentinel under the other operators is refused, and so is one a level down", async () => {
+    // @ts-expect-error a sentinel is not a number
+    await UserModel.findMany({ where: { metadata: { path: ["a"], gt: DbNull } } });
+    // @ts-expect-error nor a string to build a pattern from
+    await UserModel.findMany({ where: { metadata: { path: ["a"], string_contains: JsonNull } } });
+    // @ts-expect-error nor a document to test containment against
+    await UserModel.findMany({ where: { metadata: { path: ["a"], array_contains: AnyNull } } });
+    // @ts-expect-error and the nested operator object is refused as an object
     await UserModel.findMany({ where: { metadata: { path: ["a"], equals: { not: AnyNull } } } });
   });
 
   /**
-   * **`null` is refused, and the compiler agrees now — #371.** This was the one
-   * place the type went further than the runtime: `assertJsonOperand` let it
-   * through and the query compiled to `("metadata" #>> $1) = $2` bound to NULL,
-   * which is NULL and not true on both dialects — a predicate no row can
-   * satisfy. It is an `InvalidArgumentError` there now, so a `null` arriving
-   * dynamically is refused rather than answered wrong.
+   * **A bare `null` is accepted under `equals` / `not` at a path, and refused
+   * on the column** — the asymmetry is Prisma's and it is worth stating because
+   * it looks like an inconsistency.
    *
-   * The refusal is a divergence rather than a gap in the type: Prisma extracts
-   * with `#>` and compares as `jsonb`, so it reads this as the JSON value
-   * `null` and answers it. gemi's `#>>` yields SQL NULL for an absent key and a
-   * JSON null alike, which is the same collapse that keeps the sentinels off
-   * this filter.
+   * On the column the two empty states are both reachable and choosing between
+   * them is the whole reason the sentinels exist, so `null` is a type error and
+   * `DbNull` / `JsonNull` are required. At a path Prisma simply reads `null` as
+   * the JSON value: `{ path: […], equals: null }` and
+   * `{ path: […], equals: JsonNull }` compile to byte-identical SQL and return
+   * identical rows, measured on 6.19.2 against both dialects. There is nothing
+   * to guess, so refusing it would be gemi diverging from the oracle. That was
+   * #371's second item, and #407 closed it with the same change.
    *
-   * **`array_contains` is the same refusal for a different reason**, and it is
-   * the one path operator whose operand is a whole document, so it does not
-   * come along with the scalar arm. A bare `null` there reaches
+   * **`array_contains` still refuses a bare `null`**, and for a different
+   * reason — it is the one path operator whose operand is a whole document, so
+   * it does not come along with the scalar arm. A bare `null` there reaches
    * `dialect.jsonArrayContains` and binds as SQL NULL; `x @> NULL` is NULL, not
    * false, so the filter matches no row rather than asking anything. Only the
    * top-level operand goes — a `null` *inside* the document is an ordinary JSON
@@ -371,13 +399,15 @@ describe("Json path filters", () => {
    * type; the narrowing lives on `JsonPathOperand`'s `array_contains` arm so
    * the two do not come down to which side of a merge is taken.)
    */
-  test("null at a path is refused, because gemi cannot ask Prisma's question", async () => {
-    // @ts-expect-error `= NULL` is never true; say which empty you mean, on the column
+  test("null at a path reads as JsonNull, except under array_contains", async () => {
     await UserModel.findMany({ where: { metadata: { path: ["a"], equals: null } } });
-    // @ts-expect-error `x @> NULL` is NULL too, so containment against a bare null asks nothing
+    await UserModel.findMany({ where: { metadata: { path: ["a"], not: null } } });
+    // @ts-expect-error `x @> NULL` is NULL, so containment against a bare null asks nothing
     await UserModel.findMany({ where: { metadata: { path: ["a"], array_contains: null } } });
     // ...and it is only the *top level* that goes: a null inside the document is a value.
     await UserModel.findMany({ where: { metadata: { path: ["a"], array_contains: [1, null] } } });
+    // @ts-expect-error the numeric comparisons compare a number; Prisma's engine panics on this
+    await UserModel.findMany({ where: { metadata: { path: ["a"], gt: null } } });
   });
 
   /**

--- a/templates/saas-starter/app/models/filters.test-d.ts
+++ b/templates/saas-starter/app/models/filters.test-d.ts
@@ -375,18 +375,26 @@ describe("Json path filters", () => {
   });
 
   /**
-   * **A bare `null` is accepted under `equals` / `not` at a path, and refused
-   * on the column** — the asymmetry is Prisma's and it is worth stating because
-   * it looks like an inconsistency.
-   *
-   * On the column the two empty states are both reachable and choosing between
-   * them is the whole reason the sentinels exist, so `null` is a type error and
-   * `DbNull` / `JsonNull` are required. At a path Prisma simply reads `null` as
-   * the JSON value: `{ path: […], equals: null }` and
+   * **A bare `null` is accepted under `equals` / `not` at a path, and it means
+   * `JsonNull` there** — `{ path: […], equals: null }` and
    * `{ path: […], equals: JsonNull }` compile to byte-identical SQL and return
    * identical rows, measured on 6.19.2 against both dialects. There is nothing
    * to guess, so refusing it would be gemi diverging from the oracle. That was
    * #371's second item, and #407 closed it with the same change.
+   *
+   * On the *column* a bare `null` is accepted too and means the other thing —
+   * `DbNull`, compiling to `is null`. Neither the type nor the compiler refuses
+   * it there; `JsonFilter`'s docblock says why the type cannot. The two lines
+   * below pin that, because an earlier draft of this comment asserted the
+   * column form was a type error and nothing here would have caught it.
+   */
+  test("a bare null on the column is accepted, and reads as DbNull", async () => {
+    await UserModel.findMany({ where: { metadata: { equals: null } } });
+    await UserModel.findMany({ where: { metadata: { not: null } } });
+  });
+
+  /**
+   * ...and at a path it is the other empty — see the test above for the column.
    *
    * **`array_contains` still refuses a bare `null`**, and for a different
    * reason — it is the one path operator whose operand is a whole document, so


### PR DESCRIPTION
Closes #407. Also closes the second item of #371 (`null` at a path), which falls out of the same change.

## What compiles now

```ts
// the read in apps/web that could not leave Prisma
where.OR = [
  { payload: { path: ["operation"], equals: op } },
  { name: op, payload: { path: ["operation"], equals: AnyNull } },
];
```

`DbNull`, `JsonNull`, `AnyNull` and a bare `null` under `equals` and `not`, at a path, on **both** dialects.

## The refusal was right about `#>>` and wrong about the database

`compileJsonFilter` refused all three because "the extraction yields NULL for an absent key and for a JSON null alike". True of `#>>` — and `#>` keeps the distinction, as the issue says, and so does SQLite's `->`, which the issue did not know.

`dialect.jsonValueAt` is that second extraction:

| | extraction | `DbNull` | `JsonNull` |
| --- | --- | --- | --- |
| postgres | `("col" #> $1)::jsonb` | `… is null` | `… = $2::text::jsonb` |
| sqlite | `("col" -> ?)` | `… is null` | `… = ?` (`'null'`) |

`AnyNull` is the two or-ed, `not` the direct negations. The JSON null on the right is bound through each dialect's existing encoder — no literal reaches the SQL text.

The Postgres `::jsonb` cast is not decoration: `#>` on a `@db.Json` column yields `json`, and `json = jsonb` is not an operator. Prisma emits the same cast.

## Measuring the oracle changed the answer

The issue asked for this first, and it decided the one question it left open: it offered two options for SQLite — keep refusing, or implement `json_type` — on the premise that this might be Postgres-only.

It is not. Measured on a generated 6.19.2 client, both dialects: **Prisma answers all three at a path on SQLite too, and returns the same rows it returns on Postgres.** Refusing there would have been a divergence from the oracle rather than a difference between the databases. The operator is `->` rather than `json_type` because `->` is what Prisma emits.

Three more things came out of the same measurement:

- **A bare `null` at a path is `JsonNull`** — byte-identical SQL to the sentinel on both dialects. #371 closed this by refusing, for the `#>>` reason; the same fix reaches it.
- **The other eight operators keep refusing all three**, because Prisma does: *"Invalid value provided. … provided Enum."*
- **`gt: null` keeps its refusal, but not its message.** It claimed "Prisma does answer it; gemi does not yet". Prisma's query engine *panics* on it.

## Tests

11 differential cases against Prisma, green on both dialects. They add their own rows and reset afterwards, because the shared seed does not discriminate here: no seeded row has a JSON `null` *at* a key, so `equals: JsonNull` would have returned nothing from both clients and an implementation answering `DbNull`'s question would have passed. A row holding the JSON *string* `"null"` is in there too — the row the text extraction cannot tell from a JSON null.

The shared invariant corpus gained the new shapes, which needed a fix first: `vary` rebuilds objects from `Object.entries`, and a sentinel has no enumerable properties, so it came back as `{}` — a changed *shape* rather than a changed value. `Date` and typed arrays had the same hole. Verified load-bearing by mutation: remove the guard and `plan-key.invariants` fails on both dialects, because of the new entries.

```
packages/gemi           139 files   3553 passed
template, sqlite         23 files    883 passed
template, postgres       15 files    965 passed
template, types           6 files    120 passed
```

## What review changed

Two adversarial review passes (5 dimensions). No correctness, binding-invariant or plan-key defect in the change. What they did find, and what the later commits fix:

- **A false claim I wrote, on the question this PR exists to settle.** The prose explained the column/path difference for a bare `null` as "Prisma's asymmetry". Prisma has no asymmetry — it reads a bare `null` as the JSON value in *both* positions. The split is gemi's, and on the column it is a live silent divergence: `{ metadata: { equals: null } }` returns the SQL-NULL rows here and the JSON-null rows on Prisma. **Not fixed here** — that is released behaviour for every `Json` column filter and wants its own change and differential cases — but recorded as a `KNOWN DIVERGENCE` at `equals`, a section in `docs/orm.md`, and two pins in `known-divergences.test.ts`. Filed as #409.
- **`array_contains: null` is refused where Prisma answers.** The guard heading claimed the oracle refuses it too — true of the numeric four, false of `array_contains`. Corrected in the comment, the message and the docs.
- **A missing coverage gap and a `vary` bug** (above), plus a `JsonWriteValue` reference to a type that does not exist, and four miscounts ("the other seven operators" is eight; "the other five scalar operators" is four).

Three further findings were refuted on inspection — all pre-existing and untouched by this diff. The two worth knowing about are noted on #409.

## Scope

Not touched, per the issue: the object/array operand at a path, and `jsonb_exists`. The `assertJsonOperand` docblock's reason for refusing an object has narrowed and now says so — it used to be "the JSON-preserving extraction is Postgres-only", which is no longer true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
