### PR TITLE
Implement `_count: true`, the count-every-relation shorthand

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4376,9 +4376,20 @@ await User.findMany({ include: { _count: true } })
 ```
 
 To-many only. The explicit form refuses a to-one by name, because counting one answers 0 or 1; the
-shorthand named nothing, so there is no argument to refuse and the to-one is simply skipped. On a
-model with no to-many relations at all it raises rather than returning `{}` — there is nothing for
-it to mean, and inside a bare `select: { _count: true }` it would otherwise select no columns.
+shorthand named nothing, so there is no argument to refuse and the to-one is simply skipped.
+
+On a model with **no** to-many relations the shorthand is a compile error, not a runtime one. There
+is nothing for it to mean, and a query that type-checks and then throws on every call is the whole
+of what #394 reported — closing that for models which do have a to-many while leaving it open on
+models which do not would move the trap rather than remove it. `_count: false` stays legal
+everywhere, because the compiler short-circuits it before reaching any of this: a count switched off
+by a flag is a thing you can write on any model.
+
+A `_count` that ends up counting *nothing* is refused too, but only when it is the sole thing in a
+`select` — `select: { _count: { select: {} } }`, or every relation in it switched off. `_count`
+counts as something selected, so an empty one satisfies the "at least one field" check and then
+projects no columns at all. Under an `include` the model's own columns keep the statement valid, so
+counting nothing is simply nothing.
 
 The counted relations carry their policies exactly as the explicit form's do. That is worth stating
 because it is the part that is easy to get wrong: the shorthand names no relation, so the scope has

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3923,7 +3923,7 @@ back to batching for that node alone. It declines:
 A declined node still runs under this strategy one level down, so a decline costs one statement, not
 the subtree. A mixed include tree therefore uses both, which is fine — the results are the same
 either way, and there are tests asserting exactly that against Prisma across every relation shape
-in the differential corpus — **48** of them today, and the suite fails if this number stops
+in the differential corpus — **49** of them today, and the suite fails if this number stops
 matching the corpus.
 
 Override per call when you need to:
@@ -4367,9 +4367,29 @@ times inside that report before its own sentences were derived rather than writt
 The starter template indexes every foreign key for this reason, so a new application starts on the
 right side of it.
 
-`_count: true` (Prisma's "count every to-many relation") is **not** implemented. Name the relations
-instead — the shorthand names none, so a policy has nowhere to attach, and what it returns changes
-silently when the schema grows a relation.
+`_count: true` — Prisma's "count every to-many relation" — is the shorthand for naming them all:
+
+```ts
+await User.findMany({ include: { _count: true } })
+// _count carries one key per to-many relation on User:
+// { accounts: 3, passwordResetToken: 0, session: 1, socialAccount: 2 }
+```
+
+To-many only. The explicit form refuses a to-one by name, because counting one answers 0 or 1; the
+shorthand named nothing, so there is no argument to refuse and the to-one is simply skipped. On a
+model with no to-many relations at all it raises rather than returning `{}` — there is nothing for
+it to mean, and inside a bare `select: { _count: true }` it would otherwise select no columns.
+
+The counted relations carry their policies exactly as the explicit form's do. That is worth stating
+because it is the part that is easy to get wrong: the shorthand names no relation, so the scope has
+nowhere to attach until the shorthand is expanded, and expanding it in the compiler alone would
+count every relation unscoped. The expansion is shared with the policy walk instead, so the set that
+reaches SQL is the set that carried a scope.
+
+**What it returns changes when the schema grows a to-many relation.** That is Prisma's semantics
+rather than a wrinkle here, and it is the reason to prefer naming the relations in code you intend to
+keep: a response body that silently gains a key is a change no test asked for. The shorthand is for
+the exploratory case.
 
 ### Saying where nulls go
 
@@ -4818,6 +4838,7 @@ it looks. A model's policies apply when its rows are reached through:
 | a folded relation (the `lateral` strategy) | the scope lands *inside* the subquery |
 | `where: { rel: { some: … } }` | the `exists` subquery is scoped |
 | `_count: { select: { rel: … } }` | you can only count rows you could read |
+| `_count: true` | expanded to the relations above it, then each one scoped |
 | `orderBy: { rel: … }` | you can only sort by rows you could read |
 | `data: { rel: { create / connect: … } }` | the child's `onCreate` runs; a `connect` cannot reach a row you cannot read |
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -913,7 +913,7 @@ back to batching for that node alone. It declines:
 A declined node still runs under this strategy one level down, so a decline costs one statement, not
 the subtree. A mixed include tree therefore uses both, which is fine — the results are the same
 either way, and there are tests asserting exactly that against Prisma across every relation shape
-in the differential corpus — **48** of them today, and the suite fails if this number stops
+in the differential corpus — **49** of them today, and the suite fails if this number stops
 matching the corpus.
 
 Override per call when you need to:
@@ -1357,9 +1357,29 @@ times inside that report before its own sentences were derived rather than writt
 The starter template indexes every foreign key for this reason, so a new application starts on the
 right side of it.
 
-`_count: true` (Prisma's "count every to-many relation") is **not** implemented. Name the relations
-instead — the shorthand names none, so a policy has nowhere to attach, and what it returns changes
-silently when the schema grows a relation.
+`_count: true` — Prisma's "count every to-many relation" — is the shorthand for naming them all:
+
+```ts
+await User.findMany({ include: { _count: true } })
+// _count carries one key per to-many relation on User:
+// { accounts: 3, passwordResetToken: 0, session: 1, socialAccount: 2 }
+```
+
+To-many only. The explicit form refuses a to-one by name, because counting one answers 0 or 1; the
+shorthand named nothing, so there is no argument to refuse and the to-one is simply skipped. On a
+model with no to-many relations at all it raises rather than returning `{}` — there is nothing for
+it to mean, and inside a bare `select: { _count: true }` it would otherwise select no columns.
+
+The counted relations carry their policies exactly as the explicit form's do. That is worth stating
+because it is the part that is easy to get wrong: the shorthand names no relation, so the scope has
+nowhere to attach until the shorthand is expanded, and expanding it in the compiler alone would
+count every relation unscoped. The expansion is shared with the policy walk instead, so the set that
+reaches SQL is the set that carried a scope.
+
+**What it returns changes when the schema grows a to-many relation.** That is Prisma's semantics
+rather than a wrinkle here, and it is the reason to prefer naming the relations in code you intend to
+keep: a response body that silently gains a key is a change no test asked for. The shorthand is for
+the exploratory case.
 
 ### Saying where nulls go
 
@@ -1808,6 +1828,7 @@ it looks. A model's policies apply when its rows are reached through:
 | a folded relation (the `lateral` strategy) | the scope lands *inside* the subquery |
 | `where: { rel: { some: … } }` | the `exists` subquery is scoped |
 | `_count: { select: { rel: … } }` | you can only count rows you could read |
+| `_count: true` | expanded to the relations above it, then each one scoped |
 | `orderBy: { rel: … }` | you can only sort by rows you could read |
 | `data: { rel: { create / connect: … } }` | the child's `onCreate` runs; a `connect` cannot reach a row you cannot read |
 

--- a/docs/orm.md
+++ b/docs/orm.md
@@ -1366,9 +1366,20 @@ await User.findMany({ include: { _count: true } })
 ```
 
 To-many only. The explicit form refuses a to-one by name, because counting one answers 0 or 1; the
