### PR TITLE
Providers that translate one model call, and nothing above it

### DIFF
--- a/packages/gemi/ai/AgentProvider.test.ts
+++ b/packages/gemi/ai/AgentProvider.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { AzureOpenAIProvider, OpenAIProvider, type ProviderEvent } from "./AgentProvider";
+import type { AgentMessage } from "./types";
+
+/**
+ * Nothing here touches the network: `fetch` is replaced for the duration of the
+ * test and the SSE body is a string. What is being checked is the half of each
+ * class that is not shared — the URL it posts to, the credential it attaches,
+ * and when it reads that credential.
+ */
+const realFetch = globalThis.fetch;
+
+// A developer's shell is a shared fixture nobody wrote down. These are the
+// variables the providers read, and a machine that happens to export one turns
+// a URL assertion into a mystery failure on one laptop.
+beforeEach(() => {
+  for (const name of [
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_API_VERSION",
+  ]) {
+    vi.stubEnv(name, undefined as unknown as string);
+  }
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.unstubAllEnvs();
+});
+
+function sse(...frames: [string, unknown][]): string {
+  return frames
+    .map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+    .join("");
+}
+
+const COMPLETED = sse(
+  ["response.output_text.delta", { type: "response.output_text.delta", delta: "hi" }],
+  [
+    "response.completed",
+    { type: "response.completed", response: { usage: { input_tokens: 1, output_tokens: 2 } } },
+  ],
+);
+
+function stubFetch(body: string | Response = COMPLETED) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  globalThis.fetch = vi.fn(async (url: any, init: any) => {
+    calls.push({ url: String(url), init });
+    return typeof body === "string" ? new Response(body) : body.clone();
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+async function drain(stream: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const events: ProviderEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+const HELLO: AgentMessage[] = [
+  { id: "m1", role: "user", content: [{ type: "text", text: "hi" }], createdAt: "2026-01-01" },
+];
+
+describe("OpenAIProvider", () => {
+  test("posts a streaming Responses request and translates the answer", async () => {
+    const calls = stubFetch();
+    const provider = OpenAIProvider.model("gpt-5.4", { apiKey: "sk-test" });
+
+    const events = await drain(provider.stream({ messages: HELLO, systemPrompt: "be brief" }));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("https://api.openai.com/v1/responses");
+    expect((calls[0]!.init.headers as Record<string, string>).authorization).toBe("Bearer sk-test");
+    expect(JSON.parse(String(calls[0]!.init.body))).toMatchObject({
+      model: "gpt-5.4",
+      stream: true,
+      instructions: "be brief",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    });
+    expect(events).toEqual([
+      { type: "text-delta", delta: "hi" },
+      {
+        type: "finish",
+        reason: "stop",
+        usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+      },
+    ]);
+  });
+
+  test("capabilities come off the model id", () => {
+    expect(OpenAIProvider.model("gpt-4o").capabilities.reasoning).toBe(false);
+    expect(OpenAIProvider.model("gpt-5.4").capabilities.reasoning).toBe(true);
+  });
+
+  test("the api key falls back to the environment, so a model name is the whole config", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-from-env");
+    const calls = stubFetch();
+    await drain(OpenAIProvider.model("gpt-5.4").stream({ messages: HELLO }));
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer sk-from-env");
+  });
+
+  test("a baseURL override survives a trailing slash", async () => {
+    const calls = stubFetch();
+    await drain(
+      OpenAIProvider.model("gpt-5.4", { apiKey: "k", baseURL: "https://gw.example/v1/" }).stream({
+        messages: HELLO,
+      }),
+    );
+    expect(calls[0]!.url).toBe("https://gw.example/v1/responses");
+  });
+
+  /**
+   * A failure after the request is accepted cannot be an exception — the
+   * caller is iterating, and the deltas it already has are text the user has
+   * already read.
+   */
+  test("a rejected request comes back as an error event and a finish", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ error: { message: "Incorrect API key" } }), { status: 401 }),
+    );
+    const events = await drain(
+      OpenAIProvider.model("gpt-5.4", { apiKey: "bad", maxRetries: 0 }).stream({ messages: HELLO }),
+    );
+
+    expect(events).toEqual([
+      {
+        type: "error",
+        error: { code: "provider_error", message: "Incorrect API key", retryable: false },
+      },
+      {
+        type: "finish",
+        reason: "error",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      },
+    ]);
+  });
+
+  test("an aborted run finishes as aborted, and reports no error of its own", async () => {
+    const controller = new AbortController();
+    globalThis.fetch = vi.fn(async () => {
+      controller.abort();
+      const error = new Error("aborted");
+      error.name = "AbortError";
+      throw error;
+    }) as unknown as typeof fetch;
+
+    const events = await drain(
+      OpenAIProvider.model("gpt-5.4", { apiKey: "k" }).stream({
+        messages: HELLO,
+        signal: controller.signal,
+      }),
+    );
+    expect(events).toEqual([
+      {
+        type: "finish",
+        reason: "aborted",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      },
+    ]);
+  });
+
+  test("upload posts multipart and returns the file id a FilePart carries", async () => {
+    const calls = stubFetch(new Response(JSON.stringify({ id: "file_123" })));
+    const fileId = await OpenAIProvider.model("gpt-5.4", { apiKey: "k" }).upload(
+      new File(["hello"], "notes.txt", { type: "text/plain" }),
+    );
+
+    expect(fileId).toBe("file_123");
+    expect(calls[0]!.url).toBe("https://api.openai.com/v1/files");
+    expect(calls[0]!.init.body).toBeInstanceOf(FormData);
+    expect((calls[0]!.init.body as FormData).get("purpose")).toBe("user_data");
+    // Setting content-type by hand would drop the multipart boundary.
+    expect((calls[0]!.init.headers as Record<string, string>)["content-type"]).toBeUndefined();
+  });
+
+  test("normalizeError is on the instance, so an app never touches the provider's error shape", () => {
+    const provider = OpenAIProvider.model("gpt-5.4");
+    const normalized = provider.normalizeError(new TypeError("fetch failed"));
+    expect(normalized).toMatchObject({ code: "provider_error", retryable: true });
+  });
+});
+
+describe("AzureOpenAIProvider", () => {
+  const azure = (config: Record<string, unknown> = {}) =>
+    AzureOpenAIProvider.model("gpt-5.4", {
+      endpoint: "https://acme.openai.azure.com/",
+      apiKey: "azure-key",
+      ...config,
+    });
+
+  test("the deployment is in the URL and the api-version is pinned", async () => {
+    const calls = stubFetch();
+    await drain(azure().stream({ messages: HELLO }));
+
+    expect(calls[0]!.url).toBe(
+      "https://acme.openai.azure.com/openai/deployments/gpt-5.4/responses?api-version=2025-04-01-preview",
+    );
+    expect((calls[0]!.init.headers as Record<string, string>)["api-key"]).toBe("azure-key");
+    expect((calls[0]!.init.headers as Record<string, string>).authorization).toBeUndefined();
+  });
+
+  test("a deployment named something else is an override, not a different method", async () => {
+    const calls = stubFetch();
+    await drain(azure({ deployment: "prod" }).stream({ messages: HELLO }));
+    expect(calls[0]!.url).toContain("/openai/deployments/prod/responses");
+    // The API stays symmetrical: apps still name a model.
+    expect(azure({ deployment: "prod" }).model).toBe("gpt-5.4");
+  });
+
+  /**
+   * The reason `getToken` is a function: an Entra token minted at boot has
+   * expired by the time a long conversation reaches step nine, and that shows
+   * up as a random 401 in the middle of a working feature.
+   */
+  test("getToken is called once per request, not once per provider", async () => {
+    const calls = stubFetch();
+    let issued = 0;
+    const provider = azure({ getToken: async () => `token-${++issued}` });
+
+    await drain(provider.stream({ messages: HELLO }));
+    await drain(provider.stream({ messages: HELLO }));
+
+    expect(issued).toBe(2);
+    expect((calls[0]!.init.headers as Record<string, string>).authorization).toBe("Bearer token-1");
+    expect((calls[1]!.init.headers as Record<string, string>).authorization).toBe("Bearer token-2");
+  });
+
+  test("uploads are resource-scoped, not deployment-scoped", async () => {
+    const calls = stubFetch(new Response(JSON.stringify({ id: "assistant-file-1" })));
+    await azure().upload(new File(["x"], "x.txt"));
+    expect(calls[0]!.url).toBe(
+      "https://acme.openai.azure.com/openai/files?api-version=2025-04-01-preview",
+    );
+  });
+
+  test("an app that needs a newer api-version names it", async () => {
+    const calls = stubFetch();
+    await drain(azure({ apiVersion: "2026-01-01" }).stream({ messages: HELLO }));
+    expect(calls[0]!.url).toContain("api-version=2026-01-01");
+  });
+});

--- a/packages/gemi/ai/AgentProvider.ts
+++ b/packages/gemi/ai/AgentProvider.ts
@@ -1,5 +1,8 @@
-// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
 import type { ReasoningEffort } from "./Agent";
+import { streamResponses, uploadFile, type ResponsesEndpoint } from "./providers/call";
+import { capabilitiesForModel } from "./providers/capabilities";
+import { normalizeProviderError } from "./providers/errors";
+import { buildResponsesRequest } from "./providers/request";
 import type { JSONSchema } from "./Schema";
 import type { AgentError, AgentMessage, FinishReason, Usage } from "./types";
 
@@ -100,14 +103,27 @@ export type ProviderConfig = {
   headers?: Record<string, string>;
 };
 
