### PR TITLE
An agent mounts like a resource, and its run outlives the request

### DIFF
--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, test } from "vitest";
+
+import { HttpRequest } from "../http/HttpRequest";
+import type { AgentStreamParams } from "./Agent";
+import { AgentController, MemoryAgentStore, MemoryLiveRuns } from "./AgentController";
+import { StubAgentRun } from "./store/stubAgentRun";
+import type { AgentMessage, AgentStreamEvent, PendingToolCall } from "./types";
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const message = (id: string, role: AgentMessage["role"], text: string): AgentMessage => ({
+  id,
+  role,
+  content: [{ type: "text", text }],
+  createdAt: new Date(0).toISOString(),
+  finishReason: "stop",
+});
+
+/**
+ * The smallest thing that answers `controller.agent`.
+ *
+ * Only `stream` and `provider.upload` are ever reached, and both are recorded
+ * rather than faked deeply: the point of these tests is what the controller
+ * hands the agent and what it does with the run, not what an agent does with a
+ * turn.
+ */
+function stubAgent(run: StubAgentRun) {
+  const calls: AgentStreamParams[] = [];
+  const uploads: Blob[] = [];
+  return {
+    calls,
+    uploads,
+    agent: {
+      name: "stub",
+      tools: [] as const,
+      skills: [] as const,
+      output: undefined,
+      provider: {
+        upload: async (file: File) => {
+          uploads.push(file);
+          return "file_123";
+        },
+      },
+      stream: (params: AgentStreamParams) => {
+        calls.push(params);
+        return run;
+      },
+    } as any,
+  };
+}
+
+function jsonRequest(body: unknown, headers: Record<string, string> = {}) {
+  const raw = new Request("http://localhost/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  return new HttpRequest(raw, {}, "api", "/chat");
+}
+
+async function readSse(response: Response): Promise<string> {
+  return await response.text();
+}
+
+describe("AgentController.stream", () => {
+  test("runs stateless on the history the client sent", async () => {
+    const run = new StubAgentRun("run_1");
+    const { agent, calls } = stubAgent(run);
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      store = new MemoryAgentStore();
+    }
+
+    const controller = new Chat();
+    const history = [message("u0", "user", "earlier"), message("a0", "assistant", "sure")];
+    const response = await controller.stream(
+      jsonRequest({ messages: history, text: "and now this" }),
+    );
+
+    expect(response.headers.get("X-Stub-Run")).toBe("run_1");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.messages.map((m) => m.id)).toEqual(["u0", "a0"]);
+    expect(calls[0]!.turn).toEqual({ text: "and now this" });
+    expect(calls[0]!.threadId).toBeUndefined();
+
+    // Nothing was written anywhere: statelessness is not a mode, it is what
+    // happens when no threadId arrives.
+    run.finish({ messages: [message("u1", "user", "and now this")] });
+    await settle();
+    expect(await controller.store.loadThread("anything")).toEqual([]);
+  });
+
+  test("reads history from the store and appends the run to it when threaded", async () => {
+    const run = new StubAgentRun("run_2");
+    const { agent, calls } = stubAgent(run);
+    const store = new MemoryAgentStore();
+    await store.appendMessages("t1", [message("u0", "user", "earlier")]);
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      store = store;
+    }
+
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ threadId: "t1", text: "next" }));
+
+    expect(calls[0]!.messages.map((m) => m.id)).toEqual(["u0"]);
+    expect(calls[0]!.threadId).toBe("t1");
+    // The client's own `messages` are ignored once a thread owns the history —
+    // otherwise a client could rewrite what the server already believes.
+    expect(calls[0]!.messages).toHaveLength(1);
+
+    run.finish({
+      messages: [message("u1", "user", "next"), message("a1", "assistant", "ok")],
+    });
+    await settle();
+
+    expect((await store.loadThread("t1")).map((m) => m.id)).toEqual(["u0", "u1", "a1"]);
+  });
+
+  /**
+   * The controller is constructed per request, so anything process-lived it
+   * holds has to come from outside it. This is the test that fails if `store`
+   * goes back to being a field initializer.
+   */
+  test("keeps a thread across the fresh controller each request gets", async () => {
+    const first = new StubAgentRun("run_2a");
+    const second = new StubAgentRun("run_2b");
+    const runs = [first, second];
+    const seen: AgentStreamParams[] = [];
+
+    class Chat extends AgentController {
+      agent = {
+        provider: {},
+        stream: (params: AgentStreamParams) => {
+          seen.push(params);
+          return runs.shift()!;
+        },
+      } as any;
+      liveRuns = new MemoryLiveRuns();
+    }
+
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, text: "one" }));
+    first.finish({ messages: [message("u1", "user", "one")] });
+    await settle();
+
+    await new Chat().stream(jsonRequest({ threadId, text: "two" }));
+    second.finish({ messages: [message("u2", "user", "two")] });
+    await settle();
+
+    expect(seen[1]!.messages.map((m) => m.id)).toEqual(["u1"]);
+  });
+
+  test("fires onMessage for user and assistant messages alike", async () => {
+    const run = new StubAgentRun("run_3");
+    const { agent } = stubAgent(run);
+    const seen: string[] = [];
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      protected onMessage(m: AgentMessage) {
+        seen.push(`${m.role}:${m.id}`);
+      }
+    }
+
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ text: "hi" }));
+    run.finish({
+      messages: [message("u1", "user", "hi"), message("a1", "assistant", "hello")],
+    });
+    await settle();
+
+    expect(seen).toEqual(["user:u1", "assistant:a1"]);
+  });
+
+  test("fires onToolCall, onAwaitingInput and onError off the event stream", async () => {
+    const run = new StubAgentRun("run_4");
+    const { agent } = stubAgent(run);
+    const toolCalls: string[] = [];
+    const pendingSeen: PendingToolCall[][] = [];
+    const errors: string[] = [];
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      protected onToolCall(call: { name: string }) {
+        toolCalls.push(call.name);
+      }
+      protected onAwaitingInput(pending: PendingToolCall[]) {
+        pendingSeen.push(pending);
+      }
+      protected onError(error: { message: string }) {
+        errors.push(error.message);
+      }
+    }
+
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ text: "hi" }));
+
+    // A partial tool call is skipped: its input is still half-parsed.
+    run.emit({
+      type: "tool-call",
+      messageId: "a1",
+      part: { type: "tool-call", toolCallId: "c1", name: "bash", input: {}, partial: true },
+    } as AgentStreamEvent);
+    run.emit({
+      type: "tool-call",
+      messageId: "a1",
+      part: { type: "tool-call", toolCallId: "c1", name: "bash", input: { command: "ls" } },
+    } as AgentStreamEvent);
+    run.emit({
+      type: "awaiting-input",
+      runId: "run_4",
+      pending: [{ toolCallId: "c1", name: "bash", input: {}, kind: "approval", signature: "s" }],
+    } as AgentStreamEvent);
+    run.emit({
+      type: "error",
+      error: { code: "provider_error", message: "boom", retryable: true },
+    });
+    run.finish();
+    await settle();
+
+    expect(toolCalls).toEqual(["bash"]);
+    expect(pendingSeen).toHaveLength(1);
+    expect(errors).toEqual(["boom"]);
+  });
+
+  test("a hook that throws is reported and the run survives it", async () => {
+    const run = new StubAgentRun("run_5");
+    const { agent } = stubAgent(run);
+    const reported: unknown[] = [];
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      store = new MemoryAgentStore();
+      protected onMessage(): void {
+        throw new Error("the app's database is down");
+      }
+      protected reportHookFailure(error: unknown) {
+        reported.push(error);
+      }
+    }
+
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ threadId: "t9", text: "hi" }));
+    run.finish({
+      messages: [message("u1", "user", "hi"), message("a1", "assistant", "hello")],
+    });
+    await settle();
+
+    expect(reported).toHaveLength(2);
+    // The run still finished and the framework store still has the turn: the
+    // app's failure cost the app's row, not the answer.
+    expect((await controller.store.loadThread("t9")).map((m) => m.id)).toEqual(["u1", "a1"]);
+  });
+});
+
+describe("AgentController.attach", () => {
+  function attachable(runId = "run_a") {
+    const run = new StubAgentRun(runId);
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    return { run, controller: new Chat() };
+  }
+
+  test("returns exactly the tail from the requested cursor", async () => {
+    const { run, controller } = attachable();
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    for (const delta of ["a", "b", "c", "d"]) {
+      run.emit({ type: "text-delta", messageId: "m1", delta });
+    }
+    run.finish();
+    await settle();
+
+    const response = await controller.attach(jsonRequest({ threadId: "t1", from: 2 }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+
+    const body = await readSse(response);
+    expect(body).toContain("id: 2");
+    expect(body).toContain("id: 3");
+    expect(body).not.toContain("id: 1");
+    expect(body).toContain('"delta":"c"');
+    expect(body).not.toContain('"delta":"b"');
+  });
+
+  test("takes Last-Event-ID as the cursor when the body names none", async () => {
+    const { run, controller } = attachable("run_b");
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    for (const delta of ["a", "b", "c"]) {
+      run.emit({ type: "text-delta", messageId: "m1", delta });
+    }
+    run.finish();
+    await settle();
+
+    // The header names the last event *received*, so resuming means one past it.
+    const response = await controller.attach(
+      jsonRequest({ threadId: "t1" }, { "Last-Event-ID": "1" }),
+    );
+    const body = await readSse(response);
+    expect(body).toContain("id: 2");
+    expect(body).not.toContain("id: 1");
+    expect(body).not.toContain("id: 0");
+  });
+
+  test("misses explicitly when no run is in flight in this process", async () => {
+    const { controller } = attachable("run_c");
+    const response = await controller.attach(jsonRequest({ threadId: "nothing-here" }));
+
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("no_live_run");
+  });
+
+  test("refuses a threadless attach", async () => {
+    const { controller } = attachable("run_d");
+    const response = await controller.attach(jsonRequest({}));
+    expect(response.status).toBe(400);
+  });
+
+  test("answers 410 for a cursor the buffer has dropped", async () => {
+    const run = new StubAgentRun("run_e");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns({ maxFrames: 4 });
+    }
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    for (let i = 0; i < 10; i++) {
+      run.emit({ type: "text-delta", messageId: "m1", delta: String(i) });
+    }
+    run.finish();
+    await settle();
+
+    const response = await controller.attach(jsonRequest({ threadId: "t1", from: 0 }));
+    expect(response.status).toBe(410);
+    const body = (await response.json()) as { error: { code: string; oldestSeq: number } };
+    expect(body.error.code).toBe("frame_cursor_evicted");
+    expect(body.error.oldestSeq).toBe(6);
+  });
+});
+
+describe("AgentController.stop", () => {
+  test("returns as soon as the run is aborted, not when it has unwound", async () => {
+    const run = new StubAgentRun("run_s");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+    await settle();
+
+    const resolved = await controller.stop(
+      jsonRequest({ threadId: "t1", reason: "changed my mind" }),
+    );
+
+    expect(resolved).toEqual({ stopped: true });
+    expect(run.stopped).toBe(true);
+    expect(run.stopReason).toBe("changed my mind");
+    // The run has NOT finished unwinding: `result()` is still pending, and the
+    // terminal events are still to come on the run's own stream.
+    const raced = await Promise.race([
+      run.result().then(() => "unwound"),
+      settle().then(() => "still going"),
+    ]);
+    expect(raced).toBe("still going");
+
+    run.finish({ finishReason: "aborted" });
+  });
+
+  test("stops by runId as well as by thread", async () => {
+    const run = new StubAgentRun("run_t");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ text: "hi" }));
+
+    expect(await controller.stop(jsonRequest({ runId: "run_t" }))).toEqual({ stopped: true });
+    run.finish();
+  });
+
+  test("says so rather than throwing when there is nothing to stop", async () => {
+    const run = new StubAgentRun("run_u");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    expect(await new Chat().stop(jsonRequest({ threadId: "gone" }))).toEqual({ stopped: false });
+    run.finish();
+  });
+});
+
+describe("AgentController.upload", () => {
+  test("hands the file to the provider and returns its id", async () => {
+    const run = new StubAgentRun("run_v");
+    const { agent, uploads } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+
+    const form = new FormData();
+    form.set("file", new File(["hello"], "note.txt", { type: "text/plain" }));
+    const raw = new Request("http://localhost/api/chat/files", { method: "POST", body: form });
+
+    const result = await new Chat().upload(new HttpRequest(raw, {}, "api", "/chat/files"));
+
+    expect(result).toEqual({ fileId: "file_123" });
+    expect(uploads).toHaveLength(1);
+  });
+
+  test("refuses a body with no file field", async () => {
+    const run = new StubAgentRun("run_w");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const raw = new Request("http://localhost/api/chat/files", {
+      method: "POST",
+      body: new FormData(),
+    });
+    await expect(new Chat().upload(new HttpRequest(raw, {}, "api", "/chat/files"))).rejects.toThrow(
+      /file/,
+    );
+    run.finish();
+  });
+});
+
+describe("AgentController.instructions", () => {
+  test("is appended to the agent's own for this request", async () => {
+    const run = new StubAgentRun("run_x");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      instructions() {
+        return "Today is Tuesday.";
+      }
+    }
+    await new Chat().stream(jsonRequest({ text: "hi" }));
+    expect(calls[0]!.instructions).toBe("Today is Tuesday.");
+    run.finish();
+  });
+});
+
+describe("the request body", () => {
+  test("accepts a charset on the content type, which several clients send", async () => {
+    const run = new StubAgentRun("run_y");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const raw = new Request("http://localhost/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ text: "hi" }),
+    });
+    await new Chat().stream(new HttpRequest(raw, {}, "api", "/chat"));
+    expect(calls[0]!.turn).toEqual({ text: "hi" });
+    run.finish();
+  });
+
+  test("accepts the nested turn form too", async () => {
+    const run = new StubAgentRun("run_z");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    await new Chat().stream(
+      jsonRequest({
+        turn: { text: "yes", toolResults: [{ toolCallId: "c1", signature: "s", approve: true }] },
+      }),
+    );
+    expect(calls[0]!.turn).toEqual({
+      text: "yes",
+      toolResults: [{ toolCallId: "c1", signature: "s", approve: true }],
+    });
+    run.finish();
+  });
+});

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -58,6 +58,16 @@ function jsonRequest(body: unknown, headers: Record<string, string> = {}) {
   return new HttpRequest(raw, {}, "api", "/chat");
 }
 
+/** A POST whose body is whatever bytes are handed to it, valid JSON or not. */
+function rawRequest(body: string, contentType = "application/json") {
+  const raw = new Request("http://localhost/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body,
+  });
+  return new HttpRequest(raw, {}, "api", "/chat");
+}
+
 async function readSse(response: Response): Promise<string> {
   return await response.text();
 }
@@ -330,6 +340,55 @@ describe("AgentController.attach", () => {
     expect(response.status).toBe(400);
   });
 
