### PR TITLE
Stop discarding the nested-policy rewrite when the root model is policied

### DIFF
--- a/packages/gemi/orm/Model.ts
+++ b/packages/gemi/orm/Model.ts
@@ -857,7 +857,7 @@ export abstract class Model {
         effective = applyPolicies(
           policies,
           policy,
-          args,
+          effective,
           ormAuthoredFields(options),
         );
       }

--- a/templates/saas-starter/app/models/policies.test.ts
+++ b/templates/saas-starter/app/models/policies.test.ts
@@ -699,6 +699,83 @@ function suite(label: string, url?: string) {
     });
 
     /**
+     * The headline test again, with the root model policied too — the case the
+     * note above excludes on purpose, and the one that leaked.
+     *
+     * `$execute` builds `effective` by running `applyNestedPolicies` over the
+     * arguments, which is what pushes each counted or included relation's scope
+     * down into the tree. It then reached for `applyPolicies` and passed the
+     * *original* `args`, so the moment the root model carried any policy at all
+     * the whole nested rewrite was overwritten and thrown away. An unpolicied
+     * root skipped that branch entirely, which is why every nested-policy test
+     * in this file passed while the composition leaked.
+     *
+     * **The seed cannot discriminate on its own.** Alice owns one account and it
+     * is already in her organisation, so an unscoped include returns the right
+     * rows by accident. The second account below is what makes the assertion
+     * mean anything: it is Alice's, and it is in Bob's organisation, so it comes
+     * back if and only if the nested scope was discarded.
+     *
+     * A `redact`-only policy reproduces it identically — the trigger is
+     * `policies.length > 0`, not anything the scope does — which is why the
+     * third case carries no `scope` at all.
+     */
+    describe("with the root model policied too", () => {
+      beforeEach(async () => {
+        await Model.asSystem(() =>
+          AccountModel.create({
+            data: { userId: ALICE.id, organizationId: BOB.organizationId },
+          }),
+        );
+      });
+
+      test("a nested include is still scoped", async () => {
+        (ScopedAccount as any).$policies = [tenantScoped];
+        (ScopedUser as any).$policies = [tenantScoped];
+
+        const rows = await Model.asUser(ALICE, () =>
+          ScopedUser.findMany({ include: { accounts: true } }),
+        );
+
+        // The root scope leaves Alice alone, and her cross-organisation account
+        // is not attached to her.
+        expect(rows).toHaveLength(1);
+        const accounts = rows.flatMap((row: any) => row.accounts);
+        expect(accounts.map((a: any) => a.organizationId)).toEqual([
+          ALICE.organizationId,
+        ]);
+      });
+
+      test("a nested _count is still scoped", async () => {
+        (ScopedAccount as any).$policies = [tenantScoped];
+        (ScopedUser as any).$policies = [tenantScoped];
+
+        const rows = await Model.asUser(ALICE, () =>
+          ScopedUser.findMany({
+            include: { _count: { select: { accounts: true } } },
+          }),
+        );
+
+        // 2 is the leak: it counts the account in Bob's organisation.
+        expect(rows.map((row: any) => row._count.accounts)).toEqual([1]);
+      });
+
+      test("a root policy with no scope at all still keeps the nested scope", async () => {
+        (ScopedAccount as any).$policies = [tenantScoped];
+        (ScopedUser as any).$policies = [{ redact: (_c: any, row: any) => row }];
+
+        const rows = await Model.asUser(ALICE, () =>
+          ScopedUser.findMany({ include: { accounts: true } }),
+        );
+
+        const accounts = rows.flatMap((row: any) => row.accounts);
+        expect(accounts.map((a: any) => a.organizationId)).toEqual([
+          ALICE.organizationId,
+        ]);
+      });
+    });
+
+    /**
      * The regression guard for the wiring itself, not for the mechanism.
      *
      * The headline test above was green while the *documented* pattern leaked:


### PR DESCRIPTION
Found by the adversarial review of #411. **Pre-existing on `main`** — not introduced by that PR — but #411's `_count: true` routes through the discarded rewrite, so it has to land first.

## The defect

`$execute` scopes arguments in two passes:

```ts
let effective = args;

// pass 1 — pushes each reached model's scope down into the argument tree
effective = applyNestedPolicies(schema, effective, currentUser(), system, …);

// pass 2 — scopes the root
if (policies.length > 0) {
  if (!preScoped) {
    effective = applyPolicies(policies, policy, args, …);  // <-- `args`, not `effective`
  }
}
```

`applyPolicies` builds its result by spreading its input (`{ ...args, where: scope }`), so passing `args` overwrites `effective` and throws away everything pass 1 wrote: the scope pushed into every `include`, every `_count`, every relation filter and every relation ordering.

The fix is one word — `args` → `effective`.

## Why it survived

The trigger is `policies.length > 0` on the **root** model. With an unpolicied root the whole block is skipped and pass 1 survives intact, which is exactly the configuration every nested-policy test uses. The headline test states it outright:

> Note `User` is deliberately *unpolicied* here, so the only thing that can scope the accounts is `Account`'s own policy firing on a nested read.

Policy on the child alone is covered from several angles across `policies.test.ts`, `nested-write-policies.test.ts` and `relation-filter-policies.test.ts`. Policy on **both** — the ordinary multi-tenant shape, where the tenant model is scoped and so are its children — was covered by nothing.

The seed could not have caught it either, even with the root policied. Alice owns exactly one account and it is already in her organisation, so an unscoped include returns the correct rows by accident. The new tests give her a second account **in Bob's organisation** — hers, in his tenant — which comes back if and only if the nested scope was discarded.

## Impact

Not confined to counts. Under a policied root:

| Query | Returned | Correct |
| --- | --- | --- |
| `include: { accounts: true }` | accounts in orgs `[1, 2]` | `[1]` |
| `_count: { select: { accounts: true } }` | `2` | `1` |

A `redact`-only policy carrying no `scope` at all reproduces it identically, which pins the trigger as "the root has any policy" rather than anything the scope does — so a root model can leak through its children while doing nothing to its own rows.

## Verification

Three regression tests in `templates/saas-starter/app/models/policies.test.ts`, as a `describe` beside the headline test: nested include, nested `_count`, and the `redact`-only root. All three **fail on the previous line and pass on this one** — confirmed by stashing the one-word change and re-running.

| Suite | Result |
| --- | --- |
| saas-starter `app/models/` | 872 passed, 134 skipped |
| `packages/gemi` ORM | 2537 passed |

No existing test changed behaviour, which is its own finding: nothing in the suite depended on the discarded rewrite, and nothing caught its absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)