### PR TITLE
feat(image): default to Bun.Image for resizing and metadata

### DIFF
--- a/docs/file-storage.md
+++ b/docs/file-storage.md
@@ -113,7 +113,7 @@ const files = await Storage.list("avatars/");
 
 ### `metadata(blob | file)`
 
-Reads image metadata (width, height, format, etc.) from a `Blob`/`File` using Sharp. Returns a partial metadata object, or `{}` if the bytes aren't a decodable image — useful for validating an upload before storing it.
+Reads image metadata from a `Blob`/`File` using `Bun.Image`. Returns a partial `{ width, height, format }`, or `{}` if the bytes aren't a decodable image — useful for validating an upload before storing it.
 
 ```typescript
 const meta = await Storage.metadata(uploadedFile);
@@ -340,16 +340,26 @@ export default class extends Kernel {
 
 ## Image optimization
 
-gemi optimizes images on demand — resizing and re-encoding to WebP — through the `ImageManager`, which uses a Sharp-backed driver by default. It needs no configuration at all; supply an `image` slice only to swap the driver:
+gemi optimizes images on demand — resizing and re-encoding to WebP — through the `ImageManager`, which uses a `Bun.Image`-backed driver by default. `Bun.Image` is built into Bun, so this needs no native module and no install step. Supply an `image` slice only to swap the driver:
 
 ```typescript
 // app/config/image.ts
 import { defineImageConfig } from "gemi/services";
-import { MySharpVariant } from "../images/MySharpVariant";
+import { MyDriver } from "../images/MyDriver";
 
 export default defineImageConfig({
-  driver: new MySharpVariant(),
+  driver: new MyDriver(),
 });
+```
+
+A `Sharp` driver is still exported from `gemi/services` for apps that want Sharp's
+full fit behaviour (see the note on `fit` below). It requires `sharp` to be
+installed:
+
+```typescript
+import { defineImageConfig, Sharp } from "gemi/services";
+
+export default defineImageConfig({ driver: new Sharp() });
 ```
 
 ```typescript