-shorthand named nothing, so there is no argument to refuse and the to-one is simply skipped. On a
-model with no to-many relations at all it raises rather than returning `{}` — there is nothing for
-it to mean, and inside a bare `select: { _count: true }` it would otherwise select no columns.
+shorthand named nothing, so there is no argument to refuse and the to-one is simply skipped.
+
+On a model with **no** to-many relations the shorthand is a compile error, not a runtime one. There
+is nothing for it to mean, and a query that type-checks and then throws on every call is the whole
+of what #394 reported — closing that for models which do have a to-many while leaving it open on
+models which do not would move the trap rather than remove it. `_count: false` stays legal
+everywhere, because the compiler short-circuits it before reaching any of this: a count switched off
+by a flag is a thing you can write on any model.
+
+A `_count` that ends up counting *nothing* is refused too, but only when it is the sole thing in a
+`select` — `select: { _count: { select: {} } }`, or every relation in it switched off. `_count`
+counts as something selected, so an empty one satisfies the "at least one field" check and then
+projects no columns at all. Under an `include` the model's own columns keep the statement valid, so
+counting nothing is simply nothing.
 
 The counted relations carry their policies exactly as the explicit form's do. That is worth stating
 because it is the part that is easy to get wrong: the shorthand names no relation, so the scope has

--- a/packages/gemi/orm/compile/relation-count.test.ts
+++ b/packages/gemi/orm/compile/relation-count.test.ts
@@ -232,6 +232,69 @@ describe("what it refuses", () => {
       /_count\.select/,
     );
   });
+
+  /**
+   * A malformed *operand*, which is the one the policy walk cannot survive.
+   *
+   * `scopeCounts` reads the operand through `typeof value !== "object"` and
+   * `continue`s past anything that fails it, so `1` carries no scope — while
+   * `countPlan` reads `node?.where` as `undefined` and emits a well-formed
+   * *unscoped* `count(*)`. Two walks, one argument, opposite readings: exactly
+   * the disagreement `countableRelations` exists to prevent one level up, and
+   * what it leaks is a number rather than a row.
+   *
+   * The type already forbids it — `CountSelection` says `boolean | { where }` —
+   * so this is the untyped caller's path, which is the only kind a policy has to
+   * survive anyway.
+   */
+  test("a relation operand that is neither true nor an object", () => {
+    expect(() =>
+      plan({ include: { _count: { select: { accounts: 1 } } } }),
+    ).toThrow(/_count\.select\.accounts/);
+
+    expect(() =>
+      plan({ include: { _count: { select: { accounts: [] } } } }),
+    ).toThrow(/_count\.select\.accounts/);
+  });
+
+  /**
+   * The empty explicit form, which reaches the same dead end the shorthand's
+   * guard above covers — `_count` clears `resolveSelection`'s "at least one
+   * field" check and then projects nothing.
+   *
+   * `select: { accounts: false }` is the shape that gets there without anyone
+   * writing an empty object: a caller toggling the count off with a flag.
+   */
+  test("a _count that counts nothing, as the only thing selected", () => {
+    expect(() =>
+      compileRead(user, "findMany", { select: { _count: { select: {} } } }, sqlite),
+    ).toThrow(/No relations to count/);
+
+    expect(() =>
+      compileRead(
+        user,
+        "findMany",
+        { select: { _count: { select: { accounts: false } } } },
+        sqlite,
+      ),
+    ).toThrow(/No relations to count/);
+  });
+
+  /**
+   * ...and not under an `include`, where the model's own columns keep the
+   * statement valid. A count of nothing is then merely nothing, which is what
+   * the caller's flag asked for.
+   */
+  test("but the same under an include is allowed", () => {
+    expect(() =>
+      compileRead(
+        user,
+        "findMany",
+        { include: { _count: { select: { accounts: false } } } },
+        sqlite,
+      ),
+    ).not.toThrow();
+  });
 });
 
 /**

--- a/packages/gemi/orm/compile/relation-count.test.ts
+++ b/packages/gemi/orm/compile/relation-count.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { PostgresDialect } from "../dialect/postgres";
 import { SqliteDialect } from "../dialect/sqlite";
 import { UnsupportedQueryError } from "../errors";
-import { account, organization, user } from "../fixtures";
+import { account, membership, organization, user } from "../fixtures";
 import { applyNestedPolicies, type ModelPolicy } from "../policy";
 import * as registry from "../registry";
 import { compileRead } from "./read";
@@ -209,14 +209,18 @@ describe("what it refuses", () => {
   });
 
   /**
-   * Prisma's `_count: true` counts every to-many relation. Refused rather than
-   * approximated: it names no relation, so a policy has nowhere to attach, and
-   * what it returns changes when the schema grows a relation.
+   * The shorthand on a model with nothing to count.
+   *
+   * Refused rather than answered with `{}`, and the reason is mechanical rather
+   * than stylistic: `resolveSelection` counts `_count` as *something selected*,
+   * so `select: { _count: true }` alone would clear its "at least one field"
+   * check and then project no columns — `select  from "Membership"`, which the
+   * database rejects with a message about neither `_count` nor the model.
    */
