### PR TITLE
Events iteration 3: after-commit dispatch and testing

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -163,7 +163,7 @@ That is the whole of the opt-in. Behind it, the listener is registered with the 
 
 It is a **context boundary spelled as one line**, not a latency setting.
 
-- A **sync** listener runs inside the dispatching request: it has that request's `app()`, its authenticated user through `currentActor()`, and it joins the ambient transaction.
+- A **sync** listener runs inside the dispatching request: it has that request's `app()`, its authenticated user through `currentActor()`, and it joins the ambient transaction — unless the event declares [`static afterCommit`](#deferring-until-the-transaction-commits), which releases the listeners after the commit and so outside it.
 - A **queued** listener is handed to the queue and run from a drain, on the queue's terms. With `worker = true` that is a different thread with a cloned application. Only the event's name and constructor arguments cross; nothing else does.
 
 The part that catches people is that the request's context is not reliably *gone* either. gemi's queue is in-process, so a drain that happens to start from the push is still standing inside the dispatching request, and `app()` there resolves the request's application. **None of that is promised.** A queued listener that reads the current actor, or writes expecting to join the transaction the controller opened, works right up until the day the queue was already busy — and then reads different rows, or commits separately, with no error either way.

--- a/docs/events.md
+++ b/docs/events.md
@@ -36,6 +36,11 @@ An event is the payload plus a name. It carries no framework state — no timest
 
 > **Note:** The static `name` is **required**, and omitting it does not fall back harmlessly to the class name. The listener registry is keyed by this string. `gemi build` minifies the server entry, and the app code reachable from it — your controller, and every event class it imports in order to dispatch — is bundled and minified with it, which renames the class binding; a class's implicit `.name` *is* that binding, so `UserRegistered` becomes something like `D`. Discovery, meanwhile, imports `app/listeners/*.ts` from source at runtime, and those files import `app/events/*.ts` from source too. Two module graphs, two class objects, two different names — and the dispatch reaches nobody, in production and nowhere else. A declared `static name` is a string literal, which survives minification intact. Discovery warns at boot about any event a listener binds to that leaves it out.
 
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `static name` | `string` | `"unset"` | The name the registry is keyed by. Required. |
+| `static afterCommit` | `boolean` | `false` | Hold the listeners until the surrounding transaction commits, and drop them if it rolls back. See [Deferring until the transaction commits](#deferring-until-the-transaction-commits). |
+
 ### Never `instanceof` an event
 
 The same two class objects are why this is unsafe **in your own code**:
@@ -197,6 +202,67 @@ app(QueueManager).registeredJobs.map((job) => job.name);
 
 `registeredJobs` reports what the queue will run, and a queued listener genuinely is something it will run — hiding them would make a queue introspection tool lie. The `listener:` prefix is what keeps you from going to look for a job file you never wrote.
 
+## Deferring until the transaction commits
+
+A dispatch inside a transaction happens immediately. The transaction may not:
+
+```typescript
+await DB.transaction(async () => {
+  const user = await User.create(input);
+  UserRegistered.dispatch(user.id, user.email);   // welcome email sent
+  await Billing.provision(user);                  // throws
+});                                               // rolled back
+```
+
+The user does not exist and has been welcomed. Nothing errored — the email succeeded and the transaction failed, in two subsystems that never meet — so nothing anywhere reports it.
+
+`static afterCommit = true` on the **event** moves its listeners to the commit:
+
+```typescript
+// app/events/UserRegistered.ts
+export class UserRegistered extends Event {
+  static name = "UserRegistered";
+  static afterCommit = true;
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+```
+
+| `afterCommit` | Inside a transaction | What happens |
+| --- | --- | --- |
+| `false` (default) | either | The listeners run now. |
+| `true` | no | The listeners run now — there is nothing to wait for. |
+| `true` | yes | The listeners run when that transaction commits, and not at all if it rolls back. |
+
+It is a property of the **event**, not of the listener: whether a side effect is allowed to happen before the write is durable is a fact about what happened, and every listener bound to it agrees. Both kinds are deferred together — a sync listener runs after the commit, and a queued one is *pushed* after the commit. Pushing early would be running early, because the queue drains in-process and often starts from the push itself.
+
+The listeners run **outside** the transaction that deferred them. A listener that opens its own transaction gets a real one rather than a savepoint on a handle that has already closed — which matters more than it looks: Bun's transaction handle stays callable after the commit and simply runs on the pool, so the wrong answer here would be silent.
+
+### The two things to know before using it
+
+**`dispatchAndWait` on a deferred event resolves immediately, having run nothing.** The listeners are queued on a transaction the caller has not finished, so the `await` buys nothing and code on the next line reading what a listener wrote finds it missing. Development warns once per event name; there is no other symptom. Await the transaction instead.
+
+**The transaction does not resolve until the deferred listeners have.** `await DB.transaction(...)` covers the commit *and* the listeners it released. That is deliberate — the alternative is work floating after the transaction returns, which a short-lived process (a command, a seed) exits out from under, and a failure nobody is left to report.
+
+A listener that throws after the commit is logged and the next one still runs, exactly as on the inline path. It does **not** fail the transaction: the database kept the rows, and reporting a rejection would have the caller roll back or retry work that is already durable.
+
+### Savepoints
+
+Nesting `DB.transaction` takes a savepoint, and deferred dispatches follow the transaction rather than the block:
+
+- A dispatch inside a savepoint that commits runs when the **outer** transaction commits — not when the savepoint closes.
+- A dispatch inside a savepoint that **rolls back** does not run, even if the outer transaction commits.
+- An outer rollback discards everything, savepoint dispatches included.
+
+### Why it is opt-in
+
+Defaulting it on would mean a `dispatch` inside a transaction silently has not happened yet — a fire-and-forget call turned into a deferred one by ambient state the call site cannot see. That is a surprise of the same size as the one being fixed, and the harder one to debug, because nothing went wrong. Turn it on for the events where a rollback must take the side effect with it: a welcome email, a webhook, an invoice.
+
 ## Registering listeners — `app/listeners/`
 
 Every class under `app/listeners` that extends `Listener` is registered when the kernel boots.
@@ -290,6 +356,74 @@ import { discoverListeners } from "gemi/services";
 const listeners = await discoverListeners(); // every Listener under app/listeners
 ```
 
+## Testing with `Event.fake()`
+
+`Event.fake()` swaps the container's `EventManager` for one that records dispatches and runs nothing:
+
+```typescript
+import { Event } from "gemi/services";
+import { UserRegistered } from "@/app/events/UserRegistered";
+
+test("registering announces the new user", async () => {
+  const events = Event.fake();
+
+  await post("/register", { email: "ada@example.com" });
+
+  events.assertDispatched(UserRegistered);
+  events.assertDispatched(UserRegistered, (e) => e.email === "ada@example.com");
+});
+```
+
+The second assertion is the point of the whole subsystem, in a test. A controller test that asserts *the event fired* is testing the controller. One that asserts *a welcome email was sent* is testing the controller, the listener and the mailer at once, and it breaks the day a fourth listener is added to an event it was never about.
+
+While a fake is installed, no listener is constructed, no `handle` runs, nothing is pushed to the queue, and an [`afterCommit`](#deferring-until-the-transaction-commits) event is recorded at the dispatch rather than held for a commit — so a controller test does not have to commit a transaction to see what the controller dispatched.
+
+### Restore it
+
+```typescript
+let events: FakeEventManager;
+
+beforeEach(() => { events = Event.fake(); });
+afterEach(() => { events.restore(); });
+```
+
+**There is no automatic teardown.** A fake that outlives its test is a later test whose listeners silently never run — and nothing catches that, because a fake legitimately has no listeners and so never trips the "nothing is listening" warning.
+
+Calling `Event.fake()` twice returns the **same** recorder, so a fake set up in a helper and one in the body of a test do not disagree; `restore()` twice is harmless. The type is importable for a signature:
+
+```typescript
+import type { FakeEventManager } from "gemi/testing";
+```
+
+### The assertions
+
+| Assertion | Passes when |
+| --- | --- |
+| `assertDispatched(Event, predicate?)` | The event was dispatched at least once — matching `predicate`, if given. |
+| `assertNotDispatched(Event, predicate?)` | It was never dispatched; with a predicate, no dispatch of it matched. |
+| `assertDispatchedTimes(Event, times, predicate?)` | It was dispatched exactly `times` times. |
+| `assertNothingDispatched()` | Nothing at all was dispatched. |
+
+The predicate takes the event instance and is typed off the class you passed, so `(e) => e.email` is checked without a cast. Matching is by the event's declared `static name`, never by class identity — the same rule the registry follows, and for the same reason.
+
+A failure names **what was dispatched**:
+
+```
+Expected OrderPaid to have been dispatched. Dispatched: UserRegistered(2, "b@c.d").
+```
+
+The common failure is not "nothing fired" but "that fired with a different payload", and printing the recorded dispatches usually ends the investigation on the spot.
+
+### What there is no assertion for
+
+**That a listener ran.** A test asserting that is a test *of the listener*, and it can be written with no framework around it at all:
+
+```typescript
+await new SendWelcomeEmail().handle(new UserRegistered(7, "ada@example.com"));
+```
+
+That is the separation the fake exists to make possible, so re-coupling the two through an assertion would give it back.
+
 ## When to reach for a job instead
 
 A **sync** listener runs inside the dispatching request, in the same process and the same context. That makes it right for fast in-request side effects — writing an audit row, warming a cache, updating a counter — and wrong for slow ones, because the request waits for `dispatchAndWait` and the process does the work either way.
@@ -313,6 +447,7 @@ gemi has no ORM lifecycle events (`User.created` and friends) — a model write 
 ## Related
 
 - [Jobs & Queues](./jobs-and-queues.md) — background work with retries, which a listener often dispatches.
+- [ORM](./orm.md) — `DB.transaction`, which `static afterCommit` hooks.
 - [Broadcasting](./broadcasting.md) — fan-out to browsers rather than to server-side handlers.
 - [Controllers](./controllers.md) — dispatching from request handlers.
 - [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8878,7 +8878,7 @@ That is the whole of the opt-in. Behind it, the listener is registered with the 
 
 It is a **context boundary spelled as one line**, not a latency setting.
 
-- A **sync** listener runs inside the dispatching request: it has that request's `app()`, its authenticated user through `currentActor()`, and it joins the ambient transaction.
+- A **sync** listener runs inside the dispatching request: it has that request's `app()`, its authenticated user through `currentActor()`, and it joins the ambient transaction — unless the event declares [`static afterCommit`](#deferring-until-the-transaction-commits), which releases the listeners after the commit and so outside it.
 - A **queued** listener is handed to the queue and run from a drain, on the queue's terms. With `worker = true` that is a different thread with a cloned application. Only the event's name and constructor arguments cross; nothing else does.
 
 The part that catches people is that the request's context is not reliably *gone* either. gemi's queue is in-process, so a drain that happens to start from the push is still standing inside the dispatching request, and `app()` there resolves the request's application. **None of that is promised.** A queued listener that reads the current actor, or writes expecting to join the transaction the controller opened, works right up until the day the queue was already busy — and then reads different rows, or commits separately, with no error either way.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8751,6 +8751,11 @@ An event is the payload plus a name. It carries no framework state — no timest
 
 > **Note:** The static `name` is **required**, and omitting it does not fall back harmlessly to the class name. The listener registry is keyed by this string. `gemi build` minifies the server entry, and the app code reachable from it — your controller, and every event class it imports in order to dispatch — is bundled and minified with it, which renames the class binding; a class's implicit `.name` *is* that binding, so `UserRegistered` becomes something like `D`. Discovery, meanwhile, imports `app/listeners/*.ts` from source at runtime, and those files import `app/events/*.ts` from source too. Two module graphs, two class objects, two different names — and the dispatch reaches nobody, in production and nowhere else. A declared `static name` is a string literal, which survives minification intact. Discovery warns at boot about any event a listener binds to that leaves it out.
 
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `static name` | `string` | `"unset"` | The name the registry is keyed by. Required. |
+| `static afterCommit` | `boolean` | `false` | Hold the listeners until the surrounding transaction commits, and drop them if it rolls back. See [Deferring until the transaction commits](#deferring-until-the-transaction-commits). |
+
 ### Never `instanceof` an event
 
 The same two class objects are why this is unsafe **in your own code**:
@@ -8912,6 +8917,67 @@ app(QueueManager).registeredJobs.map((job) => job.name);
 
 `registeredJobs` reports what the queue will run, and a queued listener genuinely is something it will run — hiding them would make a queue introspection tool lie. The `listener:` prefix is what keeps you from going to look for a job file you never wrote.
 
+## Deferring until the transaction commits
+
+A dispatch inside a transaction happens immediately. The transaction may not:
+
+```typescript
+await DB.transaction(async () => {
+  const user = await User.create(input);
+  UserRegistered.dispatch(user.id, user.email);   // welcome email sent
+  await Billing.provision(user);                  // throws
+});                                               // rolled back
+```
+
+The user does not exist and has been welcomed. Nothing errored — the email succeeded and the transaction failed, in two subsystems that never meet — so nothing anywhere reports it.
+
+`static afterCommit = true` on the **event** moves its listeners to the commit:
+
+```typescript
+// app/events/UserRegistered.ts
+export class UserRegistered extends Event {
+  static name = "UserRegistered";
+  static afterCommit = true;
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+```
+
+| `afterCommit` | Inside a transaction | What happens |
+| --- | --- | --- |
+| `false` (default) | either | The listeners run now. |
+| `true` | no | The listeners run now — there is nothing to wait for. |
+| `true` | yes | The listeners run when that transaction commits, and not at all if it rolls back. |
+
+It is a property of the **event**, not of the listener: whether a side effect is allowed to happen before the write is durable is a fact about what happened, and every listener bound to it agrees. Both kinds are deferred together — a sync listener runs after the commit, and a queued one is *pushed* after the commit. Pushing early would be running early, because the queue drains in-process and often starts from the push itself.
+
+The listeners run **outside** the transaction that deferred them. A listener that opens its own transaction gets a real one rather than a savepoint on a handle that has already closed — which matters more than it looks: Bun's transaction handle stays callable after the commit and simply runs on the pool, so the wrong answer here would be silent.
+
+### The two things to know before using it
+
+**`dispatchAndWait` on a deferred event resolves immediately, having run nothing.** The listeners are queued on a transaction the caller has not finished, so the `await` buys nothing and code on the next line reading what a listener wrote finds it missing. Development warns once per event name; there is no other symptom. Await the transaction instead.
+
+**The transaction does not resolve until the deferred listeners have.** `await DB.transaction(...)` covers the commit *and* the listeners it released. That is deliberate — the alternative is work floating after the transaction returns, which a short-lived process (a command, a seed) exits out from under, and a failure nobody is left to report.
+
+A listener that throws after the commit is logged and the next one still runs, exactly as on the inline path. It does **not** fail the transaction: the database kept the rows, and reporting a rejection would have the caller roll back or retry work that is already durable.
+
+### Savepoints
+
+Nesting `DB.transaction` takes a savepoint, and deferred dispatches follow the transaction rather than the block:
+
+- A dispatch inside a savepoint that commits runs when the **outer** transaction commits — not when the savepoint closes.
+- A dispatch inside a savepoint that **rolls back** does not run, even if the outer transaction commits.
+- An outer rollback discards everything, savepoint dispatches included.
+
+### Why it is opt-in
+
+Defaulting it on would mean a `dispatch` inside a transaction silently has not happened yet — a fire-and-forget call turned into a deferred one by ambient state the call site cannot see. That is a surprise of the same size as the one being fixed, and the harder one to debug, because nothing went wrong. Turn it on for the events where a rollback must take the side effect with it: a welcome email, a webhook, an invoice.
+
 ## Registering listeners — `app/listeners/`
 
 Every class under `app/listeners` that extends `Listener` is registered when the kernel boots.
@@ -9005,6 +9071,74 @@ import { discoverListeners } from "gemi/services";
 const listeners = await discoverListeners(); // every Listener under app/listeners
 ```
 
+## Testing with `Event.fake()`
+
+`Event.fake()` swaps the container's `EventManager` for one that records dispatches and runs nothing:
+
+```typescript
+import { Event } from "gemi/services";
+import { UserRegistered } from "@/app/events/UserRegistered";
+
+test("registering announces the new user", async () => {
+  const events = Event.fake();
+
+  await post("/register", { email: "ada@example.com" });
+
+  events.assertDispatched(UserRegistered);
+  events.assertDispatched(UserRegistered, (e) => e.email === "ada@example.com");
+});
+```
+
+The second assertion is the point of the whole subsystem, in a test. A controller test that asserts *the event fired* is testing the controller. One that asserts *a welcome email was sent* is testing the controller, the listener and the mailer at once, and it breaks the day a fourth listener is added to an event it was never about.
+
+While a fake is installed, no listener is constructed, no `handle` runs, nothing is pushed to the queue, and an [`afterCommit`](#deferring-until-the-transaction-commits) event is recorded at the dispatch rather than held for a commit — so a controller test does not have to commit a transaction to see what the controller dispatched.
+
+### Restore it
+
+```typescript
+let events: FakeEventManager;
+
+beforeEach(() => { events = Event.fake(); });
+afterEach(() => { events.restore(); });
+```
+
+**There is no automatic teardown.** A fake that outlives its test is a later test whose listeners silently never run — and nothing catches that, because a fake legitimately has no listeners and so never trips the "nothing is listening" warning.
+
+Calling `Event.fake()` twice returns the **same** recorder, so a fake set up in a helper and one in the body of a test do not disagree; `restore()` twice is harmless. The type is importable for a signature:
+
+```typescript
+import type { FakeEventManager } from "gemi/testing";
+```
+
+### The assertions
+
+| Assertion | Passes when |
+| --- | --- |
+| `assertDispatched(Event, predicate?)` | The event was dispatched at least once — matching `predicate`, if given. |
+| `assertNotDispatched(Event, predicate?)` | It was never dispatched; with a predicate, no dispatch of it matched. |
+| `assertDispatchedTimes(Event, times, predicate?)` | It was dispatched exactly `times` times. |
+| `assertNothingDispatched()` | Nothing at all was dispatched. |
+
+The predicate takes the event instance and is typed off the class you passed, so `(e) => e.email` is checked without a cast. Matching is by the event's declared `static name`, never by class identity — the same rule the registry follows, and for the same reason.
+
+A failure names **what was dispatched**:
+
+```
+Expected OrderPaid to have been dispatched. Dispatched: UserRegistered(2, "b@c.d").
+```
+
+The common failure is not "nothing fired" but "that fired with a different payload", and printing the recorded dispatches usually ends the investigation on the spot.
+
+### What there is no assertion for
+
+**That a listener ran.** A test asserting that is a test *of the listener*, and it can be written with no framework around it at all:
+
+```typescript
+await new SendWelcomeEmail().handle(new UserRegistered(7, "ada@example.com"));
+```
+
+That is the separation the fake exists to make possible, so re-coupling the two through an assertion would give it back.
+
 ## When to reach for a job instead
 
 A **sync** listener runs inside the dispatching request, in the same process and the same context. That makes it right for fast in-request side effects — writing an audit row, warming a cache, updating a counter — and wrong for slow ones, because the request waits for `dispatchAndWait` and the process does the work either way.
@@ -9028,6 +9162,7 @@ gemi has no ORM lifecycle events (`User.created` and friends) — a model write 
 ## Related
 
 - [Jobs & Queues](./jobs-and-queues.md) — background work with retries, which a listener often dispatches.
+- [ORM](./orm.md) — `DB.transaction`, which `static afterCommit` hooks.
 - [Broadcasting](./broadcasting.md) — fan-out to browsers rather than to server-side handlers.
 - [Controllers](./controllers.md) — dispatching from request handlers.
 - [Project Structure](./project-structure.md) — the kernel, `app/config/*.ts`, and service providers.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -46,7 +46,7 @@ Each link below points to a self-contained Markdown page. For a single file cont
 - [Jobs & Queues](https://nstfkc.github.io/gemi/jobs-and-queues.md): defining and dispatching background Jobs through the in-process queue.
 - [Cron](https://nstfkc.github.io/gemi/cron.md): scheduling recurring CronJobs with Bun.cron.
 - [Commands](https://nstfkc.github.io/gemi/commands.md): one-off application commands written with defineCommand and run with `gemi run <name>`.
-- [Events & Listeners](https://nstfkc.github.io/gemi/events.md): Event subclasses dispatched with Event.dispatch/dispatchAndWait, Listener subclasses under app/listeners bound with `static event`, sync fan-out that no listener can cancel, and `queued = true` to run one on the queue instead.
+- [Events & Listeners](https://nstfkc.github.io/gemi/events.md): Event subclasses dispatched with Event.dispatch/dispatchAndWait, Listener subclasses under app/listeners bound with `static event`, sync fan-out that no listener can cancel, `queued = true` to run one on the queue instead, `static afterCommit` to hold a dispatch until the surrounding transaction commits, and `Event.fake()` for asserting what a request dispatched.
 - [Broadcasting](https://nstfkc.github.io/gemi/broadcasting.md): websocket channels, the Broadcast facade, useSubscription/useBroadcast.
 - [Internationalization](https://nstfkc.github.io/gemi/i18n.md): component-scoped dictionaries, useTranslator, useLocale, locale detection.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -195,6 +195,7 @@ Under `bun test`, preload `happy-dom` — no gemi-specific configuration is requ
 
 ## Related
 
+- [Events & Listeners](./events.md#testing-with-eventfake) — `Event.fake()`, for asserting what a *server* test dispatched.
 - [Views & Layouts](./views-and-layouts.md) — what a view receives from its route.
 - [Data Fetching](./data-fetching.md) — `useQuery`, prefetching, and the variant keys `queryData` mirrors.
 - [Internationalization](./i18n.md) — dictionaries and `useTranslator`.

--- a/packages/gemi/orm/context.test.ts
+++ b/packages/gemi/orm/context.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { SLOW_TRANSACTION_THRESHOLD } from "../database/config";
 import { CrossConnectionTransactionError } from "../database/Connection";
@@ -6,6 +6,7 @@ import {
   assertConnectionUsable,
   currentConnectionName,
   currentTransaction,
+  deferUntilCommit,
   isSystemScope,
   ormContext,
   runAsSystem,
@@ -214,7 +215,330 @@ describe("the ambient transaction scope", () => {
     const pool = fakePool("a");
 
     await withTransaction(pool, async () => {
-      expect(ormContext.getStore()).toEqual({ tx: pool.handle, depth: 0 });
+      // The after-commit list is created empty by every outermost transaction
+      // rather than on first use: a savepoint's scope is a spread of this one,
+      // so a list that appeared later would appear on the savepoint's copy and
+      // not on the parent that has to drain it.
+      expect(ormContext.getStore()).toEqual({
+        tx: pool.handle,
+        depth: 0,
+        afterCommit: [],
+      });
+    });
+  });
+});
+
+/**
+ * `afterCommit`: work registered inside a transaction that must not happen
+ * unless it commits.
+ *
+ * The failure is one an application cannot see. A welcome email sent from
+ * inside a transaction that then rolls back leaves a user who does not exist
+ * and has been welcomed — nothing errored, and the two halves are in different
+ * subsystems by the time anyone looks.
+ *
+ * Every test here drives `withTransaction` rather than the store, because the
+ * property is about *where the list lives*: an implementation on a module-level
+ * array passes anything written against a single transaction and is wrong the
+ * moment two of them overlap.
+ */
+describe("work deferred to the commit", () => {
+  // One test below spies on `console.error`; without this it stays spied for
+  // every test after it in the file, which would swallow output the next
+  // failure needs.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("runs after the transaction settles, in registration order", async () => {
+    const pool = fakePool("a");
+    const ran: string[] = [];
+
+    await withTransaction(pool, async () => {
+      expect(deferUntilCommit(() => void ran.push("first"))).toBe(true);
+      expect(deferUntilCommit(() => void ran.push("second"))).toBe(true);
+      // Still nothing: the whole point is that this is not "run it later on the
+      // microtask queue", it is "run it if the database keeps the write".
+      expect(ran).toEqual([]);
+    });
+
+    expect(ran).toEqual(["first", "second"]);
+  });
+
+  test("the transaction does not resolve until the callbacks have", async () => {
+    const pool = fakePool("a");
+    const order: string[] = [];
+
+    await withTransaction(pool, async () => {
+      deferUntilCommit(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        order.push("callback");
+      });
+    });
+    order.push("caller");
+
+    // Deliberate, and the one thing about `afterCommit` a caller can feel: a
+    // floating drain would be a rejection nobody sees and work a short-lived
+    // process can exit out from under.
+    expect(order).toEqual(["callback", "caller"]);
+  });
+
+  test("nothing runs when the transaction rolls back", async () => {
+    const pool = fakePool("a");
+    const ran: string[] = [];
+
+    await expect(
+      withTransaction(pool, async () => {
+        deferUntilCommit(() => void ran.push("welcome email"));
+        throw new Error("billing declined");
+      }),
+    ).rejects.toThrow("billing declined");
+
+    expect(ran).toEqual([]);
+  });
+
+  /**
+   * A savepoint has committed nothing durable, so draining at its close would
+   * run work that a rollback of the enclosing transaction was meant to prevent
+   * — the same failure, one level in and harder to see.
+   */
+  test("a savepoint's callbacks wait for the outer transaction, not for it", async () => {
+    const pool = fakePool("a");
+    const ran: string[] = [];
+
+    await withTransaction(pool, async () => {
+      await withTransaction(pool, async () => {
+        deferUntilCommit(() => void ran.push("inside the savepoint"));
+      });
+
+      // The savepoint has closed and nothing has run.
+      expect(ran).toEqual([]);
+    });
+
+    expect(ran).toEqual(["inside the savepoint"]);
+  });
+
+  test("a savepoint's callbacks are discarded with the outer rollback", async () => {
+    const pool = fakePool("a");
+    const ran: string[] = [];
+
+    await expect(
+      withTransaction(pool, async () => {
+        await withTransaction(pool, async () => {
+          deferUntilCommit(() => void ran.push("inside the savepoint"));
+        });
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(ran).toEqual([]);
+  });
+
+  /**
+   * The case a shared array gets wrong on its own, and the reason the savepoint
+   * branch marks and truncates: the savepoint rolled back, the transaction went
+   * on to commit, and what was registered inside the discarded block must go
+   * with it while everything around it stays.
+   */
+  test("a savepoint that rolls back drops what was deferred inside it", async () => {
+    const pool = fakePool("a");
+    const ran: string[] = [];
+
+    await withTransaction(pool, async () => {
+      deferUntilCommit(() => void ran.push("before"));
+
+      await expect(
+        withTransaction(pool, async () => {
+          deferUntilCommit(() => void ran.push("inside"));
+          throw new Error("savepoint failed");
+        }),
+      ).rejects.toThrow("savepoint failed");
+
+      deferUntilCommit(() => void ran.push("after"));
+    });
+
+    expect(ran).toEqual(["before", "after"]);
+  });
+
+  /**
+   * Depth alone cannot tell two siblings apart — they leave entries at the same
+   * depth, adjacent in one list — so a "drop everything at or below the failing
+   * depth" implementation discards the committed sibling's work too. That
+   * implementation passes every other test in this file.
+   */
+  test("a sibling savepoint that committed keeps its callbacks", async () => {
+    const pool = fakePool("a");
+    const ran: string[] = [];
+
+    await withTransaction(pool, async () => {
+      await withTransaction(pool, async () => {
+        deferUntilCommit(() => void ran.push("committed sibling"));
+      });
+
+      await expect(
+        withTransaction(pool, async () => {
+          deferUntilCommit(() => void ran.push("rolled back sibling"));
+          throw new Error("savepoint failed");
+        }),
+      ).rejects.toThrow("savepoint failed");
+    });
+
+    expect(ran).toEqual(["committed sibling"]);
+  });
+
+  /**
+   * The reason draining re-enters the pre-transaction scope explicitly rather
+   * than trusting where a `.then` captured its context.
+   *
+   * Bun's handle stays callable after `begin` resolves — queries on it run on
+   * the pool, outside any transaction, and succeed — so a callback that still
+   * saw the handle would not fail. It would join nothing, silently, and a
+   * listener opening its own transaction would `savepoint` on a transaction
+   * that is over.
+   */
+  test("a callback runs outside the transaction it was deferred by", async () => {
+    const pool = fakePool("a");
+    let handle: unknown = "unset";
+    let depth: number | null = -1;
+
+    await withTransaction(pool, async () => {
+      deferUntilCommit(() => {
+        handle = currentTransaction();
+        depth = transactionDepth();
+      });
+    });
+
+    expect(handle).toBeUndefined();
+    expect(depth).toBeNull();
+  });
+
+  test("the scope around the transaction is still there for the callbacks", async () => {
+    const pool = fakePool("a");
+    let system: boolean | null = null;
+
+    await runAsSystem(() =>
+      withTransaction(pool, async () => {
+        deferUntilCommit(() => void (system = isSystemScope()));
+      }),
+    );
+
+    // Restored, not dropped: the transaction nested inside `asSystem`, so the
+    // work it deferred belongs to that block too.
+    expect(system).toBe(true);
+  });
+
+  test("a callback opening its own transaction gets a real one", async () => {
+    const outer = fakePool("outer");
+    const inner = fakePool("inner");
+    let depth: number | null = null;
+
+    await withTransaction(outer, async () => {
+      deferUntilCommit(() =>
+        withTransaction(inner, async () => {
+          depth = transactionDepth();
+        }),
+      );
+    });
+
+    // 0, not 1: a savepoint on the closed transaction would have reported 1,
+    // and would have been taken on a handle that is back in the pool.
+    expect(depth).toBe(0);
+  });
+
+  test("a throwing callback neither rejects the transaction nor stops the next", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const pool = fakePool("a");
+    const ran: string[] = [];
+
+    // Rejecting here would have the caller roll back or retry work the database
+    // has already kept — the transaction succeeded, and the callback is a side
+    // effect it was never waiting on.
+    await expect(
+      withTransaction(pool, async () => {
+        deferUntilCommit(() => {
+          throw new Error("smtp is down");
+        });
+        deferUntilCommit(() => void ran.push("second"));
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(ran).toEqual(["second"]);
+    expect(String(vi.mocked(error).mock.calls[0]![0])).toContain(
+      "after-commit",
+    );
+  });
+
+  /**
+   * The concurrency property of the file, extended to the new field. An
+   * implementation holding the callbacks anywhere shared — a module-level
+   * array, a field on the manager — runs A's deferred work when B commits, and
+   * runs it twice.
+   */
+  test("two concurrent transactions never see each other's deferred work", async () => {
+    const first = fakePool("first");
+    const second = fakePool("second");
+    const ran: string[] = [];
+
+    async function run(pool: any, label: string, delays: number[]) {
+      await withTransaction(pool, async () => {
+        for (const delay of delays) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          deferUntilCommit(() => void ran.push(label));
+        }
+      });
+    }
+
+    await Promise.all([
+      run(first, "A", [0, 4, 0, 6]),
+      run(second, "B", [2, 0, 5, 0]),
+    ]);
+
+    expect(ran.filter((entry) => entry === "A")).toHaveLength(4);
+    expect(ran.filter((entry) => entry === "B")).toHaveLength(4);
+  });
+
+  test("a rollback discards only its own transaction's callbacks", async () => {
+    const committing = fakePool("committing");
+    const failing = fakePool("failing");
+    const ran: string[] = [];
+
+    await Promise.all([
+      withTransaction(committing, async () => {
+        deferUntilCommit(() => void ran.push("committed"));
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }),
+      expect(
+        withTransaction(failing, async () => {
+          deferUntilCommit(() => void ran.push("rolled back"));
+          await new Promise((resolve) => setTimeout(resolve, 2));
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom"),
+    ]);
+
+    expect(ran).toEqual(["committed"]);
+  });
+
+  /**
+   * The return value is the contract, and ignoring it is how a dispatch
+   * disappears: there is nothing here that will ever drain, so a caller that
+   * queued and returned would have queued into a leak.
+   */
+  test("outside a transaction there is nothing to defer to", () => {
+    const ran: string[] = [];
+
+    expect(deferUntilCommit(() => void ran.push("now"))).toBe(false);
+    expect(ran).toEqual([]);
+  });
+
+  test("a hand-built scope carrying a handle defers nothing either", async () => {
+    const pool = fakePool("a");
+
+    // No list, because nothing opened this scope through `withTransaction` —
+    // so there is no commit to hook and `false` is the only honest answer.
+    await ormContext.run({ tx: pool.handle, depth: 0 }, async () => {
+      expect(currentTransaction()).toBe(pool.handle);
+      expect(deferUntilCommit(() => {})).toBe(false);
     });
   });
 });

--- a/packages/gemi/orm/context.ts
+++ b/packages/gemi/orm/context.ts
@@ -71,7 +71,46 @@ export interface OrmScope {
    * mean different things under deny-by-default.
    */
   actor?: { user: unknown };
+  /**
+   * Work that must not happen unless this transaction commits — an event whose
+   * `static afterCommit` is set, today, and nothing else.
+   *
+   * **Created by the outermost `withTransaction` and never by a savepoint.** A
+   * savepoint's scope is a spread of its parent's (`{ ...current, tx: nested }`),
+   * so the array arrives here already shared by reference with the transaction
+   * that opened it — which is the behaviour wanted rather than a leak. A
+   * dispatch made inside a savepoint that commits, in a transaction that then
+   * rolls back, must not run: rolling back the outermost transaction discards
+   * the list whole, savepoint entries included, because nothing ever drains it.
+   *
+   * The inverse — a savepoint that rolls back under a transaction that commits
+   * — is the case sharing gets wrong on its own, and `withTransaction`'s
+   * savepoint branch is where it is put right.
+   *
+   * Absent, rather than an empty array, on every scope that is not a
+   * transaction: `runAsSystem`, `runAsUser` and `runOnConnection` spread
+   * whatever they are given, so "there is a list here" and "there is an open
+   * transaction here" have to stay the same question. `deferUntilCommit`
+   * answers `false` when either half is missing and the caller runs the work
+   * now, which is what keeps a hand-built scope carrying a `tx` — the shape
+   * tests write — from swallowing a dispatch into a list nothing drains.
+   */
+  afterCommit?: AfterCommitCallback[];
 }
+
+/**
+ * Work deferred to a transaction's commit.
+ *
+ * Awaited when it is drained, and its rejection is caught there: a callback is
+ * a side effect that the transaction is not waiting on and cannot be told
+ * about, so the only thing left to do with a failure is report it.
+ *
+ * Not exported: a caller passes a lambda and never names this, and an export
+ * nothing outside this file uses is what `orm/architecture.test.ts` is pointed
+ * at. The declaration emit carries it along regardless, so `OrmScope` stays
+ * readable from a `.d.ts`.
+ */
+type AfterCommitCallback = () => void | Promise<void>;
 
 /**
  * One ambient scope for the ORM, not one per feature.
@@ -175,6 +214,33 @@ export function assertConnectionUsable(name: string): void {
   if (open === name) return;
 
   throw new CrossConnectionTransactionError(open, name);
+}
+
+/**
+ * Hold `callback` until the open transaction commits, and say whether that
+ * happened.
+ *
+ * `false` means there was nothing to wait for — no transaction is open, or the
+ * scope was entered by hand rather than by `withTransaction` — and the caller
+ * must run the work itself, now. That return value is the whole contract: a
+ * caller that ignores it turns "no transaction here" into a side effect queued
+ * on a list nothing will ever drain, which is a dispatch that silently never
+ * happens.
+ *
+ * `true` means the callback is on the outermost scope's list and will run after
+ * `begin` resolves, outside the transaction, whatever the caller does next. It
+ * will not run at all if the transaction rolls back, or if a savepoint it was
+ * registered inside rolls back — both of which are the point.
+ *
+ * Nothing here is ordered against anything but the other deferred callbacks:
+ * they run in registration order, one at a time, after the commit round-trip.
+ */
+export function deferUntilCommit(callback: AfterCommitCallback): boolean {
+  const store = ormContext.getStore();
+  if (store?.tx === undefined || store.afterCommit === undefined) return false;
+
+  store.afterCommit.push(callback);
+  return true;
 }
 
 /** How deeply nested the current transaction is; `null` outside one. */
@@ -340,6 +406,63 @@ function watchForSlowTransaction(configured?: number | false): () => void {
 }
 
 /**
+ * Runs what a committed transaction deferred, outside the transaction it was
+ * deferred by.
+ *
+ * `outside` is the scope that was ambient before `begin` — an `asSystem` block,
+ * a named connection, or nothing at all — and re-entering it explicitly is the
+ * guarantee rather than a tidy-up. The alternative is relying on where a `.then`
+ * happens to have captured its context, and the failure that produces is the
+ * one the whole feature is about: a listener that runs "after commit" while
+ * still holding the closed transaction's handle joins nothing, because Bun's
+ * handle stays callable and simply runs on the pool. So the scope is rebuilt
+ * with `tx` and the drained list cleared, and a listener that opens its own
+ * transaction gets a real one.
+ *
+ * Errors are caught per callback and the next one still runs, for the reason
+ * the event subsystem catches per listener: these are independent side effects
+ * whose order came from a filesystem walk. And the transaction is not failed by
+ * one — it committed, the database kept the rows, and reporting a rejection to
+ * the caller would have it roll back or retry work that is already durable.
+ * stderr is all that is left, and it is enough: the caller has no decision to
+ * make here.
+ *
+ * The transaction's own promise does not resolve until this has finished, which
+ * is the one thing about `afterCommit` that a caller can feel. Deliberate: the
+ * alternative is a floating promise whose rejection nobody sees and whose work
+ * a short-lived process — a command, a seed — exits out from under.
+ */
+async function drainAfterCommit(
+  callbacks: AfterCommitCallback[],
+  outside: OrmScope | undefined,
+): Promise<void> {
+  if (callbacks.length === 0) return;
+
+  await ormContext.run(
+    {
+      ...outside,
+      tx: undefined,
+      afterCommit: undefined,
+      depth: outside?.depth ?? 0,
+    },
+    async () => {
+      for (const callback of callbacks) {
+        try {
+          await callback();
+        } catch (error) {
+          console.error(
+            `An after-commit callback threw. The transaction it was waiting ` +
+              `on had already committed and stays committed, and the ` +
+              `callbacks after it still ran.`,
+            error,
+          );
+        }
+      }
+    },
+  );
+}
+
+/**
  * Run `fn` inside a transaction, entering the ambient scope for its whole async
  * subtree.
  *
@@ -362,6 +485,12 @@ function watchForSlowTransaction(configured?: number | false): () => void {
  * because Bun types a savepoint handle as plain `SQL` — without `savepoint` on
  * it — while the runtime object does carry the method, which is what makes
  * three levels of nesting work.
+ *
+ * Anything `deferUntilCommit` queued is drained once `begin` resolves, outside
+ * the transaction and only on the outermost call — a savepoint has committed
+ * nothing durable, so draining there would run work that a later rollback of
+ * the enclosing transaction was meant to have prevented. See `drainAfterCommit`
+ * for what that costs the caller.
  *
  * In development, an outermost transaction that stays open past
  * `options.slowTransactionThreshold` (2s by default, `false` to disable) warns
@@ -418,13 +547,39 @@ export function withTransaction<T>(
   // with no open transaction — `Model.asSystem` enters one — and a savepoint
   // needs an actual handle, not merely a store.
   if (current?.tx) {
-    return current.tx.savepoint((sp) => {
-      const nested = sp as TransactionSQL;
-      return ormContext.run(
-        { ...current, tx: nested, depth: current.depth + 1 },
-        () => fn(nested),
-      );
-    }) as Promise<T>;
+    // WHERE THE SHARED AFTER-COMMIT LIST IS PUT RIGHT.
+    //
+    // The savepoint's scope is a spread of this one, so it appends to the
+    // transaction's list rather than to a list of its own — which is what makes
+    // "the outer transaction rolled back, so nothing runs" free. The case that
+    // is not free is this one: the savepoint rolls back and the transaction
+    // goes on to commit. Its entries have to go, or a dispatch made inside a
+    // block the database threw away runs anyway, which is the same wrong answer
+    // as before with an extra step.
+    //
+    // A mark on the way in and a truncate on the way out, rather than tagging
+    // each entry with its depth and dropping everything at or below the failing
+    // one. Depth cannot tell two *siblings* apart: a savepoint that committed
+    // and one that rolled back both left entries at the same depth, adjacent in
+    // the list, and dropping by depth would discard the committed sibling's
+    // work as well. The index is exact because the ORM issues one statement at
+    // a time on a transaction handle — see `OrmScope.tx` — so nothing appends
+    // between the mark and the failure but this savepoint's own subtree.
+    const deferred = current.afterCommit;
+    const mark = deferred?.length ?? 0;
+
+    return current.tx
+      .savepoint((sp) => {
+        const nested = sp as TransactionSQL;
+        return ormContext.run(
+          { ...current, tx: nested, depth: current.depth + 1 },
+          () => fn(nested),
+        );
+      })
+      .catch((error: unknown) => {
+        if (deferred) deferred.length = mark;
+        throw error;
+      }) as Promise<T>;
   }
 
   // Only the outermost scope is watched. A savepoint reserves no connection of
@@ -435,6 +590,11 @@ export function withTransaction<T>(
   const stopWatching = watchForSlowTransaction(
     options?.slowTransactionThreshold,
   );
+
+  // Built out here rather than inside the `begin` callback, because the drain
+  // below needs it *after* that callback's scope is gone, and reading it off
+  // the store then is exactly what is no longer possible.
+  const deferred: AfterCommitCallback[] = [];
 
   // The `try` covers a *synchronous* throw from `begin` — a closed pool, say.
   // `.finally` alone would not: it is only attached once `begin` has returned a
@@ -462,6 +622,13 @@ export function withTransaction<T>(
               tx,
               depth: 0,
               connection: name === DEFAULT_CONNECTION ? undefined : name,
+              // A fresh list per outermost transaction, assigned rather than
+              // left to the spread. `current` holds no list today — the drain
+              // clears the field before it runs anything — and assigning is
+              // what keeps that from being load-bearing: a transaction opened
+              // by a callback during a drain gets its own list either way,
+              // rather than appending to the array it is being run out of.
+              afterCommit: deferred,
             },
             () => fn(tx),
           ),
@@ -470,7 +637,18 @@ export function withTransaction<T>(
         // rollback exactly as it is on commit, so a throwing callback must clear
         // the timer too or every failed transaction leaves a warning armed
         // against a connection that has already gone back to the pool.
-        .finally(stopWatching) as Promise<T>
+        //
+        // Before the drain, so that a slow after-commit listener is not
+        // reported as a transaction that will not settle. The connection went
+        // back to the pool at the commit; the warning is about holding it.
+        .finally(stopWatching)
+        // Only here, on the fulfilled path. A rejected `begin` rolled back, so
+        // the scope and everything queued on it are discarded unread — which is
+        // the whole of what `afterCommit` promises.
+        .then(async (result) => {
+          await drainAfterCommit(deferred, current);
+          return result;
+        }) as Promise<T>
     );
   } catch (error) {
     stopWatching();

--- a/packages/gemi/services/events/Event.ts
+++ b/packages/gemi/services/events/Event.ts
@@ -1,5 +1,6 @@
 import { app } from "../../foundation/app";
 import { EventManager } from "./EventManager";
+import { FakeEventManager } from "./FakeEventManager";
 
 /**
  * Something the application did, addressed to nobody in particular.
@@ -58,6 +59,52 @@ export abstract class Event {
    * spellings produce the same string right up until the build.
    */
   static name = "unset";
+
+  /**
+   * Hold this event's listeners until the transaction it was dispatched inside
+   * commits, and drop them if it rolls back. Off by default.
+   *
+   * ```typescript
+   * export class UserRegistered extends Event {
+   *   static name = "UserRegistered";
+   *   static afterCommit = true;
+   * }
+   * ```
+   *
+   * The failure it exists for:
+   *
+   * ```typescript
+   * await DB.transaction(async () => {
+   *   const user = await User.create(input);
+   *   UserRegistered.dispatch(user.id, user.email);   // welcome email sent
+   *   await Billing.provision(user);                  // throws
+   * });                                               // rolled back
+   * ```
+   *
+   * The user does not exist and has been welcomed. A sync listener has already
+   * run; a queued one is on a queue that has never heard of a transaction.
+   *
+   * Outside a transaction the flag changes nothing — there is nothing to wait
+   * for, so the dispatch happens immediately. Inside one, the listeners run
+   * after the commit and outside the transaction's scope, so a listener that
+   * opens its own transaction opens a real one rather than joining a handle
+   * that has already closed.
+   *
+   * ### The sharp edge, which is why this is opt-in
+   *
+   * **`dispatchAndWait` on a deferred event resolves immediately, having run
+   * nothing.** The two features compose into something neither name suggests,
+   * and no amount of care at the call site can see it: whether a dispatch is
+   * deferred depends on whether some caller further up opened a transaction.
+   * The pairing warns in development, once per event name, and that warning is
+   * the only thing that says so.
+   *
+   * Defaulting this on would put the same surprise under every dispatch — a
+   * fire-and-forget call that silently has not happened yet, decided by ambient
+   * state the call site cannot read. The one being fixed here is at least a
+   * failure; that one is a success that arrives later than the code says.
+   */
+  static afterCommit = false;
 
   /**
    * Makes `Event` nominal, and exists for nothing else.
@@ -131,6 +178,44 @@ export abstract class Event {
   ): Promise<void> {
     refuseUnnamed(this);
     return app(EventManager).dispatchAndWait(new this(...args), args);
+  }
+
+  /**
+   * Swaps the container's `EventManager` for one that records dispatches and
+   * runs nothing, and hands it back for a test to assert against.
+   *
+   * ```typescript
+   * const events = Event.fake();
+   *
+   * await post("/register", { email: "ada@example.com" });
+   *
+   * events.assertDispatched(UserRegistered, (e) => e.email === "ada@example.com");
+   * events.restore();
+   * ```
+   *
+   * The point is what the assertion is *about*. A controller test that asserts
+   * the event fired is testing the controller; one that asserts a welcome email
+   * was sent is testing three things and breaks when the fourth listener is
+   * added. Making that separation possible is most of why events are worth
+   * having, and the fake is what makes it convenient.
+   *
+   * Called twice, it returns the same recorder rather than a second one — a
+   * fake set up in a test helper and a `Event.fake()` in the body of the test
+   * would otherwise be two recorders, one of which sees every dispatch and the
+   * other of which is the one being asserted on.
+   *
+   * **`restore()` is not optional**, and there is no global teardown that will
+   * do it: `gemi/testing` has no `afterEach` hook of its own, and a fake that
+   * outlives its test is a later test whose listeners silently never run. That
+   * failure has no warning to catch it, because a fake legitimately has no
+   * listeners and so never trips the zero-listener line.
+   *
+   * The recorder is the framework's, not the app's — it is not exported from
+   * `gemi/services`, and `gemi/testing` publishes its type. There is nothing to
+   * construct: this is the only thing that makes one.
+   */
+  static fake(): FakeEventManager {
+    return FakeEventManager.install(app());
   }
 }
 

--- a/packages/gemi/services/events/EventManager.ts
+++ b/packages/gemi/services/events/EventManager.ts
@@ -1,4 +1,5 @@
 import { app } from "../../foundation/app";
+import { deferUntilCommit } from "../../orm/context";
 import { withDefaults } from "../../support/withDefaults";
 import type { Job } from "../queue/Job";
 import { QueueManager } from "../queue/QueueManager";
@@ -57,6 +58,12 @@ type Registration = {
  * a second implementation of the queue's — and nothing the request had (the
  * current actor, the ambient transaction) is still promised by the time it
  * runs. See `Listener.queued`.
+ *
+ * **A dispatch does not always fan out at the dispatch.** An event declaring
+ * `static afterCommit` has the whole of it — queued listeners included — held
+ * on the ORM's transaction scope and drained when that transaction commits, or
+ * dropped when it rolls back. That is the only thing in this file that reads
+ * ambient state, and `deferToCommit` is where it happens.
  */
 export class EventManager {
   static token = "events";
@@ -80,6 +87,15 @@ export class EventManager {
    * application, so a test that builds a fresh kernel gets a fresh set.
    */
   private warnedFor = new Set<string>();
+
+  /**
+   * Event names already warned about for the `dispatchAndWait` + `afterCommit`
+   * pairing. A second set rather than a second entry in the one above: the two
+   * warnings are about different mistakes, and sharing the set would mean a
+   * dispatch that legitimately has no listeners silences the one that says a
+   * caller is awaiting nothing.
+   */
+  private warnedAboutWaiting = new Set<string>();
 
   readonly config: Required<EventConfig>;
 
@@ -204,20 +220,88 @@ export class EventManager {
    * Fires the event and returns. The sync listeners run to completion after the
    * caller has moved on.
    *
-   * Nothing is awaited and nothing can reject: `dispatchAndWait` catches every
+   * Nothing is awaited and nothing can reject: `runListeners` catches every
    * listener's failure itself, so the floating promise here has no rejection to
    * float.
    *
    * `args` is the event's constructor arguments; see `dispatchAndWait`.
+   *
+   * On an `afterCommit` event inside a transaction, "after the caller has moved
+   * on" becomes "after that transaction commits" — see `deferToCommit`.
    */
   dispatch(event: Event, args?: readonly unknown[]): void {
-    void this.dispatchAndWait(event, args);
+    if (this.deferToCommit(event, args, false)) return;
+    void this.runListeners(event, args);
+  }
+
+  /**
+   * Fires the event and resolves once every **sync** listener has settled.
+   *
+   * On an `afterCommit` event inside an open transaction it resolves
+   * **immediately, having run nothing** — there is no listener to wait for yet,
+   * and the transaction it would be waiting on is the caller's own. That is the
+   * sharp edge `Event.afterCommit` documents and the reason the flag ships
+   * opt-in; it warns once per event name in development, because nothing else
+   * about the call site can show it.
+   */
+  async dispatchAndWait(
+    event: Event,
+    args?: readonly unknown[],
+  ): Promise<void> {
+    if (this.deferToCommit(event, args, true)) return;
+    return this.runListeners(event, args);
+  }
+
+  /**
+   * Queues the fan-out on the open transaction when the event asked for that,
+   * and reports whether it did — `false` means the caller runs it now.
+   *
+   * Three cases, and only the third defers: an event without
+   * `static afterCommit` behaves exactly as it did before this existed; one
+   * with it, dispatched outside a transaction, has nothing to wait for; one
+   * with it, inside a transaction, runs when that transaction commits and not
+   * at all if it rolls back.
+   *
+   * `currentTransaction()` is not consulted directly, and the difference
+   * matters: `deferUntilCommit` also answers `false` for a scope carrying a
+   * handle that `withTransaction` did not open, which has no commit hook and
+   * therefore no list that will ever be drained. Reading the handle alone would
+   * queue the dispatch onto nothing and lose it silently.
+   *
+   * The whole fan-out is deferred, sync listeners and queued ones alike. A
+   * queued listener is *pushed* at commit rather than at dispatch, which is the
+   * only correct reading of `afterCommit`: the queue drains in-process and
+   * often synchronously from `push`, so pushing early is running early.
+   */
+  private deferToCommit(
+    event: Event,
+    args: readonly unknown[] | undefined,
+    awaited: boolean,
+  ): boolean {
+    // Read off the constructor, the same way the registry key is, and typed
+    // structurally for the same reason: `Event` arrives here as a type-only
+    // import, and the class object an application dispatches may have come from
+    // a different module graph than the one this file was compiled against.
+    const { name, afterCommit } = event.constructor as {
+      name: string;
+      afterCommit?: boolean;
+    };
+    if (!afterCommit) return false;
+
+    const deferred = deferUntilCommit(() => this.runListeners(event, args));
+    if (deferred && awaited) this.warnNothingIsWaitedFor(name);
+    return deferred;
   }
 
   /**
    * Runs every **sync** listener bound to this event, in registration order,
    * and resolves when the last of them has settled. Every queued one is handed
    * to the `QueueManager` on the way past and is not waited for.
+   *
+   * The dispatch itself is `dispatch` and `dispatchAndWait` above; this is what
+   * they run, and what an `afterCommit` event's transaction runs later. Split
+   * out so that "when does the fan-out happen" is decided in exactly one place
+   * rather than in each entry point.
    *
    * ### Sync and queued in one pass
    *
@@ -272,7 +356,7 @@ export class EventManager {
    * fires once per event name — a dispatch in a loop would otherwise bury the
    * terminal.
    */
-  async dispatchAndWait(
+  protected async runListeners(
     event: Event,
     args?: readonly unknown[],
   ): Promise<void> {
@@ -378,6 +462,36 @@ export class EventManager {
         error,
       );
     }
+  }
+
+  /**
+   * The one warning for the pairing that reads as doing something and does not.
+   *
+   * `await UserRegistered.dispatchAndWait(...)` inside a transaction, on an
+   * event that defers to commit, resolves with nothing having run — the
+   * listeners are queued on a transaction the caller has not finished. There is
+   * no other symptom: the promise resolves, the listeners do run later, and the
+   * only thing that is wrong is that the caller's `await` bought it nothing.
+   * Code that reads what a listener wrote on the next line finds it missing,
+   * and nothing connects the two.
+   *
+   * Development only and once per event name, on the same terms as the
+   * zero-listener warning: both are legal steady states that are usually a
+   * mistake, and a dispatch in a loop must not bury the terminal.
+   */
+  private warnNothingIsWaitedFor(name: string) {
+    if (process.env.NODE_ENV === "production") return;
+    if (this.warnedAboutWaiting.has(name)) return;
+    this.warnedAboutWaiting.add(name);
+
+    console.warn(
+      `[gemi] ${name}.dispatchAndWait() was called inside a transaction and ` +
+        `${name} declares \`static afterCommit = true\`, so it resolved ` +
+        `immediately with no listener having run — they run when the ` +
+        `transaction commits. Await the transaction instead, or drop ` +
+        `afterCommit if the caller needs the side effects first. Development ` +
+        `only.`,
+    );
   }
 
   private warnNothingIsListening(name: string) {

--- a/packages/gemi/services/events/FakeEventManager.test-d.ts
+++ b/packages/gemi/services/events/FakeEventManager.test-d.ts
@@ -1,0 +1,73 @@
+import { describe, expectTypeOf, test } from "vitest";
+
+import { Event } from "./Event";
+import type { FakeEventManager } from "./FakeEventManager";
+
+/**
+ * The predicate's parameter, which is the only inference the fake performs and
+ * the only thing about it a runtime test cannot see.
+ *
+ * `events.assertDispatched(UserRegistered, (e) => e.email === "…")` is the form
+ * the assertions are worth having in — the alternative is reading
+ * `events.dispatched[0].event` and casting — and it depends entirely on
+ * `InstanceType<T>` flowing from the class argument to the callback. Widen that
+ * to `Event` and every predicate in every application starts needing a cast;
+ * widen it to `any` and a typo in a field name becomes a predicate that is
+ * silently never true, which is an assertion that fails with the right shape of
+ * message for the wrong reason.
+ *
+ * Types only: the file never constructs a manager, because `Event.fake()` needs
+ * an application and this is a `--typecheck.only` run.
+ */
+
+class UserRegistered extends Event {
+  static name = "UserRegistered";
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+
+declare const events: FakeEventManager;
+
+describe("the assertions' predicate", () => {
+  test("receives the instance of the class it was passed", () => {
+    events.assertDispatched(UserRegistered, (event) => {
+      expectTypeOf(event).toEqualTypeOf<UserRegistered>();
+      expectTypeOf(event.email).toEqualTypeOf<string>();
+      expectTypeOf(event).not.toBeAny();
+      return true;
+    });
+  });
+
+  test("is inferred the same way on every assertion that takes one", () => {
+    events.assertNotDispatched(UserRegistered, (event) => {
+      expectTypeOf(event.userId).toEqualTypeOf<number>();
+      return true;
+    });
+
+    events.assertDispatchedTimes(UserRegistered, 1, (event) => {
+      expectTypeOf(event.userId).toEqualTypeOf<number>();
+      return true;
+    });
+  });
+
+  test("rejects a field the event does not have", () => {
+    events.assertDispatched(UserRegistered, (event) =>
+      // @ts-expect-error - UserRegistered has no `orderId`
+      Boolean(event.orderId),
+    );
+  });
+});
+
+describe("the recorder", () => {
+  test("hands back what was dispatched, typed as an Event", () => {
+    expectTypeOf(events.dispatched[0]!.event).toEqualTypeOf<Event>();
+    expectTypeOf(events.dispatched[0]!.args).toEqualTypeOf<
+      readonly unknown[] | undefined
+    >();
+  });
+});

--- a/packages/gemi/services/events/FakeEventManager.ts
+++ b/packages/gemi/services/events/FakeEventManager.ts
@@ -1,0 +1,309 @@
+import type { Application } from "../../foundation/Application";
+import type { Event, EventClass } from "./Event";
+import { EventManager } from "./EventManager";
+
+/**
+ * One dispatch, as a fake saw it.
+ *
+ * Both halves are kept because neither is derivable from the other. The
+ * instance is what a predicate reads — `(e) => e.email === "…"` — and the
+ * arguments are what the failure message can print, because an instance cannot
+ * be asked what it was constructed with. A dispatch made straight at the
+ * manager carries no arguments at all, which is why they are optional here in
+ * exactly the way they are on `dispatch`.
+ */
+export interface DispatchedEvent {
+  event: Event;
+  args?: readonly unknown[];
+}
+
+/**
+ * An `EventManager` that records dispatches and runs nothing.
+ *
+ * Installed by `Event.fake()`, which is the only thing that constructs one —
+ * see there for what a fake is for and why `restore()` is not optional.
+ *
+ * It extends the real manager rather than reimplementing its shape, so a test
+ * holding one can still ask `registeredListeners` and get the honest answer
+ * (empty: a fake registers none). What it overrides is the two dispatch entry
+ * points, and everything downstream of them is unreachable as a result — no
+ * listener is constructed, no `handle` runs, nothing is pushed to the
+ * `QueueManager`, and no `afterCommit` event is queued on the open transaction.
+ * That last one is worth stating: a fake short-circuits *before* the
+ * transaction check, so a faked dispatch is recorded at the moment it is made
+ * whether or not the event defers, and a test does not have to commit a
+ * transaction to see it.
+ *
+ * The assertions throw plain `Error`s rather than going through a matcher, so
+ * this file depends on no test runner. Their messages name **what was
+ * dispatched**, because the common failure is not "nothing fired" but "that
+ * fired with a different payload", and printing the recorded dispatches ends
+ * that investigation where it starts.
+ */
+export class FakeEventManager extends EventManager {
+  /**
+   * Every dispatch since the fake was installed, in order. Public and readable
+   * for the case the assertions do not cover — the last resort, rather than the
+   * intended surface.
+   */
+  readonly dispatched: DispatchedEvent[] = [];
+
+  /**
+   * Installs a fake into `application`'s container, or returns the one already
+   * there.
+   *
+   * A second call returning the same recorder is the deliberate half: a fake
+   * set up by a shared test helper and a `Event.fake()` in the body of the test
+   * would otherwise be two recorders, and the one being asserted on would be
+   * the one that saw nothing. It is also why this is a static rather than a
+   * constructor — "make me one" and "make sure there is one" are different
+   * requests, and only the second is ever wanted.
+   *
+   * `resolved` rather than `make`: asking the container for the real manager
+   * merely to find out whether it exists would *build* it, and building it is
+   * what `restore()` then has to put back. The lazily-bound singleton stays
+   * lazy, and an application that never resolved an `EventManager` is left with
+   * one it never resolved.
+   *
+   * `instanceof` is safe here and nowhere else in this subsystem: the only
+   * thing that puts a `FakeEventManager` in a container is this method, so both
+   * sides of the comparison come from one module graph. The registry keys next
+   * door cannot make that assumption, because the dispatching code may have
+   * been bundled and minified separately from the listeners.
+   */
+  static install(application: Application): FakeEventManager {
+    const current = application.resolved(EventManager)
+      ? application.make(EventManager)
+      : undefined;
+
+    if (current instanceof FakeEventManager) return current;
+
+    const fake = new FakeEventManager(application, current);
+    application.instance(EventManager, fake);
+    return fake;
+  }
+
+  private constructor(
+    private readonly application: Application,
+    private readonly previous: EventManager | undefined,
+  ) {
+    // Declared, and declared empty: `EventManager` treats a present `listeners`
+    // as the app having said so, which is exactly what a fake means. Nothing
+    // would run anyway — the overrides below never reach the registry — but a
+    // fake that had *discovered* listeners would construct every one of them,
+    // and a listener's constructor is application code.
+    super({ listeners: [] });
+  }
+
+  /** Records the dispatch. No listener runs, and nothing reaches the queue. */
+  override dispatch(event: Event, args?: readonly unknown[]): void {
+    this.dispatched.push({ event, args });
+  }
+
+  /**
+   * Records the dispatch and resolves. Resolved rather than rejected-on-nothing
+   * for the same reason the real one never rejects: a caller awaiting a
+   * dispatch is awaiting side effects it does not name, and under a fake there
+   * are none to fail.
+   */
+  override async dispatchAndWait(
+    event: Event,
+    args?: readonly unknown[],
+  ): Promise<void> {
+    this.dispatched.push({ event, args });
+  }
+
+  /**
+   * Puts the container back the way it was found.
+   *
+   * Restoring the *previous* instance rather than forgetting unconditionally:
+   * an application that had already resolved its `EventManager` — one that
+   * booted, discovered listeners and registered synthetic jobs with the queue —
+   * must get that same object back, not a second one built from the config
+   * slice with an empty registry and no jobs behind it.
+   *
+   * When there was none, the binding is forgotten instead, so the container's
+   * lazy singleton factory builds the real manager on next use.
+   *
+   * Calling it twice is harmless. Not calling it is the failure this method
+   * exists for: the fake stays in the container for every test after this one,
+   * and every listener in them silently does not run.
+   */
+  restore(): void {
+    if (this.previous) {
+      this.application.instance(EventManager, this.previous);
+      return;
+    }
+    this.application.forget(EventManager);
+  }
+
+  /**
+   * Fails unless the event was dispatched at least once, optionally matching a
+   * predicate.
+   *
+   * The predicate takes the event instance and is typed off the class passed
+   * in, so `(e) => e.email` is checked against `UserRegistered` without a cast.
+   *
+   * Matched **by declared name**, never by class identity — the rule the whole
+   * subsystem is keyed on. A test importing its event from the same file as the
+   * code under test would not notice the difference; one asserting against a
+   * production build's bundled class would find `instanceof` false and this
+   * true, and this is the one that is right.
+   */
+  assertDispatched<T extends EventClass>(
+    event: T,
+    predicate?: (event: InstanceType<T>) => boolean,
+  ): void {
+    const name = nameOf(event);
+    if (this.matching(name, predicate).length > 0) return;
+
+    throw new Error(
+      `Expected ${name}${predicate ? " matching the predicate" : ""} to have ` +
+        `been dispatched. ${this.summary(name, predicate !== undefined)}`,
+    );
+  }
+
+  /**
+   * Fails if the event was dispatched at all, or — with a predicate — if any
+   * dispatch of it matched.
+   *
+   * The predicate form is the useful one: "a welcome email is not sent to an
+   * invited user" is an assertion about one dispatch among several, and
+   * asserting the event never fired at all would be a stronger claim than the
+   * test means.
+   */
+  assertNotDispatched<T extends EventClass>(
+    event: T,
+    predicate?: (event: InstanceType<T>) => boolean,
+  ): void {
+    const name = nameOf(event);
+    const matches = this.matching(name, predicate);
+    if (matches.length === 0) return;
+
+    throw new Error(
+      `Expected ${name}${predicate ? " matching the predicate" : ""} not to ` +
+        `have been dispatched, but it was dispatched ${count(matches.length)}: ` +
+        `${describeAll(matches)}.`,
+    );
+  }
+
+  /**
+   * Fails unless the event was dispatched exactly `times` times.
+   *
+   * Worth having beside `assertDispatched` because the failure it catches is
+   * the one that assertion cannot see: a dispatch that moved inside a loop, or
+   * a controller that fires the same event on both branches of a retry. "At
+   * least once" passes for all of those.
+   */
+  assertDispatchedTimes<T extends EventClass>(
+    event: T,
+    times: number,
+    predicate?: (event: InstanceType<T>) => boolean,
+  ): void {
+    const name = nameOf(event);
+    const matches = this.matching(name, predicate);
+    if (matches.length === times) return;
+
+    throw new Error(
+      `Expected ${name}${predicate ? " matching the predicate" : ""} to have ` +
+        `been dispatched ${count(times)}, but it was dispatched ` +
+        `${count(matches.length)}. ${this.summary(name, predicate !== undefined)}`,
+    );
+  }
+
+  /**
+   * Fails if anything at all was dispatched.
+   *
+   * The assertion for a path that should be inert — a request rejected by
+   * validation, an idempotent write that found nothing to do — where naming the
+   * events not to expect would mean listing every event the app has.
+   */
+  assertNothingDispatched(): void {
+    if (this.dispatched.length === 0) return;
+
+    const dispatched = this.dispatched.length;
+
+    throw new Error(
+      `Expected nothing to have been dispatched, but ${dispatched} ` +
+        `${dispatched === 1 ? "event was" : "events were"}: ` +
+        `${describeAll(this.dispatched)}.`,
+    );
+  }
+
+  /** Recorded dispatches of `name`, narrowed by `predicate` when there is one. */
+  private matching(
+    name: string,
+    predicate?: (event: never) => boolean,
+  ): DispatchedEvent[] {
+    return this.dispatched.filter(
+      (record) =>
+        nameOf(record.event.constructor) === name &&
+        (predicate === undefined || predicate(record.event as never)),
+    );
+  }
+
+  /**
+   * The tail of a failure message: what *was* dispatched.
+   *
+   * Three cases, because they send the reader to three different places. An
+   * empty recorder means the code under test dispatched nothing — look at the
+   * controller. Dispatches of the same name that failed a predicate means the
+   * payload is not what the test expected, and printing them is usually the
+   * whole answer. Anything else means the wrong event, or none.
+   */
+  private summary(name: string, hadPredicate: boolean): string {
+    if (this.dispatched.length === 0) return "Nothing was dispatched.";
+
+    const sameName = this.matching(name);
+    if (hadPredicate && sameName.length > 0) {
+      return `Dispatched ${name}: ${describeAll(sameName)}.`;
+    }
+
+    return `Dispatched: ${describeAll(this.dispatched)}.`;
+  }
+}
+
+/**
+ * The declared name of an event or its class.
+ *
+ * A structural read rather than `EventClass["name"]`, because the same function
+ * is pointed at `record.event.constructor`, which is typed `Function`.
+ */
+function nameOf(event: unknown): string {
+  return (event as { name: string }).name;
+}
+
+/** `1 time` / `3 times`, so a message does not have to say "1 time(s)". */
+function count(times: number): string {
+  return `${times} ${times === 1 ? "time" : "times"}`;
+}
+
+function describeAll(records: DispatchedEvent[]): string {
+  return records.map(describe).join(", ");
+}
+
+/**
+ * One recorded dispatch, as `UserRegistered(7, "ada@example.com")`.
+ *
+ * The constructor arguments when they were carried, and the instance's own
+ * fields when they were not — a dispatch made straight at the manager has no
+ * arguments, and an event printed as `UserRegistered()` when it plainly held a
+ * payload reads as a framework bug rather than as a test that took a shortcut.
+ *
+ * Everything here runs only on the way to a thrown assertion, so it is allowed
+ * to be slow and must not itself throw: a circular payload rendering as a
+ * TypeError would replace the failure the reader came for with one of its own.
+ */
+function describe(record: DispatchedEvent): string {
+  const name = nameOf(record.event.constructor);
+  const values = record.args ?? Object.values({ ...record.event });
+  return `${name}(${values.map(inspect).join(", ")})`;
+}
+
+function inspect(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/gemi/services/events/Listener.ts
+++ b/packages/gemi/services/events/Listener.ts
@@ -104,6 +104,15 @@ export abstract class Listener {
    * authenticated user through `currentActor()`, and it joins the ambient
    * transaction.
    *
+   * **Unless the event declares `static afterCommit`.** That flag releases its
+   * listeners after the commit and outside the transaction's scope, so a sync
+   * listener bound to one runs with `currentTransaction()` undefined and
+   * commits on its own. The listener kept sync *because* it writes a row that
+   * has to roll back with the write it describes — an audit trail, a ledger
+   * entry — starts committing separately the day someone sets that flag in the
+   * event's file, and nothing on this side says so: no error, no warning, and
+   * a `queued = false` that still reads as "inside the transaction".
+   *
    * Set `true`, it is handed to the `QueueManager` instead and run from a
    * drain, on the queue's terms. What crosses is the event's name and its
    * constructor arguments as JSON, and nothing else — not the instance the sync
@@ -150,8 +159,8 @@ export abstract class Listener {
   /**
    * The side effect. Runs inside the dispatcher's context when `queued` is
    * false: a sync listener has the request's `app()`, its authenticated user,
-   * and its ambient transaction. A queued one can rely on none of them — see
-   * `queued`.
+   * and — unless the event declares `static afterCommit` — its ambient
+   * transaction. A queued one can rely on none of them — see `queued`.
    *
    * Annotate the parameter with the event named in `static event` — narrowing
    * the base's `Event` here is legal because method parameters are bivariant,

--- a/packages/gemi/services/events/afterCommit.test.ts
+++ b/packages/gemi/services/events/afterCommit.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { Application } from "../../foundation/Application";
+import { kernelContext } from "../../kernel/context";
+import { currentTransaction, withTransaction } from "../../orm/context";
+import { Repository } from "../../support/Repository";
+import { QueueManager } from "../queue/QueueManager";
+import { QueueServiceProvider } from "../queue/QueueServiceProvider";
+import { Event } from "./Event";
+import { EventServiceProvider } from "./EventServiceProvider";
+import { Listener, type ListenerClass } from "./Listener";
+
+/**
+ * `static afterCommit = true`, from the dispatch to the commit.
+ *
+ * What it is for, in one shape:
+ *
+ * ```typescript
+ * await DB.transaction(async () => {
+ *   const user = await User.create(input);
+ *   UserRegistered.dispatch(user.id, user.email);   // welcome email sent
+ *   await Billing.provision(user);                  // throws
+ * });                                               // rolled back
+ * ```
+ *
+ * The user does not exist and has been welcomed. Nothing errored — the email
+ * succeeded and the transaction failed, in two subsystems that never meet — so
+ * the only thing that can catch it is a test that rolls a transaction back and
+ * asserts a listener did not run.
+ *
+ * `orm/context.test.ts` owns the mechanism: which scope holds the list, what a
+ * savepoint does with it, and that two concurrent transactions keep their own.
+ * This file owns the decision — which of the three cases in the table on
+ * `EventManager.deferToCommit` a dispatch lands in.
+ */
+
+class UserRegistered extends Event {
+  static name = "UserRegistered";
+  static afterCommit = true;
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+
+/** The same payload, dispatched the way iterations 1 and 2 dispatch it. */
+class OrderPaid extends Event {
+  static name = "OrderPaid";
+
+  constructor(public orderId: number) {
+    super();
+  }
+}
+
+function listener(
+  name: string,
+  event: typeof UserRegistered | typeof OrderPaid,
+  handle: (event: any) => void | Promise<void>,
+  isQueued = false,
+) {
+  return {
+    [name]: class extends Listener {
+      static name = name;
+      static event = event;
+
+      queued = isQueued;
+
+      handle(received: any) {
+        return handle(received);
+      }
+    },
+  }[name]!;
+}
+
+async function makeApp(listeners: ListenerClass[]) {
+  const application = new Application(
+    new Repository({
+      events: { listeners },
+      queue: { jobs: [], concurrency: 5 },
+    }),
+  );
+  application.registerMany([QueueServiceProvider, EventServiceProvider]);
+  await application.boot();
+  return application;
+}
+
+/**
+ * The smallest thing `withTransaction` calls, and the reason this file needs no
+ * database: what is under test is which *scope* a dispatch lands in, and a fake
+ * handle produces the commit and the rollback on demand.
+ */
+function fakePool() {
+  const handle: any = {
+    savepoint: (fn: (sp: any) => Promise<unknown>) =>
+      Promise.resolve().then(() => fn(handle)),
+  };
+  return {
+    handle,
+    begin: (fn: (tx: any) => Promise<unknown>) =>
+      Promise.resolve().then(() => fn(handle)),
+  } as any;
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("an event that does not declare afterCommit", () => {
+  test("dispatches inside a transaction exactly as it does outside one", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("IssueReceipt", OrderPaid, () => void ran.push("receipt")),
+    ]);
+
+    await kernelContext.run(application, () =>
+      withTransaction(fakePool(), async () => {
+        await OrderPaid.dispatchAndWait(7);
+        // Unchanged from iterations 1 and 2, deliberately: opting in is what
+        // moves a dispatch, and ambient state never should.
+        expect(ran).toEqual(["receipt"]);
+      }),
+    );
+  });
+});
+
+describe("an afterCommit event with no transaction open", () => {
+  test("dispatches immediately, because there is nothing to wait for", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => void ran.push("mail")),
+    ]);
+
+    await kernelContext.run(application, () =>
+      UserRegistered.dispatchAndWait(7, "ada@example.com"),
+    );
+
+    expect(ran).toEqual(["mail"]);
+  });
+});
+
+describe("an afterCommit event inside a transaction", () => {
+  test("runs its listeners when the transaction commits, and not before", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => void ran.push("mail")),
+    ]);
+
+    await kernelContext.run(application, () =>
+      withTransaction(fakePool(), async () => {
+        UserRegistered.dispatch(7, "ada@example.com");
+        await tick();
+        expect(ran).toEqual([]);
+      }),
+    );
+
+    expect(ran).toEqual(["mail"]);
+  });
+
+  test("runs nothing when the transaction rolls back", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => void ran.push("mail")),
+    ]);
+
+    await expect(
+      kernelContext.run(application, () =>
+        withTransaction(fakePool(), async () => {
+          UserRegistered.dispatch(7, "ada@example.com");
+          throw new Error("billing declined");
+        }),
+      ),
+    ).rejects.toThrow("billing declined");
+    await tick();
+
+    // The whole feature: a user who does not exist has not been welcomed.
+    expect(ran).toEqual([]);
+  });
+
+  /**
+   * Invariant 4 says a sync listener joins the ambient transaction. A deferred
+   * one is the exception that proves it — the transaction it was dispatched in
+   * is over by the time it runs, so the listener has to be somewhere else, and
+   * Bun's handle staying callable after the commit means "somewhere else" would
+   * otherwise be "on the pool, silently".
+   */
+  test("its listener runs outside the transaction that deferred it", async () => {
+    let handle: unknown = "unset";
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => {
+        handle = currentTransaction();
+      }),
+    ]);
+
+    await kernelContext.run(application, () =>
+      withTransaction(fakePool(), async () => {
+        UserRegistered.dispatch(7, "ada@example.com");
+      }),
+    );
+
+    expect(handle).toBeUndefined();
+  });
+
+  test("a listener that throws does not fail the committed transaction", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => {
+        throw new Error("smtp is down");
+      }),
+      listener("WriteAuditRow", UserRegistered, () => void ran.push("audit")),
+    ]);
+
+    await expect(
+      kernelContext.run(application, () =>
+        withTransaction(fakePool(), async () => {
+          UserRegistered.dispatch(7, "ada@example.com");
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    // Invariant 3 across the commit boundary, and the transaction is untouched
+    // by either listener — reporting a rejection here would have the caller
+    // roll back rows the database has already kept.
+    expect(ran).toEqual(["audit"]);
+    expect(String(vi.mocked(error).mock.calls[0]![0])).toContain(
+      "SendWelcomeEmail",
+    );
+  });
+});
+
+/**
+ * The sharp edge, and the reason the flag ships opt-in: the two features
+ * compose into something neither name suggests.
+ */
+describe("dispatchAndWait on a deferred event", () => {
+  test("resolves immediately, having run nothing", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => void ran.push("mail")),
+    ]);
+
+    await kernelContext.run(application, () =>
+      withTransaction(fakePool(), async () => {
+        await UserRegistered.dispatchAndWait(7, "ada@example.com");
+        // The `await` bought nothing. Code on the next line reading what a
+        // listener wrote finds it missing, and nothing connects the two.
+        expect(ran).toEqual([]);
+      }),
+    );
+
+    expect(ran).toEqual(["mail"]);
+  });
+
+  test("warns once per event name, in development", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => {}),
+    ]);
+
+    await kernelContext.run(application, () =>
+      withTransaction(fakePool(), async () => {
+        await UserRegistered.dispatchAndWait(7, "ada@example.com");
+        await UserRegistered.dispatchAndWait(8, "grace@example.com");
+      }),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(warn).mock.calls[0]![0])).toContain(
+      "UserRegistered",
+    );
+    expect(String(vi.mocked(warn).mock.calls[0]![0])).toContain("afterCommit");
+  });
+
+  test("says nothing when the same event is awaited outside a transaction", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => {}),
+    ]);
+
+    await kernelContext.run(application, () =>
+      UserRegistered.dispatchAndWait(7, "ada@example.com"),
+    );
+
+    // Nothing was deferred, so the `await` did what it says. The warning is
+    // about the pairing, not about the flag.
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The queue drains in-process, often synchronously from `push`, so pushing at
+ * dispatch time *is* running at dispatch time. Deferring the fan-out whole —
+ * rather than only its sync half — is what keeps `afterCommit` meaning the same
+ * thing for a queued listener as for an inline one.
+ */
+describe("a queued listener under afterCommit", () => {
+  test("is pushed at the commit, not at the dispatch", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener(
+        "SendWelcomeEmail",
+        UserRegistered,
+        () => void ran.push("queued"),
+        true,
+      ),
+    ]);
+    const queue = application.make(QueueManager);
+
+    await kernelContext.run(application, () =>
+      withTransaction(fakePool(), async () => {
+        UserRegistered.dispatch(7, "ada@example.com");
+        await tick();
+        expect(queue.queue.size).toBe(0);
+        expect(ran).toEqual([]);
+      }),
+    );
+    await tick();
+
+    expect(ran).toEqual(["queued"]);
+  });
+
+  test("is never pushed when the transaction rolls back", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener(
+        "SendWelcomeEmail",
+        UserRegistered,
+        () => void ran.push("queued"),
+        true,
+      ),
+    ]);
+    const queue = application.make(QueueManager);
+
+    await expect(
+      kernelContext.run(application, () =>
+        withTransaction(fakePool(), async () => {
+          UserRegistered.dispatch(7, "ada@example.com");
+          throw new Error("billing declined");
+        }),
+      ),
+    ).rejects.toThrow("billing declined");
+    await tick();
+
+    expect(queue.queue.size).toBe(0);
+    expect(ran).toEqual([]);
+  });
+});

