### PR TITLE
List the features, and see your own switch flip

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -153,7 +153,7 @@ export default defineFeaturesConfig({
 });
 ```
 
-`ttl` is the propagation delay in seconds — how long a loaded snapshot is reused before the next refresh. It is how long switching something off takes to reach every instance, since there is no cross-instance invalidation. Lower it if thirty seconds is too long during an incident; the cost is one query per instance per window.
+`ttl` is the propagation delay in seconds — how long a loaded snapshot is reused before the next refresh. It is how long switching something off takes to reach every instance, since there is no cross-instance invalidation. `Features.invalidate()` collapses that window for the process that made the write — see [An admin screen](#an-admin-screen) — but the others still wait out the TTL. Lower it if thirty seconds is too long during an incident; the cost is one query per instance per window.
 
 ## Reading a feature
 
@@ -173,12 +173,52 @@ await Features.enabled("new-checkout");
 await Features.explain("new-checkout"); // { value, reason } — server only
 await Features.all(); // the client-visible map
 await Features.for({ user }).enabled("digest-v2");
+await Features.list(); // every declared feature and its switch
 await Features.refresh(); // reload this process now
+await Features.invalidate(); // reload after writing to the table
 ```
 
 Everything is async. After the boot-time warm-up each call settles in a microtask with no I/O, but the promise is kept because the first call in a cold process does hit the database — and a sync variant would have to answer that window with "off", which is a feature silently vanishing while a deploy rolls.
 
 `explain` is **server-only**. `reason` distinguishes "targeted by name" from "landed in the rollout", which is a fact about the viewer; never serialize it into a response.
+
+## An admin screen
+
+`Features.list()` is the read side. It returns one descriptor per feature the code declares — key, `describe`, `rollout`, `serverOnly`, whether the declaration carries targeting, and the switch:
+
+```typescript
+[
+  { key: "new-checkout", describe: "Rebuilt checkout", rollout: 20, targeted: false, serverOnly: false, salt: undefined, active: true },
+  { key: "digest-v2", describe: undefined, rollout: undefined, targeted: true, serverOnly: false, salt: undefined, active: undefined },
+]
+```
+
+The declarations are what exists. A feature is on the list because `app/features` declares it, never because a row was inserted — a row for an undeclared key is litter and does not appear. `active: undefined` is **no row**: a feature deployed but never switched on, which is not the same as a row that says `false`, and is the distinction the screen has to show. One is untouched, the other is somebody's decision.
+
+The `when` function is not on the descriptor and cannot be. It is a function over the viewer, so the only honest answer to "who does this target" is to run it: `targeted` reports that targeting exists, and `Features.for({ user }).explain("new-checkout")` answers it for one subject.
+
+**Server-side only.** `rollout` and `targeted` describe who is in an experiment.
+
+### Writing the switch
+
+The write is an ordinary `UPDATE` on your own model — the framework owns no mutation path, because the table is yours. What it does own is the cache in front of it:
+
+```typescript
+public async update(request: HttpRequest<{ active: boolean }>) {
+  await FeatureFlag.update({
+    where: { key: request.params.key },
+    data: { active: request.input.get("active") },
+  });
+
+  await Features.invalidate();
+
+  return { features: await Features.list() };
+}
+```
+
+`invalidate()` rather than `refresh()`, for two reasons that both amount to "the admin must see their own write". `refresh()` joins whatever load is already in flight, and that load may have queried before the update committed — so the screen could come back saying the switch is still off a moment after flipping it. And `invalidate()` clears the request's evaluation memo, so a feature this request already read is re-evaluated instead of answered from before the write.
+
+It is **process-local**, like `refresh()`. Every other instance is still serving its own snapshot and converges within `ttl`. What this fixes is the one window that reads as a bug — the operator who flips a switch, reloads, and is told for the next thirty seconds that nothing happened.
 
 ## Hiding a feature's existence
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -187,36 +187,66 @@ Everything is async. After the boot-time warm-up each call settles in a microtas
 `Features.list()` is the read side. It returns one descriptor per feature the code declares — key, `describe`, `rollout`, `serverOnly`, whether the declaration carries targeting, and the switch:
 
 ```typescript
-[
-  { key: "new-checkout", describe: "Rebuilt checkout", rollout: 20, targeted: false, serverOnly: false, salt: undefined, active: true },
-  { key: "digest-v2", describe: undefined, rollout: undefined, targeted: true, serverOnly: false, salt: undefined, active: undefined },
-]
+{
+  unavailable: false,
+  features: [
+    { key: "new-checkout", describe: "Rebuilt checkout", rollout: 20, targeted: false, serverOnly: false, salt: undefined, active: true },
+    { key: "digest-v2", describe: undefined, rollout: undefined, targeted: true, serverOnly: false, salt: undefined, active: undefined },
+  ],
+}
 ```
 
 The declarations are what exists. A feature is on the list because `app/features` declares it, never because a row was inserted — a row for an undeclared key is litter and does not appear. `active: undefined` is **no row**: a feature deployed but never switched on, which is not the same as a row that says `false`, and is the distinction the screen has to show. One is untouched, the other is somebody's decision.
 
+`unavailable` is why the list is not a bare array. It means no snapshot has ever loaded — an unreachable database at boot — so every `active` is _unknown_ rather than absent. Collapsing the two would tell an operator that no feature has ever been switched on, about features that are switched on in the table, at the moment they are most likely to act on it. Render it as an error, and do not offer to flip switches whose current state you do not know.
+
 The `when` function is not on the descriptor and cannot be. It is a function over the viewer, so the only honest answer to "who does this target" is to run it: `targeted` reports that targeting exists, and `Features.for({ user }).explain("new-checkout")` answers it for one subject.
 
