### PR TITLE
Run the agent loop, and sign what the client sends back

### DIFF
--- a/packages/gemi/ai/Agent.test-d.ts
+++ b/packages/gemi/ai/Agent.test-d.ts
@@ -165,3 +165,41 @@ describe("a pending tool call", () => {
     expectTypeOf<PendingToolCall<Shapes>["signature"]>().toEqualTypeOf<string>();
   });
 });
+
+describe("AgentTool.ask", () => {
+  test("is a client tool whose input is the prompt itself", () => {
+    const askName = AgentTool.ask({
+      name: "askName",
+      description: "Ask the customer their name",
+      outputSchema: s.object({ name: s.string() }),
+    });
+    expectTypeOf(askName).toEqualTypeOf<AgentTool<"askName", { question: string }, { name: string }>>();
+  });
+});
+
+describe("a skill", () => {
+  test("keeps its name a literal, so a registry of them stays discriminable", () => {
+    const skill = Skill.create({
+      name: "refund-policy",
+      description: "How refunds are decided",
+      instructions: () => "…",
+    });
+    expectTypeOf(skill).toEqualTypeOf<Skill<"refund-policy">>();
+  });
+});
+
+describe("a run", () => {
+  test("carries the tool shapes all the way into its result", () => {
+    const run = support.stream({} as any);
+    type Result = Awaited<ReturnType<typeof run.result>>;
+    expectTypeOf<Result["runId"]>().toEqualTypeOf<string>();
+
+    const part = {} as Result["messages"][number]["content"][number];
+    if (part.type === "tool-result" && part.name === "listOrders" && part.status === "ok") {
+      expectTypeOf(part.output).toEqualTypeOf<{ orderIds: string[] }>();
+    }
+    if (part.type === "tool-call" && part.name === "bash") {
+      expectTypeOf(part.input).toEqualTypeOf<{ command: string; cwd?: string }>();
+    }
+  });
+});

--- a/packages/gemi/ai/Agent.test-d.ts
+++ b/packages/gemi/ai/Agent.test-d.ts
@@ -136,6 +136,14 @@ describe("a tool definition", () => {
 });
 
 describe("an agent's tools", () => {
+  test("carry no namespace of their own, because a tool is a singleton", () => {
+    // The same tool may be grouped one way by one agent and another way by the
+    // next, so a field on the tool naming its group can only report whichever
+    // namespace was constructed last — to every agent sharing it. Where a tool
+    // sits is a property of the agent, and this is what keeps that true.
+    expectTypeOf(refundOrder).not.toHaveProperty("namespace");
+  });
+
   test("flatten out of their namespaces, keyed by tool name", () => {
     expectTypeOf<keyof Shapes>().toEqualTypeOf<"bash" | "ask" | "listOrders" | "refundOrder">();
   });

--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -1,0 +1,764 @@
+process.env.SECRET ??= "agent-test-secret";
+
+import { describe, expect, test, vi } from "vitest";
+import { Agent, AgentTool, Skill, ToolNamespace } from "./Agent";
+import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "./AgentProvider";
+import type { Schema } from "./Schema";
+import type {
+  AgentMessage,
+  AgentStreamEvent,
+  ClientToolResult,
+  PendingToolCall,
+  Usage,
+} from "./types";
+
+/**
+ * A schema built by hand rather than with `s`.
+ *
+ * `Schema<T>` carries a phantom property keyed by a symbol `Schema.ts` does not
+ * export, so nothing outside that file can produce one without a cast — and the
+ * agent loop only ever calls `safeParse` and `toJSONSchema`, so a fake keeps
+ * these tests independent of the builder's own progress.
+ */
+function schemaOf<T>(validate: (value: any) => string[], json: any = { type: "object" }): Schema<T> {
+  const schema = {
+    toJSONSchema: () => json,
+    parse(value: unknown) {
+      const result = schema.safeParse(value);
+      if (result.ok === false) throw new Error(result.errors.join(", "));
+      return result.value;
+    },
+    safeParse(value: unknown) {
+      const errors = validate(value);
+      return errors.length > 0
+        ? { ok: false as const, errors }
+        : { ok: true as const, value: value as T };
+    },
+  };
+  return schema as unknown as Schema<T>;
+}
+
+const stringField = (field: string) =>
+  schemaOf<any>((value) =>
+    value && typeof value[field] === "string" ? [] : [`${field}: expected a string`],
+  );
+
+const anything = () => schemaOf<any>(() => []);
+
+const usage = (inputTokens: number, outputTokens: number): Usage => ({
+  inputTokens,
+  outputTokens,
+  totalTokens: inputTokens + outputTokens,
+});
+
+/**
+ * Scripted `ProviderEvent`s, one script per model call.
+ *
+ * The real provider is written against the same interface elsewhere; depending
+ * on it here would make these tests a test of two things at once, and would
+ * need a network.
+ */
+class FakeProvider {
+  readonly model = "fake";
+  readonly capabilities = {
+    reasoning: true,
+    structuredOutput: true,
+    fileInput: true,
+    parallelToolCalls: true,
+    toolSearch: true,
+  };
+  readonly calls: ProviderStreamParams[] = [];
+
+  constructor(private scripts: ProviderEvent[][]) {}
+
+  stream(params: ProviderStreamParams) {
+    this.calls.push(params);
+    const script = this.scripts[this.calls.length - 1] ?? [
+      { type: "finish", reason: "stop", usage: usage(0, 0) },
+    ];
+    return (async function* () {
+      for (const event of script) yield event;
+    })();
+  }
+
+  async upload() {
+    return "file_1";
+  }
+
+  normalizeError(error: unknown) {
+    return {
+      code: "provider_error" as const,
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+}
+
+function fakeProvider(...scripts: ProviderEvent[][]) {
+  return new FakeProvider(scripts) as unknown as AgentProvider & FakeProvider;
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** Drains a run into an array while it keeps going. */
+function collect(run: { [Symbol.asyncIterator](): AsyncIterator<AgentStreamEvent> }) {
+  const events: AgentStreamEvent[] = [];
+  const done = (async () => {
+    for await (const event of run as AsyncIterable<AgentStreamEvent>) events.push(event);
+  })();
+  return { events, done };
+}
+
+const textOf = (message: AgentMessage) =>
+  message.content
+    .filter((part) => part.type === "text")
+    .map((part: any) => part.text)
+    .join("");
+
+const partsOf = (messages: AgentMessage[], type: string) =>
+  messages.flatMap((message) => message.content.filter((part) => part.type === type)) as any[];
+
+const req = {} as any;
+
+// --- fixtures ------------------------------------------------------------
+
+function greetAgent(provider: AgentProvider) {
+  return Agent.create({ name: "greeter", instructions: "Be brief.", provider });
+}
+
+const grepCalls: string[] = [];
+const grep = AgentTool.create({
+  name: "grep",
+  description: "Search",
+  inputSchema: stringField("pattern"),
+  outputSchema: anything(),
+  execute: async (input: any) => {
+    grepCalls.push(input.pattern);
+    return { matches: [`hit:${input.pattern}`] };
+  },
+});
+
+const refundCalls: string[] = [];
+const refundOrder = AgentTool.create({
+  name: "refundOrder",
+  description: "Refund an order",
+  inputSchema: stringField("orderId"),
+  outputSchema: anything(),
+  requiresApproval: true,
+  execute: async (input: any) => {
+    refundCalls.push(input.orderId);
+    return { refundId: `rf_${input.orderId}` };
+  },
+});
+
+const askUser = AgentTool.ask({
+  name: "ask",
+  description: "Ask the customer something",
+  outputSchema: schemaOf<{ answer: string }>((value) =>
+    value && typeof value.answer === "string" ? [] : ["answer: expected a string"],
+  ),
+});
+
+const toolCall = (toolCallId: string, name: string, args: unknown): ProviderEvent => ({
+  type: "tool-call",
+  toolCallId,
+  name,
+  args: JSON.stringify(args),
+});
+
+const finish = (): ProviderEvent => ({
+  type: "finish",
+  reason: "stop",
+  usage: usage(10, 5),
+});
+
+// --- tests ---------------------------------------------------------------
+
+describe("a plain run", () => {
+  test("streams text, ends `stop`, and reports what it produced", async () => {
+    const provider = fakeProvider([
+      { type: "text-delta", delta: "Hel" },
+      { type: "text-delta", delta: "lo" },
+      finish(),
+    ]);
+    const run = greetAgent(provider).stream({ messages: [], req, turn: { text: "hi" } });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+
+    expect(result.finishReason).toBe("stop");
+    expect(result.usage).toEqual(usage(10, 5));
+    expect(result.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(textOf(result.messages[1])).toBe("Hello");
+    expect(events.filter((event) => event.type === "text-delta").length).toBe(2);
+    expect(events[0]).toMatchObject({ type: "run-start" });
+    expect(events[events.length - 1]).toMatchObject({ type: "run-end", finishReason: "stop" });
+  });
+
+  test("puts the agent's instructions and the request's in the system prompt", async () => {
+    const provider = fakeProvider([finish()]);
+    const run = greetAgent(provider).stream({
+      messages: [],
+      req,
+      instructions: "Today is Tuesday.",
+    });
+    await run.result();
+    expect(provider.calls[0].systemPrompt).toBe("Be brief.\n\nToday is Tuesday.");
+  });
+});
+
+describe("a tool call", () => {
+  test("runs, and its result goes back to the model on the next step", async () => {
+    grepCalls.length = 0;
+    const provider = fakeProvider(
+      [toolCall("c1", "grep", { pattern: "needle" }), finish()],
+      [{ type: "text-delta", delta: "found it" }, finish()],
+    );
+    const agent = Agent.create({ name: "coder", provider, tools: [grep] });
+    const run = agent.stream({ messages: [], req, turn: { text: "search" } });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+
+    expect(grepCalls).toEqual(["needle"]);
+    expect(provider.calls.length).toBe(2);
+    expect(result.finishReason).toBe("stop");
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "ok",
+      output: { matches: ["hit:needle"] },
+    });
+    // Usage adds up across steps rather than reporting only the last call.
+    expect(result.usage).toEqual(usage(20, 10));
+    expect(events.some((event) => event.type === "tool-result")).toBe(true);
+  });
+
+  test("an unparseable argument comes back as a result the model can fix", async () => {
+    const provider = fakeProvider(
+      [toolCall("c1", "grep", { wrong: 1 }), finish()],
+      [{ type: "text-delta", delta: "sorry, retrying" }, finish()],
+    );
+    const agent = Agent.create({ name: "coder", provider, tools: [grep] });
+    const result = await agent.stream({ messages: [], req }).result();
+
+    const errors = partsOf(result.messages, "tool-result");
+    expect(errors[0].status).toBe("error");
+    expect(errors[0].error.code).toBe("invalid_tool_input");
+    // The point of not throwing: the run kept going and the model answered.
+    expect(provider.calls.length).toBe(2);
+    expect(result.finishReason).toBe("stop");
+  });
+
+  test("a throwing tool is a result, not an exception out of the run", async () => {
+    const boom = AgentTool.create({
+      name: "boom",
+      description: "Always fails",
+      inputSchema: anything(),
+      execute: async () => {
+        throw new Error("disk on fire");
+      },
+    });
+    const provider = fakeProvider([toolCall("c1", "boom", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "coder", provider, tools: [boom] });
+    const result = await agent.stream({ messages: [], req }).result();
+
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "error",
+      error: { code: "tool_error", message: "disk on fire" },
+    });
+    expect(result.finishReason).toBe("stop");
+  });
+
+  test("a generator tool yields progress and returns a result", async () => {
+    const streaming = AgentTool.create({
+      name: "bash",
+      description: "Run a command",
+      inputSchema: anything(),
+      execute: async function* () {
+        yield { line: "$ ls" };
+        yield { line: "a.txt" };
+        return { exitCode: 0 };
+      },
+    });
+    const provider = fakeProvider([toolCall("c1", "bash", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "coder", provider, tools: [streaming] });
+    const run = agent.stream({ messages: [], req });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+
+    expect(
+      events.filter((event) => event.type === "tool-progress").map((event: any) => event.data),
+    ).toEqual([{ line: "$ ls" }, { line: "a.txt" }]);
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "ok",
+      output: { exitCode: 0 },
+    });
+  });
+
+  test("stops at maxSteps rather than throwing", async () => {
+    const script = () => [toolCall(`c${Math.random()}`, "grep", { pattern: "x" }), finish()];
+    const provider = fakeProvider(script(), script(), script());
+    const agent = Agent.create({ name: "looper", provider, tools: [grep], maxSteps: 2 });
+    const result = await agent.stream({ messages: [], req }).result();
+
+    expect(result.finishReason).toBe("max-steps");
+    expect(provider.calls.length).toBe(2);
+    expect(result.messages[result.messages.length - 1].finishReason).toBe("max-steps");
+  });
+});
+
+// --- approvals -----------------------------------------------------------
+
+function approvalAgent(...scripts: ProviderEvent[][]) {
+  const provider = fakeProvider(...scripts);
+  return {
+    provider,
+    agent: Agent.create({ name: "support", provider, tools: [refundOrder, askUser] }),
+  };
+}
+
+/** Runs the first turn of the approval conversation. */
+async function askForApproval() {
+  refundCalls.length = 0;
+  const { agent, provider } = approvalAgent([
+    toolCall("c1", "refundOrder", { orderId: "ord_1" }),
+    finish(),
+  ]);
+  const run = agent.stream({ messages: [], req, turn: { text: "refund it" } });
+  const { events, done } = collect(run);
+  const result = await run.result();
+  await done;
+  const awaiting = events.find((event) => event.type === "awaiting-input") as any;
+  return { agent, provider, result, events, pending: awaiting?.pending as PendingToolCall[] };
+}
+
+describe("an approval", () => {
+  test("ends the run awaiting-input without running the tool", async () => {
+    const { result, pending, events } = await askForApproval();
+
+    expect(refundCalls).toEqual([]);
+    expect(result.finishReason).toBe("awaiting-input");
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({ toolCallId: "c1", name: "refundOrder", kind: "approval" });
+    expect(pending[0].signature).toBeTruthy();
+    // Terminal: the run is finished, not parked.
+    expect(events[events.length - 1]).toMatchObject({
+      type: "run-end",
+      finishReason: "awaiting-input",
+    });
+  });
+
+  test("carries through to completion on the next turn", async () => {
+    const first = await askForApproval();
+    const answer: ClientToolResult = {
+      toolCallId: "c1",
+      signature: first.pending[0].signature,
+      approve: true,
+    };
+
+    const provider = fakeProvider([{ type: "text-delta", delta: "refunded" }, finish()]);
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
+    const result = await agent
+      .stream({ messages: first.result.messages, req, turn: { toolResults: [answer] } })
+      .result();
+
+    expect(refundCalls).toEqual(["ord_1"]);
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      toolCallId: "c1",
+      status: "ok",
+      output: { refundId: "rf_ord_1" },
+    });
+    expect(textOf(result.messages[result.messages.length - 1])).toBe("refunded");
+    // The history the provider was handed has no dangling call in it.
+    const sent = provider.calls[0].messages.flatMap((message) => message.content);
+    expect(sent.filter((part) => part.type === "tool-call")).toHaveLength(1);
+    expect(sent.filter((part) => part.type === "tool-result")).toHaveLength(1);
+  });
+
+  test("a refusal leaves a denied result the model can read", async () => {
+    const first = await askForApproval();
+    const provider = fakeProvider([{ type: "text-delta", delta: "understood" }, finish()]);
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
+    const result = await agent
+      .stream({
+        messages: first.result.messages,
+        req,
+        turn: {
+          toolResults: [
+            { toolCallId: "c1", signature: first.pending[0].signature, approve: false, reason: "too late" },
+          ],
+        },
+      })
+      .result();
+
+    expect(refundCalls).toEqual([]);
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "denied",
+      cause: "refused",
+      reason: "too late",
+    });
+  });
+
+  test("a turn that answers nothing denies what was left open", async () => {
+    const first = await askForApproval();
+    const provider = fakeProvider([{ type: "text-delta", delta: "ok" }, finish()]);
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
+    const result = await agent
+      .stream({ messages: first.result.messages, req, turn: { text: "actually, what is my balance?" } })
+      .result();
+
+    expect(refundCalls).toEqual([]);
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "denied",
+      cause: "refused",
+    });
+    expect(provider.calls[0].messages.at(-1).content[0]).toMatchObject({ type: "text" });
+  });
+
+  test("rejects an approval whose input was rewritten on the way back", async () => {
+    const first = await askForApproval();
+    // A hostile client: the signature is genuine, the input is not.
+    const call: any = first.result.messages
+      .flatMap((message) => message.content)
+      .find((part) => part.type === "tool-call");
+    call.input = { orderId: "ord_99" };
+
+    const provider = fakeProvider([{ type: "text-delta", delta: "hm" }, finish()]);
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
+    const run = agent.stream({
+      messages: first.result.messages,
+      req,
+      turn: {
+        toolResults: [{ toolCallId: "c1", signature: first.pending[0].signature, approve: true }],
+      },
+    });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+
+    expect(refundCalls).toEqual([]);
+    expect(events.find((event) => event.type === "error")).toMatchObject({
+      error: { code: "invalid_tool_result" },
+    });
+    // Rejected, but not left dangling: it falls through to the implicit denial.
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "denied",
+      cause: "refused",
+    });
+  });
+
+  test("rejects a client that supplies an approval tool's output instead of approving", async () => {
+    const first = await askForApproval();
+    const provider = fakeProvider([finish()]);
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
+    const run = agent.stream({
+      messages: first.result.messages,
+      req,
+      turn: {
+        toolResults: [
+          {
+            toolCallId: "c1",
+            signature: first.pending[0].signature,
+            output: { refundId: "rf_forged" },
+          },
+        ],
+      },
+    });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+
+    expect(events.find((event) => event.type === "error")).toMatchObject({
+      error: { code: "invalid_tool_result" },
+    });
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({ status: "denied" });
+  });
+
+  test("rejects a result for a call the server never made", async () => {
+    const first = await askForApproval();
+    const provider = fakeProvider([finish()]);
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
+    const run = agent.stream({
+      messages: first.result.messages,
+      req,
+      turn: {
+        toolResults: [
+          { toolCallId: "c1", signature: first.pending[0].signature, approve: false },
+          { toolCallId: "ghost", signature: first.pending[0].signature, approve: true },
+        ],
+      },
+    });
+    const { events, done } = collect(run);
+    await run.result();
+    await done;
+
+    expect(
+      events.filter((event) => event.type === "error").map((event: any) => event.error.toolCallId),
+    ).toEqual(["ghost"]);
+  });
+});
+
+describe("a client-answered tool", () => {
+  test("ends awaiting-input and validates the answer against its output schema", async () => {
+    const { agent } = approvalAgent([toolCall("c1", "ask", { question: "which invoice?" }), finish()]);
+    const run = agent.stream({ messages: [], req, turn: { text: "refund something" } });
+    const { events, done } = collect(run);
+    const first = await run.result();
+    await done;
+    const pending = (events.find((event) => event.type === "awaiting-input") as any)
+      .pending as PendingToolCall[];
+    expect(pending[0].kind).toBe("question");
+
+    const provider = fakeProvider([finish()], [finish()]);
+    const agent2 = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
+
+    const bad = await agent2
+      .stream({
+        messages: first.messages,
+        req,
+        turn: { toolResults: [{ toolCallId: "c1", signature: pending[0].signature, output: { answer: 42 } }] },
+      })
+      .result();
+    expect(partsOf(bad.messages, "tool-result")[0]).toMatchObject({
+      status: "error",
+      error: { code: "invalid_tool_result" },
+    });
+
+    const good = await agent2
+      .stream({
+        messages: first.messages,
+        req,
+        turn: {
+          toolResults: [
+            { toolCallId: "c1", signature: pending[0].signature, output: { answer: "the March one" } },
+          ],
+        },
+      })
+      .result();
+    expect(partsOf(good.messages, "tool-result")[0]).toMatchObject({
+      status: "ok",
+      output: { answer: "the March one" },
+    });
+  });
+});
+
+// --- stopping ------------------------------------------------------------
+
+describe("stop()", () => {
+  test("leaves a valid transcript: a stopped result and an aborted message", async () => {
+    const started = deferred();
+    const hang = AgentTool.create({
+      name: "hang",
+      description: "Never returns",
+      inputSchema: anything(),
+      // Deliberately ignores the signal. A tool that does not cooperate must
+      // not be able to hold the run open.
+      execute: () => {
+        started.resolve();
+        return new Promise<any>(() => {});
+      },
+    });
+    const provider = fakeProvider([
+      { type: "text-delta", delta: "working on it" },
+      toolCall("c1", "hang", {}),
+      finish(),
+    ]);
+    const agent = Agent.create({ name: "slow", provider, tools: [hang] });
+    const messages: AgentMessage[] = [];
+    const run = agent.stream({
+      messages: [],
+      req,
+      onMessage: (message) => {
+        messages.push(message);
+      },
+    });
+    const { events, done } = collect(run);
+
+    await started.promise;
+    run.stop({ reason: "user pressed stop" });
+    const result = await run.result();
+    await done;
+
+    expect(result.finishReason).toBe("aborted");
+    const message = result.messages[result.messages.length - 1];
+    expect(message.finishReason).toBe("aborted");
+    // The text it had already produced survives; losing it would lose words the
+    // user has already read.
+    expect(textOf(message)).toBe("working on it");
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "denied",
+      cause: "stopped",
+      reason: "user pressed stop",
+    });
+    expect(events.some((event) => event.type === "tool-result")).toBe(true);
+    expect(events[events.length - 1]).toMatchObject({ finishReason: "aborted" });
+    // And it went through the message callback, so it is persisted whether or
+    // not anyone was watching.
+    expect(messages.map((m) => m.finishReason)).toContain("aborted");
+  });
+
+  test("an external signal stops the run the same way", async () => {
+    const started = deferred();
+    const hang = AgentTool.create({
+      name: "hang2",
+      description: "Never returns",
+      inputSchema: anything(),
+      execute: () => {
+        started.resolve();
+        return new Promise<any>(() => {});
+      },
+    });
+    const controller = new AbortController();
+    const provider = fakeProvider([toolCall("c1", "hang2", {}), finish()]);
+    const agent = Agent.create({ name: "slow", provider, tools: [hang] });
+    const run = agent.stream({ messages: [], req, signal: controller.signal });
+    await started.promise;
+    controller.abort();
+    expect((await run.result()).finishReason).toBe("aborted");
+  });
+});
+
+describe("a run outliving its request", () => {
+  test("a reader going away is not a stop", async () => {
+    const release = deferred<any>();
+    const slow = AgentTool.create({
+      name: "slow",
+      description: "Finishes eventually",
+      inputSchema: anything(),
+      execute: () => release.promise,
+    });
+    const provider = fakeProvider([toolCall("c1", "slow", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "patient", provider, tools: [slow] });
+    const run = agent.stream({ messages: [], req });
+
+    const response = run.toResponse();
+    expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+    await response.body!.cancel();
+
+    release.resolve({ ok: true });
+    const result = await run.result();
+    expect(result.finishReason).toBe("stop");
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({ status: "ok" });
+  });
+
+  test("frames replay from a cursor, which is what makes reattaching possible", async () => {
+    const provider = fakeProvider([
+      { type: "text-delta", delta: "a" },
+      { type: "text-delta", delta: "b" },
+      { type: "text-delta", delta: "c" },
+      finish(),
+    ]);
+    const run = greetAgent(provider).stream({ messages: [], req });
+    await run.result();
+
+    const all: number[] = [];
+    for await (const frame of run.frames()) all.push(frame.seq);
+    expect(all[0]).toBe(1);
+    expect(all).toEqual(all.map((_, index) => index + 1));
+
+    const tail: number[] = [];
+    for await (const frame of run.frames(4)) tail.push(frame.seq);
+    expect(tail).toEqual(all.slice(3));
+  });
+
+  test("toResponse writes the cursor into the SSE id field", async () => {
+    const provider = fakeProvider([{ type: "text-delta", delta: "hi" }, finish()]);
+    const run = greetAgent(provider).stream({ messages: [], req });
+    await run.result();
+
+    const body = await run.toResponse({ from: 2 }).text();
+    expect(body.startsWith("id: 2\ndata: {")).toBe(true);
+    expect(body).toContain('"type":"text-delta"');
+    expect(body.endsWith("\n\n")).toBe(true);
+  });
+});
+
+// --- skills and lowering -------------------------------------------------
+
+describe("skills", () => {
+  test("lower into the reserved namespace, and their body is read on load", async () => {
+    const instructions = vi.fn(() => "Refund within 30 days.");
+    const skill = Skill.create({
+      name: "refund-policy",
+      description: "How refunds are decided",
+      instructions,
+    });
+    const provider = fakeProvider(
+      [toolCall("c1", "refund-policy", {}), finish()],
+      [{ type: "text-delta", delta: "within 30 days" }, finish()],
+    );
+    const agent = Agent.create({ name: "support", provider, tools: [grep], skills: [skill] });
+
+    // Nothing was read at startup: an agent with twelve skills should not read
+    // twelve files to answer "hello".
+    expect(instructions).not.toHaveBeenCalled();
+
+    const result = await agent.stream({ messages: [], req }).result();
+    expect(instructions).toHaveBeenCalledTimes(1);
+
+    const namespaces = provider.calls[0].tools as any[];
+    const skills = namespaces.find((entry) => entry.name === "skills");
+    expect(skills.tools).toHaveLength(1);
+    expect(skills.tools[0]).toMatchObject({
+      name: "refund-policy",
+      description: "How refunds are decided",
+      parameters: { type: "object", properties: {}, required: [] },
+    });
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "ok",
+      output: "Refund within 30 days.",
+    });
+  });
+
+  test("an app namespace cannot be called `skills`", () => {
+    const shadow = ToolNamespace.create({
+      name: "skills",
+      description: "…",
+      tools: [grep],
+    });
+    expect(() =>
+      Agent.create({ name: "x", provider: fakeProvider(), tools: [shadow] }),
+    ).toThrow(/reserved/);
+  });
+
+  test("two tools may not share a name, because the client discriminates on it", () => {
+    const twin = AgentTool.create({
+      name: "grep",
+      description: "Another search",
+      inputSchema: anything(),
+      execute: async () => ({}),
+    });
+    expect(() =>
+      Agent.create({ name: "x", provider: fakeProvider(), tools: [grep, twin] }),
+    ).toThrow(/Two tools are named/);
+  });
+});
+
+describe("namespaces", () => {
+  test("flatten for dispatch and stay grouped for the model, carrying deferred through", async () => {
+    const crm = ToolNamespace.create({
+      name: "crm",
+      description: "Customer records",
+      deferred: true,
+      tools: [refundOrder],
+    });
+    const provider = fakeProvider([finish()]);
+    const agent = Agent.create({ name: "support", provider, tools: [grep, crm] });
+    await agent.stream({ messages: [], req }).result();
+
+    const tools = provider.calls[0].tools as any[];
+    expect(tools[0]).toMatchObject({ name: "grep", deferred: false });
+    expect(tools[1]).toMatchObject({
+      name: "crm",
+      description: "Customer records",
+      tools: [{ name: "refundOrder", deferred: true }],
+    });
+    expect(refundOrder.namespace).toBe("crm");
+  });
+});