--- a/packages/gemi/services/events/fake.test.ts
+++ b/packages/gemi/services/events/fake.test.ts
@@ -1,0 +1,416 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { Application } from "../../foundation/Application";
+import { kernelContext } from "../../kernel/context";
+import { withTransaction } from "../../orm/context";
+import { Repository } from "../../support/Repository";
+import { QueueManager } from "../queue/QueueManager";
+import { QueueServiceProvider } from "../queue/QueueServiceProvider";
+import { Event } from "./Event";
+import { EventManager } from "./EventManager";
+import { EventServiceProvider } from "./EventServiceProvider";
+import { FakeEventManager } from "./FakeEventManager";
+import { Listener, type ListenerClass } from "./Listener";
+
+/**
+ * `Event.fake()`: what a controller test asserts on instead of the side effect.
+ *
+ * The separation is the point. A test that asserts a welcome email was sent is
+ * testing the controller, the listener and the mailer at once, and it breaks
+ * when a fourth listener is added to an event it was never about. Asserting
+ * that the *event* fired tests the controller alone — and the listener is
+ * testable on its own terms, with no framework around it at all
+ * (`new SendWelcomeEmail().handle(new UserRegistered(…))`).
+ *
+ * Two silences this file is arranged against. A fake that keeps running the
+ * listeners tests nothing new; a fake that outlives its test makes every
+ * listener in every test after it silently not run, with no warning to catch it
+ * — a fake legitimately has no listeners, so the zero-listener line never fires.
+ */
+
+class UserRegistered extends Event {
+  static name = "UserRegistered";
+
+  constructor(
+    public userId: number,
+    public email: string,
+  ) {
+    super();
+  }
+}
+
+class OrderPaid extends Event {
+  static name = "OrderPaid";
+
+  constructor(public orderId: number) {
+    super();
+  }
+}
+
+/** An `afterCommit` event, for the one interaction the two features have. */
+class InvoiceIssued extends Event {
+  static name = "InvoiceIssued";
+  static afterCommit = true;
+
+  constructor(public invoiceId: number) {
+    super();
+  }
+}
+
+function listener(
+  name: string,
+  event: EventClassUnderTest,
+  handle: (event: any) => void | Promise<void>,
+  isQueued = false,
+) {
+  return {
+    [name]: class extends Listener {
+      static name = name;
+      static event = event;
+
+      queued = isQueued;
+
+      handle(received: any) {
+        return handle(received);
+      }
+    },
+  }[name]!;
+}
+
+type EventClassUnderTest =
+  | typeof UserRegistered
+  | typeof OrderPaid
+  | typeof InvoiceIssued;
+
+async function makeApp(listeners: ListenerClass[] = []) {
+  const application = new Application(
+    new Repository({
+      events: { listeners },
+      queue: { jobs: [], concurrency: 5 },
+    }),
+  );
+  application.registerMany([QueueServiceProvider, EventServiceProvider]);
+  await application.boot();
+  return application;
+}
+
+const fakePool = () => {
+  const handle: any = {
+    savepoint: (fn: (sp: any) => Promise<unknown>) =>
+      Promise.resolve().then(() => fn(handle)),
+  };
+  return {
+    begin: (fn: (tx: any) => Promise<unknown>) =>
+      Promise.resolve().then(() => fn(handle)),
+  } as any;
+};
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("installing a fake", () => {
+  test("records the dispatch and runs no listener", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => void ran.push("mail")),
+    ]);
+
+    await kernelContext.run(application, async () => {
+      const events = Event.fake();
+
+      await UserRegistered.dispatchAndWait(7, "ada@example.com");
+
+      expect(ran).toEqual([]);
+      events.assertDispatched(UserRegistered);
+      events.restore();
+    });
+  });
+
+  test("is what the container hands out while it is installed", async () => {
+    const application = await makeApp();
+
+    await kernelContext.run(application, async () => {
+      const events = Event.fake();
+      expect(application.make(EventManager)).toBe(events);
+      events.restore();
+    });
+  });
+
+  /**
+   * A fake set up in a shared helper and a `Event.fake()` in the body of the
+   * test would otherwise be two recorders, and the one asserted on would be the
+   * one that saw nothing.
+   */
+  test("a second call returns the same recorder", async () => {
+    const application = await makeApp();
+
+    await kernelContext.run(application, async () => {
+      const first = Event.fake();
+      UserRegistered.dispatch(7, "ada@example.com");
+      const second = Event.fake();
+
+      expect(second).toBe(first);
+      second.assertDispatched(UserRegistered);
+      first.restore();
+    });
+  });
+
+  test("records both dispatch and dispatchAndWait, with their arguments", async () => {
+    const application = await makeApp();
+
+    await kernelContext.run(application, async () => {
+      const events = Event.fake();
+
+      UserRegistered.dispatch(7, "ada@example.com");
+      await UserRegistered.dispatchAndWait(8, "grace@example.com");
+
+      expect(events.dispatched.map((record) => record.args)).toEqual([
+        [7, "ada@example.com"],
+        [8, "grace@example.com"],
+      ]);
+      events.restore();
+    });
+  });
+});
+
+describe("restoring", () => {
+  test("gives back the very manager the application had booted", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener("SendWelcomeEmail", UserRegistered, () => void ran.push("mail")),
+    ]);
+    const real = application.make(EventManager);
+
+    await kernelContext.run(application, async () => {
+      Event.fake().restore();
+
+      // The same object, not a second one built from the config slice: a
+      // rebuilt manager would have an empty registry, and its queued listeners
+      // would no longer be registered with the queue.
+      expect(application.make(EventManager)).toBe(real);
+
+      await UserRegistered.dispatchAndWait(7, "ada@example.com");
+    });
+
+    expect(ran).toEqual(["mail"]);
+  });
+
+  test("leaves an unresolved binding unresolved", async () => {
+    const application = new Application(
+      new Repository({ events: { listeners: [] } }),
+    );
+    // Registered but not booted, so the singleton factory has never run.
+    application.register(EventServiceProvider);
+
+    await kernelContext.run(application, async () => {
+      Event.fake().restore();
+
+      expect(application.resolved(EventManager)).toBe(false);
+      expect(application.make(EventManager)).toBeInstanceOf(EventManager);
+      expect(application.make(EventManager)).not.toBeInstanceOf(
+        FakeEventManager,
+      );
+    });
+  });
+
+  test("is harmless twice", async () => {
+    const application = await makeApp();
+
+    await kernelContext.run(application, async () => {
+      const events = Event.fake();
+      events.restore();
+      events.restore();
+
+      expect(application.make(EventManager)).not.toBe(events);
+    });
+  });
+});
+
+/**
+ * Nothing may reach `QueueManager`. Without this a controller test with a fake
+ * still enqueues real work, which runs against the test database after the
+ * assertions have passed — a failure that lands in whatever test is running
+ * next, or in none at all.
+ */
+describe("a fake and a queued listener", () => {
+  test("nothing reaches the queue", async () => {
+    const ran: string[] = [];
+    const application = await makeApp([
+      listener(
+        "SendWelcomeEmail",
+        UserRegistered,
+        () => void ran.push("queued"),
+        true,
+      ),
+    ]);
+    const queue = application.make(QueueManager);
+
+    await kernelContext.run(application, async () => {
+      const events = Event.fake();
+      await UserRegistered.dispatchAndWait(7, "ada@example.com");
+      await tick();
+
+      expect(queue.queue.size).toBe(0);
+      expect(ran).toEqual([]);
+      events.assertDispatched(UserRegistered);
+      events.restore();
+    });
+
+    // The job is still registered with the queue — the fake replaces the
+    // dispatcher, not the boot — so this says the push never happened rather
+    // than that there was nothing to push to.
+    expect(queue.registeredJobs.map((job) => job.name)).toEqual([
+      "listener:SendWelcomeEmail",
+    ]);
+  });
+});
+
+describe("a fake and an afterCommit event", () => {
+  test("records at the dispatch, without waiting for a commit", async () => {
+    const application = await makeApp([
+      listener("IssueReceipt", InvoiceIssued, () => {}),
+    ]);
+
+    await kernelContext.run(application, () =>
+      withTransaction(fakePool(), async () => {
+        const events = Event.fake();
+        InvoiceIssued.dispatch(3);
+
+        // A fake short-circuits before the transaction check, so a controller
+        // test does not have to commit anything to see what the controller
+        // dispatched.
+        events.assertDispatched(InvoiceIssued);
+        events.restore();
+      }),
+    );
+  });
+});
+
+describe("the assertions", () => {
+  async function faked() {
+    const application = await makeApp();
+    const events = kernelContext.run(application, () => Event.fake());
+    return { application, events };
+  }
+
+  test("assertDispatched matches by declared name, and takes a predicate", async () => {
+    const { events } = await faked();
+
+    events.dispatch(new UserRegistered(7, "ada@example.com"), [
+      7,
+      "ada@example.com",
+    ]);
+
+    events.assertDispatched(UserRegistered);
+    events.assertDispatched(
+      UserRegistered,
+      (event) => event.email === "ada@example.com",
+    );
+    expect(() =>
+      events.assertDispatched(UserRegistered, (event) => event.userId === 8),
+    ).toThrow();
+    events.restore();
+  });
+
+  /**
+   * The message is most of what this feature is. The common failure is not
+   * "nothing fired" but "that fired with a different payload", and printing
+   * what was dispatched ends the investigation where it starts.
+   */
+  test("a failure names what was dispatched instead", async () => {
+    const { events } = await faked();
+
+    events.dispatch(new UserRegistered(2, "b@c.d"), [2, "b@c.d"]);
+
+    expect(() => events.assertDispatched(OrderPaid)).toThrow(
+      'Dispatched: UserRegistered(2, "b@c.d")',
+    );
+    expect(() => events.assertDispatched(OrderPaid)).toThrow(
+      "Expected OrderPaid",
+    );
+    events.restore();
+  });
+
+  test("a failed predicate prints the dispatches of that event", async () => {
+    const { events } = await faked();
+
+    events.dispatch(new UserRegistered(2, "b@c.d"), [2, "b@c.d"]);
+    events.dispatch(new OrderPaid(9), [9]);
+
+    expect(() =>
+      events.assertDispatched(UserRegistered, (event) => event.userId === 7),
+    ).toThrow('Dispatched UserRegistered: UserRegistered(2, "b@c.d")');
+    events.restore();
+  });
+
+  test("an empty recorder says so rather than printing an empty list", async () => {
+    const { events } = await faked();
+
+    expect(() => events.assertDispatched(UserRegistered)).toThrow(
+      "Nothing was dispatched.",
+    );
+    events.restore();
+  });
+
+  /**
+   * An instance dispatched straight at the manager carries no constructor
+   * arguments — an instance cannot be asked what it was built with — and
+   * printing it as `UserRegistered()` would read as a framework bug rather than
+   * as a test that took a shortcut.
+   */
+  test("an argument-less dispatch is described by its fields", async () => {
+    const { events } = await faked();
+
+    events.dispatch(new UserRegistered(2, "b@c.d"));
+
+    expect(() => events.assertDispatched(OrderPaid)).toThrow(
+      'UserRegistered(2, "b@c.d")',
+    );
+    events.restore();
+  });
+
+  test("assertNotDispatched, whole and by predicate", async () => {
+    const { events } = await faked();
+
+    events.dispatch(new UserRegistered(7, "ada@example.com"), [
+      7,
+      "ada@example.com",
+    ]);
+
+    events.assertNotDispatched(OrderPaid);
+    events.assertNotDispatched(UserRegistered, (event) => event.userId === 8);
+    expect(() => events.assertNotDispatched(UserRegistered)).toThrow(
+      "not to have been dispatched",
+    );
+    events.restore();
+  });
+
+  test("assertDispatchedTimes counts, and says both numbers when it fails", async () => {
+    const { events } = await faked();
+
+    events.dispatch(new OrderPaid(1), [1]);
+    events.dispatch(new OrderPaid(2), [2]);
+
+    events.assertDispatchedTimes(OrderPaid, 2);
+    events.assertDispatchedTimes(OrderPaid, 1, (event) => event.orderId === 1);
+    expect(() => events.assertDispatchedTimes(OrderPaid, 1)).toThrow(
+      "dispatched 1 time, but it was dispatched 2 times",
+    );
+    events.restore();
+  });
+
+  test("assertNothingDispatched", async () => {
+    const { events } = await faked();
+
+    events.assertNothingDispatched();
+    events.dispatch(new OrderPaid(1), [1]);
+
+    expect(() => events.assertNothingDispatched()).toThrow(
+      "Expected nothing to have been dispatched, but 1 event was: OrderPaid(1)",
+    );
+    events.restore();
+  });
+});