-export declare abstract class AgentProvider {
+
+/** Long enough for a reasoning model to think before it says anything, short
+ *  enough that a hung connection is not mistaken for a slow one. Only covers
+ *  getting a response; the stream that follows has no deadline. */
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_RETRIES = 2;
+
+function env(name: string): string | undefined {
+  return typeof process === "undefined" ? undefined : process.env?.[name];
+}
+
+export abstract class AgentProvider {
   abstract readonly model: string;
   abstract readonly capabilities: ProviderCapabilities;
 
   /** The model ids this provider knows about — for autocomplete only; any
    *  string is still accepted, because a new model must not require a gemi
    *  release to use. */
-  static models(): readonly string[];
+  static models(): readonly string[] {
+    return [];
+  }
 
   abstract stream(params: ProviderStreamParams): ProviderStream;
 
@@ -118,23 +134,95 @@ export declare abstract class AgentProvider {
    */
   abstract upload(file: File): Promise<string>;
 
-  /** Maps a provider's error body onto the normalized codes, so an app can
-   *  branch on `rate_limited` without knowing whose rate limit it was. */
-  abstract normalizeError(error: unknown): AgentError;
+  /**
+   * Maps a provider's error body onto the normalized codes, so an app can
+   * branch on `rate_limited` without knowing whose rate limit it was.
+   *
+   * Shared rather than abstract-in-practice: Azure answers the same error
+   * envelope as OpenAI, and the one place it differs — the content filter's
+   * code, buried in `innererror` — is handled by reading both.
+   */
+  normalizeError(error: unknown): AgentError {
+    return normalizeProviderError(error);
+  }
 }
 
-export declare class OpenAIProvider extends AgentProvider {
+const OPENAI_MODELS = [
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.1",
+  "gpt-5",
+  "gpt-5-mini",
+  "gpt-4.1",
+  "gpt-4.1-mini",
+  "gpt-4o",
+  "gpt-4o-mini",
+  "o4-mini",
+  "o3",
+  "o3-mini",
+] as const;
+
+export class OpenAIProvider extends AgentProvider {
   readonly model: string;
   readonly capabilities: ProviderCapabilities;
+  protected readonly config: ProviderConfig;
+
+  constructor(model: string, config: ProviderConfig = {}) {
+    super();
+    this.model = model;
+    this.capabilities = capabilitiesForModel(model);
+    this.config = config;
+  }
 
   /** Config defaults come from gemi's config (`ai.openai`), so an app that has
    *  set `OPENAI_API_KEY` writes only the model name. */
-  static model(model: string, config?: ProviderConfig): OpenAIProvider;
-  static models(): readonly string[];
+  static model(model: string, config?: ProviderConfig): OpenAIProvider {
+    return new OpenAIProvider(model, config);
+  }
 
-  stream(params: ProviderStreamParams): ProviderStream;
-  upload(file: File): Promise<string>;
-  normalizeError(error: unknown): AgentError;
+  static models(): readonly string[] {
+    return OPENAI_MODELS;
+  }
+
+  stream(params: ProviderStreamParams): ProviderStream {
+    const body = buildResponsesRequest(params, {
+      model: this.model,
+      capabilities: this.capabilities,
+    });
+    return streamResponses(this.endpoint(), body, {
+      signal: params.signal,
+      structuredOutput: Boolean(params.output) && this.capabilities.structuredOutput,
+    });
+  }
+
+  upload(file: File): Promise<string> {
+    return uploadFile(this.endpoint(), file);
+  }
+
+  protected baseURL(): string {
+    return (this.config.baseURL ?? env("OPENAI_BASE_URL") ?? "https://api.openai.com/v1").replace(
+      /\/+$/,
+      "",
+    );
+  }
+
+  protected endpoint(): ResponsesEndpoint {
+    const base = this.baseURL();
+    const config = this.config;
+    return {
+      responsesUrl: `${base}/responses`,
+      filesUrl: `${base}/files`,
+      headers: async () => {
+        const apiKey = config.apiKey ?? env("OPENAI_API_KEY");
+        return {
+          ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+          ...config.headers,
+        };
+      },
+      timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxRetries: config.maxRetries ?? DEFAULT_MAX_RETRIES,
+    };
+  }
 }
 
 export type AzureConfig = ProviderConfig & {
@@ -142,11 +230,24 @@ export type AzureConfig = ProviderConfig & {
   endpoint?: string;
   apiVersion?: string;
   /**
+   * The deployment to call, when it is not named after the model. Azure lets
+   * whoever ran the template call it anything, and plenty of them are called
+   * `prod` — this is the override the class comment promises.
+   */
+  deployment?: string;
+  /**
    * For Entra ID instead of a key. A function, not a token, because these
    * expire mid-conversation.
    */
   getToken?: () => Promise<string>;
 };
+
+/**
+ * The api-version is pinned rather than defaulted to "latest", because Azure
+ * treats a version as a contract and a floating one turns a Tuesday morning
+ * into a debugging session. An app that needs a newer one names it.
+ */
+const AZURE_API_VERSION = "2025-04-01-preview";
 
 /**
  * Its own class rather than a flag on `OpenAIProvider`: Azure puts the
@@ -157,15 +258,77 @@ export type AzureConfig = ProviderConfig & {
  * model; mapping that onto a deployment is this class's problem, and an app
  * that named its deployment differently overrides it in config.
  */
-export declare class AzureOpenAIProvider extends AgentProvider {
+export class AzureOpenAIProvider extends AgentProvider {
   readonly model: string;
   readonly capabilities: ProviderCapabilities;
+  protected readonly config: AzureConfig;
+
+  constructor(model: string, config: AzureConfig = {}) {
+    super();
+    this.model = model;
+    // Read off the model, not the deployment: a deployment called `prod` says
+    // nothing, and an unrecognized name lands on the all-capabilities default
+    // anyway. See `capabilitiesForModel`.
+    this.capabilities = capabilitiesForModel(model);
+    this.config = config;
+  }
 
   /** Defaults from gemi's config (`ai.azure`). */
-  static model(model: string, config?: AzureConfig): AzureOpenAIProvider;
-  static models(): readonly string[];
+  static model(model: string, config?: AzureConfig): AzureOpenAIProvider {
+    return new AzureOpenAIProvider(model, config);
+  }
 
-  stream(params: ProviderStreamParams): ProviderStream;
-  upload(file: File): Promise<string>;
-  normalizeError(error: unknown): AgentError;
+  static models(): readonly string[] {
+    return OPENAI_MODELS;
+  }
+
+  stream(params: ProviderStreamParams): ProviderStream {
+    const body = buildResponsesRequest(params, {
+      model: this.deployment(),
+      capabilities: this.capabilities,
+    });
+    return streamResponses(this.endpoint(), body, {
+      signal: params.signal,
+      structuredOutput: Boolean(params.output) && this.capabilities.structuredOutput,
+    });
+  }
+
+  upload(file: File): Promise<string> {
+    return uploadFile(this.endpoint(), file);
+  }
+
+  protected deployment(): string {
+    return this.config.deployment ?? this.model;
+  }
+
+  protected endpoint(): ResponsesEndpoint {
+    const config = this.config;
+    const host = (config.baseURL ?? config.endpoint ?? env("AZURE_OPENAI_ENDPOINT") ?? "").replace(
+      /\/+$/,
+      "",
+    );
+    const apiVersion = config.apiVersion ?? env("AZURE_OPENAI_API_VERSION") ?? AZURE_API_VERSION;
+    const query = `?api-version=${encodeURIComponent(apiVersion)}`;
+    return {
+      responsesUrl: `${host}/openai/deployments/${encodeURIComponent(
+        this.deployment(),
+      )}/responses${query}`,
+      // Files are resource-scoped, not deployment-scoped: an upload is not
+      // addressed to a model.
+      filesUrl: `${host}/openai/files${query}`,
+      headers: async () => {
+        // Called per request, not per provider: an Entra token minted when the
+        // app booted is expired by the time a long conversation reaches step
+        // nine, and that failure looks like a random 401 in the middle of a
+        // working feature.
+        if (config.getToken) {
+          return { authorization: `Bearer ${await config.getToken()}`, ...config.headers };
+        }
+        const apiKey = config.apiKey ?? env("AZURE_OPENAI_API_KEY");
+        return { ...(apiKey ? { "api-key": apiKey } : {}), ...config.headers };
+      },
+      timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxRetries: config.maxRetries ?? DEFAULT_MAX_RETRIES,
+    };
+  }
 }

--- a/packages/gemi/ai/AgentProvider.ts
+++ b/packages/gemi/ai/AgentProvider.ts
@@ -191,7 +191,10 @@ export class OpenAIProvider extends AgentProvider {
     });
     return streamResponses(this.endpoint(), body, {
       signal: params.signal,
-      structuredOutput: Boolean(params.output) && this.capabilities.structuredOutput,
+      // The request carries the schema whenever the agent declared one, so the
+      // parser has to read the answer as one too — a model that ignored the
+      // parameter answers 400, not prose.
+      structuredOutput: Boolean(params.output),
     });
   }
 
@@ -289,7 +292,10 @@ export class AzureOpenAIProvider extends AgentProvider {
     });
     return streamResponses(this.endpoint(), body, {
       signal: params.signal,
-      structuredOutput: Boolean(params.output) && this.capabilities.structuredOutput,
+      // The request carries the schema whenever the agent declared one, so the
+      // parser has to read the answer as one too — a model that ignored the
+      // parameter answers 400, not prose.
+      structuredOutput: Boolean(params.output),
     });
   }
 

--- a/packages/gemi/ai/providers/call.ts
+++ b/packages/gemi/ai/providers/call.ts
@@ -1,0 +1,116 @@
+import type { ProviderEvent } from "../AgentProvider";
+import { normalizeProviderError } from "./errors";
+import { requestWithRetry, type FetchLike } from "./http";
+import type { ResponsesRequest } from "./request";
+import { decodeChunks, emptyUsage, parseResponsesStream } from "./stream";
+
+/**
+ * The parts of a call that differ between OpenAI and Azure, and nothing else.
+ *
+ * Two classes, one request path: the differences are a URL, a header and when
+ * the credential is read, so those are what gets passed in. Everything below
+ * this line — retries, decoding, event translation, what an error looks like —
+ * is identical, and duplicating it into the Azure class is how the two would
+ * start behaving differently by accident.
+ */
+export type ResponsesEndpoint = {
+  responsesUrl: string;
+  filesUrl: string;
+  /** Async because Entra tokens expire mid-conversation, so the credential has
+   *  to be read per request rather than per provider. */
+  headers: () => Promise<Record<string, string>>;
+  timeoutMs: number;
+  maxRetries: number;
+  fetchImpl?: FetchLike;
+};
+
+/**
+ * Errors reach the consumer as events, not exceptions.
+ *
+ * A `ProviderStream` that threw would make every caller wrap its `for await`,
+ * and would lose the deltas already yielded — the agent needs the text it got
+ * before the socket died, because the user has already read it.
+ */
+export async function* streamResponses(
+  endpoint: ResponsesEndpoint,
+  body: ResponsesRequest,
+  params: { signal?: AbortSignal; structuredOutput: boolean },
+): AsyncGenerator<ProviderEvent> {
+  let response: Response;
+  try {
+    response = await requestWithRetry(
+      endpoint.responsesUrl,
+      {
+        method: "POST",
+        headers: { ...(await endpoint.headers()), "content-type": "application/json" },
+        body: JSON.stringify(body),
+      },
+      {
+        maxRetries: endpoint.maxRetries,
+        timeoutMs: endpoint.timeoutMs,
+        signal: params.signal,
+        fetchImpl: endpoint.fetchImpl,
+      },
+    );
+  } catch (error) {
+    const normalized = normalizeProviderError(error);
+    // An abort is not a failure to report: the run was stopped on purpose, and
+    // `Agent` is already writing the ending. Saying so twice would put an error
+    // in a transcript the user closed themselves.
+    if (normalized.code !== "aborted") yield { type: "error", error: normalized };
+    yield {
+      type: "finish",
+      reason: normalized.code === "aborted" ? "aborted" : "error",
+      usage: emptyUsage(),
+    };
+    return;
+  }
+
+  try {
+    yield* parseResponsesStream(decodeChunks(response.body), {
+      structuredOutput: params.structuredOutput,
+    });
+  } catch (error) {
+    const normalized = normalizeProviderError(error);
+    if (normalized.code === "aborted") {
+      yield { type: "finish", reason: "aborted", usage: emptyUsage() };
+      return;
+    }
+    yield { type: "error", error: normalized };
+    yield { type: "finish", reason: "error", usage: emptyUsage() };
+  }
+}
+
+/**
+ * Uploads an attachment and returns the id a `FilePart` carries.
+ *
+ * `user_data` rather than `assistants`: this is a file a person attached to a
+ * message, not a corpus for a retrieval store, and the purpose is what decides
+ * which of the two the file can be used for.
+ */
+export async function uploadFile(endpoint: ResponsesEndpoint, file: File): Promise<string> {
+  const form = new FormData();
+  form.set("purpose", "user_data");
+  form.set("file", file);
+
+  const response = await requestWithRetry(
+    endpoint.filesUrl,
+    {
+      method: "POST",
+      // No content-type: the boundary is generated with the body, and setting
+      // the header by hand is how multipart uploads fail with a parser error
+      // that names nothing useful.
+      headers: await endpoint.headers(),
+      body: form,
+    },
+    {
+      maxRetries: endpoint.maxRetries,
+      timeoutMs: endpoint.timeoutMs,
+      fetchImpl: endpoint.fetchImpl,
+    },
+  );
+
+  const json = (await response.json()) as { id?: string };
+  if (!json?.id) throw new Error("The provider accepted the upload but returned no file id.");
+  return json.id;
+}

--- a/packages/gemi/ai/providers/capabilities.test.ts
+++ b/packages/gemi/ai/providers/capabilities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { capabilitiesForModel } from "./capabilities";
+import { capabilitiesForModel, parseFamily } from "./capabilities";
 
 describe("capabilitiesForModel()", () => {
   test("a current model has everything", () => {
@@ -63,7 +63,33 @@ describe("capabilitiesForModel()", () => {
     expect(capabilitiesForModel("  GPT-4O  ")).toEqual(capabilitiesForModel("gpt-4o"));
   });
 
-  test("omni-moderation does not read as generation zero", () => {
-    expect(capabilitiesForModel("omni-moderation-latest").toolSearch).toBe(true);
+  test("a model that only starts with o is not an o-series generation", () => {
+    for (const id of ["omni-moderation-latest", "o200k-base"]) {
+      expect(capabilitiesForModel(id), id).toEqual(capabilitiesForModel("unknown-model"));
+    }
+  });
+});
+
+/**
+ * Tested through the classifier rather than through `capabilitiesForModel`,
+ * because that is the only place the boundary is visible: `o200k-base` read as
+ * generation 200 happens to produce the same all-true answer as an unknown id
+ * today, so an assertion on capabilities would pass with the guard removed and
+ * fail the day a rule keys on `major`.
+ */
+describe("parseFamily()", () => {
+  test("reads the generation out of a model id", () => {
+    expect(parseFamily("gpt-5.4-mini-2025-01-01")).toEqual({ kind: "gpt", major: 5 });
+    expect(parseFamily("o3-mini")).toEqual({ kind: "o", major: 3 });
+    expect(parseFamily("o1")).toEqual({ kind: "o", major: 1 });
+  });
+
+  test("leading digits that are not a generation are not one", () => {
+    // A tokenizer, not a model — and `/^o(\d+)/` without the boundary calls it
+    // generation 200.
+    expect(parseFamily("o200k-base")).toBeNull();
+    // `m` is not a digit, so this one never reaches the boundary at all.
+    expect(parseFamily("omni-moderation-latest")).toBeNull();
+    expect(parseFamily("some-gateway/llama-4")).toBeNull();
   });
 });

--- a/packages/gemi/ai/providers/capabilities.test.ts
+++ b/packages/gemi/ai/providers/capabilities.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import { capabilitiesForModel } from "./capabilities";
+
+describe("capabilitiesForModel()", () => {
+  test("a current model has everything", () => {
+    expect(capabilitiesForModel("gpt-5.4")).toEqual({
+      reasoning: true,
+      structuredOutput: true,
+      fileInput: true,
+      parallelToolCalls: true,
+      toolSearch: true,
+    });
+  });
+
+  test("gpt-4o reasons about nothing and cannot search for tools", () => {
+    expect(capabilitiesForModel("gpt-4o-mini-2024-07-18")).toMatchObject({
+      reasoning: false,
+      structuredOutput: true,
+      fileInput: true,
+      toolSearch: false,
+    });
+  });
+
+  test("o1 reasons but takes its tool calls one at a time", () => {
+    expect(capabilitiesForModel("o1")).toMatchObject({
+      reasoning: true,
+      parallelToolCalls: false,
+      toolSearch: false,
+    });
+    expect(capabilitiesForModel("o3-mini")).toMatchObject({ parallelToolCalls: true });
+  });
+
+  test("gpt-3.5 gets none of it", () => {
+    expect(capabilitiesForModel("gpt-3.5-turbo")).toEqual({
+      reasoning: false,
+      structuredOutput: false,
+      fileInput: false,
+      parallelToolCalls: true,
+      toolSearch: false,
+    });
+  });
+
+  /**
+   * The load-bearing case. An id nobody shipped knowing about is assumed
+   * capable, so a model released after this release is usable by naming it —
+   * and the way that assumption fails is one loud 400, not a silently worse
+   * agent.
+   */
+  test("an unknown id gets every capability", () => {
+    for (const id of ["gpt-7", "o9-mini", "some-gateway/llama-4", "prod-deployment"]) {
+      expect(capabilitiesForModel(id), id).toEqual({
+        reasoning: true,
+        structuredOutput: true,
+        fileInput: true,
+        parallelToolCalls: true,
+        toolSearch: true,
+      });
+    }
+  });
+
+  test("case and whitespace do not change the answer", () => {
+    expect(capabilitiesForModel("  GPT-4O  ")).toEqual(capabilitiesForModel("gpt-4o"));
+  });
+
+  test("omni-moderation does not read as generation zero", () => {
+    expect(capabilitiesForModel("omni-moderation-latest").toolSearch).toBe(true);
+  });
+});

--- a/packages/gemi/ai/providers/capabilities.ts
+++ b/packages/gemi/ai/providers/capabilities.ts
@@ -1,0 +1,101 @@
+import type { ProviderCapabilities } from "../AgentProvider";
+
+/**
+ * What a model can do, read off its id.
+ *
+ * Hardcoding `true` was never an option — `reasoning: { effort }` is a 400 on
+ * gpt-4o, and `defer_loading` is a 400 on anything that predates tool search —
+ * but neither is a table lookup that only answers for ids we shipped knowing
+ * about.
+ *
+ * SO AN UNKNOWN ID GETS EVERY CAPABILITY. That is the whole point: a model
+ * released next Tuesday must be usable by writing its name, not by waiting for
+ * a gemi release. The default is chosen for how it fails, not for how often it
+ * is right. Guessing high fails loudly and once — the API rejects the request
+ * and names the parameter it disliked, and the fix is one line of config.
+ * Guessing low fails silently and forever: reasoning is dropped, every deferred
+ * schema is inlined, and the only symptom is a bigger bill and a worse answer.
+ * Unknown ids also skew new rather than old, because nobody invents the name of
+ * a model that already shipped.
+ *
+ * The named families below exist to make the *known-old* cases right, which is
+ * the only place a guess can be wrong in the quiet direction.
+ */
+export function capabilitiesForModel(model: string): ProviderCapabilities {
+  const id = normalizeModelId(model);
+
+  // Everything before the tool-era models. Listed by prefix because these names
+  // are closed sets now — nothing new will be called `gpt-3.5-*`.
+  if (id.startsWith("gpt-3.5") || id.startsWith("text-") || id.startsWith("davinci")) {
+    return {
+      reasoning: false,
+      structuredOutput: false,
+      fileInput: false,
+      parallelToolCalls: true,
+      toolSearch: false,
+    };
+  }
+
+  const family = parseFamily(id);
+
+  // o1 reasons but takes its tool calls one at a time; o3/o4 do not have that
+  // restriction. Both predate tool search.
+  if (family?.kind === "o") {
+    return {
+      reasoning: true,
+      structuredOutput: true,
+      fileInput: true,
+      parallelToolCalls: family.major > 1,
+      toolSearch: family.major >= 5,
+    };
+  }
+
+  if (family?.kind === "gpt") {
+    return {
+      // gpt-4 and gpt-4o are strong models with no reasoning parameter at all.
+      reasoning: family.major >= 5,
+      // Strict `json_schema` landed with gpt-4o; plain gpt-4 only has json_object.
+      structuredOutput: family.major > 4 || id.startsWith("gpt-4o") || id.startsWith("gpt-4.1"),
+      fileInput: family.major > 4 || id.startsWith("gpt-4o") || id.startsWith("gpt-4.1"),
+      parallelToolCalls: true,
+      // Tool search is recent-model-only.
+      toolSearch: family.major >= 5,
+    };
+  }
+
+  return {
+    reasoning: true,
+    structuredOutput: true,
+    fileInput: true,
+    parallelToolCalls: true,
+    toolSearch: true,
+  };
+}
+
+/**
+ * Azure deployment names are chosen by whoever ran the ARM template, so half of
+ * them look nothing like a model id. That is not a special case here: an
+ * unrecognizable deployment name lands on the same all-true default as an
+ * unrecognized model, for the same reason.
+ */
+function normalizeModelId(model: string): string {
+  return model.trim().toLowerCase();
+}
+
+type Family = { kind: "gpt" | "o"; major: number };
+
+/**
+ * Reads the generation number out of `gpt-5.4-mini-2025-01-01` or `o3-mini`.
+ * Only the major number is used — a point release has never taken a capability
+ * away, and treating `gpt-5.1` as unknown-therefore-capable would be the same
+ * answer anyway.
+ */
+function parseFamily(id: string): Family | null {
+  const gpt = /^gpt-(\d+)/.exec(id);
+  if (gpt?.[1]) return { kind: "gpt", major: Number(gpt[1]) };
+  // `o1`, `o3-mini`, `o4-mini`. Anchored and followed by a boundary so
+  // `omni-moderation` does not read as generation 0.
+  const o = /^o(\d+)(?:[-.]|$)/.exec(id);
+  if (o?.[1]) return { kind: "o", major: Number(o[1]) };
+  return null;
+}

--- a/packages/gemi/ai/providers/capabilities.ts
+++ b/packages/gemi/ai/providers/capabilities.ts
@@ -20,6 +20,14 @@ import type { ProviderCapabilities } from "../AgentProvider";
  *
  * The named families below exist to make the *known-old* cases right, which is
  * the only place a guess can be wrong in the quiet direction.
+ *
+ * Note what an answer of `false` does and does not buy. `reasoning: false` and
+ * `toolSearch: false` change the request, because both are optimizations and
+ * the run is identical without them. `structuredOutput: false` does not: it is
+ * reported honestly for a caller that wants to branch on it, but the request
+ * builder still sends the schema, because an agent that declared an `output`
+ * has an app waiting on a typed result and dropping the parameter would answer
+ * prose forever with nothing to branch on. See `request.ts`.
  */
 export function capabilitiesForModel(model: string): ProviderCapabilities {
   const id = normalizeModelId(model);
@@ -82,19 +90,28 @@ function normalizeModelId(model: string): string {
   return model.trim().toLowerCase();
 }
 
-type Family = { kind: "gpt" | "o"; major: number };
+export type Family = { kind: "gpt" | "o"; major: number };
 
 /**
  * Reads the generation number out of `gpt-5.4-mini-2025-01-01` or `o3-mini`.
  * Only the major number is used — a point release has never taken a capability
  * away, and treating `gpt-5.1` as unknown-therefore-capable would be the same
  * answer anyway.
+ *
+ * Exported for its own test: the classification is what the guards below are
+ * really about, and it is the only place they are observable — two ids can
+ * classify differently and still land on the same capability answer today.
  */
-function parseFamily(id: string): Family | null {
+export function parseFamily(id: string): Family | null {
   const gpt = /^gpt-(\d+)/.exec(id);
   if (gpt?.[1]) return { kind: "gpt", major: Number(gpt[1]) };
-  // `o1`, `o3-mini`, `o4-mini`. Anchored and followed by a boundary so
-  // `omni-moderation` does not read as generation 0.
+  // `o1`, `o3-mini`, `o4-mini`. The boundary is what keeps an id whose leading
+  // digits are not a generation out of this family — `o200k-base` is a
+  // tokenizer, not an o-series model, and `/^o(\d+)/` alone reads it as
+  // generation 200. (`omni-moderation` never gets this far: `m` is not a
+  // digit.) Both land on the unknown default today, so the boundary is only
+  // visible in the classification — which is where a future rule keyed on
+  // `major` would read it.
   const o = /^o(\d+)(?:[-.]|$)/.exec(id);
   if (o?.[1]) return { kind: "o", major: Number(o[1]) };
   return null;

--- a/packages/gemi/ai/providers/errors.test.ts
+++ b/packages/gemi/ai/providers/errors.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  normalizeProviderError,
+  ProviderHttpError,
+  ProviderTimeoutError,
+} from "./errors";
+
+function http(status: number, body: unknown) {
+  return normalizeProviderError(new ProviderHttpError(status, body));
+}
+
+function openaiError(fields: Record<string, unknown>) {
+  return { error: { type: "invalid_request_error", ...fields } };
+}
+
+describe("normalizeProviderError()", () => {
+  test("a rate limit is retryable and says so", () => {
+    const error = openaiError({ message: "Rate limit reached", code: "rate_limit_exceeded" });
+    expect(http(429, error)).toEqual({
+      code: "rate_limited",
+      message: "Rate limit reached",
+      retryable: true,
+    });
+  });
+
+  /**
+   * A spent quota answers 429 and will answer 429 all month. Marking it
+   * retryable turns one billing problem into `maxRetries` of them and buries
+   * the message that would have explained it.
+   */
+  test("a spent quota is a rate limit that is not worth retrying", () => {
+    expect(
+      http(
+        429,
+        openaiError({ message: "You exceeded your current quota", code: "insufficient_quota" }),
+      ),
+    ).toEqual({
+      code: "rate_limited",
+      message: "You exceeded your current quota",
+      retryable: false,
+    });
+  });
+
+  test("5xx is retryable, 4xx generally is not", () => {
+    expect(http(503, "upstream unavailable")).toMatchObject({
+      code: "provider_error",
+      retryable: true,
+    });
+    expect(http(401, openaiError({ message: "Incorrect API key" }))).toMatchObject({
+      code: "provider_error",
+      retryable: false,
+    });
+  });
+
+  test("a too-long request is its own code, so an app can trim instead of retry", () => {
+    expect(
+      http(
+        400,
+        openaiError({
+          code: "context_length_exceeded",
+          message: "maximum context length is 128000 tokens",
+        }),
+      ),
+    ).toMatchObject({ code: "context_length_exceeded", retryable: false });
+  });
+
+  test("Azure's content filter is read out of innererror, where it hides", () => {
+    expect(
+      http(400, {
+        error: {
+          code: "content_filter",
+          message: "The response was filtered",
+          innererror: { code: "ResponsibleAIPolicyViolation" },
+        },
+      }),
+    ).toMatchObject({ code: "content_filtered", retryable: false });
+  });
+
+  test("a schema the API refused is reported as a tool problem", () => {
+    expect(
+      http(
+        400,
+        openaiError({
+          message: "Invalid schema for function 'grep'",
+          param: "tools[0].parameters",
+        }),
+      ),
+    ).toMatchObject({ code: "invalid_tool_input", retryable: false });
+  });
+
+  test("an HTML error page from a proxy still normalizes", () => {
+    expect(http(502, "<html>bad gateway</html>")).toMatchObject({
+      code: "provider_error",
+      retryable: true,
+    });
+  });
+
+  test("an abort is an abort, and never retried", () => {
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    expect(normalizeProviderError(abort)).toEqual({
+      code: "aborted",
+      message: "The request was aborted.",
+      retryable: false,
+    });
+  });
+
+  test("a timeout is not an abort — the person did not stop anything", () => {
+    expect(normalizeProviderError(new ProviderTimeoutError(1000))).toMatchObject({
+      code: "provider_error",
+      retryable: true,
+    });
+  });
+
+  test("a dropped socket is retryable", () => {
+    expect(normalizeProviderError(new TypeError("fetch failed"))).toMatchObject({
+      code: "provider_error",
+      retryable: true,
+    });
+  });
+
+  test("something that is not an error at all", () => {
+    expect(normalizeProviderError("nope")).toEqual({
+      code: "unknown",
+      message: "nope",
+      retryable: false,
+    });
+  });
+});

--- a/packages/gemi/ai/providers/errors.ts
+++ b/packages/gemi/ai/providers/errors.ts
@@ -1,0 +1,165 @@
+import type { AgentError } from "../types";
+
+/**
+ * A non-2xx response, carried as an exception so the retry loop and
+ * `normalizeError` can both read it.
+ *
+ * The body is kept parsed-if-possible and raw-if-not: OpenAI and Azure both
+ * answer `{ error: { message, type, code } }` on a good day, and an HTML error
+ * page from a proxy on a bad one, and the bad day is exactly when the text
+ * matters.
+ */
+export class ProviderHttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  readonly requestId?: string;
+
+  constructor(status: number, body: unknown, requestId?: string) {
+    super(`Provider request failed with status ${status}: ${describeBody(body)}`);
+    this.name = "ProviderHttpError";
+    this.status = status;
+    this.body = body;
+    this.requestId = requestId;
+  }
+}
+
+/**
+ * The request ran out of time. Its own class because it must not read as a
+ * user abort: `stop()` means the person is done, and a timeout means the
+ * network was, and only one of those is worth trying again.
+ */
+export class ProviderTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`Provider request timed out after ${timeoutMs}ms`);
+    this.name = "ProviderTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+function describeBody(body: unknown): string {
+  const detail = errorBody(body);
+  if (detail?.message) return detail.message;
+  if (typeof body === "string") return body.slice(0, 500);
+  return "no error body";
+}
+
+type OpenAIErrorBody = { message?: string; type?: string; code?: string; param?: string };
+
+function errorBody(body: unknown): OpenAIErrorBody | null {
+  if (!body || typeof body !== "object") return null;
+  const wrapper = body as { error?: unknown };
+  const inner = wrapper.error && typeof wrapper.error === "object" ? wrapper.error : body;
+  const e = inner as OpenAIErrorBody & { innererror?: { code?: string } };
+  if (typeof e.message !== "string" && typeof e.code !== "string" && typeof e.type !== "string") {
+    return null;
+  }
+  // Azure hides the interesting code one level down when its content filter
+  // fires, and the outer code is the useless `content_filter`.
+  const code = e.innererror?.code ?? e.code;
+  return { message: e.message, type: e.type, code, param: e.param };
+}
+
+/**
+ * Provider failures onto `AgentErrorCode`.
+ *
+ * The contract an app is buying here is that it can branch on `rate_limited`
+ * without knowing whose rate limit it was, and on `retryable` without knowing
+ * which of the two APIs answered. So `retryable` is set from what is actually
+ * true of the failure — a 429 from a spent quota is not retryable no matter
+ * what its status code says, and neither is a request that will be too long
+ * again next time.
+ */
+export function normalizeProviderError(error: unknown): AgentError {
+  if (error instanceof ProviderTimeoutError) {
+    return { code: "provider_error", message: error.message, retryable: true };
+  }
+
+  if (isAbort(error)) {
+    return { code: "aborted", message: "The request was aborted.", retryable: false };
+  }
+
+  if (error instanceof ProviderHttpError) {
+    return fromStatus(error.status, errorBody(error.body), error.message);
+  }
+
+  // `fetch` rejects with a TypeError for DNS failures, refused connections and
+  // dropped sockets. Every one of those is worth another attempt.
+  if (error instanceof TypeError) {
+    return {
+      code: "provider_error",
+      message: `Could not reach the provider: ${error.message}`,
+      retryable: true,
+    };
+  }
+
+  if (error instanceof Error) {
+    return { code: "provider_error", message: error.message, retryable: false };
+  }
+
+  return { code: "unknown", message: String(error), retryable: false };
+}
+
+function fromStatus(
+  status: number,
+  body: OpenAIErrorBody | null,
+  fallbackMessage: string,
+): AgentError {
+  const message = body?.message ?? fallbackMessage;
+  const code = (body?.code ?? "").toLowerCase();
+  const type = (body?.type ?? "").toLowerCase();
+  const haystack = `${code} ${type} ${message}`.toLowerCase();
+
+  if (status === 429) {
+    // A spent quota answers 429 and will answer 429 for the rest of the month.
+    // Retrying it is how a run turns one billing problem into `maxRetries`
+    // billing problems and a much later error message.
+    const outOfCredit = code === "insufficient_quota" || haystack.includes("quota");
+    return { code: "rate_limited", message, retryable: !outOfCredit };
+  }
+
+  if (status >= 500 || status === 408 || status === 409) {
+    return { code: "provider_error", message, retryable: true };
+  }
+
+  if (isContextLength(haystack)) {
+    return { code: "context_length_exceeded", message, retryable: false };
+  }
+
+  if (isContentFilter(haystack)) {
+    return { code: "content_filtered", message, retryable: false };
+  }
+
+  // A schema the API refused. It is our request that is wrong, so the run
+  // should surface it as a tool problem rather than a generic outage.
+  if (body?.param?.startsWith("tools") || haystack.includes("invalid schema for function")) {
+    return { code: "invalid_tool_input", message, retryable: false };
+  }
+
+  return { code: "provider_error", message, retryable: false };
+}
+
+function isContextLength(haystack: string): boolean {
+  return (
+    haystack.includes("context_length_exceeded") ||
+    haystack.includes("maximum context length") ||
+    haystack.includes("context window") ||
+    haystack.includes("reduce the length")
+  );
+}
+
+function isContentFilter(haystack: string): boolean {
+  return (
+    haystack.includes("content_filter") ||
+    haystack.includes("content_policy_violation") ||
+    haystack.includes("responsibleaipolicyviolation") ||
+    haystack.includes("content management policy")
+  );
+}
+
+function isAbort(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { name?: string; code?: string };
+  return e.name === "AbortError" || e.code === "ABORT_ERR";
+}

--- a/packages/gemi/ai/providers/http.test.ts
+++ b/packages/gemi/ai/providers/http.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "vitest";
+
+import { ProviderHttpError, ProviderTimeoutError } from "./errors";
+import { backoffDelayMs, parseRetryAfter, requestWithRetry, type FetchLike } from "./http";
+
+/** Every delay is recorded instead of waited on, so the retry policy is
+ *  asserted rather than timed. */
+function harness(responses: (Response | Error)[]) {
+  const slept: number[] = [];
+  const calls: RequestInit[] = [];
+  let i = 0;
+
+  const fetchImpl: FetchLike = async (_url, init) => {
+    calls.push(init);
+    const next = responses[Math.min(i++, responses.length - 1)]!;
+    if (next instanceof Error) throw next;
+    return next;
+  };
+
+  return {
+    slept,
+    calls,
+    run: (maxRetries = 2) =>
+      requestWithRetry(
+        "https://api.example/responses",
+        { method: "POST" },
+        {
+          maxRetries,
+          timeoutMs: 0,
+          fetchImpl,
+          sleep: async (ms) => void slept.push(ms),
+          random: () => 1,
+          now: () => Date.parse("2026-01-01T00:00:00Z"),
+        },
+      ),
+  };
+}
+
+function res(status: number, body = "", headers: Record<string, string> = {}) {
+  return new Response(body, { status, headers });
+}
+
+describe("parseRetryAfter()", () => {
+  const now = Date.parse("2026-01-01T00:00:00Z");
+
+  test("seconds", () => expect(parseRetryAfter("3", now)).toBe(3000));
+  test("fractional seconds", () => expect(parseRetryAfter("1.5", now)).toBe(1500));
+  test("an HTTP date", () =>
+    expect(parseRetryAfter("Thu, 01 Jan 2026 00:00:20 GMT", now)).toBe(20_000));
+  test("a date already past clamps to zero", () =>
+    expect(parseRetryAfter("Thu, 01 Jan 2020 00:00:00 GMT", now)).toBe(0));
+  test("a header we cannot read is not a reason to give up", () =>
+    expect(parseRetryAfter("soon", now)).toBeUndefined());
+  test("absent", () => expect(parseRetryAfter(null, now)).toBeUndefined());
+});
+
+describe("backoffDelayMs()", () => {
+  test("doubles, and never exceeds the ceiling", () => {
+    const full = (attempt: number) => backoffDelayMs(attempt, () => 1);
+    expect([full(0), full(1), full(2)]).toEqual([500, 1000, 2000]);
+    expect(full(20)).toBe(20_000);
+  });
+
+  test("jitter never collapses to zero, so a retry storm still spreads", () => {
+    expect(backoffDelayMs(0, () => 0)).toBe(250);
+  });
+});
+
+describe("requestWithRetry()", () => {
+  test("returns the first success without sleeping", async () => {
+    const h = harness([res(200, "ok")]);
+    expect((await h.run()).status).toBe(200);
+    expect(h.slept).toEqual([]);
+  });
+
+  test("retries a 429 and honours Retry-After over the computed backoff", async () => {
+    const h = harness([res(429, "{}", { "retry-after": "7" }), res(200, "ok")]);
+    expect((await h.run()).status).toBe(200);
+    expect(h.slept).toEqual([7000]);
+  });
+
+  test("falls back to exponential backoff when the server said nothing", async () => {
+    const h = harness([res(500), res(500), res(200, "ok")]);
+    await h.run();
+    expect(h.slept).toEqual([500, 1000]);
+  });
+
+  test("gives up after maxRetries and throws the last response as an error", async () => {
+    const h = harness([res(503, JSON.stringify({ error: { message: "down" } }))]);
+    const error = await h.run(1).catch((e) => e);
+    expect(error).toBeInstanceOf(ProviderHttpError);
+    expect((error as ProviderHttpError).status).toBe(503);
+    expect(h.calls).toHaveLength(2);
+  });
+
+  test("a 400 is not retried — the request will be just as wrong next time", async () => {
+    const h = harness([res(400, "{}")]);
+    await h.run().catch(() => {});
+    expect(h.calls).toHaveLength(1);
+  });
+
+  test("a network failure is retried", async () => {
+    const h = harness([new TypeError("fetch failed"), res(200, "ok")]);
+    expect((await h.run()).status).toBe(200);
+    expect(h.slept).toEqual([500]);
+  });
+
+  /** `stop()` means stop, not "stop and then try three more times". */
+  test("the caller's abort is not retried", async () => {
+    const controller = new AbortController();
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    let calls = 0;
+
+    const promise = requestWithRetry(
+      "https://api.example/responses",
+      { method: "POST" },
+      {
+        maxRetries: 3,
+        timeoutMs: 0,
+        signal: controller.signal,
+        fetchImpl: async () => {
+          calls++;
+          controller.abort();
+          throw abort;
+        },
+        sleep: async () => {},
+      },
+    );
+
+    await expect(promise).rejects.toBe(abort);
+    expect(calls).toBe(1);
+  });
+
+  test("a request that never answers times out, and the timeout is retried", async () => {
+    const slept: number[] = [];
+    let calls = 0;
+
+    const response = await requestWithRetry(
+      "https://api.example/responses",
+      { method: "POST" },
+      {
+        maxRetries: 1,
+        timeoutMs: 5,
+        fetchImpl: async (_url, init) => {
+          if (calls++ === 0) {
+            return await new Promise<Response>((_resolve, reject) => {
+              init.signal?.addEventListener("abort", () => {
+                const error = new Error("aborted");
+                error.name = "AbortError";
+                reject(error);
+              });
+            });
+          }
+          return res(200, "ok");
+        },
+        sleep: async (ms) => void slept.push(ms),
+        random: () => 1,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(slept).toEqual([500]);
+  });
+
+  test("a timeout that survives every attempt surfaces as a timeout, not an abort", async () => {
+    const error = await requestWithRetry(
+      "https://api.example/responses",
+      { method: "POST" },
+      {
+        maxRetries: 0,
+        timeoutMs: 5,
+        fetchImpl: async (_url, init) =>
+          await new Promise<Response>((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => {
+              const e = new Error("aborted");
+              e.name = "AbortError";
+              reject(e);
+            });
+          }),
+        sleep: async () => {},
+      },
+    ).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ProviderTimeoutError);
+  });
+});

--- a/packages/gemi/ai/providers/http.test.ts
+++ b/packages/gemi/ai/providers/http.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "vitest";
 
 import { ProviderHttpError, ProviderTimeoutError } from "./errors";
-import { backoffDelayMs, parseRetryAfter, requestWithRetry, type FetchLike } from "./http";
+import {
+  backoffDelayMs,
+  MAX_DELAY_MS,
+  parseRetryAfter,
+  requestWithRetry,
+  type FetchLike,
+} from "./http";
 
 /** Every delay is recorded instead of waited on, so the retry policy is
  *  asserted rather than timed. */
@@ -97,6 +103,101 @@ describe("requestWithRetry()", () => {
     const h = harness([res(400, "{}")]);
     await h.run().catch(() => {});
     expect(h.calls).toHaveLength(1);
+  });
+
+  /**
+   * The one 429 that must not be retried. Only the body says which kind it is,
+   * so a status table on its own gets this wrong — and gets it wrong three
+   * times, on a card that is already declined, before reporting anything.
+   */
+  test("a spent quota is not retried, whatever its status code says", async () => {
+    const quota = JSON.stringify({
+      error: {
+        code: "insufficient_quota",
+        type: "insufficient_quota",
+        message: "You exceeded your current quota, please check your plan and billing details.",
+      },
+    });
+    const h = harness([res(429, quota)]);
+
+    await h.run(2).catch(() => {});
+    expect(h.calls).toHaveLength(1);
+    expect(h.slept).toEqual([]);
+  });
+
+  test("a 429 that is only a rate limit is still retried", async () => {
+    const h = harness([
+      res(429, JSON.stringify({ error: { code: "rate_limit_exceeded", message: "slow down" } })),
+      res(200, "ok"),
+    ]);
+    expect((await h.run()).status).toBe(200);
+    expect(h.slept).toEqual([500]);
+  });
+
+  /**
+   * A daily quota answers `Retry-After` in hours. Sitting through it holds the
+   * run — and the user's cancelled stream — open for the whole window, so the
+   * server's number is honoured only as far as the ceiling.
+   */
+  test("a Retry-After longer than the ceiling is clamped, not slept through", async () => {
+    const h = harness([res(429, "{}", { "retry-after": "3600" }), res(200, "ok")]);
+    await h.run();
+    expect(h.slept).toEqual([MAX_DELAY_MS]);
+  });
+
+  /**
+   * `stop()` means stop, and the backoff is where a retrying request spends
+   * nearly all of its time. Deliberately driven with a sleep that ignores the
+   * signal, because that is what an injected or third-party one does.
+   */
+  test("an abort during the backoff settles at once instead of finishing the wait", async () => {
+    const controller = new AbortController();
+    const started = Date.now();
+    let calls = 0;
+
+    const promise = requestWithRetry(
+      "https://api.example/responses",
+      { method: "POST" },
+      {
+        maxRetries: 3,
+        timeoutMs: 0,
+        signal: controller.signal,
+        fetchImpl: async () => {
+          calls++;
+          return res(503);
+        },
+        sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+        random: () => 1,
+      },
+    );
+
+    setTimeout(() => controller.abort(), 20);
+    const error = await promise.catch((e) => e);
+
+    expect((error as Error).name).toBe("AbortError");
+    expect(Date.now() - started).toBeLessThan(400);
+    expect(calls).toBe(1);
+  });
+
+  test("the default backoff is itself abortable", async () => {
+    const controller = new AbortController();
+    const started = Date.now();
+
+    const promise = requestWithRetry(
+      "https://api.example/responses",
+      { method: "POST" },
+      {
+        maxRetries: 3,
+        timeoutMs: 0,
+        signal: controller.signal,
+        fetchImpl: async () => res(503),
+        random: () => 1,
+      },
+    );
+
+    setTimeout(() => controller.abort(), 20);
+    await expect(promise).rejects.toThrow();
+    expect(Date.now() - started).toBeLessThan(400);
   });
 
   test("a network failure is retried", async () => {

--- a/packages/gemi/ai/providers/http.ts
+++ b/packages/gemi/ai/providers/http.ts
@@ -1,4 +1,4 @@
-import { ProviderHttpError, ProviderTimeoutError } from "./errors";
+import { normalizeProviderError, ProviderHttpError, ProviderTimeoutError } from "./errors";
 
 export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
 
@@ -10,7 +10,11 @@ export type RequestOptions = {
    *  exercised, and a retry policy that is only tested against a live API is
    *  one that gets tested during an outage. */
   fetchImpl?: FetchLike;
-  sleep?: (ms: number) => Promise<void>;
+  /** Takes the caller's signal so the default can clear its timer rather than
+   *  hold the process open for a backoff nobody is waiting for any more. An
+   *  injected sleep may ignore it: the wait is raced against the abort either
+   *  way. */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   random?: () => number;
   now?: () => number;
 };
@@ -19,7 +23,7 @@ export type RequestOptions = {
  *  enough to outlast a rate-limit window, short enough that a user watching a
  *  stream does not assume it died. */
 const BASE_DELAY_MS = 500;
-const MAX_DELAY_MS = 20_000;
+export const MAX_DELAY_MS = 20_000;
 
 /**
  * `Retry-After` in either of its two legal forms: seconds, or an HTTP date.
@@ -28,6 +32,8 @@ const MAX_DELAY_MS = 20_000;
  * reopens and we are guessing. A value in the past clamps to zero; a garbage
  * value falls back to the computed backoff, since a header we cannot read is
  * not a reason to give up on the request.
+ *
+ * Parsed here, bounded at the call site: this returns what the server said.
  */
 export function parseRetryAfter(value: string | null | undefined, now: number): number | undefined {
   if (!value) return undefined;
@@ -56,6 +62,42 @@ function isRetryableStatus(status: number): boolean {
 }
 
 /**
+ * One retry policy, not two.
+ *
+ * The status table alone cannot answer this: a 429 from a spent quota is a 429
+ * every time for the rest of the month, and retrying it turns one billing
+ * problem into `maxRetries` of them and a much later error message. Only the
+ * body says which 429 this is, and `normalizeProviderError` is where that is
+ * already read — so it is asked here rather than left to disagree with a table
+ * after the retries have happened.
+ *
+ * It is a veto, not a second opinion: the table decides which statuses are
+ * worth another attempt and the normalized verdict can only take one away.
+ * That way a future change to the error mapping cannot start retrying 400s.
+ */
+function shouldRetry(status: number, error: ProviderHttpError): boolean {
+  return isRetryableStatus(status) && normalizeProviderError(error).retryable;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(abortReason(signal));
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
  * One HTTP call, retried.
  *
  * The timeout covers getting a response, not consuming one. A streamed answer
@@ -70,10 +112,37 @@ export async function requestWithRetry(
   options: RequestOptions,
 ): Promise<Response> {
   const doFetch = options.fetchImpl ?? ((u: string, i: RequestInit) => fetch(u, i));
-  const sleep = options.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const sleep = options.sleep ?? defaultSleep;
   const random = options.random ?? Math.random;
   const now = options.now ?? Date.now;
   const maxRetries = Math.max(0, options.maxRetries);
+
+  /**
+   * A backoff nobody can interrupt is a `stop()` that does not stop.
+   *
+   * The wait is where a retrying request spends nearly all of its time — up to
+   * 20 seconds of it — and noticing the abort only at the top of the next
+   * iteration means the run holds its state, and the user watches a cancelled
+   * stream, for the rest of the window. So the sleep loses a race with the
+   * signal, and the abort propagates like any other.
+   */
+  const wait = async (ms: number): Promise<void> => {
+    const signal = options.signal;
+    if (!signal) return await sleep(ms);
+    signal.throwIfAborted();
+    let onAbort: (() => void) | undefined;
+    try {
+      await Promise.race([
+        sleep(ms, signal),
+        new Promise<never>((_resolve, reject) => {
+          onAbort = () => reject(abortReason(signal));
+          signal.addEventListener("abort", onAbort, { once: true });
+        }),
+      ]);
+    } finally {
+      if (onAbort) signal.removeEventListener("abort", onAbort);
+    }
+  };
 
   let lastError: unknown;
 
@@ -104,7 +173,7 @@ export async function requestWithRetry(
       if (options.signal?.aborted) throw error;
       lastError = timedOut ? new ProviderTimeoutError(options.timeoutMs) : error;
       if (attempt === maxRetries) throw lastError;
-      await sleep(backoffDelayMs(attempt, random));
+      await wait(backoffDelayMs(attempt, random));
       continue;
     }
 
@@ -124,10 +193,18 @@ export async function requestWithRetry(
       response.headers.get("x-request-id") ?? undefined,
     );
 
-    if (!isRetryableStatus(response.status) || attempt === maxRetries) throw error;
+    if (attempt === maxRetries || !shouldRetry(response.status, error)) throw error;
 
+    // Bounded, because `Retry-After` is a number the server chooses and a daily
+    // quota answers it in hours. Sleeping through that holds the run open for
+    // the whole window; waking early costs one request that gets the same 429
+    // and a longer, still-bounded backoff after it.
     const retryAfter = parseRetryAfter(response.headers.get("retry-after"), now());
-    await sleep(retryAfter ?? backoffDelayMs(attempt, random));
+    await wait(
+      retryAfter === undefined
+        ? backoffDelayMs(attempt, random)
+        : Math.min(retryAfter, MAX_DELAY_MS),
+    );
     lastError = error;
   }
 

--- a/packages/gemi/ai/providers/http.ts
+++ b/packages/gemi/ai/providers/http.ts
@@ -1,0 +1,151 @@
+import { ProviderHttpError, ProviderTimeoutError } from "./errors";
+
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export type RequestOptions = {
+  maxRetries: number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  /** Injected by the tests. Nothing here should ever need a real socket to be
+   *  exercised, and a retry policy that is only tested against a live API is
+   *  one that gets tested during an outage. */
+  fetchImpl?: FetchLike;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+  now?: () => number;
+};
+
+/** The floor of the backoff. Doubling from here gives 0.5s, 1s, 2s, 4s — long
+ *  enough to outlast a rate-limit window, short enough that a user watching a
+ *  stream does not assume it died. */
+const BASE_DELAY_MS = 500;
+const MAX_DELAY_MS = 20_000;
+
+/**
+ * `Retry-After` in either of its two legal forms: seconds, or an HTTP date.
+ *
+ * Honoured rather than ignored because the server knows when its window
+ * reopens and we are guessing. A value in the past clamps to zero; a garbage
+ * value falls back to the computed backoff, since a header we cannot read is
+ * not a reason to give up on the request.
+ */
+export function parseRetryAfter(value: string | null | undefined, now: number): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (/^\d+(\.\d+)?$/.test(trimmed)) return Math.max(0, Number(trimmed) * 1000);
+  const date = Date.parse(trimmed);
+  if (Number.isNaN(date)) return undefined;
+  return Math.max(0, date - now);
+}
+
+/**
+ * Exponential backoff with full jitter. The jitter is the point: without it,
+ * every request that got rate limited at the same moment retries at the same
+ * moment, and the second wave is the same size as the first.
+ */
+export function backoffDelayMs(attempt: number, random: () => number): number {
+  const ceiling = Math.min(MAX_DELAY_MS, BASE_DELAY_MS * 2 ** attempt);
+  return Math.round(ceiling * (0.5 + random() * 0.5));
+}
+
+function isRetryableStatus(status: number): boolean {
+  // 429 and the 5xx range. 409 is in here because OpenAI answers it for a
+  // request that raced with something on their side, and it succeeds on the
+  // second try.
+  return status === 429 || status === 408 || status === 409 || status >= 500;
+}
+
+/**
+ * One HTTP call, retried.
+ *
+ * The timeout covers getting a response, not consuming one. A streamed answer
+ * legitimately takes minutes, and a timeout that kept running would cut off
+ * long completions at exactly the point where they were most expensive to
+ * abandon — so the timer is cleared once the headers land, and only the
+ * caller's own signal can end the body.
+ */
+export async function requestWithRetry(
+  url: string,
+  init: RequestInit,
+  options: RequestOptions,
+): Promise<Response> {
+  const doFetch = options.fetchImpl ?? ((u: string, i: RequestInit) => fetch(u, i));
+  const sleep = options.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const random = options.random ?? Math.random;
+  const now = options.now ?? Date.now;
+  const maxRetries = Math.max(0, options.maxRetries);
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    options.signal?.throwIfAborted();
+
+    const controller = new AbortController();
+    const abortOuter = () => controller.abort(options.signal?.reason);
+    options.signal?.addEventListener("abort", abortOuter, { once: true });
+
+    let timedOut = false;
+    const timer =
+      options.timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            controller.abort();
+          }, options.timeoutMs)
+        : undefined;
+
+    let response: Response;
+    try {
+      response = await doFetch(url, { ...init, signal: controller.signal });
+    } catch (error) {
+      if (timer !== undefined) clearTimeout(timer);
+      options.signal?.removeEventListener("abort", abortOuter);
+      // The caller's abort wins outright — `stop()` means stop, not "stop and
+      // try three more times".
+      if (options.signal?.aborted) throw error;
+      lastError = timedOut ? new ProviderTimeoutError(options.timeoutMs) : error;
+      if (attempt === maxRetries) throw lastError;
+      await sleep(backoffDelayMs(attempt, random));
+      continue;
+    }
+
+    if (timer !== undefined) clearTimeout(timer);
+
+    if (response.ok) {
+      // Deliberately left attached: the caller is about to read a stream, and
+      // its own signal has to keep reaching it.
+      return response;
+    }
+
+    options.signal?.removeEventListener("abort", abortOuter);
+    const body = await readErrorBody(response);
+    const error = new ProviderHttpError(
+      response.status,
+      body,
+      response.headers.get("x-request-id") ?? undefined,
+    );
+
+    if (!isRetryableStatus(response.status) || attempt === maxRetries) throw error;
+
+    const retryAfter = parseRetryAfter(response.headers.get("retry-after"), now());
+    await sleep(retryAfter ?? backoffDelayMs(attempt, random));
+    lastError = error;
+  }
+
+  // Unreachable: the loop either returns or throws. Kept honest rather than
+  // asserted away.
+  throw lastError ?? new Error("Provider request failed with no response.");
+}
+
+async function readErrorBody(response: Response): Promise<unknown> {
+  let text: string;
+  try {
+    text = await response.text();
+  } catch {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/packages/gemi/ai/providers/request.test.ts
+++ b/packages/gemi/ai/providers/request.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, test } from "vitest";
+
+import type {
+  ProviderCapabilities,
+  ProviderStreamParams,
+  ProviderToolSpec,
+} from "../AgentProvider";
+import type { AgentMessage } from "../types";
+import { buildResponsesRequest, toResponsesInput, toResponsesTools } from "./request";
+
+const FULL: ProviderCapabilities = {
+  reasoning: true,
+  structuredOutput: true,
+  fileInput: true,
+  parallelToolCalls: true,
+  toolSearch: true,
+};
+
+const OLD: ProviderCapabilities = {
+  reasoning: false,
+  structuredOutput: true,
+  fileInput: true,
+  parallelToolCalls: true,
+  toolSearch: false,
+};
+
+function message(partial: Partial<AgentMessage> & Pick<AgentMessage, "role" | "content">) {
+  return { id: "m1", createdAt: "2026-01-01T00:00:00.000Z", ...partial } as AgentMessage;
+}
+
+function tool(partial: Partial<ProviderToolSpec> & Pick<ProviderToolSpec, "name">) {
+  return {
+    description: `does ${partial.name}`,
+    parameters: { type: "object", properties: {}, required: [], additionalProperties: false },
+    strict: true,
+    ...partial,
+  } as ProviderToolSpec;
+}
+
+function build(params: Partial<ProviderStreamParams>, capabilities = FULL) {
+  return buildResponsesRequest({ messages: [], ...params } as ProviderStreamParams, {
+    model: "gpt-5.4",
+    capabilities,
+  });
+}
+
+describe("toResponsesInput()", () => {
+  test("text and files become one input message per role", () => {
+    const items = toResponsesInput(
+      [
+        message({
+          role: "user",
+          content: [
+            { type: "text", text: "look at this" },
+            { type: "file", fileId: "file_1" },
+          ],
+        }),
+        message({ role: "assistant", content: [{ type: "text", text: "on it" }] }),
+      ],
+      FULL,
+    );
+
+    expect(items).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "look at this" },
+          { type: "input_file", file_id: "file_1" },
+        ],
+      },
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "on it" }] },
+    ]);
+  });
+
+  test("a file is dropped when the model cannot read one", () => {
+    const items = toResponsesInput(
+      [message({ role: "user", content: [{ type: "file", fileId: "file_1" }] })],
+      { ...OLD, fileInput: false },
+    );
+    expect(items).toEqual([]);
+  });
+
+  /**
+   * Order within a message is the part that is easy to get wrong and expensive
+   * to get wrong: the API validates call/output pairing positionally, so text
+   * emitted after the call it preceded is a 400.
+   */
+  test("preserves the order of parts inside one message", () => {
+    const items = toResponsesInput(
+      [
+        message({
+          role: "assistant",
+          content: [
+            { type: "reasoning", id: "rs_1", text: "thinking" },
+            { type: "text", text: "let me check" },
+            { type: "tool-call", toolCallId: "call_1", name: "grep", input: { pattern: "x" } },
+            {
+              type: "tool-result",
+              toolCallId: "call_1",
+              name: "grep",
+              status: "ok",
+              output: { matches: [] },
+            },
+            { type: "text", text: "nothing found" },
+          ],
+        }),
+      ],
+      FULL,
+    );
+
+    expect(items.map((i) => i.type)).toEqual([
+      "reasoning",
+      "message",
+      "function_call",
+      "function_call_output",
+      "message",
+    ]);
+    expect(items[2]).toEqual({
+      type: "function_call",
+      call_id: "call_1",
+      name: "grep",
+      arguments: '{"pattern":"x"}',
+    });
+  });
+
+  test("reasoning round-trips in its original shape", () => {
+    const items = toResponsesInput(
+      [
+        message({
+          role: "assistant",
+          content: [{ type: "reasoning", id: "rs_9", text: "because" }],
+        }),
+      ],
+      FULL,
+    );
+    expect(items).toEqual([
+      { type: "reasoning", id: "rs_9", summary: [{ type: "summary_text", text: "because" }] },
+    ]);
+  });
+
+  test("reasoning with no id is dropped rather than sent under an invented one", () => {
+    const items = toResponsesInput(
+      [message({ role: "assistant", content: [{ type: "reasoning", text: "orphan" }] })],
+      FULL,
+    );
+    expect(items).toEqual([]);
+  });
+
+  test("a partial tool call is not sent, because it has no result and never will", () => {
+    const items = toResponsesInput(
+      [
+        message({
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_1",
+              name: "grep",
+              input: { p: 1 },
+              partial: true,
+            },
+          ],
+        }),
+      ],
+      FULL,
+    );
+    expect(items).toEqual([]);
+  });
+
+  test("a structured output part goes back as assistant text", () => {
+    const items = toResponsesInput(
+      [
+        message({
+          role: "assistant",
+          content: [{ type: "output", value: { sentiment: "positive" } }],
+        }),
+      ],
+      FULL,
+    );
+    expect(items).toEqual([
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: '{"sentiment":"positive"}' }],
+      },
+    ]);
+  });
+
+  /**
+   * The API rejects a `function_call` with no `function_call_output`, so a
+   * denial cannot be expressed by leaving it out. What matters beyond that is
+   * that the three outcomes read differently to the model.
+   */
+  describe("every tool call gets an output, including the ones that never ran", () => {
+    function outputFor(part: any): string {
+      const items = toResponsesInput(
+        [message({ role: "assistant", content: [part] })],
+        FULL,
+      );
+      return String(items[0]!.output);
+    }
+
+    test("a refusal says the user declined", () => {
+      const text = outputFor({
+        type: "tool-result",
+        toolCallId: "call_1",
+        name: "charge",
+        status: "denied",
+        cause: "refused",
+        reason: "too much",
+      });
+      expect(text).toContain("declined");
+      expect(text).toContain("too much");
+    });
+
+    test("a stop says the run was stopped, not that the user said no", () => {
+      const text = outputFor({
+        type: "tool-result",
+        toolCallId: "call_1",
+        name: "charge",
+        status: "denied",
+        cause: "stopped",
+      });
+      expect(text).toContain("stopped");
+      expect(text).not.toContain("declined");
+    });
+
+    test("a failure reads as a failure and carries the code", () => {
+      const text = outputFor({
+        type: "tool-result",
+        toolCallId: "call_1",
+        name: "charge",
+        status: "error",
+        error: { code: "tool_error", message: "card declined", retryable: false },
+      });
+      expect(text).toContain("failed");
+      expect(text).toContain("tool_error");
+      expect(text).toContain("card declined");
+    });
+
+    test("a string result is sent as itself rather than as a quoted JSON string", () => {
+      expect(
+        outputFor({
+          type: "tool-result",
+          toolCallId: "c",
+          name: "cat",
+          status: "ok",
+          output: "hello",
+        }),
+      ).toBe("hello");
+    });
+  });
+});
+
+describe("toResponsesTools()", () => {
+  const crm = {
+    name: "crm",
+    description: "Customer records",
+    tools: [tool({ name: "listOrders", deferred: true }), tool({ name: "refundOrder" })],
+  };
+
+  test("namespaces survive, deferral maps to defer_loading, and tool_search is added", () => {
+    expect(toResponsesTools([tool({ name: "bash" }), crm], FULL)).toEqual([
+      {
+        type: "function",
+        name: "bash",
+        description: "does bash",
+        parameters: expect.anything(),
+        strict: true,
+      },
+      {
+        type: "namespace",
+        name: "crm",
+        description: "Customer records",
+        tools: [
+          {
+            type: "function",
+            name: "listOrders",
+            description: "does listOrders",
+            parameters: expect.anything(),
+            strict: true,
+            defer_loading: true,
+          },
+          {
+            type: "function",
+            name: "refundOrder",
+            description: "does refundOrder",
+            parameters: expect.anything(),
+            strict: true,
+          },
+        ],
+      },
+      { type: "tool_search" },
+    ]);
+  });
+
+  test("no tool_search entry when nothing is deferred — it would be a tool nothing can use", () => {
+    const out = toResponsesTools([tool({ name: "bash" })], FULL);
+    expect(out.some((t) => t.type === "tool_search")).toBe(false);
+  });
+
+  /**
+   * The promise `capabilities.toolSearch` makes: without it the agent behaves
+   * identically, it just costs more tokens.
+   */
+  test("without tool search, namespaces flatten and deferral is ignored", () => {
+    expect(toResponsesTools([tool({ name: "bash" }), crm], OLD)).toEqual([
+      {
+        type: "function",
+        name: "bash",
+        description: "does bash",
+        parameters: expect.anything(),
+        strict: true,
+      },
+      {
+        type: "function",
+        name: "listOrders",
+        description: "does listOrders",
+        parameters: expect.anything(),
+        strict: true,
+      },
+      {
+        type: "function",
+        name: "refundOrder",
+        description: "does refundOrder",
+        parameters: expect.anything(),
+        strict: true,
+      },
+    ]);
+  });
+});
+
+describe("buildResponsesRequest()", () => {
+  test("the shape of a minimal streaming request", () => {
+    expect(build({ systemPrompt: "be brief" })).toEqual({
+      model: "gpt-5.4",
+      input: [],
+      stream: true,
+      instructions: "be brief",
+    });
+  });
+
+  test("output becomes a strict json_schema format", () => {
+    const schema = {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    } as const;
+    expect(build({ output: { name: "classification", schema } }).text).toEqual({
+      format: { type: "json_schema", name: "classification", schema, strict: true },
+    });
+  });
+
+  test("reasoning asks for a summary, because otherwise the stream carries none", () => {
+    expect(build({ reasoning: "high" }).reasoning).toEqual({ effort: "high", summary: "auto" });
+  });
+
+  test("reasoning is dropped silently when the model has none", () => {
+    expect(build({ reasoning: "high" }, OLD).reasoning).toBeUndefined();
+  });
+
+  test("parallel_tool_calls is only sent when it has to be turned off", () => {
+    const tools = [tool({ name: "bash" })];
+    expect(build({ tools }).parallel_tool_calls).toBeUndefined();
+    expect(build({ tools }, { ...FULL, parallelToolCalls: false }).parallel_tool_calls).toBe(false);
+  });
+
+  test("an empty tool list is omitted rather than sent as []", () => {
+    expect(build({ tools: [] }).tools).toBeUndefined();
+  });
+
+  test("sampling parameters ride along only when set", () => {
+    expect(build({ temperature: 0.2, maxOutputTokens: 512 })).toMatchObject({
+      temperature: 0.2,
+      max_output_tokens: 512,
+    });
+    expect(build({}).temperature).toBeUndefined();
+  });
+});