--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -45,6 +45,31 @@ const stringField = (field: string) =>
 
 const anything = () => schemaOf<any>(() => []);
 
+/**
+ * A schema that *changes* the value it parses, which every real one does.
+ *
+ * `schemaOf` above returns its input untouched, so it cannot tell the raw model
+ * arguments apart from the parsed ones — and the difference between those two
+ * is exactly where a signed approval can come apart.
+ */
+function normalizingSchema<T>(normalize: (value: any) => any): Schema<T> {
+  const schema = {
+    toJSONSchema: () => ({ type: "object" }),
+    parse(value: unknown) {
+      const result = schema.safeParse(value);
+      if (result.ok === false) throw new Error(result.errors.join(", "));
+      return result.value;
+    },
+    safeParse(value: unknown) {
+      if (!value || typeof value !== "object") {
+        return { ok: false as const, errors: ["expected an object"] };
+      }
+      return { ok: true as const, value: normalize(value) as T };
+    },
+  };
+  return schema as unknown as Schema<T>;
+}
+
 const usage = (inputTokens: number, outputTokens: number): Usage => ({
   inputTokens,
   outputTokens,
@@ -157,6 +182,29 @@ const refundOrder = AgentTool.create({
   },
 });
 
+/**
+ * The same tool with a schema that drops a `null`-valued optional.
+ *
+ * Not a contrived case: strict mode has no notion of an omitted key, so
+ * `optional()` emits a nullable union and the model is *told* to send `null`,
+ * which the parse then drops. Any approval tool with one optional field takes
+ * this path on every call.
+ */
+const annotateCalls: any[] = [];
+const annotateOrder = AgentTool.create({
+  name: "annotateOrder",
+  description: "Refund an order, with an optional note",
+  inputSchema: normalizingSchema<any>(({ note, ...rest }: any) =>
+    note === null ? rest : { note, ...rest },
+  ),
+  outputSchema: anything(),
+  requiresApproval: true,
+  execute: async (input: any) => {
+    annotateCalls.push(input);
+    return { noted: true };
+  },
+});
+
 const askUser = AgentTool.ask({
   name: "ask",
   description: "Ask the customer something",
@@ -210,6 +258,29 @@ describe("a plain run", () => {
     });
     await run.result();
     expect(provider.calls[0].systemPrompt).toBe("Be brief.\n\nToday is Tuesday.");
+  });
+});
+
+describe("a provider error", () => {
+  test("survives a finish frame arriving after it", async () => {
+    // A content filter reports the block and then closes the call with usage.
+    // Which order the real provider emits these in is not pinned down, and a
+    // closing frame must not be able to erase what already failed.
+    const provider = fakeProvider([
+      { type: "error", error: { code: "content_filtered", message: "blocked", retryable: false } },
+      finish(),
+    ]);
+    const run = greetAgent(provider).stream({ messages: [], req, turn: { text: "hi" } });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+
+    expect(result.finishReason).toBe("error");
+    expect(events.find((event) => event.type === "error")).toMatchObject({
+      error: { code: "content_filtered", message: "blocked" },
+    });
+    // The tokens were still spent, so they are still counted.
+    expect(result.usage).toEqual(usage(10, 5));
   });
 });
 
@@ -480,6 +551,116 @@ describe("an approval", () => {
     expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({ status: "denied" });
   });
 