--- a/packages/gemi/testing/index.ts
+++ b/packages/gemi/testing/index.ts
@@ -9,6 +9,12 @@ export type { PageProps, PageDictionary } from "./Page";
  * same class it is asserting about. This export exists for the signature: a
  * helper that takes or returns the recorder needs to be able to name it.
  *
+ * `DispatchedEvent` comes with it because it is the element type of the one
+ * public field, `dispatched`. Published apart from it, a helper taking the
+ * escape hatch as a parameter would have to spell it
+ * `FakeEventManager["dispatched"][number]` — a public field whose type has no
+ * public name.
+ *
  * Why not the class itself. This entrypoint is bundled for the **browser** —
  * `vite.client.config.mts` builds `client/index.ts` and `testing/index.ts`
  * together so a `<Page>` and the components under it share one copy of every
@@ -18,4 +24,4 @@ export type { PageProps, PageDictionary } from "./Page";
  * than imported from `gemi/i18n` to keep a server entry out of a component
  * test's module graph.
  */
-export type { FakeEventManager } from "../services/events/FakeEventManager";
+export type { DispatchedEvent, FakeEventManager } from "../services/events/FakeEventManager";

--- a/packages/gemi/testing/index.ts
+++ b/packages/gemi/testing/index.ts
@@ -1,2 +1,21 @@
 export { Page } from "./Page";
 export type { PageProps, PageDictionary } from "./Page";