+  /**
+   * The case `/attach` exists for. A page reattaching on mount sends a fresh
+   * POST: no `Last-Event-ID`, and no cursor of its own, because the only handle
+   * it was ever given is the `threadId`. Reading that as frame 0 made every run
+   * longer than the buffer — a few hundred tokens of prose — answer 410, and
+   * the documented remedy of reloading the thread does not help, because the
+   * store is not written until the run ends. So the user refreshed, saw
+   * nothing, and the run kept spending invisibly.
+   */
+  test("with no cursor at all, returns the tail of a run past the buffer", async () => {
+    const run = new StubAgentRun("run_long");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns({ maxFrames: 4 });
+    }
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    for (let i = 0; i < 10; i++) {
+      run.emit({ type: "text-delta", messageId: "m1", delta: String(i) });
+    }
+    run.finish();
+    await settle();
+
+    const response = await controller.attach(jsonRequest({ threadId: "t1" }));
+
+    expect(response.status).toBe(200);
+    const body = await readSse(response);
+    expect(body).toContain("id: 6");
+    expect(body).toContain("id: 9");
+    expect(body).not.toContain("id: 5");
+  });
+
+  test("with no cursor and nothing dropped, returns the run from the start", async () => {
+    const { run, controller } = attachable("run_short");
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    for (const delta of ["a", "b"]) {
+      run.emit({ type: "text-delta", messageId: "m1", delta });
+    }
+    run.finish();
+    await settle();
+
+    const body = await readSse(await controller.attach(jsonRequest({ threadId: "t1" })));
+    expect(body).toContain("id: 0");
+    expect(body).toContain("id: 1");
+  });
+
   test("answers 410 for a cursor the buffer has dropped", async () => {
     const run = new StubAgentRun("run_e");
     const { agent } = stubAgent(run);
@@ -346,6 +405,9 @@ describe("AgentController.attach", () => {
     run.finish();
     await settle();
 
+    // Explicitly `from: 0`: this client says its transcript ends at frame 0, so
+    // handing it frame 6 onwards would leave a hole it cannot see. That is the
+    // 410, and it is exactly the request a client with no cursor is NOT making.
     const response = await controller.attach(jsonRequest({ threadId: "t1", from: 0 }));
     expect(response.status).toBe(410);
     const body = (await response.json()) as { error: { code: string; oldestSeq: number } };
@@ -479,6 +541,84 @@ describe("the request body", () => {
     });
     await new Chat().stream(new HttpRequest(raw, {}, "api", "/chat"));
     expect(calls[0]!.turn).toEqual({ text: "hi" });
+    run.finish();
+  });
+
+  /**
+   * A truncated proxy response and a mis-serialized client both land here. They
+   * used to read as an empty turn, so `stream` billed a model call with no
+   * history and no turn and dropped the user's message — which presents as the
+   * model hallucinating rather than as an error.
+   */
+  test("refuses an unparseable body instead of billing an empty run", async () => {
+    const run = new StubAgentRun("run_bad");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+
+    const response = await new Chat().stream(rawRequest('{"text": "hi"'));
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_request");
+    // The point: no run was ever started.
+    expect(calls).toHaveLength(0);
+    run.finish();
+  });
+
+  test("refuses a JSON array, which typeof would have let through", async () => {
+    const run = new StubAgentRun("run_arr");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+
+    expect((await new Chat().stream(rawRequest("[1,2,3]"))).status).toBe(400);
+    expect((await new Chat().stream(rawRequest("null"))).status).toBe(400);
+    expect(calls).toHaveLength(0);
+    run.finish();
+  });
+
+  test("attach and stop refuse a malformed body too", async () => {
+    const run = new StubAgentRun("run_bad2");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    expect((await controller.attach(rawRequest("{oops"))).status).toBe(400);
+
+    // Not `{ stopped: false }`: that means "there was nothing to stop", and a
+    // client that believes it stops asking while the run keeps going.
+    const stopped = await controller.stop(rawRequest("{oops"));
+    expect(stopped).toBeInstanceOf(Response);
+    expect((stopped as Response).status).toBe(400);
+    expect(run.stopped).toBe(false);
+
+    run.finish();
+  });
+
+  /** An empty body is a real request — a turn that just lets the model continue
+   *  — and stays a 200. Only a body that arrived and would not parse is a 400. */
+  test("still accepts a request with no body at all", async () => {
+    const run = new StubAgentRun("run_empty");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const raw = new Request("http://localhost/api/chat", { method: "POST" });
+    const response = await new Chat().stream(new HttpRequest(raw, {}, "api", "/chat"));
+
+    expect(response.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.turn).toBeUndefined();
     run.finish();
   });
 

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -325,6 +325,92 @@ describe("AgentController.attach", () => {
     expect(body).not.toContain("id: 0");
   });
 
+  // `useChat` sends `cursor` (the last frame it APPLIED) and `runId` (the run
+  // that number counts within). The controller was written against `from` and
+  // `Last-Event-ID` alone, so the four tests below are the seam between the two
+  // halves, which never met until the stack was assembled.
+  test("takes the client's `cursor` as one-past, the way Last-Event-ID is read", async () => {
+    const { run, controller } = attachable("run_cur");
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    for (const delta of ["a", "b", "c", "d"]) {
+      run.emit({ type: "text-delta", messageId: "m1", delta });
+    }
+    run.finish();
+    await settle();
+
+    const response = await controller.attach(
+      jsonRequest({ threadId: "t1", cursor: 1, runId: "run_cur" }),
+    );
+    const body = await readSse(response);
+    expect(body).toContain("id: 2");
+    expect(body).not.toContain("id: 1");
+    expect(body).toContain('"delta":"c"');
+    expect(body).not.toContain('"delta":"b"');
+  });
+
+  test("reads cursor -1 as no position at all, so a long run does not 410", async () => {
+    const { run, controller } = attachable("run_neg");
+    const liveRuns = new MemoryLiveRuns({ maxFrames: 8 });
+    (controller as { liveRuns: MemoryLiveRuns }).liveRuns = liveRuns;
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    // Past the buffer, so frame 0 is long gone. This is the mount-time reattach
+    // the route exists for: a client with no restored cursor sends -1, and
+    // reading that as "frame 0" would 410 exactly the runs worth rescuing.
+    for (let i = 0; i < 40; i++) {
+      run.emit({ type: "text-delta", messageId: "m1", delta: String(i) });
+    }
+    run.finish();
+    await settle();
+
+    const response = await controller.attach(
+      jsonRequest({ threadId: "t1", cursor: -1, runId: "run_neg" }),
+    );
+    expect(response.status).toBe(200);
+    const body = await readSse(response);
+    expect(body).toContain("id: 39");
+  });
+
+  test("forfeits a cursor that counts within a run which is not the live one", async () => {
+    const { run, controller } = attachable("run_two");
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    for (const delta of ["a", "b", "c", "d"]) {
+      run.emit({ type: "text-delta", messageId: "m1", delta });
+    }
+    run.finish();
+    await settle();
+
+    // The client applied 3 frames of an EARLIER run on this thread. seq starts
+    // at zero in every run, so honouring that 2 here would swallow the head of
+    // a run it has seen nothing of.
+    const response = await controller.attach(
+      jsonRequest({ threadId: "t1", cursor: 2, runId: "run_one" }),
+    );
+    const body = await readSse(response);
+    expect(body).toContain("id: 0");
+    expect(body).toContain('"delta":"a"');
+  });
+
+  test("an absent runId is an older question, not a wrong answer", async () => {
+    const { run, controller } = attachable("run_bare");
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    for (const delta of ["a", "b", "c", "d"]) {
+      run.emit({ type: "text-delta", messageId: "m1", delta });
+    }
+    run.finish();
+    await settle();
+
+    // `from` and `Last-Event-ID` predate the cursor/runId pairing and carry no
+    // run; an EventSource reconnecting on its own will never grow one. They
+    // must keep resuming rather than being read as a mismatch.
+    const body = await readSse(await controller.attach(jsonRequest({ threadId: "t1", from: 2 })));
+    expect(body).toContain("id: 2");
+    expect(body).not.toContain("id: 1");
+  });
+
   test("misses explicitly when no run is in flight in this process", async () => {
     const { controller } = attachable("run_c");
     const response = await controller.attach(jsonRequest({ threadId: "nothing-here" }));
@@ -457,6 +543,39 @@ describe("AgentController.stop", () => {
     await controller.stream(jsonRequest({ text: "hi" }));
 
     expect(await controller.stop(jsonRequest({ runId: "run_t" }))).toEqual({ stopped: true });
+    run.finish();
+  });
+
+  test("stops a run the client named before the server had, on a stateless turn", async () => {
+    const run = new StubAgentRun("run_early");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const controller = new Chat();
+    // No threadId — a stateless first turn. Between this POST and `run-start`
+    // reaching the client there is no `runId` either, and that window is where
+    // a user presses stop. `clientRunId` is the only handle that exists.
+    await controller.stream(jsonRequest({ clientRunId: "local_run_1", text: "hi" }));
+
+    expect(await controller.stop(jsonRequest({ clientRunId: "local_run_1" }))).toEqual({
+      stopped: true,
+    });
+    expect(run.stopped).toBe(true);
+    run.finish({ finishReason: "aborted" });
+  });
+
+  test("a clientRunId that named no run here is nothing to stop, not a crash", async () => {
+    const run = new StubAgentRun("run_unknown");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    expect(await new Chat().stop(jsonRequest({ clientRunId: "local_nope" }))).toEqual({
+      stopped: false,
+    });
     run.finish();
   });
 

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -130,7 +130,13 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * the next turn, so none of them gets an endpoint of its own.
    */
   async stream(req: HttpRequest<any, any> = new HttpRequest()): Promise<Response> {
-    const body = await readJsonBody(req);
+    const parsed = await readJsonBody(req);
+    if (parsed.error) {
+      // Before anything is registered or charged for. A run started off a body
+      // we could not read would answer nothing, at the user's expense.
+      return invalidRequest(parsed.error);
+    }
+    const body = parsed.body;
     const threadId = typeof body.threadId === "string" ? body.threadId : undefined;
     const turn = toClientTurn(body);
 
@@ -138,6 +144,14 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     // thread the server owns the history, without one the client carries it.
     // Nothing else below branches on it, which is why stateless keeps working
     // even for an app that never configures a store.
+    //
+    // The `threadId` is the client's, and nothing here checks that this caller
+    // owns it — `AgentStore` cannot, since it holds no user. A `threadId` is
+    // therefore a capability and has to be unguessable (`createThread` mints a
+    // uuid) and, for anything that matters, checked: override `instructions()`
+    // or a `store` that scopes by `req.user`. The framework's job is to make
+    // sure the route is behind the router's middleware in the first place,
+    // which `ApiRouter.agent()` now does.
     const messages = threadId
       ? await this.store.loadThread(threadId)
       : Array.isArray(body.messages)
@@ -175,9 +189,18 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * `POST /<path>/attach` — subscribe to a run already in progress, from a
    * cursor. This is a read of a live run, not a continuation of a stopped one:
    * the work never paused, the listener changed.
+   *
+   * The cursor is `from`, else `Last-Event-ID`, else the oldest frame still
+   * buffered. A cursor the buffer has dropped is a 410 naming what survives;
+   * *no* cursor is the tail, because a page reattaching on mount has no
+   * transcript to leave a hole in. See `resolveCursor`.
    */
   async attach(req: HttpRequest<any, any> = new HttpRequest()): Promise<Response> {
-    const body = await readJsonBody(req);
+    const parsed = await readJsonBody(req);
+    if (parsed.error) {
+      return invalidRequest(parsed.error);
+    }
+    const body = parsed.body;
     const threadId =
       typeof body.threadId === "string" ? body.threadId : searchParam(req, "threadId");
 
@@ -229,9 +252,22 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * The terminal events — the stopped tool results, the aborted message — go
    * out on the run's own stream, so whoever is watching it sees the ending,
    * and `onMessage` records it whether anyone is watching or not.
+   *
+   * Answers `{ stopped }` normally, and a `Response` only to reject a request
+   * it could not read — the union is the 400, not a second success shape.
    */
-  async stop(req: HttpRequest<any, any> = new HttpRequest()): Promise<{ stopped: boolean }> {
-    const body = await readJsonBody(req);
+  async stop(
+    req: HttpRequest<any, any> = new HttpRequest(),
+  ): Promise<{ stopped: boolean } | Response> {
+    const parsed = await readJsonBody(req);
+    if (parsed.error) {
+      // `{ stopped: false }` would be the wrong answer as well as the wrong
+      // status: it means "there was nothing to stop", and the truth is that we
+      // could not tell what to stop. A client that believes the first one stops
+      // asking, and the run keeps going.
+      return invalidRequest(parsed.error);
+    }
+    const body = parsed.body;
 
     let runId = typeof body.runId === "string" ? body.runId : undefined;
     if (!runId && typeof body.threadId === "string") {
@@ -412,28 +448,73 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
 // --- request plumbing ----------------------------------------------------
 
 /**
- * The body, as JSON, or `{}`.
+ * A body, or the reason there is not one.
+ *
+ * Deliberately one shape with an optional `error` rather than a discriminated
+ * union on `ok`: this package compiles with `strict: false`, and without
+ * `strictNullChecks` TypeScript will not narrow a union by a boolean
+ * discriminant — `if (!parsed.ok)` leaves `parsed.message` an error. A field
+ * that is either set or not needs no narrowing to read.
+ */
+type ParsedBody = { body: Record<string, any>; error?: string };
+
+/**
+ * The body, as JSON — or a reason it is not.
  *
  * Read off the raw request rather than through `req.input()`: that path matches
  * `Content-Type` exactly, so `application/json; charset=utf-8` — which several
  * HTTP clients send by default — parses as an empty body, and an agent turn
  * that silently loses its text is a bad way to find that out.
+ *
+ * The three cases are kept apart deliberately. NO body is a real request — a
+ * reattach, or a turn that just lets the model continue — and reads as `{}`. A
+ * body that will not parse, or that parses to something other than an object,
+ * is a failed request and has to say so: folding it into `{}` made a truncated
+ * proxy response or a mis-serialized client indistinguishable from an empty
+ * turn, so `stream` billed a model call with no history and no turn and threw
+ * the user's actual message away. That presents as the model hallucinating
+ * rather than as an error, which is the expensive way to debug it. Pre-flight
+ * failures stay ordinary HTTP errors and never reach the event stream.
+ *
+ * An array counts as malformed even though `typeof [] === "object"`: nothing
+ * downstream reads a positional body, so `[1,2,3]` could only ever have run as
+ * an empty turn.
  */
-async function readJsonBody(req: HttpRequest<any, any>): Promise<Record<string, any>> {
+async function readJsonBody(req: HttpRequest<any, any>): Promise<ParsedBody> {
   const raw = req?.rawRequest;
   if (!raw || raw.method === "GET" || raw.method === "HEAD" || !raw.body) {
-    return {};
+    return { body: {} };
   }
+
+  let text: string;
   try {
-    const text = await raw.text();
-    if (!text) {
-      return {};
-    }
-    const parsed = JSON.parse(text);
-    return parsed && typeof parsed === "object" ? parsed : {};
+    text = await raw.text();
   } catch {
-    return {};
+    // A body that stopped arriving mid-flight. Same class of failure as one
+    // that arrived truncated, and the same answer.
+    return { body: {}, error: "The request body could not be read." };
   }
+
+  if (!text.trim()) {
+    return { body: {} };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { body: {}, error: "The request body is not valid JSON." };
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { body: {}, error: "The request body must be a JSON object." };
+  }
+
+  return { body: parsed as Record<string, any> };
+}
+
+function invalidRequest(message: string): Response {
+  return jsonResponse(400, { code: "invalid_request", message });
 }
 
 /**
@@ -461,15 +542,25 @@ function toClientTurn(body: Record<string, any>): ClientTurn | undefined {
 }
 
 /**
- * Where to resume from.
+ * Where to resume from, or `undefined` for "wherever you still can".
  *
  * An explicit `from` wins, because a client that tracked its own position knows
  * something the transport does not. Otherwise `Last-Event-ID` — the browser
  * sends it on its own when an `EventSource` reconnects, and the frames put
  * `seq` in `id:` precisely so that header is already the right question. It
  * names the last event *received*, so the resume point is one past it.
+ *
+ * With neither, the answer is `undefined` and NOT 0. A client reattaching on
+ * mount is a fresh POST from a page that has just loaded: no `Last-Event-ID`,
+ * and no cursor of its own, because the only handle it was given is the
+ * `threadId`. Reading that as "resume from frame 0" asked `replay` for a frame
+ * every run longer than `maxFrames` has already evicted, so the mount-time
+ * reattach — the one case `/attach` exists for — 410'd on exactly the long runs
+ * it was meant to rescue, and the documented remedy of reloading the thread
+ * does not help because the store is only written at run end. `undefined` means
+ * the tail, which is all such a client can use anyway.
  */
-function resolveCursor(req: HttpRequest<any, any>, body: Record<string, any>): number {
+function resolveCursor(req: HttpRequest<any, any>, body: Record<string, any>): number | undefined {
   if (typeof body.from === "number" && Number.isFinite(body.from)) {
     return Math.max(0, Math.floor(body.from));
   }
@@ -480,7 +571,7 @@ function resolveCursor(req: HttpRequest<any, any>, body: Record<string, any>): n
       return Math.max(0, seq + 1);
     }
   }
-  return 0;
+  return undefined;
 }
 
 function searchParam(req: HttpRequest<any, any>, key: string): string | undefined {

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -1,9 +1,23 @@
-// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
-import type { HttpRequest } from "../http";
-import type { Controller } from "../http/Controller";
+import { Controller } from "../http/Controller";
+import { HttpRequest } from "../http/HttpRequest";
 import type { MiddlewareInput } from "../http/middlewareList";
 import type { AgentRun, AgentRunResult, AnyAgent, ToolShapesOf } from "./Agent";
-import type { AgentError, AgentMessage, PendingToolCall, ToolShapes } from "./types";
+import {
+  FrameCursorEvictedError,
+  liveRuns as defaultLiveRuns,
+  LiveRunNotFoundError,
+  MemoryLiveRuns,
+} from "./store/LiveRuns";
+import { defaultAgentStore, MemoryAgentStore } from "./store/MemoryAgentStore";
+import { sseResponse } from "./store/sse";
+import type {
+  AgentError,
+  AgentMessage,
+  AgentStreamEvent,
+  ClientTurn,
+  PendingToolCall,
+  ToolShapes,
+} from "./types";
 
 // --- storage -------------------------------------------------------------
 
@@ -23,12 +37,7 @@ export interface AgentStore {
 }
 
 /** The default: conversations last as long as the process. */
-export declare class MemoryAgentStore implements AgentStore {
-  constructor(params?: { ttlMs?: number });
-  createThread(params: { userId?: string | number }): Promise<{ threadId: string }>;
-  loadThread(threadId: string): Promise<AgentMessage[]>;
-  appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
-}
+export { defaultAgentStore, MemoryAgentStore };
 
 /**
  * The runs currently in flight, and their frames.
@@ -44,6 +53,10 @@ export declare class MemoryAgentStore implements AgentStore {
  * server, sticky routing, or a proxy that forwards by `runId`. Worth saying out
  * loud, because the failure mode behind a round-robin load balancer is a
  * refresh that usually works.
+ *
+ * This is the read side, which is all `attach` and `stop` need. Registering a
+ * run and replaying its buffer are on `MemoryLiveRuns`, the only implementation
+ * there can be — see the note there for why a second one would not help.
  */
 export interface LiveRuns {
   /** What the client asks after a refresh: is anything still going here? */
@@ -54,6 +67,13 @@ export interface LiveRuns {
   ttlMs: number;
 }
 
+export {
+  FrameCursorEvictedError,
+  LiveRunNotFoundError,
+  MemoryLiveRuns,
+  defaultLiveRuns as liveRuns,
+};
+
 // --- controller ----------------------------------------------------------
 
 export type AgentHookContext = {
@@ -62,33 +82,143 @@ export type AgentHookContext = {
   threadId?: string;
 };
 
-export declare abstract class AgentController<A extends AnyAgent = AnyAgent> extends Controller {
-  static kind: "agent-controller";
+/**
+ * `Controller.kind` is typed as the literal `"controller"`, so a subclass that
+ * declares a `kind` of its own fails the static-side check (TS2417). Widening
+ * it belongs in `http/Controller.ts`, which this slice does not own; erasing
+ * the static side of the base here is the smaller change and costs nothing —
+ * `Controller.kind` has no reader, in this package or out of it.
+ */
+const ControllerBase = Controller as new () => Controller;
+
+export abstract class AgentController<A extends AnyAgent = AnyAgent> extends ControllerBase {
+  static kind = "agent-controller" as const;
 
   /** The agent this controller serves. A property rather than a constructor
    *  argument so `Router.agent(ChatController)` can take the class, matching how
    *  every other controller is mounted. */
   abstract agent: A;
 
-  /** Defaults to `MemoryAgentStore`. */
-  store: AgentStore;
+  /**
+   * Defaults to the process-wide `MemoryAgentStore`.
+   *
+   * Whatever you put here, make it something that outlives the request: this
+   * controller is constructed fresh for every call, so `store = new
+   * MemoryAgentStore()` written here is an empty store on every turn and a
+   * threaded conversation silently reads back nothing. Assign a module-level
+   * instance, or a store whose state is somewhere else entirely.
+   */
+  store: AgentStore = defaultAgentStore;
+
+  /**
+   * Defaults to the process-wide map. Overridable so a test — or an app running
+   * two agents that must not see each other's runs — can hold its own; not so
+   * that it can be moved off the process, which is not a thing that can be
+   * done. See `MemoryLiveRuns`.
+   */
+  liveRuns: MemoryLiveRuns = defaultLiveRuns;
 
   /** Appended to the agent's static instructions for this request — the user's
    *  name, tenant, today's date. */
-  instructions(req: HttpRequest<any, any>): string | Promise<string> | void;
+  instructions(req: HttpRequest<any, any>): string | Promise<string> | void {
+    void req;
+  }
 
   /**
    * `POST /<path>` — one route for every client turn. A first message, an
    * approval, an answer to a question and a client tool's result are all just
    * the next turn, so none of them gets an endpoint of its own.
    */
-  stream(req: HttpRequest<any, any>): Promise<Response>;
+  async stream(req: HttpRequest<any, any> = new HttpRequest()): Promise<Response> {
+    const body = await readJsonBody(req);
+    const threadId = typeof body.threadId === "string" ? body.threadId : undefined;
+    const turn = toClientTurn(body);
+
+    // The whole of the stateless/threaded difference, in one expression: with a
+    // thread the server owns the history, without one the client carries it.
+    // Nothing else below branches on it, which is why stateless keeps working
+    // even for an app that never configures a store.
+    const messages = threadId
+      ? await this.store.loadThread(threadId)
+      : Array.isArray(body.messages)
+        ? (body.messages as AgentMessage[])
+        : [];
+
+    const instructions = (await this.instructions(req)) || undefined;
+
+    const run = this.agent.stream({
+      messages,
+      turn,
+      req,
+      threadId,
+      instructions,
+    }) as AgentRun;
+
+    const ctx: AgentHookContext = { req, runId: run.runId, threadId };
+
+    // Registered before the response is built: the run is now owned by the
+    // process rather than by this request, which is the property `/attach`
+    // depends on and the reason a dropped connection no longer cancels
+    // anything.
+    this.liveRuns.register(run, {
+      threadId,
+      onEvent: (event) => this.dispatchEvent(event, ctx),
+      onInternalError: (err) => this.reportHookFailure(err),
+    });
+
+    void this.persistRun(run, ctx);
+
+    return run.toResponse();
+  }
+
   /**
    * `POST /<path>/attach` — subscribe to a run already in progress, from a
    * cursor. This is a read of a live run, not a continuation of a stopped one:
    * the work never paused, the listener changed.
    */
-  attach(req: HttpRequest<any, any>): Promise<Response>;
+  async attach(req: HttpRequest<any, any> = new HttpRequest()): Promise<Response> {
+    const body = await readJsonBody(req);
+    const threadId =
+      typeof body.threadId === "string" ? body.threadId : searchParam(req, "threadId");
+
+    if (!threadId) {
+      return jsonResponse(400, {
+        code: "invalid_request",
+        message: "attach needs a threadId: it is the handle that survives a refresh.",
+      });
+    }
+
+    const live = await this.liveRuns.find({ threadId });
+    if (!live) {
+      // An explicit miss, not a 200 with an empty stream. See `MemoryLiveRuns`:
+      // behind a round-robin load balancer this is the common case, and it has
+      // to be visible as one.
+      return jsonResponse(404, {
+        code: "no_live_run",
+        message: `No run in progress for thread ${threadId} in this process.`,
+      });
+    }
+
+    try {
+      return sseResponse(this.liveRuns.replay(live.runId, resolveCursor(req, body)));
+    } catch (err) {
+      if (err instanceof FrameCursorEvictedError) {
+        // 410 rather than 404: the run is there, the position is not. A client
+        // that gets this reloads the thread instead of resuming into a hole.
+        return jsonResponse(410, {
+          code: err.code,
+          message: err.message,
+          oldestSeq: err.oldest,
+        });
+      }
+      if (err instanceof LiveRunNotFoundError) {
+        // Lost the race with eviction between `find` and `replay`.
+        return jsonResponse(404, { code: err.code, message: err.message });
+      }
+      throw err;
+    }
+  }
+
   /**
    * `POST /<path>/stop` — the explicit cancel. Since a dropped connection no
    * longer stops a run, this is the only thing that does, and it is why
@@ -100,38 +230,276 @@ export declare abstract class AgentController<A extends AnyAgent = AnyAgent> ext
    * out on the run's own stream, so whoever is watching it sees the ending,
    * and `onMessage` records it whether anyone is watching or not.
    */
-  stop(req: HttpRequest<any, any>): Promise<{ stopped: boolean }>;
+  async stop(req: HttpRequest<any, any> = new HttpRequest()): Promise<{ stopped: boolean }> {
+    const body = await readJsonBody(req);
+
+    let runId = typeof body.runId === "string" ? body.runId : undefined;
+    if (!runId && typeof body.threadId === "string") {
+      runId = (await this.liveRuns.find({ threadId: body.threadId }))?.runId;
+    }
+
+    const run = runId ? this.liveRuns.get(runId) : null;
+    if (!run) {
+      // Already finished, already evicted, or never here. Not an error: the
+      // caller wanted the run stopped and it is not running.
+      return { stopped: false };
+    }
+
+    run.stop({ reason: typeof body.reason === "string" ? body.reason : undefined });
+
+    // Deliberately not awaiting `run.result()`. Unwinding means letting tools
+    // in flight settle into `denied` results and finalizing the assistant
+    // message, which can take as long as the slowest tool — and a stop button
+    // that spins for twenty seconds is a stop button people press twice.
+    return { stopped: true };
+  }
+
   /** `POST /<path>/files` — uploads an attachment and returns its file id. */
-  upload(req: HttpRequest<any, any>): Promise<{ fileId: string }>;
+  async upload(req: HttpRequest<any, any> = new HttpRequest()): Promise<{ fileId: string }> {
+    const form = await req.rawRequest.formData();
+    const file = form.get("file");
+    if (!(file instanceof Blob)) {
+      throw new Error("upload expects a multipart body with a `file` field.");
+    }
+    // Straight through the provider: message history holds provider file ids,
+    // which is the trade `AgentProvider.upload` documents — vision and PDF
+    // input without gemi owning a storage story in v1.
+    const fileId = await this.agent.provider.upload(file as File);
+    return { fileId };
+  }
 
   /**
    * Protected, not private: these exist to be overridden. `onMessage` fires for
    * every completed message, user and assistant alike, and is the intended
    * persistence point for an app that is not using `store`.
    */
-  protected onMessage(message: AgentMessage, ctx: AgentHookContext): void | Promise<void>;
+  protected onMessage(message: AgentMessage, ctx: AgentHookContext): void | Promise<void> {
+    void message;
+    void ctx;
+  }
+
   protected onToolCall(
     call: { toolCallId: string; name: string; input: unknown },
     ctx: AgentHookContext,
-  ): void | Promise<void>;
+  ): void | Promise<void> {
+    void call;
+    void ctx;
+  }
+
   /** Fires before the stream ends `awaiting-input` — where to notify whoever
    *  has to approve, if they are not the person watching the stream. */
   protected onAwaitingInput(
     pending: PendingToolCall[],
     ctx: AgentHookContext,
-  ): void | Promise<void>;
-  protected onError(error: AgentError, ctx: AgentHookContext): void | Promise<void>;
+  ): void | Promise<void> {
+    void pending;
+    void ctx;
+  }
+
+  protected onError(error: AgentError, ctx: AgentHookContext): void | Promise<void> {
+    void error;
+    void ctx;
+  }
+
   protected onStreamComplete(
     result: AgentRunResult<ToolShapesOf<A["tools"]>, any>,
     ctx: AgentHookContext,
-  ): void | Promise<void>;
+  ): void | Promise<void> {
+    void result;
+    void ctx;
+  }
+
+  /**
+   * WHAT HAPPENS WHEN A HOOK THROWS: it is reported and the run carries on.
+   *
+   * The alternative is to fail the run, and that trade is not close. These
+   * hooks are an app's persistence and notification points; the run is a model
+   * call the user has already been charged for and whose tools may already have
+   * charged a card. Letting a failed `INSERT` in `onMessage` abort a generation
+   * mid-sentence loses the answer as well as the row, and the user cannot
+   * retry into a better outcome. So the answer survives and the failure is
+   * logged.
+   *
+   * It is logged rather than routed to `onError`: `onError` is itself a hook,
+   * and a hook that throws inside the handler for hooks that throw is a loop.
+   * Override this to send it somewhere with a pager attached.
+   */
+  protected reportHookFailure(error: unknown): void {
+    console.error("[gemi/ai] agent controller hook failed", error);
+  }
+
+  private async dispatchEvent(event: AgentStreamEvent, ctx: AgentHookContext): Promise<void> {
+    switch (event.type) {
+      case "tool-call":
+        // Skipped while the arguments are still streaming: a hook that fires
+        // per token would fire with a half-parsed input, which is worse than
+        // firing late.
+        if (!event.part.partial) {
+          await this.onToolCall(
+            {
+              toolCallId: event.part.toolCallId,
+              name: String(event.part.name),
+              input: event.part.input,
+            },
+            ctx,
+          );
+        }
+        return;
+      case "awaiting-input":
+        await this.onAwaitingInput(event.pending as PendingToolCall[], ctx);
+        return;
+      case "error":
+        await this.onError(event.error, ctx);
+        return;
+      default:
+        return;
+    }
+  }
+
+  /**
+   * Runs after the stream is over, whether or not anyone was still watching it.
+   *
+   * The messages come from `result()` rather than from the event stream because
+   * assembling a message out of deltas is the agent's job and doing it twice is
+   * how the two copies drift. It also means a stopped run persists the same way
+   * a finished one does: `stop()` finalizes the transcript, so by the time this
+   * resolves there is a valid history to store.
+   */
+  private async persistRun(run: AgentRun, ctx: AgentHookContext): Promise<void> {
+    let result: AgentRunResult<ToolShapes, unknown>;
+    try {
+      result = await run.result();
+    } catch (err) {
+      await this.safely(() =>
+        this.onError(
+          {
+            code: "unknown",
+            message: err instanceof Error ? err.message : String(err),
+            retryable: false,
+          },
+          ctx,
+        ),
+      );
+      return;
+    }
+
+    const messages = result.messages as AgentMessage[];
+
+    if (ctx.threadId && messages.length > 0) {
+      try {
+        await this.store.appendMessages(ctx.threadId, messages);
+      } catch (err) {
+        this.reportHookFailure(err);
+      }
+    }
+
+    for (const message of messages) {
+      await this.safely(() => this.onMessage(message, ctx));
+    }
+
+    await this.safely(() => this.onStreamComplete(result as any, ctx));
+  }
+
+  private async safely(fn: () => void | Promise<void>): Promise<void> {
+    try {
+      await fn();
+    } catch (err) {
+      this.reportHookFailure(err);
+    }
+  }
+}
+
+// --- request plumbing ----------------------------------------------------
+
+/**
+ * The body, as JSON, or `{}`.
+ *
+ * Read off the raw request rather than through `req.input()`: that path matches
+ * `Content-Type` exactly, so `application/json; charset=utf-8` — which several
+ * HTTP clients send by default — parses as an empty body, and an agent turn
+ * that silently loses its text is a bad way to find that out.
+ */
+async function readJsonBody(req: HttpRequest<any, any>): Promise<Record<string, any>> {
+  const raw = req?.rawRequest;
+  if (!raw || raw.method === "GET" || raw.method === "HEAD" || !raw.body) {
+    return {};
+  }
+  try {
+    const text = await raw.text();
+    if (!text) {
+      return {};
+    }
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * The client's turn, accepting both `{ turn: {...} }` and the flattened
+ * `{ text, files, toolResults }` — the second is what a hand-written `fetch`
+ * writes, and refusing it buys nothing.
+ *
+ * Returns `undefined` for an empty turn, which is a real request: reattaching
+ * to a conversation and letting the model continue is a turn with nothing in
+ * it.
+ */
+function toClientTurn(body: Record<string, any>): ClientTurn | undefined {
+  const source = body.turn && typeof body.turn === "object" ? body.turn : body;
+  const turn: ClientTurn = {};
+  if (typeof source.text === "string") {
+    turn.text = source.text;
+  }
+  if (Array.isArray(source.files)) {
+    turn.files = source.files;
+  }
+  if (Array.isArray(source.toolResults)) {
+    turn.toolResults = source.toolResults;
+  }
+  return Object.keys(turn).length > 0 ? turn : undefined;
+}
+
+/**
+ * Where to resume from.
+ *
+ * An explicit `from` wins, because a client that tracked its own position knows
+ * something the transport does not. Otherwise `Last-Event-ID` — the browser
+ * sends it on its own when an `EventSource` reconnects, and the frames put
+ * `seq` in `id:` precisely so that header is already the right question. It
+ * names the last event *received*, so the resume point is one past it.
+ */
+function resolveCursor(req: HttpRequest<any, any>, body: Record<string, any>): number {
+  if (typeof body.from === "number" && Number.isFinite(body.from)) {
+    return Math.max(0, Math.floor(body.from));
+  }
+  const header = req?.rawRequest?.headers?.get("Last-Event-ID");
+  if (header) {
+    const seq = Number.parseInt(header, 10);
+    if (Number.isFinite(seq)) {
+      return Math.max(0, seq + 1);
+    }
+  }
+  return 0;
+}
+
+function searchParam(req: HttpRequest<any, any>, key: string): string | undefined {
+  const value = req?.search?.get(key);
+  return typeof value === "string" ? value : undefined;
+}
+
+function jsonResponse(status: number, error: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 // --- routing -------------------------------------------------------------
 //
 // `agent()` itself belongs on ApiRouter next to `resource()`, which is the
 // method it works like: one call, several routes, all of them the controller's.
-// The types are sketched here because they are the ai module's contract, not
+// The types are declared here because they are the ai module's contract, not
 // the router's.
 //
 //   class Api extends ApiRouter {

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -176,6 +176,9 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     // anything.
     this.liveRuns.register(run, {
       threadId,
+      // The client's handle on a run it started, which is the only one that
+      // exists before `run-start` reaches it. See `RegisterParams`.
+      clientRunId: typeof body.clientRunId === "string" ? body.clientRunId : undefined,
       onEvent: (event) => this.dispatchEvent(event, ctx),
       onInternalError: (err) => this.reportHookFailure(err),
     });
@@ -190,10 +193,11 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * cursor. This is a read of a live run, not a continuation of a stopped one:
    * the work never paused, the listener changed.
    *
-   * The cursor is `from`, else `Last-Event-ID`, else the oldest frame still
-   * buffered. A cursor the buffer has dropped is a 410 naming what survives;
-   * *no* cursor is the tail, because a page reattaching on mount has no
-   * transcript to leave a hole in. See `resolveCursor`.
+   * The cursor is `from`, else the client's `cursor`, else `Last-Event-ID`,
+   * else the oldest frame still buffered — and it is honoured only for the run
+   * the client's `runId` names. A cursor the buffer has dropped is a 410 naming
+   * what survives; *no* cursor is the tail, because a page reattaching on mount
+   * has no transcript to leave a hole in. See `resolveCursor`.
    */
   async attach(req: HttpRequest<any, any> = new HttpRequest()): Promise<Response> {
     const parsed = await readJsonBody(req);
@@ -222,8 +226,22 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
       });
     }
 
+    // A cursor is only a number if you know which run it counts within: `seq`
+    // restarts at zero in every run, so honouring a cursor from run_1 against a
+    // live run_2 would skip that many frames off the head of a run this client
+    // has seen nothing of. `runId` is the client saying which run its cursor
+    // means; naming one that is not live forfeits the cursor and takes the
+    // tail, which is as close to the start as the buffer can offer.
+    //
+    // Only a MISMATCH forfeits. An absent `runId` is not a wrong answer, it is
+    // an older question: `from` and `Last-Event-ID` predate the pairing and
+    // carry no run, and an `EventSource` reconnecting on its own will never
+    // grow one. Those keep resuming exactly as before.
+    const cursorRunId = typeof body.runId === "string" ? body.runId : undefined;
+    const cursor = cursorRunId && cursorRunId !== live.runId ? undefined : resolveCursor(req, body);
+
     try {
-      return sseResponse(this.liveRuns.replay(live.runId, resolveCursor(req, body)));
+      return sseResponse(this.liveRuns.replay(live.runId, cursor));
     } catch (err) {
       if (err instanceof FrameCursorEvictedError) {
         // 410 rather than 404: the run is there, the position is not. A client
@@ -269,7 +287,16 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     }
     const body = parsed.body;
 
+    // Three handles, most specific first, because which ones the client has
+    // depends on how far the run got. `runId` is the server's own and settles
+    // it. `clientRunId` covers the window before `run-start`, when the client
+    // has nothing else for a stateless first turn. `threadId` is the fallback
+    // for a client that did not start this run at all — one that attached to
+    // it, whose replayed tail carried no `run-start`.
     let runId = typeof body.runId === "string" ? body.runId : undefined;
+    if (!runId && typeof body.clientRunId === "string") {
+      runId = this.liveRuns.findByClientRunId(body.clientRunId) ?? undefined;
+    }
     if (!runId && typeof body.threadId === "string") {
       runId = (await this.liveRuns.find({ threadId: body.threadId }))?.runId;
     }
@@ -563,6 +590,19 @@ function toClientTurn(body: Record<string, any>): ClientTurn | undefined {
 function resolveCursor(req: HttpRequest<any, any>, body: Record<string, any>): number | undefined {
   if (typeof body.from === "number" && Number.isFinite(body.from)) {
     return Math.max(0, Math.floor(body.from));
+  }
+  // `cursor` is what `useChat` actually sends, and it counts the other way:
+  // `from` is the frame to resume AT, `cursor` the last frame the client
+  // APPLIED — the same convention as `Last-Event-ID`, and the same `+ 1`. A
+  // client that has applied nothing sends -1, which is not a position but the
+  // absence of one, so it falls through to the tail rather than asking for
+  // frame 0 and 410ing on precisely the long runs `/attach` exists to rescue.
+  if (typeof body.cursor === "number" && Number.isFinite(body.cursor)) {
+    const applied = Math.floor(body.cursor);
+    if (applied >= 0) {
+      return applied + 1;
+    }
+    return undefined;
   }
   const header = req?.rawRequest?.headers?.get("Last-Event-ID");
   if (header) {

--- a/packages/gemi/ai/store/LiveRuns.test.ts
+++ b/packages/gemi/ai/store/LiveRuns.test.ts
@@ -139,6 +139,83 @@ describe("MemoryLiveRuns", () => {
     runs.clear();
   });
 
+  /**
+   * The mount-time reattach: a client with no cursor of its own. Asking for 0
+   * would be a 410 on any run past `maxFrames`, so no cursor means the tail.
+   */
+  test("with no cursor, starts at the oldest frame it still has", async () => {
+    const runs = new MemoryLiveRuns({ maxFrames: 4 });
+    const run = new StubAgentRun("run_k");
+    runs.register(run, { threadId: "t1" });
+
+    for (let i = 0; i < 10; i++) {
+      run.emit(textDelta(String(i)));
+    }
+    run.finish();
+    await settle();
+
+    const frames = await collect(runs.replay("run_k"));
+    expect(frames.map((f) => f.seq)).toEqual([6, 7, 8, 9]);
+    runs.clear();
+  });
+
+  test("with no cursor and nothing evicted, replays the whole run", async () => {
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_l");
+    runs.register(run, { threadId: "t1" });
+
+    run.emit(textDelta("a"));
+    run.emit(textDelta("b"));
+    run.finish();
+    await settle();
+
+    const frames = await collect(runs.replay("run_l"));
+    expect(frames.map((f) => f.seq)).toEqual([0, 1]);
+    runs.clear();
+  });
+
+  test("with no cursor on a run that has emitted nothing, waits for the first frame", async () => {
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_m");
+    runs.register(run, { threadId: "t1" });
+
+    const collected = collect(runs.replay("run_m"));
+    await settle();
+
+    run.emit(textDelta("a"));
+    run.finish();
+
+    expect((await collected).map((f) => f.seq)).toEqual([0]);
+    runs.clear();
+  });
+
+  /**
+   * Retention is this class's job and runs on its own clock. It used to run
+   * behind the hook chain, which is app code: `onAwaitingInput` is documented
+   * as the place to notify an approver, and a `fetch` with no timeout never
+   * settles — so one hanging hook pinned its run, its frames and everything
+   * they close over in the map for the life of the process. A rejection was
+   * handled; a promise that simply never settles was not.
+   */
+  test("evicts on the ttl clock even when a hook never settles", async () => {
+    const runs = new MemoryLiveRuns({ ttlMs: 10 });
+    const run = new StubAgentRun("run_n");
+    runs.register(run, {
+      threadId: "t1",
+      // The webhook that never answers.
+      onEvent: () => new Promise<void>(() => {}),
+    });
+
+    run.emit(textDelta("a"));
+    run.finish();
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(await runs.find({ threadId: "t1" })).toBeNull();
+    expect(runs.get("run_n")).toBeNull();
+    expect(runs.size).toBe(0);
+  });
+
   test("holds a finished run for ttlMs, then evicts it", async () => {
     const runs = new MemoryLiveRuns({ ttlMs: 10 });
     const run = new StubAgentRun("run_g");

--- a/packages/gemi/ai/store/LiveRuns.test.ts
+++ b/packages/gemi/ai/store/LiveRuns.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "vitest";
+
+import type { AgentStreamEvent, AgentStreamFrame } from "../types";
+import { FrameCursorEvictedError, LiveRunNotFoundError, MemoryLiveRuns } from "./LiveRuns";
+import { StubAgentRun } from "./stubAgentRun";
+
+const textDelta = (delta: string): AgentStreamEvent => ({
+  type: "text-delta",
+  messageId: "m1",
+  delta,
+});
+
+/**
+ * Lets the buffering pump catch up.
+ *
+ * The pump reads the run through an async generator, so a frame emitted on this
+ * tick is buffered a few microtasks later. A macrotask is the cheap way to be
+ * past all of them without counting.
+ */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function collect(frames: AsyncIterable<AgentStreamFrame>): Promise<AgentStreamFrame[]> {
+  const out: AgentStreamFrame[] = [];
+  for await (const frame of frames) {
+    out.push(frame);
+  }
+  return out;
+}
+
+describe("MemoryLiveRuns", () => {
+  test("finds a run by thread and hands the run itself back by id", async () => {
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_a");
+    runs.register(run, { threadId: "t1" });
+    run.emit(textDelta("hi"));
+    await settle();
+
+    const found = await runs.find({ threadId: "t1" });
+    expect(found).toEqual({ runId: "run_a", seq: 0 });
+    expect(runs.get("run_a")).toBe(run);
+
+    run.finish();
+    runs.clear();
+  });
+
+  test("misses explicitly for a thread with nothing in flight here", async () => {
+    const runs = new MemoryLiveRuns();
+    expect(await runs.find({ threadId: "nobody" })).toBeNull();
+    expect(runs.get("run_nowhere")).toBeNull();
+    // The point of the whole class: behind a round-robin balancer this is what
+    // a refresh hits, and it has to be a miss and not an empty stream.
+    expect(() => runs.replay("run_nowhere", 0)).toThrow(LiveRunNotFoundError);
+  });
+
+  test("replays the whole run, then closes", async () => {
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_b");
+    runs.register(run, { threadId: "t1" });
+
+    run.emit(textDelta("a"));
+    run.emit(textDelta("b"));
+    run.finish();
+
+    const frames = await collect(runs.replay("run_b", 0));
+    expect(frames.map((f) => f.seq)).toEqual([0, 1]);
+    runs.clear();
+  });
+
+  test("replays exactly the tail from a cursor", async () => {
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_c");
+    runs.register(run, { threadId: "t1" });
+
+    for (const chunk of ["a", "b", "c", "d"]) {
+      run.emit(textDelta(chunk));
+    }
+    run.finish();
+
+    const frames = await collect(runs.replay("run_c", 2));
+    expect(frames.map((f) => f.seq)).toEqual([2, 3]);
+    expect(frames.map((f) => (f.event as { delta: string }).delta)).toEqual(["c", "d"]);
+    runs.clear();
+  });
+
+  test("keeps delivering frames that arrive after the reader attached", async () => {
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_d");
+    runs.register(run, { threadId: "t1" });
+    run.emit(textDelta("a"));
+
+    const collected = collect(runs.replay("run_d", 0));
+    await settle();
+
+    run.emit(textDelta("b"));
+    run.finish();
+
+    expect((await collected).map((f) => f.seq)).toEqual([0, 1]);
+    runs.clear();
+  });
+
+  test("bounds the buffer, dropping the oldest frames", async () => {
+    const runs = new MemoryLiveRuns({ maxFrames: 4 });
+    const run = new StubAgentRun("run_e");
+    runs.register(run, { threadId: "t1" });
+
+    for (let i = 0; i < 10; i++) {
+      run.emit(textDelta(String(i)));
+    }
+    run.finish();
+    await settle();
+
+    const frames = await collect(runs.replay("run_e", 6));
+    expect(frames.map((f) => f.seq)).toEqual([6, 7, 8, 9]);
+    runs.clear();
+  });
+
+  test("refuses a cursor the buffer has already dropped", async () => {
+    const runs = new MemoryLiveRuns({ maxFrames: 4 });
+    const run = new StubAgentRun("run_f");
+    runs.register(run, { threadId: "t1" });
+
+    for (let i = 0; i < 10; i++) {
+      run.emit(textDelta(String(i)));
+    }
+    run.finish();
+    await settle();
+
+    // Not "here is the tail I still have": a client resuming at 0 and silently
+    // receiving frame 6 onwards has a transcript with an invisible hole in it.
+    let thrown: unknown;
+    try {
+      runs.replay("run_f", 0);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(FrameCursorEvictedError);
+    expect((thrown as FrameCursorEvictedError).requested).toBe(0);
+    expect((thrown as FrameCursorEvictedError).oldest).toBe(6);
+    runs.clear();
+  });
+
+  test("holds a finished run for ttlMs, then evicts it", async () => {
+    const runs = new MemoryLiveRuns({ ttlMs: 10 });
+    const run = new StubAgentRun("run_g");
+    runs.register(run, { threadId: "t1" });
+    run.emit(textDelta("a"));
+    run.finish();
+
+    // Still there right after the end — that is the "refresh a second late"
+    // case the ttl exists for.
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    expect(await runs.find({ threadId: "t1" })).toEqual({ runId: "run_g", seq: 0 });
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(await runs.find({ threadId: "t1" })).toBeNull();
+    expect(runs.get("run_g")).toBeNull();
+    expect(runs.size).toBe(0);
+  });
+
+  test("feeds events to onEvent in order without blocking the buffer", async () => {
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_h");
+    const seen: string[] = [];
+    runs.register(run, {
+      threadId: "t1",
+      onEvent: (event) => {
+        seen.push(event.type);
+      },
+    });
+
+    run.emit(textDelta("a"));
+    run.emit({ type: "run-end", runId: "run_h", finishReason: "stop" });
+    run.finish();
+
+    await collect(runs.replay("run_h", 0));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(seen).toEqual(["text-delta", "run-end"]);
+    runs.clear();
+  });
+
+  test("reports a throwing onEvent instead of losing the run", async () => {
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_i");
+    const failures: unknown[] = [];
+    runs.register(run, {
+      threadId: "t1",
+      onEvent: () => {
+        throw new Error("hook exploded");
+      },
+      onInternalError: (err) => failures.push(err),
+    });
+
+    run.emit(textDelta("a"));
+    run.emit(textDelta("b"));
+    run.finish();
+
+    const frames = await collect(runs.replay("run_i", 0));
+    expect(frames.map((f) => f.seq)).toEqual([0, 1]);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(failures).toHaveLength(2);
+    runs.clear();
+  });
+});

--- a/packages/gemi/ai/store/LiveRuns.ts
+++ b/packages/gemi/ai/store/LiveRuns.ts
@@ -63,6 +63,17 @@ export class LiveRunNotFoundError extends Error {
 export type RegisterParams = {
   threadId?: string;
   /**
+   * The client's own name for this run, minted before the run had one.
+   *
+   * `runId` does not reach the client until `run-start`, and a stateless first
+   * turn has no `threadId` either, so for the length of a network round trip
+   * plus the provider's time to first token there is nothing for `/stop` to
+   * name — which is exactly the window a user cancels in. `useChat` sends a
+   * `clientRunId` with every turn it starts; recording it here is what makes
+   * that window stoppable.
+   */
+  clientRunId?: string;
+  /**
    * Called once per frame, in order, off the buffering path.
    *
    * The controller's `on*` hooks hang off this. It is a callback rather than a
@@ -79,6 +90,7 @@ export type RegisterParams = {
 type Entry = {
   run: AgentRun;
   threadId?: string;
+  clientRunId?: string;
   /** A contiguous window of the run's frames, oldest first. */
   frames: AgentStreamFrame[];
   lastSeq: number;
@@ -121,6 +133,8 @@ export class MemoryLiveRuns implements LiveRuns {
   private runs = new Map<string, Entry>();
   /** Thread to the most recently registered run for it. */
   private byThread = new Map<string, string>();
+  /** The client's pre-`run-start` name for a run, to the run. */
+  private byClientRun = new Map<string, string>();
 
   constructor(params: { ttlMs?: number; maxFrames?: number } = {}) {
     this.ttlMs = params.ttlMs ?? DEFAULT_TTL_MS;
@@ -135,6 +149,7 @@ export class MemoryLiveRuns implements LiveRuns {
     const entry: Entry = {
       run: run as AgentRun,
       threadId: params.threadId,
+      clientRunId: params.clientRunId,
       frames: [],
       lastSeq: -1,
       ended: false,
@@ -146,7 +161,23 @@ export class MemoryLiveRuns implements LiveRuns {
     if (params.threadId) {
       this.byThread.set(params.threadId, run.runId);
     }
+    if (params.clientRunId) {
+      this.byClientRun.set(params.clientRunId, run.runId);
+    }
     void this.pump(entry, params);
+  }
+
+  /**
+   * The run a client named before the server had named it.
+   *
+   * Deliberately not folded into `find`, whose parameter is part of the
+   * read-side `LiveRuns` interface an app may already implement — widening that
+   * parameter would break every such implementation, and this lookup is only
+   * ever asked by `/stop`.
+   */
+  findByClientRunId(clientRunId: string): string | null {
+    const runId = this.byClientRun.get(clientRunId);
+    return runId && this.runs.has(runId) ? runId : null;
   }
 
   /** What the client asks after a refresh: is anything still going here? */
@@ -213,6 +244,7 @@ export class MemoryLiveRuns implements LiveRuns {
     }
     this.runs.clear();
     this.byThread.clear();
+    this.byClientRun.clear();
   }
 
   get size(): number {
@@ -316,6 +348,9 @@ export class MemoryLiveRuns implements LiveRuns {
       this.runs.delete(runId);
       if (entry.threadId && this.byThread.get(entry.threadId) === runId) {
         this.byThread.delete(entry.threadId);
+      }
+      if (entry.clientRunId && this.byClientRun.get(entry.clientRunId) === runId) {
+        this.byClientRun.delete(entry.clientRunId);
       }
       // Anyone still draining is holding an ended entry; wake them so they see
       // `ended` and finish rather than hanging on a promise nothing resolves.

--- a/packages/gemi/ai/store/LiveRuns.ts
+++ b/packages/gemi/ai/store/LiveRuns.ts
@@ -176,17 +176,28 @@ export class MemoryLiveRuns implements LiveRuns {
    * Throws before returning anything, so an evicted cursor and an unknown run
    * are still HTTP statuses rather than events on a stream that already
    * committed to a 200.
+   *
+   * `from` omitted means "start wherever you still can", not "start at 0".
+   * These are genuinely different requests: a client that names a cursor is
+   * telling us where its transcript ends, and handing it a later frame leaves
+   * an invisible hole — that is the 410. A client with no cursor at all — the
+   * browser reattaching on mount, which is the case `/attach` exists for — has
+   * no transcript to put a hole in, and refusing it the tail because the run is
+   * older than the buffer would 410 every run past `maxFrames`, i.e. every run
+   * long enough to be worth reattaching to.
    */
-  replay(runId: string, from = 0): AsyncIterable<AgentStreamFrame> {
+  replay(runId: string, from?: number): AsyncIterable<AgentStreamFrame> {
     const entry = this.runs.get(runId);
     if (!entry) {
       throw new LiveRunNotFoundError(runId);
     }
     const oldest = entry.frames[0]?.seq;
-    if (oldest !== undefined && from < oldest) {
+    if (from !== undefined && oldest !== undefined && from < oldest) {
       throw new FrameCursorEvictedError(runId, from, oldest);
     }
-    return this.drain(entry, runId, from);
+    // With nothing buffered — a run registered but not yet pumped — `lastSeq`
+    // is -1 and this is 0, which is the same answer by another route.
+    return this.drain(entry, runId, from ?? oldest ?? entry.lastSeq + 1);
   }
 
   /** Test seam: drops everything and cancels the pending eviction timers. */
@@ -222,9 +233,11 @@ export class MemoryLiveRuns implements LiveRuns {
         this.notify(entry);
         const onEvent = params.onEvent;
         if (onEvent) {
-          hooks = hooks.then(() => onEvent(frame.event)).catch((err) => {
-            params.onInternalError?.(err);
-          });
+          hooks = hooks
+            .then(() => onEvent(frame.event))
+            .catch((err) => {
+              params.onInternalError?.(err);
+            });
         }
       }
     } catch (err) {
@@ -234,8 +247,18 @@ export class MemoryLiveRuns implements LiveRuns {
     } finally {
       entry.ended = true;
       this.notify(entry);
-      await hooks;
+      // Eviction is scheduled off the ttl clock, BEFORE the hook chain is
+      // awaited. `hooks` is app code — `onAwaitingInput` is documented as the
+      // place to notify an approver, i.e. network I/O — and a `fetch` with no
+      // timeout never rejects, it just never settles. Awaiting it first made
+      // retention conditional on app code: one hanging hook pinned its entry,
+      // its 512 frames, the run and everything the run closes over in the map
+      // for the life of the process, and `find` kept answering with a run that
+      // ended hours ago. Retention is this class's job and belongs on its own
+      // clock. A hook still pending when the timer fires simply outlives the
+      // entry, which is fine — it holds no reference the map needed.
       this.scheduleEviction(entry);
+      await hooks;
     }
   }
 

--- a/packages/gemi/ai/store/LiveRuns.ts
+++ b/packages/gemi/ai/store/LiveRuns.ts
@@ -1,0 +1,311 @@
+import type { AgentRun } from "../Agent";
+import type { LiveRuns } from "../AgentController";
+import type { AgentStreamEvent, AgentStreamFrame } from "../types";
+
+/** Long enough that a refresh, a tab restore or a flaky mobile connection still
+ *  lands on the tail; short enough that a finished run is not resident for the
+ *  rest of the day. */
+const DEFAULT_TTL_MS = 60 * 1000;
+
+/**
+ * How many frames are kept per run.
+ *
+ * The buffer has to be bounded or it is a memory leak with a long fuse: a
+ * server that never restarts holding every token of every conversation it ever
+ * streamed. 512 frames is a couple of hundred tokens of prose plus its tool
+ * calls — comfortably more than the seconds of catch-up a reattaching client
+ * actually needs, and small enough that a thousand concurrent runs is megabytes
+ * rather than gigabytes.
+ */
+const DEFAULT_MAX_FRAMES = 512;
+
+/**
+ * A cursor older than anything still buffered.
+ *
+ * Deliberately an error rather than "here is the tail I still have". A client
+ * that asked for frame 12 and silently got frame 300 onwards has a transcript
+ * with a hole in it and no way to know — it will render a half-message, or an
+ * `awaiting-input` for a tool call it never saw. Saying so lets the client do
+ * the only correct thing, which is to reload the thread from the store.
+ */
+export class FrameCursorEvictedError extends Error {
+  readonly code = "frame_cursor_evicted";
+
+  constructor(
+    readonly runId: string,
+    readonly requested: number,
+    readonly oldest: number,
+  ) {
+    super(
+      `Frame ${requested} of run ${runId} has been evicted; the oldest frame ` +
+        `still buffered is ${oldest}. Reload the thread instead of resuming.`,
+    );
+  }
+}
+
+/**
+ * No run under that id in *this* process.
+ *
+ * Which is the honest answer, and the one worth being loud about: the run may
+ * well be alive on the box next door. See the note on `MemoryLiveRuns` — behind
+ * a round-robin load balancer this is what a refresh hits roughly (n-1)/n of
+ * the time, and an explicit miss is the difference between a bug someone finds
+ * in an hour and one that presents as "reattach sometimes does nothing".
+ */
+export class LiveRunNotFoundError extends Error {
+  readonly code = "live_run_not_found";
+
+  constructor(readonly runId: string) {
+    super(`No live run ${runId} in this process.`);
+  }
+}
+
+export type RegisterParams = {
+  threadId?: string;
+  /**
+   * Called once per frame, in order, off the buffering path.
+   *
+   * The controller's `on*` hooks hang off this. It is a callback rather than a
+   * second `run.frames()` subscription because every extra subscriber is
+   * another consumer of a generator whose multi-subscriber behaviour we do not
+   * own, and one pump is one thing to reason about.
+   */
+  onEvent?: (event: AgentStreamEvent) => void | Promise<void>;
+  /** Reported failures: a hook that threw, or a run whose frame iterator did.
+   *  Injectable so tests can assert on it instead of reading stderr. */
+  onInternalError?: (error: unknown) => void;
+};
+
+type Entry = {
+  run: AgentRun;
+  threadId?: string;
+  /** A contiguous window of the run's frames, oldest first. */
+  frames: AgentStreamFrame[];
+  lastSeq: number;
+  ended: boolean;
+  evictAt: ReturnType<typeof setTimeout> | null;
+  wake: Set<() => void>;
+  /**
+   * Bumped on every push and on the end.
+   *
+   * A reader cannot just park on "wake me when something happens": it suspends
+   * at every `yield` while its consumer reads, and anything that arrives during
+   * that suspension notifies an empty waiter set — so the reader parks *after*
+   * the event it was waiting for and never hears another. The version it read
+   * before scanning is what closes that window: if it moved, there is more to
+   * scan and the wait is skipped.
+   */
+  version: number;
+};
+
+/**
+ * The runs currently in flight in this process, and their recent frames.
+ *
+ * PER-PROCESS IS NOT AN IMPLEMENTATION SHORTCUT THAT A BETTER STORE FIXES. A
+ * running generator lives in one process, and a second server cannot attach to
+ * it — no amount of Redis moves an in-flight async iterator across a socket.
+ * Reattachment therefore needs the request to land where the run is: one
+ * server, sticky routing, or a proxy that forwards by `runId`. Worth saying out
+ * loud, because the failure mode behind a round-robin load balancer is a
+ * refresh that usually works.
+ *
+ * `find` and `replay` are built so that failure is an explicit miss — a 404
+ * naming the run, a 410 naming the cursor — and never an SSE stream that opens,
+ * says nothing and closes. An empty stream is indistinguishable from a run that
+ * finished quietly, which is exactly the confusion this is supposed to avoid.
+ */
+export class MemoryLiveRuns implements LiveRuns {
+  ttlMs: number;
+  readonly maxFrames: number;
+
+  private runs = new Map<string, Entry>();
+  /** Thread to the most recently registered run for it. */
+  private byThread = new Map<string, string>();
+
+  constructor(params: { ttlMs?: number; maxFrames?: number } = {}) {
+    this.ttlMs = params.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxFrames = params.maxFrames ?? DEFAULT_MAX_FRAMES;
+  }
+
+  /**
+   * Takes ownership of a run: starts buffering its frames and holds it until
+   * `ttlMs` past the end.
+   */
+  register(run: AgentRun, params: RegisterParams = {}): void {
+    const entry: Entry = {
+      run: run as AgentRun,
+      threadId: params.threadId,
+      frames: [],
+      lastSeq: -1,
+      ended: false,
+      evictAt: null,
+      wake: new Set(),
+      version: 0,
+    };
+    this.runs.set(run.runId, entry);
+    if (params.threadId) {
+      this.byThread.set(params.threadId, run.runId);
+    }
+    void this.pump(entry, params);
+  }
+
+  /** What the client asks after a refresh: is anything still going here? */
+  async find(params: { threadId: string }): Promise<{ runId: string; seq: number } | null> {
+    const runId = this.byThread.get(params.threadId);
+    if (!runId) {
+      return null;
+    }
+    const entry = this.runs.get(runId);
+    if (!entry) {
+      return null;
+    }
+    // `seq` is the last frame emitted, not the next one: it is the same number
+    // the transport puts in `Last-Event-ID`, so a client can compare the two
+    // without knowing which end of the range each one means.
+    return { runId, seq: entry.lastSeq };
+  }
+
+  get(runId: string): AgentRun | null {
+    return this.runs.get(runId)?.run ?? null;
+  }
+
+  /**
+   * The buffered frames from `from` onwards, followed by live ones until the
+   * run ends.
+   *
+   * Throws before returning anything, so an evicted cursor and an unknown run
+   * are still HTTP statuses rather than events on a stream that already
+   * committed to a 200.
+   */
+  replay(runId: string, from = 0): AsyncIterable<AgentStreamFrame> {
+    const entry = this.runs.get(runId);
+    if (!entry) {
+      throw new LiveRunNotFoundError(runId);
+    }
+    const oldest = entry.frames[0]?.seq;
+    if (oldest !== undefined && from < oldest) {
+      throw new FrameCursorEvictedError(runId, from, oldest);
+    }
+    return this.drain(entry, runId, from);
+  }
+
+  /** Test seam: drops everything and cancels the pending eviction timers. */
+  clear(): void {
+    for (const entry of this.runs.values()) {
+      if (entry.evictAt) {
+        clearTimeout(entry.evictAt);
+      }
+      // Marked ended before waking: a reader parked on `wait` would otherwise
+      // come back, find the entry unfinished, and park again forever.
+      entry.ended = true;
+      this.notify(entry);
+    }
+    this.runs.clear();
+    this.byThread.clear();
+  }
+
+  get size(): number {
+    return this.runs.size;
+  }
+
+  private async pump(entry: Entry, params: RegisterParams): Promise<void> {
+    // Hooks run on their own chain: they stay in order relative to each other,
+    // and a slow one never stalls the buffer a reattaching client reads from.
+    let hooks = Promise.resolve();
+    try {
+      for await (const frame of entry.run.frames()) {
+        entry.frames.push(frame);
+        entry.lastSeq = frame.seq;
+        if (entry.frames.length > this.maxFrames) {
+          entry.frames.shift();
+        }
+        this.notify(entry);
+        const onEvent = params.onEvent;
+        if (onEvent) {
+          hooks = hooks.then(() => onEvent(frame.event)).catch((err) => {
+            params.onInternalError?.(err);
+          });
+        }
+      }
+    } catch (err) {
+      // The run's own iterator failed. There is nothing left to replay, so the
+      // entry ends here; whoever is attached sees the stream close.
+      params.onInternalError?.(err);
+    } finally {
+      entry.ended = true;
+      this.notify(entry);
+      await hooks;
+      this.scheduleEviction(entry);
+    }
+  }
+
+  private async *drain(
+    entry: Entry,
+    runId: string,
+    from: number,
+  ): AsyncGenerator<AgentStreamFrame, void, void> {
+    let cursor = from;
+    while (true) {
+      const seen = entry.version;
+      const buffered = entry.frames.slice();
+      const oldest = buffered[0]?.seq;
+      if (oldest !== undefined && cursor < oldest) {
+        // The buffer rolled past this reader mid-stream. Same reasoning as the
+        // pre-flight check: a gap the client cannot see is worse than a stream
+        // that stops and says why.
+        throw new FrameCursorEvictedError(runId, cursor, oldest);
+      }
+      for (const frame of buffered) {
+        if (frame.seq >= cursor) {
+          yield frame;
+          cursor = frame.seq + 1;
+        }
+      }
+      if (entry.ended && cursor > entry.lastSeq) {
+        return;
+      }
+      await this.wait(entry, seen);
+    }
+  }
+
+  private wait(entry: Entry, seen: number): Promise<void> {
+    if (entry.version !== seen) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => entry.wake.add(resolve));
+  }
+
+  private notify(entry: Entry): void {
+    entry.version++;
+    const waiters = Array.from(entry.wake);
+    entry.wake.clear();
+    for (const resolve of waiters) {
+      resolve();
+    }
+  }
+
+  private scheduleEviction(entry: Entry): void {
+    if (entry.evictAt) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      const runId = entry.run.runId;
+      this.runs.delete(runId);
+      if (entry.threadId && this.byThread.get(entry.threadId) === runId) {
+        this.byThread.delete(entry.threadId);
+      }
+      // Anyone still draining is holding an ended entry; wake them so they see
+      // `ended` and finish rather than hanging on a promise nothing resolves.
+      this.notify(entry);
+    }, this.ttlMs);
+    // A finished run must not be the reason a process stays up.
+    (timer as { unref?: () => void }).unref?.();
+    entry.evictAt = timer;
+  }
+}
+
+/**
+ * The process-wide default, shared by every `AgentController` that does not
+ * bring its own. One map per process is the whole point — see the class note.
+ */
+export const liveRuns = new MemoryLiveRuns();

--- a/packages/gemi/ai/store/MemoryAgentStore.test.ts
+++ b/packages/gemi/ai/store/MemoryAgentStore.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+
+import type { AgentMessage } from "../types";
+import { MemoryAgentStore } from "./MemoryAgentStore";
+
+const message = (id: string, role: AgentMessage["role"], text: string): AgentMessage => ({
+  id,
+  role,
+  content: [{ type: "text", text }],
+  createdAt: new Date(0).toISOString(),
+  finishReason: "stop",
+});
+
+describe("MemoryAgentStore", () => {
+  test("creates a thread that starts empty", async () => {
+    const store = new MemoryAgentStore();
+    const { threadId } = await store.createThread({ userId: 1 });
+    expect(threadId).toMatch(/[0-9a-f-]{36}/);
+    expect(await store.loadThread(threadId)).toEqual([]);
+  });
+
+  test("appends and reads back in order", async () => {
+    const store = new MemoryAgentStore();
+    const { threadId } = await store.createThread({});
+    await store.appendMessages(threadId, [message("1", "user", "hi")]);
+    await store.appendMessages(threadId, [message("2", "assistant", "hello")]);
+
+    expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual(["1", "2"]);
+  });
+
+  test("hands out a copy, so a caller cannot edit history in place", async () => {
+    const store = new MemoryAgentStore();
+    const { threadId } = await store.createThread({});
+    await store.appendMessages(threadId, [message("1", "user", "hi")]);
+
+    (await store.loadThread(threadId)).pop();
+
+    expect(await store.loadThread(threadId)).toHaveLength(1);
+  });
+
+  test("reads an unknown thread as empty rather than throwing", async () => {
+    const store = new MemoryAgentStore();
+    expect(await store.loadThread("never-existed")).toEqual([]);
+  });
+
+  test("creates a thread on append, so a client-owned id cannot lose a turn", async () => {
+    const store = new MemoryAgentStore();
+    await store.appendMessages("client-chose-this", [message("1", "user", "hi")]);
+    expect((await store.loadThread("client-chose-this")).map((m) => m.id)).toEqual(["1"]);
+  });
+
+  test("drops a thread nobody has touched for ttlMs", async () => {
+    const store = new MemoryAgentStore({ ttlMs: 10 });
+    const { threadId } = await store.createThread({});
+    await store.appendMessages(threadId, [message("1", "user", "hi")]);
+
+    // Sweeping is throttled to once a minute, so the test has to ask from far
+    // enough in the future to get past the throttle as well as the ttl.
+    store.sweep(Date.now() + 90_000);
+
+    expect(store.size).toBe(0);
+    expect(await store.loadThread(threadId)).toEqual([]);
+  });
+
+  test("keeps a thread whose ttl has not run out", async () => {
+    const store = new MemoryAgentStore({ ttlMs: 120_000 });
+    const { threadId } = await store.createThread({});
+    await store.appendMessages(threadId, [message("1", "user", "hi")]);
+
+    store.sweep(Date.now() + 90_000);
+
+    expect(store.size).toBe(1);
+  });
+});

--- a/packages/gemi/ai/store/MemoryAgentStore.ts
+++ b/packages/gemi/ai/store/MemoryAgentStore.ts
@@ -1,0 +1,116 @@
+import type { AgentStore } from "../AgentController";
+import type { AgentMessage } from "../types";
+
+/** A day. Long enough that a conversation survives a lunch break, short enough
+ *  that a chat nobody came back to is not still resident a week later. */
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** How often the map is walked looking for expired threads. */
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+type Thread = {
+  messages: AgentMessage[];
+  /** Bumped by every read and every write: a conversation someone is still
+   *  having must not expire out from under them mid-turn. */
+  touchedAt: number;
+};
+
+/**
+ * The default store: conversations last as long as the process.
+ *
+ * It exists so that `threadId` works out of the box, not so that anything is
+ * durable — a restart loses every thread, and a second server never had them.
+ * That is the honest default for a framework store, and it is why stateless is
+ * still the mode an app gets without asking: the client carrying its own
+ * history survives a deploy, and this does not.
+ *
+ * Expiry is swept lazily rather than on a timer. A `setTimeout` per thread is a
+ * timer per conversation and a reference the GC cannot collect, and an interval
+ * running forever keeps a process alive that has nothing else to do — so the
+ * sweep happens on access, at most once a minute, and an untouched process
+ * simply stops sweeping.
+ */
+export class MemoryAgentStore implements AgentStore {
+  readonly ttlMs: number;
+
+  private threads = new Map<string, Thread>();
+  private lastSweep = 0;
+
+  constructor(params: { ttlMs?: number } = {}) {
+    this.ttlMs = params.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  async createThread(params: { userId?: string | number }): Promise<{ threadId: string }> {
+    // The user id is not part of the id and not stored: this store cannot
+    // authorize anything, and an id that looked like a key would invite an app
+    // to treat it as one. Ownership belongs to the app's own table.
+    void params;
+    const threadId = crypto.randomUUID();
+    this.threads.set(threadId, { messages: [], touchedAt: Date.now() });
+    this.sweep();
+    return { threadId };
+  }
+
+  async loadThread(threadId: string): Promise<AgentMessage[]> {
+    this.sweep();
+    const thread = this.threads.get(threadId);
+    if (!thread) {
+      // An unknown thread reads as empty rather than throwing: a thread that
+      // expired, and one the client invented, are the same situation to a
+      // conversation that has to keep working.
+      return [];
+    }
+    thread.touchedAt = Date.now();
+    // Copied, so a caller that sorts or splices the result does not edit the
+    // stored history in place.
+    return thread.messages.slice();
+  }
+
+  async appendMessages(threadId: string, messages: AgentMessage[]): Promise<void> {
+    this.sweep();
+    const thread = this.threads.get(threadId);
+    if (thread) {
+      thread.messages.push(...messages);
+      thread.touchedAt = Date.now();
+      return;
+    }
+    // Appending to a thread the store has never seen creates it. The client
+    // owns the id in stateless-with-a-thread-id setups, so refusing here would
+    // mean losing a turn that already happened.
+    this.threads.set(threadId, { messages: messages.slice(), touchedAt: Date.now() });
+  }
+
+  /** Test seam, and a way for an app to drop a conversation on request. */
+  delete(threadId: string): void {
+    this.threads.delete(threadId);
+  }
+
+  get size(): number {
+    return this.threads.size;
+  }
+
+  sweep(now = Date.now()): void {
+    if (now - this.lastSweep < SWEEP_INTERVAL_MS) {
+      return;
+    }
+    this.lastSweep = now;
+    for (const [threadId, thread] of this.threads) {
+      if (now - thread.touchedAt > this.ttlMs) {
+        this.threads.delete(threadId);
+      }
+    }
+  }
+}
+
+/**
+ * The process-wide default every `AgentController` uses unless it is given
+ * another.
+ *
+ * It has to be a shared instance, not a field initializer. A gemi controller is
+ * constructed per request — `RouteHandler.run()` does `new Controller()` every
+ * time — so `store = new MemoryAgentStore()` written in a controller field is a
+ * brand new, empty store on every turn, and a threaded conversation would read
+ * back nothing while looking like it was configured correctly. Anything
+ * process-lived that a controller holds has to be created outside it.
+ */
+export const defaultAgentStore = new MemoryAgentStore();

--- a/packages/gemi/ai/store/index.ts
+++ b/packages/gemi/ai/store/index.ts
@@ -1,0 +1,9 @@
+export { defaultAgentStore, MemoryAgentStore } from "./MemoryAgentStore";
+export {
+  FrameCursorEvictedError,
+  LiveRunNotFoundError,
+  liveRuns,
+  MemoryLiveRuns,
+  type RegisterParams,
+} from "./LiveRuns";
+export { encodeFrame, sseHeaders, sseResponse } from "./sse";

--- a/packages/gemi/ai/store/sse.ts
+++ b/packages/gemi/ai/store/sse.ts
@@ -1,0 +1,81 @@
+import type { AgentError, AgentStreamFrame } from "../types";
+
+const encoder = new TextEncoder();
+
+/**
+ * One frame, one SSE event.
+ *
+ * `id:` carries the frame's `seq`, which is what makes the browser's own
+ * `Last-Event-ID` the right cursor on reconnect — the transport asks the
+ * question the run already knows how to answer, and the client never has to
+ * track a position of its own.
+ */
+export function encodeFrame(frame: AgentStreamFrame): string {
+  return `id: ${frame.seq}\ndata: ${JSON.stringify(frame.event)}\n\n`;
+}
+
+export function sseHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "text/event-stream",
+    // `no-transform` as well as `no-store`: a proxy that gzips or rechunks the
+    // body is a proxy that buffers it, and a buffered token stream arrives all
+    // at once, which is the same as not streaming at all.
+    "Cache-Control": "no-store, no-transform",
+    Connection: "keep-alive",
+    // nginx's own name for the same thing.
+    "X-Accel-Buffering": "no",
+  };
+}
+
+/**
+ * Encodes an async iterable of frames as an SSE response.
+ *
+ * Pulls one frame per `pull` rather than looping inside `start`: a `start` that
+ * awaits the whole run does not resolve until the run is over, and the stream
+ * is not readable until it does — which would turn every streamed answer into a
+ * single delivery at the end.
+ */
+export function sseResponse(frames: AsyncIterable<AgentStreamFrame>, status = 200): Response {
+  const iterator = frames[Symbol.asyncIterator]();
+  let lastSeq = -1;
+
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const next = await iterator.next();
+        if (next.done) {
+          controller.close();
+          return;
+        }
+        lastSeq = next.value.seq;
+        controller.enqueue(encoder.encode(encodeFrame(next.value)));
+      } catch (err) {
+        // Past the headers there is no status left to fail with, so the reason
+        // goes out as the last event. Closing silently would be
+        // indistinguishable from a run that finished, which is the one thing a
+        // reattaching client must not be told by mistake.
+        const event = { type: "error", error: toAgentError(err) } as const;
+        controller.enqueue(encoder.encode(encodeFrame({ seq: lastSeq + 1, event })));
+        controller.close();
+      }
+    },
+    cancel(reason) {
+      // The client went away. Let the generator unwind so its `finally` runs
+      // and it stops waiting on frames nobody will read.
+      void iterator.return?.(reason);
+    },
+  });
+
+  return new Response(body, { status, headers: sseHeaders() });
+}
+
+// `unknown` rather than a new code: `AgentErrorCode` is the wire contract and
+// belongs to the model's failures, not to the transport's. The message names
+// the cursor, which is what a client can actually act on.
+function toAgentError(err: unknown): AgentError {
+  return {
+    code: "unknown",
+    message: err instanceof Error ? err.message : String(err),
+    retryable: false,
+  };
+}

--- a/packages/gemi/ai/store/stubAgentRun.ts
+++ b/packages/gemi/ai/store/stubAgentRun.ts
@@ -1,0 +1,121 @@
+import type { AgentRun, AgentRunResult } from "../Agent";
+import type { AgentStreamEvent, AgentStreamFrame, ToolShapes } from "../types";
+
+/**
+ * A hand-driven `AgentRun`, for tests of everything that consumes one.
+ *
+ * It lives in source rather than in a test file because both the `LiveRuns`
+ * tests and the controller tests need the same fake, and a test file that
+ * imports another test file gets that file's suites collected twice.
+ *
+ * It is deliberately a *stub satisfying the interface*, not a shrunken `Agent`:
+ * the real agent is a separate slice, and a test that imported it would be
+ * testing whichever half of the module was written last.
+ */
+export class StubAgentRun implements AgentRun<ToolShapes, unknown> {
+  readonly runId: string;
+
+  stopped = false;
+  stopReason: string | undefined;
+  /** Every `frames()` call ever made, so a test can assert on subscribers. */
+  subscriptions = 0;
+
+  private buffer: AgentStreamFrame[] = [];
+  private nextSeq = 0;
+  private done = false;
+  private wake = new Set<() => void>();
+  /** See the note on `Entry.version` in `LiveRuns`: same missed-wakeup window,
+   *  same fix. */
+  private version = 0;
+  private outcome: AgentRunResult<ToolShapes, unknown> | null = null;
+  private settle: ((result: AgentRunResult<ToolShapes, unknown>) => void) | null = null;
+  private settled: Promise<AgentRunResult<ToolShapes, unknown>>;
+
+  constructor(runId = "run_stub") {
+    this.runId = runId;
+    this.settled = new Promise((resolve) => {
+      this.settle = resolve;
+    });
+  }
+
+  /** Pushes one event onto the run, numbering it the way a real run would. */
+  emit(event: AgentStreamEvent): AgentStreamFrame {
+    const frame: AgentStreamFrame = { seq: this.nextSeq++, event };
+    this.buffer.push(frame);
+    this.notify();
+    return frame;
+  }
+
+  /** Ends the run. Everything parked on `frames()` or `result()` unblocks. */
+  finish(result: Partial<AgentRunResult<ToolShapes, unknown>> = {}): void {
+    this.outcome = {
+      runId: this.runId,
+      messages: [],
+      finishReason: "stop",
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      ...result,
+    };
+    this.done = true;
+    this.settle?.(this.outcome);
+    this.notify();
+  }
+
+  frames(from = 0): AsyncIterable<AgentStreamFrame> {
+    this.subscriptions++;
+    return this.replay(from);
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<AgentStreamEvent, void, void> {
+    for await (const frame of this.frames()) {
+      yield frame.event;
+    }
+  }
+
+  toResponse(params: { from?: number } = {}): Response {
+    return new Response(null, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Stub-Run": this.runId,
+        "X-Stub-From": String(params.from ?? 0),
+      },
+    });
+  }
+
+  result(): Promise<AgentRunResult<ToolShapes, unknown>> {
+    return this.settled;
+  }
+
+  stop(params: { reason?: string } = {}): void {
+    this.stopped = true;
+    this.stopReason = params.reason;
+  }
+
+  private async *replay(from: number): AsyncGenerator<AgentStreamFrame, void, void> {
+    let cursor = from;
+    while (true) {
+      const seen = this.version;
+      for (const frame of this.buffer.slice()) {
+        if (frame.seq >= cursor) {
+          yield frame;
+          cursor = frame.seq + 1;
+        }
+      }
+      if (this.done && cursor >= this.nextSeq) {
+        return;
+      }
+      if (this.version === seen) {
+        await new Promise<void>((resolve) => this.wake.add(resolve));
+      }
+    }
+  }
+
+  private notify(): void {
+    this.version++;
+    const waiters = Array.from(this.wake);
+    this.wake.clear();
+    for (const resolve of waiters) {
+      resolve();
+    }
+  }
+}

--- a/packages/gemi/http/ApiRouter.agent.test.ts
+++ b/packages/gemi/http/ApiRouter.agent.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "vitest";
+
+import { AgentController } from "../ai/AgentController";
+import { createFlatApiRoutes } from "../services/router/createFlatApiRoutes";
+import { ApiRouter } from "./ApiRouter";
+
+class ChatController extends AgentController {
+  agent = { name: "stub", tools: [], provider: {} } as any;
+}
+
+describe("ApiRouter.agent()", () => {
+  test("mounts four POST routes under one path", () => {
+    class Api extends ApiRouter {
+      routes = {
+        "/chat": this.agent(ChatController),
+      };
+    }
+
+    const flat = createFlatApiRoutes(new Api().routes);
+
+    expect(Object.keys(flat).sort()).toEqual(
+      ["/chat", "/chat/attach", "/chat/files", "/chat/stop"].sort(),
+    );
+    for (const path of ["/chat", "/chat/attach", "/chat/stop", "/chat/files"]) {
+      expect(Object.keys(flat[path]!).sort()).toEqual(["OPTIONS", "POST"]);
+    }
+  });
+
+  test("each path runs its own controller method", async () => {
+    const called: string[] = [];
+
+    class Recorder extends AgentController {
+      agent = {} as any;
+      async stream() {
+        called.push("stream");
+        return new Response(null);
+      }
+      async attach() {
+        called.push("attach");
+        return new Response(null);
+      }
+      async stop() {
+        called.push("stop");
+        return { stopped: true };
+      }
+      async upload() {
+        called.push("upload");
+        return { fileId: "f" };
+      }
+    }
+
+    class Api extends ApiRouter {
+      routes = { "/chat": this.agent(Recorder) };
+    }
+
+    const flat = createFlatApiRoutes(new Api().routes);
+    await flat["/chat"]!.POST!.exec();
+    await flat["/chat/attach"]!.POST!.exec();
+    await flat["/chat/stop"]!.POST!.exec();
+    await flat["/chat/files"]!.POST!.exec();
+
+    expect(called).toEqual(["stream", "attach", "stop", "upload"]);
+  });
+
+  test("builds the controller per request, not once at mount", async () => {
+    let constructed = 0;
+
+    class Counting extends AgentController {
+      agent = {} as any;
+      readonly id: number;
+      constructor() {
+        super();
+        this.id = ++constructed;
+      }
+      async stream() {
+        return new Response(String(this.id));
+      }
+    }
+
+    class Api extends ApiRouter {
+      routes = { "/chat": this.agent(Counting) };
+    }
+
+    const flat = createFlatApiRoutes(new Api().routes);
+    expect(constructed).toBe(0);
+
+    expect(await (await flat["/chat"]!.POST!.exec()).text()).toBe("1");
+    expect(await (await flat["/chat"]!.POST!.exec()).text()).toBe("2");
+  });
+
+  test("applies per-method middleware to that method only", () => {
+    class Api extends ApiRouter {
+      routes = {
+        "/chat": this.agent(ChatController).middleware({
+          stream: "auth",
+          upload: ["auth", "rate-limit"],
+        }),
+      };
+    }
+
+    const flat = createFlatApiRoutes(new Api().routes);
+
+    expect(flat["/chat"]!.POST!.middleware).toEqual(["auth"]);
+    expect(flat["/chat/files"]!.POST!.middleware).toEqual(["auth", "rate-limit"]);
+    // Not named in the config, so not guarded — the four are configured
+    // separately precisely because they are not equally sensitive.
+    expect(flat["/chat/attach"]!.POST!.middleware).toEqual([]);
+    expect(flat["/chat/stop"]!.POST!.middleware).toEqual([]);
+  });
+
+  test("takes the prefix of the router it is mounted in", () => {
+    class Nested extends ApiRouter {
+      routes = {
+        "/chat": this.agent(ChatController).middleware({ stop: "auth" }),
+      };
+    }
+    class Api extends ApiRouter {
+      routes = { "/ai": Nested };
+    }
+
+    const flat = createFlatApiRoutes(new Api().routes);
+
+    expect(Object.keys(flat).sort()).toEqual(
+      ["/ai/chat", "/ai/chat/attach", "/ai/chat/files", "/ai/chat/stop"].sort(),
+    );
+    expect(flat["/ai/chat/stop"]!.POST!.middleware).toEqual(["auth"]);
+  });
+
+  /**
+   * An agent route is flattened as a nested router, so it inherits the
+   * enclosing router's `middlewares` exactly as a nested router does — which is
+   * to say not at all: `createFlatApiRoutes` replaces `rootMiddleware` when it
+   * descends into a router instead of concatenating. That predates this method
+   * and applies to every `"/sub": SubRouter` in the framework.
+   *
+   * It is asserted here rather than left implicit because the consequence is
+   * sharper for an agent than for a sub-router: `middlewares = ["auth"]` on the
+   * router guards `this.post(...)` next door and does not guard the agent. Use
+   * `.middleware({ stream, attach, stop, upload })`, which is what the four
+   * names are for.
+   */
+  test("does NOT inherit the enclosing router's middlewares, as nested routers do not", () => {
+    class Api extends ApiRouter {
+      middlewares = ["auth"];
+      routes = {
+        "/chat": this.agent(ChatController),
+        "/plain": this.get(() => ({ ok: true })),
+      };
+    }
+
+    const flat = createFlatApiRoutes({ "/": Api });
+
+    expect(flat["/chat"]!.POST!.middleware).toEqual([]);
+    expect(flat["/plain"]!.GET!.middleware).toEqual(["auth"]);
+  });
+
+  test("mounts alongside ordinary routes without disturbing them", () => {
+    class Api extends ApiRouter {
+      routes = {
+        "/chat": this.agent(ChatController),
+        "/health": this.get(() => ({ ok: true })),
+      };
+    }
+
+    const flat = createFlatApiRoutes(new Api().routes);
+    expect(Object.keys(flat["/health"]!).sort()).toEqual(["GET", "OPTIONS"]);
+    expect(flat["/chat"]!.POST).toBeDefined();
+  });
+});

--- a/packages/gemi/http/ApiRouter.agent.test.ts
+++ b/packages/gemi/http/ApiRouter.agent.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { AgentController } from "../ai/AgentController";
 import { createFlatApiRoutes } from "../services/router/createFlatApiRoutes";
 import { ApiRouter } from "./ApiRouter";
+import { ResourceController } from "./Controller";
 
 class ChatController extends AgentController {
   agent = { name: "stub", tools: [], provider: {} } as any;
@@ -127,31 +128,106 @@ describe("ApiRouter.agent()", () => {
   });
 
   /**
-   * An agent route is flattened as a nested router, so it inherits the
-   * enclosing router's `middlewares` exactly as a nested router does — which is
-   * to say not at all: `createFlatApiRoutes` replaces `rootMiddleware` when it
-   * descends into a router instead of concatenating. That predates this method
-   * and applies to every `"/sub": SubRouter` in the framework.
-   *
-   * It is asserted here rather than left implicit because the consequence is
-   * sharper for an agent than for a sub-router: `middlewares = ["auth"]` on the
-   * router guards `this.post(...)` next door and does not guard the agent. Use
-   * `.middleware({ stream, attach, stop, upload })`, which is what the four
-   * names are for.
+   * The finding this test exists for: an agent used to come out unguarded here
+   * while both of its siblings came out guarded, because an agent is flattened
+   * as a nested router and `createFlatApiRoutes` replaces `rootMiddleware` when
+   * it descends into one. `resource()` — the method the agent was told to work
+   * like — concatenates. Same router, opposite result, and the one that lost is
+   * the model endpoint that spends money.
    */
-  test("does NOT inherit the enclosing router's middlewares, as nested routers do not", () => {
+  test("inherits the enclosing router's middlewares, exactly as resource() does", () => {
+    class Orders extends ResourceController {
+      list() {
+        return [];
+      }
+      store() {
+        return {};
+      }
+      show() {
+        return {};
+      }
+      update() {
+        return {};
+      }
+      delete() {
+        return {};
+      }
+    }
+
     class Api extends ApiRouter {
       middlewares = ["auth"];
       routes = {
         "/chat": this.agent(ChatController),
+        "/orders/:id": this.resource(Orders),
         "/plain": this.get(() => ({ ok: true })),
       };
     }
 
     const flat = createFlatApiRoutes({ "/": Api });
 
-    expect(flat["/chat"]!.POST!.middleware).toEqual([]);
+    for (const path of ["/chat", "/chat/attach", "/chat/stop", "/chat/files"]) {
+      expect(flat[path]!.POST!.middleware).toEqual(["auth"]);
+    }
+    expect(flat["/orders"]!.GET!.middleware).toEqual(["auth"]);
     expect(flat["/plain"]!.GET!.middleware).toEqual(["auth"]);
+  });
+
+  /**
+   * Declaration order must not decide whether the agent is guarded. `routes`
+   * and `middlewares` are both class fields, so writing `middlewares` below
+   * `routes` means it is still `[]` when `this.agent()` runs — which is why the
+   * router instance is captured and read at flatten time instead.
+   */
+  test("is guarded even when middlewares is declared after routes", () => {
+    class Api extends ApiRouter {
+      routes = {
+        "/chat": this.agent(ChatController),
+      };
+      middlewares = ["auth"];
+    }
+
+    const flat = createFlatApiRoutes({ "/": Api });
+    expect(flat["/chat"]!.POST!.middleware).toEqual(["auth"]);
+  });
+
+  test("puts the router's guards before the per-method ones", () => {
+    class Api extends ApiRouter {
+      middlewares = ["auth"];
+      routes = {
+        "/chat": this.agent(ChatController).middleware({ upload: "rate-limit" }),
+      };
+    }
+
+    const flat = createFlatApiRoutes({ "/": Api });
+
+    expect(flat["/chat/files"]!.POST!.middleware).toEqual(["auth", "rate-limit"]);
+    expect(flat["/chat"]!.POST!.middleware).toEqual(["auth"]);
+  });
+
+  /**
+   * A router nested inside another still replaces its parent's list rather than
+   * concatenating — that predates this method and applies to every
+   * `"/sub": SubRouter` in the framework. What matters for an agent is that it
+   * lands on the same list its siblings inside `Nested` land on, which is
+   * `Nested`'s.
+   */
+  test("takes the middlewares of the router it is written in, not the one above", () => {
+    class Nested extends ApiRouter {
+      middlewares = ["tenant"];
+      routes = {
+        "/chat": this.agent(ChatController),
+        "/plain": this.get(() => ({ ok: true })),
+      };
+    }
+    class Api extends ApiRouter {
+      middlewares = ["auth"];
+      routes = { "/ai": Nested };
+    }
+
+    const flat = createFlatApiRoutes({ "/": Api });
+
+    expect(flat["/ai/chat"]!.POST!.middleware).toEqual(["tenant"]);
+    expect(flat["/ai/plain"]!.GET!.middleware).toEqual(["tenant"]);
   });
 
   test("mounts alongside ordinary routes without disturbing them", () => {

--- a/packages/gemi/http/ApiRouter.test-d.ts
+++ b/packages/gemi/http/ApiRouter.test-d.ts
@@ -18,6 +18,10 @@ import {
   type RouteHandler,
   type StreamHandler,
 } from "./ApiRouter";
+import { Agent, AgentTool, type ToolShapesOf } from "../ai/Agent";
+import { AgentController } from "../ai/AgentController";
+import { OpenAIProvider } from "../ai/AgentProvider";
+import { s } from "../ai/Schema";
 import { Controller } from "./Controller";
 import type { HttpRequest } from "./HttpRequest";
 
@@ -131,5 +135,86 @@ describe("this.stream()", () => {
       };
     }
     return R;
+  });
+});
+
+// --- agent routes --------------------------------------------------------
+
+const lookup = AgentTool.create({
+  name: "lookup",
+  description: "Look an order up",
+  inputSchema: s.object({ orderId: s.string() }),
+  outputSchema: s.object({ status: s.string() }),
+  execute: async () => ({ status: "paid" }),
+});
+
+const supportAgent = Agent.create({
+  name: "support",
+  provider: OpenAIProvider.model("gpt-5.4"),
+  tools: [lookup],
+});
+
+class ChatController extends AgentController<typeof supportAgent> {
+  agent = supportAgent;
+}
+
+class AgentRoot extends ApiRouter {
+  routes = {
+    "/chat": this.agent(ChatController),
+    "/guarded-chat": this.agent(ChatController).middleware({ stream: "auth", stop: ["auth"] }),
+    "/json": this.get(() => ({ ok: true })),
+  };
+}
+
+type AgentRPC = CreateRPC<AgentRoot>;
+type AgentKeys = keyof AgentRPC;
+
+/**
+ * An agent is one key, not four.
+ *
+ * `useChat("/chat")` reads `RPC` looking for `{ __agent: true }`, so the mounted
+ * path has to be the key — and `/chat/attach`, `/chat/stop` and `/chat/files`
+ * have to stay out of it. They are transport for the hook, not endpoints an app
+ * calls, and a `POST:/chat/stop` in the RPC types would offer an app an
+ * untyped, signature-less way to do what `stop()` already does.
+ */
+describe("CreateRPC for an agent route", () => {
+  test("keys the route by its mounted path", () => {
+    expectTypeOf<"/chat">().toExtend<AgentKeys>();
+    expectTypeOf<"/guarded-chat">().toExtend<AgentKeys>();
+  });
+
+  test("marks it so useChat can pick it out of the same RPC interface", () => {
+    expectTypeOf<AgentRPC["/chat"]["__agent"]>().toEqualTypeOf<true>();
+  });
+
+  test("carries the agent's tool shapes, not its tools", () => {
+    expectTypeOf<AgentRPC["/chat"]["tools"]>().toEqualTypeOf<
+      ToolShapesOf<typeof supportAgent.tools>
+    >();
+    expectTypeOf<AgentRPC["/chat"]["tools"]["lookup"]["input"]>().toEqualTypeOf<{
+      orderId: string;
+    }>();
+    expectTypeOf<AgentRPC["/chat"]["tools"]["lookup"]["output"]>().toEqualTypeOf<{
+      status: string;
+    }>();
+  });
+
+  test("does not emit a key per sub-route", () => {
+    expectTypeOf<"POST:/chat">().not.toExtend<AgentKeys>();
+    expectTypeOf<"POST:/chat/attach">().not.toExtend<AgentKeys>();
+    expectTypeOf<"POST:/chat/stop">().not.toExtend<AgentKeys>();
+    expectTypeOf<"POST:/chat/files">().not.toExtend<AgentKeys>();
+    expectTypeOf<"/chat/attach">().not.toExtend<AgentKeys>();
+  });
+
+  test("leaves the router's other routes alone", () => {
+    expectTypeOf<"GET:/json">().toExtend<AgentKeys>();
+  });
+
+  test("survives .middleware(), which returns the route", () => {
+    expectTypeOf<AgentRPC["/guarded-chat"]["tools"]>().toEqualTypeOf<
+      ToolShapesOf<typeof supportAgent.tools>
+    >();
   });
 });

--- a/packages/gemi/http/ApiRouter.ts
+++ b/packages/gemi/http/ApiRouter.ts
@@ -347,16 +347,17 @@ export class ApiRouter {
    * — and the sub-routes deliberately do not appear in `CreateRPC` as keys of
    * their own: they are transport for the hook, not endpoints an app calls.
    *
-   * Guard it with `.middleware()`, not with the router's `middlewares`. Route
-   * flattening treats an agent the way it treats a nested `SubRouter`, and it
-   * replaces the enclosing router's middleware list when it descends rather
-   * than concatenating — so `middlewares = ["auth"]` next to this line covers
-   * `this.post(...)` and does not cover the agent. The four names exist so each
-   * route can be guarded on its own anyway: `upload` and `stream` are not
-   * equally cheap, and `attach` is a read.
+   * The enclosing router's `middlewares` guard all four, exactly as they guard
+   * a sibling `this.post(...)` or `this.resource(...)`, and `.middleware()`
+   * adds to them per method. That parity is the whole point: a developer who
+   * writes `middlewares = ["auth"]` on the router has guarded the model
+   * endpoint, and does not have to know that an agent is flattened as a nested
+   * router to have got it right. The four names exist so each route can *also*
+   * be guarded on its own — `upload` and `stream` are not equally cheap, and
+   * `attach` is a read.
    */
   public agent<T extends new () => AgentController<any>>(Controller: T): AgentRoute<T> {
-    return createAgentRouteHandlers(Controller) as unknown as AgentRoute<T>;
+    return createAgentRouteHandlers(Controller, this) as unknown as AgentRoute<T>;
   }
 
   public file<Input, Output, Params>(handler: CallbackHandler<Input, Output, Params>): FileHandler;
@@ -406,16 +407,22 @@ export class ApiRouter {
  * It is an `ApiRouter` subclass rather than a shape of its own, and that is the
  * whole trick: an agent mounts four paths under one key, which is exactly what
  * a nested router already does, so `createFlatApiRoutes` needs no new branch
- * and the sub-paths get prefixing, middleware and OPTIONS for free. A parallel
- * mechanism would have to reimplement all of it, and would be the second place
- * to fix when route flattening changes.
+ * and the sub-paths get prefixing, per-method middleware and OPTIONS for free.
+ * A parallel mechanism would have to reimplement all of it, and would be the
+ * second place to fix when route flattening changes.
+ *
+ * The one thing it does not inherit is the enclosing router's `middlewares` —
+ * see the constructor.
  *
  * The four handlers are built once and shared with `routes`, because
  * `.middleware()` is called on the class — at `routes = {...}` time — while
  * `routes` is read off an instance the dispatcher constructs later. Rebuilding
  * them per instance would quietly drop every per-method middleware.
  */
-function createAgentRouteHandlers<T extends new () => AgentController<any>>(Controller: T) {
+function createAgentRouteHandlers<T extends new () => AgentController<any>>(
+  Controller: T,
+  owner: ApiRouter,
+) {
   const handlers = {
     stream: new RouteHandler("POST", Controller as any, "stream"),
     attach: new RouteHandler("POST", Controller as any, "attach"),
@@ -427,6 +434,24 @@ function createAgentRouteHandlers<T extends new () => AgentController<any>>(Cont
     static __internal_brand = "AgentRoute" as const;
     static controller = Controller;
     static handlers = handlers;
+
+    constructor() {
+      super();
+      // Adopt the enclosing router's guards, which is the one thing being a
+      // nested router does NOT give us: `createFlatApiRoutes` *replaces*
+      // `rootMiddleware` when it descends into a router rather than
+      // concatenating, so without this an agent mounted next to
+      // `middlewares = ["auth"]` would come out unguarded while every sibling
+      // route came out guarded — an unauthenticated model endpoint reached by
+      // writing the idiomatic thing.
+      //
+      // Read from the router *instance* here, at flatten time, rather than
+      // from `owner.middlewares` at `this.agent()` time: `routes` and
+      // `middlewares` are both class fields, so a `middlewares` declared below
+      // `routes` has not been assigned yet when `this.agent()` runs. Capturing
+      // the instance makes declaration order irrelevant.
+      this.middlewares = [...(owner?.middlewares ?? [])];
+    }
 
     routes: ApiRoutes = {
       "/": handlers.stream,

--- a/packages/gemi/http/ApiRouter.ts
+++ b/packages/gemi/http/ApiRouter.ts
@@ -1,4 +1,10 @@
 import type { RemoveGroupPrefix } from "../client/types";
+import type {
+  AgentController,
+  AgentMiddlewareConfig,
+  AgentRoute,
+  AgentRouteRPC,
+} from "../ai/AgentController";
 import { isConstructor } from "../internal/isConstructor";
 import type { KeyAndValue, KeyAndValueToObject } from "../internal/type-utils";
 import { Controller, ResourceController, type ControllerMethods } from "./Controller";
@@ -190,6 +196,7 @@ export type ApiRoutes = Record<
   | RouteHandlers
   | typeof ApiRouter
   | ResourceRoutes<any>
+  | AgentRoute<any>
 >;
 
 export type ResourceRoutes<T extends new () => ResourceController> = {
@@ -323,6 +330,35 @@ export class ApiRouter {
     return new ResourceRouteHandlers(Controller) as unknown as ResourceRoute<T>;
   }
 
+  /**
+   * Mounts an agent controller under one path, the way `resource()` mounts a
+   * resource controller: one call, four routes, all of them this controller's.
+   *
+   * ```ts
+   * "/chat": this.agent(ChatController).middleware({ stream: "auth" }),
+   * ```
+   *
+   *   POST /chat        → stream   every client turn
+   *   POST /chat/attach → attach   reattach to a run in progress
+   *   POST /chat/stop   → stop     explicit cancel
+   *   POST /chat/files  → upload   attachments
+   *
+   * One mounted path is what gives the client one key to name — `useChat("/chat")`
+   * — and the sub-routes deliberately do not appear in `CreateRPC` as keys of
+   * their own: they are transport for the hook, not endpoints an app calls.
+   *
+   * Guard it with `.middleware()`, not with the router's `middlewares`. Route
+   * flattening treats an agent the way it treats a nested `SubRouter`, and it
+   * replaces the enclosing router's middleware list when it descends rather
+   * than concatenating — so `middlewares = ["auth"]` next to this line covers
+   * `this.post(...)` and does not cover the agent. The four names exist so each
+   * route can be guarded on its own anyway: `upload` and `stream` are not
+   * equally cheap, and `attach` is a read.
+   */
+  public agent<T extends new () => AgentController<any>>(Controller: T): AgentRoute<T> {
+    return createAgentRouteHandlers(Controller) as unknown as AgentRoute<T>;
+  }
+
   public file<Input, Output, Params>(handler: CallbackHandler<Input, Output, Params>): FileHandler;
   public file<T extends new () => Controller, K extends ControllerMethods<T>>(
     handler: T,
@@ -362,6 +398,51 @@ export class ApiRouter {
   public proxy(url: string, headers: Record<string, string> = {}) {
     return new ProxyHandler(url, headers);
   }
+}
+
+/**
+ * The runtime behind `this.agent()`.
+ *
+ * It is an `ApiRouter` subclass rather than a shape of its own, and that is the
+ * whole trick: an agent mounts four paths under one key, which is exactly what
+ * a nested router already does, so `createFlatApiRoutes` needs no new branch
+ * and the sub-paths get prefixing, middleware and OPTIONS for free. A parallel
+ * mechanism would have to reimplement all of it, and would be the second place
+ * to fix when route flattening changes.
+ *
+ * The four handlers are built once and shared with `routes`, because
+ * `.middleware()` is called on the class — at `routes = {...}` time — while
+ * `routes` is read off an instance the dispatcher constructs later. Rebuilding
+ * them per instance would quietly drop every per-method middleware.
+ */
+function createAgentRouteHandlers<T extends new () => AgentController<any>>(Controller: T) {
+  const handlers = {
+    stream: new RouteHandler("POST", Controller as any, "stream"),
+    attach: new RouteHandler("POST", Controller as any, "attach"),
+    stop: new RouteHandler("POST", Controller as any, "stop"),
+    upload: new RouteHandler("POST", Controller as any, "upload"),
+  };
+
+  return class AgentRouteHandlers extends ApiRouter {
+    static __internal_brand = "AgentRoute" as const;
+    static controller = Controller;
+    static handlers = handlers;
+
+    routes: ApiRoutes = {
+      "/": handlers.stream,
+      "/attach": handlers.attach,
+      "/stop": handlers.stop,
+      "/files": handlers.upload,
+    };
+
+    static middleware(config: AgentMiddlewareConfig) {
+      if (config.stream) handlers.stream.middleware(config.stream);
+      if (config.attach) handlers.attach.middleware(config.attach);
+      if (config.stop) handlers.stop.middleware(config.stop);
+      if (config.upload) handlers.upload.middleware(config.upload);
+      return this;
+    }
+  };
 }
 
 type TestControllerMethod<T extends new () => Controller, K extends string> =
@@ -427,15 +508,20 @@ type RouteParser<
   Prefix extends PropertyKey = "",
   K extends keyof T = keyof T,
 > = K extends any
-  ? T[K] extends ResourceRoutes<any>
-    ? ResourceRoutesParser<T[K], ParsePrefixAndKey<Prefix, K>>
-    : T[K] extends RouteHandler<any, any, any, any>
-      ? RouteHandlerParser<T[K], ParsePrefixAndKey<Prefix, K>>
-      : T[K] extends new () => ApiRouter
-        ? RouterInstanceParser<T[K], ParsePrefixAndKey<Prefix, K>>
-        : T[K] extends RouteHandlers
-          ? RouteHandlersParser<T[K], `${Prefix & string}${K extends "/" ? "" : K & string}`>
-          : never
+  ? // Checked before every other branch: `RouteHandlers` is fully optional, so
+    // *every* object type extends it, and an agent route reaching that arm
+    // would silently produce nothing.
+    T[K] extends AgentRoute<infer C>
+    ? KeyAndValue<ParsePrefixAndKey<Prefix, K>, AgentRouteRPC<C>>
+    : T[K] extends ResourceRoutes<any>
+      ? ResourceRoutesParser<T[K], ParsePrefixAndKey<Prefix, K>>
+      : T[K] extends RouteHandler<any, any, any, any>
+        ? RouteHandlerParser<T[K], ParsePrefixAndKey<Prefix, K>>
+        : T[K] extends new () => ApiRouter
+          ? RouterInstanceParser<T[K], ParsePrefixAndKey<Prefix, K>>
+          : T[K] extends RouteHandlers
+            ? RouteHandlersParser<T[K], `${Prefix & string}${K extends "/" ? "" : K & string}`>
+            : never
   : never;
 
 export type CreateRPC<T extends ApiRouter, Prefix extends PropertyKey = ""> = KeyAndValueToObject<


### PR DESCRIPTION
> **Stack**, bottom to top — each PR is based on the one above it:
> 1. `ai/1-schema` — the schema builder runtime
> 2. `ai/2-provider` — the OpenAI and Azure providers
> 3. `ai/3-agent` — the agent run loop and signing
> 4. **`ai/4-controller` — you are here** — controller, stores, `ApiRouter.agent()`
> 5. `ai/5-client` — `useChat` and stream decoding
> 6. `ai/6-exports` — module exports and the example

`AgentController` with its four routes, the in-memory stores behind them, and `ApiRouter.agent()` to mount them.

`agent(C)` returns an `ApiRouter` subclass whose four POST routes are `/`, `/attach`, `/stop`, `/files`. Piggybacking on the existing nested-router branch of `createFlatApiRoutes` means prefixing, middleware and OPTIONS come free and no file outside this slice needs editing. The four `RouteHandler`s are built once in a closure, so `.middleware()` — a static, called while `routes = {...}` is still evaluating — reaches the same objects the dispatcher later reads off an instance. `RouteParser` gets an `AgentRoute` branch *first*, because `RouteHandlers` is fully optional and every object type extends it.

## The decisions

**Stateless is the default.** No `threadId` means the client's `messages`. The whole of the difference is one expression, and nothing else branches on it, which is why stateless keeps working for an app that never configures a store.

**One pump per run, feeding both the ring buffer and the hooks.** `frames()` has multi-subscriber behaviour this slice does not own, so `LiveRuns.register` reads it once and drives the `on*` hooks on a separate promise chain.

**Readers use a version counter, not a bare notify.** A generator suspended at `yield` otherwise misses the wakeup and hangs — it parks *after* the event it was waiting for. The comment says so, because this is the thing someone will try to simplify back.

**Misses are explicit.** No live run is a 404; an evicted cursor is a 410 naming the oldest surviving frame. Not a 200 with an empty SSE stream, which is indistinguishable from a run that finished quietly.

**`stop()` calls `run.stop()` and returns without awaiting `result()`.** Unwinding takes as long as the slowest tool, and a stop button that spins for twenty seconds is one people press twice.

**`defaultAgentStore` is a module-level instance.** A controller is constructed per request, so `store = new MemoryAgentStore()` in a class body is an empty store every turn and a threaded conversation silently reads back nothing. The field's doc comment names the trap.

## Contract changes

| symbol | change | why |
|---|---|---|
| `stream` / `attach` / `stop` / `upload` | parameter gains a default: `(req = new HttpRequest())` | `RouteHandler.run()` invokes a controller method with **no** arguments — controllers get the request from the AsyncLocalStorage context, as every existing gemi controller does. Without the default the declared signature is a lie at runtime. Parameter type unchanged. |
| `AgentController` heritage | `extends (Controller as new () => Controller)` | `Controller.kind` is typed as the literal `"controller"`, so `static kind: "agent-controller"` on a subclass is TS2417. The real fix is `static kind: string` in `http/Controller.ts`, which this slice does not own. Keeps the declared literal type and `instanceof Controller`. |
| `ApiRouter.agent(C)` | the four routes now inherit the enclosing router's `middlewares` | See below. Behavioural; the `AgentRoute<T>` type is unchanged. |
| `AgentController.stop` | `Promise<{stopped: boolean}>` → `… | Response` | The `Response` arm is the 400 for an unreadable body and nothing else. Not visible in the RPC types. |
| `MemoryLiveRuns.replay` | `from` becomes optional | Omitting it means "the oldest frame still buffered" rather than "frame 0". An explicit `from` behaves exactly as before. The read-side `LiveRuns` interface is untouched — `replay` was never on it. |
| `MemoryLiveRuns.findByClientRunId` | new | See the integration section. Deliberately *not* a widening of `find`, whose parameter is part of the `LiveRuns` interface an app may already implement against. |

## What the review round changed

Four findings, two blocking; all four fixed, each with a test that fails when the fix is reverted.

- **`agent()` silently dropped the enclosing router's middlewares, and `resource()` — the method it was told to copy — does not.** `createFlatApiRoutes` *replaces* `rootMiddleware` when it descends into a nested router; `resource()` has an inline branch that concatenates. So a router guarded the idiomatic way shipped an **unauthenticated model endpoint**: anyone could POST it and burn provider spend, and since `threadId`s are client-supplied they could read and poison any thread whose id they knew. The first commit documented this and pinned it in a test named "does NOT inherit", which locked the behaviour in rather than flagging it. Fixed by having the generated router adopt its owner's middlewares in its own constructor — reading the *instance* at flatten time rather than the array at `this.agent()` time, so it also survives `middlewares` being declared below `routes` (both are class fields). The suggested fix lived in `services/router/`, which this slice does not own; the composed result is identical. Four tests, including parity with `resource()` and a plain `this.post()` in one guarded router.
- **`attach` with no explicit cursor always 410'd on any run longer than 512 frames** — i.e. exactly the case `/attach` exists for. A mount-time reattach is a fresh POST with no `Last-Event-ID` and no cursor of its own, and reading that as "resume from frame 0" asked for a frame every long run has already evicted. The documented remedy of reloading the thread does not help, because the store is only written at run end. No cursor now means the oldest surviving frame; an explicitly named evicted cursor still gets its 410, because that client does have a transcript to leave a hole in.
- **A malformed JSON body started a billed run with no history and no turn.** `catch { return {} }` made an unparseable body indistinguishable from an empty one, so a truncated body answered nothing at the user's expense and presented as the model hallucinating. Now a 400. (Shaped as `{ body, error? }` rather than a discriminated union on `ok`, because the package compiles with `strict: false` and TypeScript will not narrow a union by a boolean discriminant without `strictNullChecks`.)
- **Eviction was gated on app hook code.** `pump`'s `finally` awaited the hook chain before scheduling eviction, so an `onAwaitingInput` that fetched a webhook with no timeout pinned the entry, its 512 frames, the run and the request it closes over for the life of the process. A rejection was handled; a *pending* promise was not. Eviction is now on the ttl clock.

## Integration with the client half

The controller and `useChat` were written in parallel against the same prose and invented three different spellings of the same request. Nothing typechecked them against each other — the client posts JSON and the route reads `Record<string, any>` — so all three passed both suites and would have failed on the first real turn. Fixed here, on the level whose code was wrong, rather than at the top of the stack:

- `/attach` read `body.from`; the client sends `body.cursor`, counting the other way — the last frame it *applied*, the same convention as `Last-Event-ID`, and the same `+ 1`. The cursor was being ignored outright. `cursor: -1` (the client's "I have applied nothing") stays the tail rather than becoming frame 0, which would have reintroduced the 410 fixed above.
- `/attach` ignored `runId`, which says which run the cursor counts within. `seq` restarts at zero in every run, so a cursor from `run_1` honoured against a live `run_2` swallows that many frames off the head of a run the client has seen nothing of. Only a *mismatch* forfeits the cursor: `from` and `Last-Event-ID` predate the pairing and carry no run, and an `EventSource` reconnecting on its own never will.
- `/stop` resolved by `runId`, else `threadId`. The client's whole reason for minting a `clientRunId` is that a stateless first turn has neither until `run-start` comes back — which is the window a user cancels in. `stream()` records it and `stop()` resolves by it, second of the three.

Six tests, each confirmed to fail with its own fix reverted.

## Still open

- **A `threadId` is an unguessable capability and ownership is the app's to enforce.** `store.loadThread` has no user to check against. Scope a store by `req.user`, or check in `instructions()`. There is a comment at the call site. The framework's job is to keep the route behind the router's middleware, which `agent()` now does.
- `AgentStore.createThread` is implemented but never called — a `threadId` is always client-supplied. Server-minted ids need a protocol bit this slice did not want to invent alone.
- `stop()` answers `{stopped: true}` for a run that already ended but is still inside the ttl, because `run.stop()` is a no-op there. Distinguishing it needs an `ended` query on the read-side interface.
- `onMessage` fires at run end from `result().messages`, not as each message completes. Reconstructing messages from deltas is the agent's job and doing it twice is how two copies drift — but a long run reports nothing until it finishes.
- `liveRuns` on the controller is typed `MemoryLiveRuns`, not the declared `LiveRuns`, because that interface is read-only and registering needs more.
- `ai/store/stubAgentRun.ts` ships in the package: it is shared by two test files, and a `.test.ts` cannot be imported by another without its suites being collected twice.
- `upload()` throws a plain `Error` for a body with no `file` field, so it is a 500 where it should be a 400.
- A router's own `middlewares` still do not reach a genuinely **nested router** — that is pre-existing for every `"/sub": SubRouter` in the framework and unchanged here. The one-line fix is `[...rootMiddleware, ...router.middlewares]` in `createFlatApiRoutes.ts`, which would fix agent routes and nested routers together.

## Verification

At this branch: `bun run typecheck` clean, `bun run test:types` 7 files / 73 tests / no type errors, `bun --bun vitest run` 175 files / 4189 passed / 1 skipped. `bun run lint` reports 94 warnings and 0 errors, unchanged from the baseline and none in files this slice touched. A declaration-emit pass into a temp `outDir` was also run to confirm `build:types` does not fail on the new cross-directory type import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnj9jSx45LoYp5tiv1W8Nw
