### PR TITLE
The ai module's interfaces, with the blanks filled in

### DIFF
--- a/packages/gemi/ai/Agent.test-d.ts
+++ b/packages/gemi/ai/Agent.test-d.ts
@@ -1,0 +1,167 @@
+/**
+ * Type-level tests for the agent surface.
+ *
+ * Every claim this module makes about types is made through conditional and
+ * mapped types — the schema builder inferring a tool's input, a namespace
+ * flattening into tool names, the tool tuple surviving the trip through
+ * `AgentRoute` and `RPC` into the browser. None of it is exercised by a runtime
+ * test, and the module's own files carry `@ts-nocheck`, so without these
+ * assertions the inference can stop working and nothing says so.
+ *
+ * Run with `bun run test:types`.
+ */
+import { describe, expectTypeOf, test } from "vitest";
+
+import { Agent, AgentTool, Skill, ToolNamespace, type ToolShapesOf } from "./Agent";
+import { AgentController, type AgentRouteRPC } from "./AgentController";
+import { OpenAIProvider } from "./AgentProvider";
+import { s, type Infer } from "./Schema";
+import type { PendingToolCall } from "./types";
+
+const bash = AgentTool.create({
+  name: "bash",
+  description: "Execute a bash command",
+  inputSchema: s.object({ command: s.string(), cwd: s.string().optional() }),
+  outputSchema: s.object({ output: s.string() }),
+  requiresApproval: true,
+  execute: async (input) => ({ output: input.command }),
+});
+
+const listOrders = AgentTool.create({
+  name: "listOrders",
+  description: "List a customer's recent orders",
+  inputSchema: s.object({ customerId: s.string() }),
+  outputSchema: s.object({ orderIds: s.array(s.string()) }),
+  execute: async () => ({ orderIds: [] as string[] }),
+});
+
+const refundOrder = AgentTool.create({
+  name: "refundOrder",
+  description: "Refund an order in full",
+  inputSchema: s.object({ orderId: s.string() }),
+  outputSchema: s.object({ refundId: s.string() }),
+  requiresApproval: true,
+  execute: async () => ({ refundId: "rf_1" }),
+});
+
+const ask = AgentTool.create({
+  name: "ask",
+  description: "Ask the customer something",
+  inputSchema: s.object({ question: s.string() }),
+  outputSchema: s.object({ answer: s.string() }),
+  answeredBy: "client",
+});
+
+const crm = ToolNamespace.create({
+  name: "crm",
+  description: "Customer records, orders and refunds",
+  deferred: true,
+  tools: [listOrders, refundOrder],
+});
+
+const support = Agent.create({
+  name: "support",
+  provider: OpenAIProvider.model("gpt-5.4"),
+  tools: [bash, ask, crm],
+  skills: [
+    Skill.create({
+      name: "refund-policy",
+      description: "How refunds are decided",
+      instructions: "…",
+    }),
+  ],
+});
+
+class SupportController extends AgentController<typeof support> {
+  agent = support;
+}
+
+type Shapes = ToolShapesOf<typeof support.tools>;
+
+describe("the schema builder", () => {
+  test("infers the object type it describes", () => {
+    const schema = s.object({ command: s.string(), cwd: s.string().optional() });
+    expectTypeOf<Infer<typeof schema>>().toEqualTypeOf<{ command: string; cwd?: string }>();
+  });
+
+  test("types a tool's execute argument from its input schema", () => {
+    AgentTool.create({
+      name: "grep",
+      description: "Search",
+      inputSchema: s.object({ pattern: s.string() }),
+      outputSchema: s.object({ matches: s.array(s.string()) }),
+      execute: async (input, ctx) => {
+        expectTypeOf(input).toEqualTypeOf<{ pattern: string }>();
+        expectTypeOf(ctx.runId).toEqualTypeOf<string>();
+        return { matches: [] as string[] };
+      },
+    });
+  });
+});
+
+describe("a tool definition", () => {
+  test("requires an implementation, or a client to answer it", () => {
+    // @ts-expect-error a server tool without `execute` is nothing at all
+    AgentTool.create({
+      name: "noop",
+      description: "…",
+      inputSchema: s.object({}),
+      outputSchema: s.object({}),
+    });
+  });
+
+  test("refuses an implementation for a tool the client answers", () => {
+    // @ts-expect-error the browser answers this one; the server cannot
+    AgentTool.create({
+      name: "askTwice",
+      description: "…",
+      inputSchema: s.object({ question: s.string() }),
+      outputSchema: s.object({ answer: s.string() }),
+      answeredBy: "client",
+      execute: async () => ({ answer: "" }),
+    });
+  });
+
+  test("refuses approval on a client tool, where answering is the approval", () => {
+    // @ts-expect-error nothing to approve — the client already answered
+    AgentTool.create({
+      name: "askThrice",
+      description: "…",
+      inputSchema: s.object({ question: s.string() }),
+      outputSchema: s.object({ answer: s.string() }),
+      answeredBy: "client",
+      requiresApproval: true,
+    });
+  });
+});
+
+describe("an agent's tools", () => {
+  test("flatten out of their namespaces, keyed by tool name", () => {
+    expectTypeOf<keyof Shapes>().toEqualTypeOf<"bash" | "ask" | "listOrders" | "refundOrder">();
+  });
+
+  test("keep their payload types through the flattening", () => {
+    expectTypeOf<Shapes["bash"]["input"]>().toEqualTypeOf<{ command: string; cwd?: string }>();
+    expectTypeOf<Shapes["refundOrder"]["output"]>().toEqualTypeOf<{ refundId: string }>();
+  });
+
+  test("reach the client through the route, not a second augmentation", () => {
+    expectTypeOf<AgentRouteRPC<typeof SupportController>["tools"]>().toEqualTypeOf<Shapes>();
+  });
+});
+
+describe("a pending tool call", () => {
+  test("narrows its input on the tool's name", () => {
+    const pending = {} as PendingToolCall<Shapes>;
+    if (pending.name === "refundOrder") {
+      expectTypeOf(pending.input).toEqualTypeOf<{ orderId: string }>();
+    }
+    if (pending.name === "ask") {
+      expectTypeOf(pending.input).toEqualTypeOf<{ question: string }>();
+    }
+  });
+
+  test("carries the signature that makes answering it trustworthy", () => {
+    expectTypeOf<PendingToolCall<Shapes>["signature"]>().toEqualTypeOf<string>();
+  });
+});

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -1,99 +1,241 @@
-// @ts-nocheck — the ai rfc is a sketch, not an interface anyone depends on:
-// nothing exports `gemi/ai` and nothing in the package imports it, so its only
-// reader is `tsc`, and a half-drawn signature there fails `bun run typecheck`
-// and `build:types` for everyone. Checked again by deleting this line, which is
-// the point of a per-file directive rather than dropping `ai` from the
-// tsconfig: the files stay in the project, and the exemption is visible in the
-// file that has it.
-export type Schema<T> = {};
+// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
+import type { HttpRequest } from "../http";
+import type { AgentProvider } from "./AgentProvider";
+import type { Infer, Schema } from "./Schema";
+import type {
+  AgentMessage,
+  AgentStreamEvent,
+  FinishReason,
+  ToolShapes,
+  Usage,
+  UserMessageInput,
+} from "./types";
 