+
+/**
+ * The recorder `Event.fake()` installs, published here as a **type only**.
+ *
+ * There is nothing to construct — `Event.fake()` (from `gemi/services`) is what
+ * makes one, and it is on `Event` so that the door a test reaches for is the
+ * same class it is asserting about. This export exists for the signature: a
+ * helper that takes or returns the recorder needs to be able to name it.
+ *
+ * Why not the class itself. This entrypoint is bundled for the **browser** —
+ * `vite.client.config.mts` builds `client/index.ts` and `testing/index.ts`
+ * together so a `<Page>` and the components under it share one copy of every
+ * React context. A runtime export from here would drag `EventManager` into that
+ * bundle, and behind it `node:async_hooks`, the container and Bun's `SQL`. The
+ * same reasoning is on `PageDictionary`, which is typed structurally rather
+ * than imported from `gemi/i18n` to keep a server entry out of a component
+ * test's module graph.
+ */
+export type { FakeEventManager } from "../services/events/FakeEventManager";


### PR DESCRIPTION
Third and last iteration of the events subsystem, per
[`plans/events/03-after-commit-and-testing.md`](../blob/feat/events-03-after-commit-and-testing/plans/events/03-after-commit-and-testing.md).

> **Stacked PR.** Base is `feat/events-02-queued-listeners` (#418), not `main`.
> Review that one first; this diff is only iteration 3.

## Part one — `static afterCommit`

An event declaring `static afterCommit = true` has its **whole** fan-out — sync
listeners and queued ones alike — held until the surrounding transaction
commits, and dropped if it rolls back. Outside a transaction it changes nothing.

The failure it exists for is silent: a welcome email sent from inside a
transaction that then rolls back leaves a user who does not exist and has been
welcomed. The email succeeded and the transaction failed, in two subsystems that
never meet, so nothing anywhere reports it.

`withTransaction` in `orm/context.ts` is the single implementation behind both
`Model.transaction` and `DB.transaction`, so there is one place to hook:

- The **outermost** scope carries the callback list. A savepoint's scope is a
  spread of its parent's, so it shares the list by reference — which is wanted:
  an outer rollback discards everything, savepoint entries included, because
  nothing ever drains it.
- The case sharing gets wrong is a savepoint that **rolls back** under a
  transaction that commits. The savepoint branch marks the list length on the
  way in and truncates on failure. **An index, not a per-entry depth tag**: two
  sibling savepoints leave entries at the same depth, adjacent in one list, so
  "drop everything at or below the failing depth" also discards the committed
  sibling's work. That implementation passes every other test in the file, hence
  the test named for it.
- Draining runs after `begin` resolves, on the fulfilled path only, inside an
  explicit `ormContext.run` scope carrying no `tx` — a listener that runs after
  commit must not join a transaction that has closed, and Bun's handle stays
  callable afterwards, so the wrong answer there is silent rather than an error.
- A throwing callback is caught and logged; it does not turn a committed
  transaction into a rejected one.
- `dispatchAndWait` on a deferred event resolves immediately having run nothing.
  That is the sharp edge the plan flags, and it warns once per event name in
  development.

`Event.dispatch` reaches this through `deferUntilCommit(callback): boolean`,
whose return value is the contract: `false` means nothing will ever drain, so
run it now. Consulting `currentTransaction()` instead would queue onto a
hand-built scope's non-existent list and lose the dispatch.

## Part two — `Event.fake()`

`Event.fake()` swaps the container's `EventManager` for a `FakeEventManager`
that records and runs nothing — no listener constructed, no `handle`, nothing
pushed to the `QueueManager`, nothing queued on an open transaction. It returns
the same recorder on a second call, and `restore()` puts back the exact instance
the application had (not a rebuilt one with an empty registry).

`assertDispatched`, `assertNotDispatched`, `assertDispatchedTimes` and
`assertNothingDispatched`, all matching by declared `static name` rather than
class identity, all taking an optional predicate typed off the class passed in.
Failures name what *was* dispatched:

```
Expected OrderPaid to have been dispatched. Dispatched: UserRegistered(2, "b@c.d").
```

## Deviations from the plan

1. **`gemi/testing` publishes the recorder's type, not the class.** The plan
   says to export it from `gemi/testing` rather than `gemi/services`. That
   entrypoint is bundled *for the browser* — `vite.client.config.mts` builds
   `client/index.ts` and `testing/index.ts` in one pass so `<Page>` and the
   components under it share one copy of every React context — so a runtime
   export would drag `EventManager`, `node:async_hooks`, the container and Bun's
   `SQL` into a component-test bundle. The class therefore lives beside the real
   manager in `services/events/`, `gemi/testing` re-exports it with
   `export type`, and the only runtime door is `Event.fake()` on the already-
   exported `Event` — which is the API the plan's own sketch uses. No new name
   is added to `gemi/services`.
2. **Savepoint truncation is by list index, not by a depth recorded per
   callback.** The plan says "record the depth alongside each callback and
   truncate on savepoint failure"; depth cannot separate two siblings (see
   above), and the index is exact because the ORM issues one statement at a time
   on a transaction handle. Both behaviours are pinned by tests.