+  test("a normalizing input schema still verifies, because one value is authoritative", async () => {
+    annotateCalls.length = 0;
+    const provider = fakeProvider([
+      // What strict mode makes the model send for an omitted optional.
+      toolCall("c1", "annotateOrder", { orderId: "ord_1", note: null }),
+      finish(),
+    ]);
+    const agent = Agent.create({ name: "support", provider, tools: [annotateOrder] });
+    const first = agent.stream({ messages: [], req, turn: { text: "refund it" } });
+    const { events, done } = collect(first);
+    const asked = await first.result();
+    await done;
+    const pending = (events.find((event) => event.type === "awaiting-input") as any)
+      .pending as PendingToolCall[];
+    // The user is shown, and the server signs, the value that will actually run.
+    expect(pending[0].input).toEqual({ orderId: "ord_1" });
+
+    const answering = Agent.create({
+      name: "support",
+      provider: fakeProvider([{ type: "text-delta", delta: "done" }, finish()]),
+      tools: [annotateOrder],
+    });
+    const second = answering.stream({
+      messages: asked.messages,
+      req,
+      turn: { toolResults: [{ toolCallId: "c1", signature: pending[0].signature, approve: true }] },
+    });
+    const replay = collect(second);
+    const result = await second.result();
+    await replay.done;
+
+    // Signed over the parsed value and verified against the raw one, this came
+    // back `invalid_tool_result` and was reported to the model as a refusal —
+    // the user who clicked Approve was told they had said no.
+    expect(replay.events.filter((event) => event.type === "error")).toEqual([]);
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({ status: "ok" });
+    // And it executed with the parsed value, not the raw arguments.
+    expect(annotateCalls).toEqual([{ orderId: "ord_1" }]);
+  });
+
+  test("the same answer sent twice runs the tool once", async () => {
+    const first = await askForApproval();
+    const answer: ClientToolResult = {
+      toolCallId: "c1",
+      signature: first.pending[0].signature,
+      approve: true,
+    };
+    const provider = fakeProvider([{ type: "text-delta", delta: "refunded" }, finish()]);
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
+    const run = agent.stream({
+      messages: first.result.messages,
+      req,
+      // A retried submit, or a double-clicked button.
+      turn: { toolResults: [answer, answer] },
+    });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+
+    expect(refundCalls).toEqual(["ord_1"]);
+    // Ignored rather than reported: single use would refuse the second copy
+    // anyway, but as a forgery — and a user who double-clicked has not attacked
+    // anything, so there is nothing to tell them or to alert on.
+    expect(events.filter((event) => event.type === "error")).toEqual([]);
+    // Two results for one call is a history the provider rejects, which is the
+    // same failure the whole denied/stopped machinery exists to avoid.
+    const sent = provider.calls[0].messages.flatMap((message) => message.content);
+    expect(sent.filter((part) => part.type === "tool-result")).toHaveLength(1);
+    expect(partsOf(result.messages, "tool-result")).toHaveLength(1);
+  });
+
+  test("a captured signature does not approve the same call a second time", async () => {
+    const first = await askForApproval();
+    const answer: ClientToolResult = {
+      toolCallId: "c1",
+      signature: first.pending[0].signature,
+      approve: true,
+    };
+    const approve = () =>
+      Agent.create({
+        name: "support",
+        provider: fakeProvider([{ type: "text-delta", delta: "refunded" }, finish()]),
+        tools: [refundOrder, askUser],
+      }).stream({
+        // The history from *before* the approval — in stateless mode this comes
+        // from the browser, so rewinding it is the client's to do.
+        messages: first.result.messages,
+        req,
+        turn: { toolResults: [answer] },
+      });
+
+    await approve().result();
+    expect(refundCalls).toEqual(["ord_1"]);
+
+    const again = approve();
+    const { events, done } = collect(again);
+    const result = await again.result();
+    await done;
+
+    expect(refundCalls).toEqual(["ord_1"]);
+    expect(events.find((event) => event.type === "error")).toMatchObject({
+      error: { code: "invalid_tool_result" },
+    });
+    // Refused, not stranded: the model still gets a result for the call.
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      status: "denied",
+      cause: "refused",
+    });
+  });
+
   test("rejects a result for a call the server never made", async () => {
     const first = await askForApproval();
     const provider = fakeProvider([finish()]);
@@ -504,25 +685,43 @@ describe("an approval", () => {
   });
 });
 