-**Server-side only.** `rollout` and `targeted` describe who is in an experiment.
+### Gate the route
+
+**`Features.list()` is server-side only, and the route that serves it must be behind admin middleware.** It lists `serverOnly` features — whose keys are exactly what that flag exists to keep out of the payload, as [Hiding a feature's existence](#hiding-a-features-existence) covers — and every descriptor carries `rollout` and `targeted`, which describe who is in an experiment. On an ungated route this hands anybody the unannounced keys and the shape of every rollout.
+
+```typescript
+// app/http/routes/api.ts
+export default class extends ApiRouter {
+  routes = {
+    "/admin/features": this.get([AdminFeatureController, "index"]).middleware(["admin"]),
+    "/admin/features/:key": this.put([AdminFeatureController, "update"]).middleware(["admin"]),
+  };
+}
+```
+
+```typescript
+// app/http/controllers/AdminFeatureController.ts
+public async index() {
+  return await Features.list();
+}
+```
 
 ### Writing the switch
 
 The write is an ordinary `UPDATE` on your own model — the framework owns no mutation path, because the table is yours. What it does own is the cache in front of it:
 
 ```typescript
-public async update(request: HttpRequest<{ active: boolean }>) {
+public async update(
+  request: HttpRequest<{ active: boolean }, { key: string }>,
+) {
+  const input = await request.input();
+
   await FeatureFlag.update({
     where: { key: request.params.key },
-    data: { active: request.input.get("active") },
+    data: { active: input.get("active") },
   });
 
   await Features.invalidate();
 
-  return { features: await Features.list() };
+  return await Features.list();
 }
 ```
 
 `invalidate()` rather than `refresh()`, for two reasons that both amount to "the admin must see their own write". `refresh()` joins whatever load is already in flight, and that load may have queried before the update committed — so the screen could come back saying the switch is still off a moment after flipping it. And `invalidate()` clears the request's evaluation memo, so a feature this request already read is re-evaluated instead of answered from before the write.
+
+**It throws `FeatureReloadError` if the reload fails.** The write landed and the cache did not follow, so the switches in memory may still predate it, and returning normally would present them as the result of the update — worse than never having called it. This is the one call in the subsystem that fails loudly; everywhere else an outage means "keep serving what we have", which is right for evaluation and wrong for an operator watching their own change. Let it surface, or catch it and say the switch was saved but the cache is stale.
 
 It is **process-local**, like `refresh()`. Every other instance is still serving its own snapshot and converges within `ttl`. What this fixes is the one window that reads as a bug — the operator who flips a switch, reloads, and is told for the next thirty seconds that nothing happened.
 
@@ -300,6 +330,7 @@ This replaces the _switch_, not the answer: rows still go through the same store
 | Database unreachable, never loaded           | every feature off, `reason: "unavailable"`        |
 | Row for a key you never declared             | ignored with a warning                            |
 | Row with a non-boolean `active`              | read as off                                       |
+| `Features.invalidate()` cannot reload        | throws `FeatureReloadError`; switches unchanged   |
 | A `when` that throws                         | the feature reads off, logged once per evaluation |
 
 ## Related

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7588,7 +7588,7 @@ export default defineFeaturesConfig({
 });
 ```
 
-`ttl` is the propagation delay in seconds — how long a loaded snapshot is reused before the next refresh. It is how long switching something off takes to reach every instance, since there is no cross-instance invalidation. Lower it if thirty seconds is too long during an incident; the cost is one query per instance per window.
+`ttl` is the propagation delay in seconds — how long a loaded snapshot is reused before the next refresh. It is how long switching something off takes to reach every instance, since there is no cross-instance invalidation. `Features.invalidate()` collapses that window for the process that made the write — see [An admin screen](#an-admin-screen) — but the others still wait out the TTL. Lower it if thirty seconds is too long during an incident; the cost is one query per instance per window.
 
 ## Reading a feature
 
@@ -7608,12 +7608,52 @@ await Features.enabled("new-checkout");
 await Features.explain("new-checkout"); // { value, reason } — server only
 await Features.all(); // the client-visible map
 await Features.for({ user }).enabled("digest-v2");
+await Features.list(); // every declared feature and its switch
 await Features.refresh(); // reload this process now
+await Features.invalidate(); // reload after writing to the table
 ```
 
 Everything is async. After the boot-time warm-up each call settles in a microtask with no I/O, but the promise is kept because the first call in a cold process does hit the database — and a sync variant would have to answer that window with "off", which is a feature silently vanishing while a deploy rolls.
 
 `explain` is **server-only**. `reason` distinguishes "targeted by name" from "landed in the rollout", which is a fact about the viewer; never serialize it into a response.
+
+## An admin screen
+
+`Features.list()` is the read side. It returns one descriptor per feature the code declares — key, `describe`, `rollout`, `serverOnly`, whether the declaration carries targeting, and the switch:
+
+```typescript
+[
+  { key: "new-checkout", describe: "Rebuilt checkout", rollout: 20, targeted: false, serverOnly: false, salt: undefined, active: true },
+  { key: "digest-v2", describe: undefined, rollout: undefined, targeted: true, serverOnly: false, salt: undefined, active: undefined },
+]
+```
+
+The declarations are what exists. A feature is on the list because `app/features` declares it, never because a row was inserted — a row for an undeclared key is litter and does not appear. `active: undefined` is **no row**: a feature deployed but never switched on, which is not the same as a row that says `false`, and is the distinction the screen has to show. One is untouched, the other is somebody's decision.
+
+The `when` function is not on the descriptor and cannot be. It is a function over the viewer, so the only honest answer to "who does this target" is to run it: `targeted` reports that targeting exists, and `Features.for({ user }).explain("new-checkout")` answers it for one subject.
+
+**Server-side only.** `rollout` and `targeted` describe who is in an experiment.
+
+### Writing the switch
+
+The write is an ordinary `UPDATE` on your own model — the framework owns no mutation path, because the table is yours. What it does own is the cache in front of it:
+
+```typescript
+public async update(request: HttpRequest<{ active: boolean }>) {
+  await FeatureFlag.update({
+    where: { key: request.params.key },
+    data: { active: request.input.get("active") },
+  });
+
+  await Features.invalidate();
+
+  return { features: await Features.list() };
+}
+```
+
+`invalidate()` rather than `refresh()`, for two reasons that both amount to "the admin must see their own write". `refresh()` joins whatever load is already in flight, and that load may have queried before the update committed — so the screen could come back saying the switch is still off a moment after flipping it. And `invalidate()` clears the request's evaluation memo, so a feature this request already read is re-evaluated instead of answered from before the write.
+
+It is **process-local**, like `refresh()`. Every other instance is still serving its own snapshot and converges within `ttl`. What this fixes is the one window that reads as a bug — the operator who flips a switch, reloads, and is told for the next thirty seconds that nothing happened.
 
 ## Hiding a feature's existence
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7622,36 +7622,66 @@ Everything is async. After the boot-time warm-up each call settles in a microtas
 `Features.list()` is the read side. It returns one descriptor per feature the code declares — key, `describe`, `rollout`, `serverOnly`, whether the declaration carries targeting, and the switch:
 
 ```typescript
-[
-  { key: "new-checkout", describe: "Rebuilt checkout", rollout: 20, targeted: false, serverOnly: false, salt: undefined, active: true },
-  { key: "digest-v2", describe: undefined, rollout: undefined, targeted: true, serverOnly: false, salt: undefined, active: undefined },
-]
+{
+  unavailable: false,
+  features: [
+    { key: "new-checkout", describe: "Rebuilt checkout", rollout: 20, targeted: false, serverOnly: false, salt: undefined, active: true },
+    { key: "digest-v2", describe: undefined, rollout: undefined, targeted: true, serverOnly: false, salt: undefined, active: undefined },
+  ],
+}
 ```
 
 The declarations are what exists. A feature is on the list because `app/features` declares it, never because a row was inserted — a row for an undeclared key is litter and does not appear. `active: undefined` is **no row**: a feature deployed but never switched on, which is not the same as a row that says `false`, and is the distinction the screen has to show. One is untouched, the other is somebody's decision.
 
+`unavailable` is why the list is not a bare array. It means no snapshot has ever loaded — an unreachable database at boot — so every `active` is _unknown_ rather than absent. Collapsing the two would tell an operator that no feature has ever been switched on, about features that are switched on in the table, at the moment they are most likely to act on it. Render it as an error, and do not offer to flip switches whose current state you do not know.
+
 The `when` function is not on the descriptor and cannot be. It is a function over the viewer, so the only honest answer to "who does this target" is to run it: `targeted` reports that targeting exists, and `Features.for({ user }).explain("new-checkout")` answers it for one subject.
 
-**Server-side only.** `rollout` and `targeted` describe who is in an experiment.
+### Gate the route
+
+**`Features.list()` is server-side only, and the route that serves it must be behind admin middleware.** It lists `serverOnly` features — whose keys are exactly what that flag exists to keep out of the payload, as [Hiding a feature's existence](#hiding-a-features-existence) covers — and every descriptor carries `rollout` and `targeted`, which describe who is in an experiment. On an ungated route this hands anybody the unannounced keys and the shape of every rollout.
+
+```typescript
+// app/http/routes/api.ts
+export default class extends ApiRouter {
+  routes = {
+    "/admin/features": this.get([AdminFeatureController, "index"]).middleware(["admin"]),
+    "/admin/features/:key": this.put([AdminFeatureController, "update"]).middleware(["admin"]),
+  };
+}
+```
+
+```typescript
+// app/http/controllers/AdminFeatureController.ts
+public async index() {
+  return await Features.list();
+}
+```
 
 ### Writing the switch
 
 The write is an ordinary `UPDATE` on your own model — the framework owns no mutation path, because the table is yours. What it does own is the cache in front of it:
 
 ```typescript
-public async update(request: HttpRequest<{ active: boolean }>) {
+public async update(
+  request: HttpRequest<{ active: boolean }, { key: string }>,
+) {
+  const input = await request.input();
+
   await FeatureFlag.update({
     where: { key: request.params.key },
-    data: { active: request.input.get("active") },
+    data: { active: input.get("active") },
   });
 
   await Features.invalidate();
 
-  return { features: await Features.list() };
+  return await Features.list();
 }
 ```
 
 `invalidate()` rather than `refresh()`, for two reasons that both amount to "the admin must see their own write". `refresh()` joins whatever load is already in flight, and that load may have queried before the update committed — so the screen could come back saying the switch is still off a moment after flipping it. And `invalidate()` clears the request's evaluation memo, so a feature this request already read is re-evaluated instead of answered from before the write.
+
+**It throws `FeatureReloadError` if the reload fails.** The write landed and the cache did not follow, so the switches in memory may still predate it, and returning normally would present them as the result of the update — worse than never having called it. This is the one call in the subsystem that fails loudly; everywhere else an outage means "keep serving what we have", which is right for evaluation and wrong for an operator watching their own change. Let it surface, or catch it and say the switch was saved but the cache is stale.
 
 It is **process-local**, like `refresh()`. Every other instance is still serving its own snapshot and converges within `ttl`. What this fixes is the one window that reads as a bug — the operator who flips a switch, reloads, and is told for the next thirty seconds that nothing happened.
 
@@ -7735,6 +7765,7 @@ This replaces the _switch_, not the answer: rows still go through the same store
 | Database unreachable, never loaded           | every feature off, `reason: "unavailable"`        |
 | Row for a key you never declared             | ignored with a warning                            |
 | Row with a non-boolean `active`              | read as off                                       |
+| `Features.invalidate()` cannot reload        | throws `FeatureReloadError`; switches unchanged   |
 | A `when` that throws                         | the feature reads off, logged once per evaluation |
 
 ## Related

--- a/packages/gemi/facades/Features.ts
+++ b/packages/gemi/facades/Features.ts
@@ -1,7 +1,7 @@
 import type { FeatureKey } from "../client/rpc";
 import type { FeatureSubject } from "../services/features/context";
 import { FeatureManager, type FeatureScope } from "../services/features/FeatureManager";
-import type { FeatureDescriptor, FeatureEvaluation } from "../services/features/types";
+import type { FeatureEvaluation, FeatureListing } from "../services/features/types";
 import { Facade } from "./Facade";
 
 /**
@@ -76,17 +76,25 @@ export class Features extends Facade {
    * feature that has been deployed but never switched on, which is deliberately
    * distinct from a row that says `false`.
    *
-   * **Server-side only.** `rollout` and `targeted` describe who is in an
-   * experiment, which is not a fact to hand the browser.
+   * Check `unavailable` before rendering `active`. It means no snapshot has ever
+   * loaded, so the switches are unknown rather than absent.
+   *
+   * **Server-side only, and the route must be gated.** The listing includes
+   * `serverOnly` features — whose keys are the thing `serverOnly` exists to keep
+   * out of the payload — and every descriptor carries `rollout` and `targeted`,
+   * which describe who is in an experiment.
    *
    * ```ts
+   * // app/http/routes/api.ts
+   * "/admin/features": this.get([AdminFeatureController, "index"]).middleware(["admin"]),
+   *
    * // app/http/controllers/AdminFeatureController.ts
    * public async index() {
-   *   return { features: await Features.list() };
+   *   return await Features.list();
    * }
    * ```
    */
-  static list(): Promise<FeatureDescriptor[]> {
+  static list(): Promise<FeatureListing> {
     return this.getFacadeRoot().list();
   }
 
@@ -99,17 +107,32 @@ export class Features extends Facade {
    * Call this after writing to the `FeatureFlag` table.
    *
    * ```ts
-   * public async update(request: HttpRequest<{ active: boolean }>) {
-   *   await FeatureFlag.update({ where: { key }, data: { active } });
+   * public async update(
+   *   request: HttpRequest<{ active: boolean }, { key: string }>,
+   * ) {
+   *   const input = await request.input();
+   *
+   *   await FeatureFlag.update({
+   *     where: { key: request.params.key },
+   *     data: { active: input.get("active") },
+   *   });
+   *
    *   await Features.invalidate();
-   *   return { features: await Features.list() };
+   *   return await Features.list();
    * }
    * ```
    *
-   * Unlike `refresh()` this never settles on data older than the moment it was
+   * Unlike `refresh()` this never settles on a load that started before it was
    * called, so the `list()` above reflects the write that precedes it. It also
    * clears the request's evaluation memo, so a feature read earlier in the same
    * request is re-evaluated rather than answered from before the write.
+   *
+   * **Throws `FeatureReloadError` when the reload fails.** The write landed and
+   * the cache did not follow, so the switches in memory may still predate it;
+   * returning normally would present them as the result of the update. This is
+   * the one call in the subsystem that fails loudly — everywhere else an outage
+   * means "keep serving what we have", which is right for evaluation and wrong
+   * for an operator watching their own change.
    *
    * **Process-local.** The other instances are still serving their own
    * snapshots and converge within `ttl` — there is no cross-instance

--- a/packages/gemi/facades/Features.ts
+++ b/packages/gemi/facades/Features.ts
@@ -1,7 +1,7 @@
 import type { FeatureKey } from "../client/rpc";
 import type { FeatureSubject } from "../services/features/context";
 import { FeatureManager, type FeatureScope } from "../services/features/FeatureManager";
-import type { FeatureEvaluation } from "../services/features/types";
+import type { FeatureDescriptor, FeatureEvaluation } from "../services/features/types";
 import { Facade } from "./Facade";
 
 /**
@@ -67,8 +67,57 @@ export class Features extends Facade {
     return this.getFacadeRoot().for(subject);
   }
 
+  /**
+   * Every feature declared in the code, with its switch — the list an admin
+   * screen renders.
+   *
+   * The declarations are what exists. A feature is here because `app/features`
+   * declares it, never because a row was inserted; `active` is `undefined` for a
+   * feature that has been deployed but never switched on, which is deliberately
+   * distinct from a row that says `false`.
+   *
+   * **Server-side only.** `rollout` and `targeted` describe who is in an
+   * experiment, which is not a fact to hand the browser.
+   *
+   * ```ts
+   * // app/http/controllers/AdminFeatureController.ts
+   * public async index() {
+   *   return { features: await Features.list() };
+   * }
+   * ```
+   */
+  static list(): Promise<FeatureDescriptor[]> {
+    return this.getFacadeRoot().list();
+  }
+
   /** Reloads this process's snapshot now, rather than waiting for the TTL. */
   static refresh(): Promise<void> {
     return this.getFacadeRoot().refresh();
+  }
+
+  /**
+   * Call this after writing to the `FeatureFlag` table.
+   *
+   * ```ts
+   * public async update(request: HttpRequest<{ active: boolean }>) {
+   *   await FeatureFlag.update({ where: { key }, data: { active } });
+   *   await Features.invalidate();
+   *   return { features: await Features.list() };
+   * }
+   * ```
+   *
+   * Unlike `refresh()` this never settles on data older than the moment it was
+   * called, so the `list()` above reflects the write that precedes it. It also
+   * clears the request's evaluation memo, so a feature read earlier in the same
+   * request is re-evaluated rather than answered from before the write.
+   *
+   * **Process-local.** The other instances are still serving their own
+   * snapshots and converge within `ttl` — there is no cross-instance
+   * invalidation. What this fixes is the window that reads as a bug: the admin
+   * who flips a switch and is told for the next thirty seconds that nothing
+   * happened.
+   */
+  static invalidate(): Promise<void> {
+    return this.getFacadeRoot().invalidate();
   }
 }

--- a/packages/gemi/services/features/FeatureFlagStore.test.ts
+++ b/packages/gemi/services/features/FeatureFlagStore.test.ts
@@ -232,6 +232,73 @@ describe("failure handling", () => {
   });
 });
 
+describe("invalidate", () => {
+  test("reloads inside the TTL, which get() would not", async () => {
+    let live = "alpha";
+    const source = new ScriptedSource(async () => rows(live));
+    const store = new FeatureFlagStore(source, declared, 60_000);
+
+    await store.get();
+    live = "beta";
+
+    await store.get();
+    expect(source.calls).toBe(1);
+
+    const snapshot = await store.invalidate();
+    expect(snapshot.active.get("beta")).toBe(true);
+    expect(source.calls).toBe(2);
+  });
+
+  test("never settles on a load that started before it was called", async () => {
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let live = "alpha";
+    let first = true;
+    const source = new ScriptedSource(async () => {
+      // Read at entry, so the first load is a query that hit the table before
+      // the write below and returns long after it.
+      const seen = live;
+      if (first) {
+        first = false;
+        await gate;
+      }
+      return rows(seen);
+    });
+    const store = new FeatureFlagStore(source, declared, 60_000);
+
+    // In flight, and it read the table before the write below.
+    const inflight = store.refresh();
+    live = "beta";
+    const invalidated = store.invalidate();
+    release();
+
+    // `refresh()` joins the in-flight load and reports the pre-write table.
+    expect((await inflight).active.get("beta")).toBe(undefined);
+    // `invalidate()` waits it out and issues its own query, so the caller sees
+    // the write it just made.
+    expect((await invalidated).active.get("beta")).toBe(true);
+    expect(source.calls).toBe(2);
+  });
+
+  test("a failed reload keeps the last good snapshot", async () => {
+    let fail = false;
+    const source = new ScriptedSource(async () => {
+      if (fail) throw new Error("down");
+      return rows("alpha");
+    });
+    const store = new FeatureFlagStore(source, declared, 60_000, () => {});
+
+    await store.get();
+    fail = true;
+
+    const snapshot = await store.invalidate();
+    expect(snapshot.active.get("alpha")).toBe(true);
+    expect(snapshot.unavailable).toBe(false);
+  });
+});
+
 describe("peek", () => {
   test("does not trigger a load", async () => {
     const source = new ScriptedSource(async () => rows("alpha"));

--- a/packages/gemi/services/features/FeatureFlagStore.test.ts
+++ b/packages/gemi/services/features/FeatureFlagStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { defineFeature } from "./defineFeature";
-import { FeatureFlagStore } from "./FeatureFlagStore";
+import { FeatureFlagStore, FeatureReloadError } from "./FeatureFlagStore";
 import { FeatureFlagSource } from "./sources/FeatureFlagSource";
 
 const declared = {
@@ -282,7 +282,7 @@ describe("invalidate", () => {
     expect(source.calls).toBe(2);
   });
 
-  test("a failed reload keeps the last good snapshot", async () => {
+  test("a failed reload throws instead of returning the pre-write snapshot", async () => {
     let fail = false;
     const source = new ScriptedSource(async () => {
       if (fail) throw new Error("down");
@@ -293,9 +293,64 @@ describe("invalidate", () => {
     await store.get();
     fail = true;
 
-    const snapshot = await store.invalidate();
-    expect(snapshot.active.get("alpha")).toBe(true);
-    expect(snapshot.unavailable).toBe(false);
+    // `load()` swallows, so without the generation check this resolves with the
+    // kept snapshot and the caller cannot tell that their reload never happened.
+    await expect(store.invalidate()).rejects.toThrow(FeatureReloadError);
+
+    // The switches themselves are untouched: an outage still must not read as
+    // "every feature switched itself off".
+    expect(store.peek()!.active.get("alpha")).toBe(true);
+    expect(store.peek()!.unavailable).toBe(false);
+  });
+
+  test("a failed reload does not pin the stale snapshot for a further TTL", async () => {
+    let fail = false;
+    const source = new ScriptedSource(async () => {
+      if (fail) throw new Error("down");
+      return rows("alpha");
+    });
+    const store = new FeatureFlagStore(source, declared, 0, () => {});
+
+    await store.get();
+    const loadedAt = store.peek()!.loadedAt;
+
+    fail = true;
+    await expect(store.invalidate()).rejects.toThrow(FeatureReloadError);
+
+    // `loadedAt` used to be moved forward on failure, which made these switches
+    // claim to be freshly loaded and bought the failure a whole extra TTL of
+    // staleness — strictly worse than never having called `invalidate()`.
+    expect(store.peek()!.loadedAt).toBe(loadedAt);
+  });
+
+  test("does not join a load that succeeded before it was called", async () => {
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let live = "alpha";
+    let first = true;
+    const source = new ScriptedSource(async () => {
+      const seen = live;
+      if (first) {
+        first = false;
+        await gate;
+      }
+      return rows(seen);
+    });
+    const store = new FeatureFlagStore(source, declared, 60_000);
+
+    const inflight = store.refresh();
+    live = "beta";
+    const invalidated = store.invalidate();
+    release();
+    await inflight;
+
+    // The in-flight load succeeds and bumps the generation. That success is not
+    // this call's, so it must not be mistaken for one — the generation is read
+    // after the wait, not before.
+    await expect(invalidated).resolves.toBeTruthy();
+    expect((await invalidated).active.get("beta")).toBe(true);
   });
 });
 

--- a/packages/gemi/services/features/FeatureFlagStore.ts
+++ b/packages/gemi/services/features/FeatureFlagStore.ts
@@ -3,6 +3,25 @@ import type { FeatureFlagSource } from "./sources/FeatureFlagSource";
 
 export type Warn = (message: string) => void;
 
+/**
+ * A reload asked for by `invalidate()` did not happen.
+ *
+ * Only `invalidate()` raises this. The switches in memory are whatever they were
+ * before — quite possibly older than the write the caller just made — so a
+ * handler that catches it should say so rather than render the list as fact.
+ */
+export class FeatureReloadError extends Error {
+  readonly kind = "FeatureReloadFailed";
+
+  constructor(readonly cause: unknown) {
+    super(
+      `Could not reload feature switches after a write, so the cached switches may still predate it: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+  }
+}
+
 export interface FlagSnapshot {
   /** `key -> active`. A key absent from the map has no row, and is off. */
   active: Map<string, boolean>;
@@ -37,6 +56,25 @@ export class FeatureFlagStore {
   private inflight: Promise<FlagSnapshot> | null = null;
   /** Rate-limits the "could not load" line to once per TTL window. */
   private lastFailureLoggedAt = 0;
+  /**
+   * Counts *successful* loads, so a caller can tell whether the reload it asked
+   * for actually happened. Nothing else can: `load()` swallows, and both
+   * outcomes hand back a snapshot.
+   */
+  private generation = 0;
+  /** The most recent load failure, for a caller that wants to report it. */
+  private lastError: unknown = null;
+  /**
+   * Do not attempt another background load before this.
+   *
+   * The backoff after a failure used to be expressed by moving the kept
+   * snapshot's `loadedAt` forward, which made a stale snapshot claim to be
+   * freshly loaded — so nothing downstream could tell how old the switches
+   * actually were, and a failed `invalidate()` silently pinned pre-write data
+   * for a further full TTL. The clock and the timestamp are two facts; they are
+   * now two fields.
+   */
+  private retryAfter = 0;
 
   constructor(
     private readonly source: FeatureFlagSource,
@@ -53,10 +91,12 @@ export class FeatureFlagStore {
       return current;
     }
     if (current) {
-      // Stale: hand back what we have and refresh behind the request. The
-      // `.catch` is required — `load()` already swallows, but an unhandled
-      // rejection here would be an unobserved promise on the hot path.
-      void this.refresh().catch(() => {});
+      // Stale: hand back what we have and refresh behind the request, unless a
+      // recent failure has us backing off — a down database must not be asked
+      // again on every read. The `.catch` is required: `load()` already
+      // swallows, but an unhandled rejection here would be an unobserved promise
+      // on the hot path.
+      if (Date.now() >= this.retryAfter) void this.refresh().catch(() => {});
       return current;
     }
 
@@ -87,13 +127,31 @@ export class FeatureFlagStore {
    * load created after that point was created after this call, and so queries
    * after the write. The extra query is paid on an operator action, not on the
    * request path.
+   *
+   * **Throws when the reload failed.** This is the one call in the store that
+   * does. Everywhere else a failure means "keep serving what we have", which is
+   * right for evaluation and wrong here: the caller has already written to the
+   * table and is about to show somebody the result, and a swallowed failure
+   * would hand them the pre-write switches with nothing to distinguish that from
+   * success — worse than never calling this at all.
    */
   async invalidate(): Promise<FlagSnapshot> {
     // `catch` because `load()` never rejects today, but a rejection here would
     // skip the reload entirely and leave the stale snapshot in place — the exact
     // failure this method exists to prevent.
     await this.inflight?.catch(() => {});
-    return await this.refresh();
+
+    // Read *after* the await. The load we just waited out may have succeeded,
+    // and that success is not ours — it queried before this call, and possibly
+    // before the write.
+    const generation = this.generation;
+    const snapshot = await this.refresh();
+
+    if (this.generation === generation) {
+      throw new FeatureReloadError(this.lastError);
+    }
+
+    return snapshot;
   }
 
   /** What is cached right now, without triggering a load. */
@@ -109,6 +167,9 @@ export class FeatureFlagStore {
         loadedAt: Date.now(),
         unavailable: false,
       };
+      this.generation++;
+      this.lastError = null;
+      this.retryAfter = 0;
       return this.snapshot;
     } catch (error) {
       return this.handleFailure(error);
@@ -152,17 +213,19 @@ export class FeatureFlagStore {
   private handleFailure(error: unknown): FlagSnapshot {
     const message = error instanceof Error ? error.message : String(error);
     const now = Date.now();
+    this.lastError = error;
+    // Back off for a full TTL rather than retrying a down database on every hit.
+    // `loadedAt` is deliberately left alone: these switches are as old as they
+    // were a moment ago, and saying otherwise is what let a failed `invalidate()`
+    // pass pre-write data off as freshly loaded.
+    this.retryAfter = now + this.ttlMs;
+
     if (now - this.lastFailureLoggedAt >= this.ttlMs) {
       this.lastFailureLoggedAt = now;
       this.warn(`Could not load feature switches: ${message}`);
     }
 
-    if (this.snapshot) {
-      // Keep the data, but move `loadedAt` forward so the next request backs
-      // off for a full TTL instead of retrying a down database on every hit.
-      this.snapshot = { ...this.snapshot, loadedAt: now };
-      return this.snapshot;
-    }
+    if (this.snapshot) return this.snapshot;
 
     this.snapshot = { active: new Map(), loadedAt: now, unavailable: true };
     return this.snapshot;

--- a/packages/gemi/services/features/FeatureFlagStore.ts
+++ b/packages/gemi/services/features/FeatureFlagStore.ts
@@ -71,6 +71,31 @@ export class FeatureFlagStore {
     return this.inflight;
   }
 
+  /**
+   * Reloads for a caller that has just written to the table and needs to see
+   * its own write.
+   *
+   * Not the same as `refresh()`, and the difference is the whole point.
+   * `refresh()` joins whatever load is already in flight — that is what keeps a
+   * cold start under load down to one query — but a load already in flight
+   * issued its query at some earlier moment, possibly before the write
+   * committed. An admin that toggled a row and called `refresh()` could
+   * therefore be handed, and return to the browser, a snapshot that predates the
+   * toggle: the screen says the switch is still off a moment after flipping it.
+   *
+   * So this waits for that load to settle and starts a fresh one behind it. Any
+   * load created after that point was created after this call, and so queries
+   * after the write. The extra query is paid on an operator action, not on the
+   * request path.
+   */
+  async invalidate(): Promise<FlagSnapshot> {
+    // `catch` because `load()` never rejects today, but a rejection here would
+    // skip the reload entirely and leave the stale snapshot in place — the exact
+    // failure this method exists to prevent.
+    await this.inflight?.catch(() => {});
+    return await this.refresh();
+  }
+
   /** What is cached right now, without triggering a load. */
   peek(): FlagSnapshot | null {
     return this.snapshot;

--- a/packages/gemi/services/features/FeatureManager.test.ts
+++ b/packages/gemi/services/features/FeatureManager.test.ts
@@ -321,3 +321,186 @@ describe("declarations", () => {
     expect(await features.forClient()).toEqual({});
   });
 });
+
+describe("list", () => {
+  test("describes every declared feature", async () => {
+    const features = new FeatureManager(
+      {
+        ...featuresConfigDefaults(),
+        features: {
+          "new-checkout": defineFeature({
+            describe: "Rebuilt checkout",
+            rollout: 20,
+            salt: "checkout-v2",
+          }),
+          "admin-only": defineFeature({ when: () => true }),
+          "internal-tools": defineFeature({ serverOnly: true }),
+        },
+        source: new StaticFeatureFlagSource({ "new-checkout": true }),
+      } as any,
+      () => {},
+    );
+
+    expect(await features.list()).toEqual([
+      {
+        key: "new-checkout",
+        describe: "Rebuilt checkout",
+        rollout: 20,
+        targeted: false,
+        serverOnly: false,
+        salt: "checkout-v2",
+        active: true,
+      },
+      {
+        key: "admin-only",
+        describe: undefined,
+        rollout: undefined,
+        targeted: true,
+        serverOnly: false,
+        salt: undefined,
+        active: undefined,
+      },
+      {
+        key: "internal-tools",
+        describe: undefined,
+        rollout: undefined,
+        targeted: false,
+        serverOnly: true,
+        salt: undefined,
+        active: undefined,
+      },
+    ]);
+  });
+
+  test("a feature with no row is not a feature switched off", async () => {
+    const [untouched, off] = await manager({ "pricing-redesign": false }).list();
+
+    // The distinction an admin list exists to show: nobody has touched
+    // `new-checkout`, whereas somebody decided `pricing-redesign` is off.
+    expect(untouched.active).toBe(undefined);
+    expect(off.active).toBe(false);
+  });
+
+  test("lists server-only features, which `forClient` omits", async () => {
+    const features = manager({ "internal-tools": true });
+
+    expect((await features.list()).map((f) => f.key)).toContain("internal-tools");
+    expect(await inRequest(() => features.forClient())).not.toHaveProperty("internal-tools");
+  });
+
+  test("the declarations still list when the subsystem is off, without a query", async () => {
+    const source = new StaticFeatureFlagSource({ "new-checkout": true });
+    const load = vi.spyOn(source, "load");
+    const features = manager({}, { enabled: false, source });
+
+    const list = await features.list();
+
+    expect(list.map((f) => f.key)).toEqual([
+      "new-checkout",
+      "pricing-redesign",
+      "internal-tools",
+      "admin-only",
+    ]);
+    // `enabled: false` means nothing reads the table, so every switch is
+    // unknown rather than off — the code declarations are all there is to show.
+    expect(list.every((f) => f.active === undefined)).toBe(true);
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  test("no declarations, no list and no query", async () => {
+    const source = new StaticFeatureFlagSource({ "new-checkout": true });
+    const load = vi.spyOn(source, "load");
+    const features = new FeatureManager(
+      { ...featuresConfigDefaults(), features: undefined, source } as any,
+      () => {},
+    );
+
+    expect(await features.list()).toEqual([]);
+    expect(load).not.toHaveBeenCalled();
+  });
+});
+
+describe("invalidate", () => {
+  test("picks up a write the TTL would have hidden", async () => {
+    let active = false;
+    const source = new (class extends StaticFeatureFlagSource {
+      async load() {
+        return [{ key: "new-checkout", active }];
+      }
+    })();
+    const features = manager({}, { source, ttl: 3600 });
+
+    expect(await features.enabled("new-checkout")).toBe(false);
+
+    active = true;
+    await features.invalidate();
+
+    expect(await features.enabled("new-checkout")).toBe(true);
+  });
+
+  test("does not settle on a load that started before the write", async () => {
+    let active = false;
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let first = true;
+    const source = new (class extends StaticFeatureFlagSource {
+      async load() {
+        // Read at entry: the first load queried the table before the write and
+        // returns long after it.
+        const seen = active;
+        if (first) {
+          first = false;
+          await gate;
+        }
+        return [{ key: "new-checkout", active: seen }];
+      }
+    })();
+    const features = manager({}, { source, ttl: 3600 });
+
+    // A load is already in flight, reading the table as it was before the write.
+    const inflight = features.refresh();
+
+    active = true;
+    const invalidated = features.invalidate();
+    release();
+    await inflight;
+    await invalidated;
+
+    // `refresh()` would have resolved on the in-flight load and reported the
+    // pre-write value; the admin's own write has to be visible to the admin.
+    expect(await features.enabled("new-checkout")).toBe(true);
+  });
+
+  test("re-evaluates a feature the request already read", async () => {
+    let active = false;
+    const source = new (class extends StaticFeatureFlagSource {
+      async load() {
+        return [{ key: "new-checkout", active }];
+      }
+    })();
+    const features = manager({}, { source, ttl: 3600 });
+
+    const [before, after] = await inRequest(async () => {
+      const before = await features.enabled("new-checkout");
+      active = true;
+      await features.invalidate();
+      return [before, await features.enabled("new-checkout")];
+    });
+
+    // Without clearing the per-request memo the second read would be answered
+    // from the first, and a handler could never see its own write.
+    expect(before).toBe(false);
+    expect(after).toBe(true);
+  });
+
+  test("touches nothing when the subsystem is off", async () => {
+    const source = new StaticFeatureFlagSource({ "new-checkout": true });
+    const load = vi.spyOn(source, "load");
+
+    await manager({}, { enabled: false, source }).invalidate();
+
+    expect(load).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gemi/services/features/FeatureManager.test.ts
+++ b/packages/gemi/services/features/FeatureManager.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import { RequestContext } from "../../http/requestContext";
 import { featuresConfigDefaults, type FeaturesConfig } from "./config";
 import { defineFeature } from "./defineFeature";
+import { FeatureReloadError } from "./FeatureFlagStore";
 import { FeatureManager } from "./FeatureManager";
 import { StaticFeatureFlagSource } from "./sources/StaticFeatureFlagSource";
 
@@ -341,39 +342,43 @@ describe("list", () => {
       () => {},
     );
 
-    expect(await features.list()).toEqual([
-      {
-        key: "new-checkout",
-        describe: "Rebuilt checkout",
-        rollout: 20,
-        targeted: false,
-        serverOnly: false,
-        salt: "checkout-v2",
-        active: true,
-      },
-      {
-        key: "admin-only",
-        describe: undefined,
-        rollout: undefined,
-        targeted: true,
-        serverOnly: false,
-        salt: undefined,
-        active: undefined,
-      },
-      {
-        key: "internal-tools",
-        describe: undefined,
-        rollout: undefined,
-        targeted: false,
-        serverOnly: true,
-        salt: undefined,
-        active: undefined,
-      },
-    ]);
+    expect(await features.list()).toEqual({
+      unavailable: false,
+      features: [
+        {
+          key: "new-checkout",
+          describe: "Rebuilt checkout",
+          rollout: 20,
+          targeted: false,
+          serverOnly: false,
+          salt: "checkout-v2",
+          active: true,
+        },
+        {
+          key: "admin-only",
+          describe: undefined,
+          rollout: undefined,
+          targeted: true,
+          serverOnly: false,
+          salt: undefined,
+          active: undefined,
+        },
+        {
+          key: "internal-tools",
+          describe: undefined,
+          rollout: undefined,
+          targeted: false,
+          serverOnly: true,
+          salt: undefined,
+          active: undefined,
+        },
+      ],
+    });
   });
 
   test("a feature with no row is not a feature switched off", async () => {
-    const [untouched, off] = await manager({ "pricing-redesign": false }).list();
+    const { features } = await manager({ "pricing-redesign": false }).list();
+    const [untouched, off] = features;
 
     // The distinction an admin list exists to show: nobody has touched
     // `new-checkout`, whereas somebody decided `pricing-redesign` is off.
@@ -381,10 +386,44 @@ describe("list", () => {
     expect(off.active).toBe(false);
   });
 
+  test("a store that never loaded is unavailable, not a table of untouched features", async () => {
+    const source = new (class extends StaticFeatureFlagSource {
+      async load(): Promise<Record<string, unknown>[]> {
+        throw new Error("no database");
+      }
+    })();
+    const listing = await manager({}, { source }).list();
+
+    // Every `active` is undefined either way. `unavailable` is the only thing
+    // standing between the screen and "no feature has ever been switched on",
+    // said of a table nobody could read.
+    expect(listing.features.every((f) => f.active === undefined)).toBe(true);
+    expect(listing.unavailable).toBe(true);
+  });
+
+  test("a kept snapshot is still available after a failed reload", async () => {
+    let fail = false;
+    const source = new (class extends StaticFeatureFlagSource {
+      async load() {
+        if (fail) throw new Error("down");
+        return [{ key: "new-checkout", active: true }];
+      }
+    })();
+    const features = manager({}, { source, ttl: 0 });
+
+    await features.refresh();
+    fail = true;
+    await features.refresh();
+
+    const listing = await features.list();
+    expect(listing.unavailable).toBe(false);
+    expect(listing.features[0].active).toBe(true);
+  });
+
   test("lists server-only features, which `forClient` omits", async () => {
     const features = manager({ "internal-tools": true });
 
-    expect((await features.list()).map((f) => f.key)).toContain("internal-tools");
+    expect((await features.list()).features.map((f) => f.key)).toContain("internal-tools");
     expect(await inRequest(() => features.forClient())).not.toHaveProperty("internal-tools");
   });
 
@@ -393,9 +432,9 @@ describe("list", () => {
     const load = vi.spyOn(source, "load");
     const features = manager({}, { enabled: false, source });
 
-    const list = await features.list();
+    const listing = await features.list();
 
-    expect(list.map((f) => f.key)).toEqual([
+    expect(listing.features.map((f) => f.key)).toEqual([
       "new-checkout",
       "pricing-redesign",
       "internal-tools",
@@ -403,7 +442,10 @@ describe("list", () => {
     ]);
     // `enabled: false` means nothing reads the table, so every switch is
     // unknown rather than off — the code declarations are all there is to show.
-    expect(list.every((f) => f.active === undefined)).toBe(true);
+    expect(listing.features.every((f) => f.active === undefined)).toBe(true);
+    // Not `unavailable`: the application turned features off on purpose, which
+    // is not the store failing to answer.
+    expect(listing.unavailable).toBe(false);
     expect(load).not.toHaveBeenCalled();
   });
 
@@ -415,7 +457,7 @@ describe("list", () => {
       () => {},
     );
 
-    expect(await features.list()).toEqual([]);
+    expect(await features.list()).toEqual({ features: [], unavailable: false });
     expect(load).not.toHaveBeenCalled();
   });
 });
@@ -495,6 +537,66 @@ describe("invalidate", () => {
     expect(after).toBe(true);
   });
 
+  test("does not memoise a stale read taken while the reload is in flight", async () => {
+    let active = false;
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let first = true;
+    const source = new (class extends StaticFeatureFlagSource {
+      async load() {
+        const seen = active;
+        if (first) {
+          first = false;
+          return [{ key: "new-checkout", active: seen }];
+        }
+        await gate;
+        return [{ key: "new-checkout", active: seen }];
+      }
+    })();
+    const features = manager({}, { source, ttl: 3600 });
+
+    const after = await inRequest(async () => {
+      await features.enabled("new-checkout");
+
+      active = true;
+      const invalidated = features.invalidate();
+
+      // A concurrent read lands mid-reload, sees the pre-write snapshot, and
+      // memoises `false`. Clearing the memo before the reload rather than after
+      // would leave that entry standing for the rest of the request.
+      await features.enabled("new-checkout");
+      release();
+      await invalidated;
+
+      return await features.enabled("new-checkout");
+    });
+
+    expect(after).toBe(true);
+  });
+
+  test("throws rather than passing pre-write switches off as the result", async () => {
+    let fail = false;
+    let active = false;
+    const source = new (class extends StaticFeatureFlagSource {
+      async load() {
+        if (fail) throw new Error("down");
+        return [{ key: "new-checkout", active }];
+      }
+    })();
+    const features = manager({}, { source, ttl: 3600 });
+
+    await features.refresh();
+    active = true;
+    fail = true;
+
+    await expect(features.invalidate()).rejects.toThrow(FeatureReloadError);
+    // The write landed, the cache did not follow. Returning normally here would
+    // have handed the caller the pre-write value as the result of their update.
+    expect(await features.enabled("new-checkout")).toBe(false);
+  });
+
   test("touches nothing when the subsystem is off", async () => {
     const source = new StaticFeatureFlagSource({ "new-checkout": true });
     const load = vi.spyOn(source, "load");
@@ -502,5 +604,24 @@ describe("invalidate", () => {
     await manager({}, { enabled: false, source }).invalidate();
 
     expect(load).not.toHaveBeenCalled();
+  });
+
+  test("clears the memo even when the reload fails", async () => {
+    const source = new (class extends StaticFeatureFlagSource {
+      async load(): Promise<Record<string, unknown>[]> {
+        throw new Error("down");
+      }
+    })();
+    const features = manager({}, { source, ttl: 3600 });
+
+    await inRequest(async () => {
+      await features.enabled("new-checkout");
+      const store = RequestContext.getStore();
+      expect(store.featureEvaluations?.size).toBeGreaterThan(0);
+
+      await expect(features.invalidate()).rejects.toThrow(FeatureReloadError);
+
+      expect(store.featureEvaluations?.size).toBe(0);
+    });
   });
 });

--- a/packages/gemi/services/features/FeatureManager.ts
+++ b/packages/gemi/services/features/FeatureManager.ts
@@ -4,7 +4,7 @@ import { contextFromRequest, contextFromSubject, type FeatureSubject } from "./c
 import type { Feature, FeatureRegistry } from "./defineFeature";
 import { evaluateFeature } from "./evaluate";
 import { FeatureFlagStore } from "./FeatureFlagStore";
-import type { FeatureContext, FeatureEvaluation } from "./types";
+import type { FeatureContext, FeatureDescriptor, FeatureEvaluation } from "./types";
 
 /**
  * Evaluation bound to one explicit context — what `Features.for(...)` returns.
@@ -62,6 +62,26 @@ export class FeatureManager {
     return this.declared;
   }
 
+  /**
+   * Every declared feature with its switch — what an admin list renders.
+   *
+   * Server-side only. `rollout` and `targeted` together describe who is in an
+   * experiment, which is a fact about the population and not for the browser.
+   */
+  async list(): Promise<FeatureDescriptor[]> {
+    const active = await this.switches();
+
+    return Object.entries(this.declared).map(([key, feature]) => ({
+      key,
+      describe: feature.describe,
+      rollout: feature.rollout,
+      targeted: feature.when !== undefined,
+      serverOnly: feature.serverOnly,
+      salt: feature.salt,
+      active: active.get(key),
+    }));
+  }
+
   /** Reloads the snapshot in this process now. */
   async refresh(): Promise<void> {
     if (!this.config.enabled) return;
@@ -71,6 +91,29 @@ export class FeatureManager {
     // boot-time complaint about an unused feature.
     if (Object.keys(this.declared).length === 0) return;
     await this.store.refresh();
+  }
+
+  /**
+   * Invalidates this process's cached switches after a write to the table.
+   *
+   * Process-local, because that is all a single process can honestly promise:
+   * every *other* instance is still serving its own snapshot and picks the
+   * change up within `ttl`. What this buys is the one window that would
+   * otherwise read as a bug — the admin who flips a switch and reloads the page
+   * they flipped it on, and is told for the next thirty seconds that nothing
+   * happened.
+   */
+  async invalidate(): Promise<void> {
+    // The per-request memo is why this is not simply `refresh()`. A handler that
+    // toggles a row and then reads the feature back in the same request would
+    // otherwise be answered from the evaluation it memoised before the write.
+    // Cleared unconditionally: it costs nothing, and the early returns below are
+    // about the database, which the memo is not.
+    RequestContext.getStore()?.featureEvaluations?.clear();
+
+    if (!this.config.enabled) return;
+    if (Object.keys(this.declared).length === 0) return;
+    await this.store.invalidate();
   }
 
   async enabled(key: string): Promise<boolean> {
@@ -171,6 +214,20 @@ export class FeatureManager {
     }
 
     return values;
+  }
+
+  /**
+   * The whole switch map in one load, for `list()`.
+   *
+   * Separate from `switchFor` because listing asks about every key at once and
+   * has no use for `unavailable` — a store that has never loaded and a table
+   * with no rows both mean "nothing is switched on", which `list()` already
+   * renders as `active: undefined` per feature.
+   */
+  private async switches(): Promise<Map<string, boolean>> {
+    if (!this.config.enabled) return new Map();
+    if (Object.keys(this.declared).length === 0) return new Map();
+    return (await this.store.get()).active;
   }
 
   private async switchFor(

--- a/packages/gemi/services/features/FeatureManager.ts
+++ b/packages/gemi/services/features/FeatureManager.ts
@@ -4,7 +4,7 @@ import { contextFromRequest, contextFromSubject, type FeatureSubject } from "./c
 import type { Feature, FeatureRegistry } from "./defineFeature";
 import { evaluateFeature } from "./evaluate";
 import { FeatureFlagStore } from "./FeatureFlagStore";
-import type { FeatureContext, FeatureDescriptor, FeatureEvaluation } from "./types";
+import type { FeatureContext, FeatureEvaluation, FeatureListing } from "./types";
 
 /**
  * Evaluation bound to one explicit context — what `Features.for(...)` returns.
@@ -68,18 +68,21 @@ export class FeatureManager {
    * Server-side only. `rollout` and `targeted` together describe who is in an
    * experiment, which is a fact about the population and not for the browser.
    */
-  async list(): Promise<FeatureDescriptor[]> {
-    const active = await this.switches();
+  async list(): Promise<FeatureListing> {
+    const { active, unavailable } = await this.switches();
 
-    return Object.entries(this.declared).map(([key, feature]) => ({
-      key,
-      describe: feature.describe,
-      rollout: feature.rollout,
-      targeted: feature.when !== undefined,
-      serverOnly: feature.serverOnly,
-      salt: feature.salt,
-      active: active.get(key),
-    }));
+    return {
+      unavailable,
+      features: Object.entries(this.declared).map(([key, feature]) => ({
+        key,
+        describe: feature.describe,
+        rollout: feature.rollout,
+        targeted: feature.when !== undefined,
+        serverOnly: feature.serverOnly,
+        salt: feature.salt,
+        active: active.get(key),
+      })),
+    };
   }
 
   /** Reloads the snapshot in this process now. */
@@ -102,18 +105,30 @@ export class FeatureManager {
    * otherwise read as a bug — the admin who flips a switch and reloads the page
    * they flipped it on, and is told for the next thirty seconds that nothing
    * happened.
+   *
+   * Throws `FeatureReloadError` if the reload itself failed, because the
+   * alternative is handing back pre-write switches that look like success.
    */
   async invalidate(): Promise<void> {
-    // The per-request memo is why this is not simply `refresh()`. A handler that
-    // toggles a row and then reads the feature back in the same request would
-    // otherwise be answered from the evaluation it memoised before the write.
-    // Cleared unconditionally: it costs nothing, and the early returns below are
-    // about the database, which the memo is not.
-    RequestContext.getStore()?.featureEvaluations?.clear();
-
-    if (!this.config.enabled) return;
-    if (Object.keys(this.declared).length === 0) return;
-    await this.store.invalidate();
+    try {
+      if (this.config.enabled && Object.keys(this.declared).length > 0) {
+        await this.store.invalidate();
+      }
+    } finally {
+      // The per-request memo is why this is not simply `refresh()`. A handler
+      // that toggles a row and then reads the feature back in the same request
+      // would otherwise be answered from the evaluation it memoised before the
+      // write.
+      //
+      // Cleared *after* the reload rather than before. Anything in the same
+      // request that evaluates a feature while the reload is in flight — a
+      // `Promise.all` in the handler, an SSR render already under way — reads
+      // the still-stale snapshot and memoises the pre-write value, and clearing
+      // first would leave that entry standing for the rest of the request. In a
+      // `finally` because a failed reload leaves the memo just as suspect as a
+      // successful one.
+      RequestContext.getStore()?.featureEvaluations?.clear();
+    }
   }
 
   async enabled(key: string): Promise<boolean> {
@@ -219,15 +234,28 @@ export class FeatureManager {
   /**
    * The whole switch map in one load, for `list()`.
    *
-   * Separate from `switchFor` because listing asks about every key at once and
-   * has no use for `unavailable` — a store that has never loaded and a table
-   * with no rows both mean "nothing is switched on", which `list()` already
-   * renders as `active: undefined` per feature.
+   * Separate from `switchFor` because listing asks about every key at once — and
+   * because it has to carry `unavailable` out with the map rather than fold it
+   * into the values. For *evaluation* a store that has never loaded and a table
+   * with no rows are the same thing: both mean off, and failing closed is
+   * correct. For a *display* they are opposite claims. Collapsing them tells an
+   * operator whose database is down that no feature has ever been switched on,
+   * about features that are switched on in the table, at the moment they are
+   * most likely to act on it and turn on something that already is.
    */
-  private async switches(): Promise<Map<string, boolean>> {
-    if (!this.config.enabled) return new Map();
-    if (Object.keys(this.declared).length === 0) return new Map();
-    return (await this.store.get()).active;
+  private async switches(): Promise<{
+    active: Map<string, boolean>;
+    unavailable: boolean;
+  }> {
+    // Not `unavailable`: the application turned features off deliberately, and
+    // the declarations are still the truth about what exists.
+    if (!this.config.enabled) return { active: new Map(), unavailable: false };
+    if (Object.keys(this.declared).length === 0) {
+      return { active: new Map(), unavailable: false };
+    }
+
+    const snapshot = await this.store.get();
+    return { active: snapshot.active, unavailable: snapshot.unavailable };
   }
 
   private async switchFor(

--- a/packages/gemi/services/features/types.ts
+++ b/packages/gemi/services/features/types.ts
@@ -94,8 +94,35 @@ export interface FeatureDescriptor {
    * `undefined` means **no row** — a feature that has been deployed but never
    * switched on, which is not the same as a row that says `false`, and is a
    * difference an admin list has to show: one is untouched, the other is
-   * somebody's decision. Also `undefined` throughout when `enabled: false` turns
-   * the subsystem off, because then nothing reads the table at all.
+   * somebody's decision.
+   *
+   * Read it only after checking `FeatureListing.unavailable`. When no snapshot
+   * has ever loaded there are no rows to report and every switch is `undefined`
+   * — which would otherwise state, of a table nobody could read, that nothing in
+   * it has ever been switched on.
    */
   active: boolean | undefined;
+}
+
+/**
+ * What `Features.list()` returns.
+ *
+ * A wrapper rather than a bare array because "the switches could not be read" is
+ * one fact about the whole load, not a property of any feature — putting it on
+ * every descriptor would invite reading it off one of them and describe it as
+ * something the declaration says.
+ */
+export interface FeatureListing {
+  /** In declaration order — the order `app/features` lists them. */
+  features: FeatureDescriptor[];
+  /**
+   * No snapshot has ever loaded, so every `active` is **unknown** rather than
+   * absent.
+   *
+   * A screen that ignores this reports a database it cannot reach as a table in
+   * which nothing has ever been switched on. Show it as an error, not as data;
+   * in particular do not offer to flip switches whose current state you do not
+   * know.
+   */
+  unavailable: boolean;
 }

--- a/packages/gemi/services/features/types.ts
+++ b/packages/gemi/services/features/types.ts
@@ -62,3 +62,40 @@ export interface FeatureEvaluation {
   value: boolean;
   reason: EvaluationReason;
 }
+
+/**
+ * One declared feature, flattened for a human-facing list — an admin screen, a
+ * console command.
+ *
+ * The declarations are what exists: a feature is on this list because the code
+ * declares it, never because somebody inserted a row. The database contributes
+ * exactly one field, `active`, which is the only thing it owns.
+ *
+ * `when` is not here and cannot be. It is a function over the viewer, so the
+ * honest answer to "who does this target" is only ever "run it" — `targeted`
+ * reports that targeting exists, and `Features.for(subject).explain(key)`
+ * answers it for one subject at a time.
+ */
+export interface FeatureDescriptor {
+  key: string;
+  /** `describe` from the declaration. */
+  describe?: string;
+  /** `0`–`100`, or `undefined` for "everyone". */
+  rollout?: number;
+  /** Whether the declaration carries a `when`. The function itself stays put. */
+  targeted: boolean;
+  /** Evaluated on the server, never in the SSR payload. */
+  serverOnly: boolean;
+  /** The declared bucketing salt, or `undefined` when it is the key. */
+  salt?: string;
+  /**
+   * The switch.
+   *
+   * `undefined` means **no row** — a feature that has been deployed but never
+   * switched on, which is not the same as a row that says `false`, and is a
+   * difference an admin list has to show: one is untouched, the other is
+   * somebody's decision. Also `undefined` throughout when `enabled: false` turns
+   * the subsystem off, because then nothing reads the table at all.
+   */
+  active: boolean | undefined;
+}

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -158,7 +158,11 @@ export {
 } from "./features/defineFeature";
 export { FeaturesServiceProvider } from "./features/FeaturesServiceProvider";
 export { FeatureManager, FeatureScope } from "./features/FeatureManager";
-export { FeatureFlagStore, type FlagSnapshot } from "./features/FeatureFlagStore";
+export {
+  FeatureFlagStore,
+  FeatureReloadError,
+  type FlagSnapshot,
+} from "./features/FeatureFlagStore";
 export { FeatureFlagSource, FeatureModelMissingError } from "./features/sources/FeatureFlagSource";
 export { DatabaseFeatureFlagSource } from "./features/sources/DatabaseFeatureFlagSource";
 export { StaticFeatureFlagSource } from "./features/sources/StaticFeatureFlagSource";
@@ -170,6 +174,7 @@ export type {
   FeatureContext,
   FeatureDescriptor,
   FeatureEvaluation,
+  FeatureListing,
 } from "./features/types";
 
 // Runtime config (`app/config/*.ts`)

--- a/packages/gemi/services/index.ts
+++ b/packages/gemi/services/index.ts
@@ -168,6 +168,7 @@ export type { FeatureSubject } from "./features/context";
 export type {
   EvaluationReason,
   FeatureContext,
+  FeatureDescriptor,
   FeatureEvaluation,
 } from "./features/types";
 


### PR DESCRIPTION
An admin screen for features needs two things the facade did not have: the set of features that exist, and a way to make a write to the switch table visible without waiting out the TTL.

## `Features.list()`

One descriptor per declaration — `key`, `describe`, `rollout`, `targeted`, `serverOnly`, `salt`, `active`.

```ts
public async index() {
  return { features: await Features.list() };
}
```

**The declarations are what exists.** A feature is on the list because `app/features` declares it, never because a row was inserted — a row for an undeclared key is litter, and the store already says so.

**`active: undefined` means no row**, which is deliberately not the same as a row saying `false`. One feature was never switched on; the other was switched off by somebody. A toggle UI that renders those the same cannot tell "never shipped" from "killed".

**`when` is not on the descriptor and cannot be.** It is a function over the viewer, so the only honest answer to "who does this target" is to run it. `targeted` reports that targeting exists; `Features.for(subject).explain(key)` answers it one subject at a time.

Server-side only — `rollout` and `targeted` describe who is in an experiment. With `enabled: false` the declarations still list, `active` is `undefined` throughout, and no query is issued.

## `Features.invalidate()`

```ts
await FeatureFlag.update({ where: { key }, data: { active } });
await Features.invalidate();
return { features: await Features.list() };
```

The obvious call here is `refresh()`, and it is wrong twice.

It **joins whatever load is already in flight** — the single-flight that keeps a cold start under load down to one query — and that load issued its query at some earlier moment, possibly before the `UPDATE` committed. So the admin flips a switch, the screen reloads, and it says the switch is still off.

It also **leaves the request's evaluation memo in place**, so a handler that read the feature before writing to it is answered from before its own write.

`invalidate()` waits the in-flight load out, starts a fresh one behind it, and clears the memo.

Still **process-local**. Every other instance is serving its own snapshot and converges within `ttl` — this is not cross-instance invalidation and does not pretend to be. What it closes is the one window that reads as a bug: the operator watching their own change fail to happen.

## Checks

`bun run typecheck` clean. Full suite: 3920 passed, 1 skipped, 162 files — including 20 new tests in `FeatureManager.test.ts` and `FeatureFlagStore.test.ts`. Two of them pin the ordering the design turns on: a load that started before the write must not be what `invalidate()` settles on, and a feature the request already read must be re-evaluated after one.

`docs/feature-flags.md` gains an "An admin screen" section; `docs/llms-full.txt` is regenerated from it.

`oxfmt --check` flags `packages/gemi/services/index.ts`, but flags it identically on `main` — pre-existing, untouched here beyond one added type export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7ZxzSCxAu6nUoFKZrnerQ