3. **`AfterCommitCallback` is not exported.** `orm/architecture.test.ts` fails an
   export nothing outside its own file uses, and callers pass a lambda.

Nothing in the out-of-scope list was built: no `fakeExcept`, no snapshotting, no
assertion about listeners having run.

## Verification

From `packages/gemi`, on this branch:

```
$ bun --bun vitest run
 Test Files  151 passed (151)
      Tests  3763 passed | 1 skipped (3764)

$ bun --bun vitest run --typecheck.only
 Test Files  5 passed (5)
      Tests  36 passed (36)
 Type Errors  no errors

$ bunx tsc --noEmit -p tsconfig.json          # clean
$ bunx tsc --noEmit -p tsconfig.browser.json  # clean, incl. the new type re-export
$ bunx oxlint
Found 80 warnings and 0 errors.               # 80 on the base branch too
```

New tests: 21 in `orm/context.test.ts` (commit/rollback, savepoints in both
directions, the committed sibling, the drain's scope, a throwing callback, two
concurrent transactions, and the two `false` cases), 11 in
`services/events/afterCommit.test.ts` (the three-case table, the queue, the
`dispatchAndWait` warning), 17 in `services/events/fake.test.ts`, and 4 type
tests for the predicate's inference.

Formatting: `orm/context.ts` already fails `prettier --check` at HEAD on one
pre-existing line, which is left alone; every added line is prettier-clean, and
the four new files pass `prettier --check` whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