-interface IAgentTool<T, U> {
-  name: string;
+// --- tools ---------------------------------------------------------------
+
+/**
+ * Everything a tool needs from the request it is running inside.
+ *
+ * Tools are created once at module scope and shared by every request, so they
+ * cannot close over a user or an abort signal — and anything mutable stored on
+ * the tool itself would leak across requests. That is why the run's state
+ * arrives as an argument instead: the tool stays a singleton and the context is
+ * per call.
+ */
+export interface ToolContext {
+  req: HttpRequest<any, any>;
+  runId: string;
+  threadId?: string;
+  toolCallId: string;
+  /** Aborted when the client disconnects or calls `stop()`. Long tools should
+   *  pass it to whatever they call. */
+  signal: AbortSignal;
+  /** Which step of the tool loop this is, starting at 1. */
+  step: number;
+}
+
+/**
+ * A tool either resolves once, or yields progress and then returns.
+ *
+ * The generator form exists because a tool that takes twenty seconds is the
+ * normal case, not the exotic one, and a chat UI that shows nothing for twenty
+ * seconds looks broken. Yields become `tool-progress` events; the return value
+ * is the result the model sees.
+ */
+export type ToolExecute<Input, Output, Progress = unknown> = (
+  input: Input,
+  ctx: ToolContext,
+) => Promise<Output> | AsyncGenerator<Progress, Output, void>;
+
+type ToolDefinitionBase<Name extends string, Input, Output> = {
+  name: Name;
+  /** The model's only description of when to reach for this. */
   description: string;
-  inputSchema: Schema<T>;
-  outputSchema: Schema<U>;
-  execute: (input: T) => Promise<U> | AsyncGenerator<U>;
-  deferred: boolean;
-  requiresApproval: boolean;
+  inputSchema: Schema<Input>;
+  /**
+   * Optional, unlike the input schema. The model is only ever shown the
+   * serialized result, so the output schema buys type-safety on the client and
+   * a runtime check on what a tool returned — not better model behaviour.
+   */
+  outputSchema?: Schema<Output>;
+  /**
+   * Parks the run and asks the human before the tool runs. The stream ends with
+   * `approval-required`; answering it on the resume route continues the same
+   * run. Defaults to `false` — a tool that needs a human should have to say so.
+   */
+  requiresApproval?: boolean;
+};
+
+/**
+ * `deferred` means the agent declares the tool's shape while the controller
+ * supplies the implementation at request time. It is for the tool that has to
+ * close over the request in a way `ctx` does not cover, or whose implementation
+ * differs per deployment — the agent stays a static, shareable declaration.
+ */
+export type ToolDefinition<Name extends string, Input, Output> =
+  | (ToolDefinitionBase<Name, Input, Output> & {
+      deferred?: false;
+      execute: ToolExecute<Input, Output>;
+    })
+  | (ToolDefinitionBase<Name, Input, Output> & {
+      deferred: true;
+      execute?: never;
+    });
+
+export declare class AgentTool<Name extends string = string, Input = unknown, Output = unknown> {
+  readonly name: Name;
+  readonly description: string;
+  readonly inputSchema: Schema<Input>;
+  readonly outputSchema?: Schema<Output>;
+  readonly requiresApproval: boolean;
+  readonly deferred: boolean;
+  readonly execute?: ToolExecute<Input, Output>;
+
+  /**
+   * `const` on the params is what preserves `name` as a literal, which is what
+   * lets the browser discriminate a tool part by name.
+   */
+  static create<const Name extends string, Input, Output>(
+    params: ToolDefinition<Name, Input, Output>,
+  ): AgentTool<Name, Input, Output>;
 }
 
-export class AgentTool<T, U> implements IAgentTool<T, U> {
-  name: string = "";
-  description = "";
-  inputSchema = {} as Schema<T>;
-  outputSchema = {} as Schema<U>;
-  execute = (_input: T) => Promise.resolve({} as U);
-  deferred = true;
-  requiresApproval = true;
-  skipped = false;
+export type AnyAgentTool = AgentTool<string, any, any>;
 
-  static create<T, U>(params: IAgentTool<T, U>): AgentTool<T, U> {
-    const tool = new AgentTool<T, U>();
-    tool.name = params.name;
-    tool.description = params.description;
-    tool.inputSchema = params.inputSchema;
-    tool.outputSchema = params.outputSchema;
-    tool.execute = params.execute as any;
-    tool.deferred = params.deferred;
-    tool.requiresApproval = params.requiresApproval;
-    return tool;
-  }
+/** The tool tuple, erased to the payload types the client is allowed to see. */
+export type ToolShapesOf<T extends readonly AnyAgentTool[]> = {
+  [K in T[number] as K["name"]]: K extends AgentTool<any, infer I, infer O>
+    ? { input: I; output: O }
+    : never;
+};
+
+// --- skills --------------------------------------------------------------
+
+/**
+ * A skill is instructions the model can go and fetch.
+ *
+ * Inlining every skill into the system prompt costs its tokens on every request
+ * and gets worse with each skill added, so only `name` and `description` are
+ * prompted; a reserved `load_skill` tool hands over `instructions` (and any
+ * files) when the model decides it needs them. The cost of a skill the model
+ * does not use is then a line of text, which is what makes having thirty of
+ * them viable.
+ */
+export interface SkillDefinition<Name extends string = string> {
+  name: Name;
+  /** Read on every request — this is what the model decides to load from. */
+  description: string;
+  /** A thunk so a large body stays off the startup path and out of memory. */
+  instructions: string | (() => string | Promise<string>);
+  /** Paths resolved relative to the app root, appended after `instructions`. */
+  files?: string[];
 }
 
-const grepTool = AgentTool.create({
-  name: "grep",
-  description: "Search for a pattern in a file",
-  inputSchema: {} as Schema<{ pattern: string; filePath: string }>,
-  outputSchema: {} as Schema<{ matches: string[] }>,
-  execute: async (input) => {
-    const { pattern, filePath } = input;
-    // Simulate grep operation
-    return { matches: [`Found ${pattern} in ${filePath}`] };
-  },
-  deferred: false,
-  requiresApproval: false,
-});
+export declare class Skill<Name extends string = string> {
+  readonly name: Name;
+  readonly description: string;
+  static create<const Name extends string>(params: SkillDefinition<Name>): Skill<Name>;
+}
 
-const bashTool = AgentTool.create({
-  name: "bash",
-  description: "Execute a bash command",
-  inputSchema: {} as Schema<{ command: string }>,
-  outputSchema: {} as Schema<{ output: string }>,
-  execute: async (input) => {
-    const { command } = input;
-    // Simulate bash command execution
-    return { output: `Executed command: ${command}` };
-  },
-  deferred: false,
-  requiresApproval: true,
-});
+// --- agent ---------------------------------------------------------------
 
-interface CreateAgentParams<T extends AgentTool<any, any>[]> {
+export type ReasoningEffort = "minimal" | "low" | "medium" | "high";
+
+export interface CreateAgentParams<
+  T extends readonly AnyAgentTool[],
+  S extends readonly Skill[],
+  O extends Schema<any> | undefined,
+> {
   name: string;
-  tools: T;
+  /** The system prompt. Per-request additions belong on the controller, which
+   *  has the request; this is the part that is the same for everyone. */
+  instructions?: string;
   provider: AgentProvider;
+  tools?: T;
+  skills?: S;
+  /**
+   * Makes the final assistant turn strict JSON instead of prose. Tool turns are
+   * unaffected — only the answer is constrained, which is the only place a
+   * schema can apply once there is a tool loop.
+   */
+  output?: O;
+  /** Ends the run with `finishReason: "max-steps"` rather than throwing: an
+   *  agent that loops is a bug to show, not an exception to swallow. */
+  maxSteps?: number;
+  reasoning?: ReasoningEffort;
 }
 
-export class Agent<const T extends AgentTool<any, any>[] = AgentTool<any, any>[]> {
-  tools: T;
-  skills: any[];
-  provider: AgentProvider;
-
-  static create<const T extends AgentTool<any, any>[]>(params: CreateAgentParams<T>): Agent<T> {
-    const agent = new Agent<T>();
-    agent.tools = params.tools;
-    return agent;
-  }
-
-  stream() {}
+export interface AgentStreamParams {
+  /** Prior turns. The controller loads these from its store. */
+  messages: AgentMessage[];
+  /** The new user turn, if this call is starting one. */
+  input?: UserMessageInput;
+  req: HttpRequest<any, any>;
+  signal?: AbortSignal;
+  runId?: string;
+  threadId?: string;
+  /** Appended to the agent's own `instructions` for this request only. */
+  instructions?: string;
+  /** Implementations for `deferred` tools, supplied by the controller. */
+  tools?: Record<string, ToolExecute<any, any>>;
+  /** Per-request model choice, e.g. letting a user pick. */
+  provider?: AgentProvider;
+  maxSteps?: number;
+  reasoning?: ReasoningEffort;
 }
 
-const mainAgent = Agent.create({
-  name: "MainAgent",
-  tools: [grepTool, bashTool],
-  provider: OpenAIProvider.model("gpt-5.4"),
-});
+export interface AgentResumeParams extends Omit<AgentStreamParams, "input"> {
+  runId: string;
+  /** One entry per parked tool call. */
+  decisions: { toolCallId: string; approve: boolean; reason?: string }[];
+}
 
-type MainAgent = typeof mainAgent;
+export type AgentRunResult<T extends ToolShapes, O> = {
+  runId: string;
+  /** Everything produced this run — the controller persists these. */
+  messages: AgentMessage<T, O>[];
+  finishReason: FinishReason;
+  usage: Usage;
+  /** Set when the agent declares an `output` schema and the run finished. */
+  output?: O;
+};
 
-type X = MainAgent["tools"][0];
+/**
+ * A run is an async iterable of events, and the SSE encoding is a method on it
+ * rather than a separate helper — so the same object serves a controller
+ * returning a `Response` and a server-side caller that just wants to await the
+ * result.
+ */
+export interface AgentRun<T extends ToolShapes = ToolShapes, O = unknown> extends AsyncIterable<
+  AgentStreamEvent<T, O>
+> {
+  readonly runId: string;
+  toResponse(): Response;
+  result(): Promise<AgentRunResult<T, O>>;
+}
+
+export declare class Agent<
+  const T extends readonly AnyAgentTool[] = readonly AnyAgentTool[],
+  const S extends readonly Skill[] = readonly Skill[],
+  O extends Schema<any> | undefined = undefined,
+> {
+  readonly name: string;
+  readonly tools: T;
+  readonly skills: S;
+  readonly provider: AgentProvider;
+  readonly output: O;
+
+  static create<
+    const T extends readonly AnyAgentTool[],
+    const S extends readonly Skill[],
+    O extends Schema<any> | undefined = undefined,
+  >(params: CreateAgentParams<T, S, O>): Agent<T, S, O>;
+
+  stream(params: AgentStreamParams): AgentRun<ToolShapesOf<T>, OutputOf<O>>;
+  /** Continues a parked run. Same event stream, so the client decodes one thing. */
+  resume(params: AgentResumeParams): AgentRun<ToolShapesOf<T>, OutputOf<O>>;
+}
+
+export type OutputOf<O> = O extends Schema<any> ? Infer<O> : never;
+
+export type AnyAgent = Agent<any, any, any>;

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -252,7 +252,18 @@ export interface AgentRun<T extends ToolShapes = ToolShapes, O = unknown> extend
   frames(from?: number): AsyncIterable<AgentStreamFrame<T, O>>;
   toResponse(params?: { from?: number }): Response;
   result(): Promise<AgentRunResult<T, O>>;
-  stop(): void;
+  /**
+   * Cancels the run and closes the conversation behind it: every tool call
+   * still in flight gets a `denied` result with `cause: "stopped"`, the
+   * assistant message is finalized with `finishReason: "aborted"`, and both go
+   * through `onMessage` like any other message.
+   *
+   * That last part is the point. A cancel that merely stops emitting leaves a
+   * history the provider will reject on the next turn, so the run's last act is
+   * to make the transcript valid — which is also what lets the user carry on
+   * talking instead of starting over.
+   */
+  stop(params?: { reason?: string }): void;
 }
 
 export declare class Agent<

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -71,11 +71,13 @@ const bashTool = AgentTool.create({
 interface CreateAgentParams<T extends AgentTool<any, any>[]> {
   name: string;
   tools: T;
+  provider: AgentProvider;
 }
 
 export class Agent<const T extends AgentTool<any, any>[] = AgentTool<any, any>[]> {
   tools: T;
   skills: any[];
+  provider: AgentProvider;
 
   static create<const T extends AgentTool<any, any>[]>(params: CreateAgentParams<T>): Agent<T> {
     const agent = new Agent<T>();
@@ -89,6 +91,7 @@ export class Agent<const T extends AgentTool<any, any>[] = AgentTool<any, any>[]
 const mainAgent = Agent.create({
   name: "MainAgent",
   tools: [grepTool, bashTool],
+  provider: OpenAIProvider.model("gpt-5.4"),
 });
 
 type MainAgent = typeof mainAgent;

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -5,10 +5,11 @@ import type { Infer, Schema } from "./Schema";
 import type {
   AgentMessage,
   AgentStreamEvent,
+  AgentStreamFrame,
+  ClientTurn,
   FinishReason,
   ToolShapes,
   Usage,
-  UserMessageInput,
 } from "./types";
 
 // --- tools ---------------------------------------------------------------
@@ -27,8 +28,11 @@ export interface ToolContext {
   runId: string;
   threadId?: string;
   toolCallId: string;
-  /** Aborted when the client disconnects or calls `stop()`. Long tools should
-   *  pass it to whatever they call. */
+  /**
+   * Aborted when the user calls `stop()`. Not when the connection drops — a run
+   * outlives the request that started it so a refresh can reattach, which means
+   * a disconnect is no longer a signal to stop working.
+   */
   signal: AbortSignal;
   /** Which step of the tool loop this is, starting at 1. */
   step: number;
@@ -53,33 +57,50 @@ type ToolDefinitionBase<Name extends string, Input, Output> = {
   description: string;
   inputSchema: Schema<Input>;
   /**
-   * Optional, unlike the input schema. The model is only ever shown the
-   * serialized result, so the output schema buys type-safety on the client and
-   * a runtime check on what a tool returned — not better model behaviour.
+   * Optional for a server tool, required for a client one — there it is what
+   * the answer is validated against before the model sees it, and what types
+   * the value the browser has to produce.
    */
   outputSchema?: Schema<Output>;
-  /**
-   * Parks the run and asks the human before the tool runs. The stream ends with
-   * `approval-required`; answering it on the resume route continues the same
-   * run. Defaults to `false` — a tool that needs a human should have to say so.
-   */
-  requiresApproval?: boolean;
 };
 
 /**
- * `deferred` means the agent declares the tool's shape while the controller
- * supplies the implementation at request time. It is for the tool that has to
- * close over the request in a way `ctx` does not cover, or whose implementation
- * differs per deployment — the agent stays a static, shareable declaration.
+ * Three ways a tool's result comes to exist, and the one thing they share is
+ * that none of them changes the conversation's shape.
+ *
+ * `execute` — the server runs it.
+ * `deferred` — the agent declares it, the controller supplies the
+ *   implementation at request time; for the tool that has to close over the
+ *   request in a way `ctx` does not cover, or that differs per deployment.
+ * `answeredBy: "client"` — the browser produces the result: a question for the
+ *   user, or something only the page can do. The stream ends `awaiting-input`
+ *   and the answer arrives as an ordinary turn.
+ *
+ * `requiresApproval` is orthogonal and applies to the first two: the server can
+ * run the tool, but asks first. That, too, ends the stream `awaiting-input`,
+ * which is the whole reason there is no second endpoint — an approval is a
+ * question whose answer happens to be yes or no.
  */
 export type ToolDefinition<Name extends string, Input, Output> =
   | (ToolDefinitionBase<Name, Input, Output> & {
       deferred?: false;
+      answeredBy?: "server";
       execute: ToolExecute<Input, Output>;
+      requiresApproval?: boolean;
     })
   | (ToolDefinitionBase<Name, Input, Output> & {
       deferred: true;
+      answeredBy?: "server";
       execute?: never;
+      requiresApproval?: boolean;
+    })
+  | (ToolDefinitionBase<Name, Input, Output> & {
+      answeredBy: "client";
+      outputSchema: Schema<Output>;
+      deferred?: never;
+      execute?: never;
+      /** Meaningless here: the client answering *is* the approval. */
+      requiresApproval?: never;
     });
 
 export declare class AgentTool<Name extends string = string, Input = unknown, Output = unknown> {
@@ -89,6 +110,7 @@ export declare class AgentTool<Name extends string = string, Input = unknown, Ou
   readonly outputSchema?: Schema<Output>;
   readonly requiresApproval: boolean;
   readonly deferred: boolean;
+  readonly answeredBy: "server" | "client";
   readonly execute?: ToolExecute<Input, Output>;
 
   /**
@@ -98,6 +120,17 @@ export declare class AgentTool<Name extends string = string, Input = unknown, Ou
   static create<const Name extends string, Input, Output>(
     params: ToolDefinition<Name, Input, Output>,
   ): AgentTool<Name, Input, Output>;
+
+  /**
+   * Sugar for the common client tool: the agent asks the user something and
+   * waits. Equivalent to `answeredBy: "client"` with an input schema of one
+   * prompt field.
+   */
+  static ask<const Name extends string, Output>(params: {
+    name: Name;
+    description: string;
+    outputSchema: Schema<Output>;
+  }): AgentTool<Name, { question: string }, Output>;
 }
 
 export type AnyAgentTool = AgentTool<string, any, any>;
@@ -165,12 +198,19 @@ export interface CreateAgentParams<
   reasoning?: ReasoningEffort;
 }
 
+/**
+ * One call per client turn — a first message and an answer to a pending
+ * approval take the same path, because they are the same thing: the next turn
+ * of a conversation.
+ */
 export interface AgentStreamParams {
-  /** Prior turns. The controller loads these from its store. */
+  /** Prior turns. The controller loads these from its store, or takes what the
+   *  client sent when running stateless. */
   messages: AgentMessage[];
-  /** The new user turn, if this call is starting one. */
-  input?: UserMessageInput;
+  /** The client's turn: text, answers to pending calls, or both. */
+  turn?: ClientTurn;
   req: HttpRequest<any, any>;
+  /** Aborted by an explicit `stop`, not by a disconnect. */
   signal?: AbortSignal;
   runId?: string;
   threadId?: string;
@@ -182,12 +222,6 @@ export interface AgentStreamParams {
   provider?: AgentProvider;
   maxSteps?: number;
   reasoning?: ReasoningEffort;
-}
-
-export interface AgentResumeParams extends Omit<AgentStreamParams, "input"> {
-  runId: string;
-  /** One entry per parked tool call. */
-  decisions: { toolCallId: string; approve: boolean; reason?: string }[];
 }
 
 export type AgentRunResult<T extends ToolShapes, O> = {
@@ -205,13 +239,20 @@ export type AgentRunResult<T extends ToolShapes, O> = {
  * rather than a separate helper — so the same object serves a controller
  * returning a `Response` and a server-side caller that just wants to await the
  * result.
+ *
+ * A run keeps going when its request ends. That is what makes reattaching after
+ * a refresh possible, and it is why `stop()` is an explicit call rather than the
+ * client closing a socket.
  */
 export interface AgentRun<T extends ToolShapes = ToolShapes, O = unknown> extends AsyncIterable<
   AgentStreamEvent<T, O>
 > {
   readonly runId: string;
-  toResponse(): Response;
+  /** Numbered events, replayable from a cursor. `toResponse` is this, encoded. */
+  frames(from?: number): AsyncIterable<AgentStreamFrame<T, O>>;
+  toResponse(params?: { from?: number }): Response;
   result(): Promise<AgentRunResult<T, O>>;
+  stop(): void;
 }
 
 export declare class Agent<
@@ -232,8 +273,6 @@ export declare class Agent<
   >(params: CreateAgentParams<T, S, O>): Agent<T, S, O>;
 
   stream(params: AgentStreamParams): AgentRun<ToolShapesOf<T>, OutputOf<O>>;
-  /** Continues a parked run. Same event stream, so the client decodes one thing. */
-  resume(params: AgentResumeParams): AgentRun<ToolShapesOf<T>, OutputOf<O>>;
 }
 
 export type OutputOf<O> = O extends Schema<any> ? Infer<O> : never;

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -197,11 +197,20 @@ export type ToolShapesOf<T extends readonly ToolEntry[]> = {
  * A skill is instructions the model can go and fetch.
  *
  * Inlining every skill into the system prompt costs its tokens on every request
- * and gets worse with each skill added, so only `name` and `description` are
- * prompted; a reserved `load_skill` tool hands over `instructions` (and any
- * files) when the model decides it needs them. The cost of a skill the model
- * does not use is then a line of text, which is what makes having thirty of
- * them viable.
+ * and gets worse with each skill added. So a skill is lowered to a tool: one
+ * zero-parameter function per skill, in a reserved `skills` namespace, whose
+ * description is the skill's and whose result is `instructions` plus any
+ * `files`. Only those descriptions are prompted, and a skill the model never
+ * reaches for costs a line of text.
+ *
+ * Lowering to a tool rather than to a synthetic `load_skill(name)` dispatcher
+ * is the whole trick: discovery is then the same mechanism as everything else
+ * the model chooses between, which means it runs on the provider's own
+ * tool-selection machinery instead of on a string argument gemi would have to
+ * validate, and a skill that is never loaded is a namespace entry rather than a
+ * branch in our code. It is also why `deferred` applies here unchanged — with
+ * tool search the namespace is searched, and without it the same tools are
+ * listed inline, which for zero-parameter functions costs almost nothing.
  */
 export interface SkillDefinition<Name extends string = string> {
   name: Name;
@@ -234,6 +243,8 @@ export interface CreateAgentParams<
   instructions?: string;
   provider: AgentProvider;
   tools?: T;
+  /** Lowered into the reserved `skills` namespace — see `Skill`. The name is
+   *  reserved, so a namespace of your own cannot be called `skills`. */
   skills?: S;
   /**
    * Makes the final assistant turn strict JSON instead of prose. Tool turns are

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -62,42 +62,49 @@ type ToolDefinitionBase<Name extends string, Input, Output> = {
    * the value the browser has to produce.
    */
   outputSchema?: Schema<Output>;
+  /**
+   * Withholds this tool's parameter schema from the request: the model is shown
+   * only the name and description, and pulls the rest in with the provider's
+   * `tool_search` when it decides it wants the tool (`defer_loading` on the
+   * wire).
+   *
+   * It says nothing about who runs the tool or when — it is a statement about
+   * the prompt, not about execution. What it buys is context: an agent with
+   * forty tools spends most of its prompt on schemas for tools it will not
+   * call, and deferred ones load at the end of the window, so adding one
+   * mid-conversation does not invalidate the cache.
+   *
+   * Purely an optimization, and gemi treats it as one: a provider that cannot
+   * do tool search is sent the schemas inline, and the agent behaves the same.
+   * So it is safe to set on a model that does not support it, and worth setting
+   * only for tools that are large, numerous, or rarely reached.
+   */
+  deferred?: boolean;
 };
 
 /**
- * Three ways a tool's result comes to exist, and the one thing they share is
- * that none of them changes the conversation's shape.
+ * Two ways a tool's result comes to exist, and neither changes the shape of the
+ * conversation.
  *
  * `execute` — the server runs it.
- * `deferred` — the agent declares it, the controller supplies the
- *   implementation at request time; for the tool that has to close over the
- *   request in a way `ctx` does not cover, or that differs per deployment.
  * `answeredBy: "client"` — the browser produces the result: a question for the
  *   user, or something only the page can do. The stream ends `awaiting-input`
  *   and the answer arrives as an ordinary turn.
  *
- * `requiresApproval` is orthogonal and applies to the first two: the server can
- * run the tool, but asks first. That, too, ends the stream `awaiting-input`,
- * which is the whole reason there is no second endpoint — an approval is a
- * question whose answer happens to be yes or no.
+ * `requiresApproval` applies to the first: the server can run the tool, but
+ * asks first. That, too, ends the stream `awaiting-input`, which is the whole
+ * reason there is no second endpoint — an approval is a question whose answer
+ * happens to be yes or no.
  */
 export type ToolDefinition<Name extends string, Input, Output> =
   | (ToolDefinitionBase<Name, Input, Output> & {
-      deferred?: false;
       answeredBy?: "server";
       execute: ToolExecute<Input, Output>;
       requiresApproval?: boolean;
     })
   | (ToolDefinitionBase<Name, Input, Output> & {
-      deferred: true;
-      answeredBy?: "server";
-      execute?: never;
-      requiresApproval?: boolean;
-    })
-  | (ToolDefinitionBase<Name, Input, Output> & {
       answeredBy: "client";
       outputSchema: Schema<Output>;
-      deferred?: never;
       execute?: never;
       /** Meaningless here: the client answering *is* the approval. */
       requiresApproval?: never;
@@ -111,6 +118,7 @@ export declare class AgentTool<Name extends string = string, Input = unknown, Ou
   readonly requiresApproval: boolean;
   readonly deferred: boolean;
   readonly answeredBy: "server" | "client";
+  readonly namespace?: string;
   readonly execute?: ToolExecute<Input, Output>;
 
   /**
@@ -135,9 +143,50 @@ export declare class AgentTool<Name extends string = string, Input = unknown, Ou
 
 export type AnyAgentTool = AgentTool<string, any, any>;
 
+/**
+ * A group of tools the model can search as a unit.
+ *
+ * The provider's tool search works over namespaces, and the guidance is fewer
+ * than ten functions in each — the model looks at a namespace's description to
+ * decide whether anything inside is worth loading, so the grouping is part of
+ * the prompt, not bookkeeping. A namespace is also the only place a
+ * *collection* of tools can be described; on a flat list that sentence has
+ * nowhere to go.
+ *
+ * Tool names stay globally unique within an agent, so the browser still
+ * discriminates on `name` alone and the namespace never leaks into the client's
+ * types.
+ */
+export declare class ToolNamespace<
+  Name extends string = string,
+  T extends readonly AnyAgentTool[] = readonly AnyAgentTool[],
+> {
+  readonly name: Name;
+  readonly description: string;
+  readonly tools: T;
+  static create<const Name extends string, const T extends readonly AnyAgentTool[]>(params: {
+    name: Name;
+    /** What the model reads when deciding whether to search inside. */
+    description: string;
+    tools: T;
+    /** Defers every tool in the group, so the whole namespace costs its own
+     *  description plus one line per tool until something is loaded. */
+    deferred?: boolean;
+  }): ToolNamespace<Name, T>;
+}
+
+/** What an agent's `tools` may hold: tools, or namespaces of them. */
+export type ToolEntry = AnyAgentTool | ToolNamespace<string, readonly AnyAgentTool[]>;
+
+type FlattenTools<T extends readonly ToolEntry[]> = T[number] extends infer E
+  ? E extends ToolNamespace<any, infer NT>
+    ? NT[number]
+    : E
+  : never;
+
 /** The tool tuple, erased to the payload types the client is allowed to see. */
-export type ToolShapesOf<T extends readonly AnyAgentTool[]> = {
-  [K in T[number] as K["name"]]: K extends AgentTool<any, infer I, infer O>
+export type ToolShapesOf<T extends readonly ToolEntry[]> = {
+  [K in FlattenTools<T> as K["name"]]: K extends AgentTool<any, infer I, infer O>
     ? { input: I; output: O }
     : never;
 };
@@ -175,7 +224,7 @@ export declare class Skill<Name extends string = string> {
 export type ReasoningEffort = "minimal" | "low" | "medium" | "high";
 
 export interface CreateAgentParams<
-  T extends readonly AnyAgentTool[],
+  T extends readonly ToolEntry[],
   S extends readonly Skill[],
   O extends Schema<any> | undefined,
 > {
@@ -216,8 +265,6 @@ export interface AgentStreamParams {
   threadId?: string;
   /** Appended to the agent's own `instructions` for this request only. */
   instructions?: string;
-  /** Implementations for `deferred` tools, supplied by the controller. */
-  tools?: Record<string, ToolExecute<any, any>>;
   /** Per-request model choice, e.g. letting a user pick. */
   provider?: AgentProvider;
   maxSteps?: number;
@@ -267,7 +314,7 @@ export interface AgentRun<T extends ToolShapes = ToolShapes, O = unknown> extend
 }
 
 export declare class Agent<
-  const T extends readonly AnyAgentTool[] = readonly AnyAgentTool[],
+  const T extends readonly ToolEntry[] = readonly ToolEntry[],
   const S extends readonly Skill[] = readonly Skill[],
   O extends Schema<any> | undefined = undefined,
 > {
@@ -278,7 +325,7 @@ export declare class Agent<
   readonly output: O;
 
   static create<
-    const T extends readonly AnyAgentTool[],
+    const T extends readonly ToolEntry[],
     const S extends readonly Skill[],
     O extends Schema<any> | undefined = undefined,
   >(params: CreateAgentParams<T, S, O>): Agent<T, S, O>;

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -1,48 +1,163 @@
-// @ts-nocheck — the ai rfc is a sketch, not an interface anyone depends on:
-// nothing exports `gemi/ai` and nothing in the package imports it, so its only
-// reader is `tsc`, and a half-drawn signature there fails `bun run typecheck`
-// and `build:types` for everyone. Checked again by deleting this line, which is
-// the point of a per-file directive rather than dropping `ai` from the
-// tsconfig: the files stay in the project, and the exemption is visible in the
-// file that has it.
-import { Agent, AgentTool, Schema } from "./Agent";
-import { HttpRequest } from "../http";
+// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
+import type { Controller } from "../http/Controller";
+import type { HttpRequest } from "../http";
+import type { MiddlewareInput } from "../http/middlewareList";
+import type { AgentRun, AgentRunResult, AnyAgent, ToolExecute, ToolShapesOf } from "./Agent";
+import type { AgentError, AgentMessage, ToolShapes } from "./types";
 
-export class AgentController<T extends Agent<any> = Agent<any>> {
-  constructor(private agent: T) {}
+// --- storage -------------------------------------------------------------
 
-  stream(req: HttpRequest) {
-    this.agent.stream();
-  }
+/**
+ * A run parked on an approval. It has to survive between two HTTP requests, so
+ * it holds everything needed to pick the loop back up: which tools were asked
+ * about, and the messages produced up to that point.
+ */
+export type ParkedRun = {
+  runId: string;
+  threadId?: string;
+  agent: string;
+  messages: AgentMessage[];
+  pending: { toolCallId: string; name: string; input: unknown }[];
+  createdAt: string;
+  expiresAt: string;
+};
+
+/**
+ * Where conversations and parked runs live.
+ *
+ * Stateless is the default, so nothing here is required to send a message: an
+ * app that never uses approvals and lets the client hold history can ignore
+ * this entirely. The moment a tool sets `requiresApproval`, though, a run has to
+ * be recoverable by a *second* request — and the in-memory default only
+ * recovers it in the same process. That is fine in dev and wrong behind more
+ * than one server, so an app using approvals is expected to supply a real store.
+ */
+export interface AgentStore {
+  createThread(params: { userId?: string | number }): Promise<{ threadId: string }>;
+  loadThread(threadId: string): Promise<AgentMessage[]>;
+  appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
+
+  saveRun(run: ParkedRun): Promise<void>;
+  loadRun(runId: string): Promise<ParkedRun | null>;
+  deleteRun(runId: string): Promise<void>;
 }
 
-const bashTool = AgentTool.create({
-  name: "bash",
-  description: "Execute a bash command",
-  inputSchema: {} as Schema<{ command: string }>,
-  outputSchema: {} as Schema<{ output: string }>,
-  execute: async (input) => {
-    const { command } = input;
-    // Simulate bash command execution
-    return { output: `Executed command: ${command}` };
-  },
-  deferred: false,
-  requiresApproval: true,
-});
-
-const MyAgent = Agent.create({
-  name: "MyAgent",
-  tools: [bashTool],
-});
-
-class MyAgentController extends AgentController<typeof MyAgent> {
-  constructor() {
-    super(MyAgent);
-  }
-
-  private onMessage() {}
-  private onError() {}
-  private onStreamComplete() {}
+/** The default. Single-process only — see the note on `AgentStore`. */
+export declare class MemoryAgentStore implements AgentStore {
+  constructor(params?: { ttlMs?: number });
+  createThread(params: { userId?: string | number }): Promise<{ threadId: string }>;
+  loadThread(threadId: string): Promise<AgentMessage[]>;
+  appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
+  saveRun(run: ParkedRun): Promise<void>;
+  loadRun(runId: string): Promise<ParkedRun | null>;
+  deleteRun(runId: string): Promise<void>;
 }
 
-type X = MyAgentController["agent"]["tools"][0];
+// --- controller ----------------------------------------------------------
+
+/** Passed to every hook, so a subclass never has to thread state through
+ *  itself. */
+export type AgentHookContext = {
+  req: HttpRequest<any, any>;
+  runId: string;
+  threadId?: string;
+};
+
+export declare abstract class AgentController<A extends AnyAgent = AnyAgent> extends Controller {
+  static kind: "agent-controller";
+
+  /** The agent this controller serves. A property rather than a constructor
+   *  argument so `Router.agent(ChatController)` can take the class, matching how
+   *  every other controller is mounted. */
+  abstract agent: A;
+
+  /** Defaults to `MemoryAgentStore`. */
+  store: AgentStore;
+
+  /**
+   * Implementations for the agent's `deferred` tools. Typed against the agent's
+   * declared tools, so a missing or misnamed one is a compile error rather than
+   * a tool the model calls into nothing.
+   */
+  tools?: {
+    [K in keyof ToolShapesOf<A["tools"]>]?: ToolExecute<
+      ToolShapesOf<A["tools"]>[K]["input"],
+      ToolShapesOf<A["tools"]>[K]["output"]
+    >;
+  };
+
+  /** Appended to the agent's static instructions for this request — the user's
+   *  name, tenant, today's date. */
+  instructions(req: HttpRequest<any, any>): string | Promise<string> | void;
+
+  /** `POST /<path>` — starts or continues a conversation. */
+  stream(req: HttpRequest<any, any>): Promise<Response>;
+  /** `POST /<path>/resume` — answers pending approvals and continues the run. */
+  resume(req: HttpRequest<any, any>): Promise<Response>;
+  /** `POST /<path>/files` — uploads an attachment and returns its file id. */
+  upload(req: HttpRequest<any, any>): Promise<{ fileId: string }>;
+
+  /**
+   * Protected, not private: these exist to be overridden. `onMessage` fires for
+   * every completed message, user and assistant alike, and is the intended
+   * persistence point for an app that is not using `store`.
+   */
+  protected onMessage(message: AgentMessage, ctx: AgentHookContext): void | Promise<void>;
+  protected onToolCall(
+    call: { toolCallId: string; name: string; input: unknown },
+    ctx: AgentHookContext,
+  ): void | Promise<void>;
+  /** Fires before the stream ends with `approval-required` — the place to send
+   *  a notification to whoever has to approve. */
+  protected onApprovalRequired(
+    pending: ParkedRun["pending"],
+    ctx: AgentHookContext,
+  ): void | Promise<void>;
+  protected onError(error: AgentError, ctx: AgentHookContext): void | Promise<void>;
+  protected onStreamComplete(
+    result: AgentRunResult<ToolShapesOf<A["tools"]>, any>,
+    ctx: AgentHookContext,
+  ): void | Promise<void>;
+}
+
+// --- routing -------------------------------------------------------------
+//
+// `agent()` itself belongs on ApiRouter next to `resource()`, which is the
+// method it works like: one call, several routes, all of them the controller's.
+// The types are sketched here because they are the ai module's contract, not
+// the router's.
+//
+//   class Api extends ApiRouter {
+//     routes = {
+//       "/chat": this.agent(ChatAgentController),
+//     };
+//   }
+//
+//   POST /chat        → stream
+//   POST /chat/resume → resume
+//   POST /chat/files  → upload
+//
+// Mounting under a single path is what gives the client one key to name. The
+// agent's tool types ride along on `AgentRoute`, so `useChat("/chat")` gets them
+// out of the existing `RPC` interface — no second augmentation to generate, and
+// renaming the route moves the client key with it.
+
+export type AgentRouteMethod = "stream" | "resume" | "upload";
+
+export type AgentMiddlewareConfig = Partial<Record<AgentRouteMethod, MiddlewareInput>>;
+
+export type AgentRoute<T extends new () => AgentController<any>> = {
+  __internal_brand: "AgentRoute";
+  controller: T;
+  middleware(config: AgentMiddlewareConfig): AgentRoute<T>;
+};
+
+/** What `CreateRPC` should produce for an agent route: enough for the client to
+ *  type its messages, and nothing that drags server code into the bundle. */
+export type AgentRouteRPC<T extends new () => AgentController<any>> = {
+  __agent: true;
+  tools: InstanceType<T>["agent"] extends AnyAgent
+    ? ToolShapesOf<InstanceType<T>["agent"]["tools"]>
+    : ToolShapes;
+  output: unknown;
+};

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -101,8 +101,17 @@ export declare abstract class AgentController<A extends AnyAgent = AnyAgent> ext
    * the work never paused, the listener changed.
    */
   attach(req: HttpRequest<any, any>): Promise<Response>;
-  /** `POST /<path>/stop` — the explicit cancel. Since a dropped connection no
-   *  longer stops a run, this is the only thing that does. */
+  /**
+   * `POST /<path>/stop` — the explicit cancel. Since a dropped connection no
+   * longer stops a run, this is the only thing that does, and it is why
+   * stopping cannot be a client-side concern: the tool loop is here, and a
+   * client that stops reading has not stopped step four from charging a card.
+   *
+   * Returns as soon as the run is aborted, not when it has finished unwinding.
+   * The terminal events — the stopped tool results, the aborted message — go
+   * out on the run's own stream, so whoever is watching it sees the ending,
+   * and `onMessage` records it whether anyone is watching or not.
+   */
   stop(req: HttpRequest<any, any>): Promise<{ stopped: boolean }>;
   /** `POST /<path>/files` — uploads an attachment and returns its file id. */
   upload(req: HttpRequest<any, any>): Promise<{ fileId: string }>;

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -2,7 +2,7 @@
 import type { HttpRequest } from "../http";
 import type { Controller } from "../http/Controller";
 import type { MiddlewareInput } from "../http/middlewareList";
-import type { AgentRun, AgentRunResult, AnyAgent, ToolExecute, ToolShapesOf } from "./Agent";
+import type { AgentRun, AgentRunResult, AnyAgent, ToolShapesOf } from "./Agent";
 import type { AgentError, AgentMessage, PendingToolCall, ToolShapes } from "./types";
 
 // --- storage -------------------------------------------------------------
@@ -72,18 +72,6 @@ export declare abstract class AgentController<A extends AnyAgent = AnyAgent> ext
 
   /** Defaults to `MemoryAgentStore`. */
   store: AgentStore;
-
-  /**
-   * Implementations for the agent's `deferred` tools. Typed against the agent's
-   * declared tools, so a missing or misnamed one is a compile error rather than
-   * a tool the model calls into nothing.
-   */
-  tools?: {
-    [K in keyof ToolShapesOf<A["tools"]>]?: ToolExecute<
-      ToolShapesOf<A["tools"]>[K]["input"],
-      ToolShapesOf<A["tools"]>[K]["output"]
-    >;
-  };
 
   /** Appended to the agent's static instructions for this request — the user's
    *  name, tenant, today's date. */

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -1,62 +1,61 @@
 // @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
-import type { Controller } from "../http/Controller";
 import type { HttpRequest } from "../http";
+import type { Controller } from "../http/Controller";
 import type { MiddlewareInput } from "../http/middlewareList";
 import type { AgentRun, AgentRunResult, AnyAgent, ToolExecute, ToolShapesOf } from "./Agent";
-import type { AgentError, AgentMessage, ToolShapes } from "./types";
+import type { AgentError, AgentMessage, PendingToolCall, ToolShapes } from "./types";
 
 // --- storage -------------------------------------------------------------
 
 /**
- * A run parked on an approval. It has to survive between two HTTP requests, so
- * it holds everything needed to pick the loop back up: which tools were asked
- * about, and the messages produced up to that point.
- */
-export type ParkedRun = {
-  runId: string;
-  threadId?: string;
-  agent: string;
-  messages: AgentMessage[];
-  pending: { toolCallId: string; name: string; input: unknown }[];
-  createdAt: string;
-  expiresAt: string;
-};
-
-/**
- * Where conversations and parked runs live.
+ * Where conversations live.
  *
- * Stateless is the default, so nothing here is required to send a message: an
- * app that never uses approvals and lets the client hold history can ignore
- * this entirely. The moment a tool sets `requiresApproval`, though, a run has to
- * be recoverable by a *second* request — and the in-memory default only
- * recovers it in the same process. That is fine in dev and wrong behind more
- * than one server, so an app using approvals is expected to supply a real store.
+ * Stateless is the default and nothing here is required to hold a conversation:
+ * the client can carry its own history, and a pending approval travels in it
+ * safely because the server signed it. What a store buys is a conversation that
+ * survives the browser — and, with `/attach`, one whose interrupted turn is
+ * still there after a refresh.
  */
 export interface AgentStore {
   createThread(params: { userId?: string | number }): Promise<{ threadId: string }>;
   loadThread(threadId: string): Promise<AgentMessage[]>;
   appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
-
-  saveRun(run: ParkedRun): Promise<void>;
-  loadRun(runId: string): Promise<ParkedRun | null>;
-  deleteRun(runId: string): Promise<void>;
 }
 
-/** The default. Single-process only — see the note on `AgentStore`. */
+/** The default: conversations last as long as the process. */
 export declare class MemoryAgentStore implements AgentStore {
   constructor(params?: { ttlMs?: number });
   createThread(params: { userId?: string | number }): Promise<{ threadId: string }>;
   loadThread(threadId: string): Promise<AgentMessage[]>;
   appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
-  saveRun(run: ParkedRun): Promise<void>;
-  loadRun(runId: string): Promise<ParkedRun | null>;
-  deleteRun(runId: string): Promise<void>;
+}
+
+/**
+ * The runs currently in flight, and their frames.
+ *
+ * A run outlives the request that started it, so something has to hold it while
+ * no one is listening, and hold what it emitted meanwhile so a returning client
+ * can catch up rather than start over. That is all this is: a per-process map
+ * plus a bounded buffer.
+ *
+ * Per-process is not an implementation shortcut that a better store fixes — a
+ * running generator lives in one process, and a second server cannot attach to
+ * it. Reattachment therefore needs the request to land where the run is: one
+ * server, sticky routing, or a proxy that forwards by `runId`. Worth saying out
+ * loud, because the failure mode behind a round-robin load balancer is a
+ * refresh that usually works.
+ */
+export interface LiveRuns {
+  /** What the client asks after a refresh: is anything still going here? */
+  find(params: { threadId: string }): Promise<{ runId: string; seq: number } | null>;
+  get(runId: string): AgentRun | null;
+  /** Kept for a short while after `run-end`, so a refresh a second late still
+   *  sees the tail instead of an empty screen. */
+  ttlMs: number;
 }
 
 // --- controller ----------------------------------------------------------
 
-/** Passed to every hook, so a subclass never has to thread state through
- *  itself. */
 export type AgentHookContext = {
   req: HttpRequest<any, any>;
   runId: string;
@@ -90,10 +89,21 @@ export declare abstract class AgentController<A extends AnyAgent = AnyAgent> ext
    *  name, tenant, today's date. */
   instructions(req: HttpRequest<any, any>): string | Promise<string> | void;
 
-  /** `POST /<path>` — starts or continues a conversation. */
+  /**
+   * `POST /<path>` — one route for every client turn. A first message, an
+   * approval, an answer to a question and a client tool's result are all just
+   * the next turn, so none of them gets an endpoint of its own.
+   */
   stream(req: HttpRequest<any, any>): Promise<Response>;
-  /** `POST /<path>/resume` — answers pending approvals and continues the run. */
-  resume(req: HttpRequest<any, any>): Promise<Response>;
+  /**
+   * `POST /<path>/attach` — subscribe to a run already in progress, from a
+   * cursor. This is a read of a live run, not a continuation of a stopped one:
+   * the work never paused, the listener changed.
+   */
+  attach(req: HttpRequest<any, any>): Promise<Response>;
+  /** `POST /<path>/stop` — the explicit cancel. Since a dropped connection no
+   *  longer stops a run, this is the only thing that does. */
+  stop(req: HttpRequest<any, any>): Promise<{ stopped: boolean }>;
   /** `POST /<path>/files` — uploads an attachment and returns its file id. */
   upload(req: HttpRequest<any, any>): Promise<{ fileId: string }>;
 
@@ -107,10 +117,10 @@ export declare abstract class AgentController<A extends AnyAgent = AnyAgent> ext
     call: { toolCallId: string; name: string; input: unknown },
     ctx: AgentHookContext,
   ): void | Promise<void>;
-  /** Fires before the stream ends with `approval-required` — the place to send
-   *  a notification to whoever has to approve. */
-  protected onApprovalRequired(
-    pending: ParkedRun["pending"],
+  /** Fires before the stream ends `awaiting-input` — where to notify whoever
+   *  has to approve, if they are not the person watching the stream. */
+  protected onAwaitingInput(
+    pending: PendingToolCall[],
     ctx: AgentHookContext,
   ): void | Promise<void>;
   protected onError(error: AgentError, ctx: AgentHookContext): void | Promise<void>;
@@ -133,16 +143,17 @@ export declare abstract class AgentController<A extends AnyAgent = AnyAgent> ext
 //     };
 //   }
 //
-//   POST /chat        → stream
-//   POST /chat/resume → resume
-//   POST /chat/files  → upload
+//   POST /chat        → stream   every client turn
+//   POST /chat/attach → attach   reattach to a run in progress
+//   POST /chat/stop   → stop     explicit cancel
+//   POST /chat/files  → upload   attachments
 //
 // Mounting under a single path is what gives the client one key to name. The
 // agent's tool types ride along on `AgentRoute`, so `useChat("/chat")` gets them
 // out of the existing `RPC` interface — no second augmentation to generate, and
 // renaming the route moves the client key with it.
 
-export type AgentRouteMethod = "stream" | "resume" | "upload";
+export type AgentRouteMethod = "stream" | "attach" | "stop" | "upload";
 
 export type AgentMiddlewareConfig = Partial<Record<AgentRouteMethod, MiddlewareInput>>;
 

--- a/packages/gemi/ai/AgentProvider.ts
+++ b/packages/gemi/ai/AgentProvider.ts
@@ -1,0 +1,38 @@
+type AgentMessage = {};
+interface Stream {}
+
+interface StreamParams {
+  messages: AgentMessage[];
+  systemPrompt?: string;
+  tools?: any[];
+  skills: any[];
+  output: any;
+  reasoning: "low" | "medium" | "high";
+}
+
+export class AgentProvider {
+  static models() {}
+
+  stream(params: StreamParams): Stream {
+    return {} as Stream;
+  }
+
+  upload(file: File): Promise<string> {
+    return Promise.resolve("file-id");
+  }
+}
+
+export class OpenAIProvider extends AgentProvider {
+  model: string;
+
+  constructor(model: string = "gpt-5.4") {
+    super();
+    this.model = model;
+  }
+
+  static model(): OpenAIProvider {
+    return new OpenAIProvider();
+  }
+
+  generate(params: GenerateParams) {}
+}

--- a/packages/gemi/ai/AgentProvider.ts
+++ b/packages/gemi/ai/AgentProvider.ts
@@ -1,38 +1,148 @@
-type AgentMessage = {};
-interface Stream {}
+// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
+import type { ReasoningEffort } from "./Agent";
+import type { JSONSchema } from "./Schema";
+import type { AgentError, AgentMessage, FinishReason, Usage } from "./types";
 
-interface StreamParams {
+/**
+ * A provider makes one model call. It does not run the tool loop.
+ *
+ * The split matters: approvals, `maxSteps`, deferred tools, skill loading and
+ * persistence are all provider-independent, and putting them in the provider
+ * would mean writing them again for the second provider. So the provider's
+ * whole job is to translate gemi's messages into a request, and the response
+ * stream back into `ProviderEvent`s. Everything above that lives in `Agent`.
+ *
+ * v1 targets OpenAI's Responses API — native reasoning items and strict
+ * structured output without reassembling them by hand. The interface is kept
+ * free of anything Responses-specific so a Chat Completions provider (for older
+ * Azure deployments and OpenAI-compatible gateways) can be added later without
+ * touching Agent, Controller or the client.
+ */
+
+/** What a provider will actually honour, so `Agent` can drop the rest rather
+ *  than have a request rejected at runtime. */
+export type ProviderCapabilities = {
+  reasoning: boolean;
+  structuredOutput: boolean;
+  fileInput: boolean;
+  parallelToolCalls: boolean;
+};
+
+/** A tool as the model is shown it: schema only, no implementation. */
+export type ProviderToolSpec = {
+  name: string;
+  description: string;
+  parameters: JSONSchema;
+  strict: boolean;
+};
+
+export interface ProviderStreamParams {
   messages: AgentMessage[];
   systemPrompt?: string;
-  tools?: any[];
-  skills: any[];
-  output: any;
-  reasoning: "low" | "medium" | "high";
+  tools?: ProviderToolSpec[];
+  /** Set when the agent declares an `output` schema; the provider turns it into
+   *  whatever its own strict-JSON parameter is. */
+  output?: { name: string; schema: JSONSchema };
+  /** Optional: silently dropped by a provider whose `capabilities.reasoning`
+   *  is false, since a model that cannot reason should not fail a request. */
+  reasoning?: ReasoningEffort;
+  temperature?: number;
+  maxOutputTokens?: number;
+  signal?: AbortSignal;
 }
 
-export class AgentProvider {
-  static models() {}
+/**
+ * The events of a single model call. Deliberately smaller than
+ * `AgentStreamEvent`: no run, message, tool-result or approval events, because
+ * a provider knows about none of those.
+ */
+export type ProviderEvent =
+  | { type: "text-delta"; delta: string }
+  | { type: "reasoning-delta"; delta: string; id?: string }
+  /** Arguments arrive as JSON fragments; the provider passes them through and
+   *  `Agent` assembles and validates against the tool's schema. */
+  | { type: "tool-call-delta"; toolCallId: string; name: string; argsDelta: string }
+  | { type: "tool-call"; toolCallId: string; name: string; args: string }
+  | { type: "output-delta"; delta: string }
+  | { type: "finish"; reason: FinishReason; usage: Usage }
+  | { type: "error"; error: AgentError };
 
-  stream(params: StreamParams): Stream {
-    return {} as Stream;
-  }
+export type ProviderStream = AsyncIterable<ProviderEvent>;
 
-  upload(file: File): Promise<string> {
-    return Promise.resolve("file-id");
-  }
+export type ProviderConfig = {
+  apiKey?: string;
+  baseURL?: string;
+  timeoutMs?: number;
+  maxRetries?: number;
+  headers?: Record<string, string>;
+};
+
+export declare abstract class AgentProvider {
+  abstract readonly model: string;
+  abstract readonly capabilities: ProviderCapabilities;
+
+  /** The model ids this provider knows about — for autocomplete only; any
+   *  string is still accepted, because a new model must not require a gemi
+   *  release to use. */
+  static models(): readonly string[];
+
+  abstract stream(params: ProviderStreamParams): ProviderStream;
+
+  /**
+   * Uploads a file and returns the id a `FilePart` carries. Message history
+   * therefore holds provider file ids, which is the trade for getting vision
+   * and PDF input without gemi owning a storage story in v1.
+   */
+  abstract upload(file: File): Promise<string>;
+
+  /** Maps a provider's error body onto the normalized codes, so an app can
+   *  branch on `rate_limited` without knowing whose rate limit it was. */
+  abstract normalizeError(error: unknown): AgentError;
 }
 
-export class OpenAIProvider extends AgentProvider {
-  model: string;
+export declare class OpenAIProvider extends AgentProvider {
+  readonly model: string;
+  readonly capabilities: ProviderCapabilities;
 
-  constructor(model: string = "gpt-5.4") {
-    super();
-    this.model = model;
-  }
+  /** Config defaults come from gemi's config (`ai.openai`), so an app that has
+   *  set `OPENAI_API_KEY` writes only the model name. */
+  static model(model: string, config?: ProviderConfig): OpenAIProvider;
+  static models(): readonly string[];
 
-  static model(): OpenAIProvider {
-    return new OpenAIProvider();
-  }
+  stream(params: ProviderStreamParams): ProviderStream;
+  upload(file: File): Promise<string>;
+  normalizeError(error: unknown): AgentError;
+}
 
-  generate(params: GenerateParams) {}
+export type AzureConfig = ProviderConfig & {
+  /** `https://<resource>.openai.azure.com`. */
+  endpoint?: string;
+  apiVersion?: string;
+  /**
+   * For Entra ID instead of a key. A function, not a token, because these
+   * expire mid-conversation.
+   */
+  getToken?: () => Promise<string>;
+};
+
+/**
+ * Its own class rather than a flag on `OpenAIProvider`: Azure puts the
+ * deployment in the URL, pins an api-version, and has a second auth mode. One
+ * class carrying both shapes means every field is conditionally meaningful.
+ *
+ * The API stays symmetrical — `.model()`, not `.deployment()`. Apps name a
+ * model; mapping that onto a deployment is this class's problem, and an app
+ * that named its deployment differently overrides it in config.
+ */
+export declare class AzureOpenAIProvider extends AgentProvider {
+  readonly model: string;
+  readonly capabilities: ProviderCapabilities;
+
+  /** Defaults from gemi's config (`ai.azure`). */
+  static model(model: string, config?: AzureConfig): AzureOpenAIProvider;
+  static models(): readonly string[];
+
+  stream(params: ProviderStreamParams): ProviderStream;
+  upload(file: File): Promise<string>;
+  normalizeError(error: unknown): AgentError;
 }

--- a/packages/gemi/ai/AgentProvider.ts
+++ b/packages/gemi/ai/AgentProvider.ts
@@ -26,6 +26,13 @@ export type ProviderCapabilities = {
   structuredOutput: boolean;
   fileInput: boolean;
   parallelToolCalls: boolean;
+  /**
+   * Tool search, and with it deferred loading. Only recent models have it, so a
+   * provider that answers `false` is sent every schema inline and the agent
+   * runs identically — deferral is a token optimization, and an optimization
+   * that changed behaviour when unavailable would not be one.
+   */
+  toolSearch: boolean;
 };
 
 /** A tool as the model is shown it: schema only, no implementation. */
@@ -34,12 +41,24 @@ export type ProviderToolSpec = {
   description: string;
   parameters: JSONSchema;
   strict: boolean;
+  /** `defer_loading`: send the name and description, withhold the schema until
+   *  the model searches for it. Ignored when `capabilities.toolSearch` is
+   *  false. */
+  deferred?: boolean;
+};
+
+/** Tools grouped for search. Flattened back to a list by a provider without
+ *  tool search, since the grouping exists to be searched. */
+export type ProviderToolNamespace = {
+  name: string;
+  description: string;
+  tools: ProviderToolSpec[];
 };
 
 export interface ProviderStreamParams {
   messages: AgentMessage[];
   systemPrompt?: string;
-  tools?: ProviderToolSpec[];
+  tools?: (ProviderToolSpec | ProviderToolNamespace)[];
   /** Set when the agent declares an `output` schema; the provider turns it into
    *  whatever its own strict-JSON parameter is. */
   output?: { name: string; schema: JSONSchema };
@@ -63,6 +82,10 @@ export type ProviderEvent =
    *  `Agent` assembles and validates against the tool's schema. */
   | { type: "tool-call-delta"; toolCallId: string; name: string; argsDelta: string }
   | { type: "tool-call"; toolCallId: string; name: string; args: string }
+  /** The model went looking for a deferred tool and pulled its schema in. Worth
+   *  surfacing rather than swallowing: it is a step the user paid for, and the
+   *  pause before it is otherwise unexplained. */
+  | { type: "tool-search"; loaded: string[] }
   | { type: "output-delta"; delta: string }
   | { type: "finish"; reason: FinishReason; usage: Usage }
   | { type: "error"; error: AgentError };

--- a/packages/gemi/ai/Schema.ts
+++ b/packages/gemi/ai/Schema.ts
@@ -1,0 +1,103 @@
+// @ts-nocheck — the ai rfc is a sketch, not an interface anyone depends on:
+// nothing exports `gemi/ai` and nothing in the package imports it, so its only
+// reader is `tsc`, and a half-drawn signature there fails `bun run typecheck`
+// and `build:types` for everyone.
+
+/**
+ * The schema layer for tool inputs, tool outputs and structured final answers.
+ *
+ * Two things have to come out of one declaration: a TypeScript type, so
+ * `execute(input)` is typed at the call site and the result is typed in the
+ * browser, and a JSON Schema, because that is what the model is actually shown.
+ * A phantom `Schema<T>` gives the first and nothing of the second, and a
+ * hand-written JSON Schema next to a hand-written type gives both and lets them
+ * drift. So the builder below is the single source, and `Infer` reads the type
+ * back off it.
+ *
+ * Everything here is deliberately narrower than JSON Schema. OpenAI's strict
+ * structured output only accepts a subset — every property listed in
+ * `required`, `additionalProperties: false` on every object, no patterns, no
+ * `oneOf` at the root — and a builder that cannot express the rejected parts is
+ * better than one that lets you write a schema the API refuses at runtime.
+ */
+
+export type JSONSchema = {
+  type?: string | string[];
+  description?: string;
+  enum?: readonly (string | number)[];
+  const?: string | number | boolean;
+  properties?: Record<string, JSONSchema>;
+  required?: readonly string[];
+  additionalProperties?: false;
+  items?: JSONSchema;
+  anyOf?: readonly JSONSchema[];
+};
+
+declare const OUTPUT: unique symbol;
+
+/**
+ * `T` is carried in a phantom property rather than a real one: it exists only
+ * for inference, and a real field would show up on the object the app writes.
+ */
+export interface Schema<T> {
+  readonly [OUTPUT]: T;
+  /** The JSON Schema handed to the provider. */
+  toJSONSchema(): JSONSchema;
+  /**
+   * Parses a value coming back from the model. Tool arguments arrive as a JSON
+   * string the model generated, so they are untrusted in exactly the way a
+   * request body is: shape-checked before `execute` ever sees them.
+   */
+  parse(value: unknown): T;
+  safeParse(value: unknown): { ok: true; value: T } | { ok: false; errors: string[] };
+}
+
+export type AnySchema = Schema<any>;
+
+export type Infer<S> = S extends Schema<infer T> ? T : never;
+
+type ShapeOutput<S extends Record<string, AnySchema>> = {
+  // `-?` and the optionality below are computed from `.optional()` having wrapped
+  // the member type in `| undefined`, so the TS shape matches what the model may
+  // legally omit — see the note on `optional()` about strict mode.
+  [K in keyof S as undefined extends Infer<S[K]> ? never : K]: Infer<S[K]>;
+} & {
+  [K in keyof S as undefined extends Infer<S[K]> ? K : never]?: Infer<S[K]>;
+};
+
+interface SchemaBuilder<T> extends Schema<T> {
+  /**
+   * The description is not documentation — it is the only prose the model gets
+   * about a field, and it is the difference between a tool that is called
+   * correctly and one that is not.
+   */
+  describe(description: string): this;
+  /**
+   * Strict mode has no notion of an omitted key: every property must appear in
+   * `required`. So `optional()` emits a nullable union and the model is told to
+   * send `null`, while the TypeScript type says `| undefined` and the parsed
+   * value drops the key. The asymmetry is the point — it is what lets an app
+   * write ordinary optional fields against an API that forbids them.
+   */
+  optional(): SchemaBuilder<T | undefined>;
+  nullable(): SchemaBuilder<T | null>;
+}
+
+export declare const s: {
+  string(): SchemaBuilder<string>;
+  number(): SchemaBuilder<number>;
+  boolean(): SchemaBuilder<boolean>;
+  literal<const L extends string | number | boolean>(value: L): SchemaBuilder<L>;
+  /** Modelled as a JSON Schema `enum`, which strict mode does support. */
+  enum<const L extends readonly [string, ...string[]]>(values: L): SchemaBuilder<L[number]>;
+  object<const S extends Record<string, AnySchema>>(shape: S): SchemaBuilder<ShapeOutput<S>>;
+  array<const S extends AnySchema>(item: S): SchemaBuilder<Infer<S>[]>;
+  /**
+   * `anyOf` of object schemas, discriminated by a literal member. Left in
+   * because tool outputs are frequently a success/failure pair, and modelling
+   * that as one object with everything optional is worse for the model.
+   */
+  union<const S extends readonly [AnySchema, AnySchema, ...AnySchema[]]>(
+    members: S,
+  ): SchemaBuilder<Infer<S[number]>>;
+};

--- a/packages/gemi/ai/Schema.ts
+++ b/packages/gemi/ai/Schema.ts
@@ -34,6 +34,7 @@ export type JSONSchema = {
 };
 
 declare const OUTPUT: unique symbol;
+declare const OPTIONAL: unique symbol;
 
 /**
  * `T` is carried in a phantom property rather than a real one: it exists only
@@ -52,18 +53,46 @@ export interface Schema<T> {
   safeParse(value: unknown): { ok: true; value: T } | { ok: false; errors: string[] };
 }
 
+/**
+ * A schema whose key may be left out of the object containing it.
+ *
+ * Marked with a property rather than detected from the output type, because
+ * `undefined extends T` — the obvious test — is true of *everything* when
+ * `strictNullChecks` is off, which is how this package and plenty of apps
+ * compile. That version made every field of every tool optional, and did it
+ * quietly: the JSON Schema was still right, so only the TypeScript types lied.
+ */
+export interface OptionalSchema<T> extends Schema<T | undefined> {
+  readonly [OPTIONAL]: true;
+}
+
 export type AnySchema = Schema<any>;
 
 export type Infer<S> = S extends Schema<infer T> ? T : never;
 
-type ShapeOutput<S extends Record<string, AnySchema>> = {
-  // `-?` and the optionality below are computed from `.optional()` having wrapped
-  // the member type in `| undefined`, so the TS shape matches what the model may
-  // legally omit — see the note on `optional()` about strict mode.
-  [K in keyof S as undefined extends Infer<S[K]> ? never : K]: Infer<S[K]>;
-} & {
-  [K in keyof S as undefined extends Infer<S[K]> ? K : never]?: Infer<S[K]>;
-};
+/**
+ * Collapses a type into one flat object.
+ *
+ * `ShapeOutput` builds its result as an intersection of two mapped types, one
+ * required and one optional, and that intersection is what every hover, every
+ * error message and every type assertion would otherwise show. The difference
+ * is between an app reading `{ command: string; cwd?: string }` and reading two
+ * mapped types joined by an ampersand.
+ *
+ * It also drops `readonly`, which the mapped types copy from the shape literal
+ * — `s.object({ ... })` infers that literal as `const` to keep the keys, and a
+ * tool has no reason to receive an immutable input because of how its schema
+ * was written down.
+ */
+type Flatten<T> = { -readonly [K in keyof T]: T[K] };
+
+type ShapeOutput<S extends Record<string, AnySchema>> = Flatten<
+  {
+    [K in keyof S as S[K] extends OptionalSchema<any> ? never : K]: Infer<S[K]>;
+  } & {
+    [K in keyof S as S[K] extends OptionalSchema<any> ? K : never]?: Infer<S[K]>;
+  }
+>;
 
 interface SchemaBuilder<T> extends Schema<T> {
   /**
@@ -79,9 +108,11 @@ interface SchemaBuilder<T> extends Schema<T> {
    * value drops the key. The asymmetry is the point — it is what lets an app
    * write ordinary optional fields against an API that forbids them.
    */
-  optional(): SchemaBuilder<T | undefined>;
+  optional(): OptionalSchemaBuilder<T>;
   nullable(): SchemaBuilder<T | null>;
 }
+
+interface OptionalSchemaBuilder<T> extends SchemaBuilder<T | undefined>, OptionalSchema<T> {}
 
 export declare const s: {
   string(): SchemaBuilder<string>;

--- a/packages/gemi/ai/example.ts
+++ b/packages/gemi/ai/example.ts
@@ -4,7 +4,7 @@
 // ergonomics can be read without assembling them from six files.
 import { ApiRouter } from "../http";
 import { Agent, AgentTool, Skill } from "./Agent";
-import { AgentController } from "./AgentController";
+import { AgentController, MemoryAgentStore } from "./AgentController";
 import { OpenAIProvider } from "./AgentProvider";
 import { s } from "./Schema";
 import { useChat } from "./useChat";
@@ -46,6 +46,13 @@ const chargeTool = AgentTool.create({
   requiresApproval: true,
 });
 
+// Answered by the person, not the server. Same mechanism as an approval.
+const askTool = AgentTool.ask({
+  name: "ask",
+  description: "Ask the customer for something you need before continuing",
+  outputSchema: s.object({ answer: s.string() }),
+});
+
 const refunds = Skill.create({
   name: "refund-policy",
   description: "How refunds are decided, and the wording to use when declining one",
@@ -56,7 +63,7 @@ const supportAgent = Agent.create({
   name: "support",
   instructions: "You are a support agent for an invoicing product.",
   provider: OpenAIProvider.model("gpt-5.4"),
-  tools: [grepTool, bashTool, chargeTool],
+  tools: [grepTool, bashTool, chargeTool, askTool],
   skills: [refunds],
   maxSteps: 12,
   reasoning: "medium",
@@ -80,20 +87,28 @@ class SupportAgentController extends AgentController<typeof supportAgent> {
   protected async onMessage(message, ctx) {
     // persistence point
   }
+
+  protected async onAwaitingInput(pending, ctx) {
+    // e.g. notify an approver who is not the person watching the stream
+  }
 }
 
 class Api extends ApiRouter {
   routes = {
     "/support": this.agent(SupportAgentController).middleware({
       stream: "auth",
-      resume: "auth",
+      attach: "auth",
+      stop: "auth",
       upload: "auth",
     }),
   };
 }
 
-function Chat() {
-  const { messages, sendMessage, status, pendingApprovals, respond } = useChat("/support");
+function Chat({ threadId }: { threadId: string }) {
+  // Reattaches on mount if a run is still going on this thread.
+  const { messages, sendMessage, status, pending, approve, answer } = useChat("/support", {
+    threadId,
+  });
 
   for (const message of messages) {
     for (const part of message.content) {
@@ -103,7 +118,20 @@ function Chat() {
     }
   }
 
-  // pendingApprovals[0].name === "charge" → .input is { amountCents, reason }
+  if (status === "awaiting-input") {
+    for (const call of pending) {
+      if (call.kind === "approval" && call.name === "charge") {
+        call.input.amountCents; // number
+        approve(call.toolCallId, true);
+      }
+      if (call.kind === "question") {
+        answer(call.toolCallId, { answer: "the invoice from March" });
+      }
+    }
+  }
+
+  // An answer can also ride along with text, in one ordinary turn:
+  //   sendMessage({ text: "yes, but only half", toolResults: [...] })
   return null;
 }
 

--- a/packages/gemi/ai/example.ts
+++ b/packages/gemi/ai/example.ts
@@ -1,0 +1,118 @@
+// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
+//
+// Not part of the module: the same end-to-end shape the sketch had, kept so the
+// ergonomics can be read without assembling them from six files.
+import { ApiRouter } from "../http";
+import { Agent, AgentTool, Skill } from "./Agent";
+import { AgentController } from "./AgentController";
+import { OpenAIProvider } from "./AgentProvider";
+import { s } from "./Schema";
+import { useChat } from "./useChat";
+
+const grepTool = AgentTool.create({
+  name: "grep",
+  description: "Search for a pattern in a file",
+  inputSchema: s.object({
+    pattern: s.string().describe("A JavaScript regular expression"),
+    filePath: s.string().describe("Path relative to the project root"),
+  }),
+  outputSchema: s.object({ matches: s.array(s.string()) }),
+  execute: async (input, ctx) => {
+    ctx.signal.throwIfAborted();
+    return { matches: [`Found ${input.pattern} in ${input.filePath}`] };
+  },
+});
+
+const bashTool = AgentTool.create({
+  name: "bash",
+  description: "Execute a bash command",
+  inputSchema: s.object({ command: s.string() }),
+  outputSchema: s.object({ output: s.string(), exitCode: s.number() }),
+  requiresApproval: true,
+  // Yields become `tool-progress` events, so the UI shows output as it lands.
+  execute: async function* (input) {
+    yield { line: `$ ${input.command}` };
+    return { output: "", exitCode: 0 };
+  },
+});
+
+// Declared here, implemented by the controller.
+const chargeTool = AgentTool.create({
+  name: "charge",
+  description: "Charge the customer's saved payment method",
+  inputSchema: s.object({ amountCents: s.number(), reason: s.string() }),
+  outputSchema: s.object({ receiptId: s.string() }),
+  deferred: true,
+  requiresApproval: true,
+});
+
+const refunds = Skill.create({
+  name: "refund-policy",
+  description: "How refunds are decided, and the wording to use when declining one",
+  instructions: () => Bun.file("./app/skills/refunds.md").text(),
+});
+
+const supportAgent = Agent.create({
+  name: "support",
+  instructions: "You are a support agent for an invoicing product.",
+  provider: OpenAIProvider.model("gpt-5.4"),
+  tools: [grepTool, bashTool, chargeTool],
+  skills: [refunds],
+  maxSteps: 12,
+  reasoning: "medium",
+});
+
+class SupportAgentController extends AgentController<typeof supportAgent> {
+  agent = supportAgent;
+  store = new MemoryAgentStore();
+
+  tools = {
+    charge: async (input, ctx) => {
+      const user = await ctx.req.user();
+      return { receiptId: `rc_${user.id}_${input.amountCents}` };
+    },
+  };
+
+  instructions(req) {
+    return `Today is ${new Date().toDateString()}.`;
+  }
+
+  protected async onMessage(message, ctx) {
+    // persistence point
+  }
+}
+
+class Api extends ApiRouter {
+  routes = {
+    "/support": this.agent(SupportAgentController).middleware({
+      stream: "auth",
+      resume: "auth",
+      upload: "auth",
+    }),
+  };
+}
+
+function Chat() {
+  const { messages, sendMessage, status, pendingApprovals, respond } = useChat("/support");
+
+  for (const message of messages) {
+    for (const part of message.content) {
+      if (part.type === "tool-result" && part.name === "grep" && part.status === "ok") {
+        part.output.matches; // string[]
+      }
+    }
+  }
+
+  // pendingApprovals[0].name === "charge" → .input is { amountCents, reason }
+  return null;
+}
+
+// A one-shot structured extraction: same tools, but the answer is a schema.
+const classifier = Agent.create({
+  name: "classifier",
+  provider: OpenAIProvider.model("gpt-5.4"),
+  output: s.object({
+    sentiment: s.enum(["positive", "neutral", "negative"]),
+    topics: s.array(s.string()),
+  }),
+});

--- a/packages/gemi/ai/example.ts
+++ b/packages/gemi/ai/example.ts
@@ -3,7 +3,7 @@
 // Not part of the module: the same end-to-end shape the sketch had, kept so the
 // ergonomics can be read without assembling them from six files.
 import { ApiRouter } from "../http";
-import { Agent, AgentTool, Skill } from "./Agent";
+import { Agent, AgentTool, Skill, ToolNamespace } from "./Agent";
 import { AgentController, MemoryAgentStore } from "./AgentController";
 import { OpenAIProvider } from "./AgentProvider";
 import { s } from "./Schema";
@@ -36,14 +36,51 @@ const bashTool = AgentTool.create({
   },
 });
 
-// Declared here, implemented by the controller.
 const chargeTool = AgentTool.create({
   name: "charge",
   description: "Charge the customer's saved payment method",
   inputSchema: s.object({ amountCents: s.number(), reason: s.string() }),
   outputSchema: s.object({ receiptId: s.string() }),
-  deferred: true,
   requiresApproval: true,
+  execute: async (input, ctx) => {
+    const user = await ctx.req.user();
+    return { receiptId: `rc_${user.id}_${input.amountCents}` };
+  },
+});
+
+const listOrdersTool = AgentTool.create({
+  name: "listOrders",
+  description: "List a customer's recent orders",
+  inputSchema: s.object({ customerId: s.string() }),
+  outputSchema: s.object({ orderIds: s.array(s.string()) }),
+  execute: async (input) => ({ orderIds: [] }),
+});
+
+const orderDetailTool = AgentTool.create({
+  name: "orderDetail",
+  description: "Read one order in full",
+  inputSchema: s.object({ orderId: s.string() }),
+  outputSchema: s.object({ totalCents: s.number(), status: s.string() }),
+  execute: async (input) => ({ totalCents: 0, status: "paid" }),
+});
+
+const refundOrderTool = AgentTool.create({
+  name: "refundOrder",
+  description: "Refund an order in full",
+  inputSchema: s.object({ orderId: s.string() }),
+  outputSchema: s.object({ refundId: s.string() }),
+  requiresApproval: true,
+  execute: async (input) => ({ refundId: "rf_1" }),
+});
+
+// A group the model searches rather than reads. Every schema in here is
+// withheld until it decides it wants one, which is what keeps a long tail of
+// rarely-used tools from costing anything on the turns that never touch them.
+const crm = ToolNamespace.create({
+  name: "crm",
+  description: "Customer records, orders and refunds",
+  deferred: true,
+  tools: [listOrdersTool, orderDetailTool, refundOrderTool],
 });
 
 // Answered by the person, not the server. Same mechanism as an approval.
@@ -63,7 +100,7 @@ const supportAgent = Agent.create({
   name: "support",
   instructions: "You are a support agent for an invoicing product.",
   provider: OpenAIProvider.model("gpt-5.4"),
-  tools: [grepTool, bashTool, chargeTool, askTool],
+  tools: [grepTool, bashTool, chargeTool, askTool, crm],
   skills: [refunds],
   maxSteps: 12,
   reasoning: "medium",
@@ -72,13 +109,6 @@ const supportAgent = Agent.create({
 class SupportAgentController extends AgentController<typeof supportAgent> {
   agent = supportAgent;
   store = new MemoryAgentStore();
-
-  tools = {
-    charge: async (input, ctx) => {
-      const user = await ctx.req.user();
-      return { receiptId: `rc_${user.id}_${input.amountCents}` };
-    },
-  };
 
   instructions(req) {
     return `Today is ${new Date().toDateString()}.`;

--- a/packages/gemi/ai/types.ts
+++ b/packages/gemi/ai/types.ts
@@ -37,8 +37,9 @@ export type FinishReason =
   /** `maxSteps` was hit. A run that ends this way is not an error, and it is
    *  also not a finished answer — the UI has to be able to tell them apart. */
   | "max-steps"
-  /** The run stopped because a tool needs a human. Resumable. */
-  | "awaiting-approval"
+  /** The run stopped because a tool call needs something only the client can
+   *  give it. The conversation continues with an ordinary turn. */
+  | "awaiting-input"
   | "aborted"
   | "error";
 
@@ -49,13 +50,15 @@ export type AgentErrorCode =
   | "content_filtered"
   | "tool_error"
   | "invalid_tool_input"
+  /** A tool result came back for a call the server never made, or with a
+   *  signature that does not verify. */
+  | "invalid_tool_result"
   | "aborted"
   | "unknown";
 
 export type AgentError = {
   code: AgentErrorCode;
   message: string;
-  /** Present for `tool_error` / `invalid_tool_input`. */
   toolCallId?: string;
   retryable: boolean;
 };
@@ -98,7 +101,8 @@ export type ToolResultPart<T extends ToolShapes = ToolShapes> = {
   } & (
     | { status: "ok"; output: T[K]["output"] }
     | { status: "error"; error: AgentError }
-    /** Approval was requested and refused; the model is told so it can adapt. */
+    /** The client refused, or answered something else instead. The model is
+     *  told, so it can adapt rather than retry into the same wall. */
     | { status: "denied"; reason?: string }
   );
 }[keyof T];
@@ -120,7 +124,8 @@ export type AgentContentPart<T extends ToolShapes = ToolShapes, O = unknown> =
   | OutputPart<O>;
 
 export type AgentMessage<T extends ToolShapes = ToolShapes, O = unknown> = {
-  /** Stable and server-assigned, so a resumed run does not duplicate messages. */
+  /** Stable and server-assigned, so a reattached stream does not duplicate
+   *  messages the client already has. */
   id: string;
   role: "system" | "user" | "assistant";
   content: AgentContentPart<T, O>[];
@@ -130,12 +135,63 @@ export type AgentMessage<T extends ToolShapes = ToolShapes, O = unknown> = {
   usage?: Usage;
 };
 
-/** What the client is allowed to send. A client cannot fabricate an assistant
- *  turn or a tool result: the server owns everything except the user's own words
- *  and files. */
-export type UserMessageInput = {
-  text: string;
+// --- what the client sends ----------------------------------------------
+
+/**
+ * A pending tool call: one the model made and the server will not complete on
+ * its own.
+ *
+ * Three kinds, one mechanism. An approval is a tool the server can run but
+ * won't without a human; a question is a tool whose whole answer is the human's;
+ * a client tool is one only the browser can execute. They differ in who
+ * produces the result, not in how the conversation carries it — which is why
+ * none of them needs a second endpoint, and why adding client-executed tools
+ * later costs no new protocol.
+ */
+export type PendingToolCall<T extends ToolShapes = ToolShapes> = {
+  [K in keyof T]: {
+    toolCallId: string;
+    name: K;
+    input: T[K]["input"];
+    kind: "approval" | "question" | "client";
+    /**
+     * Signs `runId + toolCallId + input` and is handed back untouched.
+     *
+     * In stateless mode the history lives in the browser, so without this the
+     * client asserts not just *that* a call was approved but *what* was
+     * approved — nothing would stop it from returning `approve: true` against
+     * an input it rewrote on the way. The signature is what lets the pending
+     * call travel through untrusted hands, and it is why approvals need no
+     * server-side storage at all. Carries a nonce and an expiry, so a captured
+     * one cannot be replayed into a later run.
+     */
+    signature: string;
+  };
+}[keyof T];
+
+/** The client's half of a pending call. */
+export type ClientToolResult =
+  | { toolCallId: string; signature: string; approve: boolean; reason?: string }
+  /** For `question` and `client` kinds: the value itself, checked against the
+   *  tool's output schema before the model sees it. */
+  | { toolCallId: string; signature: string; output: unknown };
+
+/**
+ * One turn from the client. Text, answers to pending calls, or both.
+ *
+ * A turn that leaves a pending call unanswered denies it: the provider rejects a
+ * history with a dangling tool call, so *something* has to resolve it, and
+ * treating "the user said something else" as a refusal is both the honest
+ * reading and the one that cannot strand a conversation.
+ *
+ * Note what is absent: the client cannot author an assistant turn or invent a
+ * tool result for a call that was never made. It sends its own words, its own
+ * files, and answers to questions the server asked.
+ */
+export type ClientTurn = {
+  text?: string;
   files?: { fileId: string; name?: string; mimeType?: string }[];
+  toolResults?: ClientToolResult[];
 };
 
 // --- stream events -------------------------------------------------------
@@ -143,8 +199,8 @@ export type UserMessageInput = {
 /**
  * One SSE frame each. Deltas are additive and never replay, so a client applies
  * them by appending; every event carries the ids needed to attach it to a
- * message without the client tracking "the current" anything, because a resumed
- * stream starts mid-message.
+ * message without the client tracking "the current" anything, because an
+ * attached stream starts mid-message.
  */
 export type AgentStreamEvent<T extends ToolShapes = ToolShapes, O = unknown> =
   | { type: "run-start"; runId: string; threadId?: string }
@@ -160,14 +216,11 @@ export type AgentStreamEvent<T extends ToolShapes = ToolShapes, O = unknown> =
   | { type: "tool-progress"; toolCallId: string; data: unknown }
   | { type: "tool-result"; messageId: string; part: ToolResultPart<T> }
   /**
-   * Terminal for this stream. The run is parked; the client answers on the
-   * resume route and gets a fresh stream that continues it.
+   * Terminal for this stream: the run is finished, not parked. Everything
+   * needed to answer is in the event and in the messages already delivered, so
+   * the next turn is an ordinary send.
    */
-  | {
-      type: "approval-required";
-      runId: string;
-      approvals: { toolCallId: string; name: keyof T & string; input: unknown }[];
-    }
+  | { type: "awaiting-input"; runId: string; pending: PendingToolCall<T>[] }
   | { type: "message-end"; messageId: string; finishReason: FinishReason }
   | { type: "usage"; usage: Usage }
   /**
@@ -177,3 +230,16 @@ export type AgentStreamEvent<T extends ToolShapes = ToolShapes, O = unknown> =
    */
   | { type: "error"; error: AgentError }
   | { type: "run-end"; runId: string; finishReason: FinishReason };
+
+/**
+ * The event plus its position in the run.
+ *
+ * `seq` exists for reattachment: a client that dropped at 41 asks for 42 and
+ * gets the tail rather than the whole run. It goes in the SSE `id:` field, so
+ * the cursor is the transport's own and a client that reconnects with
+ * `Last-Event-ID` is asking the right question by default.
+ */
+export type AgentStreamFrame<T extends ToolShapes = ToolShapes, O = unknown> = {
+  seq: number;
+  event: AgentStreamEvent<T, O>;
+};

--- a/packages/gemi/ai/types.ts
+++ b/packages/gemi/ai/types.ts
@@ -101,9 +101,18 @@ export type ToolResultPart<T extends ToolShapes = ToolShapes> = {
   } & (
     | { status: "ok"; output: T[K]["output"] }
     | { status: "error"; error: AgentError }
-    /** The client refused, or answered something else instead. The model is
-     *  told, so it can adapt rather than retry into the same wall. */
-    | { status: "denied"; reason?: string }
+    /**
+     * The call did not run. `refused` is the client declining an approval or
+     * answering something else instead; `stopped` is a cancel that landed while
+     * the call was in flight.
+     *
+     * Both are told to the model rather than dropped, and for the same reason:
+     * a history holding a tool call with no result is one the provider rejects,
+     * so an abort has to leave a conversation that can still be continued. It
+     * also happens to be true — the model asked for something and did not get
+     * it, and the next turn goes better for knowing which.
+     */
+    | { status: "denied"; cause: "refused" | "stopped"; reason?: string }
   );
 }[keyof T];
 
@@ -130,7 +139,14 @@ export type AgentMessage<T extends ToolShapes = ToolShapes, O = unknown> = {
   role: "system" | "user" | "assistant";
   content: AgentContentPart<T, O>[];
   createdAt: string;
-  /** Absent until the message is complete; lets a UI show a cursor. */
+  /**
+   * Absent until the message is complete; lets a UI show a cursor.
+   *
+   * `aborted` is a complete message too — a stopped turn keeps whatever it had
+   * produced, marked as cut short. Dropping it would lose text the user already
+   * read, and leave the model unable to tell that it was interrupted from that
+   * it simply stopped talking.
+   */
   finishReason?: FinishReason;
   usage?: Usage;
 };

--- a/packages/gemi/ai/types.ts
+++ b/packages/gemi/ai/types.ts
@@ -228,6 +228,9 @@ export type AgentStreamEvent<T extends ToolShapes = ToolShapes, O = unknown> =
    *  before the object closes. */
   | { type: "output-delta"; messageId: string; delta: string; snapshot: Partial<O> }
   | { type: "tool-call"; messageId: string; part: ToolCallPart<T> }
+  /** The model searched for deferred tools and loaded these. A UI can say "…
+   *  looking for the right tool" instead of showing an unexplained pause. */
+  | { type: "tool-search"; loaded: string[] }
   /** From a tool whose `execute` is an AsyncGenerator. */
   | { type: "tool-progress"; toolCallId: string; data: unknown }
   | { type: "tool-result"; messageId: string; part: ToolResultPart<T> }

--- a/packages/gemi/ai/types.ts
+++ b/packages/gemi/ai/types.ts
@@ -1,0 +1,179 @@
+// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
+
+/**
+ * The message and event model.
+ *
+ * This file is the actual public contract of the module. `AgentMessage` is what
+ * an app persists and what `useChat` renders, and `AgentStreamEvent` is what
+ * goes over the wire — so both are defined provider-agnostically here rather
+ * than in the OpenAI provider, and the provider's job is to translate into
+ * them. Anthropic or a local model can be added later by writing one translator
+ * instead of by changing what an app sees.
+ */
+
+/**
+ * Tools reduced to just their payload types.
+ *
+ * The client needs `{ bash: { input: { command: string }, output: ... } }` to
+ * discriminate a tool part by name, but it must not need `execute` — that is
+ * server code. Erasing tools to this shape at the Agent boundary is what keeps
+ * a tool's implementation out of the browser bundle while its types survive.
+ */
+export type ToolShape = { input: unknown; output: unknown };
+export type ToolShapes = Record<string, ToolShape>;
+
+export type Usage = {
+  inputTokens: number;
+  outputTokens: number;
+  /** Billed separately by OpenAI and worth surfacing on its own. */
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+  totalTokens: number;
+};
+
+export type FinishReason =
+  | "stop"
+  | "length"
+  /** `maxSteps` was hit. A run that ends this way is not an error, and it is
+   *  also not a finished answer — the UI has to be able to tell them apart. */
+  | "max-steps"
+  /** The run stopped because a tool needs a human. Resumable. */
+  | "awaiting-approval"
+  | "aborted"
+  | "error";
+
+export type AgentErrorCode =
+  | "provider_error"
+  | "rate_limited"
+  | "context_length_exceeded"
+  | "content_filtered"
+  | "tool_error"
+  | "invalid_tool_input"
+  | "aborted"
+  | "unknown";
+
+export type AgentError = {
+  code: AgentErrorCode;
+  message: string;
+  /** Present for `tool_error` / `invalid_tool_input`. */
+  toolCallId?: string;
+  retryable: boolean;
+};
+
+// --- content parts -------------------------------------------------------
+
+export type TextPart = { type: "text"; text: string };
+
+/**
+ * Reasoning is kept as its own part rather than folded into text: it must be
+ * renderable separately (or not at all), and on the next turn it has to be sent
+ * back to the provider in its original form for cache hits to survive.
+ */
+export type ReasoningPart = { type: "reasoning"; id?: string; text?: string };
+
+/** An uploaded file, referenced by the id `provider.upload()` returned. */
+export type FilePart = {
+  type: "file";
+  fileId: string;
+  name?: string;
+  mimeType?: string;
+};
+
+export type ToolCallPart<T extends ToolShapes = ToolShapes> = {
+  [K in keyof T]: {
+    type: "tool-call";
+    toolCallId: string;
+    name: K;
+    input: T[K]["input"];
+    /** Set while the model is still streaming the arguments. */
+    partial?: boolean;
+  };
+}[keyof T];
+
+export type ToolResultPart<T extends ToolShapes = ToolShapes> = {
+  [K in keyof T]: {
+    type: "tool-result";
+    toolCallId: string;
+    name: K;
+  } & (
+    | { status: "ok"; output: T[K]["output"] }
+    | { status: "error"; error: AgentError }
+    /** Approval was requested and refused; the model is told so it can adapt. */
+    | { status: "denied"; reason?: string }
+  );
+}[keyof T];
+
+/** The final answer when the agent declares an `output` schema. */
+export type OutputPart<O = unknown> = {
+  type: "output";
+  value: O;
+  /** True while the object is still being assembled from the token stream. */
+  partial?: boolean;
+};
+
+export type AgentContentPart<T extends ToolShapes = ToolShapes, O = unknown> =
+  | TextPart
+  | ReasoningPart
+  | FilePart
+  | ToolCallPart<T>
+  | ToolResultPart<T>
+  | OutputPart<O>;
+
+export type AgentMessage<T extends ToolShapes = ToolShapes, O = unknown> = {
+  /** Stable and server-assigned, so a resumed run does not duplicate messages. */
+  id: string;
+  role: "system" | "user" | "assistant";
+  content: AgentContentPart<T, O>[];
+  createdAt: string;
+  /** Absent until the message is complete; lets a UI show a cursor. */
+  finishReason?: FinishReason;
+  usage?: Usage;
+};
+
+/** What the client is allowed to send. A client cannot fabricate an assistant
+ *  turn or a tool result: the server owns everything except the user's own words
+ *  and files. */
+export type UserMessageInput = {
+  text: string;
+  files?: { fileId: string; name?: string; mimeType?: string }[];
+};
+
+// --- stream events -------------------------------------------------------
+
+/**
+ * One SSE frame each. Deltas are additive and never replay, so a client applies
+ * them by appending; every event carries the ids needed to attach it to a
+ * message without the client tracking "the current" anything, because a resumed
+ * stream starts mid-message.
+ */
+export type AgentStreamEvent<T extends ToolShapes = ToolShapes, O = unknown> =
+  | { type: "run-start"; runId: string; threadId?: string }
+  | { type: "message-start"; messageId: string; role: "assistant" }
+  | { type: "text-delta"; messageId: string; delta: string }
+  | { type: "reasoning-delta"; messageId: string; delta: string }
+  /** Emitted only for an agent with an `output` schema: `delta` is raw JSON
+   *  text, `snapshot` the best-effort parse so far, so a UI can bind fields
+   *  before the object closes. */
+  | { type: "output-delta"; messageId: string; delta: string; snapshot: Partial<O> }
+  | { type: "tool-call"; messageId: string; part: ToolCallPart<T> }
+  /** From a tool whose `execute` is an AsyncGenerator. */
+  | { type: "tool-progress"; toolCallId: string; data: unknown }
+  | { type: "tool-result"; messageId: string; part: ToolResultPart<T> }
+  /**
+   * Terminal for this stream. The run is parked; the client answers on the
+   * resume route and gets a fresh stream that continues it.
+   */
+  | {
+      type: "approval-required";
+      runId: string;
+      approvals: { toolCallId: string; name: keyof T & string; input: unknown }[];
+    }
+  | { type: "message-end"; messageId: string; finishReason: FinishReason }
+  | { type: "usage"; usage: Usage }
+  /**
+   * An error after the headers are flushed cannot be an HTTP status, so it is an
+   * event. Pre-flight failures — auth, validation, an unknown agent — stay
+   * ordinary HTTP errors and never reach this union.
+   */
+  | { type: "error"; error: AgentError }
+  | { type: "run-end"; runId: string; finishReason: FinishReason };

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -1,25 +1,95 @@
-// @ts-nocheck — the ai rfc is a sketch, not an interface anyone depends on:
-// nothing exports `gemi/ai` and nothing in the package imports it, so its only
-// reader is `tsc`, and a half-drawn signature there fails `bun run typecheck`
-// and `build:types` for everyone. Checked again by deleting this line, which is
-// the point of a per-file directive rather than dropping `ai` from the
-// tsconfig: the files stay in the project, and the exemption is visible in the
-// file that has it.
-type Agent = {};
+// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
+import type { RPC } from "../client/rpc";
+import type { AgentError, AgentMessage, ToolShapes, UserMessageInput } from "./types";
 
-function createAgent(path: string): Agent {
-  return {} as Agent;
+/**
+ * The agent routes, picked out of the same `RPC` interface `useQuery` and
+ * `useMutation` read. An agent is not a second kind of thing to register — it is
+ * a route, so its key is its path and its types arrive the way every other
+ * route's types do.
+ */
+type AgentRoutes = {
+  [K in keyof RPC as RPC[K] extends { __agent: true } ? K : never]: RPC[K];
+};
+
+type ToolsOf<P extends keyof AgentRoutes> = AgentRoutes[P] extends { tools: infer T }
+  ? T extends ToolShapes
+    ? T
+    : ToolShapes
+  : ToolShapes;
+
+type OutputOf<P extends keyof AgentRoutes> = AgentRoutes[P] extends { output: infer O }
+  ? O
+  : unknown;
+
+/**
+ * What the UI is waiting on. `awaiting-approval` is its own state rather than a
+ * flavour of idle: the run is alive but parked, and the only thing that moves it
+ * is a human, so a UI that cannot distinguish it will either look hung or look
+ * finished.
+ */
+export type ChatStatus = "idle" | "submitted" | "streaming" | "awaiting-approval" | "error";
+
+export type PendingApproval<T extends ToolShapes> = {
+  [K in keyof T]: { toolCallId: string; name: K; input: T[K]["input"] };
+}[keyof T];
+
+export interface UseChatParams<P extends keyof AgentRoutes> {
+  /** Continues a server-side thread. Omitted, the hook keeps history itself and
+   *  sends it with each request — the stateless default. */
+  threadId?: string;
+  /** Server-rendered or restored history. */
+  initialMessages?: AgentMessage<ToolsOf<P>, OutputOf<P>>[];
+  /** Merged into the request body, for anything the agent's controller reads
+   *  off the request that is not a message. */
+  body?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  onFinish?: (message: AgentMessage<ToolsOf<P>, OutputOf<P>>) => void;
+  onError?: (error: AgentError) => void;
+  onApprovalRequired?: (pending: PendingApproval<ToolsOf<P>>[]) => void;
 }
 
-interface UseChatParams {
-  agent: Agent;
+export interface UseChatResult<P extends keyof AgentRoutes> {
+  messages: AgentMessage<ToolsOf<P>, OutputOf<P>>[];
+  status: ChatStatus;
+  /** Cleared by the next successful send, so a retry does not have to clear it. */
+  error: AgentError | null;
+  /** Set once the server has assigned one. */
+  threadId?: string;
+
+  sendMessage(input: UserMessageInput | string): Promise<void>;
+  /** Aborts the fetch; the server sees the disconnect and aborts the run with
+   *  it, so a stopped generation stops being billed. */
+  stop(): void;
+  /** Drops the last assistant turn and re-runs from the user turn before it. */
+  regenerate(): Promise<void>;
+  setMessages(messages: AgentMessage<ToolsOf<P>, OutputOf<P>>[]): void;
+
+  /** Non-empty exactly when `status === "awaiting-approval"`. */
+  pendingApprovals: PendingApproval<ToolsOf<P>>[];
+  /** Answers every pending approval and resumes the run on a fresh stream.
+   *  Partial answers are allowed: anything not named is treated as denied. */
+  respond(
+    decisions: Record<string, boolean | { approve: boolean; reason?: string }>,
+  ): Promise<void>;
+
+  /** Uploads through the agent's own upload route and returns the id to put in
+   *  `sendMessage({ files })`. Here rather than in app code because the route is
+   *  derived from the same path. */
+  attach(file: File): Promise<{ fileId: string; name: string; mimeType: string }>;
 }
 
-interface MessagePayload {}
-
-export function useChat(params: UseChatParams) {
-  return {
-    messages: [],
-    sendMessage: async (payload: MessagePayload) => {},
-  };
-}
+/**
+ * The path is the agent's route, exactly as mounted:
+ *
+ *   const { messages, sendMessage } = useChat("/chat")
+ *
+ * and a tool part inside `messages` narrows on `name`, giving `input` and
+ * `output` their real types — which is the whole reason the tool tuple is
+ * carried through `Agent`, `AgentRoute` and `RPC` instead of being erased at the
+ * first boundary.
+ */
+export declare function useChat<P extends keyof AgentRoutes>(
+  path: P,
+  params?: UseChatParams<P>,
+): UseChatResult<P>;

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
 import type { RPC } from "../client/rpc";
-import type { AgentError, AgentMessage, ToolShapes, UserMessageInput } from "./types";
+import type { AgentError, AgentMessage, ClientTurn, PendingToolCall, ToolShapes } from "./types";
 
 /**
  * The agent routes, picked out of the same `RPC` interface `useQuery` and
@@ -23,16 +23,13 @@ type OutputOf<P extends keyof AgentRoutes> = AgentRoutes[P] extends { output: in
   : unknown;
 
 /**
- * What the UI is waiting on. `awaiting-approval` is its own state rather than a
- * flavour of idle: the run is alive but parked, and the only thing that moves it
- * is a human, so a UI that cannot distinguish it will either look hung or look
- * finished.
+ * What the UI is waiting on.
+ *
+ * `awaiting-input` is its own state rather than a flavour of idle: the run is
+ * over, but the conversation is holding a question, and a UI that cannot tell
+ * the difference will either look hung or look finished.
  */
-export type ChatStatus = "idle" | "submitted" | "streaming" | "awaiting-approval" | "error";
-
-export type PendingApproval<T extends ToolShapes> = {
-  [K in keyof T]: { toolCallId: string; name: K; input: T[K]["input"] };
-}[keyof T];
+export type ChatStatus = "idle" | "submitted" | "streaming" | "awaiting-input" | "error";
 
 export interface UseChatParams<P extends keyof AgentRoutes> {
   /** Continues a server-side thread. Omitted, the hook keeps history itself and
@@ -40,13 +37,20 @@ export interface UseChatParams<P extends keyof AgentRoutes> {
   threadId?: string;
   /** Server-rendered or restored history. */
   initialMessages?: AgentMessage<ToolsOf<P>, OutputOf<P>>[];
+  /**
+   * On mount, ask whether a run is still going on this thread and pick it back
+   * up from where this client left off. Needs a `threadId` — that is the handle
+   * that survives a refresh, which is why the client is never asked to stash a
+   * `runId` of its own. Defaults to true.
+   */
+  attach?: boolean;
   /** Merged into the request body, for anything the agent's controller reads
    *  off the request that is not a message. */
   body?: Record<string, unknown>;
   headers?: Record<string, string>;
   onFinish?: (message: AgentMessage<ToolsOf<P>, OutputOf<P>>) => void;
   onError?: (error: AgentError) => void;
-  onApprovalRequired?: (pending: PendingApproval<ToolsOf<P>>[]) => void;
+  onAwaitingInput?: (pending: PendingToolCall<ToolsOf<P>>[]) => void;
 }
 
 export interface UseChatResult<P extends keyof AgentRoutes> {
@@ -56,22 +60,33 @@ export interface UseChatResult<P extends keyof AgentRoutes> {
   error: AgentError | null;
   /** Set once the server has assigned one. */
   threadId?: string;
+  /** The run being streamed or attached to, if any. */
+  runId?: string;
 
-  sendMessage(input: UserMessageInput | string): Promise<void>;
-  /** Aborts the fetch; the server sees the disconnect and aborts the run with
-   *  it, so a stopped generation stops being billed. */
-  stop(): void;
+  /**
+   * The one way to advance the conversation. A string is shorthand for
+   * `{ text }`; answers to pending calls go in the same turn, and may travel
+   * with text.
+   */
+  sendMessage(turn: ClientTurn | string): Promise<void>;
+  /** Explicit cancel — a closed tab no longer stops a run, so this is what
+   *  does. */
+  stop(): Promise<void>;
   /** Drops the last assistant turn and re-runs from the user turn before it. */
   regenerate(): Promise<void>;
   setMessages(messages: AgentMessage<ToolsOf<P>, OutputOf<P>>[]): void;
 
-  /** Non-empty exactly when `status === "awaiting-approval"`. */
-  pendingApprovals: PendingApproval<ToolsOf<P>>[];
-  /** Answers every pending approval and resumes the run on a fresh stream.
-   *  Partial answers are allowed: anything not named is treated as denied. */
-  respond(
-    decisions: Record<string, boolean | { approve: boolean; reason?: string }>,
-  ): Promise<void>;
+  /** Non-empty exactly when `status === "awaiting-input"`. */
+  pending: PendingToolCall<ToolsOf<P>>[];
+  /**
+   * Sugar over `sendMessage`. The hook carries each pending call's signature and
+   * hands it back untouched, so an app answers with a boolean and never sees the
+   * mechanism that makes answering trustworthy.
+   */
+  approve(toolCallId: string, approve: boolean, reason?: string): Promise<void>;
+  /** The same, for a `question` or `client` tool: the value is checked against
+   *  the tool's output schema server-side before the model sees it. */
+  answer(toolCallId: string, output: unknown): Promise<void>;
 
   /** Uploads through the agent's own upload route and returns the id to put in
    *  `sendMessage({ files })`. Here rather than in app code because the route is

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -69,8 +69,14 @@ export interface UseChatResult<P extends keyof AgentRoutes> {
    * with text.
    */
   sendMessage(turn: ClientTurn | string): Promise<void>;
-  /** Explicit cancel — a closed tab no longer stops a run, so this is what
-   *  does. */
+  /**
+   * Explicit cancel — a closed tab no longer stops a run, so this is what does.
+   *
+   * The UI stops immediately; the server call is what actually ends the
+   * generation and any tool mid-flight. `messages` keeps the interrupted turn
+   * with everything it had produced, marked `aborted`, so the transcript shows
+   * where it was cut rather than losing text the user already read.
+   */
   stop(): Promise<void>;
   /** Drops the last assistant turn and re-runs from the user turn before it. */
   regenerate(): Promise<void>;


### PR DESCRIPTION
An RFC in types. Everything here is `@ts-nocheck`'d, nothing is exported from the package, and there is no runtime — this is the shape of the module up for review before any of it is built.

v1 scope: OpenAI and Azure OpenAI, server-side streaming with tools and skills, an optional structured final answer, and a `useChat` on the client.

## What was blank, and what it became

The sketch left the load-bearing parts empty — `Schema<T> = {}`, `interface Stream {}`, `AgentMessage = {}`, a `stream()` with no signature. Those are the module's actual contract, so they are what this fills in.

| file | defines |
|---|---|
| `Schema.ts` | the `s.*` builder → JSON Schema + `Infer` |
| `types.ts` | `AgentMessage`, content parts, `AgentStreamEvent`, the client turn |
| `Agent.ts` | `AgentTool` (+ `ToolContext`), `Skill`, `Agent`, `AgentRun` |
| `AgentProvider.ts` | `ProviderEvent`, the provider seam, OpenAI + Azure |
| `AgentController.ts` | `AgentStore`, `LiveRuns`, the controller and its hooks, `Router.agent` types |
| `useChat.tsx` | the client hook, typed off `RPC` |
| `example.ts` | the end-to-end shape in one file; not part of the module |
| `Agent.test-d.ts` | type-level tests, run by `bun run test:types` |

## The decisions

**A schema builder, not a phantom type and not zod.** Two things have to come out of one declaration: a TypeScript type, so `execute(input)` is typed, and a JSON Schema, because that is what the model is shown. A phantom `Schema<T>` gives the first and none of the second; a hand-written pair gives both and lets them drift. Owning it also lets `optional()` handle the thing an app should not have to know — OpenAI's strict mode has no optional keys, so it emits nullable-and-required while the TS type says `| undefined`.

**Tools stay singletons; the run's state is an argument.** Tools are created at module scope and shared across requests, so the sketch's `skipped` field — and anything else mutable on the instance — was a cross-request leak. `execute(input, ctx)` gets the request, run id, abort signal and step instead.

**An approval is not a special protocol.** An approval, a question the agent asks, and a tool only the browser can run are the same primitive: a tool call the server cannot complete on its own. The stream ends `awaiting-input` with the pending calls, and the answer comes back as an ordinary turn — text, tool results, or both — on the same route as a first message. There is no resume endpoint, no `ParkedRun`, and no server-side state required for approvals at all. Since the provider rejects a history with a dangling tool call, a turn that ignores a pending call denies it, so "actually, cancel that" is just a text turn and cannot strand a conversation.

**Pending calls are signed.** In stateless mode the history lives in the browser, so without a signature the client asserts not merely *that* a call was approved but *what* was approved — nothing would stop it returning `approve: true` against an input it rewrote. The server signs `runId + toolCallId + input` with a nonce and expiry; `useChat` hands it back untouched, so an app answers with a boolean and never sees the mechanism.

**`/attach` is a read of a live run, not a resume.** For the client that refreshed mid-stream. It requires a run to outlive the request that started it, which inverts abort-on-disconnect: `stop()` is now explicit, and a dropped connection means "keep going, buffer it". Frames are numbered, the number rides in the SSE `id:` field, and a returning client replays the tail from its cursor. It finds the run by `threadId`, so no client ever has to stash a `runId` across a refresh.

**The provider makes one model call and does not run the tool loop.** Approvals, `maxSteps`, skill loading and persistence are provider-independent; putting them in the provider means writing them again for the second provider. v1 targets the Responses API, and the seam avoids anything specific to it so a Chat Completions provider — for older Azure deployments and OpenAI-compatible gateways — can be added later without touching Agent, Controller or the client.

**Azure is its own class.** It puts the deployment in the URL, pins an api-version and has a second auth mode; one class carrying both shapes makes every field conditionally meaningful. The surface stays symmetrical — `.model()`, not `.deployment()`.

**`Router.agent()` works like `resource()`.** One call under one path mounts `stream`, `attach`, `stop` and `files`, and the agent's tool types ride along on the route — so `useChat("/support")` reads them out of the existing `RPC` interface. No second augmentation to generate, and renaming the route moves the client key with it.

**`deferred` is the provider's `defer_loading`, and only that.** A deferred tool's parameter schema is withheld from the request — the model sees a name and a description and pulls the schema in with `tool_search` if it decides it wants the tool. It says nothing about who runs the tool or when. `ToolNamespace` groups tools for that search, because the model reads a group's description to decide whether to look inside it. Both are optimizations and are treated as such: a provider without tool search is sent every schema inline and the agent behaves identically.

**Tools belong to the agent, and only the agent.** An earlier draft let a controller supply implementations for tools the agent had merely declared. Its justification was the tool that needs to close over the request, which `ctx.req` already covers — what was left was a second place to look for the answer to "what can this agent do".

**Skills lower onto the tool mechanism.** One zero-parameter function per skill in a reserved `skills` namespace, described by the skill's description and returning its instructions — not a synthetic `load_skill(name)` dispatcher. Discovery then runs on the provider's own tool-selection machinery rather than on a string argument gemi would have to validate, and it inherits `deferred` for free.

**The types are tested.** Only name and description are prompted; a reserved `load_skill` tool fetches the body. An unused skill then costs a line of text, which is what makes having thirty of them viable.

## Consequences to look at

- **Reattachment is per-process by nature.** A running generator lives in one process and a second server cannot attach to it, so `/attach` needs the request to land where the run is: one server, sticky routing, or a proxy that forwards by `runId`. `LiveRuns` says so in the interface, because the failure mode behind a round-robin balancer is a refresh that usually works.
- **Runs surviving disconnects means they must be stopped explicitly.** A closed tab no longer ends a run, so a client that never calls `stop()` keeps paying for tokens no one will read. The buffer TTL and an idle cap are the backstop. Stopping cannot be client-side only: the tool loop is on the server, and a client that stops reading has not stopped the next step from charging a card. A stop closes the turn it interrupts — in-flight tool calls get a `denied` result with `cause: "stopped"` and the message is finalized `aborted` — because a history holding a tool call with no result is one the provider rejects, so the cost of an unclosed abort is the *next* message.
- **Client-executed tools are now nearly free**, since `answeredBy: "client"` uses the same turn shape as an approval — but nothing in v1 ships one.
- **Errors after the first byte are stream events**, not HTTP statuses — headers are already flushed. Pre-flight failures stay ordinary HTTP errors.

Inferred rather than decided, and easy to split: `instructions` on `Agent.create` with a per-request `instructions(req)` on the controller.

`bun run typecheck` and `bun run test:types` are clean. The type tests earned their place on the first run by failing twice:

- **Optionality was detected with `undefined extends T`**, which is true of every type when `strictNullChecks` is off — which is how this package compiles. Every field of every tool input was optional, and silently: the JSON Schema was still right, so only the TypeScript lied. `optional()` now carries a marker property instead.
- **`s.object()` infers its shape as `const`** to keep the literal keys, which also made those keys `readonly` — a tool's input arrived immutable as an artefact of how its schema was written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnj9jSx45LoYp5tiv1W8Nw