+/**
+ * Runs the first turn of the question conversation.
+ *
+ * Called once per answer rather than shared between them: a signature is
+ * single-use, so two attempts at the same pending call are a replay and the
+ * second is refused — which is the point, and not what these tests are about.
+ */
+async function askQuestion() {
+  const { agent } = approvalAgent([toolCall("c1", "ask", { question: "which invoice?" }), finish()]);
+  const run = agent.stream({ messages: [], req, turn: { text: "refund something" } });
+  const { events, done } = collect(run);
+  const result = await run.result();
+  await done;
+  const pending = (events.find((event) => event.type === "awaiting-input") as any)
+    .pending as PendingToolCall[];
+  return { result, pending };
+}
+
 describe("a client-answered tool", () => {
   test("ends awaiting-input and validates the answer against its output schema", async () => {
-    const { agent } = approvalAgent([toolCall("c1", "ask", { question: "which invoice?" }), finish()]);
-    const run = agent.stream({ messages: [], req, turn: { text: "refund something" } });
-    const { events, done } = collect(run);
-    const first = await run.result();
-    await done;
-    const pending = (events.find((event) => event.type === "awaiting-input") as any)
-      .pending as PendingToolCall[];
-    expect(pending[0].kind).toBe("question");
+    const answering = Agent.create({
+      name: "support",
+      provider: fakeProvider([finish()], [finish()]),
+      tools: [refundOrder, askUser],
+    });
 
-    const provider = fakeProvider([finish()], [finish()]);
-    const agent2 = Agent.create({ name: "support", provider, tools: [refundOrder, askUser] });
-
-    const bad = await agent2
+    const first = await askQuestion();
+    expect(first.pending[0].kind).toBe("question");
+    const bad = await answering
       .stream({
-        messages: first.messages,
+        messages: first.result.messages,
         req,
-        turn: { toolResults: [{ toolCallId: "c1", signature: pending[0].signature, output: { answer: 42 } }] },
+        turn: {
+          toolResults: [
+            { toolCallId: "c1", signature: first.pending[0].signature, output: { answer: 42 } },
+          ],
+        },
       })
       .result();
     expect(partsOf(bad.messages, "tool-result")[0]).toMatchObject({
@@ -530,13 +729,18 @@ describe("a client-answered tool", () => {
       error: { code: "invalid_tool_result" },
     });
 
-    const good = await agent2
+    const second = await askQuestion();
+    const good = await answering
       .stream({
-        messages: first.messages,
+        messages: second.result.messages,
         req,
         turn: {
           toolResults: [
-            { toolCallId: "c1", signature: pending[0].signature, output: { answer: "the March one" } },
+            {
+              toolCallId: "c1",
+              signature: second.pending[0].signature,
+              output: { answer: "the March one" },
+            },
           ],
         },
       })
@@ -601,6 +805,69 @@ describe("stop()", () => {
     // And it went through the message callback, so it is persisted whether or
     // not anyone was watching.
     expect(messages.map((m) => m.finishReason)).toContain("aborted");
+  });
+
+  test("cancels a tool approved on this turn, which runs outside the loop", async () => {
+    const started = deferred();
+    const holdOn = AgentTool.create({
+      name: "holdOn",
+      description: "Approved, then never returns",
+      inputSchema: anything(),
+      requiresApproval: true,
+      // Ignores the signal, like any tool that was not written with one.
+      execute: () => {
+        started.resolve();
+        return new Promise<any>(() => {});
+      },
+    });
+    const tools = [holdOn];
+
+    const asking = Agent.create({
+      name: "slow",
+      provider: fakeProvider([toolCall("c1", "holdOn", {}), finish()]),
+      tools,
+    });
+    const first = asking.stream({ messages: [], req, turn: { text: "do it" } });
+    const asked = collect(first);
+    const before = await first.result();
+    await asked.done;
+    const pending = (asked.events.find((event) => event.type === "awaiting-input") as any)
+      .pending as PendingToolCall[];
+
+    const persisted: AgentMessage[] = [];
+    const answering = Agent.create({ name: "slow", provider: fakeProvider([finish()]), tools });
+    const run = answering.stream({
+      messages: before.messages,
+      req,
+      turn: { toolResults: [{ toolCallId: "c1", signature: pending[0].signature, approve: true }] },
+      onMessage: (message) => {
+        persisted.push(message);
+      },
+    });
+    const { events, done } = collect(run);
+
+    await started.promise;
+    run.stop({ reason: "user pressed stop" });
+    // The approval path executes outside `runTools`, so it needs its own race
+    // against the signal — unraced, this never settled and the run hung with
+    // `c1` dangling, which is the exact state `stop()` exists to prevent.
+    const result = await run.result();
+    await done;
+
+    expect(result.finishReason).toBe("aborted");
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      toolCallId: "c1",
+      status: "denied",
+      cause: "stopped",
+      reason: "user pressed stop",
+    });
+    expect(events.some((event) => event.type === "tool-result")).toBe(true);
+    expect(events[events.length - 1]).toMatchObject({ finishReason: "aborted" });
+    // The amended message is persisted too: the report pass at the end of the
+    // ingest is one of the things the abort skipped past.
+    expect(
+      persisted.flatMap((message) => message.content).filter((part) => part.type === "tool-result"),
+    ).toHaveLength(1);
   });
 
   test("an external signal stops the run the same way", async () => {
@@ -759,6 +1026,37 @@ describe("namespaces", () => {
       description: "Customer records",
       tools: [{ name: "refundOrder", deferred: true }],
     });
-    expect(refundOrder.namespace).toBe("crm");
+  });
+
+  test("a tool may sit in a different namespace in each agent that uses it", async () => {
+    // Where a tool sits is a property of the agent, not of the tool. A tool is
+    // a module-scope singleton, so a group recorded on the tool itself is one
+    // every other agent sharing it reads — and the last one constructed wins.
+    const crm = ToolNamespace.create({
+      name: "crm",
+      description: "Customer records",
+      tools: [refundOrder],
+    });
+    const billing = ToolNamespace.create({
+      name: "billing",
+      description: "Money movements",
+      tools: [refundOrder],
+    });
+    const first = fakeProvider([finish()]);
+    const second = fakeProvider([finish()]);
+    const agentA = Agent.create({ name: "a", provider: first, tools: [crm] });
+    const agentB = Agent.create({ name: "b", provider: second, tools: [billing] });
+
+    await agentA.stream({ messages: [], req }).result();
+    await agentB.stream({ messages: [], req }).result();
+
+    const groupOf = (provider: typeof first) =>
+      (provider.calls[0].tools as any[]).map((entry) => ({
+        name: entry.name,
+        tools: entry.tools.map((tool: any) => tool.name),
+      }));
+    expect(groupOf(first)).toEqual([{ name: "crm", tools: ["refundOrder"] }]);
+    // Constructed second, and the one that would have overwritten the other.
+    expect(groupOf(second)).toEqual([{ name: "billing", tools: ["refundOrder"] }]);
   });
 });

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -5,7 +5,12 @@ import type {
   ProviderToolSpec,
 } from "./AgentProvider";
 import type { Infer, Schema } from "./Schema";
-import { readSignature, signPendingCall, verifyPendingCall } from "./signing";
+import {
+  consumePendingCall,
+  readSignature,
+  signPendingCall,
+  verifyPendingCall,
+} from "./signing";
 import type {
   AgentError,
   AgentMessage,
@@ -127,7 +132,14 @@ export class AgentTool<Name extends string = string, Input = unknown, Output = u
   readonly requiresApproval: boolean;
   readonly deferred: boolean;
   readonly answeredBy: "server" | "client";
-  readonly namespace?: string;
+  /**
+   * There is deliberately no `namespace` here. A tool is a module-scope
+   * singleton, so a field naming its group would hold whichever agent
+   * constructed its namespace last and report that to every other one — the
+   * same global-effect-from-a-local-declaration that `ToolNamespace.deferred`
+   * avoids. Where a tool sits is a property of the agent, and it lives on the
+   * agent's `ResolvedTool`.
+   */
   readonly execute?: ToolExecute<Input, Output>;
 
   private constructor(params: ToolDefinition<Name, Input, Output>) {
@@ -241,13 +253,6 @@ export class ToolNamespace<
     this.description = params.description;
     this.tools = params.tools;
     this.deferred = params.deferred === true;
-    for (const tool of params.tools) {
-      // Assigned once, at module load, to a field that is `readonly` for
-      // everyone else. Membership is part of what the model is shown, and the
-      // alternative — a tool-to-namespace map threaded through every call site
-      // that renders a prompt — is more state, not less.
-      (tool as { namespace?: string }).namespace = params.name;
-    }
   }
 
   static create<const Name extends string, const T extends readonly AnyAgentTool[]>(params: {
@@ -774,6 +779,12 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
   private produced: AgentMessage[] = [];
   private current: AgentMessage | null = null;
 
+  /** Messages from an earlier run this one has amended, by id. Cloned once and
+   *  reused, so two results for the same message do not fork it. */
+  private readonly amended = new Map<string, AgentMessage>();
+  /** Amended messages that have not yet gone through `onMessage`. */
+  private readonly unreported = new Set<AgentMessage>();
+
   private usage: Usage = emptyUsage();
   private finishReason: FinishReason = "stop";
   private output: unknown;
@@ -1100,8 +1111,14 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
           break;
         }
         case "finish": {
-          outcome = { reason: event.reason };
           this.usage = addUsage(this.usage, event.usage);
+          // The usage is taken either way, the reason only if nothing has
+          // already failed. A provider is allowed to report an error and then
+          // close the call with a finish frame — a content filter does exactly
+          // that, and it still bills for the tokens — and letting the closing
+          // frame overwrite the outcome would turn "blocked" into an empty
+          // answer with no explanation anywhere.
+          if (!outcome.error) outcome = { reason: event.reason };
           break;
         }
         case "error": {
@@ -1200,6 +1217,24 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
         });
         continue;
       }
+
+      // The parsed value replaces the raw arguments on the part, and from here
+      // on it is the only input this call has.
+      //
+      // A schema normalizes — it fills defaults, coerces, and drops the `null`s
+      // that strict mode forces a model to send for an omitted optional. So
+      // `safeParse(input)` and `input` are different values, and a pending call
+      // has to be signed over, shown as, verified against and executed with the
+      // *same* one. Keeping the raw value in the transcript and signing the
+      // parsed one meant the MACs could not match on the way back: every
+      // approval of a tool with an optional field came back looking forged, and
+      // the user who clicked Approve was told they had refused.
+      //
+      // Writing it here rather than re-parsing on the way back also avoids
+      // assuming `safeParse` is idempotent — the history now carries the value
+      // the signature covers, so verification is a comparison and not a second
+      // guess at what the first parse produced.
+      call.input = parsed.value;
 
       const kind = pendingKind(resolved.tool);
       if (kind) {
@@ -1312,9 +1347,17 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
 
     if (open.length > 0) {
       const answered = new Set<string>();
-      const touched = new Map<string, AgentMessage>();
+      const seen = new Set<string>();
 
       for (const answer of turn?.toolResults ?? []) {
+        // One answer per call, first one wins. A turn carrying the same entry
+        // twice is a retried submit or a double-clicked form, and without this
+        // it ran the approved tool twice and left two results for one
+        // toolCallId — a history the provider rejects, arrived at by exactly
+        // the machinery that exists to keep the history well formed.
+        if (seen.has(answer.toolCallId)) continue;
+        seen.add(answer.toolCallId);
+
         const target = open.find((entry) => entry.call.toolCallId === answer.toolCallId);
         if (!target) {
           // Nothing to attach it to, so it cannot be told to the model even as
@@ -1334,29 +1377,23 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
         const result = await this.resolveAnswer(target, answer);
         if (!result) continue;
         answered.add(answer.toolCallId);
-        this.attachToHistory(target, result, touched);
+        this.attachToHistory(target, result);
       }
 
       for (const entry of open) {
         if (answered.has(entry.call.toolCallId)) continue;
         // The turn said something else. That is a refusal — the honest reading,
         // and the only one that cannot strand the thread.
-        this.attachToHistory(
-          entry,
-          {
-            type: "tool-result",
-            toolCallId: entry.call.toolCallId,
-            name: entry.call.name,
-            status: "denied",
-            cause: "refused",
-          },
-          touched,
-        );
+        this.attachToHistory(entry, {
+          type: "tool-result",
+          toolCallId: entry.call.toolCallId,
+          name: entry.call.name,
+          status: "denied",
+          cause: "refused",
+        });
       }
 
-      for (const message of touched.values()) {
-        await this.report(message);
-      }
+      await this.reportAmended();
     }
 
     if (turn && (turn.text || (turn.files && turn.files.length > 0))) {
@@ -1463,14 +1500,33 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
       );
     }
 
+    // Verifying says the server once asked this exact question; spending the
+    // nonce says nobody has answered it yet. Without this step a captured token
+    // approves the same call every time it is presented — the client rewinds to
+    // the history from before the result existed and replays, and the human who
+    // approved once has approved forever.
+    if (!consumePendingCall(answer.signature)) {
+      return reject(`The answer for "${name}" has already been used. Ask again.`);
+    }
+
     if ("approve" in answer) {
       if (kind !== "approval") {
         return reject(`"${name}" is answered by the client, not approved.`);
       }
       if (answer.approve === true) {
+        // Raced against the abort signal exactly as `runTools` does. A tool
+        // that does not honour `ctx.signal` must not be able to hold the run
+        // open, and this is the one execution outside the loop — a `stop()`
+        // landing here used to hang the run forever, which is precisely the
+        // dangling state `stop()` exists to prevent.
+        //
         // Step 0: the approval landed before this run took its first model
-      // step, so it belongs to no step of this loop.
-      return this.executeTool(resolved, call, call.input, 0);
+        // step, so it belongs to no step of this loop. `call.input` is the
+        // value the signature covers — see `runTools`.
+        return raceAbort(
+          this.executeTool(resolved, call, call.input, 0),
+          this.controller.signal,
+        );
       }
       return {
         type: "tool-result",
@@ -1528,19 +1584,33 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
   private attachToHistory(
     entry: { message: AgentMessage; call: ToolCallPart },
     result: ToolResultPart,
-    touched: Map<string, AgentMessage>,
   ) {
-    let message = touched.get(entry.message.id);
+    let message = this.amended.get(entry.message.id);
     if (!message) {
       const original = entry.message;
       message = { ...original, content: [...original.content] };
       const index = this.history.indexOf(original);
       if (index >= 0) this.history[index] = message;
       this.produced.push(message);
-      touched.set(original.id, message);
+      this.amended.set(original.id, message);
     }
     message.content.push(result);
+    this.unreported.add(message);
     this.emit({ type: "tool-result", messageId: message.id, part: result });
+  }
+
+  /**
+   * Persists the messages this run amended, once each.
+   *
+   * Called both at the end of `ingestTurn` and from the abort path, because a
+   * stop that lands while an approved tool is running has to persist the
+   * results that *did* attach this turn — otherwise the work is done, the
+   * transcript on the stream shows it, and the store never hears about it.
+   */
+  private async reportAmended(): Promise<void> {
+    const pending = [...this.unreported];
+    this.unreported.clear();
+    for (const message of pending) await this.report(message);
   }
 
   // --- stopping ----------------------------------------------------------
@@ -1556,6 +1626,26 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
    * next message the user sent.
    */
   private async finalizeAborted(): Promise<void> {
+    // Calls left open anywhere in the history, not just on the message this run
+    // was building. A stop that lands while an approval this turn is executing
+    // has no current message at all — the call belongs to an *earlier* turn's
+    // message — and denying only `this.current` would leave that one dangling
+    // in the very transcript this method exists to keep valid.
+    for (const entry of this.openCalls()) {
+      if (entry.message === this.current) continue;
+      this.attachToHistory(entry, {
+        type: "tool-result",
+        toolCallId: entry.call.toolCallId,
+        name: entry.call.name,
+        status: "denied",
+        cause: "stopped",
+        reason: this.stopReason,
+      });
+    }
+    // Results that did attach this turn have not been persisted yet: the report
+    // pass at the end of `ingestTurn` is one of the things the abort skipped.
+    await this.reportAmended();
+
     const message = this.current;
     if (message) {
       const answered = new Set(

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -1,13 +1,22 @@
-// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
 import type { HttpRequest } from "../http";
-import type { AgentProvider } from "./AgentProvider";
-import type { Infer, Schema } from "./Schema";
 import type {
+  AgentProvider,
+  ProviderToolNamespace,
+  ProviderToolSpec,
+} from "./AgentProvider";
+import type { Infer, Schema } from "./Schema";
+import { readSignature, signPendingCall, verifyPendingCall } from "./signing";
+import type {
+  AgentError,
   AgentMessage,
   AgentStreamEvent,
   AgentStreamFrame,
+  ClientToolResult,
   ClientTurn,
   FinishReason,
+  PendingToolCall,
+  ToolCallPart,
+  ToolResultPart,
   ToolShapes,
   Usage,
 } from "./types";
@@ -110,7 +119,7 @@ export type ToolDefinition<Name extends string, Input, Output> =
       requiresApproval?: never;
     });
 
-export declare class AgentTool<Name extends string = string, Input = unknown, Output = unknown> {
+export class AgentTool<Name extends string = string, Input = unknown, Output = unknown> {
   readonly name: Name;
   readonly description: string;
   readonly inputSchema: Schema<Input>;
@@ -121,13 +130,26 @@ export declare class AgentTool<Name extends string = string, Input = unknown, Ou
   readonly namespace?: string;
   readonly execute?: ToolExecute<Input, Output>;
 
+  private constructor(params: ToolDefinition<Name, Input, Output>) {
+    this.name = params.name;
+    this.description = params.description;
+    this.inputSchema = params.inputSchema;
+    this.outputSchema = params.outputSchema;
+    this.requiresApproval = params.requiresApproval === true;
+    this.deferred = params.deferred === true;
+    this.answeredBy = params.answeredBy === "client" ? "client" : "server";
+    this.execute = params.execute ?? undefined;
+  }
+
   /**
    * `const` on the params is what preserves `name` as a literal, which is what
    * lets the browser discriminate a tool part by name.
    */
   static create<const Name extends string, Input, Output>(
     params: ToolDefinition<Name, Input, Output>,
-  ): AgentTool<Name, Input, Output>;
+  ): AgentTool<Name, Input, Output> {
+    return new AgentTool(params);
+  }
 
   /**
    * Sugar for the common client tool: the agent asks the user something and
@@ -138,8 +160,45 @@ export declare class AgentTool<Name extends string = string, Input = unknown, Ou
     name: Name;
     description: string;
     outputSchema: Schema<Output>;
-  }): AgentTool<Name, { question: string }, Output>;
+  }): AgentTool<Name, { question: string }, Output> {
+    return AgentTool.create({
+      name: params.name,
+      description: params.description,
+      inputSchema: questionSchema,
+      outputSchema: params.outputSchema,
+      answeredBy: "client",
+    });
+  }
 }
+
+/**
+ * The one schema this module owns, rather than one built with `s`.
+ *
+ * `Schema<T>` carries a phantom property keyed by a symbol `Schema.ts` does not
+ * export, so nothing outside that file can produce one without a cast — and
+ * reaching for `s` here would make the agent runtime depend on the schema
+ * builder for a single hard-coded object. One field, no `describe`, no
+ * optionality: the cast is cheaper than the coupling.
+ */
+const questionSchema = {
+  toJSONSchema: () => ({
+    type: "object",
+    properties: { question: { type: "string", description: "What to ask the user" } },
+    required: ["question"],
+    additionalProperties: false as const,
+  }),
+  parse(value: unknown) {
+    const result = questionSchema.safeParse(value);
+    if (result.ok === false) throw new Error(result.errors.join(", "));
+    return result.value;
+  },
+  safeParse(value: unknown) {
+    if (typeof value !== "object" || value === null || typeof (value as any).question !== "string") {
+      return { ok: false as const, errors: ["question: expected a string"] };
+    }
+    return { ok: true as const, value: { question: (value as any).question } };
+  },
+} as unknown as Schema<{ question: string }>;
 
 export type AnyAgentTool = AgentTool<string, any, any>;
 
@@ -157,13 +216,40 @@ export type AnyAgentTool = AgentTool<string, any, any>;
  * discriminates on `name` alone and the namespace never leaks into the client's
  * types.
  */
-export declare class ToolNamespace<
+export class ToolNamespace<
   Name extends string = string,
   T extends readonly AnyAgentTool[] = readonly AnyAgentTool[],
 > {
   readonly name: Name;
   readonly description: string;
   readonly tools: T;
+  /**
+   * Kept here rather than pushed onto each tool. A tool is a module-scope
+   * singleton and may be listed bare as well as inside a group; writing the
+   * group's `deferred` onto it would defer it everywhere, which is a global
+   * effect from a local declaration.
+   */
+  readonly deferred: boolean;
+
+  private constructor(params: {
+    name: Name;
+    description: string;
+    tools: T;
+    deferred?: boolean;
+  }) {
+    this.name = params.name;
+    this.description = params.description;
+    this.tools = params.tools;
+    this.deferred = params.deferred === true;
+    for (const tool of params.tools) {
+      // Assigned once, at module load, to a field that is `readonly` for
+      // everyone else. Membership is part of what the model is shown, and the
+      // alternative — a tool-to-namespace map threaded through every call site
+      // that renders a prompt — is more state, not less.
+      (tool as { namespace?: string }).namespace = params.name;
+    }
+  }
+
   static create<const Name extends string, const T extends readonly AnyAgentTool[]>(params: {
     name: Name;
     /** What the model reads when deciding whether to search inside. */
@@ -172,7 +258,9 @@ export declare class ToolNamespace<
     /** Defers every tool in the group, so the whole namespace costs its own
      *  description plus one line per tool until something is loaded. */
     deferred?: boolean;
-  }): ToolNamespace<Name, T>;
+  }): ToolNamespace<Name, T> {
+    return new ToolNamespace(params);
+  }
 }
 
 /** What an agent's `tools` may hold: tools, or namespaces of them. */
@@ -186,7 +274,7 @@ type FlattenTools<T extends readonly ToolEntry[]> = T[number] extends infer E
 
 /** The tool tuple, erased to the payload types the client is allowed to see. */
 export type ToolShapesOf<T extends readonly ToolEntry[]> = {
-  [K in FlattenTools<T> as K["name"]]: K extends AgentTool<any, infer I, infer O>
+  [K in Extract<FlattenTools<T>, AnyAgentTool> as K["name"]]: K extends AgentTool<any, infer I, infer O>
     ? { input: I; output: O }
     : never;
 };
@@ -222,11 +310,36 @@ export interface SkillDefinition<Name extends string = string> {
   files?: string[];
 }
 
-export declare class Skill<Name extends string = string> {
+export class Skill<Name extends string = string> {
   readonly name: Name;
   readonly description: string;
-  static create<const Name extends string>(params: SkillDefinition<Name>): Skill<Name>;
+  readonly instructions: string | (() => string | Promise<string>);
+  readonly files?: string[];
+
+  private constructor(params: SkillDefinition<Name>) {
+    this.name = params.name;
+    this.description = params.description;
+    this.instructions = params.instructions;
+    this.files = params.files;
+  }
+
+  static create<const Name extends string>(params: SkillDefinition<Name>): Skill<Name> {
+    return new Skill(params);
+  }
 }
+
+/** Reserved: a skill is lowered into a namespace of exactly this name. */
+export const SKILLS_NAMESPACE = "skills";
+
+const SKILLS_NAMESPACE_DESCRIPTION =
+  "Instructions this agent can load on demand. Load the relevant one before acting in the area it covers.";
+
+const EMPTY_PARAMETERS = {
+  type: "object",
+  properties: {},
+  required: [] as string[],
+  additionalProperties: false as const,
+};
 
 // --- agent ---------------------------------------------------------------
 
@@ -280,6 +393,17 @@ export interface AgentStreamParams {
   provider?: AgentProvider;
   maxSteps?: number;
   reasoning?: ReasoningEffort;
+  /**
+   * Fires once for every message this run completes — the user's turn, each
+   * assistant turn, and any earlier message this turn amended by resolving a
+   * pending call. It is the controller's persistence point, and it fires
+   * whether or not anyone is still reading the stream, which is what makes a
+   * run that outlives its request useful.
+   *
+   * A message may be reported twice across runs under the same id when a
+   * pending call is resolved later; a store keyed by id should upsert.
+   */
+  onMessage?: (message: AgentMessage) => void | Promise<void>;
 }
 
 export type AgentRunResult<T extends ToolShapes, O> = {
@@ -324,9 +448,30 @@ export interface AgentRun<T extends ToolShapes = ToolShapes, O = unknown> extend
   stop(params?: { reason?: string }): void;
 }
 
-export declare class Agent<
-  const T extends readonly ToolEntry[] = readonly ToolEntry[],
-  const S extends readonly Skill[] = readonly Skill[],
+/** A tool plus where it sits in the prompt. Fixed for the life of the agent. */
+type ResolvedTool = {
+  tool: AnyAgentTool;
+  namespace?: string;
+  deferred: boolean;
+};
+
+/** What a run needs from its agent, resolved once at `Agent.create`. */
+type RunConfig = {
+  name: string;
+  instructions?: string;
+  provider: AgentProvider;
+  registry: Map<string, ResolvedTool>;
+  providerTools: (ProviderToolSpec | ProviderToolNamespace)[];
+  output?: Schema<any>;
+  maxSteps: number;
+  reasoning?: ReasoningEffort;
+};
+
+const DEFAULT_MAX_STEPS = 8;
+
+export class Agent<
+  T extends readonly ToolEntry[] = readonly ToolEntry[],
+  S extends readonly Skill[] = readonly Skill[],
   O extends Schema<any> | undefined = undefined,
 > {
   readonly name: string;
@@ -334,16 +479,1137 @@ export declare class Agent<
   readonly skills: S;
   readonly provider: AgentProvider;
   readonly output: O;
+  readonly instructions?: string;
+  readonly maxSteps: number;
+  readonly reasoning?: ReasoningEffort;
+
+  private readonly config: RunConfig;
+
+  private constructor(params: CreateAgentParams<T, S, O>) {
+    this.name = params.name;
+    this.instructions = params.instructions;
+    this.provider = params.provider;
+    this.tools = (params.tools ?? ([] as unknown as T)) as T;
+    this.skills = (params.skills ?? ([] as unknown as S)) as S;
+    this.output = params.output as O;
+    this.maxSteps = params.maxSteps ?? DEFAULT_MAX_STEPS;
+    this.reasoning = params.reasoning;
+
+    const { registry, providerTools } = lowerTools(this.tools, this.skills);
+    this.config = {
+      name: this.name,
+      instructions: this.instructions,
+      provider: this.provider,
+      registry,
+      providerTools,
+      output: params.output as Schema<any> | undefined,
+      maxSteps: this.maxSteps,
+      reasoning: this.reasoning,
+    };
+  }
 
   static create<
     const T extends readonly ToolEntry[],
     const S extends readonly Skill[],
     O extends Schema<any> | undefined = undefined,
-  >(params: CreateAgentParams<T, S, O>): Agent<T, S, O>;
+  >(params: CreateAgentParams<T, S, O>): Agent<T, S, O> {
+    return new Agent(params);
+  }
 
-  stream(params: AgentStreamParams): AgentRun<ToolShapesOf<T>, OutputOf<O>>;
+  stream(params: AgentStreamParams): AgentRun<ToolShapesOf<T>, OutputOf<O>> {
+    const config: RunConfig = {
+      ...this.config,
+      provider: params.provider ?? this.config.provider,
+      maxSteps: params.maxSteps ?? this.config.maxSteps,
+      reasoning: params.reasoning ?? this.config.reasoning,
+    };
+    return new AgentRunImpl(config, params) as unknown as AgentRun<
+      ToolShapesOf<T>,
+      OutputOf<O>
+    >;
+  }
 }
 
 export type OutputOf<O> = O extends Schema<any> ? Infer<O> : never;
 
 export type AnyAgent = Agent<any, any, any>;
+
+// --- lowering ------------------------------------------------------------
+
+function toolSpec(resolved: ResolvedTool): ProviderToolSpec {
+  return {
+    name: resolved.tool.name,
+    description: resolved.tool.description,
+    parameters: resolved.tool.inputSchema.toJSONSchema(),
+    strict: true,
+    deferred: resolved.deferred,
+  };
+}
+
+/**
+ * Flattens the declared tuple into the registry the loop dispatches on, and the
+ * shape the provider is shown.
+ *
+ * Both are built once, at `Agent.create`, because neither depends on the
+ * request: a tool is a singleton and a namespace is a static grouping. Building
+ * them per run would be work repeated on every turn for an answer that cannot
+ * change — and it would move the name-collision errors below out of startup and
+ * into the first user's first message.
+ */
+function lowerTools(
+  entries: readonly ToolEntry[],
+  skills: readonly Skill[],
+): { registry: Map<string, ResolvedTool>; providerTools: (ProviderToolSpec | ProviderToolNamespace)[] } {
+  const registry = new Map<string, ResolvedTool>();
+  const providerTools: (ProviderToolSpec | ProviderToolNamespace)[] = [];
+
+  const register = (resolved: ResolvedTool) => {
+    if (registry.has(resolved.tool.name)) {
+      throw new Error(
+        `Two tools are named "${resolved.tool.name}". Tool names are global within an agent — the client discriminates a tool part by name alone.`,
+      );
+    }
+    registry.set(resolved.tool.name, resolved);
+  };
+
+  for (const entry of entries) {
+    if (entry instanceof ToolNamespace) {
+      if (entry.name === SKILLS_NAMESPACE) {
+        throw new Error(
+          `"${SKILLS_NAMESPACE}" is reserved for the namespace skills are lowered into. Rename the namespace — silently shadowing it would make every skill unreachable with no error to read.`,
+        );
+      }
+      const members: ProviderToolSpec[] = [];
+      for (const tool of entry.tools) {
+        const resolved = { tool, namespace: entry.name, deferred: entry.deferred || tool.deferred };
+        register(resolved);
+        members.push(toolSpec(resolved));
+      }
+      providerTools.push({ name: entry.name, description: entry.description, tools: members });
+      continue;
+    }
+    const resolved = { tool: entry, deferred: entry.deferred };
+    register(resolved);
+    providerTools.push(toolSpec(resolved));
+  }
+
+  if (skills.length > 0) {
+    const members: ProviderToolSpec[] = [];
+    for (const skill of skills) {
+      const tool = skillTool(skill);
+      register({ tool, namespace: SKILLS_NAMESPACE, deferred: false });
+      members.push({
+        name: skill.name,
+        description: skill.description,
+        parameters: EMPTY_PARAMETERS,
+        strict: true,
+        // Not deferred: the whole cost of a skill in the prompt is its name and
+        // description, and those are exactly what deferral keeps. Withholding
+        // an empty parameter object saves nothing and adds a round trip.
+        deferred: false,
+      });
+    }
+    providerTools.push({
+      name: SKILLS_NAMESPACE,
+      description: SKILLS_NAMESPACE_DESCRIPTION,
+      tools: members,
+    });
+  }
+
+  return { registry, providerTools };
+}
+
+/** The zero-parameter tool a skill becomes. */
+function skillTool(skill: Skill): AnyAgentTool {
+  return AgentTool.create({
+    name: skill.name,
+    description: skill.description,
+    inputSchema: {
+      toJSONSchema: () => EMPTY_PARAMETERS,
+      parse: () => ({}),
+      safeParse: () => ({ ok: true as const, value: {} }),
+    } as unknown as Schema<Record<string, never>>,
+    // The thunk is called here, on load, and not at startup: a skill body can
+    // be a megabyte of markdown, and an agent that declares twelve of them
+    // should not read twelve files to answer "hello".
+    execute: async () => {
+      const body =
+        typeof skill.instructions === "function"
+          ? await skill.instructions()
+          : skill.instructions;
+      const sections = [body];
+      for (const file of skill.files ?? []) {
+        sections.push(`--- ${file} ---\n${await readSkillFile(file)}`);
+      }
+      return sections.join("\n\n");
+    },
+  }) as unknown as AnyAgentTool;
+}
+
+async function readSkillFile(file: string): Promise<string> {
+  try {
+    return await Bun.file(file).text();
+  } catch (error) {
+    // A missing file is told to the model rather than thrown: the rest of the
+    // skill is still worth having, and a run should not die because one of
+    // several appendices moved.
+    return `(could not be read: ${(error as Error).message})`;
+  }
+}
+
+// --- the run -------------------------------------------------------------
+
+class RunAborted extends Error {
+  constructor() {
+    super("The run was stopped");
+    this.name = "RunAborted";
+  }
+}
+
+function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new RunAborted());
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new RunAborted());
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+  });
+}
+
+function emptyUsage(): Usage {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+}
+
+function addUsage(total: Usage, next: Usage | undefined): Usage {
+  if (!next) return total;
+  const merged: Usage = {
+    inputTokens: total.inputTokens + (next.inputTokens ?? 0),
+    outputTokens: total.outputTokens + (next.outputTokens ?? 0),
+    totalTokens: total.totalTokens + (next.totalTokens ?? 0),
+  };
+  if (next.reasoningTokens !== undefined || total.reasoningTokens !== undefined) {
+    merged.reasoningTokens = (total.reasoningTokens ?? 0) + (next.reasoningTokens ?? 0);
+  }
+  if (next.cachedInputTokens !== undefined || total.cachedInputTokens !== undefined) {
+    merged.cachedInputTokens = (total.cachedInputTokens ?? 0) + (next.cachedInputTokens ?? 0);
+  }
+  return merged;
+}
+
+function isAsyncGenerator(value: unknown): value is AsyncGenerator<unknown, unknown, void> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as AsyncGenerator).next === "function" &&
+    Symbol.asyncIterator in (value as object)
+  );
+}
+
+/**
+ * The best parse of a JSON document that is still arriving.
+ *
+ * Exists so a UI can bind fields before the object closes. It closes whatever
+ * brackets are open and drops a trailing key with no value; when even that does
+ * not parse it gives up and returns an empty object rather than throwing,
+ * because a snapshot is a convenience and a run must not die for one.
+ */
+function bestEffortParse(text: string): any {
+  if (!text.trim()) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    // fall through to repair
+  }
+  const closers: string[] = [];
+  let inString = false;
+  let escaped = false;
+  for (const char of text) {
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "{") closers.push("}");
+    else if (char === "[") closers.push("]");
+    else if (char === "}" || char === "]") closers.pop();
+  }
+  let repaired = text;
+  if (inString) repaired += '"';
+  repaired = repaired.replace(/[,:]\s*$/, "");
+  const suffix = closers.reverse().join("");
+  try {
+    return JSON.parse(repaired + suffix);
+  } catch {
+    // A trailing `"key":` leaves a property with no value; drop the key too.
+    try {
+      return JSON.parse(repaired.replace(/,?\s*"[^"]*"\s*$/, "") + suffix);
+    } catch {
+      return {};
+    }
+  }
+}
+
+type StepOutcome = {
+  reason: FinishReason;
+  error?: AgentError;
+};
+
+class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
+  readonly runId: string;
+
+  private readonly config: RunConfig;
+  private readonly params: AgentStreamParams;
+  private readonly controller = new AbortController();
+
+  private readonly buffer: AgentStreamFrame<ToolShapes, unknown>[] = [];
+  private readonly waiters = new Set<() => void>();
+  private seq = 0;
+  private ended = false;
+
+  /** The working history handed to the provider, and what this run produced. */
+  private history: AgentMessage[] = [];
+  private produced: AgentMessage[] = [];
+  private current: AgentMessage | null = null;
+
+  private usage: Usage = emptyUsage();
+  private finishReason: FinishReason = "stop";
+  private output: unknown;
+  private stopReason: string | undefined;
+
+  private readonly settled: Promise<AgentRunResult<ToolShapes, unknown>>;
+
+  constructor(config: RunConfig, params: AgentStreamParams) {
+    this.config = config;
+    this.params = params;
+    this.runId = params.runId ?? `run_${crypto.randomUUID()}`;
+    this.history = [...params.messages];
+
+    if (params.signal) {
+      if (params.signal.aborted) this.controller.abort();
+      else params.signal.addEventListener("abort", () => this.stop(), { once: true });
+    }
+
+    // Started here, not on first read. A run outlives the request that began
+    // it, so nothing may depend on someone being attached — a client that
+    // never reads still gets its tools run and its messages persisted.
+    this.settled = this.execute();
+  }
+
+  // --- event plumbing ----------------------------------------------------
+
+  private emit(event: AgentStreamEvent<ToolShapes, unknown>) {
+    if (this.ended) return;
+    this.buffer.push({ seq: ++this.seq, event });
+    this.wake();
+  }
+
+  private wake() {
+    const pending = [...this.waiters];
+    this.waiters.clear();
+    for (const resolve of pending) resolve();
+  }
+
+  private nextFrame(): Promise<void> {
+    return new Promise<void>((resolve) => this.waiters.add(resolve));
+  }
+
+  /**
+   * Replays from the buffer, then follows the run live.
+   *
+   * The whole run is buffered rather than a sliding window: a run is bounded by
+   * `maxSteps`, and a client that reconnects two steps late wanting frame 42
+   * must get frame 42 and not "the oldest I still have". Bounding it is the
+   * live-run registry's job, where the policy question is how long a *finished*
+   * run is kept.
+   */
+  async *frames(from = 0): AsyncIterable<AgentStreamFrame<ToolShapes, unknown>> {
+    let index = from > 0 ? from - 1 : 0;
+    for (;;) {
+      while (index < this.buffer.length) {
+        yield this.buffer[index++];
+      }
+      if (this.ended) return;
+      await this.nextFrame();
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<AgentStreamEvent<ToolShapes, unknown>> {
+    for await (const frame of this.frames()) {
+      yield frame.event;
+    }
+  }
+
+  toResponse(params?: { from?: number }): Response {
+    const frames = this.frames(params?.from);
+    const encoder = new TextEncoder();
+    let cancelled = false;
+
+    const body = new ReadableStream<Uint8Array>({
+      start: async (controller) => {
+        try {
+          for await (const frame of frames) {
+            if (cancelled) break;
+            // `id:` carries the cursor so a browser reconnecting with
+            // `Last-Event-ID` is already asking the right question.
+            controller.enqueue(
+              encoder.encode(`id: ${frame.seq}\ndata: ${JSON.stringify(frame.event)}\n\n`),
+            );
+          }
+        } catch {
+          // A stream that cannot be written to is a dead reader, not a dead
+          // run. Nothing to report and nothing to stop.
+        }
+        try {
+          controller.close();
+        } catch {
+          // already closed by a cancel
+        }
+      },
+      cancel: () => {
+        // Deliberately does not touch the run. A disconnect is a reader
+        // leaving; `stop()` is the only thing that cancels work, because the
+        // tool loop is here and a closed tab has not stopped step four from
+        // charging a card.
+        cancelled = true;
+      },
+    });
+
+    return new Response(body, {
+      headers: {
+        "Content-Type": "text/event-stream; charset=utf-8",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        // Tells nginx not to buffer, which would otherwise hold every frame
+        // until the response ended and make a stream look like a long pause.
+        "X-Accel-Buffering": "no",
+      },
+    });
+  }
+
+  result(): Promise<AgentRunResult<ToolShapes, unknown>> {
+    return this.settled;
+  }
+
+  stop(params?: { reason?: string }): void {
+    if (this.ended || this.controller.signal.aborted) return;
+    this.stopReason = params?.reason;
+    this.controller.abort();
+  }
+
+  // --- the loop ----------------------------------------------------------
+
+  private async execute(): Promise<AgentRunResult<ToolShapes, unknown>> {
+    this.emit({ type: "run-start", runId: this.runId, threadId: this.params.threadId });
+
+    try {
+      await this.ingestTurn();
+      await this.loop();
+    } catch (error) {
+      if (error instanceof RunAborted || this.controller.signal.aborted) {
+        await this.finalizeAborted();
+      } else {
+        const normalized = this.config.provider.normalizeError(error);
+        this.emit({ type: "error", error: normalized });
+        await this.finalizeMessage("error");
+        this.finishReason = "error";
+      }
+    }
+
+    this.emit({ type: "usage", usage: this.usage });
+    this.emit({ type: "run-end", runId: this.runId, finishReason: this.finishReason });
+    this.ended = true;
+    this.wake();
+
+    return {
+      runId: this.runId,
+      messages: this.produced as AgentMessage<ToolShapes, unknown>[],
+      finishReason: this.finishReason,
+      usage: this.usage,
+      output: this.output,
+    };
+  }
+
+  private async loop(): Promise<void> {
+    const maxSteps = Math.max(1, this.config.maxSteps);
+
+    for (let step = 1; step <= maxSteps; step++) {
+      const message = this.startMessage();
+      const outcome = await this.runStep(message);
+
+      if (outcome.error) {
+        this.emit({ type: "error", error: outcome.error });
+        await this.finalizeMessage("error");
+        this.finishReason = "error";
+        return;
+      }
+
+      const calls = message.content.filter(
+        (part): part is ToolCallPart => part.type === "tool-call",
+      );
+
+      if (calls.length === 0) {
+        this.finishReason = outcome.reason;
+        await this.finalizeMessage(outcome.reason);
+        return;
+      }
+
+      const pending = await this.runTools(message, calls, step);
+
+      if (pending.length > 0) {
+        // The message closes first, then the run says what it is waiting for:
+        // `awaiting-input` is terminal, and everything needed to answer it has
+        // to already be on the stream when it arrives.
+        this.finishReason = "awaiting-input";
+        await this.finalizeMessage("awaiting-input");
+        this.emit({ type: "awaiting-input", runId: this.runId, pending });
+        return;
+      }
+
+      if (step === maxSteps) {
+        // Not an exception. An agent that will not stop calling tools is a bug
+        // the app has to be able to see and show, and a throw here would put it
+        // in a log instead of in the transcript.
+        this.finishReason = "max-steps";
+        await this.finalizeMessage("max-steps");
+        return;
+      }
+
+      await this.finalizeMessage(outcome.reason);
+    }
+  }
+
+  private startMessage(): AgentMessage {
+    const message: AgentMessage = {
+      id: `msg_${crypto.randomUUID()}`,
+      role: "assistant",
+      content: [],
+      createdAt: new Date().toISOString(),
+    };
+    this.current = message;
+    this.history.push(message);
+    this.produced.push(message);
+    this.emit({ type: "message-start", messageId: message.id, role: "assistant" });
+    return message;
+  }
+
+  private async finalizeMessage(reason: FinishReason): Promise<void> {
+    const message = this.current;
+    if (!message) return;
+    this.current = null;
+    message.finishReason = reason;
+    this.emit({ type: "message-end", messageId: message.id, finishReason: reason });
+    await this.report(message);
+  }
+
+  private async report(message: AgentMessage): Promise<void> {
+    if (!this.params.onMessage) return;
+    try {
+      await this.params.onMessage(message);
+    } catch {
+      // Persistence failing must not take the transcript with it: the messages
+      // are still on the stream and still in `result()`.
+    }
+  }
+
+  // --- one model call ----------------------------------------------------
+
+  private async runStep(message: AgentMessage): Promise<StepOutcome> {
+    const signal = this.controller.signal;
+    const provider = this.config.provider;
+
+    let outcome: StepOutcome = { reason: "stop" };
+    const partialArgs = new Map<string, { name: string; args: string }>();
+    let outputText = "";
+
+    const stream = provider.stream({
+      messages: this.history.filter((m) => m !== message),
+      systemPrompt: await this.systemPrompt(),
+      tools: this.config.providerTools.length > 0 ? this.config.providerTools : undefined,
+      output: this.config.output
+        ? { name: "output", schema: this.config.output.toJSONSchema() }
+        : undefined,
+      reasoning: this.config.reasoning,
+      signal,
+    });
+
+    const iterator = stream[Symbol.asyncIterator]();
+    for (;;) {
+      const next = await raceAbort(Promise.resolve(iterator.next()), signal);
+      if (next.done) break;
+      const event = next.value;
+
+      switch (event.type) {
+        case "text-delta": {
+          appendText(message, "text", event.delta);
+          this.emit({ type: "text-delta", messageId: message.id, delta: event.delta });
+          break;
+        }
+        case "reasoning-delta": {
+          appendText(message, "reasoning", event.delta);
+          this.emit({ type: "reasoning-delta", messageId: message.id, delta: event.delta });
+          break;
+        }
+        case "output-delta": {
+          outputText += event.delta;
+          this.emit({
+            type: "output-delta",
+            messageId: message.id,
+            delta: event.delta,
+            snapshot: bestEffortParse(outputText),
+          });
+          break;
+        }
+        case "tool-search": {
+          this.emit({ type: "tool-search", loaded: event.loaded });
+          break;
+        }
+        case "tool-call-delta": {
+          const held = partialArgs.get(event.toolCallId) ?? { name: event.name, args: "" };
+          held.args += event.argsDelta;
+          held.name = event.name || held.name;
+          partialArgs.set(event.toolCallId, held);
+          this.emit({
+            type: "tool-call",
+            messageId: message.id,
+            part: {
+              type: "tool-call",
+              toolCallId: event.toolCallId,
+              name: held.name,
+              input: bestEffortParse(held.args),
+              partial: true,
+            },
+          });
+          break;
+        }
+        case "tool-call": {
+          partialArgs.delete(event.toolCallId);
+          const part: ToolCallPart = {
+            type: "tool-call",
+            toolCallId: event.toolCallId,
+            name: event.name,
+            // A raw string when the model produced something that is not JSON.
+            // Keeping it is what makes the `invalid_tool_input` result below
+            // readable instead of an empty object nobody can explain.
+            input: parseArgs(event.args),
+          };
+          message.content.push(part);
+          this.emit({ type: "tool-call", messageId: message.id, part });
+          break;
+        }
+        case "finish": {
+          outcome = { reason: event.reason };
+          this.usage = addUsage(this.usage, event.usage);
+          break;
+        }
+        case "error": {
+          outcome = { reason: "error", error: event.error };
+          break;
+        }
+      }
+    }
+
+    // A tool call whose arguments never finished arriving. It is still a call
+    // the model made, so it gets a part and, below, an `invalid_tool_input`
+    // result — dropping it would leave the model unable to see what went wrong.
+    for (const [toolCallId, held] of partialArgs) {
+      const part: ToolCallPart = {
+        type: "tool-call",
+        toolCallId,
+        name: held.name,
+        input: parseArgs(held.args),
+      };
+      message.content.push(part);
+      this.emit({ type: "tool-call", messageId: message.id, part });
+    }
+
+    if (this.config.output && outputText && !outcome.error) {
+      const parsed = this.config.output.safeParse(bestEffortParse(outputText));
+      if (parsed.ok === true) {
+        this.output = parsed.value;
+        message.content.push({ type: "output", value: parsed.value });
+      } else {
+        this.emit({
+          type: "error",
+          error: {
+            code: "unknown",
+            message: `The model's structured answer did not match the output schema: ${parsed.errors.join(", ")}`,
+            retryable: true,
+          },
+        });
+      }
+    }
+
+    return outcome;
+  }
+
+  private async systemPrompt(): Promise<string | undefined> {
+    const parts = [this.config.instructions, this.params.instructions].filter(
+      (part): part is string => Boolean(part && part.trim()),
+    );
+    return parts.length > 0 ? parts.join("\n\n") : undefined;
+  }
+
+  // --- tools -------------------------------------------------------------
+
+  private async runTools(
+    message: AgentMessage,
+    calls: ToolCallPart[],
+    step: number,
+  ): Promise<PendingToolCall[]> {
+    const pending: PendingToolCall[] = [];
+    const running: Promise<void>[] = [];
+
+    for (const call of calls) {
+      const resolved = this.config.registry.get(String(call.name));
+
+      if (!resolved) {
+        this.addResult(message, {
+          type: "tool-result",
+          toolCallId: call.toolCallId,
+          name: call.name,
+          status: "error",
+          error: {
+            code: "tool_error",
+            message: `There is no tool named "${String(call.name)}".`,
+            toolCallId: call.toolCallId,
+            retryable: true,
+          },
+        });
+        continue;
+      }
+
+      const parsed = resolved.tool.inputSchema.safeParse(call.input);
+      if (parsed.ok === false) {
+        // Back to the model, not up the stack. A model that mis-typed one
+        // argument can usually fix it on the next step, and throwing turns a
+        // recoverable mistake into a dead run.
+        this.addResult(message, {
+          type: "tool-result",
+          toolCallId: call.toolCallId,
+          name: call.name,
+          status: "error",
+          error: {
+            code: "invalid_tool_input",
+            message: `Invalid arguments for "${String(call.name)}": ${parsed.errors.join(", ")}`,
+            toolCallId: call.toolCallId,
+            retryable: true,
+          },
+        });
+        continue;
+      }
+
+      const kind = pendingKind(resolved.tool);
+      if (kind) {
+        pending.push({
+          toolCallId: call.toolCallId,
+          name: call.name,
+          input: parsed.value,
+          kind,
+          signature: signPendingCall({
+            runId: this.runId,
+            toolCallId: call.toolCallId,
+            name: String(call.name),
+            kind,
+            input: parsed.value,
+          }),
+        });
+        continue;
+      }
+
+      running.push(
+        this.executeTool(resolved, call, parsed.value, step)
+          .then((result) => this.addResult(message, result))
+          // Only `RunAborted` reaches here, and the abort path denies every
+          // unresolved call at once — swallowing it keeps a stopped run from
+          // also raising an unhandled rejection.
+          .catch(() => undefined),
+      );
+    }
+
+    await raceAbort(Promise.all(running).then(() => undefined), this.controller.signal);
+    return pending;
+  }
+
+  private async executeTool(
+    resolved: ResolvedTool,
+    call: ToolCallPart,
+    input: unknown,
+    step: number,
+  ): Promise<ToolResultPart> {
+    const ctx: ToolContext = {
+      req: this.params.req,
+      runId: this.runId,
+      threadId: this.params.threadId,
+      toolCallId: call.toolCallId,
+      signal: this.controller.signal,
+      step,
+    };
+
+    try {
+      const started = resolved.tool.execute!(input as any, ctx);
+      let output: unknown;
+      if (isAsyncGenerator(started)) {
+        let next = await started.next();
+        while (!next.done) {
+          this.emit({ type: "tool-progress", toolCallId: call.toolCallId, data: next.value });
+          next = await started.next();
+        }
+        output = next.value;
+      } else {
+        output = await started;
+      }
+      return {
+        type: "tool-result",
+        toolCallId: call.toolCallId,
+        name: call.name,
+        status: "ok",
+        output,
+      };
+    } catch (error) {
+      if (error instanceof RunAborted || this.controller.signal.aborted) {
+        // Left to the abort path, which denies every unresolved call at once.
+        throw new RunAborted();
+      }
+      // A throwing tool is a result, not an exception out of the run: the model
+      // is told the call failed and can try something else, which is what a
+      // person would do.
+      return {
+        type: "tool-result",
+        toolCallId: call.toolCallId,
+        name: call.name,
+        status: "error",
+        error: {
+          code: "tool_error",
+          message: error instanceof Error ? error.message : String(error),
+          toolCallId: call.toolCallId,
+          retryable: true,
+        },
+      };
+    }
+  }
+
+  private addResult(message: AgentMessage, part: ToolResultPart) {
+    message.content.push(part);
+    this.emit({ type: "tool-result", messageId: message.id, part });
+  }
+
+  // --- the client's turn -------------------------------------------------
+
+  /**
+   * Resolves what the client sent back, then adds its words.
+   *
+   * Every pending call has to come out of this with a result — signed, refused
+   * or implicitly denied. The provider rejects a history holding a tool call
+   * with no result, so leaving one open would break not this turn but the next
+   * one, at a point where the cause is no longer visible.
+   */
+  private async ingestTurn(): Promise<void> {
+    const turn = this.params.turn;
+    const open = this.openCalls();
+
+    if (open.length > 0) {
+      const answered = new Set<string>();
+      const touched = new Map<string, AgentMessage>();
+
+      for (const answer of turn?.toolResults ?? []) {
+        const target = open.find((entry) => entry.call.toolCallId === answer.toolCallId);
+        if (!target) {
+          // Nothing to attach it to, so it cannot be told to the model even as
+          // an error part — a result for a call that was never made.
+          this.emit({
+            type: "error",
+            error: {
+              code: "invalid_tool_result",
+              message: `No pending tool call with id "${answer.toolCallId}".`,
+              toolCallId: answer.toolCallId,
+              retryable: false,
+            },
+          });
+          continue;
+        }
+
+        const result = await this.resolveAnswer(target, answer);
+        if (!result) continue;
+        answered.add(answer.toolCallId);
+        this.attachToHistory(target, result, touched);
+      }
+
+      for (const entry of open) {
+        if (answered.has(entry.call.toolCallId)) continue;
+        // The turn said something else. That is a refusal — the honest reading,
+        // and the only one that cannot strand the thread.
+        this.attachToHistory(
+          entry,
+          {
+            type: "tool-result",
+            toolCallId: entry.call.toolCallId,
+            name: entry.call.name,
+            status: "denied",
+            cause: "refused",
+          },
+          touched,
+        );
+      }
+
+      for (const message of touched.values()) {
+        await this.report(message);
+      }
+    }
+
+    if (turn && (turn.text || (turn.files && turn.files.length > 0))) {
+      const message: AgentMessage = {
+        id: `msg_${crypto.randomUUID()}`,
+        role: "user",
+        content: [
+          ...(turn.text ? [{ type: "text" as const, text: turn.text }] : []),
+          ...(turn.files ?? []).map((file) => ({
+            type: "file" as const,
+            fileId: file.fileId,
+            name: file.name,
+            mimeType: file.mimeType,
+          })),
+        ],
+        createdAt: new Date().toISOString(),
+        finishReason: "stop",
+      };
+      this.history.push(message);
+      this.produced.push(message);
+      await this.report(message);
+    }
+  }
+
+  /** Tool calls in the history with no result anywhere after them. */
+  private openCalls(): { message: AgentMessage; call: ToolCallPart }[] {
+    const resolvedIds = new Set<string>();
+    for (const message of this.history) {
+      for (const part of message.content) {
+        if (part.type === "tool-result") resolvedIds.add(part.toolCallId);
+      }
+    }
+    const open: { message: AgentMessage; call: ToolCallPart }[] = [];
+    for (const message of this.history) {
+      for (const part of message.content) {
+        if (part.type === "tool-call" && !resolvedIds.has(part.toolCallId)) {
+          open.push({ message, call: part });
+        }
+      }
+    }
+    return open;
+  }
+
+  /**
+   * Verifies one answer and turns it into a result part, or reports why not.
+   *
+   * `null` means the call stays unanswered and falls through to the implicit
+   * denial above — which is the right outcome for a bad signature: the model
+   * must not see a result the server cannot vouch for.
+   */
+  private async resolveAnswer(
+    entry: { message: AgentMessage; call: ToolCallPart },
+    answer: ClientToolResult,
+  ): Promise<ToolResultPart | null> {
+    const call = entry.call;
+    const name = String(call.name);
+    const resolved = this.config.registry.get(name);
+    const reject = (message: string) => {
+      this.emit({
+        type: "error",
+        error: {
+          code: "invalid_tool_result",
+          message,
+          toolCallId: call.toolCallId,
+          retryable: false,
+        },
+      });
+      return null;
+    };
+
+    if (!resolved) {
+      return reject(`The tool "${name}" no longer exists, so its answer cannot be checked.`);
+    }
+    const kind = pendingKind(resolved.tool);
+    if (!kind) {
+      return reject(`"${name}" is a server tool with no pending question.`);
+    }
+    if (typeof answer.signature !== "string" || answer.signature.length === 0) {
+      return reject(`The answer for "${name}" carried no signature.`);
+    }
+
+    // The issuing run, read out of the token. The turn answering a pending call
+    // is a *new* run with a new id, so the id the signature was made under has
+    // to travel with the signature — and it is covered by the MAC, so a client
+    // that edits it fails below rather than being believed.
+    const issued = readSignature(answer.signature);
+    if (!issued) {
+      return reject(`The signature for "${name}" is malformed.`);
+    }
+
+    const verified = verifyPendingCall(answer.signature, {
+      runId: issued.runId,
+      toolCallId: call.toolCallId,
+      name,
+      kind,
+      input: call.input,
+    });
+
+    if (verified.ok === false) {
+      return reject(
+        verified.reason === "expired"
+          ? `The approval for "${name}" has expired. Ask again.`
+          : `The answer for "${name}" does not match the call the server made.`,
+      );
+    }
+
+    if ("approve" in answer) {
+      if (kind !== "approval") {
+        return reject(`"${name}" is answered by the client, not approved.`);
+      }
+      if (answer.approve === true) {
+        // Step 0: the approval landed before this run took its first model
+      // step, so it belongs to no step of this loop.
+      return this.executeTool(resolved, call, call.input, 0);
+      }
+      return {
+        type: "tool-result",
+        toolCallId: call.toolCallId,
+        name: call.name,
+        status: "denied",
+        cause: "refused",
+        reason: answer.reason,
+      };
+    }
+
+    if ("output" in answer) {
+      if (kind === "approval") {
+        // An approval is a tool the *server* runs. A client handing back its
+        // output would be fabricating a result, not approving one.
+        return reject(`"${name}" is approved, not answered: the server produces its result.`);
+      }
+      const schema = resolved.tool.outputSchema;
+      const parsed = schema ? schema.safeParse(answer.output) : { ok: true as const, value: answer.output };
+      if (parsed.ok === false) {
+        return {
+          type: "tool-result",
+          toolCallId: call.toolCallId,
+          name: call.name,
+          status: "error",
+          error: {
+            code: "invalid_tool_result",
+            message: `The answer for "${name}" did not match its output schema: ${parsed.errors.join(", ")}`,
+            toolCallId: call.toolCallId,
+            retryable: true,
+          },
+        };
+      }
+      return {
+        type: "tool-result",
+        toolCallId: call.toolCallId,
+        name: call.name,
+        status: "ok",
+        output: parsed.value,
+      };
+    }
+
+    return reject(`The answer for "${name}" carried neither an approval nor an output.`);
+  }
+
+  /**
+   * Puts the result next to the call that asked for it.
+   *
+   * The message being amended came from an earlier run, so it is cloned before
+   * it is touched — the caller's `messages` array is an input, not scratch
+   * space, and a controller that persisted it would otherwise see it change
+   * under it. The clone is reported through `onMessage` and returned in
+   * `result()`, which is why a store keyed by message id has to upsert.
+   */
+  private attachToHistory(
+    entry: { message: AgentMessage; call: ToolCallPart },
+    result: ToolResultPart,
+    touched: Map<string, AgentMessage>,
+  ) {
+    let message = touched.get(entry.message.id);
+    if (!message) {
+      const original = entry.message;
+      message = { ...original, content: [...original.content] };
+      const index = this.history.indexOf(original);
+      if (index >= 0) this.history[index] = message;
+      this.produced.push(message);
+      touched.set(original.id, message);
+    }
+    message.content.push(result);
+    this.emit({ type: "tool-result", messageId: message.id, part: result });
+  }
+
+  // --- stopping ----------------------------------------------------------
+
+  /**
+   * The run's last act: leave a transcript the next turn can be built on.
+   *
+   * Everything the model asked for and did not get becomes a `denied` result
+   * with `cause: "stopped"`, and the interrupted message is finalized as
+   * `aborted` keeping whatever text it had produced. Both go out on the stream
+   * and through `onMessage`. A cancel that merely stopped emitting would leave
+   * a dangling tool call, and the provider would reject the history on the very
+   * next message the user sent.
+   */
+  private async finalizeAborted(): Promise<void> {
+    const message = this.current;
+    if (message) {
+      const answered = new Set(
+        message.content
+          .filter((part): part is ToolResultPart => part.type === "tool-result")
+          .map((part) => part.toolCallId),
+      );
+      for (const part of [...message.content]) {
+        if (part.type !== "tool-call" || answered.has(part.toolCallId)) continue;
+        // A call whose arguments were still arriving is finalized too: the
+        // client has already been shown it, and an unresolved part is exactly
+        // what this method exists to prevent.
+        delete part.partial;
+        this.addResult(message, {
+          type: "tool-result",
+          toolCallId: part.toolCallId,
+          name: part.name,
+          status: "denied",
+          cause: "stopped",
+          reason: this.stopReason,
+        });
+      }
+    }
+    this.finishReason = "aborted";
+    await this.finalizeMessage("aborted");
+  }
+}
+
+function pendingKind(tool: AnyAgentTool): "approval" | "question" | "client" | null {
+  if (tool.answeredBy === "client") {
+    // A question is a client tool whose input is the prompt itself. The
+    // distinction is for the UI — one renders a dialog, the other runs code —
+    // and it costs nothing to carry.
+    return tool.inputSchema === questionSchema ? "question" : "client";
+  }
+  return tool.requiresApproval ? "approval" : null;
+}
+
+function parseArgs(args: string): any {
+  if (!args || !args.trim()) return {};
+  try {
+    return JSON.parse(args);
+  } catch {
+    return args;
+  }
+}
+
+function appendText(message: AgentMessage, type: "text" | "reasoning", delta: string) {
+  const last = message.content[message.content.length - 1];
+  if (last && last.type === type) {
+    (last as { text?: string }).text = ((last as { text?: string }).text ?? "") + delta;
+    return;
+  }
+  message.content.push(
+    type === "text" ? { type: "text", text: delta } : { type: "reasoning", text: delta },
+  );
+}

--- a/packages/gemi/ai/signing.test.ts
+++ b/packages/gemi/ai/signing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   canonicalize,
+  consumePendingCall,
   readSignature,
   signPendingCall,
   verifyPendingCall,
@@ -82,7 +83,11 @@ describe("a signed pending call", () => {
     });
   });
 
