### PR TITLE
Events iteration 2: queued listeners

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Jobs & Queues](./jobs-and-queues.md)** — defining and dispatching background `Job`s.
 - **[Cron](./cron.md)** — scheduling recurring `CronJob`s.
 - **[Commands](./commands.md)** — one-off application commands run with `gemi run`.
-- **[Events & Listeners](./events.md)** — `Event.dispatch(...)` fanning out to the listeners under `app/listeners`.
+- **[Events & Listeners](./events.md)** — `Event.dispatch(...)` fanning out to the listeners under `app/listeners`, inline or on the queue.
 - **[Broadcasting](./broadcasting.md)** — websocket channels, the `Broadcast` facade, `useSubscription` / `useBroadcast`.
 - **[Internationalization](./i18n.md)** — component-scoped dictionaries, `useTranslator`, `useLocale`, locale detection.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -177,6 +177,8 @@ If the name on the payload resolves to no registered event, the job throws with 
 
 These are the queue's, exactly as [Jobs & Queues](./jobs-and-queues.md) documents them: when `handle` throws, the listener is re-queued until it has been attempted `maxAttempts` times, and the last failure dead-letters it. A sync listener has none of this — its throw is logged once and the next listener runs.
 
+Every attempt that throws is written to stderr with the listener's name, the event it is bound to and the error, and the dead-letter is written separately, because "it failed again" and "it will not be tried again" are different things to know. By then `dispatchAndWait` has long since resolved and no caller is left to tell, so those lines are the whole of what says a side effect stopped happening.
+
 > **Note:** The queue is **in-memory and in-process**. A queued listener that has not run when the process exits does not run. That is true of every job today, but an event system invites "dispatch it and it will happen", so it is worth saying plainly: a dispatch is not a durability guarantee. Work that must survive a restart wants a row somewhere that a later pass can pick up.
 
 `dispatchAndWait` does **not** wait for a queued listener. When it resolves, every sync listener has settled and the queued ones have been handed to the queue — which may mean not started, or already failed once and re-queued.

--- a/docs/events.md
+++ b/docs/events.md
@@ -10,7 +10,7 @@ UserRegistered.dispatch(user.id, user.email);
 
 That is the whole of what this buys: adding a fourth side effect to a registration becomes **adding a file**, rather than editing the controller that already has three.
 