--- a/packages/gemi/ai/providers/request.test.ts
+++ b/packages/gemi/ai/providers/request.test.ts
@@ -168,6 +168,116 @@ describe("toResponsesInput()", () => {
     expect(items).toEqual([]);
   });
 
+  /**
+   * The bug this pins bricks a thread rather than failing a request: the
+   * history is persisted, so an orphaned output is resent on every turn and
+   * the conversation can never be continued. `stop()` produces exactly this
+   * shape — a partial call, skipped, whose in-flight result was written down.
+   */
+  test("a partial call's result is dropped with it, not left as an orphan", () => {
+    const items = toResponsesInput(
+      [
+        message({ role: "user", content: [{ type: "text", text: "refund it" }] }),
+        message({
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_1",
+              name: "refund",
+              input: { id: 7 },
+              partial: true,
+            },
+            {
+              type: "tool-result",
+              toolCallId: "call_1",
+              name: "refund",
+              status: "denied",
+              cause: "stopped",
+            },
+          ],
+        }),
+      ],
+      FULL,
+    );
+
+    expect(items.map((i) => i.type)).toEqual(["message"]);
+  });
+
+  test("a duplicated result is sent once — a second output is a 400 too", () => {
+    const items = toResponsesInput(
+      [
+        message({
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolCallId: "call_1", name: "grep", input: {} },
+            { type: "tool-result", toolCallId: "call_1", name: "grep", status: "ok", output: "a" },
+            { type: "tool-result", toolCallId: "call_1", name: "grep", status: "ok", output: "b" },
+          ],
+        }),
+      ],
+      FULL,
+    );
+
+    expect(items.map((i) => i.type)).toEqual(["function_call", "function_call_output"]);
+    expect(items[1]!.output).toBe("a");
+  });
+
+  /**
+   * The mirror image, and the same consequence: a crash between the call and
+   * its result leaves a `function_call` the API will reject forever. Saying
+   * "no result" is true, readable, and keeps the thread continuable.
+   */
+  test("a call whose result never arrived gets one, immediately after it", () => {
+    const items = toResponsesInput(
+      [
+        message({
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolCallId: "call_1", name: "grep", input: {} },
+            { type: "tool-call", toolCallId: "call_2", name: "read", input: {} },
+            { type: "tool-result", toolCallId: "call_2", name: "read", status: "ok", output: "ok" },
+          ],
+        }),
+      ],
+      FULL,
+    );
+
+    expect(items).toEqual([
+      { type: "function_call", call_id: "call_1", name: "grep", arguments: "{}" },
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "No result was recorded for this tool call. Assume it did not complete.",
+      },
+      { type: "function_call", call_id: "call_2", name: "read", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_2", output: "ok" },
+    ]);
+  });
+
+  test("an output whose call is only declared later is still an orphan", () => {
+    const items = toResponsesInput(
+      [
+        message({
+          role: "assistant",
+          content: [
+            { type: "tool-result", toolCallId: "call_1", name: "grep", status: "ok", output: "x" },
+            { type: "tool-call", toolCallId: "call_1", name: "grep", input: {} },
+          ],
+        }),
+      ],
+      FULL,
+    );
+
+    // The call keeps a synthetic output rather than borrowing the one that
+    // arrived before it: the API pairs positionally.
+    expect(items.map((i) => [i.type, i.call_id])).toEqual([
+      ["function_call", "call_1"],
+      ["function_call_output", "call_1"],
+    ]);
+    expect(items[1]!.output).toContain("No result was recorded");
+  });
+
   test("a structured output part goes back as assistant text", () => {
     const items = toResponsesInput(
       [
@@ -193,12 +303,23 @@ describe("toResponsesInput()", () => {
    * that the three outcomes read differently to the model.
    */
   describe("every tool call gets an output, including the ones that never ran", () => {
+    /** Paired with its call, because that is the only way a result reaches the
+     *  wire — an output on its own is dropped as an orphan. */
     function outputFor(part: any): string {
       const items = toResponsesInput(
-        [message({ role: "assistant", content: [part] })],
+        [
+          message({
+            role: "assistant",
+            content: [
+              { type: "tool-call", toolCallId: part.toolCallId, name: part.name, input: {} },
+              part,
+            ],
+          }),
+        ],
         FULL,
       );
-      return String(items[0]!.output);
+      expect(items.map((i) => i.type)).toEqual(["function_call", "function_call_output"]);
+      return String(items[1]!.output);
     }
 
     test("a refusal says the user declined", () => {
@@ -350,6 +471,20 @@ describe("buildResponsesRequest()", () => {
     } as const;
     expect(build({ output: { name: "classification", schema } }).text).toEqual({
       format: { type: "json_schema", name: "classification", schema, strict: true },
+    });
+  });
+
+  /**
+   * The asymmetry with `reasoning` below is the point. Dropping a reasoning
+   * effort costs quality; dropping an output schema costs the app its typed
+   * result with no error anywhere to notice. So this one is sent regardless
+   * and the API gets to say no.
+   */
+  test("output is sent even to a model we think has no structured output", () => {
+    const schema = { type: "object", properties: {} } as const;
+    const body = build({ output: { name: "c", schema } }, { ...FULL, structuredOutput: false });
+    expect(body.text).toEqual({
+      format: { type: "json_schema", name: "c", schema, strict: true },
     });
   });
 

--- a/packages/gemi/ai/providers/request.ts
+++ b/packages/gemi/ai/providers/request.ts
@@ -54,7 +54,15 @@ export function buildResponsesRequest(
     if (!capabilities.parallelToolCalls) body.parallel_tool_calls = false;
   }
 
-  if (params.output && capabilities.structuredOutput) {
+  // Deliberately NOT gated on `capabilities.structuredOutput`. An agent that
+  // declares `output` has a typed result its app is going to read, and dropping
+  // the parameter does not degrade that gracefully — it produces prose, which
+  // arrives as `text-delta`, so the app sees no output part, no error and
+  // nothing to branch on. That is the silent-forever failure `capabilities.ts`
+  // argues against: send it and let the API answer 400, which is loud, happens
+  // once, and names the parameter it disliked. `reasoning` is dropped below
+  // because it is an optimization; an output schema is the answer's shape.
+  if (params.output) {
     body.text = {
       format: {
         type: "json_schema",
@@ -139,8 +147,10 @@ export function toResponsesInput(
         }
         case "tool-call": {
           // A partial call is UI state — the arguments were still streaming
-          // when this was written down. It has no result and never had one, so
-          // sending it would create exactly the dangling call the API rejects.
+          // when this was written down, so what it holds is not what the model
+          // asked for. Sending it would create the dangling call the API
+          // rejects. If it did acquire a result (a stop landing mid-arguments
+          // does exactly that), `reconcileToolPairs` drops that half too.
           if (part.partial) break;
           flush();
           items.push({
@@ -166,7 +176,62 @@ export function toResponsesInput(
     flush();
   }
 
-  return items;
+  return reconcileToolPairs(items);
+}
+
+/** What is sent for a call whose result never made it into the history. */
+const NO_RESULT_RECORDED = "No result was recorded for this tool call. Assume it did not complete.";
+
+/**
+ * Every `function_call` has exactly one `function_call_output`, and no output
+ * stands alone.
+ *
+ * The loop above skips a `tool-call` marked `partial` — its arguments were
+ * still streaming, so it is UI state rather than something the model did — but
+ * a partial call can still acquire a result: `stop()` gives every call in
+ * flight a `denied`/`stopped` result, and a call whose arguments were mid-flight
+ * is exactly the one carrying `partial`. Emitting that result on its own is a
+ * 400 ("no tool call found for function call output"), and because the history
+ * is persisted it is a 400 on every subsequent turn — the thread is bricked,
+ * which is the failure `denied` exists to prevent.
+ *
+ * So the invariant is enforced here rather than assumed part-by-part: an
+ * unpartnered output is dropped, a repeated one is dropped, and a call left
+ * dangling by a crash between the call and its result gets a synthetic output
+ * saying so. Fabricating that line is the lesser evil — it is true, the model
+ * can read it, and the alternative is a conversation that can never be
+ * continued.
+ */
+function reconcileToolPairs(items: ResponsesInputItem[]): ResponsesInputItem[] {
+  const called = new Set<string>();
+  const answered = new Set<string>();
+  const kept: ResponsesInputItem[] = [];
+
+  for (const item of items) {
+    if (item.type === "function_call") {
+      called.add(String(item.call_id));
+    } else if (item.type === "function_call_output") {
+      const callId = String(item.call_id);
+      // Positional: the output has to come *after* its call, which is what the
+      // API checks, so a call seen later in the history does not rescue it.
+      if (!called.has(callId) || answered.has(callId)) continue;
+      answered.add(callId);
+    }
+    kept.push(item);
+  }
+
+  if (answered.size === called.size) return kept;
+
+  const out: ResponsesInputItem[] = [];
+  for (const item of kept) {
+    out.push(item);
+    if (item.type !== "function_call") continue;
+    const callId = String(item.call_id);
+    if (answered.has(callId)) continue;
+    answered.add(callId);
+    out.push({ type: "function_call_output", call_id: callId, output: NO_RESULT_RECORDED });
+  }
+  return out;
 }
 
 function textContent(role: AgentMessage["role"], text: string): Record<string, unknown> {

--- a/packages/gemi/ai/providers/request.ts
+++ b/packages/gemi/ai/providers/request.ts
@@ -1,0 +1,302 @@
+import type {
+  ProviderCapabilities,
+  ProviderStreamParams,
+  ProviderToolNamespace,
+  ProviderToolSpec,
+} from "../AgentProvider";
+import type { AgentMessage, ToolResultPart } from "../types";
+
+/**
+ * Building the request body is a pure function, on purpose.
+ *
+ * Everything hard about this provider is in here — item ordering, tool-call
+ * pairing, what a denied call looks like on the wire — and none of it needs a
+ * socket to be wrong. So it is separated from the class that posts it, and the
+ * tests assert the object rather than mocking `fetch` and reading a string.
+ */
+
+// The wire shapes, typed loosely on purpose: these mirror OpenAI's schema, and
+// a precise mirror is a second thing to keep in sync for no checking we would
+// actually get — the API is the authority and it answers in HTTP.
+export type ResponsesInputItem = Record<string, unknown>;
+export type ResponsesTool = Record<string, unknown>;
+
+export type ResponsesRequest = {
+  model: string;
+  input: ResponsesInputItem[];
+  stream: true;
+  instructions?: string;
+  tools?: ResponsesTool[];
+  parallel_tool_calls?: boolean;
+  text?: { format: Record<string, unknown> };
+  reasoning?: { effort: string; summary: "auto" };
+  temperature?: number;
+  max_output_tokens?: number;
+};
+
+export function buildResponsesRequest(
+  params: ProviderStreamParams,
+  ctx: { model: string; capabilities: ProviderCapabilities },
+): ResponsesRequest {
+  const { capabilities } = ctx;
+
+  const body: ResponsesRequest = {
+    model: ctx.model,
+    input: toResponsesInput(params.messages, capabilities),
+    stream: true,
+  };
+
+  if (params.systemPrompt) body.instructions = params.systemPrompt;
+
+  const tools = toResponsesTools(params.tools, capabilities);
+  if (tools.length > 0) {
+    body.tools = tools;
+    if (!capabilities.parallelToolCalls) body.parallel_tool_calls = false;
+  }
+
+  if (params.output && capabilities.structuredOutput) {
+    body.text = {
+      format: {
+        type: "json_schema",
+        name: params.output.name,
+        schema: params.output.schema,
+        strict: true,
+      },
+    };
+  }
+
+  // Dropped rather than refused: a model that cannot reason should still answer
+  // an agent that asked it to, because `reasoning` is the agent's preference
+  // and the provider is where preferences meet reality.
+  if (params.reasoning && capabilities.reasoning) {
+    // `summary: "auto"` is not decoration — without it the stream carries no
+    // reasoning text at all, and `ReasoningPart` would have nothing to hold.
+    body.reasoning = { effort: params.reasoning, summary: "auto" };
+  }
+
+  if (typeof params.temperature === "number") body.temperature = params.temperature;
+  if (typeof params.maxOutputTokens === "number") body.max_output_tokens = params.maxOutputTokens;
+
+  return body;
+}
+
+// --- messages ------------------------------------------------------------
+
+/**
+ * `AgentMessage[]` to Responses input items.
+ *
+ * Order is preserved *within* a message, not just between messages: a message
+ * that holds reasoning, then a tool call, then its result has to arrive in that
+ * order, because the API validates the pairing positionally. So text and file
+ * parts are buffered into one message item and that buffer is flushed the
+ * moment a non-message item appears, rather than emitting all the text first
+ * and all the calls after.
+ */
+export function toResponsesInput(
+  messages: AgentMessage[],
+  capabilities: ProviderCapabilities,
+): ResponsesInputItem[] {
+  const items: ResponsesInputItem[] = [];
+
+  for (const message of messages) {
+    const role = message.role;
+    let buffer: Record<string, unknown>[] = [];
+
+    const flush = () => {
+      if (buffer.length === 0) return;
+      items.push({ type: "message", role, content: buffer });
+      buffer = [];
+    };
+
+    for (const part of message.content ?? []) {
+      switch (part.type) {
+        case "text": {
+          if (!part.text) break;
+          buffer.push(textContent(role, part.text));
+          break;
+        }
+        case "output": {
+          // A structured answer is still the assistant's text as far as the
+          // history is concerned; re-serializing it is what lets a follow-up
+          // turn refer to what was decided.
+          if (part.partial) break;
+          buffer.push(textContent(role, JSON.stringify(part.value)));
+          break;
+        }
+        case "file": {
+          // `input_file` is only legal on an input role. An assistant message
+          // holding a file is a bug upstream, and sending it anyway turns that
+          // bug into a 400 halfway through a conversation.
+          if (!capabilities.fileInput || role === "assistant") break;
+          buffer.push({ type: "input_file", file_id: part.fileId });
+          break;
+        }
+        case "reasoning": {
+          flush();
+          const item = reasoningItem(part);
+          if (item) items.push(item);
+          break;
+        }
+        case "tool-call": {
+          // A partial call is UI state — the arguments were still streaming
+          // when this was written down. It has no result and never had one, so
+          // sending it would create exactly the dangling call the API rejects.
+          if (part.partial) break;
+          flush();
+          items.push({
+            type: "function_call",
+            call_id: part.toolCallId,
+            name: String(part.name),
+            arguments: JSON.stringify(part.input ?? {}),
+          });
+          break;
+        }
+        case "tool-result": {
+          flush();
+          items.push({
+            type: "function_call_output",
+            call_id: part.toolCallId,
+            output: toolResultOutput(part),
+          });
+          break;
+        }
+      }
+    }
+
+    flush();
+  }
+
+  return items;
+}
+
+function textContent(role: AgentMessage["role"], text: string): Record<string, unknown> {
+  return { type: role === "assistant" ? "output_text" : "input_text", text };
+}
+
+/**
+ * Reasoning goes back exactly as it came.
+ *
+ * Reshaping it — flattening the summary into text, renaming the item, dropping
+ * the id — costs two things that are hard to see and expensive to have lost:
+ * the prompt cache, which keys on the literal item, and on a reasoning model
+ * the thread of the model's own argument across turns.
+ *
+ * An item with no id is dropped instead. The id is the API's handle on stored
+ * reasoning, and an item without one is not a reasoning item the API can
+ * resolve — sending a summary under a fabricated id would be worse than
+ * sending nothing, because it would look like continuity that is not there.
+ */
+function reasoningItem(part: { id?: string; text?: string }): ResponsesInputItem | null {
+  if (!part.id) return null;
+  const item: ResponsesInputItem = { type: "reasoning", id: part.id };
+  item.summary = part.text ? [{ type: "summary_text", text: part.text }] : [];
+  return item;
+}
+
+/**
+ * Every tool call gets an output, including the ones that never ran.
+ *
+ * The API rejects a history containing a `function_call` with no matching
+ * `function_call_output`, so a denial cannot be expressed by omission — and a
+ * conversation where the user said no has to stay continuable, which is the
+ * whole reason `denied` exists in the first place.
+ *
+ * What is sent is prose rather than a status enum, because the reader is a
+ * language model: it has to be able to tell "the user refused this" from "this
+ * blew up", and those two lead to genuinely different next moves — apologize
+ * and ask, versus try another way.
+ */
+export function toolResultOutput(part: ToolResultPart): string {
+  if (part.status === "ok") {
+    return typeof part.output === "string" ? part.output : JSON.stringify(part.output ?? null);
+  }
+
+  if (part.status === "denied") {
+    const reason = part.reason ? ` Reason given: ${part.reason}` : "";
+    if (part.cause === "stopped") {
+      return `The run was stopped before this tool call could complete, so it did not run.${reason}`;
+    }
+    return `The user declined this tool call, so it did not run.${reason}`;
+  }
+
+  return `The tool call failed and produced no result. Error (${part.error?.code ?? "unknown"}): ${
+    part.error?.message ?? "no message"
+  }`;
+}
+
+// --- tools ---------------------------------------------------------------
+
+function isNamespace(
+  entry: ProviderToolSpec | ProviderToolNamespace,
+): entry is ProviderToolNamespace {
+  return Array.isArray((entry as ProviderToolNamespace).tools);
+}
+
+/**
+ * Tools and namespaces onto the Responses `tools` array.
+ *
+ * Without tool search the grouping has nothing to do — a namespace exists to be
+ * searched — so it is flattened away and every schema is sent inline with
+ * `deferred` ignored. That is the promise `capabilities.toolSearch` makes:
+ * deferral is a token optimization, and an optimization that changed which
+ * tools the model can reach would not be one.
+ */
+export function toResponsesTools(
+  tools: (ProviderToolSpec | ProviderToolNamespace)[] | undefined,
+  capabilities: ProviderCapabilities,
+): ResponsesTool[] {
+  if (!tools || tools.length === 0) return [];
+
+  if (!capabilities.toolSearch) {
+    const flat: ResponsesTool[] = [];
+    for (const entry of tools) {
+      if (isNamespace(entry)) {
+        for (const tool of entry.tools) flat.push(functionTool(tool, false));
+      } else {
+        flat.push(functionTool(entry, false));
+      }
+    }
+    return flat;
+  }
+
+  const out: ResponsesTool[] = [];
+  let anyDeferred = false;
+
+  for (const entry of tools) {
+    if (isNamespace(entry)) {
+      const inner = entry.tools.map((tool) => {
+        if (tool.deferred) anyDeferred = true;
+        return functionTool(tool, true);
+      });
+      out.push({
+        type: "namespace",
+        name: entry.name,
+        description: entry.description,
+        tools: inner,
+      });
+    } else {
+      if (entry.deferred) anyDeferred = true;
+      out.push(functionTool(entry, true));
+    }
+  }
+
+  // Without this the deferred schemas are unreachable: the model is shown a
+  // name and a description and given no way to ask for the rest, which is worse
+  // than not deferring at all. Added only when something is actually deferred,
+  // so an agent that defers nothing does not pay for a tool it cannot use.
+  if (anyDeferred) out.push({ type: "tool_search" });
+
+  return out;
+}
+
+function functionTool(tool: ProviderToolSpec, allowDeferred: boolean): ResponsesTool {
+  const spec: ResponsesTool = {
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.parameters,
+    strict: tool.strict,
+  };
+  if (allowDeferred && tool.deferred) spec.defer_loading = true;
+  return spec;
+}

--- a/packages/gemi/ai/providers/stream.test.ts
+++ b/packages/gemi/ai/providers/stream.test.ts
@@ -314,9 +314,62 @@ describe("parseResponsesStream()", () => {
     expect(events[0]).toEqual({ type: "text-delta", delta: "Hello" });
   });
 
-  test("[DONE] ends the stream", async () => {
+  /**
+   * `[DONE]` is a Chat Completions habit that OpenAI-compatible gateways bring
+   * to the Responses stream. After a terminal event it is redundant, and the
+   * parser has already returned before reading it.
+   */
+  test("[DONE] after a terminal event changes nothing", async () => {
     const events = await collect([...TEXT_STREAM, "data: [DONE]\n\n"]);
-    expect(events.at(-1)!.type).toBe("finish");
+    expect(events.at(-1)).toEqual({
+      type: "finish",
+      reason: "stop",
+      usage: expect.objectContaining({ inputTokens: 120 }),
+    });
+  });
+
+  /**
+   * On its own it is not a clean ending: it says the socket is over, not what
+   * the model did, and there is no usage and no status behind it. Reporting a
+   * stop there would tell the agent an answer finished that may have been cut
+   * in half — so it lands on the same retryable error as a dropped connection.
+   */
+  test("[DONE] without a terminal event is still an unfinished stream", async () => {
+    const events = await collect([TEXT_STREAM[2]!, "data: [DONE]\n\n"]);
+    expect(events).toEqual([
+      { type: "text-delta", delta: "Hello" },
+      {
+        type: "error",
+        error: {
+          code: "provider_error",
+          message: "The provider stream ended without a terminal event.",
+          retryable: true,
+        },
+      },
+      {
+        type: "finish",
+        reason: "error",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      },
+    ]);
+  });
+
+  /**
+   * What the `[DONE]` branch is actually for, and the only thing that fails
+   * without it: a gateway that marks the end and then holds the connection
+   * open. Treating the frame as unparseable JSON and continuing would leave
+   * the generator waiting on a chunk that never comes — this test hangs rather
+   * than fails if that guard goes.
+   */
+  test("[DONE] releases a source that never closes", async () => {
+    async function* neverEnds() {
+      yield TEXT_STREAM[2]!;
+      yield "data: [DONE]\n\n";
+      await new Promise(() => {});
+    }
+    const out: ProviderEvent[] = [];
+    for await (const event of parseResponsesStream(neverEnds())) out.push(event);
+    expect(out.at(-1)!.type).toBe("finish");
   });
 
   /**

--- a/packages/gemi/ai/providers/stream.test.ts
+++ b/packages/gemi/ai/providers/stream.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, test } from "vitest";
+
+import type { ProviderEvent } from "../AgentProvider";
+import { parseResponsesStream, sseMessages, toUsage } from "./stream";
+
+/**
+ * The fixtures are written by hand from the documented event shapes rather than
+ * recorded from a live call, so the suite runs offline and a fixture stays
+ * readable enough that a reviewer can see which case it is.
+ */
+function frame(event: string, payload: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+async function collect(
+  chunks: string[],
+  options?: { structuredOutput?: boolean },
+): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const event of parseResponsesStream(chunks, options)) out.push(event);
+  return out;
+}
+
+const USAGE = {
+  input_tokens: 120,
+  output_tokens: 30,
+  total_tokens: 150,
+  input_tokens_details: { cached_tokens: 64 },
+  output_tokens_details: { reasoning_tokens: 12 },
+};
+
+const TEXT_STREAM = [
+  frame("response.created", { type: "response.created", response: { id: "resp_1" } }),
+  frame("response.output_item.added", {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { id: "msg_1", type: "message", role: "assistant" },
+  }),
+  frame("response.output_text.delta", {
+    type: "response.output_text.delta",
+    item_id: "msg_1",
+    delta: "Hello",
+  }),
+  frame("response.output_text.delta", {
+    type: "response.output_text.delta",
+    item_id: "msg_1",
+    delta: " there",
+  }),
+  frame("response.completed", {
+    type: "response.completed",
+    response: { id: "resp_1", status: "completed", usage: USAGE },
+  }),
+];
+
+const TOOL_CALL_STREAM = [
+  frame("response.output_item.added", {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: {
+      id: "fc_item_1",
+      type: "function_call",
+      call_id: "call_abc",
+      name: "grep",
+      arguments: "",
+    },
+  }),
+  frame("response.function_call_arguments.delta", {
+    type: "response.function_call_arguments.delta",
+    item_id: "fc_item_1",
+    delta: '{"pattern"',
+  }),
+  frame("response.function_call_arguments.delta", {
+    type: "response.function_call_arguments.delta",
+    item_id: "fc_item_1",
+    delta: ':"todo"}',
+  }),
+  frame("response.function_call_arguments.done", {
+    type: "response.function_call_arguments.done",
+    item_id: "fc_item_1",
+    arguments: '{"pattern":"todo"}',
+  }),
+  frame("response.output_item.done", {
+    type: "response.output_item.done",
+    item: {
+      id: "fc_item_1",
+      type: "function_call",
+      call_id: "call_abc",
+      name: "grep",
+      arguments: '{"pattern":"todo"}',
+    },
+  }),
+  frame("response.completed", {
+    type: "response.completed",
+    response: { status: "completed", usage: USAGE },
+  }),
+];
+
+describe("sseMessages()", () => {
+  test("ignores keepalive comments and joins multi-line data", async () => {
+    const raw = [
+      ": ping\n\n",
+      "event: response.output_text.delta\n",
+      'data: {"type":"response.output_text.delta",\n',
+      'data:  "delta":"hi"}\n',
+      "\n",
+    ];
+    const messages = [];
+    for await (const message of sseMessages(raw)) messages.push(message);
+
+    expect(messages).toHaveLength(1);
+    expect(JSON.parse(messages[0]!.data)).toEqual({
+      type: "response.output_text.delta",
+      delta: "hi",
+    });
+  });
+
+  test("survives CRLF line endings and a missing final blank line", async () => {
+    const raw = ['event: error\r\ndata: {"type":"error","message":"boom"}\r\n'];
+    const messages = [];
+    for await (const message of sseMessages(raw)) messages.push(message);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.event).toBe("error");
+    expect(JSON.parse(messages[0]!.data).message).toBe("boom");
+  });
+
+  test("carries the id field, which is how reattachment gets its cursor", async () => {
+    const raw = ["id: 42\nevent: ping\ndata: {}\n\n"];
+    const messages = [];
+    for await (const message of sseMessages(raw)) messages.push(message);
+    expect(messages[0]!.id).toBe("42");
+  });
+});
+
+describe("parseResponsesStream()", () => {
+  test("text deltas and a terminal event with usage", async () => {
+    expect(await collect(TEXT_STREAM)).toEqual([
+      { type: "text-delta", delta: "Hello" },
+      { type: "text-delta", delta: " there" },
+      {
+        type: "finish",
+        reason: "stop",
+        usage: {
+          inputTokens: 120,
+          outputTokens: 30,
+          totalTokens: 150,
+          reasoningTokens: 12,
+          cachedInputTokens: 64,
+        },
+      },
+    ]);
+  });
+
+  test("the same text deltas become output deltas when an output schema was asked for", async () => {
+    const events = await collect(TEXT_STREAM, { structuredOutput: true });
+    expect(events.slice(0, 2)).toEqual([
+      { type: "output-delta", delta: "Hello" },
+      { type: "output-delta", delta: " there" },
+    ]);
+  });
+
+  test("reasoning deltas carry the item id they belong to", async () => {
+    const events = await collect([
+      frame("response.reasoning_summary_text.delta", {
+        type: "response.reasoning_summary_text.delta",
+        item_id: "rs_1",
+        delta: "Checking the ",
+      }),
+      frame("response.reasoning_text.delta", {
+        type: "response.reasoning_text.delta",
+        item_id: "rs_1",
+        delta: "invoice",
+      }),
+      frame("response.completed", { type: "response.completed", response: { usage: USAGE } }),
+    ]);
+
+    expect(events.slice(0, 2)).toEqual([
+      { type: "reasoning-delta", delta: "Checking the ", id: "rs_1" },
+      { type: "reasoning-delta", delta: "invoice", id: "rs_1" },
+    ]);
+  });
+
+  test("argument deltas are keyed to the call id, and completion is reported once", async () => {
+    const events = await collect(TOOL_CALL_STREAM);
+    expect(events).toEqual([
+      { type: "tool-call-delta", toolCallId: "call_abc", name: "grep", argsDelta: '{"pattern"' },
+      { type: "tool-call-delta", toolCallId: "call_abc", name: "grep", argsDelta: ':"todo"}' },
+      { type: "tool-call", toolCallId: "call_abc", name: "grep", args: '{"pattern":"todo"}' },
+      { type: "finish", reason: "stop", usage: expect.anything() },
+    ]);
+  });
+
+  test("a call whose arguments never got a done event still completes", async () => {
+    const events = await collect([
+      TOOL_CALL_STREAM[0]!,
+      TOOL_CALL_STREAM[1]!,
+      TOOL_CALL_STREAM[4]!,
+      TOOL_CALL_STREAM[5]!,
+    ]);
+
+    expect(events.filter((e) => e.type === "tool-call")).toEqual([
+      { type: "tool-call", toolCallId: "call_abc", name: "grep", args: '{"pattern":"todo"}' },
+    ]);
+  });
+
+  test("the tool_search call and its output collapse into one event", async () => {
+    const events = await collect([
+      frame("response.output_item.added", {
+        type: "response.output_item.added",
+        item: { id: "ts_1", type: "tool_search_call", status: "in_progress" },
+      }),
+      frame("response.output_item.done", {
+        type: "response.output_item.done",
+        item: {
+          id: "ts_out_1",
+          type: "tool_search_output",
+          tool_search_call_id: "ts_1",
+          results: [{ name: "listOrders" }, { name: "refundOrder" }],
+        },
+      }),
+      frame("response.output_item.done", {
+        type: "response.output_item.done",
+        item: {
+          id: "ts_1",
+          type: "tool_search_call",
+          results: [{ name: "listOrders" }, { name: "refundOrder" }],
+        },
+      }),
+      frame("response.completed", { type: "response.completed", response: { usage: USAGE } }),
+    ]);
+
+    expect(events.filter((e) => e.type === "tool-search")).toEqual([
+      { type: "tool-search", loaded: ["listOrders", "refundOrder"] },
+    ]);
+  });
+
+  test("an incomplete response hitting the output cap finishes as length", async () => {
+    const events = await collect([
+      frame("response.incomplete", {
+        type: "response.incomplete",
+        response: { incomplete_details: { reason: "max_output_tokens" }, usage: USAGE },
+      }),
+    ]);
+    expect(events).toEqual([{ type: "finish", reason: "length", usage: expect.anything() }]);
+  });
+
+  test("a mid-stream error becomes an error event and a finish", async () => {
+    const events = await collect([
+      frame("response.output_text.delta", {
+        type: "response.output_text.delta",
+        item_id: "msg_1",
+        delta: "partial",
+      }),
+      frame("error", {
+        type: "error",
+        error: { code: "rate_limit_exceeded", message: "Slow down." },
+      }),
+    ]);
+
+    expect(events).toEqual([
+      { type: "text-delta", delta: "partial" },
+      {
+        type: "error",
+        error: { code: "rate_limited", message: "Slow down.", retryable: true },
+      },
+      { type: "finish", reason: "error", usage: expect.anything() },
+    ]);
+  });
+
+  test("a refusal is reported as content_filtered rather than as text", async () => {
+    const events = await collect([
+      frame("response.refusal.done", {
+        type: "response.refusal.done",
+        refusal: "I can't help with that.",
+      }),
+      frame("response.completed", { type: "response.completed", response: { usage: USAGE } }),
+    ]);
+
+    expect(events[0]).toEqual({
+      type: "error",
+      error: {
+        code: "content_filtered",
+        message: "I can't help with that.",
+        retryable: false,
+      },
+    });
+  });
+
+  test("a stream that just stops is an error, not a clean finish", async () => {
+    const events = await collect([TEXT_STREAM[2]!]);
+    expect(events).toEqual([
+      { type: "text-delta", delta: "Hello" },
+      {
+        type: "error",
+        error: {
+          code: "provider_error",
+          message: "The provider stream ended without a terminal event.",
+          retryable: true,
+        },
+      },
+      {
+        type: "finish",
+        reason: "error",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      },
+    ]);
+  });
+
+  test("unparseable frames are skipped without abandoning the stream", async () => {
+    const events = await collect([
+      "event: response.output_text.delta\ndata: {not json\n\n",
+      ...TEXT_STREAM.slice(2),
+    ]);
+    expect(events[0]).toEqual({ type: "text-delta", delta: "Hello" });
+  });
+
+  test("[DONE] ends the stream", async () => {
+    const events = await collect([...TEXT_STREAM, "data: [DONE]\n\n"]);
+    expect(events.at(-1)!.type).toBe("finish");
+  });
+
+  /**
+   * The one test that would have caught every SSE bug this parser has ever had:
+   * the same fixture, one byte at a time, must produce the same events. Chunk
+   * boundaries land inside field names, inside JSON strings and between the CR
+   * and the LF, and none of that is visible when a fixture arrives whole.
+   */
+  test("byte-at-a-time chunking produces an identical event sequence", async () => {
+    for (const fixture of [TEXT_STREAM, TOOL_CALL_STREAM]) {
+      const whole = await collect(fixture);
+      const bytes = fixture.join("").split("");
+      expect(await collect(bytes)).toEqual(whole);
+    }
+  });
+});
+
+describe("toUsage()", () => {
+  test("omits the optional counters the response did not report", () => {
+    expect(toUsage({ input_tokens: 5, output_tokens: 7 })).toEqual({
+      inputTokens: 5,
+      outputTokens: 7,
+      totalTokens: 12,
+    });
+  });
+});

--- a/packages/gemi/ai/providers/stream.ts
+++ b/packages/gemi/ai/providers/stream.ts
@@ -1,0 +1,352 @@
+import type { ProviderEvent } from "../AgentProvider";
+import type { Usage } from "../types";
+
+/**
+ * The Responses SSE stream to `ProviderEvent`.
+ *
+ * Also a pure function over chunks, for the same reason the request builder is:
+ * everything that breaks here breaks on a byte boundary or a malformed frame,
+ * and neither needs a network to reproduce. The tests drive it with recorded
+ * fixture strings, including one fed a byte at a time.
+ */
+
+export type SSEMessage = { event: string; data: string; id?: string };
+
+/**
+ * Chunks to SSE messages.
+ *
+ * Written out rather than reached for as a one-liner because every shortcut
+ * here is a bug that only shows up under load. A frame split across two chunks
+ * is the normal case, not the edge case — TCP has no idea what an event is.
+ * Multi-line `data:` is spec, comment lines beginning with `:` are what
+ * keepalives look like, and a `\r\n` stream is what you get through some
+ * proxies.
+ */
+export async function* sseMessages(
+  chunks: AsyncIterable<string> | Iterable<string>,
+): AsyncGenerator<SSEMessage> {
+  let buffer = "";
+  let event = "";
+  let data: string[] = [];
+  let id: string | undefined;
+
+  const dispatch = (): SSEMessage | null => {
+    if (data.length === 0 && !event) return null;
+    const message: SSEMessage = { event, data: data.join("\n"), id };
+    event = "";
+    data = [];
+    id = undefined;
+    // A frame with a name but no data is legal and carries nothing we want.
+    return message.data ? message : null;
+  };
+
+  const handleLine = (rawLine: string): SSEMessage | null => {
+    // Trailing CR from a `\r\n` stream. Stripping it here rather than
+    // normalizing the whole buffer keeps a CR that lands on a chunk boundary
+    // from being counted as a line ending of its own.
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (line === "") return dispatch();
+    // Keepalive. Servers send these so idle connections survive proxies, and a
+    // parser that treats one as data corrupts the next real frame.
+    if (line.startsWith(":")) return null;
+
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? "" : line.slice(colon + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+
+    if (field === "event") event = value;
+    else if (field === "data") data.push(value);
+    else if (field === "id") id = value;
+    return null;
+  };
+
+  for await (const chunk of chunks as AsyncIterable<string>) {
+    buffer += chunk;
+    let newline = buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      const message = handleLine(line);
+      if (message) yield message;
+      newline = buffer.indexOf("\n");
+    }
+  }
+
+  // A stream that ends without its final blank line still has one frame in it.
+  if (buffer.length > 0) {
+    const message = handleLine(buffer);
+    if (message) yield message;
+  }
+  const last = dispatch();
+  if (last) yield last;
+}
+
+type ParseOptions = {
+  /**
+   * Set when the agent declared an `output` schema. The same
+   * `response.output_text.delta` carries prose in one case and the JSON of the
+   * final answer in the other, and only the caller knows which it asked for.
+   */
+  structuredOutput?: boolean;
+};
+
+type PendingCall = { callId: string; name: string; done: boolean };
+
+export async function* parseResponsesStream(
+  chunks: AsyncIterable<string> | Iterable<string>,
+  options: ParseOptions = {},
+): AsyncGenerator<ProviderEvent> {
+  // Keyed by `item_id`, because the argument deltas name the item and not the
+  // call, and the call id is what the rest of gemi pairs results on.
+  const calls = new Map<string, PendingCall>();
+  const searchesReported = new Set<string>();
+  let finished = false;
+
+  for await (const message of sseMessages(chunks)) {
+    if (message.data === "[DONE]") break;
+
+    let payload: Record<string, any>;
+    try {
+      payload = JSON.parse(message.data);
+    } catch {
+      // A frame we cannot read is not a reason to abandon a stream that is
+      // otherwise fine; the terminal event is what decides how this ended.
+      continue;
+    }
+
+    // The event name is duplicated in the payload's own `type`. Preferring the
+    // payload means a gateway that drops the `event:` line still parses, and
+    // the two never disagree in practice.
+    const type: string = typeof payload.type === "string" ? payload.type : message.event;
+
+    switch (type) {
+      case "response.output_text.delta": {
+        const delta = String(payload.delta ?? "");
+        if (!delta) break;
+        yield options.structuredOutput
+          ? { type: "output-delta", delta }
+          : { type: "text-delta", delta };
+        break;
+      }
+
+      // Two names for the same thing across model generations: the summary
+      // stream and, on models that expose it, the reasoning text itself.
+      case "response.reasoning_summary_text.delta":
+      case "response.reasoning_text.delta": {
+        const delta = String(payload.delta ?? "");
+        if (!delta) break;
+        yield { type: "reasoning-delta", delta, id: payload.item_id };
+        break;
+      }
+
+      case "response.output_item.added": {
+        const item = payload.item as Record<string, any> | undefined;
+        if (!item) break;
+        if (item.type === "function_call") {
+          const itemId = String(item.id ?? payload.item_id ?? item.call_id ?? "");
+          calls.set(itemId, {
+            callId: String(item.call_id ?? itemId),
+            name: String(item.name ?? ""),
+            done: false,
+          });
+        }
+        break;
+      }
+
+      case "response.function_call_arguments.delta": {
+        const call = calls.get(String(payload.item_id ?? ""));
+        if (!call) break;
+        const argsDelta = String(payload.delta ?? "");
+        if (!argsDelta) break;
+        yield {
+          type: "tool-call-delta",
+          toolCallId: call.callId,
+          name: call.name,
+          argsDelta,
+        };
+        break;
+      }
+
+      case "response.function_call_arguments.done": {
+        const itemId = String(payload.item_id ?? "");
+        const call = calls.get(itemId);
+        if (!call) break;
+        call.done = true;
+        yield {
+          type: "tool-call",
+          toolCallId: call.callId,
+          name: call.name,
+          args: String(payload.arguments ?? ""),
+        };
+        break;
+      }
+
+      case "response.output_item.done": {
+        const item = payload.item as Record<string, any> | undefined;
+        if (!item) break;
+
+        if (item.type === "function_call") {
+          const itemId = String(item.id ?? payload.item_id ?? item.call_id ?? "");
+          const call = calls.get(itemId);
+          // Belt and braces: a call whose arguments never got a `done` event
+          // still has to reach the agent, or the loop waits for a step that
+          // will not arrive.
+          if (call?.done) break;
+          yield {
+            type: "tool-call",
+            toolCallId: String(item.call_id ?? itemId),
+            name: String(item.name ?? call?.name ?? ""),
+            args: String(item.arguments ?? ""),
+          };
+          if (call) call.done = true;
+          break;
+        }
+
+        if (item.type === "tool_search_call" || item.type === "tool_search_output") {
+          // The call and its output are one thing to a user — "went looking,
+          // found these" — so they collapse into one event. Keyed by the call
+          // id it belongs to so a pair does not report twice.
+          const key = String(item.tool_search_call_id ?? item.id ?? "");
+          if (searchesReported.has(key)) break;
+          const loaded = loadedToolNames(item);
+          if (loaded.length === 0) break;
+          searchesReported.add(key);
+          yield { type: "tool-search", loaded };
+        }
+        break;
+      }
+
+      // A refusal is the model declining, and it arrives as its own item rather
+      // than as an HTTP status. Reporting it as text would put the refusal in
+      // the transcript as if it were an answer.
+      case "response.refusal.done": {
+        yield {
+          type: "error",
+          error: {
+            code: "content_filtered",
+            message: String(payload.refusal ?? "The model refused to answer."),
+            retryable: false,
+          },
+        };
+        break;
+      }
+
+      case "response.completed": {
+        finished = true;
+        yield { type: "finish", reason: "stop", usage: toUsage(payload.response?.usage) };
+        break;
+      }
+
+      case "response.incomplete": {
+        finished = true;
+        const reason = payload.response?.incomplete_details?.reason;
+        yield {
+          type: "finish",
+          reason: reason === "max_output_tokens" ? "length" : "stop",
+          usage: toUsage(payload.response?.usage),
+        };
+        break;
+      }
+
+      case "response.failed":
+      case "error": {
+        finished = true;
+        const raw = payload.response?.error ?? payload.error ?? payload;
+        yield { type: "error", error: normalizeStreamError(raw) };
+        yield { type: "finish", reason: "error", usage: toUsage(payload.response?.usage) };
+        break;
+      }
+    }
+
+    if (finished) return;
+  }
+
+  // The connection closed with no terminal event: a dropped socket, a proxy
+  // timing out, a process going away mid-answer. Reporting it as a clean stop
+  // would tell the agent the model finished talking, and it did not — so this
+  // is an error, and a retryable one, because the same request usually works.
+  if (!finished) {
+    yield {
+      type: "error",
+      error: {
+        code: "provider_error",
+        message: "The provider stream ended without a terminal event.",
+        retryable: true,
+      },
+    };
+    yield { type: "finish", reason: "error", usage: emptyUsage() };
+  }
+}
+
+function loadedToolNames(item: Record<string, any>): string[] {
+  const raw = item.results ?? item.tools ?? item.loaded ?? item.output;
+  if (!Array.isArray(raw)) return [];
+  const names: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry === "string") names.push(entry);
+    else if (entry && typeof entry.name === "string") names.push(entry.name);
+    else if (entry && typeof entry.tool_name === "string") names.push(entry.tool_name);
+  }
+  return names;
+}
+
+function normalizeStreamError(raw: any) {
+  const message = typeof raw?.message === "string" ? raw.message : "The provider stream failed.";
+  const code = String(raw?.code ?? "").toLowerCase();
+  if (code === "rate_limit_exceeded") {
+    return { code: "rate_limited" as const, message, retryable: true };
+  }
+  if (code === "context_length_exceeded") {
+    return { code: "context_length_exceeded" as const, message, retryable: false };
+  }
+  if (code.includes("content_filter")) {
+    return { code: "content_filtered" as const, message, retryable: false };
+  }
+  // Mid-stream failures are overwhelmingly transient — the request was accepted,
+  // so it was not malformed.
+  return { code: "provider_error" as const, message, retryable: true };
+}
+
+export function emptyUsage(): Usage {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+}
+
+export function toUsage(raw: any): Usage {
+  if (!raw) return emptyUsage();
+  const inputTokens = Number(raw.input_tokens ?? 0);
+  const outputTokens = Number(raw.output_tokens ?? 0);
+  const usage: Usage = {
+    inputTokens,
+    outputTokens,
+    totalTokens: Number(raw.total_tokens ?? inputTokens + outputTokens),
+  };
+  const reasoning = raw.output_tokens_details?.reasoning_tokens;
+  if (typeof reasoning === "number") usage.reasoningTokens = reasoning;
+  const cached = raw.input_tokens_details?.cached_tokens;
+  if (typeof cached === "number") usage.cachedInputTokens = cached;
+  return usage;
+}
+
+/** A `ReadableStream` of bytes to the string chunks the parser wants. Split out
+ *  so the parser never has to know it came from a socket. */
+export async function* decodeChunks(
+  body: ReadableStream<Uint8Array> | null,
+): AsyncGenerator<string> {
+  if (!body) return;
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      // `stream: true` matters: a multi-byte character can land across two
+      // reads, and decoding each read on its own turns it into two U+FFFDs.
+      if (value) yield decoder.decode(value, { stream: true });
+    }
+    const tail = decoder.decode();
+    if (tail) yield tail;
+  } finally {
+    reader.releaseLock();
+  }
+}


### PR DESCRIPTION
> **Stack**, bottom to top — each PR is based on the one above it:
> 1. `ai/1-schema` — the schema builder runtime
> 2. **`ai/2-provider` — you are here** — the OpenAI and Azure providers
> 3. `ai/3-agent` — the agent run loop and signing
> 4. `ai/4-controller` — controller, stores, `ApiRouter.agent()`
> 5. `ai/5-client` — `useChat` and stream decoding
> 6. `ai/6-exports` — module exports and the example

`AgentProvider` implemented, plus `OpenAIProvider` and `AzureOpenAIProvider`. Every declared type survives verbatim apart from the two changes disclosed below; the logic lives in `ai/providers/` as pure functions the classes compose, and the imports back to `AgentProvider.ts` are type-only, so the runtime graph is one-directional and there is no cycle.

## The decisions

**Part order is preserved inside a message, not batched by kind.** The Responses API pairs calls positionally, so the text buffer is flushed whenever a non-message item appears rather than emitting all text and then all calls. Pinned by a test asserting `["reasoning", "message", "function_call", "function_call_output", "message"]`.

**Reasoning round-trips under its own id** as `{type: "reasoning", id, summary: [summary_text]}`, and the parser feeds that id back from `item_id` so the loop closes. An id-less reasoning part is dropped rather than sent under an invented id.

**`capabilitiesForModel` defaults an unknown model id to every capability.** Guessing high fails once, loudly, naming the parameter; guessing low degrades silently forever. This is the load-bearing decision in the file and the argument is written out in full there.

**The SSE reader is hand-written rather than reached for.** Split frames, multi-line `data`, `:` keepalives, CRLF, and a missing final blank line. A stream that ends with no terminal event yields a retryable error plus `finish("error")` rather than a clean stop. There is a byte-at-a-time test that replays every fixture one character at a time.

**Retry takes an injectable `fetchImpl`/`sleep`/`random`/`now`,** so the retry policy is tested without stubbing a global. It honours `Retry-After`, jitters its backoff, and times the request but not the stream.

**`{type: "tool_search"}` is added only when something is deferred,** and namespaces flatten with `deferred` ignored when `capabilities.toolSearch` is false — so the optimization is behaviour-neutral, which is what #425 said `deferred` is.

## Contract changes

Two, both disclosed at the time and both additive:

| symbol | change | why |
|---|---|---|
| `AzureConfig` | adds optional `deployment?: string` | The class comment promised an app could override a differently-named deployment and there was no field to do it with. Default is still the model name; `.model()` stays the only entry point. |
| `AgentProvider.normalizeError` | concrete on the base rather than `abstract` | Azure answers the same error envelope as OpenAI, so both subclasses had the identical body. Still declared on both concrete classes; only the `abstract` keyword is gone. |

## What the review round changed

Three important findings and three minor, all six fixed; 14 tests added, each run against the pre-fix code and confirmed red first.

- **A partial tool call with a result emitted an orphaned `function_call_output`.** `toResponsesInput` skipped a `tool-call` with `partial: true` but had no matching guard on the `tool-result` branch, so it sent the output half of a pair whose call half it had just deleted — a permanent 400, persisted into the history, on the run's own `stop()` path. Now `reconcileToolPairs` enforces the pairing invariant over the built item list instead of trusting each branch: an output whose call was not emitted is dropped, a duplicate is dropped, and a call left dangling gets a synthetic "no result was recorded" output so the thread stays continuable.
- **A spent quota was retried anyway.** `normalizeProviderError` computed `retryable: false` for `insufficient_quota` and the retry loop never read it, deciding on the status number alone — so the documented behaviour was exactly inverted and one billing problem became `maxRetries` of them. The loop now consults the normalized verdict as a *veto* on the status table rather than a replacement, so a future change to the error mapping cannot start retrying 400s.
- **The backoff was uninterruptible and `Retry-After` was uncapped.** A 429 carrying `retry-after: 3600` slept for an hour, and `stop()` could not reach it. The wait now races the caller's signal (for an injected sleep as well as the default) and the server-supplied value is clamped to the same 20s ceiling the computed backoff has.
- **`output` was silently dropped on a model without `structuredOutput`.** The declared contract gives `reasoning` an explicit drop clause and gives `output` none. The schema is now sent whenever the agent declared one, so an incapable model answers 400 — loud, once, naming the parameter — instead of prose that arrives as `text-delta` with no output part to find. `capabilities.structuredOutput` keeps its type and is still reported honestly for callers that want to branch.
- Two test-quality findings: the `[DONE]` test asserted nothing (its fixture could not reach the branch) and the `omni-moderation` test credited a regex boundary that never fires on that input. Both were fixed, but not as proposed — the reviewer's suggested replacements were mutation-equivalent. `[DONE]` is now covered by a liveness test that times out if the `break` is deleted, and the boundary is asserted through an exported `parseFamily` on `o200k-base`, which is the only place it is observable.

## Still open

- `store` is deliberately not sent, so the API default applies and reasoning items round-trip by id. Running with `store: false` would need `include: ["reasoning.encrypted_content"]` and a field on `ReasoningPart` to carry it, and `types.ts` is not this slice's file. **Apps with a no-retention policy currently have no switch** — worth an RFC follow-up.
- The `tool_search_call` / `tool_search_output` event shape is the least pinned-down part of the parser. It reads loaded names leniently from several plausible keys; if the real shape differs this is where fixtures need re-recording against a live response.
- Config defaults come from environment variables, not from gemi's config system as the `ai.openai` / `ai.azure` comments describe. The config schema is another slice's file; wiring is a few lines once that key exists.
- `upload()` goes through the same retry helper as a streaming call, so a 5xx re-POSTs the multipart body. Replayable, but a large attachment pays twice.
- `ProviderStreamParams.signal` is honoured, and a mid-body abort was checked by hand against a local streaming server, but there is no automated test for it — only for a pre-response abort.

## Verification

At this branch: `bun run typecheck` clean, `bun run test:types` 7 files / 63 tests / no type errors, `bun --bun vitest run` 169 files / 4072 passed / 1 skipped. `bunx oxlint` over the files in this slice: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnj9jSx45LoYp5tiv1W8Nw