-  test("rejects a signature replayed into a different run", () => {
+  test("covers the run it was issued for, so a token cannot be re-pointed", () => {
+    // Note what this does *not* say. `Agent` reads the runId out of the token
+    // rather than choosing it, so this is the MAC covering the field, not a
+    // replay defence — replay is `consumePendingCall` below, and the end-to-end
+    // case is in Agent.test.ts.
     const signature = signPendingCall(claims(), { secret });
     expect(verifyPendingCall(signature, claims({ runId: "run_2" }), { secret })).toEqual({
       ok: false,
@@ -142,5 +147,39 @@ describe("a signed pending call", () => {
     } finally {
       if (previous !== undefined) process.env.SECRET = previous;
     }
+  });
+});
+
+describe("spending a signature", () => {
+  test("is single use: the second presentation of a token is a replay", () => {
+    const signature = signPendingCall(claims(), { secret });
+    // Verification is unchanged by spending — the token is still authentic, it
+    // is the question that is no longer open.
+    expect(consumePendingCall(signature)).toBe(true);
+    expect(verifyPendingCall(signature, claims(), { secret }).ok).toBe(true);
+    expect(consumePendingCall(signature)).toBe(false);
+  });
+
+  test("two calls in the same run get their own nonces", () => {
+    const first = signPendingCall(claims(), { secret });
+    const second = signPendingCall(claims({ toolCallId: "call_2" }), { secret });
+    expect(readSignature(first)?.nonce).not.toBe(readSignature(second)?.nonce);
+    expect(consumePendingCall(first)).toBe(true);
+    expect(consumePendingCall(second)).toBe(true);
+  });
+
+  test("stops holding a nonce once the token it refers to has expired", () => {
+    // What bounds the registry: an entry is worth keeping only while the token
+    // could still verify, and a token past its expiry is refused by `verify`
+    // whether or not the nonce is still on file.
+    const now = Date.now();
+    const signature = signPendingCall(claims(), { secret, ttlMs: 1000, now });
+    expect(consumePendingCall(signature, { now })).toBe(true);
+    expect(consumePendingCall(signature, { now: now + 500 })).toBe(false);
+    expect(consumePendingCall(signature, { now: now + 2000 })).toBe(true);
+  });
+
+  test("spends nothing for a token it cannot read", () => {
+    expect(consumePendingCall("not-a-token")).toBe(false);
   });
 });

--- a/packages/gemi/ai/signing.test.ts
+++ b/packages/gemi/ai/signing.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "vitest";
+import {
+  canonicalize,
+  readSignature,
+  signPendingCall,
+  verifyPendingCall,
+  type PendingCallClaims,
+} from "./signing";
+
+const secret = "signing-test-secret";
+
+function claims(overrides: Partial<PendingCallClaims> = {}): PendingCallClaims {
+  return {
+    runId: "run_1",
+    toolCallId: "call_1",
+    name: "refundOrder",
+    kind: "approval",
+    input: { orderId: "ord_1", amountCents: 4200 },
+    ...overrides,
+  };
+}
+
+describe("canonicalize", () => {
+  test("is insensitive to key order, so a round trip does not invalidate an approval", () => {
+    expect(canonicalize({ a: 1, b: [{ y: 2, x: 1 }] })).toBe(
+      canonicalize({ b: [{ x: 1, y: 2 }], a: 1 }),
+    );
+  });
+
+  test("keeps array order, where order is the value", () => {
+    expect(canonicalize([1, 2])).not.toBe(canonicalize([2, 1]));
+  });
+
+  test("drops undefined members, which do not survive JSON anyway", () => {
+    expect(canonicalize({ a: 1, b: undefined })).toBe(canonicalize({ a: 1 }));
+  });
+});
+
+describe("a signed pending call", () => {
+  test("verifies against the claims it was made from", () => {
+    const signature = signPendingCall(claims(), { secret });
+    const result = verifyPendingCall(signature, claims(), { secret });
+    expect(result.ok).toBe(true);
+    if (result.ok === true) {
+      expect(result.runId).toBe("run_1");
+      expect(result.expiresAt).toBeGreaterThan(Date.now());
+    }
+  });
+
+  test("survives an input that was parsed and re-serialized on the way back", () => {
+    const signature = signPendingCall(claims(), { secret });
+    const roundTripped = JSON.parse(
+      JSON.stringify({ amountCents: 4200, orderId: "ord_1" }),
+    );
+    expect(verifyPendingCall(signature, claims({ input: roundTripped }), { secret }).ok).toBe(
+      true,
+    );
+  });
+
+  test("carries the issuing run in the clear, because the answer arrives in a later run", () => {
+    const signature = signPendingCall(claims(), { secret });
+    expect(readSignature(signature)?.runId).toBe("run_1");
+  });
+
+  test("rejects an input rewritten on the way back", () => {
+    const signature = signPendingCall(claims(), { secret });
+    const result = verifyPendingCall(
+      signature,
+      claims({ input: { orderId: "ord_1", amountCents: 999_999 } }),
+      { secret },
+    );
+    expect(result).toEqual({ ok: false, reason: "forged" });
+  });
+
+  test("rejects an approval's signature reused to supply an output", () => {
+    // The attack the `kind` claim exists for: an approval is a tool the server
+    // runs, so a client handing back its output would be fabricating a result.
+    const signature = signPendingCall(claims(), { secret });
+    expect(verifyPendingCall(signature, claims({ kind: "client" }), { secret })).toEqual({
+      ok: false,
+      reason: "forged",
+    });
+  });
+
+  test("rejects a signature replayed into a different run", () => {
+    const signature = signPendingCall(claims(), { secret });
+    expect(verifyPendingCall(signature, claims({ runId: "run_2" }), { secret })).toEqual({
+      ok: false,
+      reason: "forged",
+    });
+  });
+
+  test("rejects a signature moved onto a different call of the same tool", () => {
+    const signature = signPendingCall(claims(), { secret });
+    expect(verifyPendingCall(signature, claims({ toolCallId: "call_2" }), { secret })).toEqual({
+      ok: false,
+      reason: "forged",
+    });
+  });
+
+  test("rejects one signed with another key", () => {
+    const signature = signPendingCall(claims(), { secret: "someone else's key" });
+    expect(verifyPendingCall(signature, claims(), { secret })).toEqual({
+      ok: false,
+      reason: "forged",
+    });
+  });
+
+  test("reports expiry separately, because it is a sentence to show and not an alert", () => {
+    const now = Date.now();
+    const signature = signPendingCall(claims(), { secret, ttlMs: 1000, now });
+    expect(verifyPendingCall(signature, claims(), { secret, now: now + 500 }).ok).toBe(true);
+    expect(verifyPendingCall(signature, claims(), { secret, now: now + 1001 })).toEqual({
+      ok: false,
+      reason: "expired",
+    });
+  });
+
+  test("reports a forgery as forged even when it is also past its stated expiry", () => {
+    const now = Date.now();
+    const signature = signPendingCall(claims(), { secret, ttlMs: 1000, now });
+    const result = verifyPendingCall(signature, claims({ runId: "run_2" }), {
+      secret,
+      now: now + 5000,
+    });
+    expect(result).toEqual({ ok: false, reason: "forged" });
+  });
+
+  test("reports a token it cannot even parse as malformed", () => {
+    expect(verifyPendingCall("not-a-token", claims(), { secret })).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+    expect(readSignature("not-a-token")).toBeNull();
+  });
+
+  test("refuses to sign without an app secret rather than using a known constant", () => {
+    const previous = process.env.SECRET;
+    delete process.env.SECRET;
+    try {
+      expect(() => signPendingCall(claims())).toThrow(/app secret/);
+    } finally {
+      if (previous !== undefined) process.env.SECRET = previous;
+    }
+  });
+});

--- a/packages/gemi/ai/signing.ts
+++ b/packages/gemi/ai/signing.ts
@@ -1,0 +1,206 @@
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+
+/**
+ * Signing for pending tool calls.
+ *
+ * A pending call travels through the browser and comes back — in stateless mode
+ * the whole history does — so the server cannot trust that what it gets back is
+ * what it sent. Without a signature the client asserts not just *that* a call
+ * was approved but *what* was approved, and nothing would stop it from
+ * returning `approve: true` against an input it rewrote on the way. Signing is
+ * what makes the round trip safe, and it is why approvals need no server-side
+ * storage at all.
+ *
+ * What is signed, and what deliberately is not:
+ *
+ *   signed — `runId`, `toolCallId`, the tool `name`, the `kind` of pending call
+ *            and a canonical serialization of the input, plus a nonce and an
+ *            expiry.
+ *   not    — the client's answer. `approve: true` / `approve: false` and a
+ *            question's output are the *point* of asking; a client that flips
+ *            its own answer has refused, not forged. What the signature buys is
+ *            that the answer is bound to the call the server actually made,
+ *            with the input the server actually saw.
+ *
+ * `kind` is in there for a specific attack: an `approval`-kind call is one the
+ * *server* runs, so a client that reused its signature on the "here is the
+ * output" arm of `ClientToolResult` would be fabricating a server tool's result
+ * rather than approving it. Binding the kind makes that a forgery instead of a
+ * shape the caller has to remember to check.
+ */
+
+/** Everything the signature commits to. */
+export type PendingCallClaims = {
+  runId: string;
+  toolCallId: string;
+  name: string;
+  kind: "approval" | "question" | "client";
+  input: unknown;
+};
+
+export type SignOptions = {
+  /** Overrides `process.env.SECRET`. Exists for tests; apps use the app key. */
+  secret?: string;
+  /**
+   * Default 24 hours. An approval waits on a human, and humans go to lunch —
+   * a short expiry turns "I approved it after standup" into an unexplained
+   * failure. Long enough to survive a working day, short enough that a token
+   * lifted from a log is not useful next month.
+   */
+  ttlMs?: number;
+  /** Injected clock, so the expiry path is testable without waiting. */
+  now?: number;
+};
+
+export type VerifyOptions = {
+  secret?: string;
+  now?: number;
+};
+
+/**
+ * A discriminated result rather than a boolean, because the two failures are
+ * different events: `expired` is a sentence to show the user, `forged` is worth
+ * logging and possibly alerting on. Collapsing them loses the only signal that
+ * says someone is probing.
+ */
+export type VerifyResult =
+  | { ok: true; runId: string; nonce: string; expiresAt: number }
+  | { ok: false; reason: "malformed" | "expired" | "forged" };
+
+const VERSION = "agt1";
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+function secretKey(override?: string): string {
+  const secret = override ?? process.env.SECRET;
+  if (!secret) {
+    // Refusing is the only safe answer. A fallback constant would make every
+    // approval in every deployment forgeable by anyone who read this file, and
+    // it would do it silently — the feature would appear to work.
+    throw new Error(
+      "Signing a pending tool call needs an app secret. Set SECRET in the environment.",
+    );
+  }
+  return secret;
+}
+
+/**
+ * Serializes a value so that the same value always produces the same string.
+ *
+ * `JSON.stringify` is not enough: it preserves insertion order, so an input
+ * that made a round trip through a client — parsed and re-serialized, with the
+ * keys in whatever order the parser produced — would hash differently and a
+ * legitimate approval would come back looking forged. Keys are sorted,
+ * `undefined` members are dropped (they do not survive JSON anyway), and arrays
+ * keep their order because in an array order *is* the value.
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort();
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalize(record[key])}`).join(",")}}`;
+}
+
+/**
+ * Length-prefixed rather than delimiter-joined. A separator is a place for two
+ * different claim sets to hash the same — `runId: "a", toolCallId: "b|c"` and
+ * `runId: "a|b", toolCallId: "c"` — and while neither field contains the
+ * separator today, that is a property of the id generator, not of this code.
+ */
+function payload(fields: string[]): string {
+  return fields.map((field) => `${field.length}:${field}`).join("");
+}
+
+function mac(secret: string, fields: string[]): Buffer {
+  return createHmac("sha256", secret).update(payload(fields)).digest();
+}
+
+function claimFields(claims: PendingCallClaims, nonce: string, expiresAt: number): string[] {
+  return [
+    VERSION,
+    claims.runId,
+    claims.toolCallId,
+    claims.name,
+    claims.kind,
+    nonce,
+    String(expiresAt),
+    canonicalize(claims.input),
+  ];
+}
+
+const encode = (value: string) => Buffer.from(value, "utf8").toString("base64url");
+const decode = (value: string) => Buffer.from(value, "base64url").toString("utf8");
+
+/** `agt1.<runId>.<nonce>.<expiry>.<mac>`, all base64url or base36. */
+export function signPendingCall(claims: PendingCallClaims, options: SignOptions = {}): string {
+  const secret = secretKey(options.secret);
+  const now = options.now ?? Date.now();
+  const expiresAt = now + (options.ttlMs ?? DEFAULT_TTL_MS);
+  const nonce = randomBytes(12).toString("base64url");
+  const signature = mac(secret, claimFields(claims, nonce, expiresAt)).toString("base64url");
+  return [VERSION, encode(claims.runId), nonce, expiresAt.toString(36), signature].join(".");
+}
+
+/**
+ * The metadata a signature carries in the clear.
+ *
+ * `Agent` needs the issuing `runId` before it can verify anything: the call was
+ * signed under the run that made it, and the turn answering it is a *new* run
+ * with a new id. Reading it out of the token is safe because the token's own
+ * MAC covers it — a client that edits the runId here fails verification, so
+ * this is "which run does this claim to belong to", not "which run does the
+ * client say it belongs to".
+ */
+export function readSignature(
+  signature: string,
+): { runId: string; nonce: string; expiresAt: number } | null {
+  const parts = signature.split(".");
+  if (parts.length !== 5 || parts[0] !== VERSION) {
+    return null;
+  }
+  const expiresAt = Number.parseInt(parts[3], 36);
+  if (!Number.isFinite(expiresAt)) {
+    return null;
+  }
+  try {
+    return { runId: decode(parts[1]), nonce: parts[2], expiresAt };
+  } catch {
+    return null;
+  }
+}
+
+export function verifyPendingCall(
+  signature: string,
+  claims: PendingCallClaims,
+  options: VerifyOptions = {},
+): VerifyResult {
+  const secret = secretKey(options.secret);
+  const parsed = readSignature(signature);
+  if (!parsed) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  const presented = Buffer.from(signature.split(".")[4], "base64url");
+  const expected = mac(secret, claimFields(claims, parsed.nonce, parsed.expiresAt));
+  // `timingSafeEqual` throws on a length mismatch, and a wrong length is
+  // already a public fact about the token — nothing is leaked by checking it
+  // first, and everything is leaked by comparing the bytes with `===`.
+  if (presented.length !== expected.length || !timingSafeEqual(presented, expected)) {
+    return { ok: false, reason: "forged" };
+  }
+
+  // Expiry is checked *after* the MAC on purpose: only a genuine token can be
+  // "expired". Reporting a forgery as expired would tell the UI to say "your
+  // approval timed out" to someone who was tampering.
+  if ((options.now ?? Date.now()) > parsed.expiresAt) {
+    return { ok: false, reason: "expired" };
+  }
+
+  return { ok: true, runId: parsed.runId, nonce: parsed.nonce, expiresAt: parsed.expiresAt };
+}

--- a/packages/gemi/ai/signing.ts
+++ b/packages/gemi/ai/signing.ts
@@ -22,6 +22,11 @@ import { createHmac, randomBytes, timingSafeEqual } from "crypto";
  *            that the answer is bound to the call the server actually made,
  *            with the input the server actually saw.
  *
+ * A verified token is not yet an answer the server may act on: it says the
+ * question was asked, not that it is still open. `consumePendingCall` at the
+ * bottom of this file spends the nonce, which is what makes an approval
+ * single-use — see the note there for what that guarantee is worth.
+ *
  * `kind` is in there for a specific attack: an `approval`-kind call is one the
  * *server* runs, so a client that reused its signature on the "here is the
  * output" arm of `ClientToolResult` would be fabricating a server tool's result
@@ -203,4 +208,66 @@ export function verifyPendingCall(
   }
 
   return { ok: true, runId: parsed.runId, nonce: parsed.nonce, expiresAt: parsed.expiresAt };
+}
+
+// --- single use ----------------------------------------------------------
+
+/**
+ * Nonces already spent, mapped to the moment they stop mattering.
+ *
+ * The MAC makes a token unforgeable; it does not make it single-use. Without
+ * this a captured signature approves the same call again every time it is
+ * presented, because a token that carries its own `runId` is a token that
+ * asserts its own binding — which is no binding at all. Verifying tells you the
+ * server once asked this exact question; spending the nonce is what says nobody
+ * has answered it yet.
+ *
+ * Deliberately in memory, and deliberately not a hard guarantee:
+ *
+ *   bounded — an entry lives at most as long as the token's TTL, and the sweep
+ *             below is amortized O(1), so the map is bounded by the approvals
+ *             actually issued in one TTL window rather than by uptime.
+ *   local   — one process. A second replica has never seen the nonce and will
+ *             accept it, so this closes the replay window rather than sealing
+ *             it. That is still worth having and it fails open, which is the
+ *             only direction a cache may fail: a lost registry costs a replay,
+ *             never a legitimate approval that stops working.
+ *
+ * The stronger guard is the app's own message store: once a call has a result
+ * next to it, the call is no longer open and the answer has nothing to attach
+ * to. This is what stands in for that in stateless mode, where the history the
+ * client returns can be rewound to before the result existed.
+ */
+const spent = new Map<string, number>();
+
+/** Sweep when the map has grown past this, so sweeping costs O(1) per insert
+ *  amortized instead of walking every entry on every approval. */
+let sweepAt = 1024;
+
+function sweep(now: number) {
+  for (const [nonce, expiresAt] of spent) {
+    if (expiresAt <= now) spent.delete(nonce);
+  }
+  sweepAt = Math.max(1024, spent.size * 2);
+}
+
+/**
+ * Spends a signature's nonce. `false` means it was already spent — the answer
+ * is a replay and must not be acted on.
+ *
+ * Separate from `verifyPendingCall` rather than folded into it, because verify
+ * is a pure question a caller may want to ask twice (logging a forgery, say)
+ * and this one is a state change that must happen exactly once per answer.
+ */
+export function consumePendingCall(signature: string, options: VerifyOptions = {}): boolean {
+  const parsed = readSignature(signature);
+  if (!parsed) return false;
+  const now = options.now ?? Date.now();
+  if (spent.size >= sweepAt) sweep(now);
+  const spentUntil = spent.get(parsed.nonce);
+  // A record past its own expiry binds nothing: the token it refers to fails
+  // verification on its own, so holding the nonce would only grow the map.
+  if (spentUntil !== undefined && spentUntil > now) return false;
+  spent.set(parsed.nonce, parsed.expiresAt);
+  return true;
 }


### PR DESCRIPTION
> **Stack**, bottom to top — each PR is based on the one above it:
> 1. `ai/1-schema` — the schema builder runtime
> 2. `ai/2-provider` — the OpenAI and Azure providers
> 3. **`ai/3-agent` — you are here** — the agent run loop and signing
> 4. `ai/4-controller` — controller, stores, `ApiRouter.agent()`
> 5. `ai/5-client` — `useChat` and stream decoding
> 6. `ai/6-exports` — module exports and the example

`Agent.ts` becomes real code: the `AgentTool` / `ToolNamespace` / `Skill` / `Agent` factories, the step loop and `AgentRunImpl`. `signing.ts` is new — HMAC-SHA256 over canonicalized claims, returning a discriminated verify result.

## The decisions

**The signature carries its issuing `runId` in the clear, covered by its own MAC.** The turn answering an approval is a *new* run, so the id it was signed under has to travel with the token. Reading it back is safe because editing it fails verification.

**Claims bind the tool name and its kind.** Kind is what stops a client reusing an approval's signature on the "here is the output" arm and fabricating a server tool's result. The client's *answer* is deliberately not signed: flipping approve to false is a refusal, not a forgery.

**The registry and the provider tool list are built once at `Agent.create`.** Name collisions and a reserved `skills` namespace fail at startup rather than in the first user's first message.

**Resolving a pending call amends the earlier message that made it, cloned rather than mutated,** so the caller's `messages` array stays an input. A store keyed by id therefore has to upsert.

**`toResponse()`'s cancel does nothing to the run.** A disconnect is not a stop. `stop()` denies every unresolved call and finalizes the message `aborted`, because a history holding a tool call with no result is one the provider rejects.

**`signing.ts` is careful in the places that are easy to get wrong:** length-prefixed MAC input rather than a delimiter join, key-sorted canonicalization, expiry checked *after* the MAC so a forgery is never reported as "your approval timed out", and a refusal to sign at all without `SECRET` rather than a fallback constant.

## Contract changes

All additive except the last, which is a removal:

| symbol | change | why |
|---|---|---|
| `AgentStreamParams.onMessage` | added, optional | `stop()` must push the aborted message through the message callback, and a run outlives its request, so it cannot rely on someone reading the stream to persist. |
| `ToolShapesOf` | `Extract<FlattenTools<T>, AnyAgentTool>` | `FlattenTools` infers an unconstrained `E`, so `K["name"]` is TS2536 once `@ts-nocheck` comes off. Resulting type is unchanged. |
| `ToolNamespace.deferred` | added | The flag had nowhere to live. Kept on the namespace rather than stamped onto member tools — a tool is a module-scope singleton and may also be listed bare. |
| `Skill.instructions` / `.files` | added as `readonly` | The lowering code reads them off the instance; a private TS field is class-scoped, not module-scoped. |
| `Agent.instructions` / `.maxSteps` / `.reasoning`, `SKILLS_NAMESPACE` | added | The declared class exposed only name/tools/skills/provider/output. `SKILLS_NAMESPACE` is exported so nothing has to spell the reserved namespace as a literal. |
| `class Agent` type params | dropped `const` modifiers | They stayed on `Agent.create`, which is where literal inference happens. Verified unobservable by the existing type tests. |
| `signing.consumePendingCall` | new export | Spends a signature's nonce. Kept out of `verifyPendingCall` so verify stays a pure predicate a caller may ask twice. |
| **`AgentTool.namespace`** | **removed** | It was on the declare-only RFC class. A tool is a module-scope singleton, so the field could only ever report whichever agent constructed its namespace last — to every agent sharing the tool. Nothing read it; `ResolvedTool.namespace` is the per-agent answer. A doc comment replaces it and a type test pins the absence. |

One behavioural change that is not visible in a type: a successfully parsed tool call's `input` on the `ToolCallPart` is now the *parsed* value rather than the raw model arguments. An unparseable call still keeps its raw arguments, so `invalid_tool_input` stays readable.

## What the review round changed

Six findings, two blocking; all six real, none declined.

- **`stop()` could not cancel a tool approved on this turn — the run hung forever.** An approval executes outside the tool loop, and `resolveAnswer` awaited it bare while `runTools` raced its executions against the abort signal. A tool that does not itself honour `ctx.signal` held the run open with no way out: nothing emitted, `run-end` never fired, the SSE body never closed. Now raced the same way. Two further holes came with it and are fixed: `finalizeAborted` now denies calls left open anywhere in the history (an approval's call belongs to an *earlier* turn's message, so there was no current message to deny), and the amended messages are reported through `onMessage` on the abort path.
- **The pending call was signed over the parsed input and verified against the raw one.** The two differ the moment a schema normalizes — and strict mode makes `optional()` a nullable union, so the model is *told* to send `null` for an omitted key and the parse drops it. Every approval of a tool with one optional field therefore came back looking forged: the user clicked Approve and was told they had refused. The parsed value is now written onto the `ToolCallPart`, so one value is authoritative and the transcript carries what the signature covers. The existing test fake could not see this class of bug at all, because its `schemaOf` returned its input untouched.
- **A captured signature replayed into a later run and re-executed the tool.** `types.ts` promises a nonce and an expiry; nothing implemented them, and the test that claimed to cover it passed a caller-chosen `runId` that `resolveAnswer` never constructs — it would have passed against code with no replay defence at all, which is what this was. `consumePendingCall` now spends the nonce, and its comment states what the guarantee is worth: TTL-bounded, one process, and it fails open, which is the only direction a cache may fail. The replay case is now driven end-to-end through `Agent.stream`.
- **The same `ClientToolResult` sent twice in one turn executed the tool twice** and wrote two results for one `toolCallId`. Guarded with a `seen` set added *before* dispatch, so first-answer-wins holds even when the first answer is rejected.
- **A provider `error` event followed by a `finish` was silently discarded** — the user got an empty assistant message and no explanation. `finish` now takes the usage unconditionally but only replaces the outcome when nothing has already failed.
- **`ToolNamespace` wrote `namespace` onto the shared tool singleton.** See the contract table above.

Two of the reviewer's suggested tests would not have discriminated and were strengthened instead: the duplicate-answer one passes on the nonce check alone unless it also asserts no error event, and the namespace one reads the provider tool list, which was correct all along.

## Still open

- Skills read files with `Bun.file(path)` resolved against `process.cwd()`, not against a gemi "app root" abstraction — none is public from `ai/`. A missing file becomes a note in the tool result rather than a throw, and that path is untested.
- `usage` is emitted once at run-end with the accumulated total. Per-step usage events would let a UI count tokens live; not implemented.
- The `output-delta` path is implemented but has no runtime test — it needs a provider that emits output deltas. The type-level side is covered.
- Tool calls within one step run concurrently, so for a parallel step the transcript's part order is the model's, not ours.
- `temperature` and `maxOutputTokens` are never set; nothing in `CreateAgentParams` or `AgentStreamParams` declares them, so they are left to the provider's defaults rather than invented here.
- **`AgentTool.ask` builds its one-field input schema by hand** rather than with `s`, and now that `s` is real underneath this branch that is a deliberate choice rather than a constraint: `Schema<T>` carries a phantom property `Schema.ts` does not export, so producing one outside that file needs a cast either way, and reaching for `s` would make the agent runtime depend on the schema builder for a single hard-coded object. `pendingKind` uses the schema's identity to tell a question from a client tool, so that discriminator has to survive any future swap. The reasoning is written at the site.

## Verification

At this branch: `bun run typecheck` clean, `bun run test:types` 7 files / 67 tests / no type errors, `bun --bun vitest run` 171 files / 4122 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnj9jSx45LoYp5tiv1W8Nw