-Listeners run **in-process and synchronously** inside the dispatching request — see [When to reach for a job instead](#when-to-reach-for-a-job-instead).
+Listeners run **in-process and synchronously** inside the dispatching request by default. One line moves a listener onto the queue instead — see [Queued listeners](#queued-listeners), and read it before you write it: `queued = true` changes what the listener can see, not only when it runs.
 
 ## Defining an event
 
@@ -83,6 +83,9 @@ There is no `static events = [A, B]`, deliberately. A listener bound to two even
 | `static name` | `string` | `"unset"` | Unique listener identifier. Required. |
 | `static event` | `Event` subclass | — | The one event this listener handles. Required. |
 | `handle` | method | — | The side effect. May be `async`. Required. |
+| `queued` | `boolean` | `false` | Run on the queue instead of inline. A [context boundary](#queued-listeners), not a performance dial. |
+| `maxAttempts` | `number` | `3` | Attempts before dead-lettering, counting the first. Ignored unless `queued`. |
+| `worker` | `boolean` | `false` | Run `handle` in a Worker thread with its own cloned app. Ignored unless `queued`. |
 
 ## Dispatching
 
@@ -102,9 +105,9 @@ When the caller genuinely needs the side effects to have happened first — a re
 await UserRegistered.dispatchAndWait(user.id, user.email);
 ```
 
-It resolves once every listener has settled. Two methods rather than one that is sometimes worth awaiting, because "should I await this?" is a question the call site should not have to guess at.
+It resolves once every **sync** listener has settled — not the [queued](#queued-listeners) ones, whatever the name suggests. Two methods rather than one that is sometimes worth awaiting, because "should I await this?" is a question the call site should not have to guess at.
 
-Listeners run **one at a time**, each awaited before the next one starts, so registration order is the order they run in and not merely the order they start. The cost is worth knowing: a listener that *hangs* — an un-timed-out request to a host that never answers — holds up every listener after it for as long as it hangs, and under `dispatch` the caller has already moved on, so the row a later listener writes is simply not there yet. A listener that can block indefinitely wants its own timeout, or a [job](./jobs-and-queues.md). A listener that *throws* is not this case — see below.
+Sync listeners run **one at a time**, each awaited before the next one starts, so registration order is the order they run in and not merely the order they start. A [queued](#queued-listeners) listener is pushed at the place it occupies in that order and not waited for, so its *dispatch* is ordered with the rest and its execution is the queue's business. The cost is worth knowing: a listener that *hangs* — an un-timed-out request to a host that never answers — holds up every listener after it for as long as it hangs, and under `dispatch` the caller has already moved on, so the row a later listener writes is simply not there yet. A listener that can block indefinitely wants its own timeout, or a [job](./jobs-and-queues.md). A listener that *throws* is not this case — see below.
 
 Neither method ever rejects. See below.
 
@@ -116,6 +119,8 @@ That is not politeness, it is the point. Listeners are independent side effects,
 
 A listener that must not fail silently should handle its own errors — retry, log to your own sink, or dispatch a [job](./jobs-and-queues.md) that can be retried and dead-lettered.
 
+All of this is the **sync** path. A [queued](#queued-listeners) listener's throw never reaches the dispatcher at all: it is the queue's, and it is retried up to `maxAttempts` and then dead-lettered.
+
 ## When nothing is listening
 
 A dispatch with no listeners is legal and does nothing. In development it warns **once per event name**:
@@ -125,6 +130,70 @@ A dispatch with no listeners is legal and does nothing. In development it warns 
 ```
 
 That single line is the whole early-warning system here, because four different mistakes produce the same symptom: an event that never declared `static name`, a typo, a listener that was never discovered, and a listener directory that was never walked. It fires once per name so that a dispatch in a loop does not bury the terminal, and never in production, where "no listeners" is an ordinary answer.
+
+## Queued listeners
+
+`queued = true` moves a listener off the request and onto the [queue](./jobs-and-queues.md), with retries, `maxAttempts`, dead-lettering and worker threads coming from there rather than from anything events add:
+
+```typescript
+// app/listeners/SendWelcomeEmail.ts
+export class SendWelcomeEmail extends Listener {
+  static name = "SendWelcomeEmail";
+  static event = UserRegistered;
+
+  queued = true;
+  maxAttempts = 5;
+
+  async handle(event: UserRegistered) {
+    await sendWelcome(event.email);
+  }
+}
+```
+
+That is the whole of the opt-in. Behind it, the listener is registered with the `QueueManager` as a job named `listener:SendWelcomeEmail`, and a dispatch pushes `["UserRegistered", [7, "ada@example.com"]]` onto the queue instead of calling `handle`.
+
+`static name` stops being a label here and becomes the queue's key, so a queued listener that does not declare one is **refused at boot** rather than warned about — see [Two listeners, one name](#two-listeners-one-name) for what the name is doing, and the note under [Defining an event](#defining-an-event) for why an implicit class name is not the same string after a production build.
+
+### What `queued = true` changes — read this part
+
+It is a **context boundary spelled as one line**, not a latency setting.
+
+- A **sync** listener runs inside the dispatching request: it has that request's `app()`, its authenticated user through `currentActor()`, and it joins the ambient transaction.
+- A **queued** listener is handed to the queue and run from a drain, on the queue's terms. With `worker = true` that is a different thread with a cloned application. Only the event's name and constructor arguments cross; nothing else does.
+
+The part that catches people is that the request's context is not reliably *gone* either. gemi's queue is in-process, so a drain that happens to start from the push is still standing inside the dispatching request, and `app()` there resolves the request's application. **None of that is promised.** A queued listener that reads the current actor, or writes expecting to join the transaction the controller opened, works right up until the day the queue was already busy — and then reads different rows, or commits separately, with no error either way.
+
+So the rule is simple: a listener that needs anything from the request stays sync; a listener that needs only the payload is free to queue.
+
+### What crosses the queue
+
+The **constructor arguments** are what is serialized, not the instance — the same bargain [`Job.dispatch`](./jobs-and-queues.md) makes. The payload is JSON, so pass plain, serializable data: numbers, strings, plain objects. A model instance, a `Date`, a function or anything holding a database handle does not survive it.
+
+On the far side the event is rebuilt with `new UserRegistered(...args)`, which means **an event constructor that does work does it again**, in whatever process runs the listener and without the request around it. Keep event constructors to assigning fields.
+
+If the name on the payload resolves to no registered event, the job throws with that name in the message rather than handing the listener `undefined` — the failure surfaces where it can still be explained, and takes the queue's ordinary retry path.
+
+### Retries, dead-lettering and durability
+
+These are the queue's, exactly as [Jobs & Queues](./jobs-and-queues.md) documents them: when `handle` throws, the listener is re-queued until it has been attempted `maxAttempts` times, and the last failure dead-letters it. A sync listener has none of this — its throw is logged once and the next listener runs.
+
+> **Note:** The queue is **in-memory and in-process**. A queued listener that has not run when the process exits does not run. That is true of every job today, but an event system invites "dispatch it and it will happen", so it is worth saying plainly: a dispatch is not a durability guarantee. Work that must survive a restart wants a row somewhere that a later pass can pick up.
+
+`dispatchAndWait` does **not** wait for a queued listener. When it resolves, every sync listener has settled and the queued ones have been handed to the queue — which may mean not started, or already failed once and re-queued.
+
+### Queued listeners in `registeredJobs`
+
+They are visible, under the prefix:
+
+```typescript
+import { app } from "gemi/foundation";
+import { QueueManager } from "gemi/services";
+
+app(QueueManager).registeredJobs.map((job) => job.name);
+// ["SendInvoiceEmail", "listener:SendWelcomeEmail"]
+```
+
+`registeredJobs` reports what the queue will run, and a queued listener genuinely is something it will run — hiding them would make a queue introspection tool lie. The `listener:` prefix is what keeps you from going to look for a job file you never wrote.
 
 ## Registering listeners — `app/listeners/`
 
@@ -221,16 +290,19 @@ const listeners = await discoverListeners(); // every Listener under app/listene
 
 ## When to reach for a job instead
 
-Listeners run **inside the dispatching request**, in the same process, in the same context: a listener has the request's `app()`, its authenticated user, and its ambient transaction. That makes them right for fast in-request side effects — writing an audit row, warming a cache, updating a counter — and wrong for slow ones, because the request waits for `dispatchAndWait` and the process still does the work either way.
+A **sync** listener runs inside the dispatching request, in the same process and the same context. That makes it right for fast in-request side effects — writing an audit row, warming a cache, updating a counter — and wrong for slow ones, because the request waits for `dispatchAndWait` and the process does the work either way.
 
-For anything slow or retryable, dispatch a [`Job`](./jobs-and-queues.md) from the listener. The queue is where retries, `maxAttempts`, dead-lettering and worker threads already live.
+A **queued** listener is the answer to that, and it is a listener rather than a job because the dispatcher still does not hold the list: adding a fifth queued side effect is still adding a file.
 
-Four mechanisms, one row each:
+Reach for a [`Job`](./jobs-and-queues.md) directly when the work is not a reaction to something that happened but a thing the caller wants done — one named unit of work, dispatched by the code that wants it, often with its own arguments that are nobody's event payload. A listener that only dispatches a job is a listener you did not need.
+
+Five mechanisms, one row each:
 
 | Mechanism | Fan-out | Where the handler runs |
 | --- | --- | --- |
 | a direct call in a controller | 1 → N | inline, and the caller names each one |
-| `Event.dispatch()` | 1 → N | inline, and the caller names none of them |
+| `Event.dispatch()`, sync listener | 1 → N | inline, and the caller names none of them |
+| `Event.dispatch()`, `queued = true` | 1 → N | the queue: retried, dead-lettered |
 | `Job.dispatch()` | 1 → 1 | the queue: retried, dead-lettered |
 | `Broadcast.publish()` | 1 → N | *clients*, over websockets |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,7 +129,7 @@
         <a class="card" href="jobs-and-queues.md"><span class="t">Jobs &amp; Queues</span><span class="d">Background Jobs through the in-process queue.</span></a>
         <a class="card" href="cron.md"><span class="t">Cron</span><span class="d">Recurring CronJobs with Bun.cron.</span></a>
         <a class="card" href="commands.md"><span class="t">Commands</span><span class="d">One-off application commands run with gemi run.</span></a>
-        <a class="card" href="events.md"><span class="t">Events &amp; Listeners</span><span class="d">Event.dispatch fanning out to listeners under app/listeners.</span></a>
+        <a class="card" href="events.md"><span class="t">Events &amp; Listeners</span><span class="d">Event.dispatch fanning out to listeners under app/listeners, inline or queued.</span></a>
         <a class="card" href="broadcasting.md"><span class="t">Broadcasting</span><span class="d">Websocket channels, Broadcast, useSubscription.</span></a>
         <a class="card" href="i18n.md"><span class="t">Internationalization</span><span class="d">Component-scoped dictionaries, useTranslator, useLocale.</span></a>
       </div>

--- a/docs/jobs-and-queues.md
+++ b/docs/jobs-and-queues.md
@@ -156,6 +156,8 @@ for (const Registered of app(QueueManager).registeredJobs) {
 }
 ```
 
+It may hold jobs you never wrote, named `listener:SendWelcomeEmail`. Those are [queued listeners](./events.md#queued-listeners) — a listener with `queued = true` is registered here as a job, so everything on this page applies to it, and the prefix is what tells you there is no job file to go and find.
+
 `discoverJobs()` answers the same question without an application around it — it walks `app/jobs` (or a directory you name) and returns the classes it finds. Every file it walks is imported, as above:
 
 ```typescript

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8892,6 +8892,8 @@ If the name on the payload resolves to no registered event, the job throws with 
 
 These are the queue's, exactly as [Jobs & Queues](./jobs-and-queues.md) documents them: when `handle` throws, the listener is re-queued until it has been attempted `maxAttempts` times, and the last failure dead-letters it. A sync listener has none of this — its throw is logged once and the next listener runs.
 
+Every attempt that throws is written to stderr with the listener's name, the event it is bound to and the error, and the dead-letter is written separately, because "it failed again" and "it will not be tried again" are different things to know. By then `dispatchAndWait` has long since resolved and no caller is left to tell, so those lines are the whole of what says a side effect stopped happening.
+
 > **Note:** The queue is **in-memory and in-process**. A queued listener that has not run when the process exits does not run. That is true of every job today, but an event system invites "dispatch it and it will happen", so it is worth saying plainly: a dispatch is not a durability guarantee. Work that must survive a restart wants a row somewhere that a later pass can pick up.
 
 `dispatchAndWait` does **not** wait for a queued listener. When it resolves, every sync listener has settled and the queued ones have been handed to the queue — which may mean not started, or already failed once and re-queued.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -63,7 +63,7 @@ See **[Getting Started](./getting-started.md)** for requirements and a first rou
 - **[Jobs & Queues](./jobs-and-queues.md)** — defining and dispatching background `Job`s.
 - **[Cron](./cron.md)** — scheduling recurring `CronJob`s.
 - **[Commands](./commands.md)** — one-off application commands run with `gemi run`.
-- **[Events & Listeners](./events.md)** — `Event.dispatch(...)` fanning out to the listeners under `app/listeners`.
+- **[Events & Listeners](./events.md)** — `Event.dispatch(...)` fanning out to the listeners under `app/listeners`, inline or on the queue.
 - **[Broadcasting](./broadcasting.md)** — websocket channels, the `Broadcast` facade, `useSubscription` / `useBroadcast`.
 - **[Internationalization](./i18n.md)** — component-scoped dictionaries, `useTranslator`, `useLocale`, locale detection.
 
@@ -8049,6 +8049,8 @@ for (const Registered of app(QueueManager).registeredJobs) {
 }
 ```
 
+It may hold jobs you never wrote, named `listener:SendWelcomeEmail`. Those are [queued listeners](./events.md#queued-listeners) — a listener with `queued = true` is registered here as a job, so everything on this page applies to it, and the prefix is what tells you there is no job file to go and find.
+
 `discoverJobs()` answers the same question without an application around it — it walks `app/jobs` (or a directory you name) and returns the classes it finds. Every file it walks is imported, as above:
 
 ```typescript
@@ -8723,7 +8725,7 @@ UserRegistered.dispatch(user.id, user.email);
 
 That is the whole of what this buys: adding a fourth side effect to a registration becomes **adding a file**, rather than editing the controller that already has three.
 
-Listeners run **in-process and synchronously** inside the dispatching request — see [When to reach for a job instead](#when-to-reach-for-a-job-instead).
+Listeners run **in-process and synchronously** inside the dispatching request by default. One line moves a listener onto the queue instead — see [Queued listeners](#queued-listeners), and read it before you write it: `queued = true` changes what the listener can see, not only when it runs.
 
 ## Defining an event
 
@@ -8796,6 +8798,9 @@ There is no `static events = [A, B]`, deliberately. A listener bound to two even
 | `static name` | `string` | `"unset"` | Unique listener identifier. Required. |
 | `static event` | `Event` subclass | — | The one event this listener handles. Required. |
 | `handle` | method | — | The side effect. May be `async`. Required. |
+| `queued` | `boolean` | `false` | Run on the queue instead of inline. A [context boundary](#queued-listeners), not a performance dial. |
+| `maxAttempts` | `number` | `3` | Attempts before dead-lettering, counting the first. Ignored unless `queued`. |
+| `worker` | `boolean` | `false` | Run `handle` in a Worker thread with its own cloned app. Ignored unless `queued`. |
 
 ## Dispatching
 
@@ -8815,9 +8820,9 @@ When the caller genuinely needs the side effects to have happened first — a re
 await UserRegistered.dispatchAndWait(user.id, user.email);
 ```
 
-It resolves once every listener has settled. Two methods rather than one that is sometimes worth awaiting, because "should I await this?" is a question the call site should not have to guess at.
+It resolves once every **sync** listener has settled — not the [queued](#queued-listeners) ones, whatever the name suggests. Two methods rather than one that is sometimes worth awaiting, because "should I await this?" is a question the call site should not have to guess at.
 
-Listeners run **one at a time**, each awaited before the next one starts, so registration order is the order they run in and not merely the order they start. The cost is worth knowing: a listener that *hangs* — an un-timed-out request to a host that never answers — holds up every listener after it for as long as it hangs, and under `dispatch` the caller has already moved on, so the row a later listener writes is simply not there yet. A listener that can block indefinitely wants its own timeout, or a [job](./jobs-and-queues.md). A listener that *throws* is not this case — see below.
+Sync listeners run **one at a time**, each awaited before the next one starts, so registration order is the order they run in and not merely the order they start. A [queued](#queued-listeners) listener is pushed at the place it occupies in that order and not waited for, so its *dispatch* is ordered with the rest and its execution is the queue's business. The cost is worth knowing: a listener that *hangs* — an un-timed-out request to a host that never answers — holds up every listener after it for as long as it hangs, and under `dispatch` the caller has already moved on, so the row a later listener writes is simply not there yet. A listener that can block indefinitely wants its own timeout, or a [job](./jobs-and-queues.md). A listener that *throws* is not this case — see below.
 
 Neither method ever rejects. See below.
 
@@ -8829,6 +8834,8 @@ That is not politeness, it is the point. Listeners are independent side effects,
 
 A listener that must not fail silently should handle its own errors — retry, log to your own sink, or dispatch a [job](./jobs-and-queues.md) that can be retried and dead-lettered.
 
+All of this is the **sync** path. A [queued](#queued-listeners) listener's throw never reaches the dispatcher at all: it is the queue's, and it is retried up to `maxAttempts` and then dead-lettered.
+
 ## When nothing is listening
 
 A dispatch with no listeners is legal and does nothing. In development it warns **once per event name**:
@@ -8838,6 +8845,70 @@ A dispatch with no listeners is legal and does nothing. In development it warns 
 ```
 
 That single line is the whole early-warning system here, because four different mistakes produce the same symptom: an event that never declared `static name`, a typo, a listener that was never discovered, and a listener directory that was never walked. It fires once per name so that a dispatch in a loop does not bury the terminal, and never in production, where "no listeners" is an ordinary answer.
+
+## Queued listeners
+
+`queued = true` moves a listener off the request and onto the [queue](./jobs-and-queues.md), with retries, `maxAttempts`, dead-lettering and worker threads coming from there rather than from anything events add:
+
+```typescript
+// app/listeners/SendWelcomeEmail.ts
+export class SendWelcomeEmail extends Listener {
+  static name = "SendWelcomeEmail";
+  static event = UserRegistered;
+
+  queued = true;
+  maxAttempts = 5;
+
+  async handle(event: UserRegistered) {
+    await sendWelcome(event.email);
+  }
+}
+```
+
+That is the whole of the opt-in. Behind it, the listener is registered with the `QueueManager` as a job named `listener:SendWelcomeEmail`, and a dispatch pushes `["UserRegistered", [7, "ada@example.com"]]` onto the queue instead of calling `handle`.
+
+`static name` stops being a label here and becomes the queue's key, so a queued listener that does not declare one is **refused at boot** rather than warned about — see [Two listeners, one name](#two-listeners-one-name) for what the name is doing, and the note under [Defining an event](#defining-an-event) for why an implicit class name is not the same string after a production build.
+
+### What `queued = true` changes — read this part
+
+It is a **context boundary spelled as one line**, not a latency setting.
+
+- A **sync** listener runs inside the dispatching request: it has that request's `app()`, its authenticated user through `currentActor()`, and it joins the ambient transaction.
+- A **queued** listener is handed to the queue and run from a drain, on the queue's terms. With `worker = true` that is a different thread with a cloned application. Only the event's name and constructor arguments cross; nothing else does.
+
+The part that catches people is that the request's context is not reliably *gone* either. gemi's queue is in-process, so a drain that happens to start from the push is still standing inside the dispatching request, and `app()` there resolves the request's application. **None of that is promised.** A queued listener that reads the current actor, or writes expecting to join the transaction the controller opened, works right up until the day the queue was already busy — and then reads different rows, or commits separately, with no error either way.
+
+So the rule is simple: a listener that needs anything from the request stays sync; a listener that needs only the payload is free to queue.
+
+### What crosses the queue
+
+The **constructor arguments** are what is serialized, not the instance — the same bargain [`Job.dispatch`](./jobs-and-queues.md) makes. The payload is JSON, so pass plain, serializable data: numbers, strings, plain objects. A model instance, a `Date`, a function or anything holding a database handle does not survive it.
+
+On the far side the event is rebuilt with `new UserRegistered(...args)`, which means **an event constructor that does work does it again**, in whatever process runs the listener and without the request around it. Keep event constructors to assigning fields.
+
+If the name on the payload resolves to no registered event, the job throws with that name in the message rather than handing the listener `undefined` — the failure surfaces where it can still be explained, and takes the queue's ordinary retry path.
+
+### Retries, dead-lettering and durability
+
+These are the queue's, exactly as [Jobs & Queues](./jobs-and-queues.md) documents them: when `handle` throws, the listener is re-queued until it has been attempted `maxAttempts` times, and the last failure dead-letters it. A sync listener has none of this — its throw is logged once and the next listener runs.
+
+> **Note:** The queue is **in-memory and in-process**. A queued listener that has not run when the process exits does not run. That is true of every job today, but an event system invites "dispatch it and it will happen", so it is worth saying plainly: a dispatch is not a durability guarantee. Work that must survive a restart wants a row somewhere that a later pass can pick up.
+
+`dispatchAndWait` does **not** wait for a queued listener. When it resolves, every sync listener has settled and the queued ones have been handed to the queue — which may mean not started, or already failed once and re-queued.
+
+### Queued listeners in `registeredJobs`
+
+They are visible, under the prefix:
+
+```typescript
+import { app } from "gemi/foundation";
+import { QueueManager } from "gemi/services";
+
+app(QueueManager).registeredJobs.map((job) => job.name);
+// ["SendInvoiceEmail", "listener:SendWelcomeEmail"]
+```
+
+`registeredJobs` reports what the queue will run, and a queued listener genuinely is something it will run — hiding them would make a queue introspection tool lie. The `listener:` prefix is what keeps you from going to look for a job file you never wrote.
 
 ## Registering listeners — `app/listeners/`
 
@@ -8934,16 +9005,19 @@ const listeners = await discoverListeners(); // every Listener under app/listene
 
 ## When to reach for a job instead
 
-Listeners run **inside the dispatching request**, in the same process, in the same context: a listener has the request's `app()`, its authenticated user, and its ambient transaction. That makes them right for fast in-request side effects — writing an audit row, warming a cache, updating a counter — and wrong for slow ones, because the request waits for `dispatchAndWait` and the process still does the work either way.
+A **sync** listener runs inside the dispatching request, in the same process and the same context. That makes it right for fast in-request side effects — writing an audit row, warming a cache, updating a counter — and wrong for slow ones, because the request waits for `dispatchAndWait` and the process does the work either way.
 
-For anything slow or retryable, dispatch a [`Job`](./jobs-and-queues.md) from the listener. The queue is where retries, `maxAttempts`, dead-lettering and worker threads already live.
+A **queued** listener is the answer to that, and it is a listener rather than a job because the dispatcher still does not hold the list: adding a fifth queued side effect is still adding a file.
 
-Four mechanisms, one row each:
+Reach for a [`Job`](./jobs-and-queues.md) directly when the work is not a reaction to something that happened but a thing the caller wants done — one named unit of work, dispatched by the code that wants it, often with its own arguments that are nobody's event payload. A listener that only dispatches a job is a listener you did not need.
+
+Five mechanisms, one row each:
 
 | Mechanism | Fan-out | Where the handler runs |
 | --- | --- | --- |
 | a direct call in a controller | 1 → N | inline, and the caller names each one |
-| `Event.dispatch()` | 1 → N | inline, and the caller names none of them |
+| `Event.dispatch()`, sync listener | 1 → N | inline, and the caller names none of them |
+| `Event.dispatch()`, `queued = true` | 1 → N | the queue: retried, dead-lettered |
 | `Job.dispatch()` | 1 → 1 | the queue: retried, dead-lettered |
 | `Broadcast.publish()` | 1 → N | *clients*, over websockets |
 
@@ -8955,7 +9029,6 @@ gemi has no ORM lifecycle events (`User.created` and friends) — a model write 
 - [Broadcasting](./broadcasting.md) — fan-out to browsers rather than to server-side handlers.
 - [Controllers](./controllers.md) — dispatching from request handlers.
 - [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.
-
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -46,7 +46,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Jobs & Queues](https://nstfkc.github.io/gemi/jobs-and-queues.md): defining and dispatching background Jobs through the in-process queue.
 - [Cron](https://nstfkc.github.io/gemi/cron.md): scheduling recurring CronJobs with Bun.cron.
 - [Commands](https://nstfkc.github.io/gemi/commands.md): one-off application commands written with defineCommand and run with `gemi run <name>`.
-- [Events & Listeners](https://nstfkc.github.io/gemi/events.md): Event subclasses dispatched with Event.dispatch/dispatchAndWait, Listener subclasses under app/listeners bound with `static event`, sync fan-out that no listener can cancel.
+- [Events & Listeners](https://nstfkc.github.io/gemi/events.md): Event subclasses dispatched with Event.dispatch/dispatchAndWait, Listener subclasses under app/listeners bound with `static event`, sync fan-out that no listener can cancel, and `queued = true` to run one on the queue instead.
 - [Broadcasting](https://nstfkc.github.io/gemi/broadcasting.md): websocket channels, the Broadcast facade, useSubscription/useBroadcast.
 - [Internationalization](https://nstfkc.github.io/gemi/i18n.md): component-scoped dictionaries, useTranslator, useLocale, locale detection.
 

--- a/packages/gemi/kernel/providers.ts
+++ b/packages/gemi/kernel/providers.ts
@@ -22,12 +22,19 @@ import { RouteServiceProvider } from "../services/router/RouteServiceProvider";
  * and the view dispatcher, the way Laravel's does.
  *
  * Order only matters for `boot()`; `register()` binds factories and resolves
- * nothing, so no provider here depends on an earlier one having run.
+ * nothing, so no provider here depends on an earlier one having run — with one
+ * exception, which is the reason to read this before reordering anything.
  *
- * `EventServiceProvider` sits after `QueueServiceProvider` for a dependency it
- * does not have yet: a queued listener is registered as a job, so its `boot()`
- * will want the queue's registry already populated. Placing it here now saves
- * reordering this list from a patch that is about something else.
+ * **`EventServiceProvider` must stay after `QueueServiceProvider`.** A queued
+ * listener is registered with the queue as a synthetic job, and
+ * `EventServiceProvider.boot()` is what hands those over. `QueueManager.useJobs`
+ * — which `QueueServiceProvider.boot()` calls with whatever it discovered under
+ * `app/jobs` — *replaces* the registry (`this.jobs = {}`). Move the events
+ * provider up and the two boots run in the order that discards: every
+ * `listener:*` entry is registered and then thrown away. Nothing errors, boot
+ * succeeds, and each queued dispatch afterwards lands on `next()`'s "Dropped a
+ * queued job: nothing is registered under the name listener:SendWelcomeEmail",
+ * long after `dispatch` returned to a caller that cannot hear it.
  */
 export const frameworkProviders: ServiceProviderConstructor[] = [
   KernelIdServiceProvider,

--- a/packages/gemi/services/discovery.ts
+++ b/packages/gemi/services/discovery.ts
@@ -338,7 +338,11 @@ function warnIfListenerNameWillNotSurviveTheBuild(listeners: ListenerClass[]) {
     console.warn(
       `Event listener ${listener.name} does not declare \`static name\`, so ` +
         `it is registered under its class name, which a production build ` +
-        `renames. Add: static name = "${listener.name}";`,
+        `renames. Nothing reads that name across a build boundary while the ` +
+        `listener is sync, which is why this is a warning — but adding ` +
+        `\`queued = true\` to it is refused at boot for the same reason, ` +
+        `because the queue's key is that string. Add: static name = ` +
+        `"${listener.name}";`,
     );
   }
 }

--- a/packages/gemi/services/discovery.ts
+++ b/packages/gemi/services/discovery.ts
@@ -322,13 +322,14 @@ function refuseListenersWithNoEvent(listeners: ListenerClass[]): void {
  * the only thing that tells them apart, and the difference only becomes visible
  * in a production build.
  *
- * Unlike a job's, a listener's own name has no second half to disagree with
- * *yet*: every reader of it today comes from this same source-side walk, so a
- * minified build and this walk cannot currently produce two different strings
- * for it. It is asked for from the start anyway, because the moment a listener
- * name is carried anywhere the server bundle can also produce — a queue
- * payload, a stored retry — the disagreement is silent and the fix would be a
- * rule changing under applications that had already shipped.
+ * A warning rather than a refusal, because a *sync* listener's name has no
+ * second half to disagree with: every reader of it comes from this same
+ * source-side walk, so a minified build and this walk cannot produce two
+ * different strings for it. A **queued** listener does have one — the name is
+ * the queue's key and it crosses a JSON boundary — and that case is refused
+ * outright, by `jobForListener`, at the point the listener is registered with
+ * the queue rather than here. This walk cannot tell the two apart without
+ * constructing every listener it found; the registry constructs them anyway.
  */
 function warnIfListenerNameWillNotSurviveTheBuild(listeners: ListenerClass[]) {
   for (const listener of listeners) {

--- a/packages/gemi/services/events/Event.ts
+++ b/packages/gemi/services/events/Event.ts
@@ -89,22 +89,30 @@ export abstract class Event {
    * A listener that throws is logged and the next one still runs, so nothing
    * here can fail on a listener's behalf. A dispatch that nothing is listening
    * for is legal and warns once, in development only.
+   *
+   * The arguments are forwarded to the manager *as well as* being used to build
+   * the instance: a queued listener receives an event rebuilt from them in
+   * another application, and an instance cannot be asked what it was
+   * constructed with.
    */
   static dispatch<T extends EventClass>(
     this: T,
     ...args: ConstructorParameters<T>
   ): void {
     refuseUnnamed(this);
-    app(EventManager).dispatch(new this(...args));
+    app(EventManager).dispatch(new this(...args), args);
   }
 
   /**
    * Fires the event and resolves once every **sync** listener has settled.
    *
-   * It does not wait for a queued listener, which by construction runs in a
-   * cloned application after this promise has resolved — "and wait" invites
+   * It does not wait for a queued listener, which the queue runs on its own
+   * terms after this promise has resolved — "and wait" invites
    * exactly that reading, so it is written down here rather than left to be
-   * discovered by a test that passes locally.
+   * discovered by a test that passes locally. A queued listener has been handed
+   * to the queue by the time this resolves and nothing more than that is true
+   * of it: it may not have started, and it may already have failed and been
+   * re-queued.
    *
    * Two methods rather than one `dispatch` that is sometimes worth awaiting,
    * because "is this worth awaiting" is a question the call site should not
@@ -122,7 +130,7 @@ export abstract class Event {
     ...args: ConstructorParameters<T>
   ): Promise<void> {
     refuseUnnamed(this);
-    return app(EventManager).dispatchAndWait(new this(...args));
+    return app(EventManager).dispatchAndWait(new this(...args), args);
   }
 }
 

--- a/packages/gemi/services/events/EventManager.test.ts
+++ b/packages/gemi/services/events/EventManager.test.ts
@@ -288,6 +288,44 @@ describe("what useListeners refuses", () => {
   });
 });
 
+/**
+ * The far side of the queue, where a name and an argument array have to become
+ * an event again.
+ *
+ * This is invariant 1 at its second boundary and the first place the manager
+ * has to resolve an *event* class by name. The registry it reads is built from
+ * the listeners' `static event`, which is why an event nobody listens for is
+ * not in it — nothing could have been queued for one.
+ */
+describe("rehydrating an event off the queue", () => {
+  test("round-trips the constructor's arguments", () => {
+    const manager = new EventManager({
+      listeners: [listener("SendWelcomeEmail", () => {})],
+    });
+
+    const event = manager.rehydrate("UserRegistered", [
+      7,
+      "ada@example.com",
+    ]) as UserRegistered;
+
+    expect(event).toBeInstanceOf(UserRegistered);
+    expect(event.userId).toBe(7);
+    expect(event.email).toBe("ada@example.com");
+  });
+
+  test("throws on a name nothing is registered for, and names it", () => {
+    const manager = new EventManager({
+      listeners: [listener("SendWelcomeEmail", () => {})],
+    });
+
+    // The one failure in this file that is not swallowed. The payload is
+    // already off the queue and the listener is a line away from being handed
+    // `undefined`, so the alternative is `event.email` failing several frames
+    // later with nothing left in scope to explain it.
+    expect(() => manager.rehydrate("OrderPaid", [])).toThrow("OrderPaid");
+  });
+});
+
 describe("the readable view", () => {
   test("is a copy, so walking it cannot edit what a dispatch runs", () => {
     const manager = new EventManager({

--- a/packages/gemi/services/events/EventManager.ts
+++ b/packages/gemi/services/events/EventManager.ts
@@ -1,7 +1,27 @@
+import { app } from "../../foundation/app";
 import { withDefaults } from "../../support/withDefaults";
+import type { Job } from "../queue/Job";
+import { QueueManager } from "../queue/QueueManager";
 import { eventConfigDefaults, type EventConfig } from "./config";
-import type { Event } from "./Event";
+import type { Event, EventClass } from "./Event";
+import { jobForListener } from "./listenerJob";
 import type { ListenerClass } from "./Listener";
+
+/**
+ * One listener, and where it runs.
+ *
+ * `queued` is an instance field, so answering "does this one go on the queue?"
+ * means constructing the listener — done once here, at registration, rather
+ * than once per dispatch. The synthetic job is built at the same moment for the
+ * same reason: `EventServiceProvider.boot()` has to hand it to the queue before
+ * the first dispatch, and a job built per dispatch would be a different class
+ * object each time under the same registry key.
+ */
+type Registration = {
+  listener: ListenerClass;
+  /** The job a queued listener is pushed as, or `null` when it runs inline. */
+  job: (new () => Job) | null;
+};
 
 /**
  * The registry a dispatch fans out through: event name -> the listeners bound
@@ -30,12 +50,30 @@ import type { ListenerClass } from "./Listener";
  *
  * **A dispatch nobody handles warns.** That is the entire early-warning system
  * for the subsystem, and it is why it is not optional; see `dispatchAndWait`.
+ *
+ * A `queued` listener is not run here at all. It is registered with the
+ * `QueueManager` as a synthetic job and pushed to it on dispatch, so retries,
+ * `maxAttempts`, dead-lettering and worker threads are the queue's rather than
+ * a second implementation of the queue's — and nothing the request had (the
+ * current actor, the ambient transaction) is still promised by the time it
+ * runs. See `Listener.queued`.
  */
 export class EventManager {
   static token = "events";
 
   /** Event name -> every listener bound to it, in registration order. */
-  private listeners: Record<string, ListenerClass[]> = {};
+  private listeners: Record<string, Registration[]> = {};
+
+  /**
+   * Event name -> the class to rebuild it from, for a listener coming back off
+   * the queue.
+   *
+   * Read from each listener's `static event` at registration, which is the one
+   * place in the subsystem an event class is dereferenced. An event nobody
+   * listens for is never in here, and that is exactly right: nothing can have
+   * been queued for it.
+   */
+  private events: Record<string, EventClass> = {};
 
   /**
    * Event names already warned about. Per-manager, and the manager is per
@@ -64,11 +102,20 @@ export class EventManager {
    * skips phase two dispatches into an empty registry, and an empty registry is
    * a legal steady state rather than an error. The development-only warning
    * below is the only thing that says so.
+   *
+   * Every listener is **constructed once here**, to read the fields that decide
+   * where it runs — `queued`, and through it `maxAttempts` and `worker`. A
+   * listener's constructor therefore runs at boot as well as on every dispatch,
+   * so it wants to assign fields and nothing else. A queued one also has its
+   * synthetic job built here; `EventServiceProvider` hands those to the queue
+   * once boot reaches it, so calling this again *after* boot would leave the
+   * queue holding jobs for listeners this registry no longer has.
    */
   useListeners(listeners: ListenerClass[]) {
     this.config.listeners = listeners;
 
     this.listeners = {};
+    this.events = {};
     const claimed = new Set<string>();
 
     for (const listener of listeners) {
@@ -87,11 +134,12 @@ export class EventManager {
         continue;
       }
 
-      // Two classes with one name. It only reaches the wire once a listener can
-      // be queued, but it is refused from the start so the rule does not appear
-      // to change under applications later — and a directory walk is what makes
-      // the clash ordinary, since nothing forces the import alias a
-      // hand-written list would have demanded.
+      // Two classes with one name, refused here and nowhere else — which is
+      // what keeps the queue from being handed two jobs called
+      // `listener:NotifyAdmins` and having to decide between them one layer
+      // down, where the loser is a side effect that reports success. A
+      // directory walk is what makes the clash ordinary, since nothing forces
+      // the import alias a hand-written list would have demanded.
       if (claimed.has(listener.name)) {
         console.error(
           `Two event listeners are named "${listener.name}" — the first is ` +
@@ -105,10 +153,36 @@ export class EventManager {
       // The one place the event class is dereferenced, and deliberately the
       // only one: this runs in the module graph that declared the class, so the
       // name it yields is the source-side one that discovery and a minified
-      // dispatcher both agree on. Nothing downstream keeps the class object.
+      // dispatcher both agree on. Nothing downstream keeps the class object —
+      // except `this.events`, which keeps it under that same string so a
+      // listener coming back off the queue has something to rebuild from. First
+      // claim wins there too: a name is what identifies an event to everything
+      // downstream, so two classes declaring one are one event already.
       const name = listener.event.name;
-      (this.listeners[name] ??= []).push(listener);
+      const instance = new listener();
+
+      this.events[name] ??= listener.event;
+      (this.listeners[name] ??= []).push({
+        listener,
+        job: instance.queued ? jobForListener(listener, instance) : null,
+      });
     }
+  }
+
+  /**
+   * The synthetic jobs the queue has to be told about — one per queued
+   * listener, named `listener:<name>`.
+   *
+   * `EventServiceProvider.boot()` is the only caller. It reads this rather than
+   * having the manager reach for the `QueueManager` itself, because
+   * registration happens in `register()`, where resolving another service is
+   * exactly what a provider must not do. A copy, so the caller cannot edit what
+   * a dispatch pushes.
+   */
+  get queuedListenerJobs(): ReadonlyArray<new () => Job> {
+    return Object.values(this.listeners)
+      .flat()
+      .flatMap(({ job }) => (job ? [job] : []));
   }
 
   /**
@@ -133,14 +207,35 @@ export class EventManager {
    * Nothing is awaited and nothing can reject: `dispatchAndWait` catches every
    * listener's failure itself, so the floating promise here has no rejection to
    * float.
+   *
+   * `args` is the event's constructor arguments; see `dispatchAndWait`.
    */
-  dispatch(event: Event): void {
-    void this.dispatchAndWait(event);
+  dispatch(event: Event, args?: readonly unknown[]): void {
+    void this.dispatchAndWait(event, args);
   }
 
   /**
-   * Runs every listener bound to this event, in registration order, and
-   * resolves when the last of them has settled.
+   * Runs every **sync** listener bound to this event, in registration order,
+   * and resolves when the last of them has settled. Every queued one is handed
+   * to the `QueueManager` on the way past and is not waited for.
+   *
+   * ### Sync and queued in one pass
+   *
+   * A queued listener is pushed at the point in the order it occupies, so its
+   * *dispatch* is ordered with the rest and its *execution* is not: the queue
+   * decides when. What that costs is worth knowing — `dispatchAndWait`
+   * resolving says every sync listener has finished and says nothing at all
+   * about a queued one, which may not have started or may already have failed
+   * twice. Whether a listener is queued is therefore a decision about what the
+   * caller can rely on having happened, not only about latency.
+   *
+   * @param args the arguments the event's constructor was called with, which
+   * `Event.dispatch` forwards. Only a queued listener needs them: the event
+   * instance itself never crosses the queue, and what is rebuilt on the other
+   * side is `new EventClass(...args)`. Dispatching a hand-built instance
+   * straight at the manager therefore cannot queue, and says so on stderr
+   * rather than pushing a payload that would rehydrate into an event with
+   * `undefined` fields.
    *
    * ### One at a time, deliberately
    *
@@ -177,7 +272,10 @@ export class EventManager {
    * fires once per event name — a dispatch in a loop would otherwise bury the
    * terminal.
    */
-  async dispatchAndWait(event: Event): Promise<void> {
+  async dispatchAndWait(
+    event: Event,
+    args?: readonly unknown[],
+  ): Promise<void> {
     const name = (event.constructor as { name: string }).name;
     const handlers = this.listeners[name];
 
@@ -186,7 +284,12 @@ export class EventManager {
       return;
     }
 
-    for (const Listener of handlers) {
+    for (const { listener: Listener, job } of handlers) {
+      if (job) {
+        this.enqueue(job, Listener, name, args);
+        continue;
+      }
+
       try {
         await new Listener().handle(event);
       } catch (error) {
@@ -196,6 +299,84 @@ export class EventManager {
           error,
         );
       }
+    }
+  }
+
+  /**
+   * Rebuilds an event from what crossed the queue.
+   *
+   * The queue carries a name and an argument array, because that is all JSON
+   * can carry: **the constructor arguments are what is serialized, not the
+   * instance** — the same bargain `Job.dispatch` makes. So an event whose
+   * constructor does work beyond assigning fields does that work a second time
+   * here, in the worker, with none of the dispatching request around it.
+   *
+   * A name that resolves to nothing throws, and is the one place in this file
+   * that does. The payload is already off the queue by the time this runs and
+   * the listener is one line away from being handed `undefined`, so the
+   * alternative is a `handle` reading `event.email` off nothing, several frames
+   * further on, with the name that would have explained it no longer in scope.
+   * A throw here is caught by `QueueManager.run` and takes the queue's ordinary
+   * retry-then-dead-letter path.
+   */
+  rehydrate(eventName: string, args: readonly unknown[] = []): Event {
+    const EventClass = this.events[eventName];
+
+    if (!EventClass) {
+      throw new Error(
+        `Cannot rebuild the event "${eventName}" that came off the queue: no ` +
+          `registered listener binds to an event of that name, so there is no ` +
+          `class to construct. A queued listener runs in an application that ` +
+          `discovered its own listeners — check that this process sees the ` +
+          `same app/listeners as the one that dispatched, and that the event ` +
+          `declares \`static name = "${eventName}"\`.`,
+      );
+    }
+
+    return new EventClass(...args);
+  }
+
+  /**
+   * Hands one queued listener to the queue, as `[eventName, args]`.
+   *
+   * Nothing is awaited: `push` returns as soon as the entry is on the queue,
+   * which is the whole of what `queued = true` buys. The event instance the
+   * sync listeners share does not go with it — only the name and the arguments
+   * do, so nothing that was resolved from the request's context can be smuggled
+   * across into an application that does not have it.
+   *
+   * Failing to queue is caught for the same reason a listener's throw is: it is
+   * one listener's problem, and the listeners after it in the walk did not do
+   * anything to deserve it. Two things reach that catch — an argument JSON
+   * cannot serialise, and an application with no queue bound — and both would
+   * otherwise reject `dispatchAndWait`, which is documented never to.
+   */
+  private enqueue(
+    job: new () => Job,
+    listener: ListenerClass,
+    eventName: string,
+    args?: readonly unknown[],
+  ) {
+    if (args === undefined) {
+      console.error(
+        `The listener ${listener.name} is queued, but ${eventName} reached ` +
+          `the dispatcher without its constructor arguments, so there is ` +
+          `nothing for the queue to rebuild it from and the listener was ` +
+          `skipped. Dispatch through ${eventName}.dispatch(...) or ` +
+          `${eventName}.dispatchAndWait(...), which carry them.`,
+      );
+      return;
+    }
+
+    try {
+      app(QueueManager).push(job, JSON.stringify([eventName, args]));
+    } catch (error) {
+      console.error(
+        `The listener ${listener.name} could not be queued for ${eventName}, ` +
+          `so it did not run and will not be retried. The listeners after it ` +
+          `still ran.`,
+        error,
+      );
     }
   }
 

--- a/packages/gemi/services/events/EventServiceProvider.ts
+++ b/packages/gemi/services/events/EventServiceProvider.ts
@@ -1,6 +1,7 @@
 import { ServiceProvider } from "../../support/ServiceProvider";
 import { withDefaults } from "../../support/withDefaults";
 import { discoverListeners } from "../discovery";
+import { QueueManager } from "../queue/QueueManager";
 import { eventConfigDefaults, type EventConfig } from "./config";
 import { EventManager } from "./EventManager";
 
@@ -35,14 +36,41 @@ export class EventServiceProvider extends ServiceProvider {
    * than before the first request — a dispatch against an empty registry is not
    * an error, it is a side effect that quietly does not happen — so the
    * registry has to be complete by the end of boot.
+   *
+   * ### Why the queue is handed the listener jobs from here
+   *
+   * A queued listener is registered with the `QueueManager` as a synthetic job,
+   * and that registration cannot happen in `register()`: resolving another
+   * service is the one thing a `register()` must not do, and the jobs are not
+   * known until discovery has run anyway. It also cannot happen before
+   * `QueueServiceProvider.boot()` fills the queue's registry, which is why this
+   * provider sits after it in `frameworkProviders` — `useJobs` replaces that
+   * registry wholesale, so the queue has to be finished with it before
+   * `registerJob` starts adding to it.
+   *
+   * The declared-listeners path falls through to it rather than returning
+   * early: an app that lists its listeners in `app/config/events.ts` still has
+   * queued ones, and skipping the queue for them would make `queued = true` a
+   * field that silently does nothing depending on how the app registers.
    */
   async boot() {
+    const manager = this.app.make(EventManager);
     const slice = this.app.config.get<EventConfig>("events", {});
-    if (slice.listeners !== undefined) return;
 
-    const { listenersDir } = withDefaults(eventConfigDefaults(), slice);
-    this.app
-      .make(EventManager)
-      .useListeners(await discoverListeners(listenersDir));
+    if (slice.listeners === undefined) {
+      const { listenersDir } = withDefaults(eventConfigDefaults(), slice);
+      manager.useListeners(await discoverListeners(listenersDir));
+    }
+
+    // Nothing queued, nothing to resolve. An application assembled out of this
+    // provider alone — a test, a script — has no `QueueManager` bound, and
+    // asking for one it has no use for would turn that into a boot failure.
+    const jobs = manager.queuedListenerJobs;
+    if (jobs.length === 0) return;
+
+    const queue = this.app.make(QueueManager);
+    for (const job of jobs) {
+      queue.registerJob(job);
+    }
   }
 }

--- a/packages/gemi/services/events/Listener.ts
+++ b/packages/gemi/services/events/Listener.ts
@@ -63,6 +63,14 @@ export abstract class Listener {
    * declaration always shadows it with its own implicit binding, which is the
    * one a minifier renames. `discoverListeners` reads the property descriptor
    * to tell a declared name from an implicit one.
+   *
+   * For a **queued** listener it is more than a label: the queue is keyed by
+   * name, the listener is registered under `listener:<name>`, and that string
+   * is what a queued dispatch carries. So a queued listener whose name is the
+   * implicit class binding is refused at registration rather than warned about
+   * — the two ends of the queue can be two different module graphs, and a name
+   * only one of them minified is a side effect that stops happening in
+   * production and reports success.
    */
   static name = "unset";
 
@@ -89,9 +97,61 @@ export abstract class Listener {
   static event: EventClass;
 
   /**
-   * The side effect. Runs inside the dispatcher's context: a sync listener has
-   * the request's `app()`, its authenticated user, and its ambient
+   * Where this listener runs. **A context boundary, not a performance dial.**
+   *
+   * Left `false`, the listener runs inline, inside the dispatcher's
+   * `kernelContext` and `ormContext`: it has the request's `app()`, the
+   * authenticated user through `currentActor()`, and it joins the ambient
    * transaction.
+   *
+   * Set `true`, it is handed to the `QueueManager` instead and run from a
+   * drain, on the queue's terms. What crosses is the event's name and its
+   * constructor arguments as JSON, and nothing else — not the instance the sync
+   * listeners share, and not a line of the request. With `worker = true` it is
+   * a different thread with a cloned application.
+   *
+   * The part that catches people is that the context is not reliably *gone*
+   * either: the queue is in-process, so a drain that happens to start from
+   * `push` is still standing in the dispatcher's context and `app()` there
+   * resolves the request's application. Nothing about that is promised. A
+   * queued listener that reads the current actor, or writes expecting to join
+   * the ambient transaction, works until the day the queue was already busy —
+   * and then reads different rows, or commits separately, with no error either
+   * way. So: a listener that needs the request's context has to stay sync, and
+   * a listener that only needs the payload is free to queue.
+   *
+   * What it buys, in exchange, is the queue's whole retry path: `maxAttempts`,
+   * `onFail`-style re-queueing and dead-lettering, none of which a sync
+   * listener has. `dispatchAndWait` does **not** wait for it.
+   */
+  queued = false;
+
+  /**
+   * Attempts before the queue gives up, counting the first. `Job`'s field and
+   * `Job`'s meaning, because it is forwarded to one.
+   *
+   * **Ignored unless `queued` is true.** A sync listener has no retry path at
+   * all — its throw is logged and the next listener runs — so a `maxAttempts`
+   * beside `queued = false` is a line that does nothing, which is why it is
+   * said here rather than in a note somewhere else.
+   */
+  maxAttempts = 3;
+
+  /**
+   * Runs `handle` in a Worker thread with its own cloned application, for a
+   * queued listener whose work is CPU-bound. `Job`'s field and `Job`'s
+   * meaning, because it is forwarded to one.
+   *
+   * **Ignored unless `queued` is true.** A sync listener runs on the
+   * dispatcher's stack by definition; there is no thread to move it to.
+   */
+  worker = false;
+
+  /**
+   * The side effect. Runs inside the dispatcher's context when `queued` is
+   * false: a sync listener has the request's `app()`, its authenticated user,
+   * and its ambient transaction. A queued one can rely on none of them — see
+   * `queued`.
    *
    * Annotate the parameter with the event named in `static event` — narrowing
    * the base's `Event` here is legal because method parameters are bivariant,

--- a/packages/gemi/services/events/listenerJob.ts
+++ b/packages/gemi/services/events/listenerJob.ts
@@ -54,6 +54,7 @@ export function jobForListener(
 
   const attempts = instance.maxAttempts;
   const inWorker = instance.worker;
+  const boundTo = listener.event.name;
 
   const job = class extends Job {
     maxAttempts = attempts;
@@ -64,15 +65,65 @@ export function jobForListener(
       const event = app(EventManager).rehydrate(eventName, args);
       await new listener().handle(event);
     }
+
+    // The queue's failure path is silent unless a job writes to it: `onFail`
+    // and `onDeadletter` on `Job` are empty bodies, and `QueueManager.run`
+    // routes every rejection into exactly those two. Without these overrides a
+    // queued listener that throws produces no output anywhere — `dispatch`
+    // returned long ago, the sync path's "the listener X threw while handling
+    // Y" line is on a branch this listener never takes, and the last thing that
+    // happens is the entry leaving the queue. A welcome email that stopped
+    // being sent in production would look exactly like one that was never
+    // dispatched.
+    //
+    // That is also what makes `rehydrate`'s throw the informative failure it is
+    // documented as: a payload naming an event this process does not know is
+    // the shape a `worker = true` listener hits when its thread booted a
+    // different build of the application, and it is unreachable from the
+    // dispatcher's stack.
+    //
+    // Both hooks, not one. `onFail` carries the error and fires per attempt, so
+    // a listener failing differently on each is visible; `onDeadletter` fires
+    // once and reports the fact no attempt is left, which is a different thing
+    // to know and the only line that means the work is gone. The final attempt
+    // logs both, deliberately.
+    //
+    // The event is named from `static event` rather than from the payload:
+    // reading the payload here means parsing it, and a throw out of either hook
+    // would escape through `QueueManager.run`'s `catch` into a `run()` nobody
+    // awaits.
+    onFail(error: Error) {
+      console.error(
+        `The listener ${listener.name} threw while handling ${boundTo} off ` +
+          `the queue. The queue will retry it up to ${attempts} times in ` +
+          `total; nothing the dispatcher did is waiting on it.`,
+        error,
+      );
+    }
+
+    onDeadletter(error: Error) {
+      console.error(
+        `The listener ${listener.name} failed every one of its ${attempts} ` +
+          `attempts at ${boundTo} and has been dead-lettered, so this side ` +
+          `effect did not happen and will not be retried.`,
+        error,
+      );
+    }
   };
 
-  // Not cosmetic, either half of it. The queue keys its registry off
-  // `job.name`, so without this the entry would be named after whatever
-  // binding this class expression picked up. And `writable: true` is what
-  // `warnIfNameWillNotSurviveTheBuild` reads to decide a name was *declared*:
-  // a synthetic class whose `name` was a non-writable own property would be
-  // reported to the author at every boot as a job they never wrote, under a
-  // fix they cannot apply.
+  // The `value` is load-bearing: the queue keys its registry off `job.name`,
+  // so without it the entry would be named after whatever binding this class
+  // expression picked up. `writable: true` is the other half, and nothing
+  // reads it today — it is here so the descriptor matches the one a declared
+  // `static name = "..."` field produces. Every "was this name declared?"
+  // check in the framework is a descriptor read rather than a value read
+  // (`discovery.ts`, and `refuseImplicitName` below), because in development
+  // the declared and the implicit spelling read the same string; and
+  // redefining `name` without the flag leaves the class's own non-writable
+  // descriptor in place. So a check later pointed at a *registered* job rather
+  // than a discovered one — the queue's registry is the obvious place to move
+  // one — would report every synthetic entry as a job the author never wrote,
+  // under a fix they cannot apply. Cheap to keep, wrong to drop.
   Object.defineProperty(job, "name", {
     value: listenerJobName(listener.name),
     writable: true,

--- a/packages/gemi/services/events/listenerJob.ts
+++ b/packages/gemi/services/events/listenerJob.ts
@@ -1,0 +1,133 @@
+import { app } from "../../foundation/app";
+import { Job } from "../queue/Job";
+import { EventManager } from "./EventManager";
+import type { Listener, ListenerClass } from "./Listener";
+
+/**
+ * The adapter that lets `queued = true` be one line: a `Job` subclass, built at
+ * registration, that runs exactly one listener.
+ *
+ * Retries, `maxAttempts`, dead-lettering, `concurrency` and worker-thread
+ * execution are four features the queue already has, already documents for
+ * applications, and is already tested on. A second queue for listeners would be
+ * four features that are almost the same as those, differing in ways nobody
+ * decided. So a queued listener is not queued by anything written here — it is
+ * a job, and everything after `push` is the queue's.
+ */
+
+/**
+ * The name a listener's synthetic job is registered under.
+ *
+ * Prefixed, and visibly so. The synthetic jobs land in
+ * `QueueManager.registeredJobs` alongside the app's own, because that getter is
+ * documented as reporting what the manager was handed and a queued listener
+ * genuinely is something the queue will run — hiding them would make a queue
+ * introspection tool lie about what is about to execute. The prefix is what
+ * keeps an author from reading `SendWelcomeEmail` there and looking for a job
+ * file they never wrote.
+ */
+export function listenerJobName(listenerName: string): string {
+  return `listener:${listenerName}`;
+}
+
+/**
+ * Builds the `Job` subclass that runs one queued listener.
+ *
+ * `instance` is the listener the caller already constructed to read `queued`
+ * off; the three fields that decide where the work runs are read from that one
+ * instance rather than from a fresh one per attempt, so a listener's
+ * constructor runs once at boot instead of once per retry.
+ *
+ * What crosses the queue is `[eventName, constructorArguments]` as JSON — a
+ * name and the arguments, never the event instance and never the classes. That
+ * is invariant 1 at its second boundary: the class objects on the pushing side
+ * and the running side can come from two different module graphs (a minified
+ * bundle and a source-side discovery walk), so a name declared as a string
+ * literal is the only thing both ends agree on. `EventManager.rehydrate` turns
+ * it back into an event.
+ */
+export function jobForListener(
+  listener: ListenerClass,
+  instance: Listener,
+): new () => Job {
+  refuseImplicitName(listener);
+
+  const attempts = instance.maxAttempts;
+  const inWorker = instance.worker;
+
+  const job = class extends Job {
+    maxAttempts = attempts;
+    worker = inWorker;
+
+    async run(...payload: unknown[]) {
+      const [eventName, args] = readPayload(payload);
+      const event = app(EventManager).rehydrate(eventName, args);
+      await new listener().handle(event);
+    }
+  };
+
+  // Not cosmetic, either half of it. The queue keys its registry off
+  // `job.name`, so without this the entry would be named after whatever
+  // binding this class expression picked up. And `writable: true` is what
+  // `warnIfNameWillNotSurviveTheBuild` reads to decide a name was *declared*:
+  // a synthetic class whose `name` was a non-writable own property would be
+  // reported to the author at every boot as a job they never wrote, under a
+  // fix they cannot apply.
+  Object.defineProperty(job, "name", {
+    value: listenerJobName(listener.name),
+    writable: true,
+  });
+
+  return job;
+}
+
+/**
+ * Refuses to queue a listener whose name is the implicit class binding.
+ *
+ * A sync listener's name is only ever read inside one module graph, so
+ * discovery warns about this and moves on. A queued one puts the name on the
+ * wire: the push side looks the job up by `listener:<name>` in its registry and
+ * the running side looks it up in *its* registry, and those two can be
+ * different builds of the same application — the main process discovering
+ * `app/listeners` from source while a `worker = true` listener runs in a thread
+ * that imported `dist/server/bootstrap.mjs`, where minification renamed the
+ * class. The names then disagree, `dispatchJob` resolves nothing, the worker
+ * reports success, and the side effect silently stops happening in production.
+ *
+ * A throw rather than a warning because the failure is invisible from every
+ * side once it happens, and because the fix is one line the author can read in
+ * the message.
+ */
+function refuseImplicitName(listener: ListenerClass): void {
+  if (Object.getOwnPropertyDescriptor(listener, "name")?.writable) return;
+
+  throw new Error(
+    `The listener ${listener.name} sets \`queued = true\` but does not ` +
+      `declare \`static name\`, so it would be registered with the queue ` +
+      `under its class name — which a production build renames while the ` +
+      `payload that names it does not. Add: static name = "${listener.name}";`,
+  );
+}
+
+/**
+ * The payload, whichever of the two shapes the queue handed it over in.
+ *
+ * The queue calls `run` two different ways and this is the only place that has
+ * to know. In-process, `QueueManager.run` spreads the parsed arguments:
+ * `run("UserRegistered", [7, "ada@example.com"])`. Through a worker thread the
+ * far side is `QueueManager.dispatchJob`, which passes the parsed array whole:
+ * `run(["UserRegistered", [7, "ada@example.com"]])`. Reading only the first
+ * shape would make `worker = true` a listener that receives an event named
+ * `undefined` — a throw out of `rehydrate`, in a worker thread, retried to
+ * dead-letter.
+ *
+ * The two are told apart by what is in the first slot rather than by counting
+ * arguments, because the payload's own first element is always the event name
+ * and a name is always a string.
+ */
+function readPayload(payload: unknown[]): [string, unknown[]] {
+  return (typeof payload[0] === "string" ? payload : payload[0]) as [
+    string,
+    unknown[],
+  ];
+}

--- a/packages/gemi/services/events/queuedListeners.test.ts
+++ b/packages/gemi/services/events/queuedListeners.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { Application } from "../../foundation/Application";
 import { kernelContext } from "../../kernel/context";
 import { Repository } from "../../support/Repository";
-import { Job } from "../queue/Job";
 import { QueueManager } from "../queue/QueueManager";
 import { QueueServiceProvider } from "../queue/QueueServiceProvider";
 import { Event } from "./Event";
@@ -89,6 +88,21 @@ async function makeApp(listeners: ListenerClass[]) {
 }
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Everything a `console.error` spy saw, one string per call.
+ *
+ * Assertions about a queued listener's failure go through this rather than
+ * through a spy on `Job.prototype.onDeadletter`, and the difference is the
+ * point: the hooks are overridden on the synthetic job, so a prototype spy
+ * would not fire, and stderr is the only thing an operator gets. A test that
+ * watched the hook would pass over an implementation that writes nothing.
+ */
+const consoleLines = (spy: { mock: { calls: unknown[][] } }) =>
+  spy.mock.calls.map((call) => call.map(String).join(" "));
+
+const deadletterLine = (spy: { mock: { calls: unknown[][] } }) =>
+  consoleLines(spy).find((line) => line.includes("dead-lettered"));
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -221,7 +235,7 @@ describe("what crosses the queue", () => {
 
 describe("a queued listener that always throws", () => {
   test("is retried and dead-lettered by the queue, on its own maxAttempts", async () => {
-    const deadlettered = vi.spyOn(Job.prototype, "onDeadletter");
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
     let attempts = 0;
 
     const application = await makeApp([
@@ -238,15 +252,47 @@ describe("a queued listener that always throws", () => {
     await kernelContext.run(application, () =>
       UserRegistered.dispatchAndWait(7, "ada@example.com"),
     );
-    await vi.waitFor(() => expect(deadlettered).toHaveBeenCalled());
+    await vi.waitFor(() => expect(deadletterLine(error)).toBeDefined());
 
     // Two, not the queue's default of three: `maxAttempts` is read off the
     // listener and forwarded to the job it is registered as.
     expect(attempts).toBe(2);
-    expect((deadlettered.mock.calls[0]![0] as Error).message).toBe(
-      "smtp is down",
-    );
     expect(application.make(QueueManager).queue.size).toBe(0);
+
+    // `dispatchAndWait` resolved before the first attempt failed, so this line
+    // is the entire signal that a side effect stopped happening. It names the
+    // listener, the event it was bound to, and the error, the way the sync
+    // path's own catch does.
+    expect(deadletterLine(error)).toContain("SendWelcomeEmail");
+    expect(deadletterLine(error)).toContain("UserRegistered");
+    expect(deadletterLine(error)).toContain("smtp is down");
+  });
+});
+
+describe("a payload naming an event this process does not know", () => {
+  test("dead-letters with the name in the message, off the queue", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const application = await makeApp([
+      listener("SendWelcomeEmail", () => {}, { maxAttempts: 1 }),
+    ]);
+    const queue = application.make(QueueManager);
+    const [job] = queue.registeredJobs;
+
+    // Pushed rather than calling `rehydrate` directly, because the path is the
+    // point: a payload already off the queue, reaching the synthetic job's
+    // `run` in a process whose event registry has no `OrderPaid`. That is the
+    // `worker = true` shape — a thread that booted a different build of the
+    // application and discovered different listeners — and nothing above `run`
+    // is still waiting to be told about it.
+    await kernelContext.run(application, () =>
+      queue.push(job!, JSON.stringify(["OrderPaid", []])),
+    );
+    await vi.waitFor(() => expect(deadletterLine(error)).toBeDefined());
+
+    expect(deadletterLine(error)).toContain("SendWelcomeEmail");
+    expect(deadletterLine(error)).toContain(
+      'Cannot rebuild the event "OrderPaid"',
+    );
   });
 });
 
@@ -288,10 +334,14 @@ describe("the synthetic job", () => {
     const name = Object.getOwnPropertyDescriptor(job, "name");
 
     expect(name?.value).toBe("listener:SendWelcomeEmail");
-    // Writable is the whole point of the redefinition, not a detail of it:
-    // discovery tells a declared `static name` from an implicit class binding
-    // by exactly this descriptor, so a non-writable one would be reported at
-    // every boot as a job the author never wrote and cannot fix.
+    // Pinned because it is easy to drop and nothing would fail if it were:
+    // `Object.defineProperty` keeps the attributes it is not given, and a
+    // class's own `name` is non-writable, so leaving the flag out produces a
+    // descriptor that every "was this name declared?" check in the framework
+    // reads as an implicit class binding. No such check is pointed at a
+    // registered job today — they all walk a directory — and one moved to the
+    // queue's registry would start reporting these as jobs the author never
+    // wrote and cannot fix.
     expect(name?.writable).toBe(true);
   });
 

--- a/packages/gemi/services/events/queuedListeners.test.ts
+++ b/packages/gemi/services/events/queuedListeners.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { Application } from "../../foundation/Application";
+import { kernelContext } from "../../kernel/context";
+import { Repository } from "../../support/Repository";
+import { Job } from "../queue/Job";
+import { QueueManager } from "../queue/QueueManager";
+import { QueueServiceProvider } from "../queue/QueueServiceProvider";
+import { Event } from "./Event";
+import { EventManager } from "./EventManager";
+import { EventServiceProvider } from "./EventServiceProvider";
+import { jobForListener } from "./listenerJob";
+import { Listener, type ListenerClass } from "./Listener";
+
+/**
+ * `queued = true`, from the dispatch to the far side of the queue.
+ *
+ * Nothing here re-tests retries or dead-lettering as behaviour — those are the
+ * queue's and `QueueManager.test.ts` owns them. What is tested is that a queued
+ * listener reaches that machinery at all, because every way it can fail to is
+ * silent: a synthetic job the queue was never told about is a dropped dispatch
+ * on stderr long after `dispatch` returned, a payload the far side cannot read
+ * is an event with `undefined` fields, and a listener that is queued when the
+ * author thought it was sync is a side effect that has not happened yet when
+ * the response goes out.
+ *
+ * The queue drains in process: `push` starts the drain itself unless one is
+ * already running, so a job is often *finished* by the time `push` returns.
+ * Tests that need to observe the queued-but-not-yet-run state therefore claim
+ * the queue as busy first, which is the state a real queue is in whenever
+ * anything else is running.
+ */
+
+class UserRegistered extends Event {
+  static name = "UserRegistered";
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+
+/**
+ * A listener built around a spy, queued or not. `static name` is declared on
+ * every one of them, as a queued listener's registration requires.
+ */
+function listener(
+  name: string,
+  handle: (event: any) => void | Promise<void>,
+  fields: Partial<Pick<Listener, "queued" | "maxAttempts" | "worker">> = {},
+) {
+  return {
+    [name]: class extends Listener {
+      static name = name;
+      static event = UserRegistered;
+
+      queued = fields.queued ?? true;
+      maxAttempts = fields.maxAttempts ?? 3;
+      worker = fields.worker ?? false;
+
+      handle(received: UserRegistered) {
+        return handle(received);
+      }
+    },
+  }[name]!;
+}
+
+/**
+ * A booted application holding the queue and the events provider, with both
+ * registries declared rather than discovered.
+ *
+ * `concurrency: 5` for the reason `QueueManager.test.ts` uses it: a retry is
+ * pushed from inside the failing job's own `catch`, before the active count has
+ * been decremented, so a concurrency of 1 sends the queue into a one-second
+ * timer between attempts.
+ */
+async function makeApp(listeners: ListenerClass[]) {
+  const application = new Application(
+    new Repository({
+      events: { listeners },
+      queue: { jobs: [], concurrency: 5 },
+    }),
+  );
+  application.registerMany([QueueServiceProvider, EventServiceProvider]);
+  await application.boot();
+  return application;
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("a dispatch with one sync listener and one queued", () => {
+  test("runs the sync one and leaves the queued one on the queue", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("WriteAuditRow", () => void ran.push("sync"), { queued: false }),
+      listener("SendWelcomeEmail", () => void ran.push("queued")),
+    ]);
+    const queue = application.make(QueueManager);
+
+    // Held, so the entry is observable between being pushed and being run.
+    queue.isRunning = true;
+
+    await kernelContext.run(application, () =>
+      UserRegistered.dispatchAndWait(7, "ada@example.com"),
+    );
+
+    expect(ran).toEqual(["sync"]);
+    expect(queue.queue.size).toBe(1);
+
+    // Driven inside the application, because that is what the job needs to
+    // rebuild the event: a drain resolves the `EventManager` out of whatever
+    // context it runs in, and a queued listener carries no application with it.
+    queue.isRunning = false;
+    await kernelContext.run(application, () => queue.next());
+    await tick();
+
+    expect(ran).toEqual(["sync", "queued"]);
+    expect(queue.queue.size).toBe(0);
+  });
+
+  test("the queued listener is registered with the queue under a listener: name", async () => {
+    const application = await makeApp([
+      listener("WriteAuditRow", () => {}, { queued: false }),
+      listener("SendWelcomeEmail", () => {}),
+    ]);
+
+    // Visible, deliberately: `registeredJobs` reports what the queue will run,
+    // and a queued listener is something it will run. The prefix is what keeps
+    // an author from looking for a job file they never wrote — and a sync
+    // listener is not there at all, because the queue never hears about it.
+    expect(
+      application.make(QueueManager).registeredJobs.map((job) => job.name),
+    ).toEqual(["listener:SendWelcomeEmail"]);
+  });
+});
+
+describe("dispatchAndWait", () => {
+  test("does not wait for a queued listener, whatever the name suggests", async () => {
+    let release!: () => void;
+    const settled: string[] = [];
+
+    const application = await makeApp([
+      listener(
+        "SendWelcomeEmail",
+        () =>
+          new Promise<void>((resolve) => {
+            release = () => {
+              settled.push("listener");
+              resolve();
+            };
+          }),
+      ),
+    ]);
+
+    await kernelContext.run(application, () =>
+      UserRegistered.dispatchAndWait(7, "ada@example.com"),
+    );
+    settled.push("caller");
+
+    // The listener has started — the queue drained on push — and the caller
+    // did not wait for it to finish. A sync listener would have reversed this.
+    expect(settled).toEqual(["caller"]);
+
+    release();
+    await tick();
+    expect(settled).toEqual(["caller", "listener"]);
+  });
+});
+
+describe("what crosses the queue", () => {
+  test("is the constructor's arguments, rebuilt into an event on the far side", async () => {
+    const seen: UserRegistered[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", (event) => void seen.push(event)),
+    ]);
+
+    await kernelContext.run(application, () =>
+      UserRegistered.dispatchAndWait(7, "ada@example.com"),
+    );
+    await tick();
+
+    expect(seen).toHaveLength(1);
+    // Round-tripped through JSON as `["UserRegistered", [7, "ada@…"]]` and
+    // rebuilt with `new UserRegistered(...)`, so the fields are equal and the
+    // instance is not the one the dispatcher built. (`toBeInstanceOf` is safe
+    // here for the reason it is unsafe in an application: one module graph.)
+    expect(seen[0]).toBeInstanceOf(UserRegistered);
+    expect(seen[0]!.userId).toBe(7);
+    expect(seen[0]!.email).toBe("ada@example.com");
+  });
+
+  test("reaches the listener through the worker's entry point too", async () => {
+    const seen: UserRegistered[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", (event) => void seen.push(event)),
+    ]);
+
+    // `dispatchJob` is what a worker thread calls on its cloned application,
+    // and it hands `run` the parsed payload whole rather than spread — the one
+    // asymmetry between the two ways the queue invokes a job. A job that reads
+    // only the spread shape gets an event named `undefined` here.
+    await kernelContext.run(application, () =>
+      application
+        .make(QueueManager)
+        .dispatchJob(
+          "listener:SendWelcomeEmail",
+          JSON.stringify(["UserRegistered", [7, "ada@example.com"]]),
+        ),
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.email).toBe("ada@example.com");
+  });
+});
+
+describe("a queued listener that always throws", () => {
+  test("is retried and dead-lettered by the queue, on its own maxAttempts", async () => {
+    const deadlettered = vi.spyOn(Job.prototype, "onDeadletter");
+    let attempts = 0;
+
+    const application = await makeApp([
+      listener(
+        "SendWelcomeEmail",
+        () => {
+          attempts++;
+          throw new Error("smtp is down");
+        },
+        { maxAttempts: 2 },
+      ),
+    ]);
+
+    await kernelContext.run(application, () =>
+      UserRegistered.dispatchAndWait(7, "ada@example.com"),
+    );
+    await vi.waitFor(() => expect(deadlettered).toHaveBeenCalled());
+
+    // Two, not the queue's default of three: `maxAttempts` is read off the
+    // listener and forwarded to the job it is registered as.
+    expect(attempts).toBe(2);
+    expect((deadlettered.mock.calls[0]![0] as Error).message).toBe(
+      "smtp is down",
+    );
+    expect(application.make(QueueManager).queue.size).toBe(0);
+  });
+});
+
+describe("a payload the queue cannot carry", () => {
+  test("is one listener's problem, not the dispatch's", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", () => void ran.push("queued")),
+      listener("WriteAuditRow", () => void ran.push("sync"), { queued: false }),
+    ]);
+
+    const circular: any = {};
+    circular.self = circular;
+
+    // JSON.stringify throws on it, and the throw happens on the dispatcher's
+    // stack rather than the listener's — so without a catch it would reject
+    // `dispatchAndWait`, which is documented never to, and take the sync
+    // listener behind it down as well.
+    await expect(
+      kernelContext.run(application, () =>
+        UserRegistered.dispatchAndWait(circular, "ada@example.com"),
+      ),
+    ).resolves.toBeUndefined();
+    await tick();
+
+    expect(ran).toEqual(["sync"]);
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain(
+      "could not be queued for UserRegistered",
+    );
+  });
+});
+
+describe("the synthetic job", () => {
+  const SendWelcomeEmail = listener("SendWelcomeEmail", () => {});
+
+  test("declares its name the way a hand-written job does", () => {
+    const job = jobForListener(SendWelcomeEmail, new SendWelcomeEmail());
+    const name = Object.getOwnPropertyDescriptor(job, "name");
+
+    expect(name?.value).toBe("listener:SendWelcomeEmail");
+    // Writable is the whole point of the redefinition, not a detail of it:
+    // discovery tells a declared `static name` from an implicit class binding
+    // by exactly this descriptor, so a non-writable one would be reported at
+    // every boot as a job the author never wrote and cannot fix.
+    expect(name?.writable).toBe(true);
+  });
+
+  test("forwards the listener's worker flag", () => {
+    const Cpu = listener("ResizeAvatar", () => {}, { worker: true });
+
+    expect(new (jobForListener(Cpu, new Cpu()))().worker).toBe(true);
+  });
+
+  test("is refused when the listener's name is the implicit class binding", () => {
+    class SendWelcomeEmail extends Listener {
+      static event = UserRegistered;
+      queued = true;
+      handle() {}
+    }
+
+    // The compiler cannot see this either: `static name` is inherited from the
+    // base, and a class declaration shadows it with its own binding — which
+    // reads the same string right up until a production build renames it.
+    expect(() =>
+      jobForListener(SendWelcomeEmail as ListenerClass, new SendWelcomeEmail()),
+    ).toThrow("does not declare `static name`");
+  });
+});
+
+describe("two queued listeners claiming one name", () => {
+  test("register one job, and both are still reported", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ran: string[] = [];
+
+    const application = await makeApp([
+      listener("NotifyAdmins", () => void ran.push("auth")),
+      listener("NotifyAdmins", () => void ran.push("billing")),
+    ]);
+
+    await kernelContext.run(application, () =>
+      UserRegistered.dispatchAndWait(7, "ada@example.com"),
+    );
+    await tick();
+
+    expect(ran).toEqual(["auth"]);
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain(
+      'Two event listeners are named "NotifyAdmins"',
+    );
+    // The clash is refused where a listener name is claimed, so the queue is
+    // never handed the second job at all — one entry, not a second collision
+    // reported one layer down.
+    expect(application.make(QueueManager).registeredJobs).toHaveLength(1);
+    expect(application.make(EventManager).registeredListeners).toHaveLength(2);
+  });
+});
+
+describe("an event dispatched straight at the manager", () => {
+  test("cannot queue, and says so instead of queueing an empty payload", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", () => void ran.push("queued")),
+    ]);
+
+    // No constructor arguments, because an instance cannot be asked what it was
+    // built with. Rebuilding from `[]` would hand the listener an event whose
+    // every field is `undefined` and run it, which is the failure this refuses.
+    await kernelContext.run(application, () =>
+      application
+        .make(EventManager)
+        .dispatchAndWait(new UserRegistered(7, "ada@example.com")),
+    );
+    await tick();
+
+    expect(ran).toEqual([]);
+    expect(application.make(QueueManager).queue.size).toBe(0);
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain("SendWelcomeEmail");
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain(
+      "without its constructor arguments",
+    );
+  });
+});

--- a/packages/gemi/services/queue/QueueManager.test.ts
+++ b/packages/gemi/services/queue/QueueManager.test.ts
@@ -114,6 +114,59 @@ describe("two jobs claiming one class name", () => {
   });
 });
 
+/**
+ * Adding one job to a registry that is already full.
+ *
+ * `useJobs` cannot do this — it replaces the registry — and the events provider
+ * needs it, because a queued listener is registered as a job after the queue's
+ * own `boot()` has run. The failure being guarded is the one `useJobs` would
+ * have had: an app's own jobs quietly gone, in a process that boots cleanly and
+ * drops every dispatch afterwards.
+ */
+describe("registerJob", () => {
+  test("adds to the registry without disturbing what is already in it", () => {
+    const queue = new QueueManager({ jobs: [ChargeCard] });
+
+    queue.registerJob(SendWelcomeEmail);
+
+    expect(queue.dispatchJob("ChargeCard", "[]")).toBe("charged");
+    expect(queue.dispatchJob("SendWelcomeEmail", "[]")).toBe("sent");
+    expect(queue.registeredJobs).toHaveLength(2);
+  });
+
+  test("refuses a name that is taken, and keeps the job that took it", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const queue = new QueueManager({ jobs: [ChargeCard] });
+
+    const impostor = {
+      ChargeCard: class ChargeCard extends Job {
+        run() {
+          return "impostor";
+        }
+      },
+    }.ChargeCard;
+
+    queue.registerJob(impostor);
+
+    expect(queue.dispatchJob("ChargeCard", "[]")).toBe("charged");
+    expect(vi.mocked(error).mock.calls[0]![0]).toContain(
+      'Two queued jobs are named "ChargeCard"',
+    );
+    // Reported anyway, the same as a duplicate handed to `useJobs`: the getter
+    // says what the manager was given, so a test can see the clash.
+    expect(queue.registeredJobs).toHaveLength(2);
+  });
+
+  test("does not edit the array `useJobs` was handed", () => {
+    const declared = [ChargeCard];
+    const queue = new QueueManager({ jobs: declared });
+
+    queue.registerJob(SendWelcomeEmail);
+
+    expect(declared).toEqual([ChargeCard]);
+  });
+});
+
 describe("the readable view", () => {
   test("is a copy, so walking it cannot edit what the queue runs from", () => {
     const queue = new QueueManager({ jobs: [ChargeCard] });

--- a/packages/gemi/services/queue/QueueManager.ts
+++ b/packages/gemi/services/queue/QueueManager.ts
@@ -2,6 +2,26 @@ import { Job } from "./Job";
 import { queueConfigDefaults, type QueueConfig } from "./config";
 import { withDefaults } from "../../support/withDefaults";
 
+/**
+ * The thread a `worker = true` job runs in.
+ *
+ * The `await` on `dispatchJob` is load-bearing and its absence was a hang.
+ * `postMessage` structured-clones its argument and a Promise is not cloneable,
+ * so an un-awaited `dispatchJob` posted the pending promise, threw
+ * `DataCloneError` inside this handler, and posted nothing at all. `runInWorker`
+ * then never settled: `run` below never returned, `activeRunningJobsCount` was
+ * never decremented, and neither the retry path nor `onDeadletter` ever fired —
+ * after `concurrency` such jobs the queue sits in `next()`'s one-second poll
+ * forever, with no error anywhere. Any job whose `run` is `async` hit it, which
+ * is every job that touches IO; a queued listener hits it unconditionally,
+ * because the synthetic job's `run` awaits `handle`.
+ *
+ * The await earns two more things. A rejecting job now reaches the `catch` and
+ * comes back as `{error}`, where the queue's ordinary retry-then-dead-letter
+ * path can have it, instead of being lost with the promise. And `destroy()` now
+ * runs after the job rather than under it, so the cloned kernel — its database
+ * connections included — outlives the work it was cloned for.
+ */
 function createWorker() {
   const APP_DIR = process.env.APP_DIR;
   const ROOT_DIR = process.env.ROOT_DIR;
@@ -20,7 +40,7 @@ function createWorker() {
         let result = null;
         let error = null;
         try {
-          result = clone.dispatchJob(event.data.jobName, event.data.args)
+          result = await clone.dispatchJob(event.data.jobName, event.data.args)
         } catch (err) {
           error = err
         }

--- a/packages/gemi/services/queue/QueueManager.ts
+++ b/packages/gemi/services/queue/QueueManager.ts
@@ -115,18 +115,55 @@ export class QueueManager {
     // name, and the reverse of the silent last-wins this replaces.
     this.jobs = {};
     for (const job of jobs) {
-      const taken = this.jobs[job.name];
-      if (taken) {
-        console.error(
-          `Two queued jobs are named "${job.name}" — the first is registered ` +
-            `and this one is not, so dispatching either would have run one of ` +
-            `them. A class name is the queue's key, so only one job can hold ` +
-            `it. Rename one.`,
-        );
-        continue;
-      }
-      this.jobs[job.name] = job;
+      this.claim(job);
     }
+  }
+
+  /**
+   * Registers one more job beside whatever `useJobs` already took.
+   *
+   * This exists for the queued-listener adapter, which registers a synthetic
+   * job per queued listener from `EventServiceProvider.boot()` — after the
+   * queue's own `boot()` has filled the registry. `useJobs` cannot serve that
+   * caller: it *replaces* the registry, so a second call would discard every
+   * job the app wrote and leave the queue holding listeners alone. Reading
+   * `registeredJobs` back, concatenating and calling `useJobs` again avoids
+   * that and is still the wrong shape — it re-runs the collision check over
+   * jobs that already passed it, so a duplicate the author has already been
+   * told about is reported a second time on every boot.
+   *
+   * Same rule as `useJobs`, deliberately: the first claim on a name wins and
+   * the second is refused out loud. And recorded in `config.jobs` either way,
+   * so `registeredJobs` keeps reporting everything the manager was handed
+   * rather than what it accepted — a refused job is visible to a test there.
+   *
+   * A new array rather than a `push`, because `useJobs` keeps the caller's
+   * array by reference and appending to it would edit the config slice or the
+   * discovered list under whoever else is holding it.
+   */
+  registerJob(job: new () => Job) {
+    this.config.jobs = [...this.config.jobs, job];
+    this.claim(job);
+  }
+
+  /**
+   * Puts one job in the registry, or refuses it because the name is taken.
+   *
+   * The rule and the reason are in `useJobs` above; this is only the shape both
+   * entry points share, so that a job arriving one at a time cannot be admitted
+   * on terms the batch would have refused.
+   */
+  private claim(job: new () => Job) {
+    if (this.jobs[job.name]) {
+      console.error(
+        `Two queued jobs are named "${job.name}" — the first is registered ` +
+          `and this one is not, so dispatching either would have run one of ` +
+          `them. A class name is the queue's key, so only one job can hold ` +
+          `it. Rename one.`,
+      );
+      return;
+    }
+    this.jobs[job.name] = job;
   }
 
   /**

--- a/plans/events/02-queued-listeners.md
+++ b/plans/events/02-queued-listeners.md
@@ -74,10 +74,20 @@ dead-lettering, `concurrency` and worker-thread execution are four features that
 already exist, are already documented for apps, and are already tested. A
 parallel implementation would be four features that are almost the same.
 
-`writable: true` on the redefined `name` is not cosmetic — it is what
-`warnIfNameWillNotSurviveTheBuild` reads to decide a name was *declared*. A
-synthetic class whose name is a non-writable own property would be reported to
-the author as a job they never wrote and cannot fix.
+`writable: true` on the redefined `name` is what makes the descriptor match the
+one a declared `static name = "..."` field produces, which is what every "was
+this name declared?" check in the framework reads — they compare descriptors,
+not strings, because the two spellings read the same string in development.
+
+**Correction, from the implementation.** This was written as
+`warnIfNameWillNotSurviveTheBuild` reading it, and that check cannot see a
+synthetic job: it is module-private to `discovery.ts` and runs only over the
+classes `discoverJobs()` found on disk, while these are built in memory and
+handed straight to `registerJob`. So nothing reads the flag today. It is kept
+because the check that would report a synthetic entry as "a job you never wrote
+and cannot fix" is one registry away — the queue's own — and because
+`Object.defineProperty` keeps the attributes it is not given, so dropping the
+flag silently leaves the class's non-writable `name` behind.
 
 ## Deliverables
 
@@ -106,16 +116,26 @@ Both are ignored when `queued` is false, and that is worth a doc comment on each
 rather than a note somewhere else: a `maxAttempts = 5` on a sync listener is a
 line an author wrote that does nothing.
 
-### 3. `static name` on `Listener` becomes required
+### 3. `static name` on a **queued** `Listener` becomes required
 
-In iteration 1 the listener's own name was internal. Here it is the queue's key
-and it crosses a JSON boundary, so it inherits the whole minification story from
-invariant 1 — and `discoverListeners` already has the check written for the
-event class; point it at the listener class too.
+In iteration 1 the listener's own name was internal. Once it is queued the name
+is the queue's key and it crosses a JSON boundary, so it inherits the whole
+minification story from invariant 1 — and `discoverListeners` already has the
+check written for the event class; point it at the listener class too.
 
-Upgrade the iteration-1 `warnIfListenerNameWillNotSurviveTheBuild` from advisory
-to something an author cannot miss: a queued listener whose name is implicit is
-a side effect that stops happening in production only.
+Upgrade the iteration-1 advisory to something an author cannot miss: a queued
+listener whose name is implicit is a side effect that stops happening in
+production only.
+
+**Narrowed, from the implementation.** This was written as "required on
+`Listener`", meaning every listener, and the refusal belongs only where the
+hazard is. The refusal is `jobForListener`'s and it throws at registration for a
+queued listener; `warnIfListenerNameWillNotSurviveTheBuild` stays a warning for
+a sync one, because a sync listener's name has no second reader for a minified
+build to disagree with — every reader of it comes from the same source-side
+walk. Refusing it would stop a boot over a failure that cannot occur, and the
+warning names the upgrade path so an author adding `queued = true` later is not
+surprised by it.
 
 ### 4. `EventManager.rehydrate(eventName, args)`
 
@@ -149,8 +169,15 @@ as its own subsection rather than a parenthesis:
 - A sync listener runs inside the dispatcher's `kernelContext` and `ormContext`.
   It sees the request's `app()`, the authenticated user via `currentActor()`,
   and joins the ambient transaction.
-- A queued listener runs later, from `QueueManager.next()`, outside all of it —
+- A queued listener runs from `QueueManager.next()` and may rely on none of it —
   and with `worker = true`, in a different thread with a cloned app.
+
+The second bullet said "outside all of it" and the docs must not: the queue is
+in-process and `push` starts the drain, so a queued listener frequently runs
+*inside* the dispatching request's context, and whether it does depends on
+whether the queue was already busy. Write it as what may be relied on, and see
+the correction under invariant 4 — an intermittently present context is the
+worse hazard of the two, not the milder one.
 
 The failure this prevents is a policied `Model` read inside a listener returning
 different rows depending on a flag the author set for latency reasons.

--- a/plans/events/README.md
+++ b/plans/events/README.md
@@ -158,10 +158,14 @@ leaves string literals alone, so both halves agree. This is the same hazard
 jobs, one subsystem over, and it is worse here because a job at least logs when
 its name resolves to nothing.
 
-Consequence: `static name` is **required on `Event`**, and required on
-`Listener` from iteration 2 (where the listener name crosses the queue's JSON
-boundary). Both get the writable-own-property check that discovery already
-applies to jobs.
+Consequence: `static name` is **required on `Event`**, and required on a
+**queued** `Listener` from iteration 2 — that is where the listener's name
+becomes the queue's key and crosses its JSON boundary. A sync listener's name is
+only ever read inside the one module graph that discovered it, so there it stays
+a warning: there is no second reader for a minified build to disagree with.
+Both get the writable-own-property check that discovery already applies to jobs;
+the refusal sits where the boundary is, at the point a listener is registered
+with the queue.
 
 **Corollary, for application code: never `instanceof` an event.** The same two
 class objects make `event instanceof UserRegistered` inside a listener `true` in
@@ -196,7 +200,22 @@ dead-letter path instead.
 
 A sync listener runs inside the dispatcher's `kernelContext` and `ormContext`:
 it has the request's `app()`, the authenticated user, and the ambient
-transaction. A queued listener runs in a cloned app with none of that.
+transaction. A queued listener may rely on none of it.
+
+**"May rely on none of it", not "has none of it"** — the second is what
+iteration 2 was written to say and it is not true of the runtime it shipped
+against. The queue is in-process and `push` starts the drain itself, so a
+queued listener frequently runs *inside* the dispatching request's context and
+`app()` there resolves the request's application. With `worker = true` it is a
+different thread with a cloned app and genuinely has nothing. Which of the two
+happens depends on whether the queue was already busy, which is not a thing an
+author decides.
+
+That makes the boundary worse than a plainly absent context, not better, and it
+is why the invariant is normative rather than descriptive: a listener that reads
+the current actor or expects the ambient transaction works until the day
+something else was already draining, and then reads different rows or commits
+separately, with no error either way.
 
 `queued = true` is therefore not a performance toggle, and must not be
 documented as one. It is a context boundary that happens to be spelled as one


### PR DESCRIPTION
**Stacked on #417** (`feat/events-01-sync-dispatch`) — review that one first; this PR's base is its branch, so the diff here is only iteration 2.

Implements [`plans/events/02-queued-listeners.md`](../blob/feat/events-02-queued-listeners/plans/events/02-queued-listeners.md).

## What it delivers

`queued = true` on a listener moves it off the request and onto the existing queue. Retries, `maxAttempts`, dead-lettering, `concurrency` and worker threads come from `QueueManager` rather than from anything written here — a queued listener is registered as a synthetic `Job` named `listener:<name>`, and a dispatch pushes `["UserRegistered", [7, "ada@example.com"]]` to it.

```typescript
export class SendWelcomeEmail extends Listener {
  static name = "SendWelcomeEmail";
  static event = UserRegistered;

  queued = true;
  maxAttempts = 5;

  async handle(event: UserRegistered) { await sendWelcome(event.email); }
}
```

- **`QueueManager.registerJob(job)`** — a single-job entry point beside `useJobs`, sharing its first-claim-wins collision handling and appending to `config.jobs` so `registeredJobs` still reports everything the manager was handed. `useJobs` replaces the registry wholesale, so `EventServiceProvider.boot()` (which runs after the queue's) could not use it without discarding every job the app wrote.
- **`Listener` gains `queued`, `maxAttempts`, `worker`** — the last two forwarded to the synthetic job, and documented as ignored when `queued` is false on the fields themselves, because a `maxAttempts = 5` on a sync listener is a line an author wrote that does nothing.
- **`static name` becomes required in earnest for a queued listener** — an implicit class name is refused at registration (a throw), not warned about. A sync listener still only warns: its name never leaves the source-side walk, while a queued one's is the queue's key on both ends, and those ends can be two different builds.
- **`EventManager.rehydrate(eventName, args)`** — a second registry (event name → class, from each listener's `static event`) and `new EventClass(...args)`. An unknown name throws with the name in the message; the payload is already off the queue by then and the alternative is `event.email` failing several frames later.
- **`EventManager.dispatch/dispatchAndWait` take the constructor arguments**, which `Event.dispatch` forwards. An instance cannot be asked what it was built with, and the arguments are what is serialized.
- **Invariant 4 documented** — in `Listener.queued`'s doc comment and in `docs/events.md` as its own subsection, plus the durability note (`a dispatch is not a durability guarantee`) and the `listener:` prefix showing up in `registeredJobs`.

## Verification

Run from `packages/gemi` in the worktree:

```
$ bun --bun vitest run services docs-imports.test.ts barrel-imports.test.ts
 Test Files  28 passed (28)
      Tests  355 passed (355)

$ bun --bun vitest run --typecheck.only services/events
 Test Files  1 passed (1)
      Tests  4 passed (4)
 Type Errors  no errors

$ bunx tsc --noEmit -p tsconfig.json
(no output)

$ bunx oxlint
Found 80 warnings and 0 errors.   # unchanged from the base branch; none in the files touched
```

New tests: `services/events/queuedListeners.test.ts` (12) covering sync + queued in one dispatch, `dispatchAndWait` not waiting, retry-to-dead-letter on the listener's own `maxAttempts`, the rehydration round trip, the worker's `dispatchJob` entry point, the synthetic job's writable `name`, `worker` forwarding, the implicit-name refusal, two queued listeners claiming one name, a payload JSON cannot carry, and a manager-level dispatch that cannot queue. Plus `rehydrate` in `EventManager.test.ts` and three `registerJob` cases in `QueueManager.test.ts`.

## Deviations from the plan

1. **The constructor arguments are passed to the manager, not recovered from the event.** The plan writes `push(job, JSON.stringify([event.constructor.name, ctorArgs]))` without saying where `ctorArgs` comes from — an event instance does not remember them, and the base class cannot capture them (`super()` runs before the subclass assigns its fields). So `dispatch(event, args?)` takes them and `Event.dispatch` forwards them. A queued listener reached without them is skipped with a line on stderr naming both, rather than queueing `[]` and rehydrating an event whose every field is `undefined`.
2. **The name escalation in §3 landed as a refusal for *queued* listeners only**, in `jobForListener`, rather than as a change to `warnIfListenerNameWillNotSurviveTheBuild`. Discovery cannot tell a queued listener from a sync one without constructing every class it found; the registry constructs them anyway, and the plan's own sentence for the escalation ("a queued listener whose name is implicit is a side effect that stops happening in production only") is about queued ones. Sync listeners keep the iteration-1 warning.
3. **The synthetic job's `run` reads two payload shapes.** `QueueManager.run` spreads the parsed arguments while `QueueManager.dispatchJob` — the worker thread's entry point — passes the parsed array whole. That asymmetry is pre-existing and affects every job with arguments, not just these; it is worked around in `readPayload` rather than fixed, because fixing it changes what every existing `worker = true` job receives. Worth its own issue.
4. **The context boundary is documented as "not promised" rather than "gone".** gemi's queue is in-process and `push` starts the drain itself, so a queued listener frequently runs inside the dispatching request's `kernelContext` — `app()` there resolves the request's application. Claiming isolation the runtime does not provide would be the more dangerous doc, so both the field comment and `docs/events.md` say the context may be there and may not, and that nothing may rely on it.

## Also worth a reviewer's eye

- `EventServiceProvider.boot()` no longer returns early when `listeners` is declared in config — it skips discovery but still hands the queued listeners' jobs to the queue, otherwise `queued = true` would silently do nothing for an app that lists its listeners.
- The queue push is wrapped in its own `try`: an argument JSON cannot serialize, or an application with no queue bound, would otherwise reject `dispatchAndWait`, which is documented never to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)