### PR TITLE
Go to definition on a route path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 
 ### Views & client
 - **[Views & Layouts](./views-and-layouts.md)** — view components, server data binding, nested layouts, `Head`, breadcrumbs.
-- **[Data Fetching](./data-fetching.md)** — `useQuery`, the mutation hooks, the `Query` prefetch facade, and the type-safe `gemi.d.ts` layer.
+- **[Data Fetching](./data-fetching.md)** — `useQuery`, the mutation hooks, the `Query` prefetch facade, the type-safe `gemi.d.ts` layer, and the TypeScript plugin that makes go-to-definition work on a route path.
 - **[Forms](./forms.md)** — the `Form` component, surfacing validation errors, form status hooks.
 - **[Navigation](./navigation.md)** — `Link`, `useNavigate`, `useParams`, `useSearchParams`, and the `Redirect` component vs. facade.
 - **[Testing Views](./testing.md)** — `<Page>` from `gemi/testing`: mounting a view with route params, dictionaries, prefetched query data and a signed-in user.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 
 ### Views & client
 - **[Views & Layouts](./views-and-layouts.md)** — view components, server data binding, nested layouts, `Head`, breadcrumbs.
-- **[Data Fetching](./data-fetching.md)** — `useQuery`, the mutation hooks, the `Query` prefetch facade, the type-safe `gemi.d.ts` layer, and the TypeScript plugin that makes go-to-definition work on a route path.
+- **[Data Fetching](./data-fetching.md)** — `useQuery`, the mutation hooks, the `Query` prefetch facade, the type-safe RPC layer, and the TypeScript plugin that makes go-to-definition work on a route path.
 - **[Forms](./forms.md)** — the `Form` component, surfacing validation errors, form status hooks.
 - **[Navigation](./navigation.md)** — `Link`, `useNavigate`, `useParams`, `useSearchParams`, and the `Redirect` component vs. facade.
 - **[Testing Views](./testing.md)** — `<Page>` from `gemi/testing`: mounting a view with route params, dictionaries, prefetched query data and a signed-in user.
@@ -76,7 +76,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 | **Controller** | Server logic behind a route; receives `HttpRequest` | [controllers](./controllers.md) |
 | **Facade** | Static proxy to a container-resolved service | [facades](./facades.md) |
 | **View** | Default-export React component rendered for a URL | [views-and-layouts](./views-and-layouts.md) |
-| **`gemi.d.ts`** | Generated types binding client hooks to your routes | [data-fetching](./data-fetching.md) |
+| **RPC types** | The `RPC` / `ViewRPC` augmentation binding client hooks to your routes; ships with the package | [data-fetching](./data-fetching.md) |
 
 ## A few things that will bite you
 
@@ -90,4 +90,4 @@ These are the counter-intuitive rules worth knowing up front — each is covered
 - **Middleware is a string DSL.** `auth`, `cache:...`, `rate-limit:N`, etc., and `-auth` *cancels* an inherited middleware. Most names (`admin`, `role:...`) are **app-registered aliases**, not built-ins. See [Middleware](./middleware.md).
 - **The query hook is `useQuery`, not `useGet`.** Some app-level notes mention `useGet`; it does not exist in gemi. See [Data Fetching](./data-fetching.md).
 - **Routing is explicit.** A view/controller file name has no relation to its URL — the mapping lives in a router. See [Routing](./routing.md).
-- **`gemi.d.ts` is generated — never edit it by hand.** Regenerate the API surface with `gemi ide:generate-api-manifest`. See [CLI](./cli.md).
+- **There is nothing to generate for the typed network layer.** The `RPC` / `ViewRPC` augmentation ships inside the package and is derived from your routers by the compiler. Apps upgrading from 0.55 or earlier must delete their root `gemi.d.ts` and its `types` entry — see [UPGRADE.md](../UPGRADE.md). See [Data Fetching](./data-fetching.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,13 +142,15 @@ It reports one thing: a class carrying policies the registered class does not. A
 
 ## `gemi ide:generate-api-manifest`
 
-Generates the API route manifest used for editor integration (jump-to-definition from a route path to its controller method).
+Generates the API route manifest behind the Emacs integration in `packages/gemi/ide/emacs`, which lists your routes and jumps to the handler you pick.
 
 ```bash
 gemi ide:generate-api-manifest
 ```
 
 It statically parses your API routes starting from `app/http/routes/api.ts`, resolves each route + HTTP method to the source position of its handler (the controller method when the route is `this.get(Controller, "method")`, otherwise the router callback), and writes a manifest under `.gemi/cache/api-routes-manifest`. This is meant to be run by tooling rather than by hand.
+
+For go-to-definition *from a route path you have already written* — `useQuery("/reports")`, `<Link href="/about">` — use the TypeScript language service plugin instead, which works in any editor that runs `tsserver`. See [Data Fetching → Jumping from a path to its handler](./data-fetching.md#jumping-from-a-path-to-its-handler).
 
 ## `gemi app:component-tree`
 

--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -3,8 +3,8 @@
 gemi ships a small set of typed hooks for talking to your API routes from the
 client, plus a server-side facade for priming that data during SSR. Every hook is
 fully type-safe: the endpoint path, its params, its search input, and its response
-shape are all inferred from your API routes through the generated `gemi.d.ts` network
-layer. You never write a raw `fetch` or hand-annotate a response type.
+shape are all inferred from your API routes through the type augmentation `gemi/client`
+ships. You never write a raw `fetch` or hand-annotate a response type.
 
 All hooks and components below come from `gemi/client`:
 
@@ -436,10 +436,15 @@ response types from your `api.ts` / `view.ts` routers and applies them to `useQu
 the mutation hooks, `Form`, and `ViewProps` / `LayoutProps` automatically. You get
 autocomplete for valid paths and params and typed response data, with no manual wiring.
 
-This is backed by a `gemi.d.ts` that augments the `RPC` and `ViewRPC` interfaces with
-`CreateRPC<Api>` and `CreateViewRPC<View>`. It is wired up for you in the template and
-needs no regeneration — the types are derived from your routers by the compiler, so they
-follow a route the moment you add one.
+This is backed by an augmentation of the `RPC` and `ViewRPC` interfaces that reads your
+`api.ts` and `view.ts` routers. Since 0.56 it ships inside the package and is referenced
+by `gemi/client` and `gemi/facades`, so importing from either is the whole of the wiring
+— there is nothing to install and nothing to regenerate. The types are derived from your
+routers by the compiler, so they follow a route the moment you add one.
+
+> Upgrading from 0.55 or earlier? Delete your app's root `gemi.d.ts` and its
+> `"./node_modules/gemi/gemi.d.ts"` entry in `tsconfig.json`'s `types` — leaving them is
+> not a no-op. See [UPGRADE.md](../UPGRADE.md).
 
 ### Jumping from a path to its handler
 

--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -436,9 +436,37 @@ response types from your `api.ts` / `view.ts` routers and applies them to `useQu
 the mutation hooks, `Form`, and `ViewProps` / `LayoutProps` automatically. You get
 autocomplete for valid paths and params and typed response data, with no manual wiring.
 
-> **Note:** This is backed by a generated `gemi.d.ts` at your app root — don't edit it by
-> hand. Regenerate it after changing API routes with `gemi ide:generate-api-manifest`
-> (see the [CLI reference](./cli.md)).
+This is backed by a `gemi.d.ts` that augments the `RPC` and `ViewRPC` interfaces with
+`CreateRPC<Api>` and `CreateViewRPC<View>`. It is wired up for you in the template and
+needs no regeneration — the types are derived from your routers by the compiler, so they
+follow a route the moment you add one.
+
+### Jumping from a path to its handler
+
+The path in `useQuery("/reports")` names a handler as precisely as a call names a
+function, but the connection is made by conditional types rather than by a symbol, so
+go-to-definition has nothing to follow and stops at the string. gemi ships a TypeScript
+language service plugin that closes that gap. Add it to your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "gemi/ide/typescript-plugin" }]
+  }
+}
+```
+
+Go to definition on a route path then jumps to the code behind it — the controller
+method for `this.get(HomeController, "index")`, the callback for an inline handler, the
+right method of a `resource()` for the verb you are using, and for a view path both the
+component and the handler feeding it. Hovering a path names the route and its handler.
+It works on any typed path: `useQuery`, `useMutation`, `useMutate`, `Form`'s `action`,
+`Link`'s `href`, and on wrappers you write over them.
+
+> **VS Code** ships its own copy of TypeScript and ignores `plugins` unless told to use
+> the workspace's: run **TypeScript: Select TypeScript Version → Use Workspace Version**
+> once per project. Editors that drive `tsserver` over LSP — Neovim, Emacs, Helix,
+> JetBrains — read `tsconfig.json` directly and need nothing extra.
 
 ## Related
 
@@ -446,4 +474,3 @@ autocomplete for valid paths and params and typed response data, with no manual 
 - [Views and Layouts](./views-and-layouts.md) — server props vs. client queries.
 - [Controllers](./controllers.md) — writing the endpoints these hooks call.
 - [File Storage](./file-storage.md) — handling `useUpload` on the server.
-- [CLI](./cli.md) — regenerating `gemi.d.ts`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ bunx prisma migrate deploy    # initialize the database and generate the Prisma 
 bun dev                       # start the development server
 ```
 
-The generated project is the canonical gemi layout: an `app/` directory (server entry, client entry, kernel, `config/`, `providers/`, routes, controllers, views, email, i18n, database), plus `gemi.config.ts`, `gemi.d.ts`, `vite.config.mjs`, `tsconfig.json`, a `prisma/` schema, and a `Dockerfile`. See [Project Structure](./project-structure.md) for a full tour.
+The generated project is the canonical gemi layout: an `app/` directory (server entry, client entry, kernel, `config/`, `providers/`, routes, controllers, views, email, i18n, database), plus `gemi.config.ts`, `vite.config.mjs`, `tsconfig.json`, a `prisma/` schema, and a `Dockerfile`. See [Project Structure](./project-structure.md) for a full tour.
 
 ## Commands
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
       <h2>Views &amp; client</h2>
       <div class="grid">
         <a class="card" href="views-and-layouts.md"><span class="t">Views &amp; Layouts</span><span class="d">Components, server data, nested layouts, Head, breadcrumbs.</span></a>
-        <a class="card" href="data-fetching.md"><span class="t">Data Fetching</span><span class="d">useQuery, mutations, Query prefetch, gemi.d.ts types.</span></a>
+        <a class="card" href="data-fetching.md"><span class="t">Data Fetching</span><span class="d">useQuery, mutations, Query prefetch, RPC types.</span></a>
         <a class="card" href="forms.md"><span class="t">Forms</span><span class="d">The Form component, validation errors, status hooks.</span></a>
         <a class="card" href="navigation.md"><span class="t">Navigation</span><span class="d">Link, useNavigate, params, search, Redirect.</span></a>
         <a class="card" href="testing.md"><span class="t">Testing Views</span><span class="d">Page from gemi/testing: params, dictionaries, query data, user.</span></a>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1093,13 +1093,15 @@ It reports one thing: a class carrying policies the registered class does not. A
 
 ## `gemi ide:generate-api-manifest`
 
-Generates the API route manifest used for editor integration (jump-to-definition from a route path to its controller method).
+Generates the API route manifest behind the Emacs integration in `packages/gemi/ide/emacs`, which lists your routes and jumps to the handler you pick.
 
 ```bash
 gemi ide:generate-api-manifest
 ```
 
 It statically parses your API routes starting from `app/http/routes/api.ts`, resolves each route + HTTP method to the source position of its handler (the controller method when the route is `this.get(Controller, "method")`, otherwise the router callback), and writes a manifest under `.gemi/cache/api-routes-manifest`. This is meant to be run by tooling rather than by hand.