-  test("the bare shorthand, naming the form that works", () => {
-    expect(() => plan({ include: { _count: true } })).toThrow(
-      /_count: \{ select: \{ <relation>: true \} \}/,
-    );
+  test("the shorthand on a model with no to-many relations", () => {
+    expect(() =>
+      compileRead(membership, "findMany", { include: { _count: true } }, sqlite),
+    ).toThrow(/no to-many relations/);
   });
 
   test("a _count that is not an object", () => {
@@ -226,6 +230,62 @@ describe("what it refuses", () => {
   test("a _count with no select", () => {
     expect(() => plan({ include: { _count: { accounts: true } } })).toThrow(
       /_count\.select/,
+    );
+  });
+});
+
+/**
+ * `_count: true` — Prisma's "count every to-many relation" (#394).
+ *
+ * Expanded rather than special-cased, and in two places that must agree:
+ * `countableRelations` is what the compiler projects from and what the policy
+ * walk scopes, so the set that reaches SQL is the set that carried a scope. The
+ * tests below pin both halves of that, because the failure when they drift is a
+ * count the reader cannot tell is unscoped — it is a number, not a row.
+ */
+describe("the bare shorthand", () => {
+  test("expands to the explicit form's SQL, exactly", () => {
+    expect(projection({ include: { _count: true } })).toBe(
+      projection({ include: { _count: { select: { accounts: true } } } }),
+    );
+  });
+
+  /**
+   * The to-one is skipped rather than refused. The explicit form *does* refuse
+   * `organization` by name — counting it answers 0 or 1 — but the shorthand
+   * named nothing, so there is no argument to report and skipping it is the
+   * whole of what Prisma's shorthand means. `user` carries one of each, which is
+   * why it is the fixture here.
+   */
+  test("counts the to-many and skips the to-one", () => {
+    const text = plan({ include: { _count: true } }).text;
+
+    expect(text).toContain(`as "_count.accounts"`);
+    expect(text).not.toContain(`_count.organization`);
+  });
+
+  /**
+   * Two to-many relations, declared `users` then `accounts` and projected the
+   * other way round. Not cosmetic: the plan cache canonicalises key order, so an
+   * expansion that followed declaration order would mint one entry per ordering
+   * the schema happens to have.
+   */
+  test("projects them sorted, not in declaration order", () => {
+    const text = compileRead(
+      organization,
+      "findMany",
+      { include: { _count: true } },
+      sqlite,
+    ).text;
+
+    expect(text.indexOf(`"_count.accounts"`)).toBeLessThan(
+      text.indexOf(`"_count.users"`),
+    );
+  });
+
+  test("select carries it as well as include", () => {
+    expect(plan({ select: { id: true, _count: true } }).text).toContain(
+      `as "_count.accounts"`,
     );
   });
 });
@@ -309,6 +369,86 @@ describe("policies", () => {
       {},
       false,
       lookup([]),
+    );
+
+    expect(out).toBe(args);
+  });
+
+  /**
+   * **The shorthand carries the scope too**, and this is the assertion #394
+   * turns on. `_count: true` names no relation, so nothing here has a node to
+   * hang a scope on until it is expanded — and an unexpanded shorthand reaching
+   * the compiler is expanded *there*, where policies are not, so every count
+   * would be over rows the caller cannot read. That is the leak the shorthand
+   * was refused over, and it returns a number rather than a row: nothing in the
+   * response looks wrong.
+   */
+  test("the shorthand is expanded, then scoped", () => {
+    const out = applyNestedPolicies(
+      root,
+      { include: { _count: true } },
+      { organizationId: 7 },
+      false,
+      lookup([tenant]),
+    );
+
+    expect(out.include._count).toEqual({
+      select: { accounts: { where: { organizationId: 7 } } },
+    });
+  });
+
+  /**
+   * ...and only then. An unpolicied shorthand stays `true`, so the plan key does
+   * not move for the queries this walk has nothing to say about — the same trade
+   * the explicit form's test above pins. The compiler expands it either way, so
+   * the SQL is identical; what differs is one cache entry versus two.
+   */
+  test("an unpolicied shorthand is returned unchanged, identically", () => {
+    const args = { include: { _count: true } };
+    const out = applyNestedPolicies(root, args, {}, false, lookup([]));
+
+    expect(out).toBe(args);
+  });
+
+  /**
+   * A model with a *mix*: `users` is policied and `accounts` is not. The
+   * unpolicied half has to survive the expansion as `true` rather than being
+   * dropped, or the shorthand would quietly count fewer relations under a policy
+   * than without one.
+   */
+  test("expanding for one policied relation keeps the others", () => {
+    const mixed = {
+      relations: {
+        users: { model: "User", kind: "many" as const },
+        accounts: { model: "Account", kind: "many" as const },
+      },
+    };
+
+    const out = applyNestedPolicies(
+      mixed,
+      { include: { _count: true } },
+      { organizationId: 7 },
+      false,
+      (model: string) =>
+        model === "User"
+          ? { policies: [tenant], schema: { name: "User", relations: {} } }
+          : { policies: [], schema: { name: "Account", relations: {} } },
+    );
+
+    expect(out.include._count.select).toEqual({
+      accounts: true,
+      users: { where: { organizationId: 7 } },
+    });
+  });
+
+  test("asSystem suspends the shorthand as well", () => {
+    const args = { include: { _count: true } };
+    const out = applyNestedPolicies(
+      root,
+      args,
+      { organizationId: 7 },
+      true,
+      lookup([tenant]),
     );
 
     expect(out).toBe(args);

--- a/packages/gemi/orm/compile/relation-count.ts
+++ b/packages/gemi/orm/compile/relation-count.ts
@@ -5,7 +5,7 @@ import {
   UnsupportedQueryError,
 } from "../errors";
 import type { ModelSchema, RelationSchema } from "../schema";
-import { COUNT_KEY } from "../relation-filters";
+import { COUNT_KEY, countableRelations } from "../relation-filters";
 import { type Fragment, concat, sql } from "./fragment";
 import { correlate } from "./correlate";
 import { compileWhere } from "./where";
@@ -141,24 +141,48 @@ function countPlan(
   };
 }
 
-/** `_count: { select: { … } }`, which is the only form that carries a policy. */
+/**
+ * `_count: { select: { … } }`, or the `_count: true` shorthand expanded into it.
+ *
+ * The shorthand was refused until #394, and the refusal gave two reasons. The
+ * first — "it names no relation, so a policy has nowhere to attach" — was about
+ * *where* the expansion happens rather than whether it can: expanded here and
+ * nowhere else, the policy walk would still see `true`, `scopeCounts` would
+ * return it untouched, and every count would be unscoped. So `policy.ts` expands
+ * it too, through the same `countableRelations`, and this stays the compiler's
+ * own total-function copy for the same reason `include: { accounts: true }`
+ * compiles when the compiler is called directly: scoping is `$exec`'s job,
+ * uniformly, and the compiler compiles what it is handed.
+ *
+ * The second reason — what it returns changes when the schema grows a relation —
+ * is true, and is Prisma's semantics rather than a defect this could fix. It is
+ * documented at the shorthand in `docs/orm.md` instead of being answered with a
+ * refusal.
+ */
 function readCountSelection(
   schema: ModelSchema,
   node: unknown,
   operation: string,
 ): Record<string, unknown> {
   if (node === true) {
-    // Prisma's shorthand counts *every* to-many relation. Not implemented, and
-    // the reason is worth stating rather than leaving as a gap: it names no
-    // relation, so a policy has nowhere to attach per-relation — and what it
-    // returns changes silently when the schema grows a relation.
-    throw new UnsupportedQueryError(
-      "_count",
-      schema.name,
-      operation,
-      `'_count: true' is not implemented. Name the relations: ` +
-        `_count: { select: { <relation>: true } }.`,
-    );
+    const countable = countableRelations(schema);
+
+    // A model with nothing to count. Refused rather than answered with `{}`,
+    // and not only for tidiness: `select: { _count: true }` alone would then
+    // project no columns at all — `resolveSelection` counts `_count` as
+    // something selected, so an empty expansion passes its "at least one field"
+    // check and emits `select  from "User"`, which is not valid SQL.
+    if (countable.length === 0) {
+      throw new UnsupportedQueryError(
+        "_count",
+        schema.name,
+        operation,
+        `${schema.name} has no to-many relations, so there is nothing for ` +
+          `'_count: true' to count.`,
+      );
+    }
+
+    return Object.fromEntries(countable.map((name) => [name, true]));
   }
 
   if (typeof node !== "object" || node === null || Array.isArray(node)) {

--- a/packages/gemi/orm/compile/relation-count.ts
+++ b/packages/gemi/orm/compile/relation-count.ts
@@ -73,8 +73,50 @@ export function planRelationCounts(
       );
     }
 
+    // A malformed operand is refused rather than counted, and the reason is the
+    // policy walk rather than tidiness. `scopeCounts` reaches for `value.where`
+    // through the same `typeof value !== "object"` test and `continue`s past
+    // anything that fails it, so an operand like `1` or `"true"` carries no
+    // scope — while `countPlan` reads `node?.where` as `undefined` and emits a
+    // perfectly good unscoped `count(*)`. That is the one disagreement between
+    // the two walks that this file's arrangement is supposed to make impossible,
+    // and what it leaks is a number over rows the caller cannot read.
+    //
+    // Refused *here* rather than taught to `scopeCounts`, because this is where
+    // the same malformation on a relation node is already refused — `include:
+    // { accounts: 1 }` raises rather than compiling — which is what makes the
+    // identical `continue` in `applyNestedPolicies` safe.
+    if (value !== true && (typeof value !== "object" || Array.isArray(value))) {
+      throw new InvalidArgumentError(
+        `_count.select.${key}`,
+        schema.name,
+        operation,
+        "Expected true or an object holding 'where'.",
+      );
+    }
+
     plans.push(
       countPlan(schema, relation, value, dialect, operation, plans.length, args),
+    );
+  }
+
+  // A `_count` that names no relation it will actually count — `select: {}`, or
+  // every relation switched off with a flag. Refused for the same mechanical
+  // reason the `_count: true` shorthand is refused on a model with nothing to
+  // count, and this is the other route to that state: `resolveSelection` counts
+  // `_count` as *something selected*, so an empty plan list still clears its "at
+  // least one field" check and then projects no columns, emitting
+  // `select  from "User"` for the driver to reject with a syntax error.
+  //
+  // Only under `select`. An `include` carries the model's default columns, so
+  // the statement stays valid and a count of nothing is merely nothing.
+  if (plans.length === 0 && args?.select) {
+    throw new InvalidArgumentError(
+      "_count.select",
+      schema.name,
+      operation,
+      "No relations to count, and '_count' is the only thing selected. " +
+        "Name at least one relation, or select a column beside it.",
     );
   }
 

--- a/packages/gemi/orm/corpus.ts
+++ b/packages/gemi/orm/corpus.ts
@@ -52,6 +52,13 @@ export const READS: unknown[] = [
   { include: { accounts: { orderBy: { id: "asc" } } } },
   { include: { accounts: { orderBy: { id: "desc" } } } },
   { include: { _count: { select: { accounts: true } } } },
+  // The shorthand, which expands to the entry above on this schema —
+  // `userWithProfile` has exactly one to-many. Two shapes, one statement, and
+  // two keys: that direction is allowed, and the entry is here so the *other*
+  // direction stays measured. If the expansion ever picked up the to-one, this
+  // and the line above would compile differently and the discrimination suite
+  // would say so.
+  { include: { _count: true } },
   { orderBy: { id: "asc" } },
   { orderBy: { id: "desc" } },
   { orderBy: { name: { sort: "asc", nulls: "first" } } },

--- a/packages/gemi/orm/policy.ts
+++ b/packages/gemi/orm/policy.ts
@@ -9,6 +9,7 @@ import {
 import type { Operation } from "./plan";
 import {
   COUNT_KEY,
+  countableRelations,
   isOperatorForm,
   relationFilterOperators,
 } from "./relation-filters";
@@ -1822,11 +1823,36 @@ function scopeCounts(
   lookup: PolicyLookup,
 ): unknown {
   if (system) return node;
-  if (typeof node !== "object" || node === null || Array.isArray(node)) {
+
+  // `_count: true` — Prisma's shorthand for "every to-many relation". It names
+  // no relation, so there is nothing here to hang a scope on until it is
+  // expanded, and an unexpanded shorthand walked past this point reaches the
+  // compiler, which expands it *there* and counts every relation unscoped.
+  //
+  // That is the leak the shorthand was refused over until #394, and it is the
+  // reason the expansion is shared rather than living in `compile/`: both sides
+  // derive the same relation list from `countableRelations`, so the set this
+  // scopes is exactly the set the compiler projects.
+  //
+  // Expanded into the explicit form only when a policy actually applies —
+  // `rewritten` below stays undefined otherwise and the shorthand goes on
+  // untouched. The alternative, rewriting unconditionally, moves the plan key
+  // for every `_count: true` on an unpolicied model: a cache invalidation and a
+  // canonical-shape change in exchange for nothing, which is the same trade the
+  // `node === true` branch in `applyNestedPolicies` declines a few lines up.
+  const shorthand = node === true;
+
+  if (
+    !shorthand &&
+    (typeof node !== "object" || node === null || Array.isArray(node))
+  ) {
     return node;
   }
 
-  const selection = (node as Record<string, unknown>).select;
+  const selection = shorthand
+    ? Object.fromEntries(countableRelations(schema).map((name) => [name, true]))
+    : (node as Record<string, unknown>).select;
+
   if (
     typeof selection !== "object" ||
     selection === null ||
@@ -1864,9 +1890,14 @@ function scopeCounts(
     }
   }
 
-  return rewritten
-    ? { ...(node as Record<string, unknown>), select: rewritten }
-    : node;
+  if (!rewritten) return node;
+
+  // The shorthand has no object to preserve keys from — it *was* `true` — so the
+  // scoped form is written out whole. The explicit form keeps whatever else sat
+  // beside `select`, which is nothing today and is not this walk's to discard.
+  return shorthand
+    ? { select: rewritten }
+    : { ...(node as Record<string, unknown>), select: rewritten };
 }
 
 /**

--- a/packages/gemi/orm/relation-filters.ts
+++ b/packages/gemi/orm/relation-filters.ts
@@ -83,3 +83,30 @@ export function isOperatorForm(
  * to skip it.
  */
 export const COUNT_KEY = "_count";
+
+/**
+ * The relations `_count: true` expands to: every to-many, sorted.
+ *
+ * Prisma's shorthand names no relation, so both sides of the arrangement above
+ * have to derive the same list from the schema — the compiler to project one
+ * subquery per relation, the policy walk to attach each counted model's scope.
+ * A list they derived separately is the failure `COUNT_KEY` exists to prevent,
+ * one level up: the compiler would count a relation the walk never scoped, and
+ * what leaks is a *number* over rows the caller cannot read.
+ *
+ * To-many only, because that is what the shorthand means. The explicit form
+ * refuses a to-one by name — counting one answers 0 or 1, which its nullability
+ * already says — but the shorthand named nothing, so there is no argument to
+ * refuse and skipping it is the whole of Prisma's semantics.
+ *
+ * Sorted for the reason every walk in the compiler is: the plan cache
+ * canonicalises key order, so the expansion has to be stable or one shorthand
+ * mints an entry per key ordering the schema happens to have.
+ */
+export function countableRelations(schema: {
+  relations: Record<string, { kind: "one" | "many" }>;
+}): string[] {
+  return Object.keys(schema.relations)
+    .filter((name) => schema.relations[name]?.kind === "many")
+    .sort();
+}

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -796,6 +796,48 @@ type CountSelection<M extends ModelTypeInfo> = {
 };
 
 /**
+ * The relation names `_count: true` expands to — the type-level statement of
+ * `countableRelations`, which the compiler and the policy walk derive at runtime.
+ */
+type CountableRelationNames<M extends ModelTypeInfo> = {
+  [K in keyof Relations<M>]: Relations<M>[K]["kind"] extends "many" ? K : never;
+}[keyof Relations<M>];
+
+/**
+ * The same device as {@link ToOneRelationsCannotBeCounted}, for the model that
+ * has nothing to count at all rather than the relation that cannot be counted.
+ */
+type ThereIsNothingToCount = {
+  "this model has no to-many relations, so there is nothing to count": never;
+};
+
+/**
+ * What the `_count: true` shorthand accepts, per model.
+ *
+ * `readCountSelection` throws when the model has no to-many relation, so the key
+ * has to be refused here or the shorthand becomes exactly the defect it was
+ * implemented to close: valid TypeScript that raises on every call. #394 is a
+ * report of that shape — a controller ported from Prisma type-checked, passed
+ * review and 500'd on every request — and closing it only for models that do
+ * have a to-many would have moved the trap rather than removed it. Prisma refuses
+ * the same call structurally: it emits no `_count` key in the input type for such
+ * a model.
+ *
+ * `false` stays legal either way. `planRelationCounts` short-circuits on it
+ * before ever reaching the throw, so a caller toggling a count off with a flag is
+ * writing something that works, on every model.
+ *
+ * `[…] extends […]` rather than a bare conditional, because a naked type
+ * parameter distributes over the union of relation names and would answer per
+ * relation instead of once per model.
+ */
+type CountShorthand<M extends ModelTypeInfo> = [
+  CountableRelationNames<M>,
+] extends [never]
+  ? false | ThereIsNothingToCount
+  : boolean;
+
+/**
  * `select`, one level. Relations carry their own nested arguments, so the type
  * is mutually recursive with the operation args — bounded, as ever, by what the
  * caller wrote.
@@ -805,13 +847,13 @@ export type SelectInput<M extends ModelTypeInfo> = {
 } & {
   [K in keyof Relations<M>]?: boolean | RelationArgs<Relations<M>[K]>;
 } & {
-  _count?: boolean | { select?: CountSelection<M> };
+  _count?: CountShorthand<M> | { select?: CountSelection<M> };
 };
 
 export type IncludeInput<M extends ModelTypeInfo> = {
   [K in keyof Relations<M>]?: boolean | RelationArgs<Relations<M>[K]>;
 } & {
-  _count?: boolean | { select?: CountSelection<M> };
+  _count?: CountShorthand<M> | { select?: CountSelection<M> };
 };
 
 export type OmitInput<M extends ModelTypeInfo> = {

--- a/packages/gemi/orm/types.ts
+++ b/packages/gemi/orm/types.ts
@@ -237,10 +237,22 @@ type RelationPayload<R extends RelationInfo, A> = R["kind"] extends "many"
 /**
  * `_count` inside a `select` or an `include`: the number of related rows, per
  * relation named.
+ *
+ * The second branch is the `_count: true` shorthand, which names none and
+ * therefore returns every **to-many** relation — the set `countableRelations`
+ * hands the compiler and the policy walk. It said `keyof Relations<M>` while the
+ * shorthand was refused, which was unreachable and wrong in the same breath: a
+ * to-one is skipped by the expansion, so promising `number` for one would have
+ * typed a key that is never on the row the moment #394 made the shorthand
+ * reachable.
  */
 type RelationCountPayload<M extends ModelTypeInfo, A> = "select" extends keyof A
   ? { [K in Requested<NonNullable<A["select"]>> & keyof Relations<M>]: number }
-  : { [K in keyof Relations<M>]: number };
+  : {
+      [K in keyof Relations<M> as Relations<M>[K]["kind"] extends "many"
+        ? K
+        : never]: number;
+    };
 
 type SelectPayload<M extends ModelTypeInfo, S> = {
   [K in Requested<S>]: K extends keyof Scalars<M>

--- a/templates/saas-starter/app/models/differential.test.ts
+++ b/templates/saas-starter/app/models/differential.test.ts
@@ -528,6 +528,18 @@ const CASES: [string, string, unknown][] = [
     include: { _count: { select: { accounts: true } } },
     orderBy: { id: "asc" },
   }],
+  // The `_count: true` shorthand (#394), and the only place its semantics are
+  // actually *checked* rather than reasoned about. `countableRelations` derives
+  // "every to-many" from gemi's schema and Prisma derives it from its own, so
+  // this compares the two derivations on the real model — a relation missing
+  // from one side, or a to-one counted by either, shows up as a key difference
+  // in the row rather than as a compile error.
+  ["the _count shorthand", "findMany", {
+    include: { _count: true }, orderBy: { id: "asc" },
+  }],
+  ["the _count shorthand inside a select", "findMany", {
+    select: { name: true, _count: true }, orderBy: { id: "asc" },
+  }],
 
   // --- ordering by a relation ---------------------------------------------
   //

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -746,18 +746,28 @@ function suite(label: string, url?: string) {
         ]);
       });
 
-      test("a nested _count is still scoped", async () => {
+      /**
+       * Both spellings, because they carry their scope by different routes. The
+       * explicit form is scoped where it is written; the shorthand names no
+       * relation at all, so `scopeCounts` has to expand it first and then scope
+       * what the expansion produced. Only the second is new here — but both land
+       * in the same `effective` that was being discarded, so the shorthand had
+       * two ways to leak and this pins the one the other test cannot reach.
+       */
+      test("a nested _count is still scoped, in both spellings", async () => {
         (ScopedAccount as any).$policies = [tenantScoped];
         (ScopedUser as any).$policies = [tenantScoped];
 
-        const rows = await Model.asUser(ALICE, () =>
-          ScopedUser.findMany({
+        const [explicit, shorthand] = await Model.asUser(ALICE, async () => [
+          await ScopedUser.findMany({
             include: { _count: { select: { accounts: true } } },
           }),
-        );
+          await ScopedUser.findMany({ include: { _count: true } }),
+        ]);
 
         // 2 is the leak: it counts the account in Bob's organisation.
-        expect(rows.map((row: any) => row._count.accounts)).toEqual([1]);
+        expect(explicit.map((row: any) => row._count.accounts)).toEqual([1]);
+        expect(shorthand.map((row: any) => row._count.accounts)).toEqual([1]);
       });
 
       test("a root policy with no scope at all still keeps the nested scope", async () => {

--- a/templates/saas-starter/app/models/select.test-d.ts
+++ b/templates/saas-starter/app/models/select.test-d.ts
@@ -393,3 +393,44 @@ describe("_count takes a filter over the rows it counts", () => {
     });
   });
 });
+
+/**
+ * **The `_count: true` shorthand** — #394.
+ *
+ * `toEqualTypeOf` on the whole object rather than key-by-key, deliberately. The
+ * assertion that matters is the one a per-key check cannot make: that
+ * `organization` and `profile` are **absent**. The payload's shorthand branch
+ * said `keyof Relations<M>` while the shorthand was refused at runtime — every
+ * relation, to-one included — which was unreachable and therefore untested, and
+ * would have typed two keys that are never on the row the moment the refusal
+ * lifted.
+ *
+ * `runtime` here is `countableRelations`: the compiler projects one subquery per
+ * to-many and the policy walk scopes that same set, so this type is the third
+ * statement of the same list and the one a caller reads.
+ */
+describe("_count: true is every to-many relation, and only those", () => {
+  test("include", async () => {
+    const user = await UserModel.findFirst({ include: { _count: true } });
+
+    expectTypeOf(user!._count).toEqualTypeOf<{
+      accounts: number;
+      session: number;
+      passwordResetToken: number;
+      socialAccount: number;
+    }>();
+  });
+
+  test("select spells it identically", async () => {
+    const user = await UserModel.findFirst({
+      select: { name: true, _count: true },
+    });
+
+    expectTypeOf(user!._count).toEqualTypeOf<{
+      accounts: number;
+      session: number;
+      passwordResetToken: number;
+      socialAccount: number;
+    }>();
+  });
+});

--- a/templates/saas-starter/app/models/select.test-d.ts
+++ b/templates/saas-starter/app/models/select.test-d.ts
@@ -434,3 +434,59 @@ describe("_count: true is every to-many relation, and only those", () => {
     }>();
   });
 });
+
+/**
+ * **The shorthand is refused where the runtime refuses it** — the other half of
+ * #394, and the half that is easy to leave open.
+ *
+ * `readCountSelection` throws when the model has no to-many relation, so a
+ * `_count: true` the type accepts on such a model is valid TypeScript that raises
+ * on every call. That is the exact defect #394 reports — a controller ported from
+ * Prisma type-checked, passed review, and 500'd on every request — so answering
+ * the shorthand for models that have a to-many while leaving it type-checkable on
+ * models that do not would have moved the trap rather than closed it. Nine of the
+ * template's fourteen models are in that class.
+ *
+ * Prisma refuses the same call structurally: it emits no `_count` key in the
+ * input type for such a model.
+ */
+describe("_count: true is refused on a model with no to-many relations", () => {
+  test("include", async () => {
+    await AccountModel.findMany({
+      // @ts-expect-error Account's relations are all to-one, so there is nothing to count
+      include: { _count: true },
+    });
+  });
+
+  test("select", async () => {
+    await AccountModel.findMany({
+      // @ts-expect-error same, in the select spelling
+      select: { id: true, _count: true },
+    });
+  });
+
+  /**
+   * Nested, which is the shape #394 actually reported: the shorthand sat inside
+   * a parent's `include`, where nothing about the outer model says whether the
+   * child can be counted.
+   */
+  test("nested inside a parent's include", async () => {
+    await UserModel.findMany({
+      include: {
+        // @ts-expect-error Account is still Account one level down
+        accounts: { include: { _count: true } },
+      },
+    });
+  });
+
+  /**
+   * `false` stays legal on every model. `planRelationCounts` short-circuits on it
+   * before reaching the throw, so a caller toggling a count off with a flag is
+   * writing something that works — refusing it would break a spelling the runtime
+   * accepts, which is the same class of divergence in the other direction.
+   */
+  test("but false is accepted, because the runtime accepts it", async () => {
+    await AccountModel.findMany({ include: { _count: false } });
+    await UserModel.findMany({ include: { _count: false } });
+  });
+});


### PR DESCRIPTION
Closes #394.

## The report

`include: { _count: true }` threw `UnsupportedQueryError` at runtime, pointing at the explicit `_count: { select: { … } }` form. #394 is an external report of what that costs in practice — a set of controllers ported from Prisma kept a `variants: { include: { _count: true } }`, type-checked, passed review, and then 500'd on every request to a customer-facing endpoint.

The sharp edge is not the refusal, it is that the refusal was invisible until traffic. `RelationCountPayload` returned `{ [K in keyof Relations<M>]: number }` for the shorthand, so the type system actively vouched for a query that always threw. The reporter offers the cheaper fix themselves — make it a compile-time error — and that would close the trap. It closes it by telling everyone porting from Prisma to rewrite the query, on a shorthand whose semantics are unambiguous and whose machinery already exists, so this answers it instead.

## What the expansion is, and why it lives where it does

`countableRelations(schema)` — every to-many relation, sorted — is the single derivation, and **both** the compiler and the policy walk read from it. That sharing is the entire difficulty of the change.

The original refusal gave two reasons. The first, *"it names no relation, so a policy has nowhere to attach"*, was an argument about **where** the expansion happens rather than whether it can happen at all. Expanded in `compile/relation-count.ts` alone, the policy walk still sees `true`, `scopeCounts` hands it back untouched, and every count is over rows the caller cannot read. So `policy.ts` expands it too, through the same helper, and the set that reaches SQL is exactly the set that carried a scope.

That failure mode is worth naming because of how it presents: what leaks is a **number**, not a row. Nothing in the response body looks wrong.

The compiler keeps its own copy of the expansion rather than depending on the walk having run, for the same reason `include: { accounts: true }` compiles when the compiler is called directly — scoping is `$exec`'s job, uniformly, and the compiler compiles what it is handed.

The policy walk expands **only when a policy actually applies**. Rewriting unconditionally would move the plan-cache key for every `_count: true` on an unpolicied model — a cache invalidation and a canonical-shape change in exchange for nothing, since the compiler expands it either way and the SQL is identical. This is the same trade the `node === true` branch in `applyNestedPolicies` already declines a few lines up.

## Semantics

**To-many only.** The explicit form refuses a to-one *by name*, because counting one answers 0 or 1 — which its nullability already says. The shorthand named nothing, so there is no argument to report back and skipping it is the whole of what Prisma's shorthand means.

`RelationCountPayload` now filters to `kind extends "many"`. It previously said `keyof Relations<M>`, which was unreachable and wrong in the same breath: a to-one would have been typed as a key that is never on the row, the moment the refusal lifted.

**A model with no to-many relations still raises**, rather than answering `{}`. The reason is mechanical: `resolveSelection` counts `_count` as *something selected*, so an empty expansion clears its "at least one field" check and then projects no columns — `select  from "Membership"`.

**What it returns changes when the schema grows a to-many relation.** This was the refusal's second reason. It is true, it is Prisma's semantics rather than a defect this could fix, and it is now documented at the shorthand — with a note to prefer naming the relations in code you intend to keep — instead of being answered with a throw.

## Tests

- **Two differential cases** (`include` and inside a `select`) run the shorthand against Prisma on the real starter schema. This is the only place the semantics are *checked* rather than reasoned about: `countableRelations` derives "every to-many" from gemi's schema and Prisma derives it from its own, so a relation missing from one side, or a to-one counted by either, shows up as a key difference in the row.
- **A corpus entry**, so the shorthand and the explicit form keep compiling identically on a one-to-many schema — if the expansion ever picked up the to-one, the discrimination suite says so. Corpus count 48 → 49, and the docs figure moves with it.
- **Policy tests** covering the four cases that matter: the shorthand is expanded then scoped; an unpolicied shorthand is returned *identically* (`toBe`, pinning the plan-key trade above); a mixed model keeps its unpolicied relations as `true` rather than dropping them; `asSystem` suspends it.
- **Type tests** asserting the payload with `toEqualTypeOf` on the whole object rather than key-by-key — the assertion that matters is the one a per-key check cannot make, that `organization` and `profile` are *absent*.

## Verification

| Suite | Result |
| --- | --- |
| `packages/gemi` ORM (64 files) | 2545 passed |
| saas-starter differential (vs Prisma) | 265 passed |
| saas-starter type tests | 27 passed, no type errors |

`bun run typecheck` in `packages/gemi` reports one error — `vite/dictionaryPlugin.ts` cannot find `magic-string`. It reproduces on clean `main` with this branch stashed, so it is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)