### PR TITLE
Events iteration 1: sync dispatch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Jobs & Queues](./jobs-and-queues.md)** — defining and dispatching background `Job`s.
 - **[Cron](./cron.md)** — scheduling recurring `CronJob`s.
 - **[Commands](./commands.md)** — one-off application commands run with `gemi run`.
+- **[Events & Listeners](./events.md)** — `Event.dispatch(...)` fanning out to the listeners under `app/listeners`.
 - **[Broadcasting](./broadcasting.md)** — websocket channels, the `Broadcast` facade, `useSubscription` / `useBroadcast`.
 - **[Internationalization](./i18n.md)** — component-scoped dictionaries, `useTranslator`, `useLocale`, locale detection.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -104,6 +104,8 @@ await UserRegistered.dispatchAndWait(user.id, user.email);
 
 It resolves once every listener has settled. Two methods rather than one that is sometimes worth awaiting, because "should I await this?" is a question the call site should not have to guess at.
 
+Listeners run **one at a time**, each awaited before the next one starts, so registration order is the order they run in and not merely the order they start. The cost is worth knowing: a listener that *hangs* — an un-timed-out request to a host that never answers — holds up every listener after it for as long as it hangs, and under `dispatch` the caller has already moved on, so the row a later listener writes is simply not there yet. A listener that can block indefinitely wants its own timeout, or a [job](./jobs-and-queues.md). A listener that *throws* is not this case — see below.
+
 Neither method ever rejects. See below.
 
 ## When a listener throws

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,242 @@
+# Events & Listeners
+
+An event is something your application did, announced to nobody in particular. A **listener** is one side effect of it, in its own file. One dispatch fans out to every listener bound to that event, and the code that dispatched it does not hold the list.
+
+```typescript
+// The controller stops knowing what happens next.
+const user = await User.create(input);
+UserRegistered.dispatch(user.id, user.email);
+```
+
+That is the whole of what this buys: adding a fourth side effect to a registration becomes **adding a file**, rather than editing the controller that already has three.
+
+Listeners run **in-process and synchronously** inside the dispatching request — see [When to reach for a job instead](#when-to-reach-for-a-job-instead).
+
+## Defining an event
+
+An event is a class extending `Event` (from `gemi/services`) with a **static `name`** and a constructor holding the payload. Events live wherever you like; `app/events/` is the convention.
+
+```typescript
+// app/events/UserRegistered.ts
+import { Event } from "gemi/services";
+
+export class UserRegistered extends Event {
+  static name = "UserRegistered";
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+```
+
+An event is the payload plus a name. It carries no framework state — no timestamp, no id, no "stop propagation" — because each of those is a field you can add yourself if you want one, and a listener that could cancel the listeners after it would make registration order matter (see [When a listener throws](#when-a-listener-throws)).
+
+> **Note:** The static `name` is **required**, and omitting it does not fall back harmlessly to the class name. The listener registry is keyed by this string. `gemi build` minifies the server entry, and the app code reachable from it — your controller, and every event class it imports in order to dispatch — is bundled and minified with it, which renames the class binding; a class's implicit `.name` *is* that binding, so `UserRegistered` becomes something like `D`. Discovery, meanwhile, imports `app/listeners/*.ts` from source at runtime, and those files import `app/events/*.ts` from source too. Two module graphs, two class objects, two different names — and the dispatch reaches nobody, in production and nowhere else. A declared `static name` is a string literal, which survives minification intact. Discovery warns at boot about any event a listener binds to that leaves it out.
+
+### Never `instanceof` an event
+
+The same two class objects are why this is unsafe **in your own code**:
+
+```typescript
+// Don't. `true` in development and in every test, `false` in a production build.
+if (event instanceof UserRegistered) { /* ... */ }
+```
+
+Your listener's `UserRegistered` came from source; the instance it was handed was built from the bundled one. Nothing the framework does can fix that, so the framework's job is to never need it — which is why a listener binds to exactly one event and always knows what it received.
+
+## Writing a listener
+
+A listener is a class extending `Listener` (from `gemi/services`) under `app/listeners/`, with a static `name`, a static `event`, and a `handle` method.
+
+```typescript
+// app/listeners/SendWelcomeEmail.ts
+import { Listener } from "gemi/services";
+import { UserRegistered } from "@/app/events/UserRegistered";
+
+export class SendWelcomeEmail extends Listener {
+  static name = "SendWelcomeEmail";
+  static event = UserRegistered;
+
+  async handle(event: UserRegistered) {
+    await sendWelcome(event.email);
+  }
+}
+```
+
+The directory is read at boot, so writing the file is all it takes — there is no list to keep alongside it.
+
+**The binding lives on the listener, not on the event.** The listener is the thing with an opinion about what it cares about; an event has no business knowing who is watching. An event listing its listeners would also put the property back the way it was: adding a side effect would mean editing an existing file.
+
+**Annotate `handle` with the event you bound to.** Narrowing the base class's `Event` parameter is legal and is how the payload gets typed without a generic to carry around. What the compiler *cannot* check is that the annotation and `static event` agree — a static and an instance member cannot reference each other's types. Copy a listener, change the static, forget the annotation, and TypeScript is satisfied while the listener receives something else. The failure is local and immediate (that one listener reads a field that is not there, in its own stack), which is why it is an accepted seam rather than a reason to complicate the API.
+
+### One event per listener
+
+There is no `static events = [A, B]`, deliberately. A listener bound to two events has to discriminate inside `handle`, and the natural way to write that is `event instanceof UserRegistered` — which is exactly the line that is `true` in every test and `false` in production. Two events wanting the same side effect are two small listeners calling one shared function.
+
+### Configurable fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `static name` | `string` | `"unset"` | Unique listener identifier. Required. |
+| `static event` | `Event` subclass | — | The one event this listener handles. Required. |
+| `handle` | method | — | The side effect. May be `async`. Required. |
+
+## Dispatching
+
+Call `dispatch` with exactly the arguments your event's constructor takes — the call is typed against it, the same way `Job.dispatch` is typed against `run`.
+
+```typescript
+import { UserRegistered } from "@/app/events/UserRegistered";
+
+UserRegistered.dispatch(user.id, user.email);
+```
+
+`dispatch` returns `void`. It fires the listeners and moves on; nothing they do can be reported back to the call site.
+
+When the caller genuinely needs the side effects to have happened first — a request that renders what a listener wrote, or a test asserting on the result — use `dispatchAndWait`:
+
+```typescript
+await UserRegistered.dispatchAndWait(user.id, user.email);
+```
+
+It resolves once every listener has settled. Two methods rather than one that is sometimes worth awaiting, because "should I await this?" is a question the call site should not have to guess at.
+
+Neither method ever rejects. See below.
+
+## When a listener throws
+
+Each listener runs inside its own `try`. A throw is logged with the event name, the listener name and the error, and **the next listener still runs**.
+
+That is not politeness, it is the point. Listeners are independent side effects, and their order comes from a filesystem walk rather than from anything you chose — so letting listener 2 cancel 3 through 5 would make that walk load-bearing, which is the exact coupling events exist to remove. For the same reason neither `dispatch` nor `dispatchAndWait` rejects: a rejection would make listener 1's failure the dispatcher's problem while listener 5's silently was not, depending only on where in the walk the throw landed.
+
+A listener that must not fail silently should handle its own errors — retry, log to your own sink, or dispatch a [job](./jobs-and-queues.md) that can be retried and dead-lettered.
+
+## When nothing is listening
+
+A dispatch with no listeners is legal and does nothing. In development it warns **once per event name**:
+
+```
+[gemi] UserRegistered was dispatched and nothing is listening for it. ...
+```
+
+That single line is the whole early-warning system here, because four different mistakes produce the same symptom: an event that never declared `static name`, a typo, a listener that was never discovered, and a listener directory that was never walked. It fires once per name so that a dispatch in a loop does not bury the terminal, and never in production, where "no listeners" is an ordinary answer.
+
+## Registering listeners — `app/listeners/`
+
+Every class under `app/listeners` that extends `Listener` is registered when the kernel boots.
+
+Event classes are **not** discovered, and there is no `eventsDir`. Each event is already in the module graph — imported by the listener that binds to it, and by the code that dispatches it — so a walk over them would only be a boot cost.
+
+### Two listeners, one name
+
+A listener's `static name` identifies it, and two classes cannot claim the same one. The first is registered, the second is refused with a line on stderr. A directory walk is what makes that ordinary: `auth/NotifyAdmins.ts` beside `billing/NotifyAdmins.ts` is a natural thing to write, and nothing forces the import alias a hand-written list would have demanded. Rename one.
+
+Both still appear in `registeredListeners`, which reports what the manager was handed rather than what it accepted, so a test walking it sees the clash.
+
+### A listener that binds to nothing stops the boot
+
+A `Listener` subclass with no `static event` cannot be registered under any name, so it would be a file you wrote that never runs. Discovery refuses it by name rather than warning, because there is no reading of it under which you meant it.
+
+The usual cause is a **shared abstract base living in `app/listeners`**. The walk excludes gemi's own `Listener` and nothing else, so a base beside its subclasses is discovered like one of them — and if it does declare a `static event`, it is *registered* like one of them too, constructed with its `handle` called on every dispatch of that event. Keep shared bases outside the listeners directory.
+
+### What the walk costs
+
+A class does not exist until its module has run, so there is no way to read a directory of classes without importing it. **Every `.ts`/`.tsx` file under `app/listeners` is imported at boot** — in development and in production, on every start — and a file that *does something* when it is imported does that thing at boot.
+
+So `app/listeners` wants to hold listener declarations rather than merely contain some. A file that cannot be imported at all fails the boot naming itself, rather than being quietly left out of the registry.
+
+The walk skips what certainly is not a declaration: `.d.ts` files, tests, type tests and benchmarks by their filename suffix, dot-directories, `node_modules`, and anything under a directory carrying its own `package.json`.
+
+Registration order is the walk's order — sorted per directory, and by name within a file. It is reproducible, and it is not meaningful: nothing about a directory layout was chosen to express "run this listener first", so no listener may depend on running before another.
+
+## Configuring — `app/config/events.ts`
+
+The `events` slice is where you can take over registration yourself. Declaring `listeners` turns discovery off and uses your list verbatim — reach for it when the listeners live somewhere the walk cannot reach, when you want a deliberate subset, or when the deploy ships only the build output and there is no `app/listeners` on disk to read.
+
+```typescript
+// app/config/events.ts
+import { defineEventConfig } from "gemi/services";
+import { SendWelcomeEmail } from "@/app/listeners/SendWelcomeEmail";
+
+export default defineEventConfig({
+  listeners: [SendWelcomeEmail], // omit to discover them from app/listeners
+});
+```
+
+`defineEventConfig` is an identity helper — it exists only to type the object.
+
+**A present `listeners` wins, and `listeners: []` is present.** An empty array means an application with no listeners and is honoured as such; it does not mean "go and find some". Leaving the key out — or leaving the slice out entirely — is what asks for discovery.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `listeners` | `Listener` subclasses | *discovered* | Every listener to register. Omit to discover them from `listenersDir`. |
+| `listenersDir` | `string` | `"app/listeners"` | Where to discover them. Relative to the project root, or absolute. |
+
+The slice is wired into the kernel by name:
+
+```typescript
+// app/kernel/Kernel.ts
+import { Kernel } from "gemi/kernel";
+import events from "../config/events";
+
+export default class extends Kernel {
+  config = { events /* , ...other slices */ };
+}
+```
+
+Behind the scenes the framework's `EventServiceProvider` reads that slice in its `register()` and binds an `EventManager` singleton into the container under the token `"events"`, then fills in the discovered listeners in its `boot()`.
+
+## Resolving the manager
+
+`EventManager` is a normal container binding:
+
+```typescript
+import { app } from "gemi/foundation";
+import { EventManager } from "gemi/services";
+
+app(EventManager); // typed EventManager, no cast
+```
+
+`registeredListeners` is the set it ended up with, discovered or declared — that is what a test asserts against:
+
+```typescript
+import { app } from "gemi/foundation";
+import { EventManager } from "gemi/services";
+
+expect(app(EventManager).registeredListeners).toHaveLength(3);
+```
+
+`discoverListeners()` answers the same question without an application around it. Every file it walks is imported, as above:
+
+```typescript
+import { discoverListeners } from "gemi/services";
+
+const listeners = await discoverListeners(); // every Listener under app/listeners
+```
+
+## When to reach for a job instead
+
+Listeners run **inside the dispatching request**, in the same process, in the same context: a listener has the request's `app()`, its authenticated user, and its ambient transaction. That makes them right for fast in-request side effects — writing an audit row, warming a cache, updating a counter — and wrong for slow ones, because the request waits for `dispatchAndWait` and the process still does the work either way.
+
+For anything slow or retryable, dispatch a [`Job`](./jobs-and-queues.md) from the listener. The queue is where retries, `maxAttempts`, dead-lettering and worker threads already live.
+
+Four mechanisms, one row each:
+
+| Mechanism | Fan-out | Where the handler runs |
+| --- | --- | --- |
+| a direct call in a controller | 1 → N | inline, and the caller names each one |
+| `Event.dispatch()` | 1 → N | inline, and the caller names none of them |
+| `Job.dispatch()` | 1 → 1 | the queue: retried, dead-lettered |
+| `Broadcast.publish()` | 1 → N | *clients*, over websockets |
+
+gemi has no ORM lifecycle events (`User.created` and friends) — a model write does not emit anything. Dispatch explicitly from the code that did the write.
+
+## Related
+
+- [Jobs & Queues](./jobs-and-queues.md) — background work with retries, which a listener often dispatches.
+- [Broadcasting](./broadcasting.md) — fan-out to browsers rather than to server-side handlers.
+- [Controllers](./controllers.md) — dispatching from request handlers.
+- [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,6 +129,7 @@
         <a class="card" href="jobs-and-queues.md"><span class="t">Jobs &amp; Queues</span><span class="d">Background Jobs through the in-process queue.</span></a>
         <a class="card" href="cron.md"><span class="t">Cron</span><span class="d">Recurring CronJobs with Bun.cron.</span></a>
         <a class="card" href="commands.md"><span class="t">Commands</span><span class="d">One-off application commands run with gemi run.</span></a>
+        <a class="card" href="events.md"><span class="t">Events &amp; Listeners</span><span class="d">Event.dispatch fanning out to listeners under app/listeners.</span></a>
         <a class="card" href="broadcasting.md"><span class="t">Broadcasting</span><span class="d">Websocket channels, Broadcast, useSubscription.</span></a>
         <a class="card" href="i18n.md"><span class="t">Internationalization</span><span class="d">Component-scoped dictionaries, useTranslator, useLocale.</span></a>
       </div>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -61,6 +61,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Email](./email.md)** — the `Email` class, jsx-email templates, the Resend driver, localization and scheduling.
 - **[Jobs & Queues](./jobs-and-queues.md)** — defining and dispatching background `Job`s.
 - **[Cron](./cron.md)** — scheduling recurring `CronJob`s.
+- **[Events & Listeners](./events.md)** — `Event.dispatch(...)` fanning out to the listeners under `app/listeners`.
 - **[Broadcasting](./broadcasting.md)** — websocket channels, the `Broadcast` facade, `useSubscription` / `useBroadcast`.
 - **[Internationalization](./i18n.md)** — component-scoped dictionaries, `useTranslator`, `useLocale`, locale detection.
 
@@ -8699,6 +8700,252 @@ Use a **command** for work a person starts, by hand, once. Use a [**cron job**](
 - [CLI](./cli.md) — `gemi run` and every other command.
 - [Cron](./cron.md) — recurring scheduled work.
 - [Jobs & Queues](./jobs-and-queues.md) — background work triggered on demand.
+- [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.
+
+
+---
+
+## Events & Listeners
+
+An event is something your application did, announced to nobody in particular. A **listener** is one side effect of it, in its own file. One dispatch fans out to every listener bound to that event, and the code that dispatched it does not hold the list.
+
+```typescript
+// The controller stops knowing what happens next.
+const user = await User.create(input);
+UserRegistered.dispatch(user.id, user.email);
+```
+
+That is the whole of what this buys: adding a fourth side effect to a registration becomes **adding a file**, rather than editing the controller that already has three.
+
+Listeners run **in-process and synchronously** inside the dispatching request — see [When to reach for a job instead](#when-to-reach-for-a-job-instead).
+
+## Defining an event
+
+An event is a class extending `Event` (from `gemi/services`) with a **static `name`** and a constructor holding the payload. Events live wherever you like; `app/events/` is the convention.
+
+```typescript
+// app/events/UserRegistered.ts
+import { Event } from "gemi/services";
+
+export class UserRegistered extends Event {
+  static name = "UserRegistered";
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+```
+
+An event is the payload plus a name. It carries no framework state — no timestamp, no id, no "stop propagation" — because each of those is a field you can add yourself if you want one, and a listener that could cancel the listeners after it would make registration order matter (see [When a listener throws](#when-a-listener-throws)).
+
+> **Note:** The static `name` is **required**, and omitting it does not fall back harmlessly to the class name. The listener registry is keyed by this string. `gemi build` minifies the server entry, and the app code reachable from it — your controller, and every event class it imports in order to dispatch — is bundled and minified with it, which renames the class binding; a class's implicit `.name` *is* that binding, so `UserRegistered` becomes something like `D`. Discovery, meanwhile, imports `app/listeners/*.ts` from source at runtime, and those files import `app/events/*.ts` from source too. Two module graphs, two class objects, two different names — and the dispatch reaches nobody, in production and nowhere else. A declared `static name` is a string literal, which survives minification intact. Discovery warns at boot about any event a listener binds to that leaves it out.
+
+### Never `instanceof` an event
+
+The same two class objects are why this is unsafe **in your own code**:
+
+```typescript
+// Don't. `true` in development and in every test, `false` in a production build.
+if (event instanceof UserRegistered) { /* ... */ }
+```
+
+Your listener's `UserRegistered` came from source; the instance it was handed was built from the bundled one. Nothing the framework does can fix that, so the framework's job is to never need it — which is why a listener binds to exactly one event and always knows what it received.
+
+## Writing a listener
+
+A listener is a class extending `Listener` (from `gemi/services`) under `app/listeners/`, with a static `name`, a static `event`, and a `handle` method.
+
+```typescript
+// app/listeners/SendWelcomeEmail.ts
+import { Listener } from "gemi/services";
+import { UserRegistered } from "@/app/events/UserRegistered";
+
+export class SendWelcomeEmail extends Listener {
+  static name = "SendWelcomeEmail";
+  static event = UserRegistered;
+
+  async handle(event: UserRegistered) {
+    await sendWelcome(event.email);
+  }
+}
+```
+
+The directory is read at boot, so writing the file is all it takes — there is no list to keep alongside it.
+
+**The binding lives on the listener, not on the event.** The listener is the thing with an opinion about what it cares about; an event has no business knowing who is watching. An event listing its listeners would also put the property back the way it was: adding a side effect would mean editing an existing file.
+
+**Annotate `handle` with the event you bound to.** Narrowing the base class's `Event` parameter is legal and is how the payload gets typed without a generic to carry around. What the compiler *cannot* check is that the annotation and `static event` agree — a static and an instance member cannot reference each other's types. Copy a listener, change the static, forget the annotation, and TypeScript is satisfied while the listener receives something else. The failure is local and immediate (that one listener reads a field that is not there, in its own stack), which is why it is an accepted seam rather than a reason to complicate the API.
+
+### One event per listener
+
+There is no `static events = [A, B]`, deliberately. A listener bound to two events has to discriminate inside `handle`, and the natural way to write that is `event instanceof UserRegistered` — which is exactly the line that is `true` in every test and `false` in production. Two events wanting the same side effect are two small listeners calling one shared function.
+
+### Configurable fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `static name` | `string` | `"unset"` | Unique listener identifier. Required. |
+| `static event` | `Event` subclass | — | The one event this listener handles. Required. |
+| `handle` | method | — | The side effect. May be `async`. Required. |
+
+## Dispatching
+
+Call `dispatch` with exactly the arguments your event's constructor takes — the call is typed against it, the same way `Job.dispatch` is typed against `run`.
+
+```typescript
+import { UserRegistered } from "@/app/events/UserRegistered";
+
+UserRegistered.dispatch(user.id, user.email);
+```
+
+`dispatch` returns `void`. It fires the listeners and moves on; nothing they do can be reported back to the call site.
+
+When the caller genuinely needs the side effects to have happened first — a request that renders what a listener wrote, or a test asserting on the result — use `dispatchAndWait`:
+
+```typescript
+await UserRegistered.dispatchAndWait(user.id, user.email);
+```
+
+It resolves once every listener has settled. Two methods rather than one that is sometimes worth awaiting, because "should I await this?" is a question the call site should not have to guess at.
+
+Neither method ever rejects. See below.
+
+## When a listener throws
+
+Each listener runs inside its own `try`. A throw is logged with the event name, the listener name and the error, and **the next listener still runs**.
+
+That is not politeness, it is the point. Listeners are independent side effects, and their order comes from a filesystem walk rather than from anything you chose — so letting listener 2 cancel 3 through 5 would make that walk load-bearing, which is the exact coupling events exist to remove. For the same reason neither `dispatch` nor `dispatchAndWait` rejects: a rejection would make listener 1's failure the dispatcher's problem while listener 5's silently was not, depending only on where in the walk the throw landed.
+
+A listener that must not fail silently should handle its own errors — retry, log to your own sink, or dispatch a [job](./jobs-and-queues.md) that can be retried and dead-lettered.
+
+## When nothing is listening
+
+A dispatch with no listeners is legal and does nothing. In development it warns **once per event name**:
+
+```
+[gemi] UserRegistered was dispatched and nothing is listening for it. ...
+```
+
+That single line is the whole early-warning system here, because four different mistakes produce the same symptom: an event that never declared `static name`, a typo, a listener that was never discovered, and a listener directory that was never walked. It fires once per name so that a dispatch in a loop does not bury the terminal, and never in production, where "no listeners" is an ordinary answer.
+
+## Registering listeners — `app/listeners/`
+
+Every class under `app/listeners` that extends `Listener` is registered when the kernel boots.
+
+Event classes are **not** discovered, and there is no `eventsDir`. Each event is already in the module graph — imported by the listener that binds to it, and by the code that dispatches it — so a walk over them would only be a boot cost.
+
+### Two listeners, one name
+
+A listener's `static name` identifies it, and two classes cannot claim the same one. The first is registered, the second is refused with a line on stderr. A directory walk is what makes that ordinary: `auth/NotifyAdmins.ts` beside `billing/NotifyAdmins.ts` is a natural thing to write, and nothing forces the import alias a hand-written list would have demanded. Rename one.
+
+Both still appear in `registeredListeners`, which reports what the manager was handed rather than what it accepted, so a test walking it sees the clash.
+
+### A listener that binds to nothing stops the boot
+
+A `Listener` subclass with no `static event` cannot be registered under any name, so it would be a file you wrote that never runs. Discovery refuses it by name rather than warning, because there is no reading of it under which you meant it.
+
+The usual cause is a **shared abstract base living in `app/listeners`**. The walk excludes gemi's own `Listener` and nothing else, so a base beside its subclasses is discovered like one of them — and if it does declare a `static event`, it is *registered* like one of them too, constructed with its `handle` called on every dispatch of that event. Keep shared bases outside the listeners directory.
+
+### What the walk costs
+
+A class does not exist until its module has run, so there is no way to read a directory of classes without importing it. **Every `.ts`/`.tsx` file under `app/listeners` is imported at boot** — in development and in production, on every start — and a file that *does something* when it is imported does that thing at boot.
+
+So `app/listeners` wants to hold listener declarations rather than merely contain some. A file that cannot be imported at all fails the boot naming itself, rather than being quietly left out of the registry.
+
+The walk skips what certainly is not a declaration: `.d.ts` files, tests, type tests and benchmarks by their filename suffix, dot-directories, `node_modules`, and anything under a directory carrying its own `package.json`.
+
+Registration order is the walk's order — sorted per directory, and by name within a file. It is reproducible, and it is not meaningful: nothing about a directory layout was chosen to express "run this listener first", so no listener may depend on running before another.
+
+## Configuring — `app/config/events.ts`
+
+The `events` slice is where you can take over registration yourself. Declaring `listeners` turns discovery off and uses your list verbatim — reach for it when the listeners live somewhere the walk cannot reach, when you want a deliberate subset, or when the deploy ships only the build output and there is no `app/listeners` on disk to read.
+
+```typescript
+// app/config/events.ts
+import { defineEventConfig } from "gemi/services";
+import { SendWelcomeEmail } from "@/app/listeners/SendWelcomeEmail";
+
+export default defineEventConfig({
+  listeners: [SendWelcomeEmail], // omit to discover them from app/listeners
+});
+```
+
+`defineEventConfig` is an identity helper — it exists only to type the object.
+
+**A present `listeners` wins, and `listeners: []` is present.** An empty array means an application with no listeners and is honoured as such; it does not mean "go and find some". Leaving the key out — or leaving the slice out entirely — is what asks for discovery.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `listeners` | `Listener` subclasses | *discovered* | Every listener to register. Omit to discover them from `listenersDir`. |
+| `listenersDir` | `string` | `"app/listeners"` | Where to discover them. Relative to the project root, or absolute. |
+
+The slice is wired into the kernel by name:
+
+```typescript
+// app/kernel/Kernel.ts
+import { Kernel } from "gemi/kernel";
+import events from "../config/events";
+
+export default class extends Kernel {
+  config = { events /* , ...other slices */ };
+}
+```
+
+Behind the scenes the framework's `EventServiceProvider` reads that slice in its `register()` and binds an `EventManager` singleton into the container under the token `"events"`, then fills in the discovered listeners in its `boot()`.
+
+## Resolving the manager
+
+`EventManager` is a normal container binding:
+
+```typescript
+import { app } from "gemi/foundation";
+import { EventManager } from "gemi/services";
+
+app(EventManager); // typed EventManager, no cast
+```
+
+`registeredListeners` is the set it ended up with, discovered or declared — that is what a test asserts against:
+
+```typescript
+import { app } from "gemi/foundation";
+import { EventManager } from "gemi/services";
+
+expect(app(EventManager).registeredListeners).toHaveLength(3);
+```
+
+`discoverListeners()` answers the same question without an application around it. Every file it walks is imported, as above:
+
+```typescript
+import { discoverListeners } from "gemi/services";
+
+const listeners = await discoverListeners(); // every Listener under app/listeners
+```
+
+## When to reach for a job instead
+
+Listeners run **inside the dispatching request**, in the same process, in the same context: a listener has the request's `app()`, its authenticated user, and its ambient transaction. That makes them right for fast in-request side effects — writing an audit row, warming a cache, updating a counter — and wrong for slow ones, because the request waits for `dispatchAndWait` and the process still does the work either way.
+
+For anything slow or retryable, dispatch a [`Job`](./jobs-and-queues.md) from the listener. The queue is where retries, `maxAttempts`, dead-lettering and worker threads already live.
+
+Four mechanisms, one row each:
+
+| Mechanism | Fan-out | Where the handler runs |
+| --- | --- | --- |
+| a direct call in a controller | 1 → N | inline, and the caller names each one |
+| `Event.dispatch()` | 1 → N | inline, and the caller names none of them |
+| `Job.dispatch()` | 1 → 1 | the queue: retried, dead-lettered |
+| `Broadcast.publish()` | 1 → N | *clients*, over websockets |
+
+gemi has no ORM lifecycle events (`User.created` and friends) — a model write does not emit anything. Dispatch explicitly from the code that did the write.
+
+## Related
+
+- [Jobs & Queues](./jobs-and-queues.md) — background work with retries, which a listener often dispatches.
+- [Broadcasting](./broadcasting.md) — fan-out to browsers rather than to server-side handlers.
+- [Controllers](./controllers.md) — dispatching from request handlers.
 - [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.
 
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -56,11 +56,13 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Authorization](./authorization.md)** — role-based middleware and authorization errors.
 
 ### Services & facades
+- **[Services](./services.md)** — your own singletons: `Service`, `boot()`, and constructor-default injection.
 - **[Facades](./facades.md)** — reference for `Auth`, `Redirect`, `Lang`, `Storage`, `Query`, `Broadcast`, `Url`, `Log`, `Meta`, `Cookie`, `Redis`.
 - **[File Storage](./file-storage.md)** — the `Storage` facade, filesystem/S3 drivers, image optimization, the `Image` component.
 - **[Email](./email.md)** — the `Email` class, jsx-email templates, the Resend driver, localization and scheduling.
 - **[Jobs & Queues](./jobs-and-queues.md)** — defining and dispatching background `Job`s.
 - **[Cron](./cron.md)** — scheduling recurring `CronJob`s.
+- **[Commands](./commands.md)** — one-off application commands run with `gemi run`.
 - **[Events & Listeners](./events.md)** — `Event.dispatch(...)` fanning out to the listeners under `app/listeners`.
 - **[Broadcasting](./broadcasting.md)** — websocket channels, the `Broadcast` facade, `useSubscription` / `useBroadcast`.
 - **[Internationalization](./i18n.md)** — component-scoped dictionaries, `useTranslator`, `useLocale`, locale detection.
@@ -326,15 +328,17 @@ If present, `app/preload.ts` runs once, before the server starts, for both `gemi
 - **`i18n/`** — translation dictionaries created with `Dictionary.create` from `gemi/i18n`, exported as a single default object.
 - **`database/prisma.ts`** — your Prisma client instance, imported wherever you query the database.
 
-### `cron/`, `jobs/` and `commands/` — the three discovered directories
+### `cron/`, `jobs/`, `listeners/` and `commands/` — the four discovered directories
 
-These directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, every class under `app/jobs` extending `Job` is registered at boot, and every command under `app/commands` is available to `gemi run` — with nothing anywhere naming them. Writing the file is the registration. The `schedule`, `queue` and `command` slices can still declare their list explicitly, which turns the walk off and uses the declared list verbatim; an empty array is a declaration too, and means an app with none.
+These directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, every class under `app/jobs` extending `Job` is registered at boot, every class under `app/listeners` extending `Listener` is bound to the event it declares at boot, and every command under `app/commands` is available to `gemi run` — with nothing anywhere naming them. Writing the file is the registration. The `schedule`, `queue`, `events` and `command` slices can still declare their list explicitly, which turns the walk off and uses the declared list verbatim; an empty array is a declaration too, and means an app with none.
+
+`app/listeners` is the one the scaffold does not create — the template ships no listeners, and the directory is simply absent until you write the first one, which is not an error.
 
 Discovery imports every `.ts`/`.tsx` file it walks, because a class does not exist until its module has run — so a file in one of these directories that does work when imported does that work when the directory is read. Keep them to declarations.
 
-`app/commands` differs in **when** it is read: cron and queue discovery happen during boot, because a tick or a dispatch can arrive at any moment afterwards, while commands are walked only by `gemi run`. A registry no request consults has no reason to cost every production process an import of every file under it.
+`app/commands` differs in **when** it is read: cron, queue and listener discovery happen during boot, because a tick or a dispatch can arrive at any moment afterwards, while commands are walked only by `gemi run`. A registry no request consults has no reason to cost every production process an import of every file under it.
 
-See [Cron](./cron.md), [Jobs & Queues](./jobs-and-queues.md) and [Commands](./commands.md) for the walk's skip rules and the reasons for reading a directory at all.
+See [Cron](./cron.md), [Jobs & Queues](./jobs-and-queues.md), [Events & Listeners](./events.md) and [Commands](./commands.md) for the walk's skip rules and the reasons for reading a directory at all.
 
 ## The Kernel
 
@@ -514,6 +518,8 @@ export default defineMiddlewareConfig({
 | `image` | `defineImageConfig` | `gemi/services` |
 | `ratelimiter` | `defineRateLimiterConfig` | `gemi/services` |
 | `schedule` | `defineScheduleConfig` | `gemi/services` |
+| `events` | `defineEventConfig` | `gemi/services` |
+| `command` | `defineCommandConfig` | `gemi/services` |
 | `route` | `defineRouteConfig` | `gemi/services` |
 | `translation` | `defineTranslationConfig` | `gemi/i18n` (also re-exported from `gemi/services`) |
 | `middleware` | `defineMiddlewareConfig` | `gemi/http` |
@@ -8810,6 +8816,8 @@ await UserRegistered.dispatchAndWait(user.id, user.email);
 ```
 
 It resolves once every listener has settled. Two methods rather than one that is sometimes worth awaiting, because "should I await this?" is a question the call site should not have to guess at.
+
+Listeners run **one at a time**, each awaited before the next one starts, so registration order is the order they run in and not merely the order they start. The cost is worth knowing: a listener that *hangs* — an un-timed-out request to a host that never answers — holds up every listener after it for as long as it hangs, and under `dispatch` the caller has already moved on, so the row a later listener writes is simply not there yet. A listener that can block indefinitely wants its own timeout, or a [job](./jobs-and-queues.md). A listener that *throws* is not this case — see below.
 
 Neither method ever rejects. See below.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -46,6 +46,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Jobs & Queues](https://nstfkc.github.io/gemi/jobs-and-queues.md): defining and dispatching background Jobs through the in-process queue.
 - [Cron](https://nstfkc.github.io/gemi/cron.md): scheduling recurring CronJobs with Bun.cron.
 - [Commands](https://nstfkc.github.io/gemi/commands.md): one-off application commands written with defineCommand and run with `gemi run <name>`.
+- [Events & Listeners](https://nstfkc.github.io/gemi/events.md): Event subclasses dispatched with Event.dispatch/dispatchAndWait, Listener subclasses under app/listeners bound with `static event`, sync fan-out that no listener can cancel.
 - [Broadcasting](https://nstfkc.github.io/gemi/broadcasting.md): websocket channels, the Broadcast facade, useSubscription/useBroadcast.
 - [Internationalization](https://nstfkc.github.io/gemi/i18n.md): component-scoped dictionaries, useTranslator, useLocale, locale detection.
 
@@ -54,6 +55,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - Application commands are `defineCommand(...).handle(...)` chains under `app/commands`, run with `gemi run <name>` — a chain, not a class, because a class body cannot type its own handler.
 - The client query hook is `useQuery` (not `useGet`).
 - The server-side `Redirect` facade works by throwing — never wrap it in try/catch.
+- An event declares `static name` and a listener binds to it with `static event`; never `instanceof` an event in application code, because a production build and the listener walk hold two different class objects for it.
 - Middleware is a string DSL (`auth`, `cache:...`, `rate-limit:N`); `-name` cancels an inherited middleware.
 - The typed network layer needs no codegen: the `RPC` / `ViewRPC` augmentation ships inside the package. An app upgrading from 0.55 or earlier must delete its root `gemi.d.ts` and its `types` entry.
 - Runtime config lives in `app/config/*.ts` (`defineMailConfig`, `defineAuthConfig`, …) and is read through `Repository` from `gemi/support`. `gemi.config.ts` / `gemi/config` is the unrelated BUILD config.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -85,15 +85,17 @@ If present, `app/preload.ts` runs once, before the server starts, for both `gemi
 - **`i18n/`** — translation dictionaries created with `Dictionary.create` from `gemi/i18n`, exported as a single default object.
 - **`database/prisma.ts`** — your Prisma client instance, imported wherever you query the database.
 
-### `cron/`, `jobs/` and `commands/` — the three discovered directories
+### `cron/`, `jobs/`, `listeners/` and `commands/` — the four discovered directories
 
-These directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, every class under `app/jobs` extending `Job` is registered at boot, and every command under `app/commands` is available to `gemi run` — with nothing anywhere naming them. Writing the file is the registration. The `schedule`, `queue` and `command` slices can still declare their list explicitly, which turns the walk off and uses the declared list verbatim; an empty array is a declaration too, and means an app with none.
+These directories are read, not listed. Every class under `app/cron` extending `CronJob` is scheduled at boot, every class under `app/jobs` extending `Job` is registered at boot, every class under `app/listeners` extending `Listener` is bound to the event it declares at boot, and every command under `app/commands` is available to `gemi run` — with nothing anywhere naming them. Writing the file is the registration. The `schedule`, `queue`, `events` and `command` slices can still declare their list explicitly, which turns the walk off and uses the declared list verbatim; an empty array is a declaration too, and means an app with none.
+
+`app/listeners` is the one the scaffold does not create — the template ships no listeners, and the directory is simply absent until you write the first one, which is not an error.
 
 Discovery imports every `.ts`/`.tsx` file it walks, because a class does not exist until its module has run — so a file in one of these directories that does work when imported does that work when the directory is read. Keep them to declarations.
 
-`app/commands` differs in **when** it is read: cron and queue discovery happen during boot, because a tick or a dispatch can arrive at any moment afterwards, while commands are walked only by `gemi run`. A registry no request consults has no reason to cost every production process an import of every file under it.
+`app/commands` differs in **when** it is read: cron, queue and listener discovery happen during boot, because a tick or a dispatch can arrive at any moment afterwards, while commands are walked only by `gemi run`. A registry no request consults has no reason to cost every production process an import of every file under it.
 
-See [Cron](./cron.md), [Jobs & Queues](./jobs-and-queues.md) and [Commands](./commands.md) for the walk's skip rules and the reasons for reading a directory at all.
+See [Cron](./cron.md), [Jobs & Queues](./jobs-and-queues.md), [Events & Listeners](./events.md) and [Commands](./commands.md) for the walk's skip rules and the reasons for reading a directory at all.
 
 ## The Kernel
 
@@ -273,6 +275,8 @@ export default defineMiddlewareConfig({
 | `image` | `defineImageConfig` | `gemi/services` |
 | `ratelimiter` | `defineRateLimiterConfig` | `gemi/services` |
 | `schedule` | `defineScheduleConfig` | `gemi/services` |
+| `events` | `defineEventConfig` | `gemi/services` |
+| `command` | `defineCommandConfig` | `gemi/services` |
 | `route` | `defineRouteConfig` | `gemi/services` |
 | `translation` | `defineTranslationConfig` | `gemi/i18n` (also re-exported from `gemi/services`) |
 | `middleware` | `defineMiddlewareConfig` | `gemi/http` |

--- a/packages/gemi/kernel/providers.ts
+++ b/packages/gemi/kernel/providers.ts
@@ -4,6 +4,7 @@ import { DatabaseServiceProvider } from "../database/DatabaseServiceProvider";
 import { TranslationServiceProvider } from "../i18n/TranslationServiceProvider";
 import { ScheduleServiceProvider } from "../services/cron/ScheduleServiceProvider";
 import { MailServiceProvider } from "../services/email/MailServiceProvider";
+import { EventServiceProvider } from "../services/events/EventServiceProvider";
 import { FilesystemServiceProvider } from "../services/file-storage/FilesystemServiceProvider";
 import { ImageServiceProvider } from "../services/image-optimization/ImageServiceProvider";
 import { KernelIdServiceProvider } from "../services/kernel-id/KernelIdServiceProvider";
@@ -16,12 +17,17 @@ import { RedisServiceProvider } from "../services/redis/RedisServiceProvider";
 import { RouteServiceProvider } from "../services/router/RouteServiceProvider";
 
 /**
- * The providers every gemi app boots with, in registration order. Fifteen
- * providers for sixteen services — `RouteServiceProvider` owns both the api and
- * the view dispatcher, the way Laravel's does.
+ * The providers every gemi app boots with, in registration order. Sixteen
+ * providers for seventeen services — `RouteServiceProvider` owns both the api
+ * and the view dispatcher, the way Laravel's does.
  *
  * Order only matters for `boot()`; `register()` binds factories and resolves
  * nothing, so no provider here depends on an earlier one having run.
+ *
+ * `EventServiceProvider` sits after `QueueServiceProvider` for a dependency it
+ * does not have yet: a queued listener is registered as a job, so its `boot()`
+ * will want the queue's registry already populated. Placing it here now saves
+ * reordering this list from a patch that is about something else.
  */
 export const frameworkProviders: ServiceProviderConstructor[] = [
   KernelIdServiceProvider,
@@ -33,6 +39,7 @@ export const frameworkProviders: ServiceProviderConstructor[] = [
   LogServiceProvider,
   FilesystemServiceProvider,
   QueueServiceProvider,
+  EventServiceProvider,
   RedisServiceProvider,
   BroadcastServiceProvider,
   ImageServiceProvider,

--- a/packages/gemi/services/discovery.test.ts
+++ b/packages/gemi/services/discovery.test.ts
@@ -17,7 +17,16 @@ import type { ConfigItems } from "../support/Repository";
 import { Scheduler } from "./cron/Scheduler";
 import { ScheduleServiceProvider } from "./cron/ScheduleServiceProvider";
 import { CronJob } from "./cron/CronJob";
-import { discoverCommands, discoverCronJobs, discoverJobs } from "./discovery";
+import {
+  discoverCommands,
+  discoverCronJobs,
+  discoverJobs,
+  discoverListeners,
+} from "./discovery";
+import { EventManager } from "./events/EventManager";
+import { EventServiceProvider } from "./events/EventServiceProvider";
+import { Event } from "./events/Event";
+import { Listener } from "./events/Listener";
 import { Job } from "./queue/Job";
 import { QueueManager } from "./queue/QueueManager";
 import { QueueServiceProvider } from "./queue/QueueServiceProvider";
@@ -78,6 +87,38 @@ export class ${name} extends CronJob {
   cron = ${JSON.stringify(expression)};
 }`;
 
+const EVENT = JSON.stringify(resolve(import.meta.dirname, "events/Event.ts"));
+const LISTENER = JSON.stringify(
+  resolve(import.meta.dirname, "events/Listener.ts"),
+);
+
+/**
+ * An `Event` subclass. `declared` picks which of the two spellings of a name it
+ * gets — the string literal that survives a production build, or the implicit
+ * class binding that does not. Both read the same in development, which is the
+ * whole reason the check on them is on the property descriptor.
+ */
+const event = (name: string, declared = true) => `import { Event } from ${EVENT};
+export class ${name} extends Event {
+  ${declared ? `static name = ${JSON.stringify(name)};` : ""}
+}`;
+
+/**
+ * A `Listener` bound to an event it imports the way an app would — from
+ * `app/events`, a directory nothing walks.
+ */
+const listener = (
+  name: string,
+  eventName: string,
+  { from = "../events", declared = true } = {},
+) => `import { Listener } from ${LISTENER};
+import { ${eventName} } from "${from}/${eventName}";
+export class ${name} extends Listener {
+  ${declared ? `static name = ${JSON.stringify(name)};` : ""}
+  static event = ${eventName};
+  handle() {}
+}`;
+
 /**
  * Boots an application holding nothing but the provider under test, the way
  * `RateLimitMiddleware.test.ts` does — a real container, so the register/boot
@@ -85,7 +126,10 @@ export class ${name} extends CronJob {
  */
 async function boot(
   config: ConfigItems,
-  Provider: typeof QueueServiceProvider | typeof ScheduleServiceProvider,
+  Provider:
+    | typeof QueueServiceProvider
+    | typeof ScheduleServiceProvider
+    | typeof EventServiceProvider,
 ) {
   const application = new Application(new Repository(config));
   applications.push(application);
@@ -503,6 +547,368 @@ export const config = { retries: 3 };`,
         (command) => command.commandName,
       ),
     ).toEqual(["db:seed"]);
+  });
+});
+
+/**
+ * Listeners, the fourth directory discovery reads.
+ *
+ * The walk is the same one, so the skip rules are covered above. What is
+ * specific here is that a listener carries a *second* class — the event it
+ * binds to — and the registry is keyed by that event's name. So there are two
+ * name checks rather than one, and the second is the one that matters from the
+ * first dispatch: an event whose name is the implicit class binding is renamed
+ * by a production build on the dispatching side while discovery reads the
+ * listener's copy from source, and the dispatch then reaches nobody, silently
+ * and in production only.
+ */
+describe("asking an application what listeners it has", () => {
+  test("finds every Listener subclass under the directory, nested included", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/events/OrderPaid.ts": event("OrderPaid"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+      "app/listeners/billing/IssueReceipt.ts": listener(
+        "IssueReceipt",
+        "OrderPaid",
+        { from: "../../events" },
+      ),
+    });
+
+    // The walk's order: entries are sorted per directory, and capitals sort
+    // before lowercase, so the file beats the directory beside it. Reproducible
+    // — which is all it is. Nothing may depend on one listener running before
+    // another, because nothing about a filesystem layout was chosen to say so.
+    expect(names(await discoverListeners(join(root, "app/listeners")))).toEqual([
+      "SendWelcomeEmail",
+      "IssueReceipt",
+    ]);
+  });
+
+  test("never returns the base class, however it got re-exported", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+      "app/listeners/base.ts": `export { Listener } from ${LISTENER};`,
+    });
+
+    expect(names(await discoverListeners(join(root, "app/listeners")))).toEqual([
+      "SendWelcomeEmail",
+    ]);
+  });
+
+  test("a directory that does not exist is an empty list, not a throw", async () => {
+    const root = project({ "app/config/events.ts": "" });
+
+    expect(await discoverListeners(join(root, "app/listeners"))).toEqual([]);
+  });
+
+  test("a file that will not import stops the walk and names it", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/Broken.ts": `import "./styles.css?raw";
+export class Broken {}`,
+    });
+
+    // Not a skip. Four listeners found out of five looks exactly like five out
+    // of five, and the one that vanished is a side effect nobody is waiting on.
+    await expect(
+      discoverListeners(join(root, "app/listeners")),
+    ).rejects.toThrow(/Broken\.ts could not be imported/);
+  });
+
+  /**
+   * A listener that binds to nothing is refused rather than warned about: it
+   * can be registered under no name, so it is a file the author wrote that will
+   * never run — and the compiler cannot see it, because `static event` is
+   * declared on the base and every subclass inherits the declaration whether or
+   * not it assigns one.
+   */
+  test("a listener with no `static event` stops the walk, by name", async () => {
+    const root = project({
+      "app/listeners/Unbound.ts": `import { Listener } from ${LISTENER};
+export class Unbound extends Listener {
+  static name = "Unbound";
+  handle() {}
+}`,
+    });
+
+    await expect(
+      discoverListeners(join(root, "app/listeners")),
+    ).rejects.toThrow(/Unbound declare no `static event`/);
+  });
+});
+
+/**
+ * The hazard discovery adds rather than removes, in its events form — and here
+ * it is worse than the queue's, because a dropped job at least says so on
+ * stderr while a dispatch that reaches no listener says nothing at all outside
+ * development.
+ */
+describe("a name that will not survive a production build", () => {
+  test("the event's is warned about, with the line that fixes it", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered", false),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+    });
+
+    await discoverListeners(join(root, "app/listeners"));
+
+    const message = vi.mocked(warn).mock.calls.at(-1)![0] as string;
+    expect(message).toContain("Event UserRegistered");
+    expect(message).toContain('static name = "UserRegistered"');
+  });
+
+  test("the listener's own is warned about too", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+        { declared: false },
+      ),
+    });
+
+    await discoverListeners(join(root, "app/listeners"));
+
+    expect(vi.mocked(warn).mock.calls.at(-1)![0]).toContain(
+      'Event listener SendWelcomeEmail does not declare `static name`',
+    );
+  });
+
+  test("a listener and an event that both declare one are left alone", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+    });
+
+    await discoverListeners(join(root, "app/listeners"));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The check reads the property descriptor, and this is what stops it
+   * degrading into a tautology on the next refactor: both classes below report
+   * the same `.name`, and only one of them will still report it after a
+   * minifier has been over the file that dispatches it.
+   */
+  test("the two spellings are told apart exactly, not guessed at", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const root = project({
+      // Same string on both sides. `Implicit` gets it from the class binding.
+      "app/events/Declared.ts": event("Declared"),
+      "app/events/Implicit.ts": event("Implicit", false),
+      "app/listeners/OnDeclared.ts": listener("OnDeclared", "Declared"),
+      "app/listeners/OnImplicit.ts": listener("OnImplicit", "Implicit"),
+    });
+
+    await discoverListeners(join(root, "app/listeners"));
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(vi.mocked(warn).mock.calls[0]![0]).toContain("Event Implicit");
+  });
+
+  test("and the descriptor is what separates them", () => {
+    class Implicit extends Event {}
+    class Explicit extends Event {
+      static name = "Explicit";
+    }
+
+    expect(Implicit.name).toBe("Implicit");
+    expect(Object.getOwnPropertyDescriptor(Implicit, "name")?.writable).toBe(
+      false,
+    );
+    expect(Object.getOwnPropertyDescriptor(Explicit, "name")?.writable).toBe(
+      true,
+    );
+  });
+});
+
+describe("the listener registry", () => {
+  test("is filled from app/listeners when the slice leaves `listeners` out", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+      "app/listeners/NotifyAdmins.ts": listener(
+        "NotifyAdmins",
+        "UserRegistered",
+      ),
+    });
+
+    const application = await boot(
+      { events: { listenersDir: join(root, "app/listeners") } },
+      EventServiceProvider,
+    );
+
+    // Two listeners on one event is the normal case here, where two jobs on one
+    // name is the pathological one.
+    expect(names(application.make(EventManager).registeredListeners)).toEqual([
+      "NotifyAdmins",
+      "SendWelcomeEmail",
+    ]);
+  });
+
+  test("an app with no `events` slice at all discovers, from the default app/listeners", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+    });
+
+    await withProjectRoot(root, async () => {
+      const application = await boot({}, EventServiceProvider);
+
+      expect(names(application.make(EventManager).registeredListeners)).toEqual(
+        ["SendWelcomeEmail"],
+      );
+    });
+  });
+
+  test("an explicit list wins and the directory is never read", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+    });
+
+    class Ping extends Event {
+      static name = "Ping";
+    }
+    class LogThePing extends Listener {
+      static name = "LogThePing";
+      static event = Ping;
+      handle() {}
+    }
+
+    const application = await boot(
+      {
+        events: {
+          listeners: [LogThePing],
+          listenersDir: join(root, "app/listeners"),
+        },
+      },
+      EventServiceProvider,
+    );
+
+    expect(names(application.make(EventManager).registeredListeners)).toEqual([
+      "LogThePing",
+    ]);
+  });
+
+  test("`listeners: []` means an app with no listeners, not one that wants them found", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+    });
+
+    const application = await boot(
+      { events: { listeners: [], listenersDir: join(root, "app/listeners") } },
+      EventServiceProvider,
+    );
+
+    expect(application.make(EventManager).registeredListeners).toEqual([]);
+  });
+
+  test("`listeners: undefined` counts as absent and discovers", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": event("UserRegistered"),
+      "app/listeners/SendWelcomeEmail.ts": listener(
+        "SendWelcomeEmail",
+        "UserRegistered",
+      ),
+    });
+
+    const application = await boot(
+      {
+        events: {
+          listeners: undefined,
+          listenersDir: join(root, "app/listeners"),
+        },
+      },
+      EventServiceProvider,
+    );
+
+    expect(names(application.make(EventManager).registeredListeners)).toEqual([
+      "SendWelcomeEmail",
+    ]);
+  });
+
+  test("a missing app/listeners leaves the registry empty rather than failing to boot", async () => {
+    const root = project({ "app/config/events.ts": "" });
+
+    const application = await boot(
+      { events: { listenersDir: join(root, "app/listeners") } },
+      EventServiceProvider,
+    );
+
+    expect(application.make(EventManager).registeredListeners).toEqual([]);
+  });
+
+  /**
+   * End to end, through a real container: the file on disk is what runs.
+   * Everything else here asserts on the registry, which cannot tell a listener
+   * that was registered from one that was registered *and dispatched to*.
+   */
+  test("and a dispatch reaches what was discovered", async () => {
+    const root = project({
+      "app/events/UserRegistered.ts": `import { Event } from ${EVENT};
+export class UserRegistered extends Event {
+  static name = "UserRegistered";
+  constructor(email) { super(); this.email = email; }
+}`,
+      "app/listeners/SendWelcomeEmail.ts": `import { Listener } from ${LISTENER};
+import { UserRegistered } from "../events/UserRegistered";
+export const seen = [];
+export class SendWelcomeEmail extends Listener {
+  static name = "SendWelcomeEmail";
+  static event = UserRegistered;
+  handle(event) { seen.push(event.email); }
+}`,
+    });
+
+    const application = await boot(
+      { events: { listenersDir: join(root, "app/listeners") } },
+      EventServiceProvider,
+    );
+
+    const { UserRegistered } = await import(
+      join(root, "app/events/UserRegistered.ts")
+    );
+    const { seen } = await import(
+      join(root, "app/listeners/SendWelcomeEmail.ts")
+    );
+
+    await application
+      .make(EventManager)
+      .dispatchAndWait(new UserRegistered("ada@example.com"));
+
+    expect(seen).toEqual(["ada@example.com"]);
   });
 });
 

--- a/packages/gemi/services/discovery.ts
+++ b/packages/gemi/services/discovery.ts
@@ -11,6 +11,9 @@ import { commandConfigDefaults } from "../console/config";
 import { isUnfinishedBuilder } from "../console/builder";
 import { CronJob } from "./cron/CronJob";
 import { scheduleConfigDefaults } from "./cron/config";
+import { eventConfigDefaults } from "./events/config";
+import type { EventClass } from "./events/Event";
+import { Listener, type ListenerClass } from "./events/Listener";
 import { Job } from "./queue/Job";
 import { queueConfigDefaults } from "./queue/config";
 
@@ -228,4 +231,154 @@ function refuseUnfinishedBuilders(files: string[]): void {
       `    export default defineCommand("my-command")\n` +
       `      .handle(async ({ line }) => { line("hello") })`,
   );
+}
+
+/**
+ * The `Listener` subclasses under `dir`, defaulting to the config slice's
+ * `app/listeners`.
+ *
+ * This is what an `events` config slice with no `listeners` key resolves to.
+ * Call it directly to ask what an application would register: every listener,
+ * in the order it would register them.
+ *
+ * Only listeners are walked. Event classes are never discovered — each is
+ * imported by the listener that binds to it and by the code that dispatches it,
+ * so there is nothing a walk over them would find that is not already in the
+ * module graph.
+ *
+ * **Known residual, matching jobs and cron.** `discoverClasses` excludes the
+ * `base` it is handed and not intermediates, so an abstract listener base
+ * written in `listenersDir` and extended by its siblings is discovered and
+ * registered alongside them — constructed, with its `handle` called, on every
+ * dispatch of whatever event it declares. Keep shared bases outside the
+ * directory.
+ *
+ * Every file underneath is imported, so calling this runs the app's listener
+ * modules — the cost `discoverClasses` documents at length, paid once per call.
+ *
+ * @throws DiscoveryError if a discovered listener declares no `static event`.
+ */
+export async function discoverListeners(
+  dir: string = eventConfigDefaults().listenersDir,
+): Promise<ListenerClass[]> {
+  const resolved = resolveDir(dir);
+  warnIfSourceIsMissing(resolved, "event listeners", "events");
+
+  const listeners = (await discoverClasses(
+    resolved,
+    Listener,
+  )) as ListenerClass[];
+
+  refuseListenersWithNoEvent(listeners);
+  warnIfListenerNameWillNotSurviveTheBuild(listeners);
+  warnIfEventNameWillNotSurviveTheBuild(listeners);
+
+  return listeners;
+}
+
+/**
+ * Stops the walk for a listener that binds to nothing.
+ *
+ * `static event` is declared as required on the base and the compiler still
+ * cannot see it missing: every subclass inherits the declaration whether or not
+ * it assigns to one, so `typeof SomeListener` type-checks either way. What the
+ * author gets instead is a file that is imported, registered under no name, and
+ * never called — the silence this whole module is arranged against.
+ *
+ * A throw rather than a warning, because there is no reading of a listener with
+ * no event under which the author meant it. The usual cause is the residual
+ * above: an abstract base sharing a gate between two listeners, sitting in
+ * `listenersDir` where the walk finds it. Moving it out is the fix, and the
+ * message says so — the alternative, excluding it by some guess about
+ * abstractness, is how a discovery pass ends up quietly covering less than the
+ * directory holds.
+ */
+function refuseListenersWithNoEvent(listeners: ListenerClass[]): void {
+  const orphans = listeners.filter((listener) => !listener.event);
+  if (orphans.length === 0) return;
+
+  throw new DiscoveryError(
+    `${orphans
+      .map((listener) => listener.name)
+      .join(", ")} declare no \`static event\`, so there is no event name to ` +
+      `register them under and their \`handle\` would never run. Every ` +
+      `listener binds to exactly one event:\n\n` +
+      `    static event = UserRegistered;\n\n` +
+      `If this is an abstract base its subclasses extend, move it out of the ` +
+      `listeners directory — the walk excludes gemi's \`Listener\` and ` +
+      `nothing else, so a base sitting beside its subclasses is registered ` +
+      `and run like one of them.`,
+  );
+}
+
+/**
+ * Says something about a discovered listener that never declared `static name`.
+ *
+ * The hazard is `warnIfNameWillNotSurviveTheBuild`'s, one subsystem over: a
+ * `static name = "..."` class field defines a *writable* own property while the
+ * implicit class binding does not, and a minifier renames the binding while
+ * leaving the string literal alone. The two spellings are indistinguishable by
+ * value — both read `"SendWelcomeEmail"` in development — so the descriptor is
+ * the only thing that tells them apart, and the difference only becomes visible
+ * in a production build.
+ *
+ * Unlike a job's, a listener's own name has no second half to disagree with
+ * *yet*: every reader of it today comes from this same source-side walk, so a
+ * minified build and this walk cannot currently produce two different strings
+ * for it. It is asked for from the start anyway, because the moment a listener
+ * name is carried anywhere the server bundle can also produce — a queue
+ * payload, a stored retry — the disagreement is silent and the fix would be a
+ * rule changing under applications that had already shipped.
+ */
+function warnIfListenerNameWillNotSurviveTheBuild(listeners: ListenerClass[]) {
+  for (const listener of listeners) {
+    if (Object.getOwnPropertyDescriptor(listener, "name")?.writable) continue;
+
+    console.warn(
+      `Event listener ${listener.name} does not declare \`static name\`, so ` +
+        `it is registered under its class name, which a production build ` +
+        `renames. Add: static name = "${listener.name}";`,
+    );
+  }
+}
+
+/**
+ * Says something about the *event* a discovered listener binds to, when that
+ * event's name is the implicit class binding.
+ *
+ * This is the check that matters from the first dispatch, and it is the reason
+ * `discoverListeners` reads `static event` at all. The registry is keyed by the
+ * event's name; the dispatcher supplies that name from the class it constructs.
+ * A production build minifies the server entry and the app code reachable from
+ * it — the controller, and the event class it imports in order to dispatch —
+ * while discovery imports `app/listeners/*.ts` from source, and those files
+ * import `app/events/*.ts` from source too. Two module graphs, two class
+ * objects, and an implicit `.name` that reads `"UserRegistered"` on one side
+ * and `"D"` on the other. The dispatch then finds no listeners, which is legal,
+ * normal, and completely silent.
+ *
+ * A declared `static name` is a string literal, which survives minification
+ * intact, and the two halves agree again.
+ *
+ * Checked through the descriptor rather than the string, and not by comparing
+ * `event.name` to anything: in development the two spellings produce the same
+ * value, so a check on the string would be a tautology that passes forever.
+ */
+function warnIfEventNameWillNotSurviveTheBuild(listeners: ListenerClass[]) {
+  const warned = new Set<EventClass>();
+
+  for (const { event } of listeners) {
+    if (warned.has(event)) continue;
+    if (Object.getOwnPropertyDescriptor(event, "name")?.writable) continue;
+    warned.add(event);
+
+    console.warn(
+      `Event ${event.name} does not declare \`static name\`, so it is ` +
+        `dispatched under its class name. A production build minifies the ` +
+        `code that dispatches it and renames the class, while discovery reads ` +
+        `the listener's copy from source and does not — so the dispatch would ` +
+        `reach no listener in production and nowhere else. Add: ` +
+        `static name = "${event.name}";`,
+    );
+  }
 }

--- a/packages/gemi/services/events/Event.test.ts
+++ b/packages/gemi/services/events/Event.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "vitest";
+
+import { Application } from "../../foundation/Application";
+import { kernelContext } from "../../kernel/context";
+import { Repository } from "../../support/Repository";
+import { Event } from "./Event";
+import { EventServiceProvider } from "./EventServiceProvider";
+import { Listener, type ListenerClass } from "./Listener";
+
+/**
+ * The class side, which is the only half an application ever calls.
+ *
+ * Everything in `EventManager.test.ts` reaches the manager directly, and a
+ * manager that works says nothing about whether `UserRegistered.dispatch(...)`
+ * reaches it. Three things live only here and are silent when broken: the
+ * container lookup (a `dispatch` bound to the wrong token, or to a manager
+ * captured at module scope rather than resolved per context, fires into
+ * nothing), the argument forwarding (a dropped spread builds an event whose
+ * payload fields are all `undefined`, and every listener still runs), and
+ * `refuseUnnamed`. None of them fails loudly, and none of them is covered by a
+ * test that constructs the event itself.
+ */
+
+class UserRegistered extends Event {
+  static name = "UserRegistered";
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+
+/** A listener that records what `handle` received, in `seen`. */
+function listener(seen: UserRegistered[]) {
+  return class SendWelcomeEmail extends Listener {
+    static name = "SendWelcomeEmail";
+    static event = UserRegistered;
+
+    handle(event: UserRegistered) {
+      seen.push(event);
+    }
+  };
+}
+
+/**
+ * An application holding nothing but the events provider, with its listeners
+ * declared rather than discovered — `register()` alone binds the manager, so
+ * there is no directory to walk and no boot to wait for.
+ */
+function makeApp(listeners: ListenerClass[] = []) {
+  const application = new Application(new Repository({ events: { listeners } }));
+  application.register(EventServiceProvider);
+  return application;
+}
+
+describe("dispatching from the class", () => {
+  test("resolves the manager out of the current application and runs its listeners", async () => {
+    const seen: UserRegistered[] = [];
+    const application = makeApp([listener(seen)]);
+
+    kernelContext.run(application, () =>
+      UserRegistered.dispatch(7, "ada@example.com"),
+    );
+    // `dispatch` returns before its listeners have; one turn is enough for a
+    // synchronous handle, and the assertion is about what it was handed.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(seen).toHaveLength(1);
+    // The constructor's arguments, forwarded through `ConstructorParameters`.
+    // A dropped spread leaves both of these `undefined` and the listener still
+    // runs, so this is the assertion that sees it.
+    expect(seen[0]!.userId).toBe(7);
+    expect(seen[0]!.email).toBe("ada@example.com");
+  });
+
+  test("reads the application from the context it was called in, not one captured earlier", async () => {
+    const first: UserRegistered[] = [];
+    const second: UserRegistered[] = [];
+    const one = makeApp([listener(first)]);
+    const other = makeApp([listener(second)]);
+
+    await kernelContext.run(one, () =>
+      UserRegistered.dispatchAndWait(1, "a@example.com"),
+    );
+    await kernelContext.run(other, () =>
+      UserRegistered.dispatchAndWait(2, "b@example.com"),
+    );
+
+    expect(first.map((event) => event.userId)).toEqual([1]);
+    expect(second.map((event) => event.userId)).toEqual([2]);
+  });
+
+  test("dispatchAndWait does not resolve until the listeners have", async () => {
+    let release!: () => void;
+    const settled: string[] = [];
+
+    class SlowListener extends Listener {
+      static name = "SlowListener";
+      static event = UserRegistered;
+
+      handle() {
+        return new Promise<void>((resolve) => {
+          release = () => {
+            settled.push("listener");
+            resolve();
+          };
+        });
+      }
+    }
+
+    const application = makeApp([SlowListener]);
+
+    const waiting = kernelContext
+      .run(application, () => UserRegistered.dispatchAndWait(1, "a@x.com"))
+      .then(() => settled.push("caller"));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).toEqual([]);
+
+    release();
+    await waiting;
+    expect(settled).toEqual(["listener", "caller"]);
+  });
+});
+
+/**
+ * The cheap half of invariant 1: an event whose name is not a name cannot be
+ * routed, so it is refused rather than dispatched into a registry that has no
+ * key for it. The refusal happens before the container is touched, which is why
+ * these run without an application around them.
+ */
+describe("dispatching an event with no name", () => {
+  /** The base, still holding the inherited `"unset"`. */
+  const unnamed = Event as unknown as {
+    dispatch(): void;
+    dispatchAndWait(): Promise<void>;
+  };
+
+  /**
+   * A class expression returned rather than bound, so nothing names it. Any
+   * binding — `const X = class …`, an object property, `export default` —
+   * would, which is why this has to be built out of reach of one.
+   */
+  const anonymous = () =>
+    (class extends Event {}) as unknown as { dispatch(): void };
+
+  test("refuses the base itself", () => {
+    expect(() => unnamed.dispatch()).toThrow(
+      "Cannot dispatch an event with no name",
+    );
+  });
+
+  test("refuses an anonymous class, whose own name is the empty string", () => {
+    // Not the inherited `"unset"`: a class expression with no binding to take a
+    // name from gets an own, non-writable `name` of `""`. Checking `"unset"`
+    // alone would let this dispatch under the key `""` and surface as an
+    // ordinary event nobody happens to be listening for.
+    expect(Object.getOwnPropertyDescriptor(anonymous(), "name")?.value).toBe("");
+
+    expect(() => anonymous().dispatch()).toThrow(
+      "Cannot dispatch an event with no name",
+    );
+  });
+
+  test("refuses dispatchAndWait on the same terms, and before it returns a promise", () => {
+    expect(() => unnamed.dispatchAndWait()).toThrow(
+      "Cannot dispatch an event with no name",
+    );
+  });
+});

--- a/packages/gemi/services/events/Event.ts
+++ b/packages/gemi/services/events/Event.ts
@@ -129,14 +129,23 @@ export abstract class Event {
 /**
  * Stops a dispatch that could not be routed anywhere.
  *
- * Only reachable from a class that inherited the `"unset"` default without
- * shadowing it — the base itself, or an anonymous class expression that never
- * got a binding to take a name from. A throw rather than a warning because
- * there is no listener that could be registered under `"unset"`, so the
- * alternative is a dispatch that silently does nothing.
+ * Two values reach it and neither is a name a listener could have registered
+ * under. `"unset"` is the inherited default, which only the base itself still
+ * has — a class *declaration* always shadows it with its own binding. `""` is
+ * what an anonymous class expression with no binding to take a name from gets:
+ * an own, non-writable `name` of the empty string rather than the inherited
+ * default, so checking `"unset"` alone would let `(class extends Event {})`
+ * through to dispatch under the key `""` and surface as the generic
+ * zero-listener warning instead of the message that names the fix.
+ *
+ * A throw rather than a warning because there is no listener that could be
+ * registered under either, so the alternative is a dispatch that silently does
+ * nothing. This is only the floor: a declared `static name` and the implicit
+ * class binding are indistinguishable by value here, and `discoverListeners`
+ * reading the property descriptor is what tells those two apart.
  */
 function refuseUnnamed(event: EventClass): void {
-  if (event.name !== "unset") return;
+  if (event.name !== "unset" && event.name !== "") return;
 
   throw new Error(
     `Cannot dispatch an event with no name. Add \`static name\` to this Event ` +

--- a/packages/gemi/services/events/Event.ts
+++ b/packages/gemi/services/events/Event.ts
@@ -1,0 +1,156 @@
+import { app } from "../../foundation/app";
+import { EventManager } from "./EventManager";
+
+/**
+ * Something the application did, addressed to nobody in particular.
+ *
+ * An event is the payload plus a name. It carries no framework state — no
+ * timestamp, no id, no `propagationStopped` — because every one of those is a
+ * field the application can declare itself if it wants one, and a listener that
+ * could stop the next listener would make registration order load-bearing when
+ * that order comes from a filesystem walk nobody chose.
+ *
+ * ```typescript
+ * // app/events/UserRegistered.ts
+ * export class UserRegistered extends Event {
+ *   static name = "UserRegistered";
+ *   constructor(
+ *     public userId: number,
+ *     public email: string,
+ *   ) {
+ *     super();
+ *   }
+ * }
+ * ```
+ *
+ * ### Why `static name` is required and not a convenience
+ *
+ * The registry is keyed by this string, never by the class object, and that is
+ * the least obvious decision in the subsystem. `gemi build` minifies the server
+ * entry, and the app code reachable from it — the controller, and every event
+ * class that controller imports in order to dispatch — is bundled and minified
+ * with it. Discovery, meanwhile, imports `app/listeners/*.ts` from source at
+ * runtime, and those files import `app/events/*.ts` from source too. Two module
+ * graphs, two `UserRegistered` class objects. A map keyed by the class would
+ * look up the bundled one, find the entry registered under the source one, and
+ * return nothing — a dispatch with zero listeners, which is legal, normal, and
+ * completely silent. It would work in development, pass every test, and do
+ * nothing in production.
+ *
+ * A declared `static name` is a string literal and minification leaves string
+ * literals alone, so both halves agree.
+ *
+ * The same two class objects are why **application code must never `instanceof`
+ * an event**: inside a listener, `event instanceof UserRegistered` is `true` in
+ * development and `false` in a production build. Nothing the framework can do
+ * fixes that, so the framework's job is to never need it — which is why a
+ * listener binds to exactly one event.
+ */
+export abstract class Event {
+  /**
+   * The name this event registers and dispatches under. Required.
+   *
+   * The `"unset"` default is the floor rather than the check: a `class
+   * UserRegistered extends Event {}` shadows this with its own implicit class
+   * binding, which reads `"UserRegistered"` in development and something like
+   * `"D"` in a minified bundle. `discoverListeners` is what tells a declared
+   * name from an implicit one — it reads the property descriptor, because both
+   * spellings produce the same string right up until the build.
+   */
+  static name = "unset";
+
+  /**
+   * Makes `Event` nominal, and exists for nothing else.
+   *
+   * An event carries no framework state, so `Event`'s instance side is empty —
+   * and an empty type is structurally satisfied by *everything*, which would
+   * make the one constraint the compiler can enforce here vacuous:
+   * `static event = SomeRandomClass` would type-check, register under a name
+   * nothing dispatches, and never run. `declare` means no field is emitted and
+   * no subclass has to initialise it; `protected` means only a real subclass
+   * can produce a value of this type.
+   */
+  declare protected readonly __isEvent: true;
+
+  /**
+   * Fires the event and returns immediately. Every sync listener bound to it
+   * runs; none of them can report anything back here.
+   *
+   * The arguments are the event's constructor arguments, typed through
+   * `ConstructorParameters` — the same trick `Job.dispatch` plays through
+   * `Parameters<T["run"]>`, so the two subsystems read the same way at the call
+   * site.
+   *
+   * ```typescript
+   * const user = await User.create(input);
+   * UserRegistered.dispatch(user.id, user.email);
+   * ```
+   *
+   * A listener that throws is logged and the next one still runs, so nothing
+   * here can fail on a listener's behalf. A dispatch that nothing is listening
+   * for is legal and warns once, in development only.
+   */
+  static dispatch<T extends EventClass>(
+    this: T,
+    ...args: ConstructorParameters<T>
+  ): void {
+    refuseUnnamed(this);
+    app(EventManager).dispatch(new this(...args));
+  }
+
+  /**
+   * Fires the event and resolves once every **sync** listener has settled.
+   *
+   * It does not wait for a queued listener, which by construction runs in a
+   * cloned application after this promise has resolved — "and wait" invites
+   * exactly that reading, so it is written down here rather than left to be
+   * discovered by a test that passes locally.
+   *
+   * Two methods rather than one `dispatch` that is sometimes worth awaiting,
+   * because "is this worth awaiting" is a question the call site should not
+   * have to guess at. This one is for a caller that genuinely needs the side
+   * effects to have happened before it continues — a request that renders what
+   * a listener wrote, a test asserting on the result.
+   *
+   * Never rejects. A listener's failure is that listener's, and letting it
+   * surface here would mean listener 1's throw becomes the caller's problem
+   * while listener 5's does not, depending only on where in a filesystem walk
+   * the throw landed.
+   */
+  static dispatchAndWait<T extends EventClass>(
+    this: T,
+    ...args: ConstructorParameters<T>
+  ): Promise<void> {
+    refuseUnnamed(this);
+    return app(EventManager).dispatchAndWait(new this(...args));
+  }
+}
+
+/**
+ * Stops a dispatch that could not be routed anywhere.
+ *
+ * Only reachable from a class that inherited the `"unset"` default without
+ * shadowing it — the base itself, or an anonymous class expression that never
+ * got a binding to take a name from. A throw rather than a warning because
+ * there is no listener that could be registered under `"unset"`, so the
+ * alternative is a dispatch that silently does nothing.
+ */
+function refuseUnnamed(event: EventClass): void {
+  if (event.name !== "unset") return;
+
+  throw new Error(
+    `Cannot dispatch an event with no name. Add \`static name\` to this Event ` +
+      `subclass — the listener registry is keyed by that string, and by that ` +
+      `string alone, so an event without one cannot reach a listener.`,
+  );
+}
+
+/**
+ * An `Event` subclass, as `Listener.event` holds one and as `dispatch` narrows
+ * `this` to.
+ *
+ * Concrete rather than `abstract new`, because the only thing anyone does with
+ * one of these is construct it: a listener bound to an abstract event would
+ * register under a name nothing can ever dispatch.
+ */
+export type EventClass = new (...args: any[]) => Event;

--- a/packages/gemi/services/events/EventManager.test.ts
+++ b/packages/gemi/services/events/EventManager.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { Event } from "./Event";
+import { EventManager } from "./EventManager";
+import { Listener } from "./Listener";
+
+/**
+ * Fan-out, and the three ways it goes quiet.
+ *
+ * Every failure this file guards is silent by nature. A dispatch nothing is
+ * registered for is legal; a listener that throws takes its own side effect
+ * with it and nothing else; a listener the registry refused is a file the
+ * author wrote that never runs. None of them raises anything a caller can see,
+ * which is why the assertions are on the console and on the registry rather
+ * than on a return value — `dispatch` returns `void` and `dispatchAndWait`
+ * resolves either way, deliberately.
+ */
+
+class UserRegistered extends Event {
+  static name = "UserRegistered";
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+
+class OrderPaid extends Event {
+  static name = "OrderPaid";
+}
+
+/** A listener whose `handle` is observable through the spy it is built with. */
+function listener(
+  name: string,
+  handle: (event: any) => void | Promise<void>,
+  event = UserRegistered,
+) {
+  return {
+    [name]: class extends Listener {
+      static name = name;
+      static event = event;
+      handle(received: UserRegistered) {
+        return handle(received);
+      }
+    },
+  }[name]!;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("a dispatch with listeners", () => {
+  test("runs every one of them, on the instance the arguments built", async () => {
+    const seen: Array<[string, UserRegistered]> = [];
+    const manager = new EventManager({
+      listeners: [
+        listener(
+          "SendWelcomeEmail",
+          (event) => void seen.push(["mail", event]),
+        ),
+        listener("NotifyAdmins", (event) => void seen.push(["admins", event])),
+      ],
+    });
+
+    const event = new UserRegistered(7, "ada@example.com");
+    await manager.dispatchAndWait(event);
+
+    expect(seen.map(([who]) => who)).toEqual(["mail", "admins"]);
+    // The same instance reaches both — an event is a payload, and nothing
+    // clones or serialises it on the way to a sync listener.
+    expect(seen.every(([, received]) => received === event)).toBe(true);
+    expect(seen[0]![1].userId).toBe(7);
+    expect(seen[0]![1].email).toBe("ada@example.com");
+  });
+
+  test("only the listeners bound to that event", async () => {
+    const ran: string[] = [];
+    const manager = new EventManager({
+      listeners: [
+        listener("SendWelcomeEmail", () => void ran.push("SendWelcomeEmail")),
+        listener(
+          "IssueReceipt",
+          () => void ran.push("IssueReceipt"),
+          OrderPaid,
+        ),
+      ],
+    });
+
+    await manager.dispatchAndWait(new UserRegistered(1, "a@example.com"));
+
+    expect(ran).toEqual(["SendWelcomeEmail"]);
+  });
+});
+
+/**
+ * Invariant 3, and the one a refactor breaks.
+ *
+ * Listeners are independent side effects, and their order comes from a
+ * filesystem walk rather than from anything an author chose — so letting
+ * listener 2 cancel 3 through 5 would make that walk load-bearing, which is the
+ * exact coupling the subsystem exists to remove.
+ */
+describe("a listener that throws", () => {
+  const failing = () =>
+    new EventManager({
+      listeners: [
+        listener("First", () => void ran.push("First")),
+        listener("Middle", () => {
+          throw new Error("smtp is down");
+        }),
+        listener("Last", () => void ran.push("Last")),
+      ],
+    });
+
+  let ran: string[] = [];
+
+  afterEach(() => {
+    ran = [];
+  });
+
+  test("does not stop the listeners after it, and is logged with both names", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await failing().dispatchAndWait(new UserRegistered(1, "a@example.com"));
+
+    expect(ran).toEqual(["First", "Last"]);
+
+    const [message, cause] = vi.mocked(error).mock.calls[0]!;
+    expect(message).toContain("Middle");
+    expect(message).toContain("UserRegistered");
+    expect((cause as Error).message).toBe("smtp is down");
+  });
+
+  test("does not make dispatchAndWait reject", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      failing().dispatchAndWait(new UserRegistered(1, "a@example.com")),
+    ).resolves.toBeUndefined();
+  });
+
+  test("does not make the fire-and-forget dispatch reject either", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    try {
+      failing().dispatch(new UserRegistered(1, "a@example.com"));
+      // Two turns: one for the loop's own awaits, one for a rejection that
+      // would have escaped `dispatch`'s floating promise.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      process.off("unhandledRejection", unhandled);
+    }
+
+    expect(ran).toEqual(["First", "Last"]);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+});
+
+describe("dispatchAndWait", () => {
+  test("does not resolve until an async listener has", async () => {
+    let release!: () => void;
+    const settled = vi.fn();
+    const manager = new EventManager({
+      listeners: [
+        listener(
+          "SlowListener",
+          () => new Promise<void>((resolve) => (release = resolve)),
+        ),
+      ],
+    });
+
+    const waiting = manager
+      .dispatchAndWait(new UserRegistered(1, "a@example.com"))
+      .then(settled);
+
+    // Several turns, so "not settled yet" is a claim about the listener's
+    // promise rather than about microtask ordering.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(settled).not.toHaveBeenCalled();
+
+    release();
+    await waiting;
+    expect(settled).toHaveBeenCalled();
+  });
+});
+
+/**
+ * Invariant 2. The whole early-warning system for the subsystem: a registry
+ * keyed by the wrong string, a name that does not survive a production build, a
+ * typo, and a listener directory that was never walked all produce this one
+ * symptom.
+ */
+describe("a dispatch nothing is listening for", () => {
+  test("warns once per event name, however often it is dispatched", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const manager = new EventManager({ listeners: [] });
+
+    await manager.dispatchAndWait(new UserRegistered(1, "a@example.com"));
+    await manager.dispatchAndWait(new UserRegistered(2, "b@example.com"));
+    await manager.dispatchAndWait(new UserRegistered(3, "c@example.com"));
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(warn).mock.calls[0]![0]).toContain("UserRegistered");
+  });
+
+  test("warns again for a different event", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const manager = new EventManager({ listeners: [] });
+
+    await manager.dispatchAndWait(new UserRegistered(1, "a@example.com"));
+    await manager.dispatchAndWait(new OrderPaid());
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(warn).mock.calls[1]![0]).toContain("OrderPaid");
+  });
+
+  test("is remembered per manager, so a fresh application warns again", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await new EventManager().dispatchAndWait(new UserRegistered(1, "a@x.com"));
+    await new EventManager().dispatchAndWait(new UserRegistered(1, "a@x.com"));
+
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  test("says nothing in production, where zero listeners is just the answer", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      await new EventManager({ listeners: [] }).dispatchAndWait(
+        new UserRegistered(1, "a@example.com"),
+      );
+    } finally {
+      process.env.NODE_ENV = previous;
+    }
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("what useListeners refuses", () => {
+  test("a listener with no `static event`, by name", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    class Unbound extends Listener {
+      static name = "Unbound";
+      handle() {}
+    }
+
+    // The compiler cannot see this: `static event` is declared on the base, so
+    // every subclass inherits the declaration whether or not it assigns one.
+    const manager = new EventManager({ listeners: [Unbound as never] });
+
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain("Unbound");
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain("static event");
+    // Still reported as handed in, so a test can see what was refused.
+    expect(manager.registeredListeners).toEqual([Unbound]);
+  });
+
+  test("a second listener claiming a name the first took", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ran: string[] = [];
+
+    const manager = new EventManager({
+      listeners: [
+        listener("NotifyAdmins", () => void ran.push("auth")),
+        listener("NotifyAdmins", () => void ran.push("billing")),
+      ],
+    });
+
+    await manager.dispatchAndWait(new UserRegistered(1, "a@example.com"));
+
+    expect(ran).toEqual(["auth"]);
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain(
+      'Two event listeners are named "NotifyAdmins"',
+    );
+    // Both appear here — the getter reports what came in, not what the registry
+    // accepted, so the clash is visible rather than tidied away.
+    expect(manager.registeredListeners).toHaveLength(2);
+  });
+});
+
+describe("the readable view", () => {
+  test("is a copy, so walking it cannot edit what a dispatch runs", () => {
+    const manager = new EventManager({
+      listeners: [listener("SendWelcomeEmail", () => {})],
+    });
+
+    (manager.registeredListeners as unknown[]).length = 0;
+
+    expect(manager.registeredListeners).toHaveLength(1);
+  });
+});

--- a/packages/gemi/services/events/EventManager.ts
+++ b/packages/gemi/services/events/EventManager.ts
@@ -1,0 +1,198 @@
+import { withDefaults } from "../../support/withDefaults";
+import { eventConfigDefaults, type EventConfig } from "./config";
+import type { Event } from "./Event";
+import type { ListenerClass } from "./Listener";
+
+/**
+ * The registry a dispatch fans out through: event name -> the listeners bound
+ * to it.
+ *
+ * Shaped after `QueueManager` deliberately — constructed in `register()` from
+ * whatever the config slice declared, handed the discovered set in `boot()`,
+ * and reporting through a `registered*` getter what it was *given* rather than
+ * what it accepted, so a test can see a collision instead of having it tidied
+ * away.
+ *
+ * Three things are not `QueueManager`'s, and each is a decision rather than a
+ * detail:
+ *
+ * **Many listeners per key.** Two listeners for one event is the normal case
+ * here, where two jobs for one name is the pathological one. So the map holds
+ * arrays and `useListeners` appends. The collision it does refuse is two
+ * *listener classes* claiming one `static name`.
+ *
+ * **Registration order is the walk's order, and means nothing.** It is stable —
+ * `discoverClasses` sorts per directory and the module namespace sorts by name
+ * — so it is reproducible, but no listener may depend on running before
+ * another, because nothing about a filesystem layout was chosen to express
+ * that. What makes it safe to say is the rule below: nothing a listener does
+ * can stop the next one.
+ *
+ * **A dispatch nobody handles warns.** That is the entire early-warning system
+ * for the subsystem, and it is why it is not optional; see `dispatchAndWait`.
+ */
+export class EventManager {
+  static token = "events";
+
+  /** Event name -> every listener bound to it, in registration order. */
+  private listeners: Record<string, ListenerClass[]> = {};
+
+  /**
+   * Event names already warned about. Per-manager, and the manager is per
+   * application, so a test that builds a fresh kernel gets a fresh set.
+   */
+  private warnedFor = new Set<string>();
+
+  readonly config: Required<EventConfig>;
+
+  constructor(config: EventConfig = {}) {
+    this.config = withDefaults(eventConfigDefaults(), config);
+    this.useListeners(this.config.listeners);
+  }
+
+  /**
+   * Replaces the registered set, for the provider to hand over what it found
+   * under `app/listeners`.
+   *
+   * Two phases, for the reason `QueueManager.useJobs` documents: the manager is
+   * constructed in `register()`, which is synchronous and must resolve nothing,
+   * while reading a directory and importing what is in it is neither. So the
+   * manager is built from whatever the config slice declared — nothing, when
+   * the app left `listeners` out — and the discovered set arrives in `boot()`.
+   *
+   * The consequence worth knowing: anything that constructs an application and
+   * skips phase two dispatches into an empty registry, and an empty registry is
+   * a legal steady state rather than an error. The development-only warning
+   * below is the only thing that says so.
+   */
+  useListeners(listeners: ListenerClass[]) {
+    this.config.listeners = listeners;
+
+    this.listeners = {};
+    const claimed = new Set<string>();
+
+    for (const listener of listeners) {
+      // Declared as required on the base class and still checked here: every
+      // subclass inherits the declaration whether or not it assigns to it, so
+      // `typeof SomeListener` satisfies `ListenerClass` either way and the
+      // compiler cannot see the omission. Refused rather than registered under
+      // some fallback, because there is no fallback — a listener with no event
+      // is a file the author wrote that nothing will ever call.
+      if (!listener.event) {
+        console.error(
+          `Listener ${listener.name} does not declare \`static event\`, so ` +
+            `there is no event name to register it under and its handle will ` +
+            `never run. Add: static event = SomeEvent;`,
+        );
+        continue;
+      }
+
+      // Two classes with one name. It only reaches the wire once a listener can
+      // be queued, but it is refused from the start so the rule does not appear
+      // to change under applications later — and a directory walk is what makes
+      // the clash ordinary, since nothing forces the import alias a
+      // hand-written list would have demanded.
+      if (claimed.has(listener.name)) {
+        console.error(
+          `Two event listeners are named "${listener.name}" — the first is ` +
+            `registered and this one is not. A listener's name identifies it ` +
+            `across the framework, so only one class can hold it. Rename one.`,
+        );
+        continue;
+      }
+      claimed.add(listener.name);
+
+      // The one place the event class is dereferenced, and deliberately the
+      // only one: this runs in the module graph that declared the class, so the
+      // name it yields is the source-side one that discovery and a minified
+      // dispatcher both agree on. Nothing downstream keeps the class object.
+      const name = listener.event.name;
+      (this.listeners[name] ??= []).push(listener);
+    }
+  }
+
+  /**
+   * What the manager was handed, discovered or declared.
+   *
+   * "Is this listener registered?" is a question with a silent wrong answer —
+   * an unregistered listener is a side effect that does not happen, and nothing
+   * is waiting on it to notice. This is where a test asks it out loud.
+   *
+   * It reports what came in, not what the registry accepted, so a name claimed
+   * twice appears twice here — deliberately, the same way `QueueManager` and
+   * `Scheduler` do. A copy, so a walk over it cannot edit what dispatch reads.
+   */
+  get registeredListeners(): ReadonlyArray<ListenerClass> {
+    return [...this.config.listeners];
+  }
+
+  /**
+   * Fires the event and returns. The sync listeners run to completion after the
+   * caller has moved on.
+   *
+   * Nothing is awaited and nothing can reject: `dispatchAndWait` catches every
+   * listener's failure itself, so the floating promise here has no rejection to
+   * float.
+   */
+  dispatch(event: Event): void {
+    void this.dispatchAndWait(event);
+  }
+
+  /**
+   * Runs every listener bound to this event, in registration order, and
+   * resolves when the last of them has settled.
+   *
+   * ### Errors
+   *
+   * Each listener runs inside its own `try`. A throw is logged with the event
+   * name, the listener name, and the error, and the loop continues — listeners
+   * are independent side effects, and letting listener 2 cancel 3 through 5
+   * would make a filesystem walk's order load-bearing. Neither this nor
+   * `dispatch` ever rejects, for the same reason from the caller's side: a
+   * rejection would make listener 1's failure the dispatcher's problem while
+   * listener 5's silently is not.
+   *
+   * ### Why zero listeners is worth a line on stderr
+   *
+   * A registry keyed by the wrong string, a `static name` that does not survive
+   * a production build, a typo, and a listener directory that was never walked
+   * all produce the same single symptom: nobody handled it. Zero listeners is
+   * also a perfectly legal steady state, so the warning is development-only and
+   * fires once per event name — a dispatch in a loop would otherwise bury the
+   * terminal.
+   */
+  async dispatchAndWait(event: Event): Promise<void> {
+    const name = (event.constructor as { name: string }).name;
+    const handlers = this.listeners[name];
+
+    if (!handlers?.length) {
+      this.warnNothingIsListening(name);
+      return;
+    }
+
+    for (const Listener of handlers) {
+      try {
+        await new Listener().handle(event);
+      } catch (error) {
+        console.error(
+          `The listener ${Listener.name} threw while handling ${name}. The ` +
+            `listeners after it still ran — a listener's failure is its own.`,
+          error,
+        );
+      }
+    }
+  }
+
+  private warnNothingIsListening(name: string) {
+    if (process.env.NODE_ENV === "production") return;
+    if (this.warnedFor.has(name)) return;
+    this.warnedFor.add(name);
+
+    console.warn(
+      `[gemi] ${name} was dispatched and nothing is listening for it. A ` +
+        `listener registers under the name its event declares, so check that ` +
+        `app/listeners holds a Listener with \`static event = ${name}\` and ` +
+        `that ${name} declares \`static name = "${name}"\`. Development only.`,
+    );
+  }
+}

--- a/packages/gemi/services/events/EventManager.ts
+++ b/packages/gemi/services/events/EventManager.ts
@@ -142,6 +142,22 @@ export class EventManager {
    * Runs every listener bound to this event, in registration order, and
    * resolves when the last of them has settled.
    *
+   * ### One at a time, deliberately
+   *
+   * Each listener is awaited before the next one starts, rather than started
+   * together under a `Promise.allSettled`. Concurrency would make "registration
+   * order" a claim about start order only, and the order it is a claim about is
+   * the one `registeredListeners` reports and the discovery tests assert on.
+   *
+   * What it costs is worth knowing, because it is the one way listener
+   * independence is not total: a listener that *hangs* — an un-timed-out
+   * `fetch` to a host that never answers — delays every listener after it for
+   * as long as it hangs, and under `dispatch` the caller has already moved on,
+   * so an audit row a later listener writes simply is not there yet. A throw is
+   * not this: that is caught below and the next listener runs immediately. A
+   * listener that can block indefinitely is a listener that wants its own
+   * timeout, or a `Job`.
+   *
    * ### Errors
    *
    * Each listener runs inside its own `try`. A throw is logged with the event

--- a/packages/gemi/services/events/EventServiceProvider.ts
+++ b/packages/gemi/services/events/EventServiceProvider.ts
@@ -1,0 +1,48 @@
+import { ServiceProvider } from "../../support/ServiceProvider";
+import { withDefaults } from "../../support/withDefaults";
+import { discoverListeners } from "../discovery";
+import { eventConfigDefaults, type EventConfig } from "./config";
+import { EventManager } from "./EventManager";
+
+export class EventServiceProvider extends ServiceProvider {
+  register() {
+    this.app.singleton(
+      EventManager,
+      () => new EventManager(this.app.config.get<EventConfig>("events", {})),
+    );
+  }
+
+  /**
+   * Fills in the listener registry when the app did not declare one.
+   *
+   * ### Why the raw slice and not the manager's config
+   *
+   * The decision here is whether the app said anything, and by the time the
+   * manager holds a config it can no longer tell: `withDefaults` treats an
+   * absent key and an `undefined` one alike and substitutes the default `[]`,
+   * which is the same value an app writes when it means "no listeners, and I
+   * mean it". Reading the slice before defaults are applied is the only place
+   * the difference still exists.
+   *
+   * So: `listeners` present, including `listeners: []`, is used verbatim and no
+   * directory is read. Absent or `undefined`, the classes under `listenersDir`
+   * are.
+   *
+   * ### Why phase two
+   *
+   * Discovery imports every file it walks, which is asynchronous, and
+   * `register()` is not. It also has to finish before the first dispatch rather
+   * than before the first request — a dispatch against an empty registry is not
+   * an error, it is a side effect that quietly does not happen — so the
+   * registry has to be complete by the end of boot.
+   */
+  async boot() {
+    const slice = this.app.config.get<EventConfig>("events", {});
+    if (slice.listeners !== undefined) return;
+
+    const { listenersDir } = withDefaults(eventConfigDefaults(), slice);
+    this.app
+      .make(EventManager)
+      .useListeners(await discoverListeners(listenersDir));
+  }
+}

--- a/packages/gemi/services/events/Listener.test-d.ts
+++ b/packages/gemi/services/events/Listener.test-d.ts
@@ -1,0 +1,104 @@
+import { describe, expectTypeOf, test } from "vitest";
+
+import { Event } from "./Event";
+import { Listener } from "./Listener";
+
+/**
+ * The two things the compiler enforces about a listener, and only those two.
+ *
+ * The binding between `static event` and the annotation on `handle` is *not*
+ * one of them — a static and an instance member cannot reference each other's
+ * types, so nothing here can check that a listener declaring
+ * `static event = UserRegistered` handles a `UserRegistered`. That seam is
+ * accepted, and documented on `Listener` itself.
+ *
+ * What is left is worth pinning precisely because it is small and load-bearing.
+ * Both halves are one convenience away from being widened into `any`: typing
+ * `static event` loosely would let a listener bind to something that is not an
+ * event and register under a name nothing dispatches, and the bivariance below
+ * is what the whole no-generic design rests on — if a `strictFunctionTypes`
+ * -adjacent change ever stopped method parameters being bivariant, every
+ * listener in every application would stop compiling at once, and it would be
+ * this file that said why.
+ */
+
+class UserRegistered extends Event {
+  static name = "UserRegistered";
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+
+describe("the event a listener binds to", () => {
+  test("keeps its own type, so the class is readable off the static", () => {
+    class SendWelcomeEmail extends Listener {
+      static name = "SendWelcomeEmail";
+      static event = UserRegistered;
+
+      handle() {}
+    }
+
+    expectTypeOf(SendWelcomeEmail.event).toEqualTypeOf<typeof UserRegistered>();
+    expectTypeOf(SendWelcomeEmail.event).not.toBeAny();
+  });
+
+  test("has to be an Event subclass", () => {
+    class NotAnEvent {
+      userId = 1;
+    }
+
+    // The error lands on the class, not on the assignment: an incompatible
+    // static is reported as "class static side incorrectly extends base class
+    // static side", which is a property of the declaration as a whole.
+    // @ts-expect-error - NotAnEvent does not extend Event
+    class Broken extends Listener {
+      static event = NotAnEvent;
+
+      handle() {}
+    }
+
+    expectTypeOf(Broken).not.toBeAny();
+  });
+});
+
+describe("handle", () => {
+  /**
+   * The bivariance the no-generic design leans on. `Listener` annotates
+   * `handle(event: Event)`; a subclass narrowing that parameter to the one
+   * event it binds to is what gives application code a typed payload without a
+   * `Listener<UserRegistered>` generic to carry around.
+   */
+  test("may narrow the base's Event parameter to one event", () => {
+    class SendWelcomeEmail extends Listener {
+      static name = "SendWelcomeEmail";
+      static event = UserRegistered;
+
+      handle(event: UserRegistered) {
+        expectTypeOf(event.email).toEqualTypeOf<string>();
+        expectTypeOf(event.userId).toEqualTypeOf<number>();
+        expectTypeOf(event).not.toBeAny();
+      }
+    }
+
+    expectTypeOf<
+      Parameters<SendWelcomeEmail["handle"]>[0]
+    >().toEqualTypeOf<UserRegistered>();
+  });
+
+  test("may take nothing, and may be async", () => {
+    class Ignores extends Listener {
+      static name = "Ignores";
+      static event = UserRegistered;
+
+      async handle() {}
+    }
+
+    expectTypeOf<ReturnType<Ignores["handle"]>>().toEqualTypeOf<
+      Promise<void>
+    >();
+  });
+});

--- a/packages/gemi/services/events/Listener.ts
+++ b/packages/gemi/services/events/Listener.ts
@@ -1,0 +1,126 @@
+import type { Event, EventClass } from "./Event";
+
+/**
+ * One side effect of one event, in its own file.
+ *
+ * ```typescript
+ * // app/listeners/SendWelcomeEmail.ts
+ * export class SendWelcomeEmail extends Listener {
+ *   static name = "SendWelcomeEmail";
+ *   static event = UserRegistered;
+ *
+ *   async handle(event: UserRegistered) {
+ *     await Mail.send(event.email, ...);
+ *   }
+ * }
+ * ```
+ *
+ * That is the whole of what the subsystem buys: adding a fourth side effect to
+ * a registration is adding a file, rather than editing the controller that
+ * already has three.
+ *
+ * ### Why the binding lives here and not on the event
+ *
+ * The listener is the thing with an opinion about what it cares about; an event
+ * has no business knowing who is watching. An event listing its listeners would
+ * also put the property back the way it was — adding a side effect would edit
+ * an existing file.
+ *
+ * ### Why the binding is a value at all
+ *
+ * Laravel binds a listener to an event by reflecting on the type-hint of
+ * `handle(UserRegistered $event)`. TypeScript erases types at runtime, so that
+ * mechanism cannot exist here and the binding has to be carried as a value.
+ * That constraint turns out to be a favourable one: it is also what makes the
+ * payload types flow without a generated registry.
+ *
+ * ### The seam, written down rather than hidden
+ *
+ * **Nothing checks that `static event` and the annotation on `handle` agree.**
+ * A static and an instance member cannot reference each other's types, so the
+ * compiler sees `static event = UserRegistered` and `handle(event: OrderPaid)`
+ * as two unrelated declarations. Copy a listener, change the static, forget the
+ * annotation, and TypeScript is satisfied while the listener receives something
+ * else.
+ *
+ * It is accepted because the failure is local and immediate — that one listener
+ * reads a field that is not there, in its own stack — rather than the
+ * misroute-shaped failures the rest of this subsystem is arranged against. The
+ * `Listener.test-d.ts` beside this file pins the two halves the compiler *does*
+ * enforce, so a later refactor reaching for convenience cannot widen them to
+ * `any` unnoticed.
+ */
+export abstract class Listener {
+  /**
+   * The name this listener is reported and de-duplicated under. Required.
+   *
+   * Two listener classes claiming one name is refused at registration, and a
+   * discovery walk makes that ordinary: `auth/NotifyAdmins.ts` beside
+   * `billing/NotifyAdmins.ts` is a natural thing to write, and nothing forces
+   * the import alias a hand-written list would have demanded.
+   *
+   * As on `Event`, the `"unset"` default is a floor and not the check — a class
+   * declaration always shadows it with its own implicit binding, which is the
+   * one a minifier renames. `discoverListeners` reads the property descriptor
+   * to tell a declared name from an implicit one.
+   */
+  static name = "unset";
+
+  /**
+   * The event class this listener handles. Exactly one, required.
+   *
+   * It holds the **class**, not its name. The name is read off it once, at
+   * registration, inside `EventManager.useListeners` — and that read happens in
+   * the module graph that declared the class, so the name it yields is the
+   * source one. Nothing downstream keeps the class object, because a registry
+   * keyed by class identity is wrong in production only.
+   *
+   * There is no `static events = [A, B]`, deliberately. A listener bound to two
+   * events has to discriminate inside `handle`, and the natural way to write
+   * that is `if (event instanceof UserRegistered)` — which is `true` in every
+   * test and `false` in a production build, for the reason `Event`'s own doc
+   * comment gives. Two events wanting the same side effect are two small
+   * listeners calling one shared function.
+   *
+   * Declared as required, and still checked at runtime: every subclass inherits
+   * this declaration whether or not it assigns to it, so the compiler cannot
+   * see a listener that left it out. `EventManager` refuses one out loud.
+   */
+  static event: EventClass;
+
+  /**
+   * The side effect. Runs inside the dispatcher's context: a sync listener has
+   * the request's `app()`, its authenticated user, and its ambient
+   * transaction.
+   *
+   * Annotate the parameter with the event named in `static event` — narrowing
+   * the base's `Event` here is legal because method parameters are bivariant,
+   * which is what lets this class avoid a generic parameter. Nothing checks
+   * that the two agree; see the note on the class.
+   *
+   * Abstract, so a listener that forgets it fails to compile rather than
+   * silently handling nothing.
+   *
+   * A throw is caught, logged with both names, and the next listener still
+   * runs. Listeners are independent side effects by construction, and their
+   * order is a filesystem walk's — letting one cancel the rest would make that
+   * order load-bearing, which is the exact coupling this subsystem exists to
+   * remove.
+   */
+  abstract handle(event: Event): void | Promise<void>;
+}
+
+/**
+ * A `Listener` subclass, as the registry and the `events` config slice hold
+ * one.
+ *
+ * Zero-argument, because the manager constructs one per dispatch and has
+ * nothing to pass it. The `event` member is typed as present even though
+ * `EventManager` checks for it at runtime: an inherited declaration is
+ * indistinguishable from an assignment to the type system, so this is the
+ * shape, and the runtime check is what covers the difference.
+ */
+export type ListenerClass = (new () => Listener) & {
+  name: string;
+  event: EventClass;
+};

--- a/packages/gemi/services/events/config.ts
+++ b/packages/gemi/services/events/config.ts
@@ -1,0 +1,66 @@
+import type { ListenerClass } from "./Listener";
+
+// Config key: `events`. Derived from `EventServiceProvider`.
+export interface EventConfig {
+  /**
+   * The `Listener` subclasses this application registers, or nothing.
+   *
+   * ### Why "or nothing" is the point
+   *
+   * A dispatch fans out to whatever the `EventManager` holds for the event's
+   * name, and an event nothing is registered for is not an error — it is the
+   * ordinary state of an application that has not written that listener yet.
+   * So this list is a second spelling of `app/listeners`, kept in step by hand,
+   * and what the two disagreeing costs is a side effect that stops happening,
+   * with a development-only warning as the only trace. Nothing fails, nothing
+   * is dropped from a log: the welcome email simply is not sent.
+   *
+   * Leaving this out spells it once: the listeners are the classes under
+   * `listenersDir`.
+   *
+   * ### The rule, exactly
+   *
+   * **Declared wins, and `[]` is declared.** A `listeners` that is present is
+   * used verbatim and no directory is read — that is the escape hatch for an
+   * app whose listeners live somewhere this cannot walk, for one that
+   * deliberately registers a subset, and for a deploy that ships no source. An
+   * empty array means an app with no listeners and says so; it does not mean
+   * "find some".
+   *
+   * **Absent or `undefined` discovers.** `undefined` counts as absent for the
+   * same reason `withDefaults` treats it that way everywhere else: a key spread
+   * in from an optional value is an omission, not an instruction.
+   */
+  listeners?: ListenerClass[];
+
+  /**
+   * Where to look when `listeners` was not declared. Relative to the project
+   * root, or absolute.
+   *
+   * Every `.ts`/`.tsx` file underneath it is imported at boot and every
+   * exported class extending `Listener` is registered, so this wants to be a
+   * directory of listener declarations rather than a directory that merely
+   * contains some. That includes an abstract base a few listeners share: the
+   * walk excludes the framework's `Listener` and nothing else, so a base
+   * sitting here is registered alongside its subclasses and its `handle` runs
+   * on every dispatch of whatever event it declares. Keep shared bases outside
+   * this directory.
+   *
+   * There is no `eventsDir` to go with it. Event classes are never discovered
+   * — each is imported by the listener that binds to it and by the code that
+   * dispatches it, so nothing needs to walk them and a walk that imported them
+   * anyway would only be a boot cost.
+   */
+  listenersDir?: string;
+}
+
+export function defineEventConfig(config: EventConfig): EventConfig {
+  return config;
+}
+
+export function eventConfigDefaults(): Required<EventConfig> {
+  return {
+    listeners: [],
+    listenersDir: "app/listeners",
+  };
+}

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -70,6 +70,14 @@ export { QueueServiceProvider } from "./queue/QueueServiceProvider";
 export { QueueManager } from "./queue/QueueManager";
 export { Job } from "./queue/Job";
 
+// Events. `Event` shadows the DOM's global of the same name inside a module
+// that imports it, which is what you want in server code and worth knowing in a
+// file that also touches the browser one.
+export { EventServiceProvider } from "./events/EventServiceProvider";
+export { EventManager } from "./events/EventManager";
+export { Event, type EventClass } from "./events/Event";
+export { Listener, type ListenerClass } from "./events/Listener";
+
 // Image optimization
 export { ImageServiceProvider } from "./image-optimization/ImageServiceProvider";
 export { ImageManager } from "./image-optimization/ImageManager";
@@ -123,10 +131,16 @@ export type {
 export type { CommandContext } from "../console/context";
 export { CommandRegistry } from "../console/CommandRegistry";
 
-// Discovery. What a `jobs`-less `queue` or `schedule` slice resolves to, and
-// the only way left to ask an application what it has: the config array a test
-// used to import may not exist any more.
-export { discoverJobs, discoverCronJobs, discoverCommands } from "./discovery";
+// Discovery. What a `jobs`-less `queue` or `schedule` slice resolves to, what a
+// `listeners`-less `events` slice resolves to, and the only way left to ask an
+// application what it has: the config array a test used to import may not exist
+// any more.
+export {
+  discoverJobs,
+  discoverCronJobs,
+  discoverCommands,
+  discoverListeners,
+} from "./discovery";
 
 // Redis
 export { RedisServiceProvider } from "./redis/RedisServiceProvider";
@@ -171,6 +185,11 @@ export {
   queueConfigDefaults,
   type QueueConfig,
 } from "./queue/config";
+export {
+  defineEventConfig,
+  eventConfigDefaults,
+  type EventConfig,
+} from "./events/config";
 export {
   defineImageConfig,
   imageConfigDefaults,

--- a/plans/events/01-sync-dispatch.md
+++ b/plans/events/01-sync-dispatch.md
@@ -229,10 +229,13 @@ production build.
 
 **Known residual, matching jobs and cron.** `discoverClasses` excludes the
 `base` it is handed but not intermediates, so an abstract listener base written
-in `app/listeners` and extended by its siblings is itself discovered and
-registered. It will be constructed and its `handle` called on every matching
-dispatch. `discoverClasses`'s own doc comment describes this shape as the one
-"an app reaches for when several jobs share a gate", so it is not hypothetical.
+in `app/listeners` and extended by its siblings is itself discovered. If it
+declares a `static event` of its own it is also registered, constructed, and
+its `handle` called on every matching dispatch; if it does not, the refusal
+above stops the boot instead — which is the more common shape of this mistake,
+and the one that message is written for. `discoverClasses`'s own doc comment
+describes this shape as the one "an app reaches for when several jobs share a
+gate", so it is not hypothetical.
 Document it in `docs/events.md`; keep shared bases outside `listenersDir`. A
 `static abstract = true` opt-out is the fix if it bites, and is deliberately not
 built now.

--- a/plans/events/01-sync-dispatch.md
+++ b/plans/events/01-sync-dispatch.md
@@ -1,0 +1,344 @@
+# Iteration 1 — Sync dispatch
+
+**Goal.** `UserRegistered.dispatch(user.id, user.email)` in a controller runs
+every listener under `app/listeners` that was written against `UserRegistered`,
+in-process, with the payload fully typed at both ends.
+
+No queueing, no transaction awareness, no test fakes. Those are iterations 2 and
+3 and each of them is additive. This one is the skeleton, and it is worth
+shipping alone: a listener that does a fast in-request side effect is a real use
+of it.
+
+Read [README.md](./README.md) first — especially invariants 1 and 2, which this
+iteration establishes and the later ones only inherit.
+
+## Read first
+
+- `packages/gemi/services/queue/Job.ts` — 25 lines, and the closest thing to
+  what `Event` is. Note the `static dispatch` typed through
+  `Parameters<T["run"]>`; `Event.dispatch` is the same trick through
+  `ConstructorParameters`.
+- `packages/gemi/services/queue/QueueManager.ts` — `useJobs` and the collision
+  handling. `EventManager` is shaped like this and makes the same choices for
+  the same reasons.
+- `packages/gemi/services/queue/config.ts` — the "declared wins, and `[]` is
+  declared" doc comment. The `listeners` slice repeats it, and the reasoning
+  transfers verbatim.
+- `packages/gemi/services/queue/QueueServiceProvider.ts` — why discovery lives
+  in `boot()` and reads the *raw* slice rather than the defaulted config.
+- `packages/gemi/services/discovery.ts` — `discoverJobs`, `resolveDir`,
+  `warnIfSourceIsMissing`, and `warnIfNameWillNotSurviveTheBuild`. All four have
+  an events counterpart; the last one is invariant 1.
+- `packages/gemi/support/discover.ts` — `discoverClasses(dir, base, ignore,
+  onSkipped)`. The `base` is excluded from results but intermediate classes are
+  not.
+- `packages/gemi/kernel/providers.ts` — `frameworkProviders`, in registration
+  order. Order matters for `boot()` only.
+- `packages/gemi/support/Service.ts` — `static token`, the house pattern for a
+  class declaring its own registration key, which `static name` and
+  `static event` follow.
+- `packages/gemi/services/index.ts` — the barrel. `gemi/services` publishes no
+  subpaths, so anything an app needs has to be re-exported here.
+- `packages/gemi/barrel-imports.test.ts` — why the barrel must not pull in
+  anything heavy at module scope.
+
+## Deliverables
+
+### 1. `packages/gemi/services/events/Event.ts`
+
+```ts
+// sketch
+export abstract class Event {
+  static name = "unset";
+
+  static dispatch<T extends new (...args: any[]) => Event>(
+    this: T,
+    ...args: ConstructorParameters<T>
+  ): void {
+    app(EventManager).dispatch(new this(...args));
+  }
+
+  static dispatchAndWait<T extends new (...args: any[]) => Event>(
+    this: T,
+    ...args: ConstructorParameters<T>
+  ): Promise<void> {
+    return app(EventManager).dispatchAndWait(new this(...args));
+  }
+}
+```
+
+Two methods rather than one, because "is this worth awaiting" is a question the
+call site should not have to guess at. `dispatch` is fire-and-forget and matches
+`Job.dispatch`'s shape; `dispatchAndWait` resolves once every sync listener has
+settled — it does **not** wait for queued ones, and its doc comment says so in
+those words, because "and wait" invites exactly that reading.
+
+`static name = "unset"` and a throw on dispatching it, copied from `Job`. The
+throw is the cheap half of invariant 1; `warnIfNameWillNotSurviveTheBuild` in
+§4 is the half that catches the case where a name exists but is the implicit
+class binding.
+
+The event instance is what listeners receive. It carries no framework state —
+no timestamp, no id, no `propagationStopped`. An event is the payload plus a
+name, and anything else is a field the app can add itself.
+
+### 2. `packages/gemi/services/events/Listener.ts`
+
+```ts
+// sketch
+export abstract class Listener {
+  static name = "unset";
+  static event: EventClass;
+
+  queued = false;
+
+  abstract handle(event: Event): void | Promise<void>;
+}
+```
+
+One exported name, and a plain class — `extends Listener`, the way everything
+else in gemi is written. No generic parameter: the base annotates `handle` with
+`Event` and method parameter bivariance is what lets `SendWelcomeEmail` narrow
+it to `UserRegistered` without one.
+
+`static event` holds the event **class**, not its name. The name is read from it
+at registration time inside `useListeners`, not here, and that is deliberate:
+the class reference is only ever dereferenced in the module graph that declared
+it, so the name it yields is the source one. Nothing downstream holds the class
+for dispatch (invariant 1).
+
+`handle` is abstract so a listener that forgets it fails to compile rather than
+silently handling nothing.
+
+`static event` is typed as an `Event` subclass constructor, which is as far as
+the type system reaches. **It cannot check that `static event` agrees with the
+annotation on `handle`** — statics and instance members cannot reference each
+other's types — and the README records that as an accepted seam. The `.test-d.ts`
+under **Tests** pins the half that *is* checkable, so the constraint is not
+quietly widened to `any` by a later refactor reaching for convenience.
+
+The plan deliberately does **not** grow a `static events` array. The reasoning
+is in the README under "One event per listener"; the short version is that the
+plural form pushes `instanceof` into application code, where it is `true` in
+every test and `false` in production.
+
+### 3. `packages/gemi/services/events/EventManager.ts`
+
+```ts
+// sketch
+export class EventManager {
+  static token = "events";   // free — checked against every registered token
+
+  private listeners: Record<string, ListenerClass[]> = {};
+  private warnedFor = new Set<string>();
+
+  constructor(config: EventConfig = {}) { ... }
+
+  useListeners(listeners: ListenerClass[]) { ... }
+  get registeredListeners(): ReadonlyArray<ListenerClass> { ... }
+
+  dispatch(event: Event): void { void this.dispatchAndWait(event); }
+  async dispatchAndWait(event: Event): Promise<void> { ... }
+}
+```
+
+Shaped after `QueueManager` deliberately — same construction-in-`register()`,
+same `use*` handover from `boot()`, same `registered*` getter reporting what it
+was *handed* rather than what it accepted, so a test can see a collision instead
+of having it tidied away.
+
+Three behaviours that are not `QueueManager`'s:
+
+**Many listeners per key, not one.** `Record<string, Listener[]>`, appended to.
+Two listeners for one event is the normal case here, where two jobs for one name
+is the pathological one. The collision `useListeners` does have to refuse is two
+*listener classes* with the same `static name` — that only matters once
+iteration 2 puts the name on the wire, but it is refused from the start so the
+rule does not appear to change later.
+
+**Registration order is the walk's order.** `discoverClasses` documents its
+order as stable — the walk's, and within a file the module namespace's, which
+the language sorts by name. It is therefore reproducible but not *meaningful*,
+and no listener may depend on running before another. Invariant 3 is what makes
+that safe to say: nothing a listener does can stop the next one.
+
+**A zero-listener dispatch warns, in development, once per event name**
+(invariant 2):
+
+```ts
+// sketch
+if (!handlers?.length && process.env.NODE_ENV !== "production") {
+  if (!this.warnedFor.has(name)) {
+    this.warnedFor.add(name);
+    console.warn(
+      `[gemi] ${name} was dispatched and nothing is listening for it. ` +
+        `A listener registers under the name its event declares, so check ` +
+        `that app/listeners holds a Listener with \`static event = ${name}\` ` +
+        `and that ${name} declares \`static name = "${name}"\`. ` +
+        `Development only.`,
+    );
+  }
+}
+```
+
+Once per name, because a dispatch in a loop would otherwise bury the terminal.
+`warnedFor` is per-manager and the manager is per-app, so a test that builds a
+fresh kernel gets a fresh set.
+
+**Errors.** Each listener runs inside its own `try`. A throw is logged with the
+event name, the listener name, and the error, and the loop continues. Nothing
+propagates to the dispatcher — `dispatch` has already returned, and
+`dispatchAndWait` resolving to a rejection would mean listener 1's failure
+becomes the caller's problem while listener 5's does not, depending only on
+where the throw landed. Neither method rejects.
+
+### 4. `packages/gemi/services/discovery.ts` — `discoverListeners`
+
+The fourth function in the file, built exactly like `discoverJobs`:
+
+```ts
+// sketch
+export async function discoverListeners(
+  dir: string = eventConfigDefaults().listenersDir,
+): Promise<ListenerClass[]> {
+  const resolved = resolveDir(dir);
+  warnIfSourceIsMissing(resolved, "event listeners", "events");
+  const listeners = await discoverClasses(resolved, Listener);
+  warnIfListenerNameWillNotSurviveTheBuild(listeners);
+  warnIfEventNameWillNotSurviveTheBuild(listeners);
+  return listeners;
+}
+```
+
+Two name checks rather than one, and the second is the one that matters. A
+listener's own name does not go on the wire until iteration 2, but the **event**
+name is invariant 1 from the first dispatch. Each listener carries its event
+class on `static event`, so the check is
+`Object.getOwnPropertyDescriptor(L.event, "name")?.writable` — the same exact
+test `warnIfNameWillNotSurviveTheBuild` uses, for the same reason: a declared
+`static name` is a writable own property while an implicit class binding is not.
+
+A listener whose `static event` is missing entirely is refused here rather than
+warned about. It cannot be registered under any name, so it would be a file the
+author wrote that never runs — the silence this whole file is arranged against.
+
+Do not skip this by checking the string instead. `UserRegistered.name` reads
+`"UserRegistered"` in development whether it was declared or not; the descriptor
+is what tells the two apart, and the difference only becomes visible in a
+production build.
+
+**Known residual, matching jobs and cron.** `discoverClasses` excludes the
+`base` it is handed but not intermediates, so an abstract listener base written
+in `app/listeners` and extended by its siblings is itself discovered and
+registered. It will be constructed and its `handle` called on every matching
+dispatch. `discoverClasses`'s own doc comment describes this shape as the one
+"an app reaches for when several jobs share a gate", so it is not hypothetical.
+Document it in `docs/events.md`; keep shared bases outside `listenersDir`. A
+`static abstract = true` opt-out is the fix if it bites, and is deliberately not
+built now.
+
+### 5. `packages/gemi/services/events/config.ts`
+
+```ts
+// sketch
+// Config key: `events`. Derived from `EventServiceProvider`.
+export interface EventConfig {
+  listeners?: ListenerClass[];
+  listenersDir?: string;
+}
+
+export function defineEventConfig(config: EventConfig): EventConfig { return config; }
+
+export function eventConfigDefaults(): Required<EventConfig> {
+  return { listeners: [], listenersDir: "app/listeners" };
+}
+```
+
+The `listeners` doc comment carries the same rule as `queue.jobs`, and the
+reasoning transfers with one substitution: what a hand-maintained list drifting
+out of step costs here is not a dropped job but a side effect that stops
+happening, with the zero-listener warning (development only) as the only trace.
+
+No `eventsDir`. Event classes are never discovered — they are imported by the
+listener that binds to them and by the controller that dispatches them, so
+nothing needs to walk them, and a directory walk that imported them for no
+reason would just be a boot cost.
+
+### 6. `packages/gemi/services/events/EventServiceProvider.ts`
+
+`register()` binds the singleton from the raw slice. `boot()` does discovery,
+and reads the **raw** slice — not the defaulted config — for the reason
+`QueueServiceProvider.boot` documents at length: `withDefaults` cannot tell an
+absent key from an `undefined` one, and both from a deliberate `[]`, so the raw
+slice is the only place the distinction still exists.
+
+Registered in `kernel/providers.ts`. Position does not matter in iteration 1
+(`register()` resolves nothing, and its `boot()` depends on no other provider) —
+but put it **after** `QueueServiceProvider`, because iteration 2 needs its
+`boot()` to run after the queue's registry is populated. Putting it in the right
+place now saves a reordering in a patch that is otherwise about something else.
+
+### 7. Exports and docs
+
+- `services/index.ts` gains an `// Events` section: `EventServiceProvider`,
+  `EventManager`, `Event`, `Listener`, `defineEventConfig`, and
+  `discoverListeners`. Every manager in that file is exported beside its
+  provider; `docs-imports.test.ts` exists because `AuthManager` was not.
+- Nothing new in the `exports` map. `gemi/services` already publishes and
+  `barrel-imports.test.ts` guards what it costs — none of these modules imports
+  anything at module scope beyond the container, so the barrel stays cheap.
+- `docs/events.md`, plus an entry in `docs/README.md` and `docs/llms.txt` /
+  `llms-full.txt` if those are generated rather than written.
+- `docs-imports.test.ts` checks every `import … from "gemi/…"` in the docs
+  against the entrypoint, so the doc and the barrel land together or the suite
+  fails.
+
+## Tests
+
+Colocated vitest, following `QueueManager.test.ts`.
+
+- **Fan-out.** Two listeners on one event, both run, both receive the same
+  instance with the constructor's arguments on it.
+- **Isolation.** Three listeners, the middle one throws: the third still runs,
+  neither `dispatch` nor `dispatchAndWait` rejects, the error is logged with
+  both names. This is invariant 3 and it is the one a refactor breaks.
+- **`dispatchAndWait` actually waits.** An async listener that resolves on a
+  deferred; assert the promise has not settled before it does.
+- **Zero listeners warn once.** Dispatch the same event three times, one
+  warning. Dispatch a second unlistened event, a second warning. Nothing in
+  `NODE_ENV=production`.
+- **The name check reads the descriptor, not the string.** Build one event class
+  with `static name = "X"` and one whose name is implicit but reads `"X"`
+  anyway; only the second warns. Without this test the check silently degrades
+  to a tautology on the next refactor.
+- **`registeredListeners` reports what was handed in**, including a duplicate
+  `static name` that `useListeners` refused.
+- **Order is the walk's order**, asserted against a fixture directory, so the
+  "reproducible but not meaningful" claim in §3 is at least the first half true.
+- **Discovery**: a fixture `app/listeners` tree; a nested directory; a file that
+  cannot be imported raises `DiscoveryError` rather than being skipped.
+- **Declared wins, and `[]` is declared** — three provider-level cases
+  (`listeners: [X]`, `listeners: []`, key absent), asserting whether the
+  directory was read at all.
+- **A listener with no `static event` is refused**, by name, at `useListeners`.
+
+And one type test, `services/events/Listener.test-d.ts`, following
+`console/builder.test-d.ts`:
+
+- `static event = SomethingThatIsNotAnEvent` is an error.
+- `handle(event: UserRegistered)` narrowing the base's `Event` parameter is
+  *not* an error — that is the bivariance the no-generic design leans on, and if
+  a future `strictFunctionTypes`-adjacent change breaks it, every listener in
+  every app breaks at once.
+
+Neither can express the seam itself. The point of writing them down is that the
+two things the compiler *does* enforce here are load-bearing and easy to widen
+into `any` by accident.
+
+## Out of scope
+
+`queued`, `afterCommit`, `Event.fake()`, event subclass listeners (a listener
+bound to a base event class receiving its subclasses), wildcard listeners, and
+listener priority. The last two are worth resisting specifically: priority is
+invariant 3 arriving through the back door, and a wildcard listener cannot be
+typed against a payload.

--- a/plans/events/02-queued-listeners.md
+++ b/plans/events/02-queued-listeners.md
@@ -1,0 +1,194 @@
+# Iteration 2 — Queued listeners
+
+**Goal.** `queued = true` on a listener moves it off the request path and onto
+the existing queue, with `maxAttempts`, retries, dead-lettering and worker
+threads coming from `QueueManager` rather than from anything written here.
+
+```typescript
+export class SendWelcomeEmail extends Listener {
+  static name = "SendWelcomeEmail";
+  static event = UserRegistered;
+  queued = true;
+  maxAttempts = 5;
+
+  async handle(event: UserRegistered) { await Mail.send(event.email, ...); }
+}
+```
+
+This is the iteration the stated use case actually wants — moving controller
+side effects off the request — so most listeners in a real app will carry the
+flag. That is the argument for making it one line, and also the argument for
+being loud about what it changes (invariant 4).
+
+## Prerequisite state
+
+Iteration 1 is merged. Every dispatch goes through `EventManager`, listeners are
+discovered from `app/listeners`, and `Event` declares `static name`.
+
+## Read first
+
+- `packages/gemi/services/queue/QueueManager.ts` — `push`, `next`, `run`, and
+  `useJobs`. Three things below hinge on details in this file: `push` keys the
+  queue entry off `job.name`, `useJobs` **replaces** the whole registry, and
+  `run` reads `maxAttempts` and `worker` off a fresh instance per attempt.
+- `packages/gemi/services/queue/Job.ts` — the hooks `run`/`onSuccess`/`onFail`/
+  `onDeadletter` and their signatures, all of which the adapter has to satisfy.
+- `docs/jobs-and-queues.md` — the retry semantics, stated for apps, which
+  queued listeners now inherit verbatim.
+- `packages/gemi/kernel/Kernel.ts` — `registerServices` and the two collision
+  guards, for what "already bound" means.
+- `packages/gemi/services/queue/QueueManager.test.ts` — how the queue is driven
+  in a test without a running server.
+
+## The shape: one synthetic job per queued listener
+
+A queued listener is registered with the queue as a `Job` subclass generated at
+boot:
+
+```ts
+// sketch
+function jobForListener(L: ListenerClass): new () => Job {
+  const cls = class extends Job {
+    maxAttempts = new L().maxAttempts;
+    worker = new L().worker;
+
+    async run(eventName: string, args: unknown[]) {
+      const event = app(EventManager).rehydrate(eventName, args);
+      await new L().handle(event);
+    }
+  };
+  Object.defineProperty(cls, "name", {
+    value: `listener:${L.name}`,
+    writable: true,
+  });
+  return cls;
+}
+```
+
+`EventManager.dispatch` then splits: sync listeners are awaited in place as in
+iteration 1, and each queued one becomes `app(QueueManager).push(job,
+JSON.stringify([event.constructor.name, ctorArgs]))`.
+
+Why adapt rather than grow a second queue: retries, `maxAttempts`,
+dead-lettering, `concurrency` and worker-thread execution are four features that
+already exist, are already documented for apps, and are already tested. A
+parallel implementation would be four features that are almost the same.
+
+`writable: true` on the redefined `name` is not cosmetic — it is what
+`warnIfNameWillNotSurviveTheBuild` reads to decide a name was *declared*. A
+synthetic class whose name is a non-writable own property would be reported to
+the author as a job they never wrote and cannot fix.
+
+## Deliverables
+
+### 1. `QueueManager.registerJob(job)`
+
+`useJobs` replaces the registry wholesale (`this.jobs = {}`), so
+`EventServiceProvider.boot()` cannot simply call it — the queue's own `boot()`
+has already populated the registry by then, and calling `useJobs` again would
+discard it. Reading `registeredJobs`, concatenating and calling `useJobs` back
+works and is the wrong shape: it re-runs every collision check against jobs that
+already passed them and reports duplicates a second time.
+
+Add a single-job entry point beside `useJobs`, sharing its collision handling —
+first claim wins, second refused on stderr — and appending to `config.jobs` so
+`registeredJobs` keeps reporting everything it was handed.
+
+Provider order matters from here: `EventServiceProvider` must sit **after**
+`QueueServiceProvider` in `frameworkProviders`, because its `boot()` writes into
+a registry the queue's `boot()` fills. Iteration 1 put it there already.
+
+### 2. `Listener` gains `maxAttempts` and `worker`
+
+Instance fields on `Listener`, defaulting to `3` and `false` — the same
+defaults and the same meanings as `Job`, because they *are* `Job`'s, forwarded.
+Both are ignored when `queued` is false, and that is worth a doc comment on each
+rather than a note somewhere else: a `maxAttempts = 5` on a sync listener is a
+line an author wrote that does nothing.
+
+### 3. `static name` on `Listener` becomes required
+
+In iteration 1 the listener's own name was internal. Here it is the queue's key
+and it crosses a JSON boundary, so it inherits the whole minification story from
+invariant 1 — and `discoverListeners` already has the check written for the
+event class; point it at the listener class too.
+
+Upgrade the iteration-1 `warnIfListenerNameWillNotSurviveTheBuild` from advisory
+to something an author cannot miss: a queued listener whose name is implicit is
+a side effect that stops happening in production only.
+
+### 4. `EventManager.rehydrate(eventName, args)`
+
+The queue hands the worker a name and an argument array; something has to turn
+that back into an event instance. This is the second place invariant 1 is load-
+bearing, and the first place `EventManager` needs to resolve an **event** class
+by name rather than a listener.
+
+So `EventManager` keeps a second registry: event name → event class, populated
+from each listener's `static event` at `useListeners` time. An event nobody
+listens for is never in it, which is exactly right — nothing can be queued for
+it.
+
+Rehydration is `new EventClass(...args)`, matching how `QueueManager` already
+treats a job payload: **the constructor arguments are what is serialized, not
+the instance.** An event whose constructor does work beyond assigning fields
+does that work again in the worker; say so in the docs, next to the existing
+"pass plain, serializable data" note for jobs.
+
+A name that resolves to nothing here is the one case that must throw rather than
+warn: the payload is already off the queue, the listener is about to be called
+with `undefined`, and a `handle` reading `event.email` off it would fail
+somewhere much less informative.
+
+### 5. Documentation of the context boundary (invariant 4)
+
+`queued = true` is a context boundary spelled as a field, and this is where it
+gets written down properly — in the field's doc comment, and in `docs/events.md`
+as its own subsection rather than a parenthesis:
+
+- A sync listener runs inside the dispatcher's `kernelContext` and `ormContext`.
+  It sees the request's `app()`, the authenticated user via `currentActor()`,
+  and joins the ambient transaction.
+- A queued listener runs later, from `QueueManager.next()`, outside all of it —
+  and with `worker = true`, in a different thread with a cloned app.
+
+The failure this prevents is a policied `Model` read inside a listener returning
+different rows depending on a flag the author set for latency reasons.
+
+### 6. Durability, stated plainly
+
+`QueueManager.queue` is a `Set` in memory. A queued listener that has not run
+when the process exits does not run. This is not new — it is true of every job
+today — but an event system invites "dispatch it and it will happen", so the
+docs say the opposite in the queued section: a dispatch is not a durability
+guarantee, and work that must survive a restart wants a row somewhere.
+
+## Tests
+
+- **Sync and queued in one dispatch.** Two listeners on one event, one of each:
+  the sync one has run by the time `dispatchAndWait` resolves and the queued one
+  has not; drive the queue and it runs.
+- **`dispatchAndWait` does not wait for queued listeners.** The explicit form of
+  the above, because the method name suggests otherwise.
+- **Retries come from the queue.** A queued listener with `maxAttempts = 2` that
+  always throws: attempted twice, `onDeadletter` reached. Assert against
+  `QueueManager`'s existing path rather than re-testing retry logic.
+- **Rehydration round-trips.** Constructor arguments in, equal field values on
+  the instance the listener receives.
+- **An unknown event name on the queue throws**, with the name in the message.
+- **The synthetic job's `name` is a writable own property**, so the discovery
+  warning does not fire on it. Cheap, and it protects a non-obvious line.
+- **`registerJob` refuses a duplicate** without discarding the existing
+  registry — the failure mode `useJobs` would have had.
+- **Two listeners with the same `static name`** are refused at `useListeners`,
+  and both still appear in `registeredListeners`.
+
+## Open
+
+**Do synthetic jobs belong in `QueueManager.registeredJobs`?** As written they
+do, under `listener:SendWelcomeEmail`. In favour: `registeredJobs` is documented
+as reporting what the manager was handed, a queued listener genuinely is
+something the queue will run, and hiding it makes a queue introspection tool
+lie. Against: an app listing its jobs now sees entries it never wrote, and the
+prefix is the only thing marking them. Ship visible; revisit if the noise is
+real.

--- a/plans/events/03-after-commit-and-testing.md
+++ b/plans/events/03-after-commit-and-testing.md
@@ -1,0 +1,187 @@
+# Iteration 3 — After-commit dispatch, and testing
+
+**Goal.** Two unrelated things that both only become possible once the
+subsystem exists, and neither of which is large enough for its own iteration.
+
+1. `static afterCommit = true` on an event: dispatched inside a transaction, its
+   listeners run when that transaction commits, and not at all if it rolls back.
+2. `Event.fake()` and the assertions, so a controller test can say what was
+   dispatched without running the side effects.
+
+## Prerequisite state
+
+Iterations 1 and 2 are merged.
+
+## Read first
+
+- `packages/gemi/orm/context.ts` — `ormContext`, the `OrmScope` interface,
+  `withTransaction`, and `transactionDepth()`. The whole of part one lands in
+  this file and it is worth reading the doc comments before touching it; the
+  savepoint branch and the outermost branch are structurally different and only
+  one of them may run the callbacks.
+- `packages/gemi/orm/context.test.ts` — especially "two concurrent transactions
+  never see each other's handle", which is the property part one must not break.
+- `packages/gemi/testing/index.ts` and `Page.tsx` — what the testing entrypoint
+  currently publishes, and its idioms.
+- `packages/gemi/services/queue/QueueManager.test.ts` — how a test drives the
+  queue, for the interaction between a fake and a queued listener.
+
+---
+
+## Part one — `afterCommit`
+
+### The problem
+
+```typescript
+await DB.transaction(async () => {
+  const user = await User.create(input);
+  UserRegistered.dispatch(user.id, user.email);   // welcome email sent
+  await Billing.provision(user);                  // throws
+});                                               // rolled back
+```
+
+The user does not exist and has been welcomed. Sync listeners have already run;
+queued ones are on an in-memory queue that has no idea a transaction was
+involved. Laravel added `ShouldDispatchAfterCommit` for exactly this shape.
+
+gemi can detect it precisely, which not every framework can: `ormContext` holds
+the open handle and the nesting depth, and `withTransaction` is the single
+implementation behind both `Model.transaction` and `DB.transaction`, so there is
+one place to hook and no second path around it.
+
+### Deliverables
+
+**1. `OrmScope` gains an after-commit callback list.**
+
+Held on the **outermost** scope only, and this is the part to get right. A
+savepoint's scope is created by spreading the current one
+(`{ ...current, tx: nested, depth: current.depth + 1 }`), so a naive array field
+is shared by reference with the parent — which is, for once, the behaviour
+wanted: a dispatch inside a savepoint that commits, in a transaction that then
+rolls back, must not run. Rolling back the outer transaction discards the whole
+list, savepoint entries included.
+
+The inverse — a savepoint that rolls back while the outer transaction commits —
+is the case the shared array gets wrong, and it needs handling: entries added
+inside a savepoint that is rolled back must be dropped. Record the depth
+alongside each callback and truncate on savepoint failure.
+
+**2. `withTransaction` drains the list on commit.**
+
+Only in the outermost branch, after `begin` resolves — never in the savepoint
+branch, which has not committed anything durable. On rejection, the scope is
+discarded and nothing runs.
+
+Draining happens **outside** the transaction scope, deliberately: a listener
+that runs after commit must not join the transaction that just closed, and
+`ormContext.run` with a scope carrying no `tx` is how to guarantee it. A
+listener that opens its own transaction then does so cleanly.
+
+A throwing callback must not turn a committed transaction into a rejected one —
+the transaction succeeded, and reporting otherwise would have the caller roll
+back work the database has already kept. Catch, log, continue, exactly as
+invariant 3 requires within a single dispatch.
+
+**3. `Event` gains `static afterCommit = false`.**
+
+`EventManager.dispatch` checks `currentTransaction()`. Three cases:
+
+| `afterCommit` | in a transaction | behaviour |
+| --- | --- | --- |
+| `false` | either | dispatch now — unchanged from iterations 1 and 2 |
+| `true` | no | dispatch now; there is nothing to wait for |
+| `true` | yes | queue the dispatch on the scope, drain on commit |
+
+`dispatchAndWait` on a deferred event resolves **immediately**, having run
+nothing. That is a genuinely sharp edge and the reason this ships opt-in: the
+two features compose into something that does not do what either name suggests.
+The doc comment on `afterCommit` says so, and the pairing warns in development.
+
+**4. Opt-in, not default.**
+
+Defaulting it on would mean a `dispatch` inside a transaction silently does not
+happen yet — turning a fire-and-forget call into a deferred one based on ambient
+state the call site cannot see. That is a different surprise of the same size as
+the one being fixed, and it is the one that is harder to debug because nothing
+went wrong. Revisit for a major once there is usage to look at.
+
+### Tests
+
+- Commit runs the deferred listeners; rollback runs nothing.
+- A deferred dispatch inside a savepoint runs when the **outer** transaction
+  commits, not when the savepoint does.
+- A savepoint that rolls back inside a transaction that commits: the dispatch
+  made inside the savepoint does not run; one made before it does.
+- Callbacks run outside the transaction — `currentTransaction()` is `undefined`
+  inside a deferred listener.
+- A throwing callback does not reject the transaction, and the next callback
+  runs.
+- Two concurrent transactions do not see each other's deferred dispatches. This
+  is the existing `context.test.ts` property extended to the new field, and it
+  is the one an implementation on a module-level array gets wrong.
+- `afterCommit` with no transaction open dispatches immediately.
+
+---
+
+## Part two — testing
+
+### `Event.fake()`
+
+```typescript
+// sketch
+const events = Event.fake();
+
+await post("/register", { email: "a@b.c" });
+
+events.assertDispatched(UserRegistered);
+events.assertDispatched(UserRegistered, (e) => e.email === "a@b.c");
+events.assertNotDispatched(WelcomeBackEmail);
+events.assertNothingDispatched();
+```
+
+A fake swaps the container binding for a recording `EventManager` that registers
+no listeners and runs nothing. The point is the second line of the sketch: a
+controller test asserting *that the event fired* is testing the controller, and
+a controller test asserting *that a welcome email was sent* is testing three
+things and will break when the fourth listener is added. Events are worth having
+mostly because they make that separation possible, and a fake is what makes it
+convenient.
+
+The predicate form takes the event instance and is typed off the class passed
+in — the same `InstanceType<T>` inference `Listener()` uses.
+
+### Deliverables
+
+- A `FakeEventManager` extending `EventManager`, overriding `dispatch` /
+  `dispatchAndWait` to record and return.
+- `Event.fake()` binds it, returns it, and returns the *same* instance on a
+  second call within a test so `Event.fake()` in a helper and in the test body
+  do not disagree.
+- Restoration. Whatever `testing/` already does for teardown; if there is no
+  hook, the returned object gets a `restore()` and the docs show it in
+  `afterEach`. A fake that outlives its test is a subsequent test whose
+  listeners silently never run — the same silence as invariant 2 and with no
+  warning to catch it, since a fake legitimately has no listeners.
+- `assertDispatched`, `assertNotDispatched`, `assertDispatchedTimes`,
+  `assertNothingDispatched`. Failure messages name what *was* dispatched — the
+  common failure is an event fired with a different payload than expected, and
+  "expected UserRegistered, dispatched: UserRegistered(2, 'b@c.d')" ends the
+  investigation on the spot.
+- Exported from `gemi/testing`, not `gemi/services` — it is test-only, and
+  `barrel-imports.test.ts` is about not making every app pay for things it does
+  not use.
+
+### The interaction worth testing
+
+A fake and a **queued** listener. Nothing should reach `QueueManager`: a faked
+dispatch records and stops. Without this, a controller test with a fake still
+enqueues real work, which runs against a test database after the assertions have
+passed.
+
+## Out of scope
+
+`Event.fakeExcept()` / partial fakes, snapshotting dispatched events, and any
+assertion about *listeners* having run. The last is the one that will be asked
+for and is worth declining: a test that asserts a listener ran is a test of the
+listener, and it can call `new SendWelcomeEmail().handle(new UserRegistered(…))`
+directly with no framework involvement at all.

--- a/plans/events/README.md
+++ b/plans/events/README.md
@@ -230,10 +230,15 @@ Flagged where they land, not settled here.
   (iteration 2). They will, under a `listener:` prefix, unless deliberately
   filtered. Visible is probably right; noisy is the counter-argument.
 - **What happens to an abstract listener base that lives in `app/listeners`?**
-  It gets discovered and registered, because `discoverClasses` excludes only the
-  `base` it was handed, not intermediates. Jobs and cron have the same residual
-  today. Iteration 1 documents it; a `static abstract = true` opt-out is
-  available if it turns out to bite.
+  It gets discovered either way, because `discoverClasses` excludes only the
+  `base` it was handed, not intermediates. What happens next depends on whether
+  it declares `static event`. **Without one it stops the boot** — iteration 1 §4
+  refuses a listener that binds to nothing rather than warning about it, and the
+  message names the class and says to move a shared base out of the directory.
+  That is the shared-gate case, and it is the narrower answer of the two. **With
+  one** it is registered and run like any other listener, which is the residual
+  jobs and cron have today. Iteration 1 documents both; a
+  `static abstract = true` opt-out is available if it turns out to bite.
 - **Should `afterCommit` be the default in a later major?** Iteration 3 ships it
   opt-in and revisits with usage.
 

--- a/plans/events/README.md
+++ b/plans/events/README.md
@@ -1,0 +1,249 @@
+# gemi events — implementation plan
+
+Laravel-style events and listeners: one dispatch fans out to N handlers the
+dispatcher does not know about.
+
+```typescript
+// the controller stops knowing what happens next
+const user = await User.create(input);
+UserRegistered.dispatch(user.id, user.email);
+```
+
+The thing being bought is that adding a fourth side effect becomes adding a
+file, rather than editing the controller that already has three.
+
+## Stack position
+
+**Branch from `main`.** Nothing here depends on in-flight work. The three
+iterations are independently shippable and want to land in order; each is a
+release-note-sized change on its own.
+
+## Why this is a small subsystem and not a large one
+
+gemi already has three "something happened, now react" mechanisms, and the gap
+between them is narrow:
+
+| Mechanism | Fan-out | Where the handler runs |
+| --- | --- | --- |
+| `Job.dispatch()` | 1 → 1 | queue, retried, dead-lettered |
+| `BroadcastManager.publish()` | 1 → N | *clients*, over websockets |
+| a direct call in a controller | 1 → N | inline, and the caller names each one |
+
+What is missing is exactly one row: **1 → N server-side handlers, where the
+dispatcher does not hold the list.** Everything else an event system is
+sometimes asked to do — retries, dead-lettering, worker threads, pushing to a
+browser — is already built and should be reached rather than rebuilt. That is
+why iteration 2 adapts `QueueManager` instead of growing a second queue.
+
+**This plan does not include ORM lifecycle events** (`User.created` and
+friends). That is a different system: it hooks the write path in `orm/`, it has
+its own transaction-commit semantics, and it would arrive through
+`Model.$exec` rather than through a dispatcher. If it is ever wanted, it wants
+its own plan and can emit into this one.
+
+## The one thing that does not port from Laravel
+
+Laravel binds a listener to an event by **reflecting on the type-hint** of
+`handle(UserRegistered $event)`. TypeScript erases types at runtime, so that
+mechanism cannot exist here. The binding has to be carried as a *value*.
+
+This is the constraint the API shape falls out of, and it is a favourable one:
+making the binding a value is also what makes the payload types flow without a
+generated registry.
+
+```typescript
+// app/events/UserRegistered.ts
+import { Event } from "gemi/services";
+
+export class UserRegistered extends Event {
+  static name = "UserRegistered";
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+```
+
+```typescript
+// app/listeners/SendWelcomeEmail.ts
+import { Listener } from "gemi/services";
+import { UserRegistered } from "@/app/events/UserRegistered";
+
+export class SendWelcomeEmail extends Listener {
+  static name = "SendWelcomeEmail";
+  static event = UserRegistered;
+  queued = true;
+
+  async handle(event: UserRegistered) {
+    await Mail.send(event.email, ...);
+  }
+}
+```
+
+**The binding lives on the listener, not the event.** The listener is the thing
+with an opinion about what it cares about; an event has no business knowing who
+is watching. That direction is also what keeps the property the subsystem is
+bought for — adding a side effect is adding a file, and no existing file is
+edited.
+
+**A `static event` field, not a `Listener(UserRegistered)` class factory.** The
+factory is the only shape in which the event cannot drift apart from `handle`'s
+annotation, because it infers the parameter. It was rejected for reading oddly,
+which is a fair price to refuse to pay for something every app writes dozens of
+times: `static event` is how every other class in gemi declares things about
+itself (`static token`, `static name`, `static $policies`).
+
+No generic parameter is needed. `Listener` declares `handle(event: Event)`
+and method parameter bivariance lets a subclass narrow it to `UserRegistered`.
+
+What that costs is written down rather than hidden: **nothing checks that
+`static event` and the annotation on `handle` agree.** Copy a listener, change
+the static, forget the annotation, and TypeScript is satisfied while the
+listener receives something else. It is an accepted seam, and it is accepted
+because the failure is local and immediate — that one listener reads a field
+that is not there, in its own stack — rather than the misroute-shaped failures
+the invariants below exist to prevent. `static event` is constrained to an
+`Event` subclass, which is as far as the type system reaches here.
+
+`dispatch` forwarding its arguments to the constructor mirrors `Job.dispatch`'s
+existing `Parameters<T["run"]>` trick, so the two subsystems read the same way
+at the call site.
+
+### One event per listener
+
+`static event`, singular, and `static events = [A, B]` is deliberately not
+offered.
+
+A listener bound to two events has to discriminate inside `handle`, and the
+natural way to write that is `if (event instanceof UserRegistered)`. That is
+unsound here for precisely the reason invariant 1 gives: the controller
+dispatches an instance built from the **bundled** `UserRegistered` while the
+listener's `instanceof` tests against the **source** one, so it is `false` in
+production and `true` in every test. The plural form's ergonomics invite a
+silent production-only bug into application code, which is a worse thing to ship
+than a little duplication.
+
+Two events wanting the same side effect are two small listeners calling one
+shared function.
+
+## Invariants
+
+These hold across all three iterations. Each is here because breaking it
+produces a *silent* wrong result rather than an error.
+
+### 1. The registry is keyed by declared `static name`, never by class identity
+
+This is the least obvious decision in the plan and the one most likely to be
+"simplified" away, so it is first.
+
+A `Map<typeof Event, Listener[]>` keyed by the class object is the obvious
+implementation and it is wrong in production only. `gemi build` minifies the
+server entry, and the app code reachable from it — the controller, and every
+event class that controller imports in order to dispatch — is bundled and
+minified with it. Discovery, meanwhile, imports `app/listeners/*.ts` from source
+at runtime, and those files import `app/events/UserRegistered.ts` from source
+too. **Two module graphs, two `UserRegistered` class objects.** An
+identity-keyed map looks up the bundled one, finds the entry registered under
+the source one, and returns nothing.
+
+The failure that produces is a dispatch with zero listeners, which is legal,
+normal, and completely silent. It would work in development, pass every test,
+and do nothing in production.
+
+A declared `static name = "UserRegistered"` is a string literal. Minification
+leaves string literals alone, so both halves agree. This is the same hazard
+`services/discovery.ts:warnIfNameWillNotSurviveTheBuild` already documents for
+jobs, one subsystem over, and it is worse here because a job at least logs when
+its name resolves to nothing.
+
+Consequence: `static name` is **required on `Event`**, and required on
+`Listener` from iteration 2 (where the listener name crosses the queue's JSON
+boundary). Both get the writable-own-property check that discovery already
+applies to jobs.
+
+**Corollary, for application code: never `instanceof` an event.** The same two
+class objects make `event instanceof UserRegistered` inside a listener `true` in
+development and `false` in a production build. Nothing the framework does can
+fix that, so the framework's job is to never need it — which is why a listener
+binds to exactly one event (above), and why `docs/events.md` says this out loud
+rather than leaving it to be discovered.
+
+### 2. A dispatch with zero listeners warns in development
+
+Following directly from invariant 1: the one observable symptom of the bug
+above, of a typo'd event name, and of a listener directory that was never
+walked, is all the same symptom — nobody handled it. Since zero listeners is
+also a perfectly legal steady state, the warning is development-only and fires
+once per event name.
+
+This is the entire early-warning system for the subsystem. It is cheap and it
+is not optional.
+
+### 3. One listener's failure never prevents another listener from running
+
+Listeners are independent side effects by construction. Letting listener 2
+cancel 3 through 5 makes registration order load-bearing, which is the exact
+coupling the subsystem exists to remove — and registration order comes from a
+filesystem walk, so it is not even something an author chose.
+
+Each listener's error is caught, logged with the event and listener names, and
+the next one runs. Queued listeners keep the queue's existing retry and
+dead-letter path instead.
+
+### 4. Whether a listener is sync or queued changes what `app()` resolves to
+
+A sync listener runs inside the dispatcher's `kernelContext` and `ormContext`:
+it has the request's `app()`, the authenticated user, and the ambient
+transaction. A queued listener runs in a cloned app with none of that.
+
+`queued = true` is therefore not a performance toggle, and must not be
+documented as one. It is a context boundary that happens to be spelled as one
+line. Every doc and doc comment that mentions it says so.
+
+### 5. Nothing in the framework dispatches an event
+
+Only application code does, in these three iterations. Framework-internal
+fan-out has other mechanisms and adding a framework event now would fix its
+name and payload before there is a second consumer to check the shape against.
+
+## Decisions, settled
+
+| Decision | Choice | Why not the other one |
+| --- | --- | --- |
+| Binding direction | on the **listener** (`static event`) | an event listing its listeners means adding a side effect edits an existing file, and it puts knowledge of the watchers in the thing being watched |
+| Binding spelling | `static event = E` field | `Listener(E)` as a class factory is the only drift-proof shape, and reads oddly enough to lose the trade for something written this often |
+| Events per listener | exactly one | the plural form forces `instanceof` in app code, which is unsound across the build boundary (invariant 1) |
+| Default execution | **sync**, `queued = true` opts out | errors surface at the dispatch site; the listener keeps the request's context. Most listeners in an app like this will opt in — that is fine, and it should be a decision each one makes out loud |
+| Await semantics | `dispatch()` returns `void`; `dispatchAndWait()` returns a promise | one method that is sometimes worth awaiting is a method nobody knows whether to await |
+| Listener errors | caught per listener, logged, others continue | see invariant 3 |
+| Registration | discovered from `app/listeners`, `listeners` config slice overrides | matches jobs, cron and commands; same "declared wins, and `[]` is declared" rule |
+| Queued execution | adapts `QueueManager` | retries, `maxAttempts`, dead-lettering and worker threads already exist and are already tested |
+| Transaction safety | opt-in `static afterCommit = true` | see iteration 3 — defaulting it on would make `dispatch` inside a transaction silently not happen yet, which is its own surprise |
+
+## Decisions, open
+
+Flagged where they land, not settled here.
+
+- **Do synthetic listener jobs appear in `QueueManager.registeredJobs`?**
+  (iteration 2). They will, under a `listener:` prefix, unless deliberately
+  filtered. Visible is probably right; noisy is the counter-argument.
+- **What happens to an abstract listener base that lives in `app/listeners`?**
+  It gets discovered and registered, because `discoverClasses` excludes only the
+  `base` it was handed, not intermediates. Jobs and cron have the same residual
+  today. Iteration 1 documents it; a `static abstract = true` opt-out is
+  available if it turns out to bite.
+- **Should `afterCommit` be the default in a later major?** Iteration 3 ships it
+  opt-in and revisits with usage.
+
+## Iterations
+
+1. **[Sync dispatch](./01-sync-dispatch.md)** — `Event`, `Listener`,
+   `EventManager`, discovery, sync fan-out, the zero-listener warning. Useful on
+   its own.
+2. **[Queued listeners](./02-queued-listeners.md)** — `queued = true`, routed
+   through `QueueManager` via a synthetic job per listener.
+3. **[After-commit and testing](./03-after-commit-and-testing.md)** —
+   `afterCommit` hooked into `withTransaction`, plus `Event.fake()` and the
+   assertions.


### PR DESCRIPTION
Iteration 1 of `plans/events` — `Event`, `Listener`, `EventManager`, discovery, sync fan-out, and the zero-listener warning. The plan files land with this PR under `plans/events/`.

```typescript
// app/events/UserRegistered.ts
export class UserRegistered extends Event {
  static name = "UserRegistered";
  constructor(public userId: number, public email: string) { super(); }
}

// app/listeners/SendWelcomeEmail.ts
export class SendWelcomeEmail extends Listener {
  static name = "SendWelcomeEmail";
  static event = UserRegistered;
  async handle(event: UserRegistered) { await sendWelcome(event.email); }
}

// the controller stops knowing what happens next
UserRegistered.dispatch(user.id, user.email);
```

## What it delivers

- **`services/events/Event.ts`** — `static name`, `dispatch` (void) and `dispatchAndWait` (resolves when every sync listener has settled), both typed through `ConstructorParameters` the way `Job.dispatch` is typed through `Parameters<T["run"]>`.
- **`services/events/Listener.ts`** — `static name`, `static event`, abstract `handle`. No generic parameter: the base annotates `handle(event: Event)` and method-parameter bivariance is what lets a subclass narrow it.
- **`services/events/EventManager.ts`** — token `"events"`, `Record<string, ListenerClass[]>`, `useListeners` / `registeredListeners` shaped after `QueueManager`.
- **`services/events/config.ts`** — the `events` slice, carrying the queue's "declared wins, and `[]` is declared" rule. No `eventsDir`: event classes are never discovered.
- **`services/events/EventServiceProvider.ts`** — binds in `register()`, discovers in `boot()` off the **raw** slice, registered after `QueueServiceProvider`.
- **`services/discovery.ts`** — `discoverListeners`, plus the two name checks and the refusal described below.
- Barrel exports, `docs/events.md`, and entries in `docs/README.md`, `docs/index.html`, `docs/llms.txt` and `docs/llms-full.txt`.

## The three decisions worth reviewing

**The registry is keyed by the declared `static name`, never by class identity.** A class-keyed map is wrong in production only: `gemi build` bundles and minifies the controller and every event class it imports to dispatch, while discovery imports `app/listeners/*.ts` — and their `app/events/*.ts` — from source. Two module graphs, two class objects, and a lookup that finds nothing. `warnIfEventNameWillNotSurviveTheBuild` reads `Object.getOwnPropertyDescriptor(event, "name")?.writable`, because in development a declared name and an implicit one read the same string.

**A dispatch nothing handles warns once per event name, in development only.** That single line is the only symptom of four different mistakes, and zero listeners is also a legal steady state.

**One listener's failure never stops another.** Each listener runs in its own `try`; the throw is logged with both names and the loop continues. Neither `dispatch` nor `dispatchAndWait` rejects — a rejection would make listener 1's failure the caller's problem while listener 5's silently was not, depending only on where in a filesystem walk the throw landed.

## Deviations from the plan

- **`queued` is not shipped.** The deliverable sketch in §2 shows `queued = false`, but `queued` is also on the iteration's own out-of-scope list, and shipping the field before the queue routing exists would mean `queued = true` runs the listener synchronously inside the request while the author believes it does not — the silent no-op the invariants exist to prevent. Iteration 2 adds it with the behaviour.
- **`Event` carries a `declare protected readonly __isEvent: true` marker.** The plan asks the `.test-d.ts` to make `static event = SomethingThatIsNotAnEvent` an error, and an event has no instance members, so `new (...args: any[]) => Event` was structurally satisfied by every class in existence. `declare` emits no field and no subclass initialises it; without it that half of the type test is vacuous.
- **`EventClass` and `ListenerClass` are exported from the barrel** alongside the six names the plan lists, since `EventConfig.listeners` is written in terms of one of them.
- **A listener with no `static event` is refused in two places.** `discoverListeners` throws a `DiscoveryError` naming the classes (the plan's "refused here rather than warned about"), and `EventManager.useListeners` logs and skips (the plan's test, "refused, by name, at `useListeners`") so an explicit `listeners: [...]` slice does not take the boot down. Note the interaction with the documented residual: an abstract base in `listenersDir` **with** a `static event` is still discovered and registered like a listener, as the plan says; one **without** now stops the boot with a message telling the author to move it out of the directory.

## Verification

From `packages/gemi`, on the worktree:

```
$ bunx tsc --noEmit -p tsconfig.json
(no output)

$ bunx oxlint
Found 80 warnings and 0 errors.
Finished in 47ms on 527 files with 93 rules using 8 threads.
   # 80/0 is also what `main` reports; nothing under services/events warns.

$ bun --bun vitest run services/events services/discovery.test.ts docs-imports.test.ts barrel-imports.test.ts
 Test Files  4 passed (4)
      Tests  68 passed (68)

$ bunx vitest run --typecheck.only
 Test Files  4 passed (4)
      Tests  32 passed (32)
Type Errors  no errors

$ bun --bun vitest run services support foundation kernel container console
 Test Files  38 passed (38)
      Tests  509 passed (509)
```

The last one is the regression check on adding a sixteenth framework provider: every suite that boots a kernel is in it.

Formatting: the new files under `services/events/` are prettier-clean. `services/index.ts`, `services/discovery.ts` and `services/discovery.test.ts` were **not** run through a formatter — the first two already fail `oxfmt --check` at `HEAD` and the third already fails `prettier --check`, so formatting them would have buried a small edit in unrelated churn. Their diffs are hand-matched to the surrounding style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)