+
+For go-to-definition *from a route path you have already written* — `useQuery("/reports")`, `<Link href="/about">` — use the TypeScript language service plugin instead, which works in any editor that runs `tsserver`. See [Data Fetching → Jumping from a path to its handler](./data-fetching.md#jumping-from-a-path-to-its-handler).
 
 ## `gemi app:component-tree`
 
@@ -2455,9 +2457,37 @@ response types from your `api.ts` / `view.ts` routers and applies them to `useQu
 the mutation hooks, `Form`, and `ViewProps` / `LayoutProps` automatically. You get
 autocomplete for valid paths and params and typed response data, with no manual wiring.
 
-> **Note:** This is backed by a generated `gemi.d.ts` at your app root — don't edit it by
-> hand. Regenerate it after changing API routes with `gemi ide:generate-api-manifest`
-> (see the [CLI reference](./cli.md)).
+This is backed by a `gemi.d.ts` that augments the `RPC` and `ViewRPC` interfaces with
+`CreateRPC<Api>` and `CreateViewRPC<View>`. It is wired up for you in the template and
+needs no regeneration — the types are derived from your routers by the compiler, so they
+follow a route the moment you add one.
+
+### Jumping from a path to its handler
+
+The path in `useQuery("/reports")` names a handler as precisely as a call names a
+function, but the connection is made by conditional types rather than by a symbol, so
+go-to-definition has nothing to follow and stops at the string. gemi ships a TypeScript
+language service plugin that closes that gap. Add it to your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "gemi/ide/typescript-plugin" }]
+  }
+}
+```
+
+Go to definition on a route path then jumps to the code behind it — the controller
+method for `this.get(HomeController, "index")`, the callback for an inline handler, the
+right method of a `resource()` for the verb you are using, and for a view path both the
+component and the handler feeding it. Hovering a path names the route and its handler.
+It works on any typed path: `useQuery`, `useMutation`, `useMutate`, `Form`'s `action`,
+`Link`'s `href`, and on wrappers you write over them.
+
+> **VS Code** ships its own copy of TypeScript and ignores `plugins` unless told to use
+> the workspace's: run **TypeScript: Select TypeScript Version → Use Workspace Version**
+> once per project. Editors that drive `tsserver` over LSP — Neovim, Emacs, Helix,
+> JetBrains — read `tsconfig.json` directly and need nothing extra.
 
 ## Related
 
@@ -2465,7 +2495,6 @@ autocomplete for valid paths and params and typed response data, with no manual 
 - [Views and Layouts](./views-and-layouts.md) — server props vs. client queries.
 - [Controllers](./controllers.md) — writing the endpoints these hooks call.
 - [File Storage](./file-storage.md) — handling `useUpload` on the server.
-- [CLI](./cli.md) — regenerating `gemi.d.ts`.
 
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -42,7 +42,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 
 ### Views & client
 - **[Views & Layouts](./views-and-layouts.md)** — view components, server data binding, nested layouts, `Head`, breadcrumbs.
-- **[Data Fetching](./data-fetching.md)** — `useQuery`, the mutation hooks, the `Query` prefetch facade, and the type-safe `gemi.d.ts` layer.
+- **[Data Fetching](./data-fetching.md)** — `useQuery`, the mutation hooks, the `Query` prefetch facade, the type-safe RPC layer, and the TypeScript plugin that makes go-to-definition work on a route path.
 - **[Forms](./forms.md)** — the `Form` component, surfacing validation errors, form status hooks.
 - **[Navigation](./navigation.md)** — `Link`, `useNavigate`, `useParams`, `useSearchParams`, and the `Redirect` component vs. facade.
 - **[Testing Views](./testing.md)** — `<Page>` from `gemi/testing`: mounting a view with route params, dictionaries, prefetched query data and a signed-in user.
@@ -76,7 +76,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 | **Controller** | Server logic behind a route; receives `HttpRequest` | [controllers](./controllers.md) |
 | **Facade** | Static proxy to a container-resolved service | [facades](./facades.md) |
 | **View** | Default-export React component rendered for a URL | [views-and-layouts](./views-and-layouts.md) |
-| **`gemi.d.ts`** | Generated types binding client hooks to your routes | [data-fetching](./data-fetching.md) |
+| **RPC types** | The `RPC` / `ViewRPC` augmentation binding client hooks to your routes; ships with the package | [data-fetching](./data-fetching.md) |
 
 ## A few things that will bite you
 
@@ -90,7 +90,7 @@ These are the counter-intuitive rules worth knowing up front — each is covered
 - **Middleware is a string DSL.** `auth`, `cache:...`, `rate-limit:N`, etc., and `-auth` *cancels* an inherited middleware. Most names (`admin`, `role:...`) are **app-registered aliases**, not built-ins. See [Middleware](./middleware.md).
 - **The query hook is `useQuery`, not `useGet`.** Some app-level notes mention `useGet`; it does not exist in gemi. See [Data Fetching](./data-fetching.md).
 - **Routing is explicit.** A view/controller file name has no relation to its URL — the mapping lives in a router. See [Routing](./routing.md).
-- **`gemi.d.ts` is generated — never edit it by hand.** Regenerate the API surface with `gemi ide:generate-api-manifest`. See [CLI](./cli.md).
+- **There is nothing to generate for the typed network layer.** The `RPC` / `ViewRPC` augmentation ships inside the package and is derived from your routers by the compiler. Apps upgrading from 0.55 or earlier must delete their root `gemi.d.ts` and its `types` entry — see [UPGRADE.md](../UPGRADE.md). See [Data Fetching](./data-fetching.md).
 
 
 ---
@@ -144,7 +144,7 @@ bunx prisma migrate deploy    # initialize the database and generate the Prisma 
 bun dev                       # start the development server
 ```
 
-The generated project is the canonical gemi layout: an `app/` directory (server entry, client entry, kernel, `config/`, `providers/`, routes, controllers, views, email, i18n, database), plus `gemi.config.ts`, `gemi.d.ts`, `vite.config.mjs`, `tsconfig.json`, a `prisma/` schema, and a `Dockerfile`. See [Project Structure](./project-structure.md) for a full tour.
+The generated project is the canonical gemi layout: an `app/` directory (server entry, client entry, kernel, `config/`, `providers/`, routes, controllers, views, email, i18n, database), plus `gemi.config.ts`, `vite.config.mjs`, `tsconfig.json`, a `prisma/` schema, and a `Dockerfile`. See [Project Structure](./project-structure.md) for a full tour.
 
 ## Commands
 
@@ -282,7 +282,7 @@ app/
     prisma.ts            # the Prisma client instance
 ```
 
-Root-level files support the app: [`gemi.config.ts`](./configuration.md) (Vite/Bun plugin config), `gemi.d.ts` (type augmentation for the type-safe RPC layer), `vite.config.mjs`, `tsconfig.json`, the `prisma/` schema, and a `Dockerfile`.
+Root-level files support the app: [`gemi.config.ts`](./configuration.md) (Vite/Bun plugin config), `vite.config.mjs`, `tsconfig.json`, the `prisma/` schema, and a `Dockerfile`. The type augmentation behind the type-safe RPC layer ships inside the package as of 0.56 — an app that still has a root `gemi.d.ts` should delete it, see [UPGRADE.md](../UPGRADE.md).
 
 > **`gemi.config.ts` and `app/config/` are different things.** `gemi.config.ts` is *build* config (Vite/Bun plugins), imported from `gemi/config`. `app/config/*.ts` is *runtime* config for framework services, consumed by the container. They never overlap.
 
@@ -2207,8 +2207,8 @@ when its handler supplies one.
 gemi ships a small set of typed hooks for talking to your API routes from the
 client, plus a server-side facade for priming that data during SSR. Every hook is
 fully type-safe: the endpoint path, its params, its search input, and its response
-shape are all inferred from your API routes through the generated `gemi.d.ts` network
-layer. You never write a raw `fetch` or hand-annotate a response type.
+shape are all inferred from your API routes through the type augmentation `gemi/client`
+ships. You never write a raw `fetch` or hand-annotate a response type.
 
 All hooks and components below come from `gemi/client`:
 
@@ -2457,10 +2457,15 @@ response types from your `api.ts` / `view.ts` routers and applies them to `useQu
 the mutation hooks, `Form`, and `ViewProps` / `LayoutProps` automatically. You get
 autocomplete for valid paths and params and typed response data, with no manual wiring.
 
-This is backed by a `gemi.d.ts` that augments the `RPC` and `ViewRPC` interfaces with
-`CreateRPC<Api>` and `CreateViewRPC<View>`. It is wired up for you in the template and
-needs no regeneration — the types are derived from your routers by the compiler, so they
-follow a route the moment you add one.
+This is backed by an augmentation of the `RPC` and `ViewRPC` interfaces that reads your
+`api.ts` and `view.ts` routers. Since 0.56 it ships inside the package and is referenced
+by `gemi/client` and `gemi/facades`, so importing from either is the whole of the wiring
+— there is nothing to install and nothing to regenerate. The types are derived from your
+routers by the compiler, so they follow a route the moment you add one.
+
+> Upgrading from 0.55 or earlier? Delete your app's root `gemi.d.ts` and its
+> `"./node_modules/gemi/gemi.d.ts"` entry in `tsconfig.json`'s `types` — leaving them is
+> not a no-op. See [UPGRADE.md](../UPGRADE.md).
 
 ### Jumping from a path to its handler
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -22,7 +22,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 ## Views & client
 
 - [Views & Layouts](https://nstfkc.github.io/gemi/views-and-layouts.md): view components, server data binding, nested layouts, Head, breadcrumbs.
-- [Data Fetching](https://nstfkc.github.io/gemi/data-fetching.md): the useQuery hook, mutation hooks, the Query prefetch facade, and the generated gemi.d.ts type layer.
+- [Data Fetching](https://nstfkc.github.io/gemi/data-fetching.md): the useQuery hook, mutation hooks, the Query prefetch facade, the gemi.d.ts type layer, and the TypeScript plugin that makes go-to-definition work on a route path.
 - [Forms](https://nstfkc.github.io/gemi/forms.md): the Form component, surfacing validation errors, form-status hooks.
 - [Navigation](https://nstfkc.github.io/gemi/navigation.md): Link, useNavigate, useParams, useSearchParams, and the Redirect component vs facade.
 - [Testing Views](https://nstfkc.github.io/gemi/testing.md): the Page component from gemi/testing — mounting a view with seeded route params, dictionaries, prefetched useQuery data and a signed-in user.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -22,7 +22,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 ## Views & client
 
 - [Views & Layouts](https://nstfkc.github.io/gemi/views-and-layouts.md): view components, server data binding, nested layouts, Head, breadcrumbs.
-- [Data Fetching](https://nstfkc.github.io/gemi/data-fetching.md): the useQuery hook, mutation hooks, the Query prefetch facade, the gemi.d.ts type layer, and the TypeScript plugin that makes go-to-definition work on a route path.
+- [Data Fetching](https://nstfkc.github.io/gemi/data-fetching.md): the useQuery hook, mutation hooks, the Query prefetch facade, the RPC type layer, and the TypeScript plugin that makes go-to-definition work on a route path.
 - [Forms](https://nstfkc.github.io/gemi/forms.md): the Form component, surfacing validation errors, form-status hooks.
 - [Navigation](https://nstfkc.github.io/gemi/navigation.md): Link, useNavigate, useParams, useSearchParams, and the Redirect component vs facade.
 - [Testing Views](https://nstfkc.github.io/gemi/testing.md): the Page component from gemi/testing — mounting a view with seeded route params, dictionaries, prefetched useQuery data and a signed-in user.
@@ -55,7 +55,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - The client query hook is `useQuery` (not `useGet`).
 - The server-side `Redirect` facade works by throwing — never wrap it in try/catch.
 - Middleware is a string DSL (`auth`, `cache:...`, `rate-limit:N`); `-name` cancels an inherited middleware.
-- `gemi.d.ts` is generated (`gemi ide:generate-api-manifest`) — do not edit it by hand.
+- The typed network layer needs no codegen: the `RPC` / `ViewRPC` augmentation ships inside the package. An app upgrading from 0.55 or earlier must delete its root `gemi.d.ts` and its `types` entry.
 - Runtime config lives in `app/config/*.ts` (`defineMailConfig`, `defineAuthConfig`, …) and is read through `Repository` from `gemi/support`. `gemi.config.ts` / `gemi/config` is the unrelated BUILD config.
 - Subsystem hooks (`filterRecipients`, `onLogCreated`, `onSignUp`, `detectLocale`, `extendSession`, …) are plain properties on a config slice, not methods to override on a provider.
 - A `ServiceProvider` (from `gemi/support`) registers bindings: `register()` binds and must not resolve; `boot()` runs after every provider registered and may resolve.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -42,7 +42,7 @@ app/
     prisma.ts            # the Prisma client instance
 ```
 
-Root-level files support the app: [`gemi.config.ts`](./configuration.md) (Vite/Bun plugin config), `gemi.d.ts` (type augmentation for the type-safe RPC layer), `vite.config.mjs`, `tsconfig.json`, the `prisma/` schema, and a `Dockerfile`.
+Root-level files support the app: [`gemi.config.ts`](./configuration.md) (Vite/Bun plugin config), `vite.config.mjs`, `tsconfig.json`, the `prisma/` schema, and a `Dockerfile`. The type augmentation behind the type-safe RPC layer ships inside the package as of 0.56 — an app that still has a root `gemi.d.ts` should delete it, see [UPGRADE.md](../UPGRADE.md).
 
 > **`gemi.config.ts` and `app/config/` are different things.** `gemi.config.ts` is *build* config (Vite/Bun plugins), imported from `gemi/config`. `app/config/*.ts` is *runtime* config for framework services, consumed by the container. They never overlap.
 

--- a/packages/gemi/ide/typescript-plugin/README.md
+++ b/packages/gemi/ide/typescript-plugin/README.md
@@ -1,0 +1,149 @@
+# gemi TypeScript language service plugin
+
+Makes a route path behave like a reference to the code that serves it.
+
+```tsx
+const { data } = useQuery("/suspense-demo/metrics");
+//                         ^ go to definition → SuspenseDemoController.metrics()
+
+const nav = <Link href="/about">About</Link>;
+//                       ^ go to definition → app/views/About.tsx, and its handler
+```
+
+Without it, following one call site means opening `app/http/routes/api.ts`,
+finding the entry, reading which controller and method it names, and opening
+that file — for a connection the type system already knows about.
+
+## Why a plugin
+
+`useQuery("/reports")` names its handler as precisely as a function call names a
+function: the string is checked against the router at compile time, and
+autocomplete offers only paths that exist. But the connection is made by
+conditional types — `CreateRPC` maps a `routes` object to a union of string
+literal keys — not by a symbol. There is nothing for go-to-definition to follow,
+so it stops at the literal.
+
+A language service plugin is the only place that gap can be closed, because
+closing it takes two things at once: the AST of the router (to know what
+`"/reports"` maps to) and the checker (to resolve `HomeController` through its
+import to a class, and `"index"` to a method that might be inherited). tsserver
+has both, already loaded.
+
+## Enabling it
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "gemi/ide/typescript-plugin" }]
+  }
+}
+```
+
+**VS Code** ships its own copy of TypeScript and ignores `plugins` unless told to
+use the workspace's: run **TypeScript: Select TypeScript Version → Use Workspace
+Version** once per project. Editors that drive tsserver over LSP — Neovim, Emacs,
+Helix, JetBrains — read `tsconfig.json` directly and need nothing extra.
+
+Options, all optional:
+
+| Key           | Default                         |                                                      |
+| ------------- | ------------------------------- | ---------------------------------------------------- |
+| `projectRoot` | the `tsconfig.json`'s directory | where the app's `app/` folder sits                   |
+| `viewsDir`    | `<projectRoot>/app/views`       | where `this.view("auth/SignIn")` finds its component |
+| `enable`      | `true`                          | set `false` to switch off without editing the array  |
+
+## What it answers
+
+**Go to definition** on a route path resolves to:
+
+| Route                               | Lands on                                                                 |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| `this.get(HomeController, "index")` | `index()`, in the controller — through imports, aliases and base classes |
+| `this.get(() => …)`                 | the callback, in the router                                              |
+| `this.resource(ProductsController)` | the method for that verb — `list`, `store`, `show`, `update`, `delete`   |
+| `this.view("Reports", [C, "m"])`    | the component _and_ the handler, offered as two definitions              |
+| anything it cannot read through     | the `routes` entry itself, one line from the answer                      |
+
+**Hover** names the route and where its handler lives, appended to whatever
+TypeScript already had to say.
+
+Everything else is delegated untouched — an identifier, an import specifier, an
+object key that happens to look like a path, `config["/home"]`. The plugin answers
+only where the position really is a route path and the path really is in the
+table, and it never throws: a surprise degrades to "not a route", because a
+broken jump beats an editor with no language features.
+
+## How it picks the right route
+
+A path can carry several handlers — a `GET` and a `POST` at `/products`, or an
+API route and a view sharing a name. Three signals narrow it, each applied only
+when narrowing leaves something:
+
+1. **The parameter's constraint.** `useQuery(url: T)` declares
+   `T extends keyof GetRPC`, so the constraint of the parameter this argument
+   fills _is_ the GET route set. Comparing that set against each verb's paths
+   identifies the verb — with no hook name hardcoded anywhere, which is why a
+   wrapper an app writes over `useQuery` works for free.
+2. **A verb named outright.** `useMutation("PUT", …)` and
+   `<Form action=… method="PUT">`. Keyed off the shape — a verb in the preceding
+   argument, a sibling `method` attribute — not off the callee's name.
+3. **The attribute.** `href` means a page, `action` means an endpoint.
+
+When several routes still survive, all are returned and the editor offers the
+choice. That is the honest answer for a path that genuinely carries two handlers.
+
+## What it cannot see
+
+Routes assembled anywhere but a `routes` property initializer — built in a
+constructor, spread in from elsewhere, returned by a helper. This is a floor
+rather than a gap: `CreateRPC` cannot see those either, so a route declared that
+way has no typed call site to jump _from_.
+
+## Layout
+
+|                  |                                                                                                                                         |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`       | the tsserver entry point (`export =`), config, and the guard that keeps a failure from taking the language service down                 |
+| `plugin.ts`      | the language service proxy: `getDefinitionAndBoundSpan`, `getDefinitionAtPosition`, `getQuickInfoAtPosition`, and the route table cache |
+| `routeTable.ts`  | walks the router tree into `path → handler location`                                                                                    |
+| `routePath.ts`   | value-level mirrors of the template literal types that build RPC keys                                                                   |
+| `entryPoints.ts` | finds the routers, by reading the `RPC` / `ViewRPC` interfaces                                                                          |
+| `callSite.ts`    | decides whether a string literal is naming a route, and what narrows it                                                                 |
+| `lookup.ts`      | matches a call site against the table                                                                                                   |
+
+The route table is built once and reused until one of the files it was derived
+from changes, so typing in a component does not rebuild it. On the
+`saas-starter` template it is 26 API paths and 21 view paths, walked from 34
+files, in about 2ms.
+
+## Tests
+
+```
+bun --bun vitest run ide/typescript-plugin
+```
+
+Four files, in rough order of how much they would catch:
+
+- **`rpcParity.test.ts`** is the one that matters. The walker's key set has to be
+  character-identical to `keyof RPC`, because the string being looked up was
+  typed by a developer whose autocomplete came from `CreateRPC` — and nothing
+  else enforces that, since the two live in different languages. So it asks the
+  checker for `keyof RPC` over the _same fixture_ the walker reads and requires
+  the sets to be equal. A route shape added to `ApiRouter` fails here until the
+  walker learns it.
+- **`plugin.test.ts`** drives a real `LanguageService` through
+  `decorateLanguageService`: spans, definitions, hover, delegation, cache reuse.
+- **`routeTable.test.ts`** pins where each jump lands, down to the line.
+- **`routePath.test.ts`** pins the path-composition transcription, quirks
+  included — `/(app)/` joined to `/(admin)/users` really does produce
+  `///users`, and matching the type matters more than being right.
+
+`fixture.ts` and `testProject.ts` are the shared harness: an in-memory project
+with `gemi/*` mapped at the package source, so the tests run against the real
+`ApiRouter` and the real `useQuery`.
+
+Typecheck with `bun run typecheck`, which covers this directory through its own
+`tsconfig.json` — see the comment in it for why it is not part of the package's.
+
+Build with `bun run build:ts-plugin`. See `WHY-PACKAGE-JSON.md` for how tsserver
+finds the result.

--- a/packages/gemi/ide/typescript-plugin/README.md
+++ b/packages/gemi/ide/typescript-plugin/README.md
@@ -83,7 +83,10 @@ when narrowing leaves something:
    `T extends keyof GetRPC`, so the constraint of the parameter this argument
    fills _is_ the GET route set. Comparing that set against each verb's paths
    identifies the verb — with no hook name hardcoded anywhere, which is why a
-   wrapper an app writes over `useQuery` works for free.
+   wrapper an app writes over `useQuery` works for free. A path that arrives as a
+   property of an options object rather than as an argument —
+   `mutate({ path: "/reports" })`, `useMutate`'s real signature — is read the
+   same way, through the property's own constraint.
 2. **A verb named outright.** `useMutation("PUT", …)` and
    `<Form action=… method="PUT">`. Keyed off the shape — a verb in the preceding
    argument, a sibling `method` attribute — not off the callee's name.
@@ -95,9 +98,16 @@ choice. That is the honest answer for a path that genuinely carries two handlers
 ## What it cannot see
 
 Routes assembled anywhere but a `routes` property initializer — built in a
-constructor, spread in from elsewhere, returned by a helper. This is a floor
-rather than a gap: `CreateRPC` cannot see those either, so a route declared that
-way has no typed call site to jump _from_.
+constructor, returned by a helper. This is a floor rather than a gap:
+`CreateRPC` cannot see those either, so a route declared that way has no typed
+call site to jump _from_.
+
+A spread _inside_ the initializer — `...sharedRoutes` — is the one shape where
+the two disagree. `CreateRPC` works from the declared type of `routes` and keeps
+it; the walk reads syntax and drops it, so the path autocompletes and does not
+jump. Each one is named in the tsserver log, and it costs only itself: a path the
+walk never saw is left out of the constraint comparison rather than breaking it,
+so verb narrowing keeps working everywhere else.
 
 ## Layout
 
@@ -107,7 +117,7 @@ way has no typed call site to jump _from_.
 | `plugin.ts`      | the language service proxy: `getDefinitionAndBoundSpan`, `getDefinitionAtPosition`, `getQuickInfoAtPosition`, and the route table cache |
 | `routeTable.ts`  | walks the router tree into `path → handler location`                                                                                    |
 | `routePath.ts`   | value-level mirrors of the template literal types that build RPC keys                                                                   |
-| `entryPoints.ts` | finds the routers, by reading the `RPC` / `ViewRPC` interfaces                                                                          |
+| `entryPoints.ts` | finds the routers, by asking the checker for `gemi/client`'s `RPC` / `ViewRPC`                                                          |
 | `callSite.ts`    | decides whether a string literal is naming a route, and what narrows it                                                                 |
 | `lookup.ts`      | matches a call site against the table                                                                                                   |
 
@@ -122,7 +132,7 @@ files, in about 2ms.
 bun --bun vitest run ide/typescript-plugin
 ```
 
-Four files, in rough order of how much they would catch:
+Five files, in rough order of how much they would catch:
 
 - **`rpcParity.test.ts`** is the one that matters. The walker's key set has to be
   character-identical to `keyof RPC`, because the string being looked up was
@@ -134,13 +144,21 @@ Four files, in rough order of how much they would catch:
 - **`plugin.test.ts`** drives a real `LanguageService` through
   `decorateLanguageService`: spans, definitions, hover, delegation, cache reuse.
 - **`routeTable.test.ts`** pins where each jump lands, down to the line.
+- **`entryPoints.test.ts`** covers discovery, where a failure is silent by
+  nature: `client/rpc.ts` mounts `/auth/*` in every project, so "we found
+  something" is always true and cannot stand in for "we found the app". It pins
+  the augmentation shapes an app can be in — the package's own, an installed
+  app's under `node_modules`, a leftover pre-0.56 `gemi.d.ts` — and what is
+  logged when none of them names a router.
 - **`routePath.test.ts`** pins the path-composition transcription, quirks
   included — `/(app)/` joined to `/(admin)/users` really does produce
   `///users`, and matching the type matters more than being right.
 
 `fixture.ts` and `testProject.ts` are the shared harness: an in-memory project
 with `gemi/*` mapped at the package source, so the tests run against the real
-`ApiRouter` and the real `useQuery`.
+`ApiRouter` and the real `useQuery`. The fixture app has no `gemi.d.ts` of its
+own — since 0.56 the augmentation ships with the package, and mapping `gemi/*`
+at the source is what puts the fixture in the same shape as an installed app.
 
 Typecheck with `bun run typecheck`, which covers this directory through its own
 `tsconfig.json` — see the comment in it for why it is not part of the package's.

--- a/packages/gemi/ide/typescript-plugin/WHY-PACKAGE-JSON.md
+++ b/packages/gemi/ide/typescript-plugin/WHY-PACKAGE-JSON.md
@@ -1,0 +1,33 @@
+# Why there is a `package.json` here
+
+tsserver does not resolve a plugin through the package's `exports` map. It does
+plain Node directory resolution against the name in `tsconfig.json`, probing, in
+order:
+
+```
+<pkg>/ide/typescript-plugin/package.json     ← this file
+<pkg>/package.json
+<pkg>/ide/typescript-plugin.js
+<pkg>/ide/typescript-plugin/index.js
+```
+
+The built plugin lives at `<pkg>/dist/ide/typescript-plugin/index.js`, like every
+other build output in this package, which is on none of those paths. This
+`package.json` is the one probe location that can point at it, so it exists only
+to say `main`.
+
+Two consequences worth knowing:
+
+- **In this repo the plugin needs a build.** `main` names a file under `dist/`,
+  so `bun run build:ts-plugin` has to have run before an editor can load it from
+  `templates/saas-starter`. The published tarball always has it.
+- **`scripts/build-publish.ts` stages this file explicitly.** That script
+  assembles the tarball from `dist/` plus a short list, rather than from the
+  `files` field, so a new file outside `dist/` is invisible to it until it is
+  named there. It is, and a check at the end of that script fails the publish if
+  `main` does not resolve.
+
+The `"./ide/typescript-plugin"` entry in the package's `exports` map is not what
+makes any of this work — it is there so `scripts/build-publish.ts` verifies the
+built file exists, and so the subpath is a declared part of the package surface
+rather than an accident of layout.

--- a/packages/gemi/ide/typescript-plugin/ast.ts
+++ b/packages/gemi/ide/typescript-plugin/ast.ts
@@ -1,0 +1,173 @@
+import type ts from "typescript";
+
+import type { Span, TargetKind } from "./types";
+
+/**
+ * The `typescript` module, as tsserver hands it to a plugin.
+ *
+ * A language service plugin must never `require("typescript")` itself — the
+ * editor may be running a different copy than the one resolvable from the
+ * plugin's own `node_modules`, and two copies means enums with different
+ * numeric values and `instanceof`-style identity checks that quietly fail. Every
+ * function here takes the injected module instead.
+ */
+export type TS = typeof ts;
+
+/** Strips the wrappers that carry no meaning for what an expression *is*. */
+export function unwrapExpression(ts: TS, node: ts.Expression): ts.Expression {
+  let current = node;
+  for (;;) {
+    if (ts.isParenthesizedExpression(current)) current = current.expression;
+    else if (ts.isAsExpression(current)) current = current.expression;
+    else if (ts.isSatisfiesExpression(current)) current = current.expression;
+    else if (ts.isNonNullExpression(current)) current = current.expression;
+    else if (ts.isTypeAssertionExpression(current)) current = current.expression;
+    else return current;
+  }
+}
+
+/**
+ * Peels the fluent builders a route entry can be wrapped in —
+ * `this.get(...).middleware([...])`, `this.layout(...).alwaysRun()` — down to
+ * the `this.<method>(...)` call that decides what the route is.
+ */
+export function unwrapBuilderChain(ts: TS, node: ts.Expression): ts.Expression {
+  const chainable = new Set(["middleware", "alwaysRun"]);
+  let current = unwrapExpression(ts, node);
+  while (
+    ts.isCallExpression(current) &&
+    ts.isPropertyAccessExpression(current.expression) &&
+    chainable.has(current.expression.name.text)
+  ) {
+    current = unwrapExpression(ts, current.expression.expression);
+  }
+  return current;
+}
+
+export interface ThisCall {
+  method: string;
+  args: readonly ts.Expression[];
+  node: ts.CallExpression;
+}
+
+/** Matches `this.<method>(...)`, the shape every route builder takes. */
+export function getThisCall(ts: TS, node: ts.Expression): ThisCall | undefined {
+  if (!ts.isCallExpression(node)) return undefined;
+  const callee = node.expression;
+  if (!ts.isPropertyAccessExpression(callee)) return undefined;
+  if (callee.expression.kind !== ts.SyntaxKind.ThisKeyword) return undefined;
+  return { method: callee.name.text, args: node.arguments, node };
+}
+
+/**
+ * The string an expression denotes, whether it is spelled inline or reached
+ * through a constant. The checker answers the second case for free, so
+ * `this.get(Controller, METHOD)` resolves as well as `this.get(Controller, "x")`.
+ */
+export function getStringValue(
+  ts: TS,
+  checker: ts.TypeChecker,
+  node: ts.Expression | undefined,
+): string | undefined {
+  if (!node) return undefined;
+  const expression = unwrapExpression(ts, node);
+  if (ts.isStringLiteralLike(expression)) return expression.text;
+  const type = checker.getTypeAtLocation(expression);
+  if (type.isStringLiteral()) return type.value;
+  return undefined;
+}
+
+/** The key of a `routes` entry, including `[SOME_CONST]: ...` computed keys. */
+export function getPropertyKeyText(
+  ts: TS,
+  checker: ts.TypeChecker,
+  name: ts.PropertyName,
+): string | undefined {
+  if (ts.isStringLiteralLike(name)) return name.text;
+  if (ts.isIdentifier(name)) return name.text;
+  if (ts.isNumericLiteral(name)) return name.text;
+  if (ts.isComputedPropertyName(name)) return getStringValue(ts, checker, name.expression);
+  return undefined;
+}
+
+/** Follows imports and aliases to the class an expression names. */
+export function resolveClassDeclaration(
+  ts: TS,
+  checker: ts.TypeChecker,
+  node: ts.Expression,
+): ts.ClassLikeDeclaration | undefined {
+  if (ts.isClassExpression(node)) return node;
+  let symbol = checker.getSymbolAtLocation(node);
+  if (!symbol) return undefined;
+  if (symbol.flags & ts.SymbolFlags.Alias) symbol = checker.getAliasedSymbol(symbol);
+  const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+  return declaration && ts.isClassLike(declaration) ? declaration : undefined;
+}
+
+/**
+ * The object literal assigned to a class's `routes` property.
+ *
+ * A router that builds `routes` anywhere but its own initializer — in a
+ * constructor, from a spread, behind a helper — is invisible here. That is a
+ * deliberate floor rather than a gap to close: the same shapes are invisible to
+ * `CreateRPC`, so a route declared that way has no typed call site to jump from.
+ */
+export function getRoutesObjectLiteral(
+  ts: TS,
+  classDeclaration: ts.ClassLikeDeclaration,
+): ts.ObjectLiteralExpression | undefined {
+  for (const member of classDeclaration.members) {
+    if (!ts.isPropertyDeclaration(member)) continue;
+    if (!member.name || !ts.isIdentifier(member.name) || member.name.text !== "routes") continue;
+    if (!member.initializer) continue;
+    const initializer = unwrapExpression(ts, member.initializer);
+    if (ts.isObjectLiteralExpression(initializer)) return initializer;
+  }
+  return undefined;
+}
+
+export function spanOf(node: ts.Node): Span {
+  const start = node.getStart(node.getSourceFile());
+  return { start, length: node.getEnd() - start };
+}
+
+/** The identifier a declaration is named by, which is where a jump should land. */
+export function nameNodeOf(ts: TS, declaration: ts.Declaration): ts.Node {
+  const named = declaration as ts.NamedDeclaration;
+  return named.name && !ts.isComputedPropertyName(named.name) ? named.name : declaration;
+}
+
+export function targetFromDeclaration(
+  ts: TS,
+  declaration: ts.Declaration,
+  name: string,
+  containerName: string,
+  kind: TargetKind,
+): {
+  fileName: string;
+  span: Span;
+  contextSpan: Span;
+  name: string;
+  containerName: string;
+  kind: TargetKind;
+} {
+  return {
+    fileName: declaration.getSourceFile().fileName,
+    span: spanOf(nameNodeOf(ts, declaration)),
+    contextSpan: spanOf(declaration),
+    name,
+    containerName,
+    kind,
+  };
+}
+
+/** The class name to show alongside a handler, skipping `export default class`'s `"default"`. */
+export function displayNameOfClass(
+  ts: TS,
+  checker: ts.TypeChecker,
+  expression: ts.Expression,
+): string {
+  const declaration = resolveClassDeclaration(ts, checker, expression);
+  if (declaration?.name) return declaration.name.text;
+  return expression.getText();
+}

--- a/packages/gemi/ide/typescript-plugin/ast.ts
+++ b/packages/gemi/ide/typescript-plugin/ast.ts
@@ -107,10 +107,16 @@ export function resolveClassDeclaration(
 /**
  * The object literal assigned to a class's `routes` property.
  *
- * A router that builds `routes` anywhere but its own initializer — in a
- * constructor, from a spread, behind a helper — is invisible here. That is a
- * deliberate floor rather than a gap to close: the same shapes are invisible to
- * `CreateRPC`, so a route declared that way has no typed call site to jump from.
+ * A router that assigns `routes` anywhere but its own initializer — in a
+ * constructor, behind a helper — is invisible here, and that is a deliberate
+ * floor rather than a gap to close: those shapes are invisible to `CreateRPC`
+ * too, so a route declared that way has no typed call site to jump from.
+ *
+ * A spread *inside* the initializer is the one case where the two disagree.
+ * `RouteParser` reads the declared type of `routes` and so keeps it; the walk
+ * reads syntax and drops it. `RouteTableBuilder.noteUnreadableEntry` logs each
+ * one it meets, because a route that autocompletes and does not jump is
+ * otherwise indistinguishable from a bug in this plugin.
  */
 export function getRoutesObjectLiteral(
   ts: TS,

--- a/packages/gemi/ide/typescript-plugin/callSite.ts
+++ b/packages/gemi/ide/typescript-plugin/callSite.ts
@@ -1,0 +1,206 @@
+import type ts from "typescript";
+
+import { getStringValue, type TS } from "./ast";
+import type { HttpVerb } from "./types";
+
+const HTTP_VERBS = new Set<string>(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+/** Attributes that name a page to navigate to rather than an endpoint to call. */
+const VIEW_ATTRIBUTES = new Set(["href", "to"]);
+/** Attributes that name an endpoint to submit to. `<Form action=… method=…>`. */
+const ACTION_ATTRIBUTES = new Set(["action"]);
+
+export interface RouteQuery {
+  node: ts.StringLiteralLike;
+  /** The literal's text — the route path as the user typed it. */
+  path: string;
+  /**
+   * The paths this position is allowed to hold, when the signature says so.
+   *
+   * `useQuery(url: T)` declares `T extends keyof GetRPC`, so the constraint of
+   * the parameter this argument fills *is* the GET route set — which is how a
+   * `useQuery` call is told apart from a `useMutation` one without either name
+   * appearing here. Any wrapper an app writes over these hooks carries the same
+   * constraint through, and is understood for free.
+   */
+  allowedPaths?: ReadonlySet<string>;
+  /** A verb the call site names outright, e.g. `useMutation("PUT", …)`. */
+  verb?: HttpVerb;
+  /** Whether the surrounding syntax means a page or an endpoint. */
+  prefer?: "api" | "view";
+}
+
+/**
+ * Decides whether the string literal at `position` is naming a route, and
+ * gathers whatever the surrounding code says about *which* route.
+ *
+ * Nothing here confirms the path exists — that is the route table's job. This
+ * only answers "could this be a route reference, and what narrows it".
+ */
+export function findRouteQuery(
+  ts: TS,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  position: number,
+): RouteQuery | undefined {
+  const node = findStringLiteral(ts, sourceFile, position);
+  if (!node) return undefined;
+  if (!isRouteReferencePosition(ts, node)) return undefined;
+
+  return {
+    node,
+    path: node.text,
+    allowedPaths: allowedPathsAt(ts, checker, node),
+    ...contextHints(ts, checker, node),
+  };
+}
+
+function findStringLiteral(
+  ts: TS,
+  sourceFile: ts.SourceFile,
+  position: number,
+): ts.StringLiteralLike | undefined {
+  let found: ts.StringLiteralLike | undefined;
+  const visit = (node: ts.Node): void => {
+    if (position < node.getFullStart() || position > node.getEnd()) return;
+    if (ts.isStringLiteralLike(node)) {
+      // Inside the quotes only: at the closing quote the request belongs to
+      // whatever follows, and hijacking it there would be surprising.
+      const start = node.getStart(sourceFile);
+      if (position > start && position < node.getEnd()) found = node;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return found;
+}
+
+/**
+ * Rejects the string positions that already mean something else, so the plugin
+ * never shadows a definition TypeScript can answer better itself.
+ */
+function isRouteReferencePosition(ts: TS, node: ts.StringLiteralLike): boolean {
+  const parent = node.parent;
+  if (!parent) return false;
+
+  // Module specifiers already go to definition — the module.
+  if (ts.isImportDeclaration(parent) || ts.isExportDeclaration(parent)) return false;
+  if (ts.isImportTypeNode(parent) || ts.isExternalModuleReference(parent)) return false;
+  if (ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent)) return false;
+
+  // A key, not a value.
+  if (
+    (ts.isPropertyAssignment(parent) ||
+      ts.isPropertySignature(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isPropertyDeclaration(parent) ||
+      ts.isEnumMember(parent)) &&
+    parent.name === node
+  ) {
+    return false;
+  }
+
+  // A type, where the definition is the type declaration.
+  if (ts.isLiteralTypeNode(parent)) return false;
+
+  // `config["/home"]` — TypeScript resolves this to the property, and that is
+  // the better answer.
+  if (ts.isElementAccessExpression(parent) && parent.argumentExpression === node) return false;
+
+  return true;
+}
+
+function allowedPathsAt(
+  ts: TS,
+  checker: ts.TypeChecker,
+  node: ts.StringLiteralLike,
+): ReadonlySet<string> | undefined {
+  const call = node.parent;
+  if (!call || (!ts.isCallExpression(call) && !ts.isNewExpression(call))) return undefined;
+
+  const args = call.arguments ?? ts.factory.createNodeArray<ts.Expression>();
+  const index = args.indexOf(node);
+  if (index < 0) return undefined;
+
+  const declaration = checker.getResolvedSignature(call)?.getDeclaration();
+  if (!declaration || !ts.isFunctionLike(declaration)) return undefined;
+
+  const parameter = declaration.parameters[index];
+  // A rest parameter's elements are not this simple to index into, and no route
+  // argument is declared that way.
+  if (!parameter || parameter.dotDotDotToken) return undefined;
+
+  const parameterType = checker.getTypeAtLocation(parameter);
+  const constraint = checker.getBaseConstraintOfType(parameterType) ?? parameterType;
+  return stringLiteralSet(constraint);
+}
+
+/** The set a type denotes, or `undefined` if it is anything but string literals. */
+function stringLiteralSet(type: ts.Type): ReadonlySet<string> | undefined {
+  const members = type.isUnion() ? type.types : [type];
+  const paths = new Set<string>();
+  for (const member of members) {
+    if (!member.isStringLiteral()) return undefined;
+    paths.add(member.value);
+  }
+  return paths.size > 0 ? paths : undefined;
+}
+
+function contextHints(
+  ts: TS,
+  checker: ts.TypeChecker,
+  node: ts.StringLiteralLike,
+): { verb?: HttpVerb; prefer?: "api" | "view" } {
+  const attribute = enclosingJsxAttribute(ts, node);
+  if (attribute) {
+    const name = ts.isIdentifier(attribute.name) ? attribute.name.text : attribute.name.getText();
+    if (VIEW_ATTRIBUTES.has(name)) return { prefer: "view" };
+    if (ACTION_ATTRIBUTES.has(name)) {
+      return { prefer: "api", verb: siblingMethodVerb(ts, checker, attribute) ?? "POST" };
+    }
+    return {};
+  }
+
+  // `useMutation("PUT", "/products/:id")`: the verb sits in the argument
+  // before the path. Keyed off the shape rather than the callee's name, so a
+  // wrapper that forwards both arguments is understood too.
+  const call = node.parent;
+  if (call && ts.isCallExpression(call)) {
+    const index = call.arguments.indexOf(node);
+    const previous = index > 0 ? call.arguments[index - 1] : undefined;
+    const value = getStringValue(ts, checker, previous)?.toUpperCase();
+    if (value && HTTP_VERBS.has(value)) return { verb: value as HttpVerb, prefer: "api" };
+  }
+
+  return {};
+}
+
+function enclosingJsxAttribute(ts: TS, node: ts.StringLiteralLike): ts.JsxAttribute | undefined {
+  const parent = node.parent;
+  if (!parent) return undefined;
+  if (ts.isJsxAttribute(parent)) return parent;
+  if (ts.isJsxExpression(parent) && parent.parent && ts.isJsxAttribute(parent.parent)) {
+    return parent.parent;
+  }
+  return undefined;
+}
+
+function siblingMethodVerb(
+  ts: TS,
+  checker: ts.TypeChecker,
+  attribute: ts.JsxAttribute,
+): HttpVerb | undefined {
+  const attributes = attribute.parent;
+  if (!attributes || !ts.isJsxAttributes(attributes)) return undefined;
+  for (const sibling of attributes.properties) {
+    if (!ts.isJsxAttribute(sibling)) continue;
+    const name = ts.isIdentifier(sibling.name) ? sibling.name.text : sibling.name.getText();
+    if (name !== "method" || !sibling.initializer) continue;
+    const initializer = ts.isJsxExpression(sibling.initializer)
+      ? sibling.initializer.expression
+      : sibling.initializer;
+    const value = getStringValue(ts, checker, initializer)?.toUpperCase();
+    if (value && HTTP_VERBS.has(value)) return value as HttpVerb;
+  }
+  return undefined;
+}

--- a/packages/gemi/ide/typescript-plugin/callSite.ts
+++ b/packages/gemi/ide/typescript-plugin/callSite.ts
@@ -115,24 +115,70 @@ function allowedPathsAt(
   checker: ts.TypeChecker,
   node: ts.StringLiteralLike,
 ): ReadonlySet<string> | undefined {
-  const call = node.parent;
-  if (!call || (!ts.isCallExpression(call) && !ts.isNewExpression(call))) return undefined;
+  const site = argumentSite(ts, node);
+  if (!site) return undefined;
 
-  const args = call.arguments ?? ts.factory.createNodeArray<ts.Expression>();
-  const index = args.indexOf(node);
-  if (index < 0) return undefined;
-
-  const declaration = checker.getResolvedSignature(call)?.getDeclaration();
+  const declaration = checker.getResolvedSignature(site.call)?.getDeclaration();
   if (!declaration || !ts.isFunctionLike(declaration)) return undefined;
 
-  const parameter = declaration.parameters[index];
+  const parameter = declaration.parameters[site.index];
   // A rest parameter's elements are not this simple to index into, and no route
   // argument is declared that way.
   if (!parameter || parameter.dotDotDotToken) return undefined;
 
-  const parameterType = checker.getTypeAtLocation(parameter);
-  const constraint = checker.getBaseConstraintOfType(parameterType) ?? parameterType;
+  // The *declared* type, not the contextual one: by the time inference has run,
+  // the contextual type of `"/reports"` is `"/reports"`, which says nothing
+  // about what else was allowed there.
+  let type = checker.getTypeAtLocation(parameter);
+  if (site.property !== undefined) {
+    const symbol = type.getProperty(site.property);
+    if (!symbol) return undefined;
+    type = checker.getTypeOfSymbolAtLocation(symbol, parameter);
+  }
+
+  const constraint = checker.getBaseConstraintOfType(type) ?? type;
   return stringLiteralSet(constraint);
+}
+
+interface ArgumentSite {
+  call: ts.CallExpression | ts.NewExpression;
+  index: number;
+  /** Set when the path is a property of an options object rather than the argument. */
+  property?: string;
+}
+
+/**
+ * The call an argument belongs to, and where in it.
+ *
+ * A path is usually an argument outright — `useQuery("/reports")` — but
+ * `useMutate`'s is a property of an options object: `mutate({ path: "/reports" })`
+ * (`client/useMutate.ts`). Both are declared the same way, `T extends keyof
+ * GetRPC`, one on the parameter and one on a property of it, so both are located
+ * here and read through the same constraint afterwards. Any other hook that
+ * takes its path in an options object is covered by the same rule.
+ */
+function argumentSite(ts: TS, node: ts.StringLiteralLike): ArgumentSite | undefined {
+  const parent = node.parent;
+  if (!parent) return undefined;
+
+  if (ts.isCallExpression(parent) || ts.isNewExpression(parent)) {
+    const index = [...(parent.arguments ?? [])].indexOf(node);
+    return index < 0 ? undefined : { call: parent, index };
+  }
+
+  if (!ts.isPropertyAssignment(parent) || parent.initializer !== node) return undefined;
+  const property =
+    ts.isIdentifier(parent.name) || ts.isStringLiteralLike(parent.name)
+      ? parent.name.text
+      : undefined;
+  if (property === undefined) return undefined;
+
+  const object = parent.parent;
+  if (!ts.isObjectLiteralExpression(object)) return undefined;
+  const call = object.parent;
+  if (!call || (!ts.isCallExpression(call) && !ts.isNewExpression(call))) return undefined;
+  const index = [...(call.arguments ?? [])].indexOf(object);
+  return index < 0 ? undefined : { call, index, property };
 }
 
 /** The set a type denotes, or `undefined` if it is anything but string literals. */

--- a/packages/gemi/ide/typescript-plugin/entryPoints.test.ts
+++ b/packages/gemi/ide/typescript-plugin/entryPoints.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+
+import { createFixture, GEMI_PATHS, LEGACY_GEMI_ENV, tableFor } from "./fixture";
+import { lookupRoute } from "./lookup";
+import type { RouteQuery } from "./callSite";
+import { createTestProject, type TestProject } from "./testProject";
+
+/**
+ * How the plugin finds an application's routers, and what it says when it cannot.
+ *
+ * The default fixture already covers the shape a 0.56 app has — the package's
+ * own `gemi.d.ts`, reached through `AppRPC<Api>` — so what is left here is the
+ * shapes around it: an app that has not deleted its old `gemi.d.ts`, and an app
+ * whose routers the augmentation cannot name at all. The second is the one worth
+ * a test: `client/rpc.ts` mounts `/auth/*` in every gemi project, so a check for
+ * "did we find anything" is always true, and a total failure to find the app's
+ * own routers would otherwise go unmentioned.
+ */
+describe("router discovery", () => {
+  test("a pre-0.56 gemi.d.ts alongside the package's does not double the table", () => {
+    // Both declarations name the same `Api` and the same `View`, one through
+    // `CreateRPC` and one through `AppRPC`. Two mounts of one router at one
+    // prefix is one router.
+    const project = createFixture({ "gemi.d.ts": LEGACY_GEMI_ENV });
+    const table = tableFor(project);
+
+    expect(table.diagnostics).toEqual([]);
+    expect(table.api.get("/home")).toHaveLength(1);
+    expect(table.api.get("/thing")).toHaveLength(2); // a GET and a POST, not four
+    expect(table.views.get("/pricing")).toHaveLength(1);
+  });
+
+  test("an augmentation that only exists inside node_modules is still read", () => {
+    // What an installed app looks like since 0.56: every file declaring `RPC` —
+    // the package's own and the augmentation that extends it — is under
+    // `node_modules`. A file walk cannot see them, and must not learn to: the
+    // whole point of skipping that directory is to stay cheap. Asking the
+    // checker for `gemi/client`'s exports has no such blind spot.
+    //
+    // The rest of the fixture cannot resolve this: the router is somewhere the
+    // convention fallback does not look, so finding `/tucked-away` is proof the
+    // node_modules declaration was read.
+    const project = createTestProject(
+      {
+        "node_modules/gemi/client/index.d.ts": `
+export interface RPC {}
+export declare function useQuery<T extends keyof RPC>(url: T): unknown;
+`,
+        "node_modules/gemi/http/index.d.ts": `
+export declare class ApiRouter { routes: any; get(...args: any[]): any; }
+export type CreateRPC<T, P extends string = ""> = {};
+`,
+        "node_modules/gemi/gemi.d.ts": `
+import type Api from "@/app/routers/api";
+import type { CreateRPC } from "gemi/http";
+declare module "gemi/client" {
+  export interface RPC extends CreateRPC<Api> {}
+}
+`,
+        "app/routers/api.ts": `
+import { ApiRouter } from "gemi/http";
+export default class Root extends ApiRouter {
+  routes = { "/tucked-away": this.get(() => ({ ok: true })) };
+}
+`,
+        "app/views/Page.tsx": `
+import { useQuery } from "gemi/client";
+export default () => useQuery("/tucked-away");
+`,
+      },
+      { paths: { "gemi/*": ["./node_modules/gemi/*"] } },
+    );
+    const table = tableFor(project);
+
+    expect(table.api.has("/tucked-away")).toBe(true);
+    expect(table.diagnostics).toEqual([]);
+  });
+
+  test("an augmentation that names none of the app's routers is reported and worked around", () => {
+    // An app on a layout the augmentation's `@/app/*` import does not reach —
+    // the case `AppRPC`'s `IsAny` guard exists for. The framework's own
+    // `/auth/*` mounts still come through, which is exactly why they cannot be
+    // taken as evidence that discovery worked.
+    const project = createFixture({}, { paths: { ...GEMI_PATHS, "@/app/*": ["./elsewhere/*"] } });
+    const table = tableFor(project);
+
+    expect(table.diagnostics.join("\n")).toContain("names none of this project's routers");
+    expect(table.api.has("/auth/me")).toBe(true);
+    // ...and the convention fallback, which the diagnostic announces, rescues it.
+    expect(table.api.has("/home")).toBe(true);
+    expect(table.views.has("/pricing")).toBe(true);
+  });
+});
+
+const SPREAD_ROUTER = `
+import { ApiRouter, Controller } from "gemi/http";
+
+class HomeController extends Controller {
+  index() { return { ok: true }; }
+  archive() { return { archived: true }; }
+}
+
+export default class Root extends ApiRouter {
+  routes = {
+    "/thing": {
+      get: this.get(HomeController, "index"),
+      post: this.post(HomeController, "archive"),
+    },
+    ...{ "/spread": this.get(HomeController, "index") },
+  };
+}
+`;
+
+/** `keyof GetRPC` as the checker resolves it — what a `useQuery` argument accepts. */
+function getPathsFromTypes(project: TestProject): ReadonlySet<string> {
+  const program = project.service.getProgram()!;
+  const checker = program.getTypeChecker();
+  const keys = program.getSourceFile("/project/keys.ts")!;
+
+  for (const statement of keys.statements) {
+    if (!project.ts.isTypeAliasDeclaration(statement) || statement.name.text !== "ApiKeys")
+      continue;
+    const type = checker.getTypeAtLocation(statement.name);
+    const members = type.isUnion() ? type.types : [type];
+    const paths = members
+      .filter((member) => member.isStringLiteral())
+      .map((member) => (member as { value: string }).value)
+      .filter((key) => key.startsWith("GET:"))
+      .map((key) => key.slice("GET:".length));
+    if (paths.length === 0) throw new Error("keyof RPC did not resolve to string literals");
+    return new Set(paths);
+  }
+  throw new Error("no ApiKeys alias in keys.ts");
+}
+
+describe("a routes entry the walk cannot read", () => {
+  const project = createFixture({ "app/http/routes/api.ts": SPREAD_ROUTER });
+  const table = tableFor(project);
+
+  test("is named in the diagnostics rather than dropped in silence", () => {
+    // `RouteParser` reads the declared type of `routes` and keeps the spread's
+    // paths, so `/spread` autocompletes and has no row here. The tsserver log is
+    // the only place that can say so.
+    expect(getPathsFromTypes(project)).toContain("/spread");
+    expect(table.api.has("/spread")).toBe(false);
+    expect(table.api.has("/thing")).toBe(true);
+    expect(table.diagnostics.join("\n")).toContain("spread");
+  });
+
+  test("does not disable verb narrowing at every other call site", () => {
+    // The hole is one path; the damage used to be the whole project. `keyof
+    // GetRPC` holds `/spread` and the table does not, so testing one against
+    // the other wholesale failed for every verb at once — and `useQuery("/thing")`
+    // started offering its POST handler, a symptom nowhere near its cause.
+    const query = { path: "/thing", allowedPaths: getPathsFromTypes(project) } as RouteQuery;
+
+    const verbs = lookupRoute(table, query).map((match) =>
+      match.candidate.kind === "api" ? match.candidate.entry.verb : match.candidate.kind,
+    );
+    expect(verbs).toEqual(["GET"]);
+  });
+});

--- a/packages/gemi/ide/typescript-plugin/entryPoints.ts
+++ b/packages/gemi/ide/typescript-plugin/entryPoints.ts
@@ -1,0 +1,300 @@
+import type ts from "typescript";
+
+import { resolveClassDeclaration, unwrapExpression, type TS } from "./ast";
+
+/** A router class and the path prefix it is mounted under. */
+export interface RouterMount {
+  declaration: ts.ClassLikeDeclaration;
+  prefix: string;
+}
+
+export interface RootRouters {
+  api: RouterMount[];
+  view: RouterMount[];
+  /** Files consulted to get here — part of the table's cache key. */
+  dependencies: string[];
+  diagnostics: string[];
+}
+
+const RPC_INTERFACES = {
+  api: { interfaceName: "RPC", helperName: "CreateRPC" },
+  view: { interfaceName: "ViewRPC", helperName: "CreateViewRPC" },
+} as const;
+
+const CONFIG_HELPER = "defineRouteConfig";
+const CONFIG_MODULE = "gemi/services";
+
+/** Conventional locations, tried only when nothing more authoritative is readable. */
+const FALLBACK_API_ROUTER = "app/http/routes/api";
+const FALLBACK_VIEW_ROUTER = "app/http/routes/view";
+
+/**
+ * Finds every router whose routes a client call site can name, and the prefix
+ * each is mounted under.
+ *
+ * The authority is the `RPC` and `ViewRPC` interfaces, because they are what
+ * the call site is typed against. An app declares its own routers by augmenting
+ * them:
+ *
+ * ```ts
+ * declare module "gemi/client" {
+ *   export interface RPC extends CreateRPC<Api> {}
+ * }
+ * ```
+ *
+ * and the framework's base declaration in `client/rpc.ts` adds its own —
+ * `CreateRPC<AuthApiRouter, "/auth">`. Reading the interfaces therefore picks up
+ * both, with the right prefixes, and picks up exactly the routes `useQuery`
+ * will accept. Reading the app's route config instead would find the app's
+ * routers and miss `/auth/me`, which is as jumpable as any other route.
+ *
+ * The route config and then convention are the fallbacks, for a project that has
+ * routers but no `gemi.d.ts` yet.
+ */
+export function findRootRouters(ts: TS, program: ts.Program, projectRoot: string): RootRouters {
+  const checker = program.getTypeChecker();
+  const result: RootRouters = { api: [], view: [], dependencies: [], diagnostics: [] };
+
+  for (const kind of ["api", "view"] as const) {
+    const { interfaceName, helperName } = RPC_INTERFACES[kind];
+    for (const declaration of findInterfaceDeclarations(ts, checker, program, interfaceName)) {
+      result.dependencies.push(declaration.getSourceFile().fileName);
+      for (const mount of readMounts(ts, checker, declaration, helperName)) {
+        result[kind].push(mount);
+        result.dependencies.push(mount.declaration.getSourceFile().fileName);
+      }
+    }
+  }
+
+  if (result.api.length > 0 || result.view.length > 0) return result;
+
+  result.diagnostics.push(
+    "no RPC / ViewRPC augmentation found — falling back to the app's route config. " +
+      "Add one to gemi.d.ts so route types and route jumps agree.",
+  );
+
+  const config = findRouteConfigCall(ts, program);
+  if (config) {
+    result.dependencies.push(config.getSourceFile().fileName);
+    const object = unwrapExpression(ts, config.arguments[0] ?? config);
+    if (ts.isObjectLiteralExpression(object)) {
+      for (const kind of ["api", "view"] as const) {
+        const declaration = readRootRouter(ts, checker, object, kind);
+        if (!declaration) continue;
+        result[kind].push({ declaration, prefix: "" });
+        result.dependencies.push(declaration.getSourceFile().fileName);
+      }
+    }
+  }
+
+  if (result.api.length === 0) {
+    const declaration = findConventionalRouter(ts, program, projectRoot, FALLBACK_API_ROUTER);
+    if (declaration) {
+      result.api.push({ declaration, prefix: "" });
+      result.dependencies.push(declaration.getSourceFile().fileName);
+    }
+  }
+  if (result.view.length === 0) {
+    const declaration = findConventionalRouter(ts, program, projectRoot, FALLBACK_VIEW_ROUTER);
+    if (declaration) {
+      result.view.push({ declaration, prefix: "" });
+      result.dependencies.push(declaration.getSourceFile().fileName);
+    }
+  }
+
+  if (result.api.length === 0 && result.view.length === 0) {
+    result.diagnostics.push(
+      `no routers found: no ${CONFIG_HELPER}() call and nothing at ${projectRoot}/${FALLBACK_API_ROUTER}`,
+    );
+  }
+  return result;
+}
+
+/**
+ * Every declaration of an interface by this name, merged ones included.
+ *
+ * Only the app's own files are searched, which is enough to find one
+ * declaration — the augmentation. From there the checker supplies the rest of
+ * the merge group, including the framework's declaration inside `node_modules`,
+ * without walking a single file in it.
+ */
+function findInterfaceDeclarations(
+  ts: TS,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  name: string,
+): ts.InterfaceDeclaration[] {
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.fileName.includes("/node_modules/")) continue;
+
+    const local = findInterfaceIn(ts, sourceFile, name);
+    if (!local) continue;
+
+    const symbol = checker.getSymbolAtLocation(local.name);
+    const declarations = symbol?.declarations?.filter((declaration) =>
+      ts.isInterfaceDeclaration(declaration),
+    );
+    return declarations && declarations.length > 0 ? declarations : [local];
+  }
+  return [];
+}
+
+function findInterfaceIn(
+  ts: TS,
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.InterfaceDeclaration | undefined {
+  let found: ts.InterfaceDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isInterfaceDeclaration(node) && node.name.text === name) {
+      found = node;
+      return;
+    }
+    // Interfaces live at the top level or inside `declare module "…" { … }`;
+    // nothing deeper needs visiting.
+    if (ts.isSourceFile(node) || ts.isModuleDeclaration(node) || ts.isModuleBlock(node)) {
+      ts.forEachChild(node, visit);
+    }
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/** Reads `extends CreateRPC<Router, "/prefix">` off an interface declaration. */
+function readMounts(
+  ts: TS,
+  checker: ts.TypeChecker,
+  declaration: ts.InterfaceDeclaration,
+  helperName: string,
+): RouterMount[] {
+  const mounts: RouterMount[] = [];
+  for (const clause of declaration.heritageClauses ?? []) {
+    for (const type of clause.types) {
+      if (!ts.isIdentifier(type.expression) || type.expression.text !== helperName) continue;
+      const [routerArgument, prefixArgument] = type.typeArguments ?? [];
+      if (!routerArgument) continue;
+
+      const router = resolveClassFromTypeNode(ts, checker, routerArgument);
+      if (!router) continue;
+
+      mounts.push({ declaration: router, prefix: readPrefix(ts, checker, prefixArgument) });
+    }
+  }
+  return mounts;
+}
+
+function resolveClassFromTypeNode(
+  ts: TS,
+  checker: ts.TypeChecker,
+  node: ts.TypeNode,
+): ts.ClassLikeDeclaration | undefined {
+  if (!ts.isTypeReferenceNode(node)) return undefined;
+  const name = ts.isQualifiedName(node.typeName) ? node.typeName.right : node.typeName;
+  return resolveClassDeclaration(ts, checker, name as unknown as ts.Expression);
+}
+
+function readPrefix(ts: TS, checker: ts.TypeChecker, node: ts.TypeNode | undefined): string {
+  if (!node) return "";
+  if (ts.isLiteralTypeNode(node) && ts.isStringLiteral(node.literal)) return node.literal.text;
+  const type = checker.getTypeFromTypeNode(node);
+  return type.isStringLiteral() ? type.value : "";
+}
+
+function findRouteConfigCall(ts: TS, program: ts.Program): ts.CallExpression | undefined {
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.isDeclarationFile) continue;
+    if (sourceFile.fileName.includes("/node_modules/")) continue;
+
+    // Cheap gate: only files that import the helper get walked. Import
+    // statements are always at the top, so this scans a handful of nodes per
+    // file rather than every node in the project.
+    const localName = importedNameOf(ts, sourceFile);
+    if (!localName) continue;
+
+    let found: ts.CallExpression | undefined;
+    const visit = (node: ts.Node): void => {
+      if (found) return;
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === localName
+      ) {
+        found = node;
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    ts.forEachChild(sourceFile, visit);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** The local name `defineRouteConfig` is imported under, if this file imports it. */
+function importedNameOf(ts: TS, sourceFile: ts.SourceFile): string | undefined {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const specifier = statement.moduleSpecifier;
+    if (!ts.isStringLiteralLike(specifier) || specifier.text !== CONFIG_MODULE) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (imported === CONFIG_HELPER) return element.name.text;
+    }
+  }
+  return undefined;
+}
+
+function readRootRouter(
+  ts: TS,
+  checker: ts.TypeChecker,
+  config: ts.ObjectLiteralExpression,
+  section: "api" | "view",
+): ts.ClassLikeDeclaration | undefined {
+  const sectionValue = getPropertyValue(ts, config, section);
+  if (!sectionValue || !ts.isObjectLiteralExpression(sectionValue)) return undefined;
+  const rootRouter = getPropertyValue(ts, sectionValue, "rootRouter");
+  return rootRouter ? resolveClassDeclaration(ts, checker, rootRouter) : undefined;
+}
+
+function getPropertyValue(
+  ts: TS,
+  object: ts.ObjectLiteralExpression,
+  name: string,
+): ts.Expression | undefined {
+  for (const property of object.properties) {
+    if (ts.isPropertyAssignment(property)) {
+      const key = property.name;
+      const text = ts.isIdentifier(key) || ts.isStringLiteralLike(key) ? key.text : undefined;
+      if (text === name) return unwrapExpression(ts, property.initializer);
+    } else if (ts.isShorthandPropertyAssignment(property) && property.name.text === name) {
+      return property.name;
+    }
+  }
+  return undefined;
+}
+
+function findConventionalRouter(
+  ts: TS,
+  program: ts.Program,
+  projectRoot: string,
+  relativePath: string,
+): ts.ClassLikeDeclaration | undefined {
+  const checker = program.getTypeChecker();
+  for (const extension of [".ts", ".tsx"]) {
+    const sourceFile = program.getSourceFile(`${projectRoot}/${relativePath}${extension}`);
+    if (!sourceFile) continue;
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+    if (!moduleSymbol) continue;
+    for (const exported of checker.getExportsOfModule(moduleSymbol)) {
+      if (exported.name !== "default") continue;
+      const resolved =
+        exported.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exported) : exported;
+      const declaration = resolved.valueDeclaration ?? resolved.declarations?.[0];
+      if (declaration && ts.isClassLike(declaration)) return declaration;
+    }
+  }
+  return undefined;
+}

--- a/packages/gemi/ide/typescript-plugin/entryPoints.ts
+++ b/packages/gemi/ide/typescript-plugin/entryPoints.ts
@@ -17,12 +17,14 @@ export interface RootRouters {
 }
 
 const RPC_INTERFACES = {
-  api: { interfaceName: "RPC", helperName: "CreateRPC" },
-  view: { interfaceName: "ViewRPC", helperName: "CreateViewRPC" },
+  api: { interfaceName: "RPC" },
+  view: { interfaceName: "ViewRPC" },
 } as const;
 
 const CONFIG_HELPER = "defineRouteConfig";
 const CONFIG_MODULE = "gemi/services";
+/** The module `RPC` and `ViewRPC` are declared in and augmented into. */
+const CLIENT_MODULE = "gemi/client";
 
 /** Conventional locations, tried only when nothing more authoritative is readable. */
 const FALLBACK_API_ROUTER = "app/http/routes/api";
@@ -48,29 +50,46 @@ const FALLBACK_VIEW_ROUTER = "app/http/routes/view";
  * will accept. Reading the app's route config instead would find the app's
  * routers and miss `/auth/me`, which is as jumpable as any other route.
  *
- * The route config and then convention are the fallbacks, for a project that has
- * routers but no `gemi.d.ts` yet.
+ * The route config and then convention are the fallbacks, for a project whose
+ * routers the augmentation does not name. They are chosen on whether the app's
+ * *own* routers were found, not on whether anything was: `client/rpc.ts` mounts
+ * `/auth/*` unconditionally, so "some mount exists" is true of every gemi
+ * project and would make total discovery failure silent.
  */
 export function findRootRouters(ts: TS, program: ts.Program, projectRoot: string): RootRouters {
   const checker = program.getTypeChecker();
   const result: RootRouters = { api: [], view: [], dependencies: [], diagnostics: [] };
+  // One router can be reached through more than one declaration in the merge
+  // group — the package's own augmentation and an app's leftover `gemi.d.ts`
+  // name the same `Api`. Walking it twice would double every route it holds.
+  const seen = new Set<string>();
 
   for (const kind of ["api", "view"] as const) {
-    const { interfaceName, helperName } = RPC_INTERFACES[kind];
+    const { interfaceName } = RPC_INTERFACES[kind];
     for (const declaration of findInterfaceDeclarations(ts, checker, program, interfaceName)) {
       result.dependencies.push(declaration.getSourceFile().fileName);
-      for (const mount of readMounts(ts, checker, declaration, helperName)) {
+      for (const mount of readMounts(ts, checker, declaration)) {
+        const fileName = mount.declaration.getSourceFile().fileName;
+        const key = `${kind}\0${mount.prefix}\0${fileName}\0${mount.declaration.pos}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
         result[kind].push(mount);
-        result.dependencies.push(mount.declaration.getSourceFile().fileName);
+        result.dependencies.push(fileName);
       }
     }
   }
 
-  if (result.api.length > 0 || result.view.length > 0) return result;
+  const hasAppMount = (kind: "api" | "view") =>
+    result[kind].some((mount) =>
+      isApplicationFile(mount.declaration.getSourceFile().fileName, projectRoot),
+    );
+
+  if (hasAppMount("api") || hasAppMount("view")) return result;
 
   result.diagnostics.push(
-    "no RPC / ViewRPC augmentation found — falling back to the app's route config. " +
-      "Add one to gemi.d.ts so route types and route jumps agree.",
+    "the RPC / ViewRPC augmentation names none of this project's routers — falling back " +
+      "to the app's route config. Check that gemi/client is imported and that " +
+      `${projectRoot}/${FALLBACK_API_ROUTER}.ts typechecks, so route types and route jumps agree.`,
   );
 
   const config = findRouteConfigCall(ts, program);
@@ -87,14 +106,14 @@ export function findRootRouters(ts: TS, program: ts.Program, projectRoot: string
     }
   }
 
-  if (result.api.length === 0) {
+  if (!hasAppMount("api")) {
     const declaration = findConventionalRouter(ts, program, projectRoot, FALLBACK_API_ROUTER);
     if (declaration) {
       result.api.push({ declaration, prefix: "" });
       result.dependencies.push(declaration.getSourceFile().fileName);
     }
   }
-  if (result.view.length === 0) {
+  if (!hasAppMount("view")) {
     const declaration = findConventionalRouter(ts, program, projectRoot, FALLBACK_VIEW_ROUTER);
     if (declaration) {
       result.view.push({ declaration, prefix: "" });
@@ -102,21 +121,31 @@ export function findRootRouters(ts: TS, program: ts.Program, projectRoot: string
     }
   }
 
-  if (result.api.length === 0 && result.view.length === 0) {
+  if (!hasAppMount("api") && !hasAppMount("view")) {
     result.diagnostics.push(
-      `no routers found: no ${CONFIG_HELPER}() call and nothing at ${projectRoot}/${FALLBACK_API_ROUTER}`,
+      `no application routers found: no ${CONFIG_HELPER}() call and nothing at ${projectRoot}/${FALLBACK_API_ROUTER}`,
     );
   }
   return result;
 }
 
+/** Whether a file belongs to the application rather than to a package it installs. */
+function isApplicationFile(fileName: string, projectRoot: string): boolean {
+  return fileName.startsWith(`${projectRoot}/`) && !fileName.includes("/node_modules/");
+}
+
 /**
  * Every declaration of an interface by this name, merged ones included.
  *
- * Only the app's own files are searched, which is enough to find one
- * declaration — the augmentation. From there the checker supplies the rest of
- * the merge group, including the framework's declaration inside `node_modules`,
- * without walking a single file in it.
+ * The interfaces are asked for through the `gemi/client` module symbol rather
+ * than found by walking files, because since 0.56 the augmentation ships inside
+ * the package: in an installed app the only file declaring `RPC` is
+ * `node_modules/gemi/dist/gemi.d.ts`, which a file walk that skips
+ * `node_modules` — as it must, to stay cheap — will never see. The module symbol
+ * has no such blind spot. Reaching it costs one scan of the top-level statements
+ * of the app's own files, looking for an `import … from "gemi/client"` or a
+ * `declare module "gemi/client"`; from there the checker supplies the whole
+ * merge group, package and application declarations alike.
  */
 function findInterfaceDeclarations(
   ts: TS,
@@ -124,6 +153,21 @@ function findInterfaceDeclarations(
   program: ts.Program,
   name: string,
 ): ts.InterfaceDeclaration[] {
+  const fromModule = findClientModuleSymbol(ts, checker, program);
+  if (fromModule) {
+    const exported = checker.getExportsOfModule(fromModule).find((symbol) => symbol.name === name);
+    const resolved =
+      exported && exported.flags & ts.SymbolFlags.Alias
+        ? checker.getAliasedSymbol(exported)
+        : exported;
+    const declarations = resolved?.declarations?.filter((declaration) =>
+      ts.isInterfaceDeclaration(declaration),
+    );
+    if (declarations && declarations.length > 0) return declarations;
+  }
+
+  // No file names `gemi/client` — a project that has not imported it yet. Fall
+  // back to finding one declaration by hand and letting the checker merge.
   for (const sourceFile of program.getSourceFiles()) {
     if (sourceFile.fileName.includes("/node_modules/")) continue;
 
@@ -137,6 +181,44 @@ function findInterfaceDeclarations(
     return declarations && declarations.length > 0 ? declarations : [local];
   }
   return [];
+}
+
+/** The symbol for the `gemi/client` module, reached through any reference to it. */
+function findClientModuleSymbol(
+  ts: TS,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+): ts.Symbol | undefined {
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.fileName.includes("/node_modules/")) continue;
+
+    for (const statement of sourceFile.statements) {
+      const reference = clientModuleReference(ts, statement);
+      if (!reference) continue;
+      const symbol = checker.getSymbolAtLocation(reference);
+      if (symbol) return symbol;
+    }
+  }
+  return undefined;
+}
+
+/** The node naming `gemi/client` in a statement, if the statement names it. */
+function clientModuleReference(ts: TS, statement: ts.Statement): ts.Node | undefined {
+  if (ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement)) {
+    const specifier = statement.moduleSpecifier;
+    if (specifier && ts.isStringLiteralLike(specifier) && specifier.text === CLIENT_MODULE) {
+      return specifier;
+    }
+    return undefined;
+  }
+  if (
+    ts.isModuleDeclaration(statement) &&
+    ts.isStringLiteralLike(statement.name) &&
+    statement.name.text === CLIENT_MODULE
+  ) {
+    return statement.name;
+  }
+  return undefined;
 }
 
 function findInterfaceIn(
@@ -161,24 +243,39 @@ function findInterfaceIn(
   return found;
 }
 
-/** Reads `extends CreateRPC<Router, "/prefix">` off an interface declaration. */
+/**
+ * Reads `extends CreateRPC<Router, "/prefix">` off an interface declaration.
+ *
+ * The helper's name is deliberately not read. `CreateRPC` is only the direct
+ * spelling; the package's own augmentation goes through an alias —
+ * `extends AppRPC<Api>`, where `AppRPC` guards an unresolved `@/app/*` before it
+ * can instantiate `CreateRPC` and blow the instantiation depth. Matching the
+ * name `CreateRPC` rejected that, which since 0.56 is every application's own
+ * routers. So the type arguments are what is read: whichever resolves to a class
+ * is the router, and a string literal beside it is its prefix. Any wrapper —
+ * the package's, or one an application writes — is understood the same way.
+ */
 function readMounts(
   ts: TS,
   checker: ts.TypeChecker,
   declaration: ts.InterfaceDeclaration,
-  helperName: string,
 ): RouterMount[] {
   const mounts: RouterMount[] = [];
   for (const clause of declaration.heritageClauses ?? []) {
     for (const type of clause.types) {
-      if (!ts.isIdentifier(type.expression) || type.expression.text !== helperName) continue;
-      const [routerArgument, prefixArgument] = type.typeArguments ?? [];
-      if (!routerArgument) continue;
-
-      const router = resolveClassFromTypeNode(ts, checker, routerArgument);
-      if (!router) continue;
-
-      mounts.push({ declaration: router, prefix: readPrefix(ts, checker, prefixArgument) });
+      let router: ts.ClassLikeDeclaration | undefined;
+      let prefix = "";
+      for (const argument of type.typeArguments ?? []) {
+        if (!router) {
+          const resolved = resolveClassFromTypeNode(ts, checker, argument);
+          if (resolved) {
+            router = resolved;
+            continue;
+          }
+        }
+        if (!prefix) prefix = readPrefix(ts, checker, argument);
+      }
+      if (router) mounts.push({ declaration: router, prefix });
     }
   }
   return mounts;

--- a/packages/gemi/ide/typescript-plugin/fixture.ts
+++ b/packages/gemi/ide/typescript-plugin/fixture.ts
@@ -1,3 +1,4 @@
+import type ts from "typescript";
 import { dirname, join } from "node:path";
 
 import { buildRouteTable } from "./routeTable";
@@ -99,8 +100,17 @@ export default class RootView extends ViewRouter {
 }
 `;
 
-/** What `gemi.d.ts` looks like in a real app. */
-const GEMI_ENV = `
+/**
+ * The augmentation an app carried before 0.56, when `gemi.d.ts` lived at its root.
+ *
+ * Not part of the fixture: since 0.56 the package ships the augmentation itself,
+ * and `paths` above maps `gemi/*` at the package source, so the fixture app is
+ * already wired the way a `bun add gemi` app is — through
+ * `packages/gemi/gemi.d.ts`, whose `AppRPC<Api>` resolves `@/app/*` against this
+ * project. Tests that need the old shape, or a second declaration alongside the
+ * package's, pass this in explicitly.
+ */
+export const LEGACY_GEMI_ENV = `
 import type Api from "@/app/http/routes/api";
 import type View from "@/app/http/routes/view";
 import type { CreateRPC, CreateViewRPC } from "gemi/http";
@@ -117,7 +127,13 @@ export type ApiKeys = keyof RPC;
 export type ViewKeys = keyof ViewRPC;
 `;
 
-export function createFixture(extraFiles: Record<string, string> = {}): TestProject {
+/** Maps `gemi/*` at the package source, so the fixture compiles against the real types. */
+export const GEMI_PATHS = { "gemi/*": [join(GEMI_ROOT, "*")] };
+
+export function createFixture(
+  extraFiles: Record<string, string> = {},
+  extraCompilerOptions: ts.CompilerOptions = {},
+): TestProject {
   return createTestProject(
     {
       "app/http/routes/api.ts": API_ROUTER,
@@ -128,11 +144,10 @@ export function createFixture(extraFiles: Record<string, string> = {}): TestProj
       "app/views/OrgOverview.tsx": "export default function OrgOverview() { return null; }",
       "app/views/OrgSettings.tsx": "export default function OrgSettings() { return null; }",
       "app/views/auth/SignIn.tsx": "export default function SignIn() { return null; }",
-      "gemi.d.ts": GEMI_ENV,
       "keys.ts": KEYS,
       ...extraFiles,
     },
-    { paths: { "gemi/*": [join(GEMI_ROOT, "*")] } },
+    { paths: GEMI_PATHS, ...extraCompilerOptions },
   );
 }
 

--- a/packages/gemi/ide/typescript-plugin/fixture.ts
+++ b/packages/gemi/ide/typescript-plugin/fixture.ts
@@ -1,0 +1,145 @@
+import { dirname, join } from "node:path";
+
+import { buildRouteTable } from "./routeTable";
+import { createTestProject, type TestProject } from "./testProject";
+import type { RouteTable } from "./types";
+
+/**
+ * A gemi app, in memory, wired to the real framework.
+ *
+ * The fixture app declares every route shape the walker understands —
+ * controller-backed and inline handlers, an inherited controller method, a
+ * nested router, a resource, a verb map, a route group, `file`/`stream`, views
+ * under a layout — so a test that walks it exercises all of them, and
+ * `rpcParity.test.ts` can hold the whole set against `keyof RPC`.
+ *
+ * `paths` maps `gemi/*` at the package source rather than a stand-in, which is
+ * what makes that comparison mean anything. React does not resolve inside the
+ * harness, so the fixture has type errors — none of them in the route types,
+ * which is all any of this reads.
+ */
+const GEMI_ROOT = dirname(dirname(import.meta.dirname));
+
+const API_ROUTER = `
+import { ApiRouter, Controller, ResourceController } from "gemi/http";
+
+class HomeController extends Controller {
+  index() { return { ok: true }; }
+  archive() { return { archived: true }; }
+}
+
+class BaseReportsController extends Controller {
+  shared() { return { shared: 1 }; }
+}
+
+// Inherits \`shared\` — the walker has to resolve through the base class the way
+// the checker does.
+class ReportsController extends BaseReportsController {}
+
+class ProductsController extends ResourceController {
+  async list() { return { items: [] as number[] }; }
+  async show() { return { item: 1 }; }
+  async store() { return { id: 1 }; }
+  async update() { return { id: 1 }; }
+  async delete() { return { ok: true }; }
+}
+
+class OrgRouter extends ApiRouter {
+  routes = {
+    "/": this.get(HomeController, "index"),
+    "/products/:productId": this.resource(ProductsController),
+  };
+}
+
+export default class Root extends ApiRouter {
+  routes = {
+    "/health": this.get(() => ({ ok: true })),
+    "/home": this.get(HomeController, "index"),
+    "/home/archive": this.delete(HomeController, "archive"),
+    "/reports": this.get(ReportsController, "shared"),
+    "/guarded": this.get(() => ({ g: 1 })).middleware(["auth"]),
+    "/replaced": this.put(() => ({ id: 1 })),
+    "/patched": this.patch(() => ({ p: true })),
+    "/thing": {
+      get: this.get(HomeController, "index"),
+      post: this.post(HomeController, "archive"),
+    },
+    "/org/:orgId": OrgRouter,
+    "/(group)/grouped": this.get(() => ({ grouped: true })),
+    "/download": this.file(() => null),
+    "/video": this.stream(() => null),
+  };
+}
+`;
+
+const VIEW_ROUTER = `
+import { Controller, ViewRouter } from "gemi/http";
+
+class PageController extends Controller {
+  overview() { return { a: 1 }; }
+  settings() { return { b: 2 }; }
+}
+
+class AuthRouter extends ViewRouter {
+  routes = {
+    "/sign-in": this.view("auth/SignIn"),
+  };
+}
+
+export default class RootView extends ViewRouter {
+  routes = {
+    "/": this.view("Home", [PageController, "overview"]),
+    "/auth": AuthRouter,
+    "/org/:orgId": this.layout("OrgLayout", [PageController, "overview"], {
+      "/": this.view("OrgOverview"),
+      "/settings": this.view("OrgSettings", [PageController, "settings"]),
+    }),
+    "/(marketing)/pricing": this.view("Pricing"),
+  };
+}
+`;
+
+/** What `gemi.d.ts` looks like in a real app. */
+const GEMI_ENV = `
+import type Api from "@/app/http/routes/api";
+import type View from "@/app/http/routes/view";
+import type { CreateRPC, CreateViewRPC } from "gemi/http";
+
+declare module "gemi/client" {
+  export interface RPC extends CreateRPC<Api> {}
+  export interface ViewRPC extends CreateViewRPC<View> {}
+}
+`;
+
+const KEYS = `
+import type { RPC, ViewRPC } from "gemi/client";
+export type ApiKeys = keyof RPC;
+export type ViewKeys = keyof ViewRPC;
+`;
+
+export function createFixture(extraFiles: Record<string, string> = {}): TestProject {
+  return createTestProject(
+    {
+      "app/http/routes/api.ts": API_ROUTER,
+      "app/http/routes/view.ts": VIEW_ROUTER,
+      "app/views/Home.tsx": "export default function Home() { return null; }",
+      "app/views/Pricing.tsx": "export default function Pricing() { return null; }",
+      "app/views/OrgLayout.tsx": "export default function OrgLayout() { return null; }",
+      "app/views/OrgOverview.tsx": "export default function OrgOverview() { return null; }",
+      "app/views/OrgSettings.tsx": "export default function OrgSettings() { return null; }",
+      "app/views/auth/SignIn.tsx": "export default function SignIn() { return null; }",
+      "gemi.d.ts": GEMI_ENV,
+      "keys.ts": KEYS,
+      ...extraFiles,
+    },
+    { paths: { "gemi/*": [join(GEMI_ROOT, "*")] } },
+  );
+}
+
+export function tableFor(project: TestProject): RouteTable {
+  return buildRouteTable(project.ts, project.service.getProgram()!, {
+    projectRoot: project.projectRoot,
+    viewsDir: `${project.projectRoot}/app/views`,
+    fileExists: project.fileExists,
+  });
+}

--- a/packages/gemi/ide/typescript-plugin/index.ts
+++ b/packages/gemi/ide/typescript-plugin/index.ts
@@ -1,0 +1,86 @@
+import type ts from "typescript";
+
+import { decorateLanguageService, describeError } from "./plugin";
+import type { GemiPluginConfig } from "./types";
+
+/**
+ * gemi's TypeScript language service plugin.
+ *
+ * Enable it in the app's `tsconfig.json`:
+ *
+ * ```json
+ * {
+ *   "compilerOptions": {
+ *     "plugins": [{ "name": "gemi/ide/typescript-plugin" }]
+ *   }
+ * }
+ * ```
+ *
+ * VS Code ships its own copy of TypeScript and ignores `plugins` unless told to
+ * use the workspace's — run **TypeScript: Select TypeScript Version → Use
+ * Workspace Version** once per project. Editors that drive tsserver over LSP
+ * (Neovim, Emacs, Helix, JetBrains) read `tsconfig.json` directly and need
+ * nothing extra.
+ *
+ * See `README.md` in this directory for what it does and how it decides.
+ *
+ * The module's only export is the initializer tsserver calls — `export =` admits
+ * no others — so the config shape lives in `./types` as `GemiPluginConfig`.
+ */
+function init(modules: { typescript: typeof ts }): ts.server.PluginModule {
+  const tsModule = modules.typescript;
+
+  return {
+    create(info: ts.server.PluginCreateInfo): ts.LanguageService {
+      const log = (message: string) => info.project.projectService.logger.info(`[gemi] ${message}`);
+
+      try {
+        const config = (info.config ?? {}) as GemiPluginConfig;
+        if (config.enable === false) {
+          log("disabled by config");
+          return info.languageService;
+        }
+
+        const projectRoot = trimTrailingSlash(
+          config.projectRoot
+            ? absolute(config.projectRoot, info.project.getCurrentDirectory())
+            : info.project.getCurrentDirectory(),
+        );
+        const viewsDir = trimTrailingSlash(
+          config.viewsDir ? absolute(config.viewsDir, projectRoot) : `${projectRoot}/app/views`,
+        );
+
+        log(`activated for ${projectRoot} (views: ${viewsDir})`);
+
+        return decorateLanguageService({
+          ts: tsModule,
+          languageService: info.languageService,
+          projectRoot,
+          viewsDir,
+          fileExists: (fileName) => info.serverHost.fileExists(fileName),
+          getScriptVersion: (fileName) => info.project.getScriptVersion(fileName),
+          log,
+        });
+      } catch (error) {
+        // Returning the undecorated service is the difference between "route
+        // jumps do not work" and "the editor has no language features".
+        log(
+          `failed to activate, falling back to the plain language service — ${describeError(error)}`,
+        );
+        return info.languageService;
+      }
+    },
+  };
+}
+
+function absolute(path: string, base: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  if (normalized.startsWith("/") || /^[a-zA-Z]:\//.test(normalized)) return normalized;
+  return `${trimTrailingSlash(base)}/${normalized.replace(/^\.\//, "")}`;
+}
+
+function trimTrailingSlash(path: string): string {
+  return path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+}
+
+export = init;

--- a/packages/gemi/ide/typescript-plugin/lookup.ts
+++ b/packages/gemi/ide/typescript-plugin/lookup.ts
@@ -15,6 +15,8 @@ const VERB_ORDER: HttpVerb[] = ["GET", "POST", "PUT", "PATCH", "DELETE"];
 interface RouteIndex {
   pathsByVerb: Map<HttpVerb, Set<string>>;
   viewPaths: Set<string>;
+  /** Every path the walk found, of any verb or kind. */
+  knownPaths: Set<string>;
 }
 
 const indexes = new WeakMap<RouteTable, RouteIndex>();
@@ -23,20 +25,25 @@ function indexOf(table: RouteTable): RouteIndex {
   const cached = indexes.get(table);
   if (cached) return cached;
 
+  const knownPaths = new Set<string>();
   const pathsByVerb = new Map<HttpVerb, Set<string>>();
   for (const entries of table.api.values()) {
     for (const entry of entries) {
       let paths = pathsByVerb.get(entry.verb);
       if (!paths) pathsByVerb.set(entry.verb, (paths = new Set()));
       paths.add(entry.path);
+      knownPaths.add(entry.path);
     }
   }
   const viewPaths = new Set<string>();
   for (const entries of table.views.values()) {
-    for (const entry of entries) viewPaths.add(entry.path);
+    for (const entry of entries) {
+      viewPaths.add(entry.path);
+      knownPaths.add(entry.path);
+    }
   }
 
-  const index = { pathsByVerb, viewPaths };
+  const index = { pathsByVerb, viewPaths, knownPaths };
   indexes.set(table, index);
   return index;
 }
@@ -67,13 +74,15 @@ export function lookupRoute(table: RouteTable, query: RouteQuery): RouteMatch[] 
     );
   }
   if (query.allowedPaths) {
-    const { pathsByVerb, viewPaths } = indexOf(table);
-    const allowed = query.allowedPaths;
-    candidates = narrow(candidates, (candidate) =>
-      candidate.kind === "api"
-        ? isSubset(allowed, pathsByVerb.get(candidate.entry.verb))
-        : isSubset(allowed, viewPaths),
-    );
+    const { pathsByVerb, viewPaths, knownPaths } = indexOf(table);
+    const allowed = intersect(query.allowedPaths, knownPaths);
+    if (allowed.size > 0) {
+      candidates = narrow(candidates, (candidate) =>
+        candidate.kind === "api"
+          ? isSubset(allowed, pathsByVerb.get(candidate.entry.verb))
+          : isSubset(allowed, viewPaths),
+      );
+    }
   }
 
   candidates.sort(compareCandidates);
@@ -103,6 +112,30 @@ function isSubset(subset: ReadonlySet<string>, superset: Set<string> | undefined
     if (!superset.has(value)) return false;
   }
   return true;
+}
+
+/**
+ * The accepted paths, minus the ones the walk never saw.
+ *
+ * Without this the containment test is all-or-nothing across the whole project.
+ * `keyof GetRPC` comes from the declared type of `routes` and so includes shapes
+ * the walk drops — a spread entry, say (`routeTable.ts` logs one when it meets
+ * one). A single such path is not in *any* verb's set, so every verb fails the
+ * subset test at once, every candidate survives, and disambiguation stops
+ * working at call sites nowhere near the route that was missed.
+ *
+ * A path the walk never saw has no row to jump to either way, so dropping it
+ * from the comparison costs nothing and keeps the damage where it belongs.
+ */
+function intersect(
+  subset: ReadonlySet<string>,
+  universe: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const kept = new Set<string>();
+  for (const value of subset) {
+    if (universe.has(value)) kept.add(value);
+  }
+  return kept;
 }
 
 function compareCandidates(a: RouteCandidate, b: RouteCandidate): number {

--- a/packages/gemi/ide/typescript-plugin/lookup.ts
+++ b/packages/gemi/ide/typescript-plugin/lookup.ts
@@ -1,0 +1,136 @@
+import type { RouteQuery } from "./callSite";
+import type { ApiRouteEntry, HttpVerb, RouteTable, RouteTarget, ViewRouteEntry } from "./types";
+
+export type RouteCandidate =
+  | { kind: "api"; entry: ApiRouteEntry }
+  | { kind: "view"; entry: ViewRouteEntry };
+
+export interface RouteMatch {
+  candidate: RouteCandidate;
+  targets: RouteTarget[];
+}
+
+const VERB_ORDER: HttpVerb[] = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+
+interface RouteIndex {
+  pathsByVerb: Map<HttpVerb, Set<string>>;
+  viewPaths: Set<string>;
+}
+
+const indexes = new WeakMap<RouteTable, RouteIndex>();
+
+function indexOf(table: RouteTable): RouteIndex {
+  const cached = indexes.get(table);
+  if (cached) return cached;
+
+  const pathsByVerb = new Map<HttpVerb, Set<string>>();
+  for (const entries of table.api.values()) {
+    for (const entry of entries) {
+      let paths = pathsByVerb.get(entry.verb);
+      if (!paths) pathsByVerb.set(entry.verb, (paths = new Set()));
+      paths.add(entry.path);
+    }
+  }
+  const viewPaths = new Set<string>();
+  for (const entries of table.views.values()) {
+    for (const entry of entries) viewPaths.add(entry.path);
+  }
+
+  const index = { pathsByVerb, viewPaths };
+  indexes.set(table, index);
+  return index;
+}
+
+/**
+ * The routes a call site could mean, best first.
+ *
+ * Each signal narrows only when narrowing leaves something — a `href` pointing
+ * at what turns out to be an API route, or a `method="PUT"` on a path with no
+ * PUT handler, still gets the jump it can rather than none. When more than one
+ * route survives, all of them are returned and the editor offers the choice;
+ * that is the honest answer for a path that genuinely carries two handlers.
+ */
+export function lookupRoute(table: RouteTable, query: RouteQuery): RouteMatch[] {
+  let candidates: RouteCandidate[] = [
+    ...(table.api.get(query.path) ?? []).map((entry) => ({ kind: "api", entry }) as const),
+    ...(table.views.get(query.path) ?? []).map((entry) => ({ kind: "view", entry }) as const),
+  ];
+  if (candidates.length === 0) return [];
+
+  if (query.prefer) {
+    candidates = narrow(candidates, (candidate) => candidate.kind === query.prefer);
+  }
+  if (query.verb) {
+    candidates = narrow(
+      candidates,
+      (candidate) => candidate.kind === "api" && candidate.entry.verb === query.verb,
+    );
+  }
+  if (query.allowedPaths) {
+    const { pathsByVerb, viewPaths } = indexOf(table);
+    const allowed = query.allowedPaths;
+    candidates = narrow(candidates, (candidate) =>
+      candidate.kind === "api"
+        ? isSubset(allowed, pathsByVerb.get(candidate.entry.verb))
+        : isSubset(allowed, viewPaths),
+    );
+  }
+
+  candidates.sort(compareCandidates);
+  return candidates.map((candidate) => ({ candidate, targets: candidate.entry.targets }));
+}
+
+/** Applies a filter, unless doing so would leave nothing to jump to. */
+function narrow(
+  candidates: RouteCandidate[],
+  predicate: (candidate: RouteCandidate) => boolean,
+): RouteCandidate[] {
+  const kept = candidates.filter(predicate);
+  return kept.length > 0 ? kept : candidates;
+}
+
+/**
+ * Whether every path the call site accepts is served by this verb.
+ *
+ * The direction matters. A `useQuery` argument accepts exactly the GET paths,
+ * so testing the *accepted set* against each verb's paths identifies the verb;
+ * testing one path against the set would not, because a path with both a GET
+ * and a POST handler belongs to both.
+ */
+function isSubset(subset: ReadonlySet<string>, superset: Set<string> | undefined): boolean {
+  if (!superset) return false;
+  for (const value of subset) {
+    if (!superset.has(value)) return false;
+  }
+  return true;
+}
+
+function compareCandidates(a: RouteCandidate, b: RouteCandidate): number {
+  if (a.kind !== b.kind) return a.kind === "api" ? -1 : 1;
+  if (a.kind === "api" && b.kind === "api") {
+    return VERB_ORDER.indexOf(a.entry.verb) - VERB_ORDER.indexOf(b.entry.verb);
+  }
+  // A path's view comes before the layout wrapping it.
+  const rank = (kind: "view" | "layout") => (kind === "view" ? 0 : 1);
+  return rank((a.entry as ViewRouteEntry).kind) - rank((b.entry as ViewRouteEntry).kind);
+}
+
+/** `GET /products`, `view /reports` — the heading a hover leads with. */
+export function describeCandidate(candidate: RouteCandidate): string {
+  return candidate.kind === "api"
+    ? `${candidate.entry.verb} ${candidate.entry.path}`
+    : `${candidate.entry.kind} ${candidate.entry.path}`;
+}
+
+export function describeTarget(target: RouteTarget): string {
+  switch (target.kind) {
+    case "controller-method":
+      return `${target.containerName}.${target.name}()`;
+    case "inline-handler":
+      return "inline handler";
+    case "view-component":
+      return `${target.name} component`;
+    case "route-entry":
+      return `${target.containerName} routes entry`;
+  }
+}

--- a/packages/gemi/ide/typescript-plugin/package.json
+++ b/packages/gemi/ide/typescript-plugin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "gemi-typescript-plugin",
+  "private": true,
+  "main": "../../dist/ide/typescript-plugin/index.js"
+}

--- a/packages/gemi/ide/typescript-plugin/plugin.test.ts
+++ b/packages/gemi/ide/typescript-plugin/plugin.test.ts
@@ -1,0 +1,304 @@
+import type ts from "typescript";
+import { describe, expect, test } from "vitest";
+
+import { createFixture } from "./fixture";
+import { decorateLanguageService } from "./plugin";
+import type { TestProject } from "./testProject";
+
+/**
+ * The plugin as an editor sees it: a position in a file, a list of places to go.
+ *
+ * These go through `decorateLanguageService` rather than the pieces underneath,
+ * because the contract that matters is the language service one — the right span
+ * underlined, the right definitions returned, and everything that is not a route
+ * handed straight back to TypeScript.
+ */
+const PAGE_FILE = "app/views/Page.tsx";
+
+const PAGE = `
+import { useQuery, useMutation, useMutate } from "gemi/client";
+import { Link, Form } from "gemi/client";
+
+const table = { "/home": 1 };
+
+export default function Page() {
+  useQuery("/home");
+  useQuery("/thing");
+  useQuery("/org/:orgId/products");
+  useQuery("/auth/me");
+  useMutation("POST", "/thing");
+  useMutate()("/reports");
+  const loose = "/reports";
+  const read = table["/home"];
+  return (
+    <>
+      <Link href="/pricing">pricing</Link>
+      <Form action="/thing" method="POST" />
+      <Form action="/thing" onSuccess={() => {}} />
+    </>
+  );
+}
+`;
+
+interface Harness {
+  project: TestProject;
+  service: ts.LanguageService;
+  logs: string[];
+  /** Definitions for `quoted` inside the unique snippet `marker`, as `file name`. */
+  definitionsAt(marker: string, quoted?: string): string[];
+  quickInfoAt(marker: string, quoted?: string): string;
+  boundTextAt(marker: string, quoted?: string): string | undefined;
+  positionOf(marker: string, offsetInMarker: number): number;
+  rebuildCount(): number;
+}
+
+function createHarness(): Harness {
+  const project = createFixture({ [PAGE_FILE]: PAGE });
+  const logs: string[] = [];
+  const service = decorateLanguageService({
+    ts: project.ts,
+    languageService: project.service,
+    projectRoot: project.projectRoot,
+    viewsDir: `${project.projectRoot}/app/views`,
+    fileExists: project.fileExists,
+    getScriptVersion: project.getScriptVersion,
+    log: (message) => logs.push(message),
+  });
+
+  /** Just inside the opening quote of `quoted`, which must sit inside `marker`. */
+  const inside = (marker: string, quoted: string) => {
+    const at = marker.indexOf(quoted);
+    if (at === -1) throw new Error(`${JSON.stringify(quoted)} is not in ${JSON.stringify(marker)}`);
+    return project.offsetOf(PAGE_FILE, marker) + at + 1;
+  };
+
+  const definitions = (position: number) =>
+    service.getDefinitionAndBoundSpan(`/project/${PAGE_FILE}`, position);
+
+  return {
+    project,
+    service,
+    logs,
+    positionOf: (marker, offsetInMarker) => project.offsetOf(PAGE_FILE, marker) + offsetInMarker,
+    definitionsAt(marker, quoted = firstQuoted(marker)) {
+      return (definitions(inside(marker, quoted))?.definitions ?? []).map((definition) => {
+        const relative = definition.fileName.replace(`${project.projectRoot}/`, "");
+        return `${relative} ${definition.name}`;
+      });
+    },
+    quickInfoAt(marker, quoted = firstQuoted(marker)) {
+      const info = service.getQuickInfoAtPosition(`/project/${PAGE_FILE}`, inside(marker, quoted));
+      return (info?.documentation ?? []).map((part) => part.text).join("\n");
+    },
+    boundTextAt(marker, quoted = firstQuoted(marker)) {
+      const result = definitions(inside(marker, quoted));
+      return result && project.textAt(PAGE_FILE, result.textSpan);
+    },
+    rebuildCount: () => logs.filter((line) => line.startsWith("built route table")).length,
+  };
+}
+
+/** The first `"…"` in a snippet, which is the path in every marker but one. */
+function firstQuoted(marker: string): string {
+  const match = /"[^"]*"/.exec(marker);
+  if (!match) throw new Error(`no quoted string in ${JSON.stringify(marker)}`);
+  return match[0];
+}
+
+describe("go to definition on an API route", () => {
+  const harness = createHarness();
+
+  test("a useQuery path resolves to the controller method behind it", () => {
+    expect(harness.definitionsAt('useQuery("/home")')).toEqual(["app/http/routes/api.ts index"]);
+  });
+
+  test("the underlined span is the path, without its quotes", () => {
+    expect(harness.boundTextAt('useQuery("/home")')).toBe("/home");
+  });
+
+  test("useQuery picks the GET handler where a path carries several verbs", () => {
+    // `/thing` has both a GET and a POST. Nothing in the call names a verb; the
+    // parameter's constraint is the GET route set, and that is what separates
+    // them.
+    expect(harness.definitionsAt('useQuery("/thing")')).toEqual(["app/http/routes/api.ts index"]);
+  });
+
+  test("useMutation picks the handler for the verb it was given", () => {
+    expect(harness.definitionsAt('useMutation("POST", "/thing")', '"/thing"')).toEqual([
+      "app/http/routes/api.ts archive",
+    ]);
+  });
+
+  test("a route reached through a nested router and a resource resolves", () => {
+    expect(harness.definitionsAt('useQuery("/org/:orgId/products")')).toEqual([
+      "app/http/routes/api.ts list",
+    ]);
+  });
+
+  test("a framework route resolves into the framework's own source", () => {
+    const [definition] = harness.definitionsAt('useQuery("/auth/me")');
+    expect(definition).toContain("/auth/");
+  });
+
+  test("a path given to a hook that returns a function resolves too", () => {
+    // The callee is the *result* of a call, and the constraint still comes
+    // through the resolved signature.
+    expect(harness.definitionsAt('useMutate()("/reports")')).toEqual([
+      "app/http/routes/api.ts shared",
+    ]);
+  });
+
+  test("the older getDefinitionAtPosition entry point answers the same way", () => {
+    // Some clients — Neovim's built-in LSP among them — reach tsserver's
+    // `definition` command, which lands here rather than on the bound-span
+    // variant. Both have to answer or the feature works in some editors only.
+    const definitions = harness.service.getDefinitionAtPosition(
+      `/project/${PAGE_FILE}`,
+      harness.positionOf('useQuery("/home")', 11),
+    );
+    expect(definitions?.map((definition) => definition.name)).toEqual(["index"]);
+  });
+
+  test("a route path held in a variable resolves as well", () => {
+    // No call to take a constraint from, so every verb at the path is offered.
+    // One handler serves `/reports`, so there is still only one answer.
+    expect(harness.definitionsAt('const loose = "/reports"')).toEqual([
+      "app/http/routes/api.ts shared",
+    ]);
+  });
+});
+
+describe("go to definition on a view route", () => {
+  const harness = createHarness();
+
+  test("a Link href resolves to the view component", () => {
+    expect(harness.definitionsAt('<Link href="/pricing">')).toEqual([
+      "app/views/Pricing.tsx Pricing",
+    ]);
+  });
+
+  test("a Form action resolves to the handler for its method", () => {
+    expect(harness.definitionsAt('<Form action="/thing" method="POST" />', '"/thing"')).toEqual([
+      "app/http/routes/api.ts archive",
+    ]);
+  });
+
+  test("a Form with no method still resolves to POST, not GET", () => {
+    // `method` defaults to `"POST"` in the component, so an omitted attribute
+    // is not an absent verb. `/thing` carries both a GET and a POST, which is
+    // the only shape where getting this wrong is visible.
+    expect(
+      harness.definitionsAt('<Form action="/thing" onSuccess={() => {}} />', '"/thing"'),
+    ).toEqual(["app/http/routes/api.ts archive"]);
+  });
+});
+
+describe("what the plugin leaves to TypeScript", () => {
+  const harness = createHarness();
+
+  test("an import specifier still goes to the module", () => {
+    const result = harness.service.getDefinitionAndBoundSpan(
+      `/project/${PAGE_FILE}`,
+      harness.positionOf('"gemi/client";\nimport { Link', 3),
+    );
+    expect(result?.definitions?.[0]?.fileName).toContain("/client/index.ts");
+  });
+
+  test("an object key that looks like a route is not hijacked", () => {
+    const result = harness.service.getDefinitionAndBoundSpan(
+      `/project/${PAGE_FILE}`,
+      harness.positionOf('const table = { "/home": 1 }', 18),
+    );
+    // TypeScript's own answer: the property, in this file.
+    expect(result?.definitions?.[0]?.kind).toBe("property");
+    expect(result?.definitions?.[0]?.fileName).toContain(PAGE_FILE);
+  });
+
+  test("an element access resolves to the property, not the route", () => {
+    const result = harness.service.getDefinitionAndBoundSpan(
+      `/project/${PAGE_FILE}`,
+      harness.positionOf('table["/home"]', 7),
+    );
+    expect(result?.definitions?.[0]?.fileName).toContain(PAGE_FILE);
+  });
+
+  test("an identifier is resolved by TypeScript as usual", () => {
+    const result = harness.service.getDefinitionAndBoundSpan(
+      `/project/${PAGE_FILE}`,
+      harness.positionOf('useQuery("/home")', 2),
+    );
+    expect(result?.definitions?.[0]?.name).toBe("useQuery");
+  });
+});
+
+describe("hover", () => {
+  const harness = createHarness();
+
+  test("names the route and where its handler lives", () => {
+    const documentation = harness.quickInfoAt('useQuery("/home")');
+    expect(documentation).toContain("GET /home");
+    expect(documentation).toContain("HomeController.index()");
+    expect(documentation).toContain("app/http/routes/api.ts:5");
+  });
+
+  test("leads with the route, since TypeScript says nothing about a path literal", () => {
+    const info = harness.service.getQuickInfoAtPosition(
+      `/project/${PAGE_FILE}`,
+      harness.positionOf('useQuery("/home")', 11),
+    );
+    expect(info?.displayParts?.map((part) => part.text).join("")).toBe("GET /home");
+  });
+
+  test("hovering anything else is TypeScript's answer, untouched", () => {
+    const info = harness.service.getQuickInfoAtPosition(
+      `/project/${PAGE_FILE}`,
+      harness.positionOf('useQuery("/home")', 2),
+    );
+    expect(info?.displayParts?.map((part) => part.text).join("")).toContain("useQuery");
+    expect(info?.documentation?.map((part) => part.text).join("")).not.toContain("GET /home");
+  });
+});
+
+describe("keeping up with edits", () => {
+  test("a rebuilt router changes where the jump lands", () => {
+    const harness = createHarness();
+    expect(harness.definitionsAt('useQuery("/home")')).toEqual(["app/http/routes/api.ts index"]);
+
+    const api = "/project/app/http/routes/api.ts";
+    const source = harness.project.service.getProgram()!.getSourceFile(api)!.text;
+    harness.project.update(
+      api,
+      source.replace(
+        '"/home": this.get(HomeController, "index")',
+        '"/home": this.get(HomeController, "archive")',
+      ),
+    );
+
+    expect(harness.definitionsAt('useQuery("/home")')).toEqual(["app/http/routes/api.ts archive"]);
+  });
+
+  test("an edit to a file the table never read reuses it", () => {
+    const harness = createHarness();
+    harness.definitionsAt('useQuery("/home")');
+    expect(harness.rebuildCount()).toBe(1);
+
+    // Editing the page the query is written on must not rebuild the router
+    // index — that is the difference between one walk and one per keystroke.
+    harness.project.update(`/project/${PAGE_FILE}`, `${PAGE}\n// typing in the component`);
+    harness.definitionsAt('useQuery("/home")');
+    harness.definitionsAt('useQuery("/thing")');
+
+    expect(harness.rebuildCount()).toBe(1);
+  });
+
+  test("a new file in the project is noticed", () => {
+    const harness = createHarness();
+    harness.definitionsAt('useQuery("/home")');
+    const before = harness.rebuildCount();
+
+    harness.project.update("/project/added.ts", "export const added = 1;");
+    harness.definitionsAt('useQuery("/home")');
+
+    expect(harness.rebuildCount()).toBe(before + 1);
+  });
+});

--- a/packages/gemi/ide/typescript-plugin/plugin.test.ts
+++ b/packages/gemi/ide/typescript-plugin/plugin.test.ts
@@ -27,7 +27,10 @@ export default function Page() {
   useQuery("/org/:orgId/products");
   useQuery("/auth/me");
   useMutation("POST", "/thing");
-  useMutate()("/reports");
+  const mutate = useMutate();
+  mutate({ path: "/reports" });
+  mutate({ path: "/thing" });
+  mutate({ path: "/org/:orgId" });
   const loose = "/reports";
   const read = table["/home"];
   return (
@@ -143,8 +146,26 @@ describe("go to definition on an API route", () => {
   test("a path given to a hook that returns a function resolves too", () => {
     // The callee is the *result* of a call, and the constraint still comes
     // through the resolved signature.
-    expect(harness.definitionsAt('useMutate()("/reports")')).toEqual([
+    expect(harness.definitionsAt('mutate({ path: "/reports" })')).toEqual([
       "app/http/routes/api.ts shared",
+    ]);
+  });
+
+  test("a path held in an options object narrows the same way an argument does", () => {
+    // `mutate({ path, params?, search? })` is the real `useMutate` signature —
+    // the path is a property, not an argument. Its `T extends keyof GetRPC` is
+    // the same constraint every other hook carries, so `/thing`'s POST handler
+    // has to be ruled out here exactly as it is for `useQuery`.
+    expect(harness.definitionsAt('mutate({ path: "/thing" })')).toEqual([
+      "app/http/routes/api.ts index",
+    ]);
+  });
+
+  test("an options-object path cannot mean a view route", () => {
+    // `/org/:orgId` is a layout, a view and a GET endpoint. `keyof GetRPC`
+    // admits only the last, so the two view components are not offered.
+    expect(harness.definitionsAt('mutate({ path: "/org/:orgId" })')).toEqual([
+      "app/http/routes/api.ts index",
     ]);
   });
 

--- a/packages/gemi/ide/typescript-plugin/plugin.ts
+++ b/packages/gemi/ide/typescript-plugin/plugin.ts
@@ -1,0 +1,261 @@
+import type ts from "typescript";
+
+import type { TS } from "./ast";
+import { findRouteQuery } from "./callSite";
+import { describeCandidate, describeTarget, lookupRoute, type RouteMatch } from "./lookup";
+import { buildRouteTable } from "./routeTable";
+import type { RouteTable, RouteTarget, Span, TargetKind } from "./types";
+
+export interface PluginHost {
+  ts: TS;
+  languageService: ts.LanguageService;
+  /** Directory holding the app's `app/` folder. */
+  projectRoot: string;
+  /** Where `this.view("auth/SignIn")` resolves `auth/SignIn.tsx`. */
+  viewsDir: string;
+  fileExists(fileName: string): boolean;
+  /** Opaque token that changes when a file's contents do. */
+  getScriptVersion(fileName: string): string;
+  log(message: string): void;
+}
+
+/**
+ * Wraps a language service so that a route path behaves like a reference to the
+ * code that serves it.
+ *
+ * `useQuery("/reports")` names its handler as precisely as a function call names
+ * a function — the string is checked against the router at compile time — but
+ * TypeScript has no way to know that, because the connection is made by
+ * conditional types rather than by a symbol. So go-to-definition stops at the
+ * literal, and reading one call site means opening the router, finding the
+ * entry, and following it to the controller by hand.
+ *
+ * Everything else is delegated untouched. The two methods below answer only when
+ * the position really is a route path that really is in the table; in every
+ * other case the wrapped service replies, so nothing TypeScript already does
+ * well gets worse.
+ */
+export function decorateLanguageService(host: PluginHost): ts.LanguageService {
+  const { ts, languageService } = host;
+  const routes = createRouteTableCache(host);
+
+  // Forward every method by hand rather than subclassing or spreading: the
+  // interface grows with each TypeScript release, and a proxy built from the
+  // instance's own keys picks up whatever this copy actually has.
+  const forwarded: Record<string, unknown> = Object.create(null);
+  const source = languageService as unknown as Record<string, unknown>;
+  for (const key of Object.keys(source)) {
+    const member = source[key];
+    if (typeof member !== "function") continue;
+    forwarded[key] = (...args: unknown[]) =>
+      (member as (...a: unknown[]) => unknown).apply(languageService, args);
+  }
+  const proxy = forwarded as unknown as ts.LanguageService;
+
+  proxy.getDefinitionAndBoundSpan = (fileName, position) => {
+    const matched = match(fileName, position);
+    if (!matched) return languageService.getDefinitionAndBoundSpan(fileName, position);
+
+    const definitions = toDefinitions(ts, matched.matches);
+    if (definitions.length === 0) {
+      return languageService.getDefinitionAndBoundSpan(fileName, position);
+    }
+    return { textSpan: matched.textSpan, definitions };
+  };
+
+  // `getDefinitionAtPosition` is the older entry point; some editors still call
+  // it, and Neovim's built-in LSP client reaches it through tsserver's
+  // `definition` command. Answering both keeps behaviour identical across them.
+  proxy.getDefinitionAtPosition = (fileName, position) => {
+    const matched = match(fileName, position);
+    if (!matched) return languageService.getDefinitionAtPosition(fileName, position);
+    const definitions = toDefinitions(ts, matched.matches);
+    return definitions.length > 0
+      ? definitions
+      : languageService.getDefinitionAtPosition(fileName, position);
+  };
+
+  proxy.getQuickInfoAtPosition = (fileName, position) => {
+    const original = languageService.getQuickInfoAtPosition(fileName, position);
+    const matched = match(fileName, position);
+    if (!matched) return original;
+
+    const { heading, documentation } = describeMatches(host, matched.matches);
+    // TypeScript has nothing to say about a string literal in argument
+    // position, so there is usually no original to preserve — but when there
+    // is, it is the parameter's type, which is worth keeping above the route.
+    if (original) {
+      return {
+        ...original,
+        documentation: [...(original.documentation ?? []), ...documentation],
+      };
+    }
+    return {
+      kind: ts.ScriptElementKind.string,
+      kindModifiers: "",
+      textSpan: matched.textSpan,
+      displayParts: heading,
+      documentation,
+    };
+  };
+
+  return proxy;
+
+  /**
+   * Nothing here is allowed to throw. A language service plugin that raises
+   * takes the editor's IntelliSense down with it, and a broken jump is a far
+   * better failure than a dead language server — so any surprise degrades to
+   * "not a route" and the wrapped service answers instead.
+   */
+  function match(
+    fileName: string,
+    position: number,
+  ): { matches: RouteMatch[]; textSpan: ts.TextSpan } | undefined {
+    try {
+      const program = languageService.getProgram();
+      const sourceFile = program?.getSourceFile(fileName);
+      if (!program || !sourceFile) return undefined;
+
+      const query = findRouteQuery(ts, program.getTypeChecker(), sourceFile, position);
+      if (!query) return undefined;
+
+      const matches = lookupRoute(routes.get(program), query);
+      if (matches.length === 0) return undefined;
+
+      // The span the editor underlines: the path itself, not its quotes.
+      const start = query.node.getStart(sourceFile) + 1;
+      return { matches, textSpan: { start, length: query.node.text.length } };
+    } catch (error) {
+      host.log(`route lookup failed at ${fileName}:${position} — ${describeError(error)}`);
+      return undefined;
+    }
+  }
+}
+
+export function describeError(error: unknown): string {
+  return error instanceof Error ? `${error.message}\n${error.stack ?? ""}` : String(error);
+}
+
+function toDefinitions(ts: TS, matches: RouteMatch[]): ts.DefinitionInfo[] {
+  const definitions: ts.DefinitionInfo[] = [];
+  const seen = new Set<string>();
+  for (const { candidate, targets } of matches) {
+    for (const target of targets) {
+      const key = `${target.fileName}:${target.span.start}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      definitions.push({
+        fileName: target.fileName,
+        textSpan: toTextSpan(target.span),
+        contextSpan: target.contextSpan ? toTextSpan(target.contextSpan) : undefined,
+        kind: scriptElementKind(ts, target.kind),
+        name: target.name,
+        containerName: target.containerName || describeCandidate(candidate),
+        containerKind: ts.ScriptElementKind.unknown,
+      });
+    }
+  }
+  return definitions;
+}
+
+function describeMatches(
+  host: PluginHost,
+  matches: RouteMatch[],
+): { heading: ts.SymbolDisplayPart[]; documentation: ts.SymbolDisplayPart[] } {
+  const lines: string[] = [];
+  for (const { candidate, targets } of matches) {
+    lines.push(describeCandidate(candidate));
+    for (const target of targets) {
+      lines.push(`  → ${describeTarget(target)} · ${location(host, target)}`);
+    }
+  }
+  return {
+    heading: [
+      {
+        text: matches.map(({ candidate }) => describeCandidate(candidate)).join(", "),
+        kind: "text",
+      },
+    ],
+    documentation: [{ text: lines.join("\n"), kind: "text" }],
+  };
+}
+
+function location(host: PluginHost, target: RouteTarget): string {
+  const relative = target.fileName.startsWith(`${host.projectRoot}/`)
+    ? target.fileName.slice(host.projectRoot.length + 1)
+    : target.fileName;
+  const sourceFile = host.languageService.getProgram()?.getSourceFile(target.fileName);
+  if (!sourceFile) return relative;
+  const { line } = sourceFile.getLineAndCharacterOfPosition(target.span.start);
+  return `${relative}:${line + 1}`;
+}
+
+function toTextSpan(span: Span): ts.TextSpan {
+  return { start: span.start, length: span.length };
+}
+
+function scriptElementKind(ts: TS, kind: TargetKind): ts.ScriptElementKind {
+  switch (kind) {
+    case "controller-method":
+      return ts.ScriptElementKind.memberFunctionElement;
+    case "inline-handler":
+      return ts.ScriptElementKind.functionElement;
+    case "view-component":
+      return ts.ScriptElementKind.functionElement;
+    case "route-entry":
+      return ts.ScriptElementKind.memberVariableElement;
+  }
+}
+
+interface RouteTableCache {
+  get(program: ts.Program): RouteTable;
+}
+
+/**
+ * Keeps the route table across edits that cannot have changed it.
+ *
+ * A definition request arrives on a keystroke, and the program object is new
+ * every time — so program identity alone would mean rebuilding the table on
+ * every character typed anywhere in the project. The table records which files
+ * it was derived from, and those are re-read only when one of their versions
+ * moves. The file count is part of the key too, because a route can also appear
+ * by a file being created, which no existing version reflects.
+ */
+function createRouteTableCache(host: PluginHost): RouteTableCache {
+  let cached: { table: RouteTable; versions: Map<string, string>; fileCount: number } | undefined;
+
+  return {
+    get(program) {
+      const fileCount = program.getSourceFiles().length;
+      if (cached && cached.fileCount === fileCount && isUnchanged(cached.versions)) {
+        return cached.table;
+      }
+
+      const started = Date.now();
+      const table = buildRouteTable(host.ts, program, {
+        projectRoot: host.projectRoot,
+        viewsDir: host.viewsDir,
+        fileExists: host.fileExists,
+      });
+      const versions = new Map<string, string>();
+      for (const fileName of table.dependencies) {
+        versions.set(fileName, host.getScriptVersion(fileName));
+      }
+      cached = { table, versions, fileCount };
+
+      host.log(
+        `built route table in ${Date.now() - started}ms: ${table.api.size} api paths, ` +
+          `${table.views.size} view paths, from ${table.dependencies.length} files`,
+      );
+      for (const diagnostic of table.diagnostics) host.log(diagnostic);
+      return table;
+    },
+  };
+
+  function isUnchanged(versions: Map<string, string>): boolean {
+    for (const [fileName, version] of versions) {
+      if (host.getScriptVersion(fileName) !== version) return false;
+    }
+    return true;
+  }
+}

--- a/packages/gemi/ide/typescript-plugin/routePath.test.ts
+++ b/packages/gemi/ide/typescript-plugin/routePath.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  joinHandlerMapKey,
+  parsePrefixAndKey,
+  removeDoubleSlash,
+  removeGroupPrefix,
+  removeTrailingId,
+} from "./routePath";
+
+/**
+ * These pin the *transcription*, not the design. Each case is a string the
+ * template-literal types in `http/ApiRouter.ts` and `client/types.ts` produce,
+ * including the ones they produce by accident — a bare `"health/"` keeps its
+ * trailing slash, a second `(group)` in one segment survives. Matching the
+ * types matters more than being right, because the strings a user can type into
+ * `useQuery` are the ones the types emit.
+ *
+ * `rpcParity.test.ts` is the other half: it checks the whole walk against
+ * `CreateRPC` over the same source, so a divergence these cases miss is caught
+ * by construction rather than by having been thought of.
+ */
+describe("removeDoubleSlash", () => {
+  test("collapses every doubled slash", () => {
+    expect(removeDoubleSlash("/a//b//c")).toBe("/a/b/c");
+    expect(removeDoubleSlash("///a")).toBe("/a");
+  });
+
+  test("leaves a single-slash path alone", () => {
+    expect(removeDoubleSlash("/a/b")).toBe("/a/b");
+  });
+});
+
+describe("removeGroupPrefix", () => {
+  test("drops a route group and the slash it leaves behind", () => {
+    expect(removeGroupPrefix("/(marketing)/pricing")).toBe("/pricing");
+    expect(removeGroupPrefix("/(app)")).toBe("/");
+  });
+
+  test("drops only the first group, as the type does", () => {
+    expect(removeGroupPrefix("/(a)/(b)/x")).toBe("/(b)/x");
+  });
+
+  test("leaves an unclosed parenthesis alone", () => {
+    expect(removeGroupPrefix("/(oops/x")).toBe("/(oops/x");
+  });
+});
+
+describe("parsePrefixAndKey", () => {
+  test("joins a prefix to a key", () => {
+    expect(parsePrefixAndKey("", "/health")).toBe("/health");
+    expect(parsePrefixAndKey("/org", "/products")).toBe("/org/products");
+  });
+
+  test("collapses the seam a root-mounted router creates", () => {
+    expect(parsePrefixAndKey("/org", "/")).toBe("/org");
+    expect(parsePrefixAndKey("/", "/")).toBe("/");
+    expect(parsePrefixAndKey("/org/", "/products")).toBe("/org/products");
+    expect(parsePrefixAndKey("/a", "//b")).toBe("/a/b");
+  });
+
+  test("drops a trailing slash once there are two segments", () => {
+    expect(parsePrefixAndKey("/org/products", "/")).toBe("/org/products");
+    expect(parsePrefixAndKey("", "/health/")).toBe("/health");
+  });
+
+  test("keeps a trailing slash the type also keeps", () => {
+    // `${T1}/${T2}/` needs two slashes; "health/" has one.
+    expect(parsePrefixAndKey("", "health/")).toBe("health/");
+  });
+
+  test("strips a route group from a prefix", () => {
+    expect(parsePrefixAndKey("/(app)", "/dashboard")).toBe("/dashboard");
+    expect(parsePrefixAndKey("/(app)", "/")).toBe("/");
+  });
+
+  test("reproduces the slashes a group on both sides of a seam leaves behind", () => {
+    // `/(app)/` + `/(admin)/users` hits the `//` branch, whose two halves are
+    // degrouped to "/" and "/users" and then rejoined with a third slash. The
+    // type really does emit this, so a route declared this way is spelled
+    // `"///users"` at every call site and has to be spelled that way here.
+    expect(parsePrefixAndKey("/(app)/", "/(admin)/users")).toBe("///users");
+  });
+});
+
+describe("removeTrailingId", () => {
+  test("drops the last param segment so a resource gets its collection path", () => {
+    expect(removeTrailingId("/:orgId/products/:productId")).toBe("/:orgId/products");
+    expect(removeTrailingId("/products/:id")).toBe("/products");
+  });
+
+  test("leaves a path with no param segment alone", () => {
+    expect(removeTrailingId("/products")).toBe("/products");
+  });
+
+  test("empties a key that is nothing but an id segment", () => {
+    // Not a reachable route — and reproducing the empty string is what keeps
+    // the plugin from inventing a `/` collection route the types never emitted.
+    expect(removeTrailingId("/:id")).toBe("");
+  });
+});
+
+describe("joinHandlerMapKey", () => {
+  test("concatenates raw, groups included, as RouteHandlersParser does", () => {
+    expect(joinHandlerMapKey("/org", "/things")).toBe("/org/things");
+    expect(joinHandlerMapKey("/(app)", "/things")).toBe("/(app)/things");
+  });
+
+  test("treats a bare slash as no segment at all", () => {
+    expect(joinHandlerMapKey("/org", "/")).toBe("/org");
+  });
+});

--- a/packages/gemi/ide/typescript-plugin/routePath.ts
+++ b/packages/gemi/ide/typescript-plugin/routePath.ts
@@ -1,0 +1,107 @@
+/**
+ * Value-level mirrors of the template-literal types that build RPC keys.
+ *
+ * The plugin has to arrive at exactly the same strings `CreateRPC` and
+ * `CreateViewRPC` produce — a route the type system spells `/org/:orgId/products`
+ * and the plugin spells `/org/:orgId/products/` is a route the plugin can never
+ * be asked about, because the string the user typed came from the types.
+ *
+ * So each function here is a transcription of one conditional type in
+ * `http/ApiRouter.ts` / `http/ViewRouter.ts` / `client/types.ts`, quirks
+ * included: `removeGroupPrefix` strips one group and not all of them,
+ * `parsePrefixAndKey` collapses one double slash and not all of them. Where the
+ * behaviour looks wrong, it is wrong in the same direction as the types, which
+ * is the only property that matters. `routePath.test.ts` pins the pairs, and
+ * `http/ApiRouter.test-d.ts` pins the type side.
+ */
+
+/** Mirrors `RemoveDoubleSlash` in `client/types.ts` — recursive, unlike its callers. */
+export function removeDoubleSlash(input: string): string {
+  const at = input.indexOf("//");
+  if (at === -1) return input;
+  return removeDoubleSlash(`${input.slice(0, at)}/${input.slice(at + 2)}`);
+}
+
+/**
+ * Mirrors `RemoveGroupPrefix` in `client/types.ts`.
+ *
+ * Strips the *first* `(group)` — a route folder that organises the tree without
+ * appearing in the URL — and then collapses the double slash that removal
+ * leaves behind. A second group in the same segment survives, exactly as it
+ * does in the type.
+ */
+export function removeGroupPrefix(input: string): string {
+  const open = input.indexOf("(");
+  if (open === -1) return input;
+  const close = input.indexOf(")", open + 1);
+  if (close === -1) return input;
+  return removeDoubleSlash(`${input.slice(0, open)}${input.slice(close + 1)}`);
+}
+
+/**
+ * Mirrors `ParsePrefixAndKey`, which both routers declare identically: join a
+ * parent prefix to a child key and normalise the seam.
+ *
+ * The `${infer T1}//${infer T2}` and `${infer T1}/${infer T2}/` patterns infer
+ * the leftmost-shortest `T1`, so both branches split at the *first* slash that
+ * satisfies the pattern — not the last, and not every one.
+ */
+export function parsePrefixAndKey(prefix: string, key: string): string {
+  const joined = `${prefix}${key}`;
+  if (joined === "//") return "/";
+
+  const doubleSlash = joined.indexOf("//");
+  if (doubleSlash !== -1) {
+    return `${removeGroupPrefix(joined.slice(0, doubleSlash))}/${removeGroupPrefix(
+      joined.slice(doubleSlash + 2),
+    )}`;
+  }
+
+  if (joined.endsWith("/")) {
+    // `${T1}/${T2}/` needs two distinct slashes, so a bare "health/" falls
+    // through to the default branch keeping its trailing slash — as it does in
+    // the type.
+    const first = joined.indexOf("/");
+    if (first !== -1 && first < joined.length - 1) {
+      return `${removeGroupPrefix(joined.slice(0, first))}/${removeGroupPrefix(
+        joined.slice(first + 1, -1),
+      )}`;
+    }
+  }
+
+  return removeGroupPrefix(joined);
+}
+
+/**
+ * Mirrors `RemoveTrailingId` in `http/ApiRouter.ts` — drops the last `:param`
+ * segment, which is how a resource's collection routes (`list`, `store`) get
+ * their path from the same key the member routes (`show`, `update`, `delete`)
+ * use.
+ *
+ * `"/:orgId/products/:productId"` → `"/:orgId/products"`. A key that is nothing
+ * but an id segment empties out, which is not a reachable route — reproducing
+ * that rather than "correcting" it to `"/"` keeps the plugin from claiming a
+ * route the types never emitted.
+ *
+ * The type's `"X"` branch is transcribed for fidelity even though no input
+ * reaches it: `Head` is everything before the first `/:`, so it cannot itself
+ * begin with `/:`.
+ */
+export function removeTrailingId(input: string): string {
+  const at = input.indexOf("/:");
+  if (at === -1) return input;
+  const head = input.slice(0, at);
+  const tail = input.slice(at + 2);
+  if (tail.includes("/:")) return `${head}/:${removeTrailingId(tail)}`;
+  if (head.startsWith("/:")) return "X";
+  return head;
+}
+
+/**
+ * Mirrors the `RouteHandlers` branch of `RouteParser`, which — unlike every
+ * other branch — concatenates raw instead of going through `ParsePrefixAndKey`.
+ * A verb-map value therefore keeps any group parentheses in its prefix.
+ */
+export function joinHandlerMapKey(prefix: string, key: string): string {
+  return `${prefix}${key === "/" ? "" : key}`;
+}

--- a/packages/gemi/ide/typescript-plugin/routeTable.test.ts
+++ b/packages/gemi/ide/typescript-plugin/routeTable.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "vitest";
+
+import { createFixture, tableFor } from "./fixture";
+import { createTestProject, type TestProject } from "./testProject";
+import { buildRouteTable } from "./routeTable";
+import type { RouteTarget } from "./types";
+
+/**
+ * Where a route jump lands.
+ *
+ * `rpcParity.test.ts` covers the other half — that the walker finds the same
+ * *set* of routes the types do. This covers what each one points at, which is
+ * the part a developer actually experiences: the difference between landing on
+ * `reportsData()` and landing on the top of a 400-line router.
+ */
+function targetsFor(project: TestProject, path: string, verb = "GET"): RouteTarget[] {
+  const table = tableFor(project);
+  const entry = table.api.get(path)?.find((candidate) => candidate.verb === verb);
+  if (!entry) throw new Error(`no ${verb} ${path} in table: ${[...table.api.keys()].join(", ")}`);
+  return entry.targets;
+}
+
+/** The source text a target selects, plus where it selects it. */
+function landing(project: TestProject, target: RouteTarget): string {
+  const relative = target.fileName.replace(`${project.projectRoot}/`, "");
+  return `${relative}:${project.locationOf(relative, target.span.start)} ${project.textAt(
+    relative,
+    target.span,
+  )}`;
+}
+
+describe("API route targets", () => {
+  const project = createFixture();
+
+  test("a controller-backed route points at the method, not the class", () => {
+    const [target] = targetsFor(project, "/home");
+    expect(target.kind).toBe("controller-method");
+    expect(target.containerName).toBe("HomeController");
+    expect(target.name).toBe("index");
+    expect(landing(project, target)).toBe("app/http/routes/api.ts:5:3 index");
+  });
+
+  test("a method inherited from a base controller resolves to the base", () => {
+    // `ReportsController` declares nothing; `shared` is on its base. Resolving
+    // through the instance type rather than the class body is what finds it.
+    const [target] = targetsFor(project, "/reports");
+    expect(target.kind).toBe("controller-method");
+    expect(target.containerName).toBe("ReportsController");
+    expect(landing(project, target)).toBe("app/http/routes/api.ts:10:3 shared");
+  });
+
+  test("an inline handler points at the callback", () => {
+    const [target] = targetsFor(project, "/health");
+    expect(target.kind).toBe("inline-handler");
+    expect(project.textAt("app/http/routes/api.ts", target.span)).toBe("() => ({ ok: true })");
+  });
+
+  test("a middleware-wrapped route still finds its handler", () => {
+    const [target] = targetsFor(project, "/guarded");
+    expect(target.kind).toBe("inline-handler");
+  });
+
+  test("each resource verb points at its own controller method", () => {
+    const collection = "/org/:orgId/products";
+    const member = "/org/:orgId/products/:productId";
+    const named = (path: string, verb: string) => {
+      const [target] = targetsFor(project, path, verb);
+      return `${target.containerName}.${target.name}`;
+    };
+
+    expect(named(collection, "GET")).toBe("ProductsController.list");
+    expect(named(collection, "POST")).toBe("ProductsController.store");
+    expect(named(member, "GET")).toBe("ProductsController.show");
+    expect(named(member, "PUT")).toBe("ProductsController.update");
+    expect(named(member, "DELETE")).toBe("ProductsController.delete");
+  });
+
+  test("a verb map resolves each verb separately", () => {
+    expect(targetsFor(project, "/thing", "GET")[0].name).toBe("index");
+    expect(targetsFor(project, "/thing", "POST")[0].name).toBe("archive");
+  });
+
+  test("a framework route points into the framework's own source", () => {
+    const [target] = targetsFor(project, "/auth/me");
+    expect(target.fileName).toMatch(/\/auth\/(routes|AuthController)\.ts$/);
+  });
+});
+
+describe("view route targets", () => {
+  const project = createFixture();
+
+  test("a view offers its component and then its handler", () => {
+    const table = tableFor(project);
+    const [entry] = table.views.get("/org/:orgId/settings")!;
+    expect(entry.targets.map((target) => target.kind)).toEqual([
+      "view-component",
+      "controller-method",
+    ]);
+    expect(entry.targets[0].fileName).toBe("/project/app/views/OrgSettings.tsx");
+    expect(entry.targets[1].name).toBe("settings");
+  });
+
+  test("a view with no handler offers only its component", () => {
+    const table = tableFor(project);
+    const [entry] = table.views.get("/auth/sign-in")!;
+    expect(entry.targets).toHaveLength(1);
+    expect(entry.targets[0].fileName).toBe("/project/app/views/auth/SignIn.tsx");
+  });
+
+  test("a layout is indexed alongside the view sharing its path", () => {
+    const table = tableFor(project);
+    const kinds = table.views.get("/org/:orgId")!.map((entry) => entry.kind);
+    expect(kinds.sort()).toEqual(["layout", "view"]);
+  });
+});
+
+describe("shapes the walker cannot read through", () => {
+  /**
+   * The floor matters as much as the ceiling. A route built by a helper the
+   * walker does not understand still has a `routes` entry, and landing on that
+   * entry is a far better answer than landing nowhere — the developer is one
+   * line from the handler either way.
+   */
+  const project = createTestProject({
+    "app/http/routes/api.ts": `
+import { ApiRouter } from "gemi/http";
+declare function makeHandler(): any;
+export default class Root extends ApiRouter {
+  routes = {
+    "/odd": makeHandler(),
+    "/fine": this.get(() => ({ ok: true })),
+  };
+}
+`,
+    "gemi.d.ts": `
+import type Api from "@/app/http/routes/api";
+import type { CreateRPC } from "gemi/http";
+declare module "gemi/client" {
+  export interface RPC extends CreateRPC<Api> {}
+}
+`,
+  });
+
+  test("an unrecognised handler shape is skipped rather than guessed at", () => {
+    const table = tableFor(project);
+    expect(table.api.has("/odd")).toBe(false);
+    expect(table.api.has("/fine")).toBe(true);
+  });
+
+  test("a handler the walker cannot resolve falls back to the routes entry", () => {
+    const fallback = createTestProject({
+      "app/http/routes/api.ts": `
+import { ApiRouter } from "gemi/http";
+declare const Controller: any;
+export default class Root extends ApiRouter {
+  routes = {
+    "/dynamic": this.get(Controller, someName()),
+  };
+}
+declare function someName(): any;
+`,
+      "gemi.d.ts": `
+import type Api from "@/app/http/routes/api";
+import type { CreateRPC } from "gemi/http";
+declare module "gemi/client" {
+  export interface RPC extends CreateRPC<Api> {}
+}
+`,
+    });
+
+    const [target] = buildRouteTable(fallback.ts, fallback.service.getProgram()!, {
+      projectRoot: fallback.projectRoot,
+      viewsDir: `${fallback.projectRoot}/app/views`,
+      fileExists: fallback.fileExists,
+    }).api.get("/dynamic")![0].targets;
+
+    expect(target.kind).toBe("route-entry");
+    expect(fallback.textAt("app/http/routes/api.ts", target.span)).toBe('"/dynamic"');
+  });
+});

--- a/packages/gemi/ide/typescript-plugin/routeTable.ts
+++ b/packages/gemi/ide/typescript-plugin/routeTable.ts
@@ -1,0 +1,467 @@
+import type ts from "typescript";
+
+import {
+  displayNameOfClass,
+  getPropertyKeyText,
+  getRoutesObjectLiteral,
+  getStringValue,
+  getThisCall,
+  resolveClassDeclaration,
+  spanOf,
+  targetFromDeclaration,
+  unwrapBuilderChain,
+  unwrapExpression,
+  type TS,
+} from "./ast";
+import { findRootRouters } from "./entryPoints";
+import { joinHandlerMapKey, parsePrefixAndKey, removeTrailingId } from "./routePath";
+import type { ApiRouteEntry, HttpVerb, RouteTable, RouteTarget, ViewRouteEntry } from "./types";
+
+export interface BuildOptions {
+  /** Directory the app's `app/` folder sits in. */
+  projectRoot: string;
+  /** Where `this.view("auth/SignIn")` looks for `auth/SignIn.tsx`. */
+  viewsDir: string;
+  fileExists: (fileName: string) => boolean;
+}
+
+const VERBS: Record<string, HttpVerb> = {
+  get: "GET",
+  post: "POST",
+  put: "PUT",
+  patch: "PATCH",
+  delete: "DELETE",
+};
+
+/**
+ * The five routes `this.resource(C)` expands to, and where each lands.
+ *
+ * `list` and `store` sit on the collection — the route key with its trailing
+ * `:id` segment removed — and the other three on the member. That split is
+ * `ResourceRoutes`' `first`/`second` in `http/ApiRouter.ts`.
+ */
+const RESOURCE_ROUTES: ReadonlyArray<{
+  method: string;
+  verb: HttpVerb;
+  scope: "collection" | "member";
+}> = [
+  { method: "list", verb: "GET", scope: "collection" },
+  { method: "store", verb: "POST", scope: "collection" },
+  { method: "show", verb: "GET", scope: "member" },
+  { method: "update", verb: "PUT", scope: "member" },
+  { method: "delete", verb: "DELETE", scope: "member" },
+];
+
+const VIEW_EXTENSIONS = [".tsx", ".jsx", ".ts", ".js"];
+
+/**
+ * Walks an app's router tree and records, for every route the client can name,
+ * where its handler is written.
+ *
+ * The walk mirrors `RouteParser`/`RoutesParser` rather than the runtime: those
+ * conditional types are what turn a `routes` object into the string literals a
+ * `useQuery` call site is constrained to, so matching them is what makes a
+ * lookup by that literal possible. Everything the types reach, this reaches;
+ * everything they drop (`file`, `stream`, `proxy`) is still indexed, marked
+ * `inRpc: false`, because a hardcoded URL elsewhere in the app may still name it.
+ */
+export function buildRouteTable(ts: TS, program: ts.Program, options: BuildOptions): RouteTable {
+  return new RouteTableBuilder(ts, program, options).build();
+}
+
+class RouteTableBuilder {
+  private readonly checker: ts.TypeChecker;
+  private readonly api = new Map<string, ApiRouteEntry[]>();
+  private readonly views = new Map<string, ViewRouteEntry[]>();
+  private readonly dependencies = new Set<string>();
+  private readonly diagnostics: string[] = [];
+
+  constructor(
+    private readonly ts: TS,
+    private readonly program: ts.Program,
+    private readonly options: BuildOptions,
+  ) {
+    this.checker = program.getTypeChecker();
+  }
+
+  build(): RouteTable {
+    const roots = findRootRouters(this.ts, this.program, this.options.projectRoot);
+    for (const dependency of roots.dependencies) this.dependencies.add(dependency);
+    this.diagnostics.push(...roots.diagnostics);
+
+    for (const mount of roots.api) this.walkApiRouter(mount.declaration, mount.prefix, []);
+    for (const mount of roots.view) this.walkViewRouter(mount.declaration, mount.prefix, []);
+
+    return {
+      api: this.api,
+      views: this.views,
+      dependencies: [...this.dependencies],
+      diagnostics: this.diagnostics,
+    };
+  }
+
+  // -- API routers ---------------------------------------------------------
+
+  private walkApiRouter(
+    classDeclaration: ts.ClassLikeDeclaration,
+    prefix: string,
+    stack: ts.ClassLikeDeclaration[],
+  ): void {
+    const ts = this.ts;
+    const routes = getRoutesObjectLiteral(ts, classDeclaration);
+    if (!routes) return;
+    this.dependencies.add(classDeclaration.getSourceFile().fileName);
+
+    for (const property of routes.properties) {
+      if (!ts.isPropertyAssignment(property)) continue;
+      const key = getPropertyKeyText(ts, this.checker, property.name);
+      if (key === undefined) continue;
+      const value = unwrapExpression(ts, property.initializer);
+
+      // A bare class reference mounts another router under this key.
+      const nested = resolveClassDeclaration(ts, this.checker, value);
+      if (nested && getRoutesObjectLiteral(ts, nested)) {
+        // Guard the current chain, not every router seen: mounting the same
+        // router at two prefixes is legitimate, mounting it inside itself is not.
+        if (stack.includes(nested)) {
+          this.diagnostics.push(
+            `router cycle at ${parsePrefixAndKey(prefix, key)}; stopped descending`,
+          );
+          continue;
+        }
+        this.walkApiRouter(nested, parsePrefixAndKey(prefix, key), [...stack, nested]);
+        continue;
+      }
+
+      // A verb map — `{ get: this.get(...), post: this.post(...) }` — puts
+      // several verbs on one path. `RouteHandlersParser` concatenates its
+      // prefix raw, so this key does not go through `parsePrefixAndKey`.
+      if (ts.isObjectLiteralExpression(value)) {
+        const path = joinHandlerMapKey(prefix, key);
+        for (const inner of value.properties) {
+          if (!ts.isPropertyAssignment(inner)) continue;
+          this.addApiRoute(path, unwrapExpression(ts, inner.initializer), inner, classDeclaration);
+        }
+        continue;
+      }
+
+      this.addApiRoute(parsePrefixAndKey(prefix, key), value, property, classDeclaration);
+    }
+  }
+
+  private addApiRoute(
+    path: string,
+    value: ts.Expression,
+    entryNode: ts.PropertyAssignment,
+    router: ts.ClassLikeDeclaration,
+  ): void {
+    const call = getThisCall(this.ts, unwrapBuilderChain(this.ts, value));
+    if (!call) return;
+    const fallback = this.routeEntryTarget(entryNode, router);
+
+    if (call.method === "resource") {
+      const controller = call.args[0];
+      const collection = removeTrailingId(path);
+      for (const { method, verb, scope } of RESOURCE_ROUTES) {
+        const target = controller ? this.controllerMethodTarget(controller, method) : undefined;
+        this.pushApi({
+          path: scope === "collection" ? collection : path,
+          verb,
+          inRpc: true,
+          targets: [target ?? fallback],
+        });
+      }
+      return;
+    }
+
+    const verb = VERBS[call.method];
+    if (verb) {
+      this.pushApi({ path, verb, inRpc: true, targets: this.handlerTargets(call.args, fallback) });
+      return;
+    }
+
+    // `file` and `stream` are GET routes that `CreateRPC` drops; `proxy`
+    // forwards elsewhere and has no local handler to jump to.
+    if (call.method === "file" || call.method === "stream") {
+      this.pushApi({
+        path,
+        verb: "GET",
+        inRpc: false,
+        targets: this.handlerTargets(call.args, fallback),
+      });
+      return;
+    }
+    if (call.method === "proxy") {
+      this.pushApi({ path, verb: "GET", inRpc: false, targets: [fallback] });
+    }
+  }
+
+  private pushApi(entry: ApiRouteEntry): void {
+    const existing = this.api.get(entry.path);
+    if (existing) existing.push(entry);
+    else this.api.set(entry.path, [entry]);
+  }
+
+  // -- View routers --------------------------------------------------------
+
+  private walkViewRouter(
+    classDeclaration: ts.ClassLikeDeclaration,
+    prefix: string,
+    stack: ts.ClassLikeDeclaration[],
+  ): void {
+    const routes = getRoutesObjectLiteral(this.ts, classDeclaration);
+    if (!routes) return;
+    this.dependencies.add(classDeclaration.getSourceFile().fileName);
+    this.walkViewRoutes(routes, prefix, stack, classDeclaration);
+  }
+
+  private walkViewRoutes(
+    routes: ts.ObjectLiteralExpression,
+    prefix: string,
+    stack: ts.ClassLikeDeclaration[],
+    router: ts.ClassLikeDeclaration,
+  ): void {
+    const ts = this.ts;
+    for (const property of routes.properties) {
+      if (!ts.isPropertyAssignment(property)) continue;
+      const key = getPropertyKeyText(ts, this.checker, property.name);
+      if (key === undefined) continue;
+      const value = unwrapExpression(ts, property.initializer);
+      const path = parsePrefixAndKey(prefix, key);
+
+      const nested = resolveClassDeclaration(ts, this.checker, value);
+      if (nested && getRoutesObjectLiteral(ts, nested)) {
+        if (stack.includes(nested)) {
+          this.diagnostics.push(`view router cycle at ${path}; stopped descending`);
+          continue;
+        }
+        this.walkViewRouter(nested, path, [...stack, nested]);
+        continue;
+      }
+
+      const call = getThisCall(ts, unwrapBuilderChain(ts, value));
+      if (!call) continue;
+      const fallback = this.routeEntryTarget(property, router);
+
+      switch (call.method) {
+        case "view":
+          this.pushView({
+            path,
+            kind: "view",
+            inRpc: true,
+            targets: this.viewTargets(call.args[0], call.args[1], fallback),
+          });
+          break;
+
+        case "redirect":
+          this.pushView({
+            path,
+            kind: "view",
+            inRpc: true,
+            targets: this.viewTargets(undefined, call.args[0], fallback),
+          });
+          break;
+
+        case "file":
+          // `RoutesParser` maps `FileRoute` to `never`, so no typed call site
+          // names this path — indexed for hardcoded URLs only.
+          this.pushView({
+            path,
+            kind: "view",
+            inRpc: false,
+            targets: this.viewTargets(undefined, call.args[0], fallback),
+          });
+          break;
+
+        case "layout": {
+          // `layout(viewPath, handler, routes)` and `layout(viewPath, routes)`
+          // are both legal; the children are whichever argument is an object.
+          const second = call.args[1] ? unwrapExpression(ts, call.args[1]) : undefined;
+          const third = call.args[2] ? unwrapExpression(ts, call.args[2]) : undefined;
+          const children =
+            third && ts.isObjectLiteralExpression(third)
+              ? third
+              : second && ts.isObjectLiteralExpression(second)
+                ? second
+                : undefined;
+          const handler = children === second ? undefined : second;
+
+          this.pushView({
+            path,
+            kind: "layout",
+            inRpc: true,
+            targets: this.viewTargets(call.args[0], handler, fallback),
+          });
+          if (children) this.walkViewRoutes(children, path, stack, router);
+          break;
+        }
+      }
+    }
+  }
+
+  private pushView(entry: ViewRouteEntry): void {
+    const existing = this.views.get(entry.path);
+    if (existing) existing.push(entry);
+    else this.views.set(entry.path, [entry]);
+  }
+
+  /**
+   * A view route has up to two places worth going: the component it renders and
+   * the controller method that feeds it. Both are offered, component first —
+   * editors show a picker when a definition resolves to more than one place.
+   */
+  private viewTargets(
+    viewPath: ts.Expression | undefined,
+    handler: ts.Expression | undefined,
+    fallback: RouteTarget,
+  ): RouteTarget[] {
+    const targets: RouteTarget[] = [];
+    const component = viewPath ? this.viewComponentTarget(viewPath) : undefined;
+    if (component) targets.push(component);
+    if (handler) targets.push(...this.handlerTargets([handler], fallback, { silent: true }));
+    return targets.length > 0 ? targets : [fallback];
+  }
+
+  private viewComponentTarget(viewPath: ts.Expression): RouteTarget | undefined {
+    const ts = this.ts;
+    const relative = getStringValue(ts, this.checker, viewPath);
+    if (!relative) return undefined;
+
+    for (const extension of VIEW_EXTENSIONS) {
+      const fileName = `${this.options.viewsDir}/${relative}${extension}`;
+      const sourceFile = this.program.getSourceFile(fileName);
+      if (sourceFile) {
+        this.dependencies.add(fileName);
+        const exported = this.defaultExportDeclaration(sourceFile);
+        if (exported) {
+          return targetFromDeclaration(ts, exported, relative, "view", "view-component");
+        }
+        return {
+          fileName,
+          span: { start: 0, length: 0 },
+          name: relative,
+          containerName: "view",
+          kind: "view-component",
+        };
+      }
+      // A view nothing imports is absent from the program even though it is on
+      // disk — the whole point of the views directory is that the framework
+      // loads it, not the app. Jumping to the file still works.
+      if (this.options.fileExists(fileName)) {
+        return {
+          fileName,
+          span: { start: 0, length: 0 },
+          name: relative,
+          containerName: "view",
+          kind: "view-component",
+        };
+      }
+    }
+    return undefined;
+  }
+
+  private defaultExportDeclaration(sourceFile: ts.SourceFile): ts.Declaration | undefined {
+    const moduleSymbol = this.checker.getSymbolAtLocation(sourceFile);
+    if (!moduleSymbol) return undefined;
+    for (const exported of this.checker.getExportsOfModule(moduleSymbol)) {
+      if (exported.name !== "default") continue;
+      const resolved =
+        exported.flags & this.ts.SymbolFlags.Alias
+          ? this.checker.getAliasedSymbol(exported)
+          : exported;
+      const declaration = resolved.valueDeclaration ?? resolved.declarations?.[0];
+      if (declaration) return declaration;
+    }
+    return undefined;
+  }
+
+  // -- Handlers ------------------------------------------------------------
+
+  /**
+   * Where a route's arguments say its work happens.
+   *
+   * `(Controller, "method")` and `[Controller, "method"]` — the API and view
+   * spellings of the same thing — resolve to the method. An inline callback
+   * resolves to itself. Anything else falls back to the `routes` entry, so a
+   * shape this does not understand degrades to a jump into the router rather
+   * than to no jump at all.
+   */
+  private handlerTargets(
+    args: readonly ts.Expression[],
+    fallback: RouteTarget,
+    options: { silent?: boolean } = {},
+  ): RouteTarget[] {
+    const ts = this.ts;
+    const first = args[0] ? unwrapExpression(ts, args[0]) : undefined;
+    if (!first) return options.silent ? [] : [fallback];
+
+    if (ts.isArrayLiteralExpression(first)) {
+      const [controller, method] = first.elements;
+      const name = getStringValue(ts, this.checker, method);
+      const target = controller && name ? this.controllerMethodTarget(controller, name) : undefined;
+      return [target ?? fallback];
+    }
+
+    if (ts.isFunctionExpression(first) || ts.isArrowFunction(first)) {
+      return [
+        {
+          fileName: first.getSourceFile().fileName,
+          span: spanOf(first),
+          contextSpan: spanOf(first),
+          name: "handler",
+          containerName: "",
+          kind: "inline-handler",
+        },
+      ];
+    }
+
+    const methodName = getStringValue(ts, this.checker, args[1]);
+    if (methodName) {
+      const target = this.controllerMethodTarget(first, methodName);
+      if (target) return [target];
+    }
+
+    return options.silent ? [] : [fallback];
+  }
+
+  /**
+   * The declaration of `methodName` on the class an expression names.
+   *
+   * Resolved through the instance type rather than the class body, so a method
+   * inherited from a base controller — or reached through an import alias, or a
+   * re-export — is found the same way the compiler finds it.
+   */
+  private controllerMethodTarget(
+    controller: ts.Expression,
+    methodName: string,
+  ): RouteTarget | undefined {
+    const type = this.checker.getTypeAtLocation(controller);
+    const instance = type.getConstructSignatures()[0]?.getReturnType();
+    const property = instance?.getProperty(methodName);
+    const declaration = property?.declarations?.[0];
+    if (!declaration) return undefined;
+
+    this.dependencies.add(declaration.getSourceFile().fileName);
+    return targetFromDeclaration(
+      this.ts,
+      declaration,
+      methodName,
+      displayNameOfClass(this.ts, this.checker, controller),
+      "controller-method",
+    );
+  }
+
+  private routeEntryTarget(
+    property: ts.PropertyAssignment,
+    router: ts.ClassLikeDeclaration,
+  ): RouteTarget {
+    return {
+      fileName: property.getSourceFile().fileName,
+      span: spanOf(property.name),
+      contextSpan: spanOf(property),
+      name: getPropertyKeyText(this.ts, this.checker, property.name) ?? "route",
+      containerName: router.name?.text ?? "router",
+      kind: "route-entry",
+    };
+  }
+}

--- a/packages/gemi/ide/typescript-plugin/routeTable.ts
+++ b/packages/gemi/ide/typescript-plugin/routeTable.ts
@@ -113,7 +113,10 @@ class RouteTableBuilder {
     this.dependencies.add(classDeclaration.getSourceFile().fileName);
 
     for (const property of routes.properties) {
-      if (!ts.isPropertyAssignment(property)) continue;
+      if (!ts.isPropertyAssignment(property)) {
+        this.noteUnreadableEntry(property, prefix, classDeclaration);
+        continue;
+      }
       const key = getPropertyKeyText(ts, this.checker, property.name);
       if (key === undefined) continue;
       const value = unwrapExpression(ts, property.initializer);
@@ -223,7 +226,10 @@ class RouteTableBuilder {
   ): void {
     const ts = this.ts;
     for (const property of routes.properties) {
-      if (!ts.isPropertyAssignment(property)) continue;
+      if (!ts.isPropertyAssignment(property)) {
+        this.noteUnreadableEntry(property, prefix, router);
+        continue;
+      }
       const key = getPropertyKeyText(ts, this.checker, property.name);
       if (key === undefined) continue;
       const value = unwrapExpression(ts, property.initializer);
@@ -448,6 +454,33 @@ class RouteTableBuilder {
       methodName,
       displayNameOfClass(this.ts, this.checker, controller),
       "controller-method",
+    );
+  }
+
+  /**
+   * A `routes` entry the walk cannot read, recorded rather than dropped in silence.
+   *
+   * `RouteParser` works from the *declared type* of `routes`, so a spread —
+   * `...sharedRoutes` — contributes its paths to `keyof RPC` and to autocomplete
+   * while the walk, which reads syntax, has no row for any of them. The result is
+   * a path that typechecks and offers no jump, and (see `intersect` in
+   * `lookup.ts`) a hole that used to cost verb narrowing project-wide. The
+   * tsserver log is the only place that can say which route went missing.
+   */
+  private noteUnreadableEntry(
+    property: ts.ObjectLiteralElementLike,
+    prefix: string,
+    router: ts.ClassLikeDeclaration,
+  ): void {
+    const ts = this.ts;
+    const what = ts.isSpreadAssignment(property)
+      ? `the spread \`...${property.expression.getText()}\``
+      : ts.isShorthandPropertyAssignment(property)
+        ? `the shorthand entry \`${property.name.text}\``
+        : "an entry";
+    this.diagnostics.push(
+      `${router.name?.text ?? "router"} mounted at ${prefix || "/"}: ${what} in \`routes\` ` +
+        `cannot be read statically — the routes it holds are typed but not jumpable`,
     );
   }
 

--- a/packages/gemi/ide/typescript-plugin/rpcParity.test.ts
+++ b/packages/gemi/ide/typescript-plugin/rpcParity.test.ts
@@ -49,9 +49,13 @@ describe("the route table against the RPC types", () => {
   const project = createFixture();
   const table = tableFor(project);
 
-  test("reaches the app's routers through the gemi.d.ts augmentation", () => {
+  test("reaches the app's routers through the augmentation the package ships", () => {
+    // The fixture has no `gemi.d.ts` of its own, exactly like a 0.56 app: the
+    // augmentation arrives with the package and names `Api` through `AppRPC`,
+    // an alias rather than `CreateRPC` itself. Reaching the app's routers from
+    // there is what the discovery in `entryPoints.ts` exists to do.
     expect(table.diagnostics).toEqual([]);
-    expect(table.dependencies).toContain("/project/gemi.d.ts");
+    expect(table.dependencies.some((file) => file.endsWith("/gemi/gemi.d.ts"))).toBe(true);
     expect(table.dependencies).toContain("/project/app/http/routes/api.ts");
     expect(table.dependencies).toContain("/project/app/http/routes/view.ts");
   });

--- a/packages/gemi/ide/typescript-plugin/rpcParity.test.ts
+++ b/packages/gemi/ide/typescript-plugin/rpcParity.test.ts
@@ -1,0 +1,112 @@
+import * as ts from "typescript";
+import { describe, expect, test } from "vitest";
+
+import { createFixture, tableFor } from "./fixture";
+import type { TestProject } from "./testProject";
+
+/**
+ * The walk in `routeTable.ts`, checked against the types it exists to mirror.
+ *
+ * A lookup only works if the plugin's idea of a route key is character-identical
+ * to `CreateRPC`'s, because the string being looked up was typed by a developer
+ * whose autocomplete came from `CreateRPC`. Nothing enforces that agreement: the
+ * two live in different files, in different languages — one a template literal
+ * type, the other a `.slice()` — and a change to either is invisible to the
+ * other.
+ *
+ * So this test asserts no list of expected keys. It asks the checker for
+ * `keyof RPC` — the very type an app's `useQuery` call is constrained to — and
+ * requires the walker's key set to equal it. A route shape added to `ApiRouter`
+ * fails here until the walker learns it; a path rule that changes in either
+ * place fails here until it changes in both.
+ */
+
+/** The members of a `type X = …` union alias, as the checker resolves it. */
+function unionMembers(project: TestProject, fileName: string, aliasName: string): string[] {
+  const program = project.service.getProgram()!;
+  const sourceFile = program.getSourceFile(`/project/${fileName}`);
+  if (!sourceFile) throw new Error(`fixture ${fileName} is not in the program`);
+  const checker = program.getTypeChecker();
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isTypeAliasDeclaration(statement) || statement.name.text !== aliasName) continue;
+    const type = checker.getTypeAtLocation(statement.name);
+    const members = type.isUnion() ? type.types : [type];
+    const keys = members.map((member) =>
+      member.isStringLiteral() ? member.value : checker.typeToString(member),
+    );
+    // A fixture that failed to typecheck resolves to `never`/`any`, which would
+    // make an equality assertion pass against an empty set.
+    if (keys.length === 0 || keys.some((key) => key === "never" || key === "any")) {
+      throw new Error(`${aliasName} did not resolve to string literals: ${keys.join(", ")}`);
+    }
+    return keys.sort();
+  }
+  throw new Error(`no type alias ${aliasName} in ${fileName}`);
+}
+
+describe("the route table against the RPC types", () => {
+  const project = createFixture();
+  const table = tableFor(project);
+
+  test("reaches the app's routers through the gemi.d.ts augmentation", () => {
+    expect(table.diagnostics).toEqual([]);
+    expect(table.dependencies).toContain("/project/gemi.d.ts");
+    expect(table.dependencies).toContain("/project/app/http/routes/api.ts");
+    expect(table.dependencies).toContain("/project/app/http/routes/view.ts");
+  });
+
+  test("indexes exactly the API routes RPC exposes", () => {
+    const fromTypes = unionMembers(project, "keys.ts", "ApiKeys");
+    const fromWalk = [...table.api.values()]
+      .flat()
+      .filter((entry) => entry.inRpc)
+      .map((entry) => `${entry.verb}:${entry.path}`)
+      .sort();
+
+    expect(fromWalk).toEqual(fromTypes);
+
+    // Not a vacuous pass: the fixture declares every route shape the walker
+    // handles, and both sides have to reach all of them.
+    expect(fromTypes).toContain("GET:/org/:orgId/products");
+    expect(fromTypes).toContain("DELETE:/org/:orgId/products/:productId");
+    expect(fromTypes).toContain("GET:/grouped");
+    expect(fromTypes).toContain("POST:/thing");
+    expect(fromTypes.length).toBeGreaterThanOrEqual(16);
+  });
+
+  test("indexes the framework's own routes, at the prefix RPC mounts them under", () => {
+    // `client/rpc.ts` declares `RPC extends CreateRPC<AuthApiRouter, "/auth">`,
+    // so `useQuery("/auth/me")` typechecks in every gemi app. Discovery driven
+    // by the app's route config would find the app's routers and miss these.
+    const authPaths = [...table.api.keys()].filter((path) => path.startsWith("/auth/"));
+    expect(authPaths.length).toBeGreaterThan(0);
+
+    const target = table.api.get("/auth/me")?.[0]?.targets[0];
+    expect(target?.fileName).toContain("/auth/");
+  });
+
+  test("indexes exactly the view routes ViewRPC exposes", () => {
+    const fromTypes = unionMembers(project, "keys.ts", "ViewKeys");
+    const fromWalk = [...table.views.values()]
+      .flat()
+      .filter((entry) => entry.inRpc)
+      .map((entry) => `${entry.kind}:${entry.path}`)
+      .sort();
+
+    expect(fromWalk).toEqual(fromTypes);
+    expect(fromTypes).toContain("view:/auth/sign-in");
+    expect(fromTypes).toContain("layout:/org/:orgId");
+    expect(fromTypes).toContain("view:/pricing");
+  });
+
+  test("indexes the file and stream routes RPC drops, marked as such", () => {
+    const excluded = [...table.api.values()]
+      .flat()
+      .filter((entry) => !entry.inRpc)
+      .map((entry) => `${entry.verb}:${entry.path}`)
+      .sort();
+
+    expect(excluded).toEqual(["GET:/download", "GET:/video"]);
+  });
+});

--- a/packages/gemi/ide/typescript-plugin/testProject.ts
+++ b/packages/gemi/ide/typescript-plugin/testProject.ts
@@ -1,0 +1,146 @@
+import * as tsModule from "typescript";
+
+/**
+ * An in-memory TypeScript project, for exercising the plugin the way tsserver
+ * does.
+ *
+ * The plugin's whole job is to answer questions about a `LanguageService`, so
+ * the tests give it a real one rather than a stub — the same `getProgram()`, the
+ * same checker, the same `getDefinitionAndBoundSpan` underneath. Files live in a
+ * map instead of on disk, which keeps the fixtures readable inline and keeps the
+ * tests from depending on a template that may or may not be checked out.
+ */
+export interface TestProject {
+  ts: typeof tsModule;
+  service: tsModule.LanguageService;
+  projectRoot: string;
+  fileExists: (fileName: string) => boolean;
+  /** Byte offset of `marker` in `fileName`; throws if it is not there or not unique. */
+  offsetOf: (fileName: string, marker: string) => number;
+  /** `line:column` (1-based) of an offset, for readable assertions. */
+  locationOf: (fileName: string, offset: number) => string;
+  textAt: (fileName: string, span: tsModule.TextSpan) => string;
+  update: (fileName: string, content: string) => void;
+  /** The same version token the language service host reports. */
+  getScriptVersion: (fileName: string) => string;
+}
+
+const PROJECT_ROOT = "/project";
+
+const COMPILER_OPTIONS: tsModule.CompilerOptions = {
+  target: tsModule.ScriptTarget.ESNext,
+  module: tsModule.ModuleKind.ESNext,
+  moduleResolution: tsModule.ModuleResolutionKind.Bundler,
+  jsx: tsModule.JsxEmit.ReactJSX,
+  strict: true,
+  skipLibCheck: true,
+  noEmit: true,
+  paths: { "@/app/*": ["./app/*"] },
+  baseUrl: PROJECT_ROOT,
+};
+
+export function createTestProject(
+  files: Record<string, string>,
+  extraCompilerOptions: tsModule.CompilerOptions = {},
+): TestProject {
+  const compilerOptions: tsModule.CompilerOptions = {
+    ...COMPILER_OPTIONS,
+    ...extraCompilerOptions,
+    paths: { ...COMPILER_OPTIONS.paths, ...extraCompilerOptions.paths },
+  };
+  const contents = new Map<string, string>();
+  const versions = new Map<string, number>();
+
+  const write = (fileName: string, content: string) => {
+    const absolute = fileName.startsWith("/") ? fileName : `${PROJECT_ROOT}/${fileName}`;
+    contents.set(absolute, content);
+    versions.set(absolute, (versions.get(absolute) ?? 0) + 1);
+  };
+  for (const [fileName, content] of Object.entries(files)) write(fileName, content);
+
+  const defaultLib = tsModule.getDefaultLibFilePath(compilerOptions);
+
+  const host: tsModule.LanguageServiceHost = {
+    getScriptFileNames: () => [...contents.keys()],
+    getScriptVersion: (fileName) => String(versions.get(fileName) ?? 0),
+    getScriptSnapshot: (fileName) => {
+      const content = contents.get(fileName);
+      if (content !== undefined) return tsModule.ScriptSnapshot.fromString(content);
+      if (!tsModule.sys.fileExists(fileName)) return undefined;
+      return tsModule.ScriptSnapshot.fromString(tsModule.sys.readFile(fileName)!);
+    },
+    getCurrentDirectory: () => PROJECT_ROOT,
+    getCompilationSettings: () => compilerOptions,
+    getDefaultLibFileName: () => defaultLib,
+    fileExists: (fileName) => contents.has(fileName) || tsModule.sys.fileExists(fileName),
+    readFile: (fileName) => contents.get(fileName) ?? tsModule.sys.readFile(fileName),
+    readDirectory: tsModule.sys.readDirectory,
+    // Module resolution gives up on a directory it cannot see, and the virtual
+    // ones are not on disk — so `./rpc` next to `/project/app.ts` would not
+    // resolve without this.
+    directoryExists: (directory) =>
+      virtualDirectories().has(trimTrailingSlash(directory)) ||
+      tsModule.sys.directoryExists(directory),
+    getDirectories: (directory) =>
+      directory.startsWith(PROJECT_ROOT) ? [] : tsModule.sys.getDirectories(directory),
+    realpath: (fileName) => fileName,
+  };
+
+  function virtualDirectories(): Set<string> {
+    const directories = new Set<string>();
+    for (const fileName of contents.keys()) {
+      let directory = fileName.slice(0, fileName.lastIndexOf("/"));
+      while (directory.startsWith(PROJECT_ROOT)) {
+        directories.add(directory);
+        directory = directory.slice(0, directory.lastIndexOf("/"));
+      }
+    }
+    return directories;
+  }
+
+  function trimTrailingSlash(value: string): string {
+    return value.length > 1 && value.endsWith("/") ? value.slice(0, -1) : value;
+  }
+
+  const service = tsModule.createLanguageService(host, tsModule.createDocumentRegistry());
+
+  const contentOf = (fileName: string) => {
+    const absolute = fileName.startsWith("/") ? fileName : `${PROJECT_ROOT}/${fileName}`;
+    const content = contents.get(absolute);
+    if (content === undefined) throw new Error(`no such file in test project: ${absolute}`);
+    return content;
+  };
+
+  return {
+    ts: tsModule,
+    service,
+    projectRoot: PROJECT_ROOT,
+    fileExists: (fileName) => contents.has(fileName),
+    offsetOf(fileName, marker) {
+      const content = contentOf(fileName);
+      const first = content.indexOf(marker);
+      if (first === -1) throw new Error(`marker ${JSON.stringify(marker)} not in ${fileName}`);
+      if (content.indexOf(marker, first + 1) !== -1) {
+        throw new Error(`marker ${JSON.stringify(marker)} is not unique in ${fileName}`);
+      }
+      return first;
+    },
+    locationOf(fileName, offset) {
+      const content = contentOf(fileName);
+      const before = content.slice(0, offset);
+      const line = before.split("\n").length;
+      const column = offset - (before.lastIndexOf("\n") + 1) + 1;
+      return `${line}:${column}`;
+    },
+    textAt(fileName, span) {
+      return contentOf(fileName).slice(span.start, span.start + span.length);
+    },
+    update: write,
+    getScriptVersion: (fileName) => host.getScriptVersion(fileName),
+  };
+}
+
+/** Absolute path inside the test project, for comparing against tool output. */
+export function projectPath(relative: string): string {
+  return `${PROJECT_ROOT}/${relative}`;
+}

--- a/packages/gemi/ide/typescript-plugin/tsconfig.json
+++ b/packages/gemi/ide/typescript-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  // The plugin is checked here rather than through the package's main
+  // `tsconfig.json` for two reasons: that one emits declarations into `dist/`,
+  // and the plugin needs none — tsserver `require()`s the built JS and no
+  // TypeScript ever imports it — and it excludes `*.test.ts`, which for a
+  // directory this small leaves most of the code unchecked.
+  //
+  // So this config covers everything in the directory, tests and fixtures
+  // included, and emits nothing. `bun run typecheck` runs it.
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": false,
+    "types": ["node"]
+  },
+  "include": ["."]
+}

--- a/packages/gemi/ide/typescript-plugin/types.ts
+++ b/packages/gemi/ide/typescript-plugin/types.ts
@@ -1,0 +1,77 @@
+/** The `plugins` entry's options in an app's `tsconfig.json`. */
+export interface GemiPluginConfig {
+  /**
+   * Directory the app's `app/` folder sits in. Defaults to the directory
+   * holding the `tsconfig.json` that enabled the plugin, which is right unless
+   * the two have been separated.
+   */
+  projectRoot?: string;
+  /** Overrides `<projectRoot>/app/views` as where view components are found. */
+  viewsDir?: string;
+  /** Set to `false` to disable without editing the `plugins` array. */
+  enable?: boolean;
+}
+
+export type HttpVerb = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface Span {
+  start: number;
+  length: number;
+}
+
+export type TargetKind =
+  /** A method on a `Controller` — `this.get(HomeController, "index")`. */
+  | "controller-method"
+  /** An inline callback — `this.get(() => ...)`. */
+  | "inline-handler"
+  /** A view's React component file — `this.view("auth/SignIn")`. */
+  | "view-component"
+  /**
+   * The `routes` entry itself. Used when nothing more precise resolves, so a
+   * jump always lands somewhere useful rather than doing nothing.
+   */
+  | "route-entry";
+
+export interface RouteTarget {
+  fileName: string;
+  /** What to select on arrival — a handler's name, not its whole body. */
+  span: Span;
+  /** The surrounding declaration; editors use it to frame the landing span. */
+  contextSpan?: Span;
+  name: string;
+  containerName: string;
+  kind: TargetKind;
+}
+
+interface RouteEntryBase {
+  path: string;
+  targets: RouteTarget[];
+  /**
+   * Whether the route reaches the client's RPC types. `file`, `stream` and
+   * `proxy` routes are real routes that `CreateRPC` drops, so no typed call
+   * site can name them — they are indexed anyway, for hardcoded URLs.
+   */
+  inRpc: boolean;
+}
+
+export interface ApiRouteEntry extends RouteEntryBase {
+  verb: HttpVerb;
+}
+
+export interface ViewRouteEntry extends RouteEntryBase {
+  kind: "view" | "layout";
+}
+
+export interface RouteTable {
+  /** Path → one entry per verb declared at it. */
+  api: Map<string, ApiRouteEntry[]>;
+  /** Path → its view entry, plus the layout entry when a layout shares the path. */
+  views: Map<string, ViewRouteEntry[]>;
+  /**
+   * Every file whose contents the table was derived from. The plugin rebuilds
+   * when one of them changes and reuses the table when none has.
+   */
+  dependencies: string[];
+  /** Non-fatal problems worth surfacing in the tsserver log. */
+  diagnostics: string[];
+}

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -14,7 +14,8 @@
     "gemi-orm-generator": "./dist/bin/orm-generator.js"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "ide/typescript-plugin/package.json"
   ],
   "module": true,
   "exports": {
@@ -38,17 +39,19 @@
     "./orm": "./orm/index.ts",
     "./support": "./support/index.ts",
     "./console/run": "./console/run.ts",
+    "./ide/typescript-plugin": "./ide/typescript-plugin/index.ts",
     "./bun/preload": "./bun/preload.ts",
     "./bun/plugin": "./bun/plugin.ts"
   },
   "scripts": {
     "lint": "oxlint",
-    "typecheck": "tsc --noEmit -p tsconfig.json",
-    "build": "NODE_ENV=production bun run build:core && bun run build:bin && bun run build:types && bun run build:client && bun run build:plugin && bun run build:client-types && bun run build:augmentation",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p ide/typescript-plugin/tsconfig.json",
+    "build": "NODE_ENV=production bun run build:core && bun run build:bin && bun run build:types && bun run build:client && bun run build:plugin && bun run build:ts-plugin && bun run build:client-types && bun run build:augmentation",
     "build:core": "bun ./scripts/build.ts",
     "build:bin": "bun build --outdir=./dist/bin --target=bun --external=vite --external=react-dom --external=react/jsx-runtime --external=bun --external=sharp --external=@azure/storage-blob --sourcemap ./bin/gemi.ts ./bin/orm-generator.ts && bun ./scripts/prepare-bin.ts",
     "build:client": "rm -rf dist/client dist/testing dist/chunks && vite build -c vite.client.config.mts",
     "build:plugin": "vite build -c vite.plugin.config.mts",
+    "build:ts-plugin": "bun ./scripts/build-ts-plugin.ts",
     "build:types": "tsc",
     "build:client-types": "tsc -p tsconfig.browser.json",
     "test": "bun --bun vitest",

--- a/packages/gemi/scripts/build-publish.ts
+++ b/packages/gemi/scripts/build-publish.ts
@@ -56,6 +56,15 @@ delete publishPkg.devDependencies;
 await rm(STAGING, { recursive: true, force: true });
 await mkdir(STAGING, { recursive: true });
 await cp("dist", join(STAGING, "dist"), { recursive: true });
+// The one shipped file that is not build output. tsserver resolves a language
+// service plugin by Node directory rules and never reads `exports`, so
+// `gemi/ide/typescript-plugin` only resolves if this `package.json` is in the
+// tarball to point `main` at the built file. See the note beside it.
+await mkdir(join(STAGING, "ide", "typescript-plugin"), { recursive: true });
+await cp(
+  join("ide", "typescript-plugin", "package.json"),
+  join(STAGING, "ide", "typescript-plugin", "package.json"),
+);
 await Bun.write(
   join(STAGING, "package.json"),
   `${JSON.stringify(publishPkg, null, 2)}\n`,
@@ -133,6 +142,26 @@ for (const subpath of BARRELS) {
     );
     process.exit(1);
   }
+}
+
+// The plugin is the one entry whose loader ignores `exports`, so the check
+// above cannot speak for it: tsserver reaches it through
+// `ide/typescript-plugin/package.json`'s `main`. A tarball where that path
+// dangles installs fine and produces an editor that quietly has no route jumps,
+// with the reason buried in the tsserver log.
+const pluginShim = join(STAGING, "ide", "typescript-plugin", "package.json");
+const pluginMain = join(
+  STAGING,
+  "ide",
+  "typescript-plugin",
+  (await Bun.file(pluginShim).json()).main,
+);
+if (!(await Bun.file(pluginMain).exists())) {
+  console.error(
+    `Refusing to stage gemi@${pkg.version}: the TypeScript plugin's package.json ` +
+      `points main at ${pluginMain}, which was not built. Run \`bun run build:ts-plugin\`.`,
+  );
+  process.exit(1);
 }
 
 console.log(

--- a/packages/gemi/scripts/build-ts-plugin.ts
+++ b/packages/gemi/scripts/build-ts-plugin.ts
@@ -1,0 +1,42 @@
+/**
+ * Builds the TypeScript language service plugin.
+ *
+ * It cannot ride along in `scripts/build.ts`, which emits ESM for Bun. tsserver
+ * loads a plugin with `require()`, in Node, so this one has to be CommonJS with
+ * a Node target — and standalone, because `splitting: true` would hand it a
+ * shared chunk that `require()` cannot follow.
+ *
+ * `typescript` stays external on purpose. A plugin must use the copy tsserver
+ * injects, never one of its own: two copies means two sets of enum values and
+ * two `SyntaxKind` numberings, and the mismatch shows up as a plugin that
+ * silently matches nothing.
+ */
+const result = await Bun.build({
+  entrypoints: ["./ide/typescript-plugin/index.ts"],
+  outdir: "./dist/ide/typescript-plugin",
+  target: "node",
+  format: "cjs",
+  external: ["typescript"],
+  sourcemap: "external",
+  minify: false,
+});
+
+if (!result.success) {
+  console.error("TypeScript plugin build failed");
+  for (const message of result.logs) console.error(message);
+  process.exit(1);
+}
+
+// tsserver's `require` has to find `module.exports` as the initializer
+// function. A bundler that emits `exports.default = …` instead produces a
+// plugin the editor loads and then ignores, with nothing in the log to say so.
+const output = await Bun.file("./dist/ide/typescript-plugin/index.js").text();
+if (!/module\.exports\s*=/.test(output)) {
+  console.error(
+    "Refusing the built plugin: dist/ide/typescript-plugin/index.js does not assign " +
+      "module.exports, so tsserver would require() it and get an object it cannot call.",
+  );
+  process.exit(1);
+}
+
+console.log("Built dist/ide/typescript-plugin/index.js");

--- a/packages/gemi/tsconfig.json
+++ b/packages/gemi/tsconfig.json
@@ -14,7 +14,13 @@
   // shipped, none of them checked. (A sixth, `runtime`, was in that list until
   // it was deleted as dead.)
   //
-  // `client` is covered by tsconfig.browser.json instead.
+  // `client` is covered by tsconfig.browser.json instead, and
+  // `ide/typescript-plugin` by its own — see below.
+  //
+  // `ide/typescript-plugin` is excluded from *this* config but is not
+  // unchecked: it has its own `tsconfig.json`, which `bun run typecheck` also
+  // runs. It stays out of here because this config emits declarations into
+  // `dist/`, and the plugin needs none — tsserver `require()`s the built JS.
   //
   // KNOWINGLY EXCLUDED, and not for the reason it looks like: `bun/` holds two
   // public exports of its own — `./bun/preload` and `./bun/plugin` — so the

--- a/templates/saas-starter/tsconfig.json
+++ b/templates/saas-starter/tsconfig.json
@@ -19,6 +19,13 @@
     "paths": {
       "@/app/*": ["./app/*"]
     },
+    // Makes go-to-definition on a route path — `useQuery("/suspense-demo/metrics")`,
+    // `<Link href="/dashboard">` — jump to the handler or view behind it.
+    //
+    // VS Code ships its own TypeScript and ignores this unless told to use the
+    // workspace's: run "TypeScript: Select TypeScript Version → Use Workspace
+    // Version" once. Editors that drive tsserver over LSP need nothing extra.
+    "plugins": [{ "name": "gemi/ide/typescript-plugin" }],
     "types": ["vite/client", "bun"]
   }
 }


### PR DESCRIPTION
`useQuery("/reports")` names its handler as precisely as a call names a function — the string is checked against the router at compile time, and autocomplete offers only paths that exist. But the connection is made by conditional types rather than by a symbol, so go-to-definition has nothing to follow and stops at the literal. Reading one call site meant opening `api.ts`, finding the entry, and following it to the controller by hand.

This adds a TypeScript language service plugin that closes the gap, enabled with one line in an app's `tsconfig.json`:

```json
"plugins": [{ "name": "gemi/ide/typescript-plugin" }]
```

It answers on any typed path — `useQuery`, `useMutation`, `useMutate`, `Form`'s `action`, `Link`'s `href`, and wrappers an app writes over them — resolving to the controller method, the inline callback, the `resource()` method for that verb, or for a view both the component and its handler. Hover names the route and where its handler lives. Everything else is delegated untouched, and nothing here can throw: a surprise degrades to "not a route", because a broken jump beats an editor with no language features.

Verified against the `saas-starter` template through a live `tsserver`:

```
useQuery("/suspense-demo/metrics")   → SuspenseDemoController.metrics()
useQuery("/test")                    → HomeController.index()
<Link href="/about">                 → app/views/About.tsx + its handler
<Form action="/home">                → HomeController.post()      (POST default)
<Form action="/auth/sign-up">        → AuthController.signUp()    (framework route)
```

## Three decisions worth reviewing

**Routers are discovered by reading the `RPC` / `ViewRPC` interfaces, not the app's route config.** The interfaces are what the call site is typed against, and their heritage clauses carry the router *and* its prefix — including the framework's own `CreateRPC<AuthApiRouter, "/auth">`, so `/auth/me` is as jumpable as any app route. Config-driven discovery would have found the app's routers and missed it. Only the app's own files are scanned to find one declaration; the checker supplies the rest of the merge group, so `node_modules` is never walked.

**The verb comes from the parameter's constraint, with no hook name hardcoded anywhere.** `useQuery(url: T)` declares `T extends keyof GetRPC`, so the constraint of the parameter an argument fills *is* the GET route set; testing that set against each verb's paths identifies the verb. A path carrying both a GET and a POST resolves correctly from either hook, and an app's own wrapper works for free. `useMutation`'s `K extends keyof Methods[M]` does not resolve to literals (probed, not assumed), so that case falls back to reading a verb from the preceding argument — keyed off shape, not callee name — and JSX falls back to the attribute name.

**`rpcParity.test.ts` is the load-bearing test.** The walker's key set has to be character-identical to `keyof RPC`, and nothing else enforces that: one side is a template literal type, the other a `.slice()`. So it asks the checker for `keyof RPC` over the same fixture the walker reads and requires set equality. It immediately caught three misreadings of the types:

- `ParsePrefixAndKey<"/org", "/">` is `/org`, not `/org/`
- `/(app)/` joined to `/(admin)/users` really does produce `///users`
- `RemoveTrailingId<"/:id">` is `""`, not the `"X"` the type appears to promise

`routePath.ts` reproduces all three rather than correcting them, because matching the types is what makes a lookup possible at all.

## Packaging note

tsserver ignores the `exports` map and resolves a plugin by Node directory rules, so `ide/typescript-plugin/package.json` exists only to point `main` at the built file. `build-publish.ts` stages it explicitly and fails the publish if it dangles. See `WHY-PACKAGE-JSON.md`.

In-repo the plugin needs `bun run build:ts-plugin` before an editor can load it from the template; the published tarball always has it.

## Also

Fixes a doc error next door: `data-fetching.md` claimed `gemi ide:generate-api-manifest` regenerates `gemi.d.ts`. It does not — it builds the manifest behind the Emacs integration, and `gemi.d.ts` needs no regeneration.

## Checks

`bun --bun vitest run ide/typescript-plugin` → 55 passing. Full package suite green (3,477). `bun run typecheck` covers the new directory through its own `tsconfig.json`. Lint and `oxfmt` clean.

## Known follow-ups (not in this PR)

- `VIEW_EXTENSIONS` tries `.tsx/.jsx/.ts/.js`, but the runtime only ever resolves `app/views/<path>.tsx` — both `createRollupInput` and `httpProd`'s manifest lookup are `.tsx`-only. One-line fix.
- Go-to-definition and completions for the view path *inside* the router (`this.view("partial/Reports")`), which is untyped today — a typo compiles and renders the 404 view silently. Discussed but deliberately not implemented here.
- `bin/ide/generateApiManifest.ts` now overlaps with this walk and has gaps it does not (it reads a verb-map object as nested paths, and hardcodes `@/app` resolution). Left alone so the Emacs integration keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