@@ -366,7 +376,7 @@ export default class extends Kernel {
 
 A custom driver subclasses `ImageOptimizationDriver` (from `gemi/services`) and implements `resize(buffer, params)`.
 
-The `Sharp` driver's `resize` accepts `ResizeParameters`:
+`resize` accepts `ResizeParameters`:
 
 ```typescript
 type ResizeParameters = {
@@ -378,6 +388,18 @@ type ResizeParameters = {
 ```
 
 Zero or missing `width`/`height` is treated as "unconstrained" for that dimension, and the output is always encoded as WebP.
+
+> **`fit` on the default driver.** `Bun.Image` resizes with `fill` (stretch to
+> exactly `width`×`height`) or `inside` (shrink to fit inside the box, aspect
+> preserved). It has no crop primitive, so `cover` and `outside` — which fill the
+> box and discard the overflow — map to `fill`, honouring the requested
+> dimensions but distorting the aspect ratio. `contain` maps to `inside`, the
+> same fit without letterbox padding.
+>
+> This only applies when **both** `width` and `height` are given; with one
+> dimension the aspect ratio is preserved either way and `fit` is ignored. The
+> `Image` component only ever sends `w`, so it is unaffected. Use the `Sharp`
+> driver if you need true `cover` cropping.
 
 ### How images are served
 

--- a/packages/gemi/facades/Storage.ts
+++ b/packages/gemi/facades/Storage.ts
@@ -1,7 +1,3 @@
-//@ts-ignore
-import sharp from "sharp";
-
-import { Buffer } from "node:buffer";
 import type { Prettify } from "../utils/type";
 
 import { RequestContext } from "../http/requestContext";
@@ -14,7 +10,10 @@ import type {
 import { FilesystemManager } from "../services/file-storage/FilesystemManager";
 import { Facade } from "./Facade";
 
-type Metadata = Prettify<sharp.Metadata>;
+// `Bun.Image` reports only the header fields — `width`, `height` and `format`.
+// The richer `sharp.Metadata` shape this used to return (`size`, `space`,
+// `channels`, `density`, `hasAlpha`, `exif`, …) is no longer available.
+type Metadata = Prettify<Bun.Image.Metadata>;
 
 export class Storage extends Facade {
   static getFacadeAccessor() {
@@ -26,9 +25,8 @@ export class Storage extends Facade {
   }
 
   static async metadata(obj: Blob | File): Promise<Partial<Metadata>> {
-    const buffer = Buffer.from(await obj.arrayBuffer());
     try {
-      return await sharp(buffer).metadata();
+      return await new Bun.Image(obj).metadata();
     } catch {
       return {};
     }

--- a/packages/gemi/services/image-optimization/config.ts
+++ b/packages/gemi/services/image-optimization/config.ts
@@ -1,5 +1,5 @@
+import { BunImage } from "./drivers/BunImageDriver";
 import type { ImageOptimizationDriver } from "./drivers/ImageOptimizationDriver";
-import { Sharp } from "./drivers/SharpDriver";
 
 // Config key: `image`.
 export interface ImageConfig {
@@ -12,6 +12,6 @@ export function defineImageConfig(config: ImageConfig): ImageConfig {
 
 export function imageConfigDefaults(): Required<ImageConfig> {
   return {
-    driver: new Sharp(),
+    driver: new BunImage(),
   };
 }

--- a/packages/gemi/services/image-optimization/drivers/BunImageDriver.test.ts
+++ b/packages/gemi/services/image-optimization/drivers/BunImageDriver.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+
+import { BunImage } from "./BunImageDriver";
+
+// A 24-bit BMP is the cheapest raster `Bun.Image` will decode, so the fixture
+// needs no binary asset in the tree. 2:1 makes every aspect-ratio assertion
+// below unambiguous.
+function makeBmp(width: number, height: number) {
+  const rowSize = Math.ceil((width * 3) / 4) * 4;
+  const pixelBytes = rowSize * height;
+  const bmp = Buffer.alloc(54 + pixelBytes);
+
+  bmp.write("BM", 0);
+  bmp.writeUInt32LE(54 + pixelBytes, 2);
+  bmp.writeUInt32LE(54, 10);
+  bmp.writeUInt32LE(40, 14);
+  bmp.writeInt32LE(width, 18);
+  bmp.writeInt32LE(height, 22);
+  bmp.writeUInt16LE(1, 26);
+  bmp.writeUInt16LE(24, 28);
+  bmp.writeUInt32LE(pixelBytes, 34);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const offset = 54 + y * rowSize + x * 3;
+      bmp[offset] = (x * 255) / width;
+      bmp[offset + 1] = (y * 255) / height;
+      bmp[offset + 2] = 128;
+    }
+  }
+
+  return bmp;
+}
+
+const source = makeBmp(200, 100);
+const driver = new BunImage();
+
+async function resize(parameters: Parameters<BunImage["resize"]>[1]) {
+  const out = await driver.resize(source, parameters);
+  return { out, ...(await new Bun.Image(out).metadata()) };
+}
+
+describe("resize", () => {
+  test("always encodes WebP, whatever the source format was", async () => {
+    expect((await resize({ width: 50, height: 0 })).format).toBe("webp");
+    expect((await resize({ width: 0, height: 0 })).format).toBe("webp");
+  });
+
+  test("preserves the aspect ratio when only a width is given", async () => {
+    // The `<Image>` component only ever sends `w`, so this is the hot path.
+    const { width, height } = await resize({ width: 50, height: 0 });
+
+    expect([width, height]).toEqual([50, 25]);
+  });
+
+  test("preserves the aspect ratio when only a height is given", async () => {
+    // `Bun.Image.resize()` requires a width, so the driver derives one from the
+    // source ratio rather than passing the height through alone.
+    const { width, height } = await resize({ width: 0, height: 50 });
+
+    expect([width, height]).toEqual([100, 50]);
+  });
+
+  test("re-encodes at source size when neither dimension is given", async () => {
+    const { width, height } = await resize({ width: 0, height: 0 });
+
+    expect([width, height]).toEqual([200, 100]);
+  });
+
+  test("treats negative dimensions as unconstrained", async () => {
+    const { width, height } = await resize({ width: 50, height: -1 });
+
+    expect([width, height]).toEqual([50, 25]);
+  });
+});
+
+describe("fit", () => {
+  // `Bun.Image` has no crop primitive, so the cropping fits collapse onto
+  // `fill`. Locked in here because the mapping is lossy and silent.
+  test.each([
+    ["cover", 50, 50],
+    ["fill", 50, 50],
+    ["outside", 50, 50],
+    ["contain", 50, 25],
+    ["inside", 50, 25],
+  ] as const)("%s produces %ix%i", async (fit, expectedW, expectedH) => {
+    const { width, height } = await resize({ width: 50, height: 50, fit });
+
+    expect([width, height]).toEqual([expectedW, expectedH]);
+  });
+
+  test("defaults to cover when omitted, matching the resize route", async () => {
+    const { width, height } = await resize({ width: 50, height: 50 });
+
+    expect([width, height]).toEqual([50, 50]);
+  });
+
+  test("is inert when only one dimension is constrained", async () => {
+    const cover = await resize({ width: 50, height: 0, fit: "cover" });
+    const inside = await resize({ width: 50, height: 0, fit: "inside" });
+
+    expect([cover.width, cover.height]).toEqual([50, 25]);
+    expect([inside.width, inside.height]).toEqual([50, 25]);
+  });
+});
+
+describe("quality", () => {
+  test("falls back to 80 when unset or zero", async () => {
+    const unset = await resize({ width: 50, height: 0 });
+    const zero = await resize({ width: 50, height: 0, quality: 0 });
+
+    expect(zero.out.byteLength).toBe(unset.out.byteLength);
+  });
+
+  test("a lower quality yields fewer bytes", async () => {
+    const low = await resize({ width: 50, height: 0, quality: 30 });
+    const high = await resize({ width: 50, height: 0, quality: 95 });
+
+    expect(low.out.byteLength).toBeLessThan(high.out.byteLength);
+  });
+});
+
+test("returns a Buffer, as the driver contract requires", async () => {
+  const out = await driver.resize(source, { width: 50, height: 0 });
+
+  expect(Buffer.isBuffer(out)).toBe(true);
+});
+
+test("rejects bytes that are not a decodable image", async () => {
+  await expect(
+    driver.resize(Buffer.from([1, 2, 3]), { width: 50, height: 0 }),
+  ).rejects.toThrow();
+});

--- a/packages/gemi/services/image-optimization/drivers/BunImageDriver.ts
+++ b/packages/gemi/services/image-optimization/drivers/BunImageDriver.ts
@@ -1,0 +1,48 @@
+import { ImageOptimizationDriver } from "./ImageOptimizationDriver";
+import type { FitEnum, ResizeParameters } from "./types";
+
+// `Bun.Image` resizes with `fill` (stretch to exactly width×height) or
+// `inside` (shrink to fit within the box, aspect preserved). It has no crop
+// primitive, so sharp's `cover`/`outside` — which fill the box and discard the
+// overflow — have no faithful equivalent. They map to `fill`, which honours the
+// requested dimensions at the cost of distorting the aspect ratio. `contain`
+// maps to `inside`, which is the same fit without the letterbox padding.
+//
+// This only bites when *both* `w` and `h` are given: with one dimension the
+// aspect ratio is preserved either way and `fit` is inert. The built-in
+// `<Image>` component only ever sends `w`, so it never reaches this table.
+const FIT: Record<keyof FitEnum, "fill" | "inside"> = {
+  cover: "fill",
+  fill: "fill",
+  outside: "fill",
+  contain: "inside",
+  inside: "inside",
+};
+
+export class BunImage extends ImageOptimizationDriver {
+  async resize(buffer: Buffer, parameters: ResizeParameters) {
+    const { height, width, quality, fit } = parameters;
+
+    const image = new Bun.Image(buffer);
+    const targetWidth = width > 0 ? width : 0;
+    const targetHeight = height > 0 ? height : 0;
+
+    if (targetWidth > 0 && targetHeight > 0) {
+      image.resize(targetWidth, targetHeight, { fit: FIT[fit ?? "cover"] });
+    } else if (targetWidth > 0) {
+      image.resize(targetWidth);
+    } else if (targetHeight > 0) {
+      // `resize()` requires a width, so derive one from the source aspect
+      // ratio to get sharp's height-only behaviour. `metadata()` only decodes
+      // the header, so this costs a header parse rather than a second decode.
+      const source = await new Bun.Image(buffer).metadata();
+      const scaled = Math.max(
+        1,
+        Math.round((source.width * targetHeight) / source.height),
+      );
+      image.resize(scaled, targetHeight, { fit: "fill" });
+    }
+
+    return await image.webp({ quality: quality > 0 ? quality : 80 }).toBuffer();
+  }
+}

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -78,6 +78,7 @@ export type {
   ResizeParameters,
 } from "./image-optimization/drivers/types";
 export { ImageOptimizationDriver } from "./image-optimization/drivers/ImageOptimizationDriver";
+export { BunImage } from "./image-optimization/drivers/BunImageDriver";
 export { Sharp } from "./image-optimization/drivers/SharpDriver";
 
 // Auth


### PR DESCRIPTION
Replaces the Sharp-backed image optimization driver with one built on `Bun.Image`, and moves `Storage.metadata()` onto it as well. `Bun.Image` ships with Bun, so the common image path no longer needs a native module.

## What changed

- **New `BunImage` driver** (`services/image-optimization/drivers/BunImageDriver.ts`), now the default in `imageConfigDefaults()` and exported from `gemi/services`.
- **`Storage.metadata()`** uses `Bun.Image`, which accepts a `Blob` directly — the `Buffer` round-trip is gone. Same `{}`-on-undecodable contract as before.
- **`Sharp` is kept and still exported.** It is public API, so rather than redefine it under a name that would no longer be true, it stays as an opt-in driver — and it remains the only way to get true `cover` cropping.

## Why `sharp` is still a peer dependency

`Bun.Image` cannot decode SVG (`ERR_IMAGE_UNKNOWN_FORMAT`, confirmed at runtime), and Bun has no SVG rasterization API at all. `ViewRouteDispatcher.ts:493` rasterizes satori's SVG output to PNG for OG images, so that call is deliberately left on sharp and is untouched by this PR.

## Behavior changes

**`fit` mapping.** `Bun.Image` resizes with `fill` (stretch to exactly `width`×`height`) or `inside` (shrink to fit, aspect preserved) and has no crop primitive. The 5-value API is preserved so existing URLs keep working:

| requested | applied | result for a 2:1 source at 50×50 |
| --- | --- | --- |
| `cover`, `outside`, `fill` | `fill` | `50×50`, aspect distorted |
| `contain`, `inside` | `inside` | `50×25` |

`cover` therefore no longer crops. This only applies when **both** `w` and `h` are given — with one dimension the aspect ratio is preserved either way and `fit` is inert. The built-in `<Image>` component only ever sends `w`, so nothing in the framework path reaches this table. Use the `Sharp` driver if you need real cropping.

**`Storage.metadata()` returns less.** `{width, height, format}` only; `size`, `space`, `channels`, `density`, `hasAlpha` and `exif` are no longer available. Nothing in the repo read those fields, but it is a public type narrowing for template users.

**EXIF auto-orientation.** `Bun.Image` auto-orients by default where sharp did not, so rotated phone photos now come out upright rather than sideways. Kept as the correct behavior for a web optimizer; `{ autoOrient: false }` restores byte-level parity with the old output.

## Testing

- 16 new driver tests covering the fit mapping, single-dimension and unconstrained resizes, quality fallback, the `Buffer` contract, and undecodable input. There was no coverage here previously.
- Mutation-checked: flipping the `cover` mapping fails 2 of them.
- Full suite green — 140 files, 3550 passed, 1 skipped.
- `tsc --noEmit` exit 0, with both changed files confirmed present in the program.
- oxlint 0 errors (the 2 warnings are pre-existing in `facades/Auth.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
