### PR TITLE
The chat hook, and a cursor that knows which run it counts

### DIFF
--- a/packages/gemi/ai/client/reducer.test.ts
+++ b/packages/gemi/ai/client/reducer.test.ts
@@ -98,9 +98,7 @@ describe("applyFrame over a run", () => {
   });
 
   test("message-start opens an empty assistant message", () => {
-    expect(at(1).messages).toEqual([
-      { id: "m1", role: "assistant", content: [], createdAt: NOW },
-    ]);
+    expect(at(1).messages).toEqual([{ id: "m1", role: "assistant", content: [], createdAt: NOW }]);
   });
 
   test("text deltas coalesce into one part", () => {
@@ -136,12 +134,7 @@ describe("applyFrame over a run", () => {
   test("text after a tool call opens a new part rather than merging backwards", () => {
     const content = at(6).messages[0]!.content;
 
-    expect(content.map((part) => part.type)).toEqual([
-      "text",
-      "tool-call",
-      "tool-result",
-      "text",
-    ]);
+    expect(content.map((part) => part.type)).toEqual(["text", "tool-call", "tool-result", "text"]);
     expect(content[3]).toEqual({ type: "text", text: " Found one." });
   });
 
@@ -247,6 +240,50 @@ describe("replay", () => {
     expect(again).toBe(state);
   });
 
+  test("a run replayed onto a transcript that already has it does not double the text", () => {
+    // A restored client whose cursor was lost (or ignored) asks `/attach` and is
+    // handed the whole run back. Every frame is new to the cursor — it is -1 —
+    // so `seq` cannot help; the finished message is the only evidence that this
+    // is replay, and it is enough.
+    const restored = initialChatState({
+      messages: [
+        { id: "u1", role: "user", content: [{ type: "text", text: "hi" }], createdAt: NOW },
+        {
+          id: "m1",
+          role: "assistant",
+          content: [{ type: "text", text: "Let me look. Found one." }],
+          createdAt: NOW,
+          finishReason: "awaiting-input",
+        },
+      ],
+    });
+
+    const replayed = fold(restored, RUN);
+
+    expect(replayed.messages).toHaveLength(2);
+    expect(replayed.messages[1]!.content).toEqual([
+      { type: "text", text: "Let me look. Found one." },
+      // The upserts still land — they are keyed, so applying them again is the
+      // same list. Only the additive deltas are refused.
+      expect.objectContaining({ type: "tool-call", toolCallId: "tc_1" }),
+      expect.objectContaining({ type: "tool-result", toolCallId: "tc_1" }),
+    ]);
+  });
+
+  test("a reasoning delta for a finished message is refused too", () => {
+    const finished = fold(initialChatState(), [
+      { seq: 0, event: { type: "reasoning-delta", messageId: "m1", delta: "hm" } },
+      { seq: 1, event: { type: "message-end", messageId: "m1", finishReason: "stop" } },
+    ]);
+
+    const replayed = fold(finished, [
+      { seq: 0, event: { type: "run-start", runId: "run_9" } },
+      { seq: 1, event: { type: "reasoning-delta", messageId: "m1", delta: "hm" } },
+    ]);
+
+    expect(replayed.messages[0]!.content).toEqual([{ type: "reasoning", text: "hm" }]);
+  });
+
   test("a client handed only the tail builds the message it never saw start", () => {
     // The `/attach` case with nothing kept: no run-start, no message-start, and
     // the first frame is already halfway through m1. A reducer that assumed it
@@ -346,6 +383,52 @@ describe("the rest of the event union", () => {
     expect(state.messages[0]!.finishReason).toBe("aborted");
   });
 
+  test("run-end finishes off this run's messages and leaves an earlier one's alone", () => {
+    // A superseded turn: run_1's answer was cut off mid-sentence and never got a
+    // `message-end`, so it is sitting there with no finish reason. When run_2
+    // ends cleanly, "every assistant message with no finish reason" would sweep
+    // it up and label an interrupted answer a completed one — which is then what
+    // the next stateless turn tells the model happened.
+    const interrupted = fold(initialChatState(), [
+      { seq: 0, event: { type: "run-start", runId: "run_1" } },
+      { seq: 1, event: { type: "message-start", messageId: "m1", role: "assistant" } },
+      { seq: 2, event: { type: "text-delta", messageId: "m1", delta: "Half a sen" } },
+    ]);
+
+    const after = fold(interrupted, [
+      { seq: 0, event: { type: "run-start", runId: "run_2" } },
+      { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+      { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "A whole one." } },
+      { seq: 3, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+    ]);
+
+    expect(after.messages.map((message) => message.finishReason)).toEqual([undefined, "stop"]);
+  });
+
+  test("usage with no assistant message of its own is dropped, not put on the user's turn", () => {
+    // A run that errors after the provider counted input tokens, or one whose
+    // only output is a tool call the client has to resolve, emits `usage` while
+    // the last message is still the optimistic user turn. Token counts against
+    // what the user typed are simply false.
+    const user: AgentMessage = {
+      id: "u1",
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+      createdAt: NOW,
+    };
+    const state = fold(initialChatState({ messages: [user] }), [
+      { seq: 0, event: { type: "run-start", runId: "run_1" } },
+      {
+        seq: 1,
+        event: { type: "usage", usage: { inputTokens: 5, outputTokens: 0, totalTokens: 5 } },
+      },
+      { seq: 2, event: { type: "run-end", runId: "run_1", finishReason: "error" } },
+    ]);
+
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]!.usage).toBeUndefined();
+  });
+
   test("tool-search and tool-progress advance the cursor and nothing else", () => {
     const before = at(6);
     const after = fold(before, [
@@ -380,6 +463,26 @@ describe("markAborted", () => {
     const state = markAborted(at(7));
 
     expect(state.pending).toHaveLength(1);
+  });
+
+  test("only the run in hand is cut short, not an older unfinished turn", () => {
+    // A restored transcript can legitimately carry an assistant message with no
+    // finish reason — the interrupted turn a previous session kept. Stopping
+    // today's run is not a statement about it.
+    const stale: AgentMessage = {
+      id: "old",
+      role: "assistant",
+      content: [{ type: "text", text: "from last time" }],
+      createdAt: NOW,
+    };
+    const state = markAborted(
+      fold(initialChatState({ messages: [stale] }), [
+        { seq: 0, event: { type: "run-start", runId: "run_1" } },
+        { seq: 1, event: { type: "text-delta", messageId: "m1", delta: "today" } },
+      ]),
+    );
+
+    expect(state.messages.map((message) => message.finishReason)).toEqual([undefined, "aborted"]);
   });
 
   test("a user turn is never stamped with a finish reason", () => {

--- a/packages/gemi/ai/client/reducer.test.ts
+++ b/packages/gemi/ai/client/reducer.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, test } from "vitest";
+import type { AgentMessage, AgentStreamFrame } from "../types";
+import { applyFrame, initialChatState, markAborted, type ChatState } from "./reducer";
+
+const NOW = "2026-09-02T00:00:00.000Z";
+
+/**
+ * One realistic run: the assistant says something, calls a tool (arguments
+ * streaming in, so the call arrives twice), gets a result, says something else,
+ * then parks on a question.
+ */
+const RUN: AgentStreamFrame[] = [
+  { seq: 0, event: { type: "run-start", runId: "run_1", threadId: "th_1" } },
+  { seq: 1, event: { type: "message-start", messageId: "m1", role: "assistant" } },
+  { seq: 2, event: { type: "text-delta", messageId: "m1", delta: "Let me look." } },
+  {
+    seq: 3,
+    event: {
+      type: "tool-call",
+      messageId: "m1",
+      part: {
+        type: "tool-call",
+        toolCallId: "tc_1",
+        name: "grep",
+        input: { pattern: "TODO" },
+        partial: true,
+      },
+    },
+  },
+  {
+    seq: 4,
+    event: {
+      type: "tool-call",
+      messageId: "m1",
+      part: {
+        type: "tool-call",
+        toolCallId: "tc_1",
+        name: "grep",
+        input: { pattern: "TODO", filePath: "a.ts" },
+      },
+    },
+  },
+  {
+    seq: 5,
+    event: {
+      type: "tool-result",
+      messageId: "m1",
+      part: {
+        type: "tool-result",
+        toolCallId: "tc_1",
+        name: "grep",
+        status: "ok",
+        output: { matches: ["a.ts:1"] },
+      },
+    },
+  },
+  { seq: 6, event: { type: "text-delta", messageId: "m1", delta: " Found one." } },
+  {
+    seq: 7,
+    event: {
+      type: "awaiting-input",
+      runId: "run_1",
+      pending: [
+        {
+          toolCallId: "tc_2",
+          name: "ask",
+          input: { question: "Which file?" },
+          kind: "question",
+          signature: "sig_2",
+        },
+      ],
+    },
+  },
+  {
+    seq: 8,
+    event: {
+      type: "usage",
+      usage: { inputTokens: 100, outputTokens: 20, totalTokens: 120 },
+    },
+  },
+  { seq: 9, event: { type: "message-end", messageId: "m1", finishReason: "awaiting-input" } },
+  { seq: 10, event: { type: "run-end", runId: "run_1", finishReason: "awaiting-input" } },
+];
+
+function fold(state: ChatState, frames: AgentStreamFrame[]) {
+  return frames.reduce((acc, frame) => applyFrame(acc, frame, NOW), state);
+}
+
+function at(upTo: number) {
+  return fold(initialChatState(), RUN.slice(0, upTo + 1));
+}
+
+describe("applyFrame over a run", () => {
+  test("run-start records the ids and nothing else", () => {
+    const state = at(0);
+
+    expect(state).toMatchObject({ runId: "run_1", threadId: "th_1", messages: [], seq: 0 });
+  });
+
+  test("message-start opens an empty assistant message", () => {
+    expect(at(1).messages).toEqual([
+      { id: "m1", role: "assistant", content: [], createdAt: NOW },
+    ]);
+  });
+
+  test("text deltas coalesce into one part", () => {
+    const state = fold(at(1), [
+      { seq: 2, event: { type: "text-delta", messageId: "m1", delta: "ab" } },
+      { seq: 3, event: { type: "text-delta", messageId: "m1", delta: "cd" } },
+    ]);
+
+    expect(state.messages[0]!.content).toEqual([{ type: "text", text: "abcd" }]);
+  });
+
+  test("a re-streamed tool call replaces the partial one instead of appearing twice", () => {
+    const state = at(4);
+
+    expect(state.messages[0]!.content).toEqual([
+      { type: "text", text: "Let me look." },
+      {
+        type: "tool-call",
+        toolCallId: "tc_1",
+        name: "grep",
+        input: { pattern: "TODO", filePath: "a.ts" },
+      },
+    ]);
+  });
+
+  test("a tool result lands next to its call", () => {
+    const content = at(5).messages[0]!.content;
+
+    expect(content).toHaveLength(3);
+    expect(content[2]).toMatchObject({ type: "tool-result", toolCallId: "tc_1", status: "ok" });
+  });
+
+  test("text after a tool call opens a new part rather than merging backwards", () => {
+    const content = at(6).messages[0]!.content;
+
+    expect(content.map((part) => part.type)).toEqual([
+      "text",
+      "tool-call",
+      "tool-result",
+      "text",
+    ]);
+    expect(content[3]).toEqual({ type: "text", text: " Found one." });
+  });
+
+  test("awaiting-input parks the run with the pending call", () => {
+    const state = at(7);
+
+    expect(state.pending).toEqual([
+      {
+        toolCallId: "tc_2",
+        name: "ask",
+        input: { question: "Which file?" },
+        kind: "question",
+        signature: "sig_2",
+      },
+    ]);
+    expect(state.runId).toBe("run_1");
+  });
+
+  test("usage attaches to the message that just ended", () => {
+    expect(at(8).messages[0]!.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 120,
+    });
+  });
+
+  test("message-end stamps the finish reason", () => {
+    expect(at(9).messages[0]!.finishReason).toBe("awaiting-input");
+  });
+
+  test("run-end clears the run but keeps the question", () => {
+    const state = at(10);
+
+    expect(state.runId).toBeUndefined();
+    expect(state.finishReason).toBe("awaiting-input");
+    expect(state.pending).toHaveLength(1);
+    expect(state.seq).toBe(10);
+  });
+});
+
+describe("replay", () => {
+  test("applying the whole run twice changes nothing", () => {
+    const once = fold(initialChatState(), RUN);
+    const twice = fold(once, RUN);
+
+    // Identity, not just equality: `applyFrame` returns the state it was given
+    // when the frame is at or below the cursor, and the hook reads that to know
+    // it must not fire `onFinish` a second time.
+    expect(twice).toBe(once);
+  });
+
+  test("a single redelivered delta does not append its text twice", () => {
+    const state = at(2);
+    const again = applyFrame(state, RUN[2]!, NOW);
+
+    expect(again.messages[0]!.content).toEqual([{ type: "text", text: "Let me look." }]);
+  });
+
+  test("resuming from any mid-run cursor converges on the same conversation", () => {
+    const full = fold(initialChatState(), RUN);
+
+    for (let cursor = 0; cursor < RUN.length - 1; cursor++) {
+      // What a client actually has after a refresh: its messages, the question
+      // it was holding, the thread, and how far it got. Not `runId` — that is
+      // the server's to hand back, which is why `/attach` is asked by thread.
+      const dropped = at(cursor);
+      const resumed = initialChatState({
+        messages: dropped.messages,
+        pending: dropped.pending,
+        threadId: dropped.threadId,
+        seq: dropped.seq,
+      });
+
+      const caughtUp = fold(resumed, RUN.slice(cursor + 1));
+
+      expect(caughtUp.messages, `resumed at ${cursor}`).toEqual(full.messages);
+      expect(caughtUp.pending, `resumed at ${cursor}`).toEqual(full.pending);
+      expect(caughtUp.threadId, `resumed at ${cursor}`).toEqual(full.threadId);
+      expect(caughtUp.seq, `resumed at ${cursor}`).toBe(full.seq);
+    }
+  });
+
+  test("a second run restarts the numbering and is not swallowed by the cursor", () => {
+    // The ordinary second turn of a conversation. Every frame of run_2 is at or
+    // below the cursor run_1 left behind, so without the run-start exemption the
+    // whole answer reads as already-applied.
+    const first = fold(initialChatState(), RUN);
+    const second = fold(first, [
+      { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_1" } },
+      { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+      { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "second answer" } },
+      { seq: 3, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+    ]);
+
+    expect(second.messages).toHaveLength(2);
+    expect(second.messages[1]!.content).toEqual([{ type: "text", text: "second answer" }]);
+  });
+
+  test("a redelivered run-start for the run in hand still dedupes", () => {
+    const state = at(2);
+    const again = applyFrame(state, RUN[0]!, NOW);
+
+    expect(again).toBe(state);
+  });
+
+  test("a client handed only the tail builds the message it never saw start", () => {
+    // The `/attach` case with nothing kept: no run-start, no message-start, and
+    // the first frame is already halfway through m1. A reducer that assumed it
+    // saw frame 1 drops all of this on the floor.
+    const state = fold(initialChatState(), RUN.slice(5));
+
+    expect(state.messages).toHaveLength(1);
+    const message = state.messages[0]!;
+    expect(message.id).toBe("m1");
+    expect(message.role).toBe("assistant");
+    expect(message.content.map((part) => part.type)).toEqual(["tool-result", "text"]);
+    expect(message.finishReason).toBe("awaiting-input");
+    expect(state.pending).toHaveLength(1);
+  });
+});
+
+describe("the rest of the event union", () => {
+  test("reasoning is its own part and does not merge into text", () => {
+    const state = fold(initialChatState(), [
+      { seq: 0, event: { type: "reasoning-delta", messageId: "m1", delta: "hm" } },
+      { seq: 1, event: { type: "reasoning-delta", messageId: "m1", delta: "mm" } },
+      { seq: 2, event: { type: "text-delta", messageId: "m1", delta: "answer" } },
+    ]);
+
+    expect(state.messages[0]!.content).toEqual([
+      { type: "reasoning", text: "hmmm" },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
+  test("output snapshots replace rather than accumulate, so a late client is right", () => {
+    const late = fold(initialChatState(), [
+      {
+        seq: 4,
+        event: {
+          type: "output-delta",
+          messageId: "m1",
+          delta: '"neutral"}',
+          snapshot: { sentiment: "neutral" },
+        },
+      },
+      { seq: 5, event: { type: "message-end", messageId: "m1", finishReason: "stop" } },
+    ]);
+
+    expect(late.messages[0]!.content).toEqual([
+      { type: "output", value: { sentiment: "neutral" }, partial: false },
+    ]);
+  });
+
+  test("an error clears pending, so awaiting-input cannot be true alongside it", () => {
+    const state = fold(at(7), [
+      {
+        seq: 8,
+        event: {
+          type: "error",
+          error: { code: "provider_error", message: "upstream 500", retryable: true },
+        },
+      },
+    ]);
+
+    expect(state.error).toEqual({
+      code: "provider_error",
+      message: "upstream 500",
+      retryable: true,
+    });
+    expect(state.pending).toEqual([]);
+  });
+
+  test("a tool result for a pending call resolves it", () => {
+    const state = fold(at(7), [
+      {
+        seq: 8,
+        event: {
+          type: "tool-result",
+          messageId: "m1",
+          part: {
+            type: "tool-result",
+            toolCallId: "tc_2",
+            name: "ask",
+            status: "ok",
+            output: { answer: "a.ts" },
+          },
+        },
+      },
+    ]);
+
+    expect(state.pending).toEqual([]);
+  });
+
+  test("run-end ends a message whose message-end was never seen", () => {
+    const state = fold(initialChatState(), [
+      { seq: 20, event: { type: "text-delta", messageId: "m9", delta: "half" } },
+      { seq: 21, event: { type: "run-end", runId: "run_1", finishReason: "aborted" } },
+    ]);
+
+    // Otherwise the message renders a cursor for the rest of the session.
+    expect(state.messages[0]!.finishReason).toBe("aborted");
+  });
+
+  test("tool-search and tool-progress advance the cursor and nothing else", () => {
+    const before = at(6);
+    const after = fold(before, [
+      { seq: 7, event: { type: "tool-search", loaded: ["refundOrder"] } },
+      { seq: 8, event: { type: "tool-progress", toolCallId: "tc_1", data: { line: "$ ls" } } },
+    ]);
+
+    expect(after.messages).toEqual(before.messages);
+    expect(after.seq).toBe(8);
+  });
+});
+
+describe("markAborted", () => {
+  test("keeps the interrupted turn and marks it cut short", () => {
+    const state = markAborted(at(6));
+
+    expect(state.messages[0]!.content).toHaveLength(4);
+    expect(state.messages[0]!.finishReason).toBe("aborted");
+    expect(state.runId).toBeUndefined();
+  });
+
+  test("does not rewrite a message that already finished", () => {
+    const finished = fold(initialChatState(), [
+      { seq: 0, event: { type: "text-delta", messageId: "m1", delta: "done" } },
+      { seq: 1, event: { type: "message-end", messageId: "m1", finishReason: "stop" } },
+    ]);
+
+    expect(markAborted(finished).messages[0]!.finishReason).toBe("stop");
+  });
+
+  test("leaves a question standing: stopping a run does not answer it", () => {
+    const state = markAborted(at(7));
+
+    expect(state.pending).toHaveLength(1);
+  });
+
+  test("a user turn is never stamped with a finish reason", () => {
+    const user: AgentMessage = {
+      id: "u1",
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+      createdAt: NOW,
+    };
+    const state = markAborted(initialChatState({ messages: [user] }));
+
+    expect(state.messages[0]!.finishReason).toBeUndefined();
+  });
+});

--- a/packages/gemi/ai/client/reducer.ts
+++ b/packages/gemi/ai/client/reducer.ts
@@ -1,0 +1,319 @@
+import type {
+  AgentContentPart,
+  AgentError,
+  AgentMessage,
+  AgentStreamFrame,
+  FinishReason,
+  PendingToolCall,
+  ToolShapes,
+} from "../types";
+
+/**
+ * Frames to a message list.
+ *
+ * The rule the whole file is built around: **a client may be handed any
+ * suffix of a run, and may be handed the same frame twice.** An attached
+ * stream starts mid-message, a reconnect replays from a cursor, and a proxy
+ * that retries is entitled to deliver a frame again. So nothing here tracks
+ * "the current message" — every event that touches a message names it, and a
+ * message the list has never heard of is created on the spot rather than
+ * dropped.
+ *
+ * The two mechanisms that make that work:
+ *
+ *   - `seq` guards replay. A frame at or below the state's cursor is a no-op,
+ *     and `applyFrame` returns the *same object* so a caller can tell nothing
+ *     happened. Without it a redelivered `text-delta` would append its text a
+ *     second time — a bug that looks fine until someone refreshes.
+ *   - every mutation is either an append that the seq guard already protects,
+ *     or an upsert keyed by an id. Tool calls and tool results arrive more than
+ *     once (a call re-streams as its arguments grow), so those are keyed by
+ *     `toolCallId`, never pushed blindly.
+ */
+
+export type ChatState<T extends ToolShapes = ToolShapes, O = unknown> = {
+  messages: AgentMessage<T, O>[];
+  /** Non-empty exactly while the conversation is holding a question. */
+  pending: PendingToolCall<T>[];
+  error: AgentError | null;
+  runId?: string;
+  threadId?: string;
+  /**
+   * The highest frame applied. This is the cursor `/attach` is asked to resume
+   * from, which is why it lives in the state a client keeps rather than in the
+   * stream reader that dies with the connection.
+   */
+  seq: number;
+  /**
+   * Which run `seq` counts within.
+   *
+   * Separate from `runId`, which is cleared when the run ends because a UI asks
+   * it whether anything is live. The cursor outlives the run it belongs to: a
+   * frame from run_1 redelivered after run_1 finished is still a duplicate, and
+   * without somewhere to remember that, replaying a finished run would look
+   * exactly like the start of a new one.
+   */
+  cursorRunId?: string;
+  finishReason?: FinishReason;
+};
+
+export function initialChatState<T extends ToolShapes = ToolShapes, O = unknown>(
+  init: {
+    messages?: AgentMessage<T, O>[];
+    pending?: PendingToolCall<T>[];
+    threadId?: string;
+    /** Where a restored client left off. `-1` means "I have seen nothing". */
+    seq?: number;
+  } = {},
+): ChatState<T, O> {
+  return {
+    messages: init.messages ? [...init.messages] : [],
+    pending: init.pending ? [...init.pending] : [],
+    error: null,
+    threadId: init.threadId,
+    seq: init.seq ?? -1,
+  };
+}
+
+/**
+ * Apply one frame.
+ *
+ * `now` is an argument rather than a `Date.now()` call so the reducer stays a
+ * pure function of its inputs — it is only ever read when a frame arrives for a
+ * message the list has not seen, which is precisely the mid-run-attach path a
+ * test needs to pin down.
+ */
+export function applyFrame<T extends ToolShapes = ToolShapes, O = unknown>(
+  state: ChatState<T, O>,
+  frame: AgentStreamFrame<T, O>,
+  now: string = new Date().toISOString(),
+): ChatState<T, O> {
+  // A `seq` is a position within *one* run, so the second turn of a
+  // conversation numbers its frames from zero again and the cursor left over
+  // from the first would silently swallow the whole answer. `run-start` naming
+  // a run this state has not seen is the one frame entitled to drop the cursor.
+  const startsNewRun =
+    frame.event.type === "run-start" && frame.event.runId !== state.cursorRunId;
+  // Identity, not a copy: the hook reads `next === prev` as "already applied"
+  // and skips the callbacks that would otherwise fire twice.
+  if (!startsNewRun && frame.seq <= state.seq) return state;
+  return { ...reduce(state, frame.event, now), seq: frame.seq };
+}
+
+function reduce<T extends ToolShapes, O>(
+  state: ChatState<T, O>,
+  event: AgentStreamFrame<T, O>["event"],
+  now: string,
+): ChatState<T, O> {
+  switch (event.type) {
+    case "run-start":
+      return {
+        ...state,
+        runId: event.runId,
+        cursorRunId: event.runId,
+        threadId: event.threadId ?? state.threadId,
+        finishReason: undefined,
+      };
+
+    case "message-start":
+      return withMessage(state, event.messageId, now, (message) => ({
+        ...message,
+        role: event.role,
+      }));
+
+    case "text-delta":
+      return withMessage(state, event.messageId, now, (message) => ({
+        ...message,
+        content: appendText(message.content, event.delta),
+      }));
+
+    case "reasoning-delta":
+      return withMessage(state, event.messageId, now, (message) => ({
+        ...message,
+        content: appendReasoning(message.content, event.delta),
+      }));
+
+    case "output-delta":
+      // `snapshot` is the whole object so far, not an increment, so the raw
+      // `delta` text is dropped here on purpose: replacing beats accumulating
+      // when a client may have missed the first half of the JSON.
+      return withMessage(state, event.messageId, now, (message) => ({
+        ...message,
+        content: upsert(
+          message.content,
+          { type: "output", value: event.snapshot as O, partial: true },
+          (part) => part.type === "output",
+        ),
+      }));
+
+    case "tool-call":
+      // Keyed, because the same call re-streams as its arguments fill in.
+      return withMessage(state, event.messageId, now, (message) => ({
+        ...message,
+        content: upsert(
+          message.content,
+          event.part,
+          (part) => part.type === "tool-call" && part.toolCallId === event.part.toolCallId,
+        ),
+      }));
+
+    case "tool-result": {
+      const next = withMessage(state, event.messageId, now, (message) => ({
+        ...message,
+        content: upsert(
+          message.content,
+          event.part,
+          (part) => part.type === "tool-result" && part.toolCallId === event.part.toolCallId,
+        ),
+      }));
+      // A result is the answer to a pending call, whoever produced it — the
+      // human here, or the server after an approval. Either way it is no longer
+      // pending, and leaving it in the list would keep the UI asking.
+      return {
+        ...next,
+        pending: next.pending.filter((call) => call.toolCallId !== event.part.toolCallId),
+      };
+    }
+
+    case "awaiting-input":
+      return { ...state, runId: event.runId, pending: [...event.pending] };
+
+    case "message-end":
+      return withMessage(state, event.messageId, now, (message) => ({
+        ...message,
+        finishReason: event.finishReason,
+        content: message.content.map((part) =>
+          part.type === "output" && part.partial ? { ...part, partial: false } : part,
+        ),
+      }));
+
+    case "usage": {
+      // The only event with no id of its own. It belongs to the message that
+      // just ended, and the last one in the list is the only reading available
+      // — an assignment rather than an append, so a replay is harmless.
+      if (state.messages.length === 0) return state;
+      const messages = state.messages.slice();
+      const last = messages[messages.length - 1]!;
+      messages[messages.length - 1] = { ...last, usage: event.usage };
+      return { ...state, messages };
+    }
+
+    case "error":
+      // Clearing `pending` here is what keeps "pending is non-empty exactly
+      // when the UI is awaiting input" true: a run that errored is not holding
+      // a question any more, it is holding a failure.
+      return { ...state, error: event.error, pending: [] };
+
+    case "run-end":
+      return {
+        ...state,
+        runId: undefined,
+        finishReason: event.finishReason,
+        // A safety net for the client that attached late and never saw a
+        // `message-end`: once the run is over nothing is still streaming, so a
+        // message left without a finish reason would show a cursor forever.
+        messages: state.messages.map((message) =>
+          message.role === "assistant" && message.finishReason === undefined
+            ? { ...message, finishReason: event.finishReason }
+            : message,
+        ),
+      };
+
+    // `tool-search` and `tool-progress` are consumed and not stored: neither has
+    // a place in `AgentMessage`, and inventing one would change a contract four
+    // other slices compile against. The seq still advances, so the cursor stays
+    // right.
+    default:
+      return state;
+  }
+}
+
+/**
+ * The interrupted turn, kept.
+ *
+ * `stop()` calls this before the server has said anything, because the point of
+ * stopping is that the UI reacts now. Whatever the assistant had produced stays
+ * in the list marked `aborted` — dropping it would lose text the user already
+ * read, and would leave the transcript unable to say it was cut short.
+ *
+ * `pending` is untouched: a question the conversation is holding survives a
+ * stopped run, and clearing it would silently discard the answer the user still
+ * owes.
+ */
+export function markAborted<T extends ToolShapes = ToolShapes, O = unknown>(
+  state: ChatState<T, O>,
+): ChatState<T, O> {
+  return {
+    ...state,
+    runId: undefined,
+    finishReason: "aborted",
+    messages: state.messages.map((message) =>
+      message.role === "assistant" && message.finishReason === undefined
+        ? { ...message, finishReason: "aborted" as FinishReason }
+        : message,
+    ),
+  };
+}
+
+// --- helpers -------------------------------------------------------------
+
+function withMessage<T extends ToolShapes, O>(
+  state: ChatState<T, O>,
+  messageId: string,
+  now: string,
+  update: (message: AgentMessage<T, O>) => AgentMessage<T, O>,
+): ChatState<T, O> {
+  const index = state.messages.findIndex((message) => message.id === messageId);
+  if (index === -1) {
+    // The mid-stream attach. Every id-carrying event describes an assistant
+    // message — `message-start` is the only event that declares a role and it
+    // declares that one — so a placeholder is enough to hang the tail on.
+    const blank: AgentMessage<T, O> = {
+      id: messageId,
+      role: "assistant",
+      content: [],
+      createdAt: now,
+    };
+    return { ...state, messages: [...state.messages, update(blank)] };
+  }
+  const messages = state.messages.slice();
+  messages[index] = update(messages[index]!);
+  return { ...state, messages };
+}
+
+function appendText<T extends ToolShapes, O>(
+  content: AgentContentPart<T, O>[],
+  delta: string,
+): AgentContentPart<T, O>[] {
+  const last = content[content.length - 1];
+  // Coalesced into the trailing text part, but only if it *is* trailing: a
+  // delta after a tool call opens a new part, which is what lets a UI render
+  // "thinking / call / answer" in the order it happened.
+  if (last && last.type === "text") {
+    return [...content.slice(0, -1), { type: "text", text: last.text + delta }];
+  }
+  return [...content, { type: "text", text: delta }];
+}
+
+function appendReasoning<T extends ToolShapes, O>(
+  content: AgentContentPart<T, O>[],
+  delta: string,
+): AgentContentPart<T, O>[] {
+  const last = content[content.length - 1];
+  if (last && last.type === "reasoning") {
+    return [...content.slice(0, -1), { ...last, text: (last.text ?? "") + delta }];
+  }
+  return [...content, { type: "reasoning", text: delta }];
+}
+
+function upsert<T extends ToolShapes, O>(
+  content: AgentContentPart<T, O>[],
+  part: AgentContentPart<T, O>,
+  match: (part: AgentContentPart<T, O>) => boolean,
+): AgentContentPart<T, O>[] {
+  const index = content.findIndex(match);
+  if (index === -1) return [...content, part];
+  const next = content.slice();
+  next[index] = part;
+  return next;
+}

--- a/packages/gemi/ai/client/reducer.ts
+++ b/packages/gemi/ai/client/reducer.ts
@@ -25,6 +25,10 @@ import type {
  *     and `applyFrame` returns the *same object* so a caller can tell nothing
  *     happened. Without it a redelivered `text-delta` would append its text a
  *     second time — a bug that looks fine until someone refreshes.
+ *   - a finished message is closed to further deltas. `seq` catches a redelivery
+ *     within a run, but not a server that replays a run from zero to a client
+ *     that already has the transcript; `message-end` is terminal, so a delta for
+ *     a message that already carries a finish reason is replay by definition.
  *   - every mutation is either an append that the seq guard already protects,
  *     or an upsert keyed by an id. Tool calls and tool results arrive more than
  *     once (a call re-streams as its arguments grow), so those are keyed by
@@ -54,6 +58,19 @@ export type ChatState<T extends ToolShapes = ToolShapes, O = unknown> = {
    * exactly like the start of a new one.
    */
   cursorRunId?: string;
+  /**
+   * The messages the run in hand has touched, oldest first.
+   *
+   * `run-end` and `markAborted` both have to finish off a message whose
+   * `message-end` never arrived, and "every assistant message with no finish
+   * reason" is the wrong set to do it over: a superseded turn from an earlier
+   * run is sitting in exactly that state, and stamping it with *this* run's
+   * reason would relabel an interrupted answer as a clean completion. So the
+   * reducer remembers which messages this run actually wrote to, and finishes
+   * off only those. Reset by `run-start`; on a mid-run attach it simply fills
+   * up from the first frame that names a message, which is the same set.
+   */
+  runMessageIds: string[];
   finishReason?: FinishReason;
 };
 
@@ -64,6 +81,12 @@ export function initialChatState<T extends ToolShapes = ToolShapes, O = unknown>
     threadId?: string;
     /** Where a restored client left off. `-1` means "I have seen nothing". */
     seq?: number;
+    /**
+     * Which run that `seq` counts within. A cursor without it is a number with
+     * no units — frames number from zero in every run, so `seq: 10` means
+     * nothing until you know whether the live run is the one that reached 10.
+     */
+    cursorRunId?: string;
   } = {},
 ): ChatState<T, O> {
   return {
@@ -72,6 +95,8 @@ export function initialChatState<T extends ToolShapes = ToolShapes, O = unknown>
     error: null,
     threadId: init.threadId,
     seq: init.seq ?? -1,
+    cursorRunId: init.cursorRunId,
+    runMessageIds: [],
   };
 }
 
@@ -92,8 +117,7 @@ export function applyFrame<T extends ToolShapes = ToolShapes, O = unknown>(
   // conversation numbers its frames from zero again and the cursor left over
   // from the first would silently swallow the whole answer. `run-start` naming
   // a run this state has not seen is the one frame entitled to drop the cursor.
-  const startsNewRun =
-    frame.event.type === "run-start" && frame.event.runId !== state.cursorRunId;
+  const startsNewRun = frame.event.type === "run-start" && frame.event.runId !== state.cursorRunId;
   // Identity, not a copy: the hook reads `next === prev` as "already applied"
   // and skips the callbacks that would otherwise fire twice.
   if (!startsNewRun && frame.seq <= state.seq) return state;
@@ -112,6 +136,7 @@ function reduce<T extends ToolShapes, O>(
         runId: event.runId,
         cursorRunId: event.runId,
         threadId: event.threadId ?? state.threadId,
+        runMessageIds: [],
         finishReason: undefined,
       };
 
@@ -121,13 +146,22 @@ function reduce<T extends ToolShapes, O>(
         role: event.role,
       }));
 
+    // The two additive cases, and the only two that can double text. `seq`
+    // catches an ordinary redelivery, but a client resuming with a cursor the
+    // server ignores — or asked for the whole run when it already had the
+    // transcript — gets frames it cannot recognise as duplicates. A finished
+    // message is the one thing it can: `message-end` is terminal, so a delta
+    // arriving for a message that already carries a finish reason is replay by
+    // definition and appending it would show the answer twice.
     case "text-delta":
+      if (isFinished(state, event.messageId)) return state;
       return withMessage(state, event.messageId, now, (message) => ({
         ...message,
         content: appendText(message.content, event.delta),
       }));
 
     case "reasoning-delta":
+      if (isFinished(state, event.messageId)) return state;
       return withMessage(state, event.messageId, now, (message) => ({
         ...message,
         content: appendReasoning(message.content, event.delta),
@@ -188,13 +222,24 @@ function reduce<T extends ToolShapes, O>(
       }));
 
     case "usage": {
-      // The only event with no id of its own. It belongs to the message that
-      // just ended, and the last one in the list is the only reading available
-      // — an assignment rather than an append, so a replay is harmless.
-      if (state.messages.length === 0) return state;
+      // The only event with no id of its own, so it goes on the last assistant
+      // message — an assignment rather than an append, so a replay is harmless.
+      //
+      // The role test is the point. A run that counts its input tokens before
+      // opening a message — one that errors early, or whose only output is a
+      // tool call the client must resolve — emits `usage` while the last message
+      // in the list is still the user's own optimistic turn, and token counts
+      // rendered against what the user typed are simply false. With no assistant
+      // message to hang it on, dropping it is the honest answer.
+      //
+      // Deliberately *not* narrowed to the messages this run touched: a client
+      // resuming from a cursor mid-message has touched none of them yet, and
+      // narrowing would make `usage` the one event that fails to converge from
+      // an arbitrary cursor, which is the property the whole file is for.
+      const index = lastIndexWhere(state.messages, (message) => message.role === "assistant");
+      if (index === -1) return state;
       const messages = state.messages.slice();
-      const last = messages[messages.length - 1]!;
-      messages[messages.length - 1] = { ...last, usage: event.usage };
+      messages[index] = { ...messages[index]!, usage: event.usage };
       return { ...state, messages };
     }
 
@@ -212,11 +257,13 @@ function reduce<T extends ToolShapes, O>(
         // A safety net for the client that attached late and never saw a
         // `message-end`: once the run is over nothing is still streaming, so a
         // message left without a finish reason would show a cursor forever.
-        messages: state.messages.map((message) =>
-          message.role === "assistant" && message.finishReason === undefined
-            ? { ...message, finishReason: event.finishReason }
-            : message,
-        ),
+        //
+        // Scoped to this run's own messages. A turn superseded by a second send
+        // is also sitting there unfinished, and it was *not* finished by this
+        // run — stamping it "stop" would tell the user, and the model on the
+        // next stateless turn, that an answer cut off mid-sentence ended
+        // cleanly.
+        messages: finishUnended(state, event.finishReason),
       };
 
     // `tool-search` and `tool-progress` are consumed and not stored: neither has
@@ -247,15 +294,41 @@ export function markAborted<T extends ToolShapes = ToolShapes, O = unknown>(
     ...state,
     runId: undefined,
     finishReason: "aborted",
-    messages: state.messages.map((message) =>
-      message.role === "assistant" && message.finishReason === undefined
-        ? { ...message, finishReason: "aborted" as FinishReason }
-        : message,
-    ),
+    // This run's messages only, for the same reason `run-end` is scoped: an
+    // older turn that was already cut short is not cut short again by this one,
+    // and a restored transcript may legitimately carry an unfinished message
+    // that has nothing to do with the run being stopped.
+    messages: finishUnended(state, "aborted"),
   };
 }
 
 // --- helpers -------------------------------------------------------------
+
+/** The messages this run wrote, finished off with `reason` if they never ended. */
+function finishUnended<T extends ToolShapes, O>(
+  state: ChatState<T, O>,
+  reason: FinishReason,
+): AgentMessage<T, O>[] {
+  return state.messages.map((message) =>
+    message.role === "assistant" &&
+    message.finishReason === undefined &&
+    state.runMessageIds.includes(message.id)
+      ? { ...message, finishReason: reason }
+      : message,
+  );
+}
+
+function isFinished<T extends ToolShapes, O>(state: ChatState<T, O>, messageId: string) {
+  const message = state.messages.find((candidate) => candidate.id === messageId);
+  return message !== undefined && message.finishReason !== undefined;
+}
+
+function lastIndexWhere<M>(items: M[], match: (item: M) => boolean) {
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (match(items[i]!)) return i;
+  }
+  return -1;
+}
 
 function withMessage<T extends ToolShapes, O>(
   state: ChatState<T, O>,
@@ -264,6 +337,11 @@ function withMessage<T extends ToolShapes, O>(
   update: (message: AgentMessage<T, O>) => AgentMessage<T, O>,
 ): ChatState<T, O> {
   const index = state.messages.findIndex((message) => message.id === messageId);
+  // Every id-carrying event marks its message as one this run touched, which is
+  // what `run-end` and `markAborted` read to know whose loose ends are theirs.
+  const runMessageIds = state.runMessageIds.includes(messageId)
+    ? state.runMessageIds
+    : [...state.runMessageIds, messageId];
   if (index === -1) {
     // The mid-stream attach. Every id-carrying event describes an assistant
     // message — `message-start` is the only event that declares a role and it
@@ -274,11 +352,11 @@ function withMessage<T extends ToolShapes, O>(
       content: [],
       createdAt: now,
     };
-    return { ...state, messages: [...state.messages, update(blank)] };
+    return { ...state, runMessageIds, messages: [...state.messages, update(blank)] };
   }
   const messages = state.messages.slice();
   messages[index] = update(messages[index]!);
-  return { ...state, messages };
+  return { ...state, runMessageIds, messages };
 }
 
 function appendText<T extends ToolShapes, O>(

--- a/packages/gemi/ai/client/sse.test.ts
+++ b/packages/gemi/ai/client/sse.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "vitest";
+import { decodeSSE, SSEFrameDecoder } from "./sse";
+
+/**
+ * A realistic wire fixture, including the three things a hand-rolled parser
+ * usually gets wrong: a keepalive comment, a `data:` payload spread over two
+ * lines, and a non-ASCII character whose UTF-8 bytes can be split by a chunk
+ * boundary.
+ */
+const WIRE =
+  ": keepalive\n\n" +
+  'id: 0\ndata: {"type":"run-start","runId":"run_1","threadId":"th_1"}\n\n' +
+  'id: 1\ndata: {"type":"message-start","messageId":"m1","role":"assistant"}\n\n' +
+  'id: 2\ndata: {"type":"text-delta",\ndata: "messageId":"m1","delta":"héllo ✅"}\n\n' +
+  ": keepalive\n\n" +
+  'id: 3\ndata: {"type":"message-end","messageId":"m1","finishReason":"stop"}\n\n' +
+  'id: 4\ndata: {"type":"run-end","runId":"run_1","finishReason":"stop"}\n\n';
+
+function collect(decoder: SSEFrameDecoder, chunks: (string | Uint8Array)[]) {
+  const frames = chunks.flatMap((chunk) => decoder.push(chunk));
+  return [...frames, ...decoder.flush()];
+}
+
+describe("SSEFrameDecoder", () => {
+  test("decodes a run, taking seq from the id field", () => {
+    const frames = collect(new SSEFrameDecoder(), [WIRE]);
+
+    expect(frames.map((f) => f.seq)).toEqual([0, 1, 2, 3, 4]);
+    expect(frames.map((f) => f.event.type)).toEqual([
+      "run-start",
+      "message-start",
+      "text-delta",
+      "message-end",
+      "run-end",
+    ]);
+  });
+
+  test("multi-line data rejoins with a newline, so the JSON still parses", () => {
+    const [, , delta] = collect(new SSEFrameDecoder(), [WIRE]);
+
+    expect(delta!.event).toEqual({ type: "text-delta", messageId: "m1", delta: "héllo ✅" });
+  });
+
+  test("keepalive comments produce no frames", () => {
+    const frames = collect(new SSEFrameDecoder(), [": keepalive\n\n:\n\n: another\n\n"]);
+
+    expect(frames).toEqual([]);
+  });
+
+  test("every byte-level split of the same stream decodes identically", () => {
+    // The real failure mode: `reader.read()` boundaries have nothing to do with
+    // event boundaries, and a multi-byte character split across two chunks is
+    // what turns "usually works" into a mangled delta once in a thousand runs.
+    const bytes = new TextEncoder().encode(WIRE);
+    const whole = collect(new SSEFrameDecoder(), [bytes]);
+
+    for (let cut = 0; cut <= bytes.length; cut++) {
+      const split = collect(new SSEFrameDecoder(), [bytes.slice(0, cut), bytes.slice(cut)]);
+      expect(split, `split at byte ${cut}`).toEqual(whole);
+    }
+  });
+
+  test("a chunk boundary inside a data line does not lose the line", () => {
+    const cut = WIRE.indexOf('"delta"');
+    const frames = collect(new SSEFrameDecoder(), [WIRE.slice(0, cut), WIRE.slice(cut)]);
+
+    expect(frames).toHaveLength(5);
+  });
+
+  test("a truncated tail is discarded rather than half-applied", () => {
+    const decoder = new SSEFrameDecoder();
+    const frames = collect(decoder, [
+      'id: 0\ndata: {"type":"run-start","runId":"run_1"}\n\n',
+      'id: 1\ndata: {"type":"text-de',
+    ]);
+
+    // Four bytes of a text-delta is not a text-delta. An event with no
+    // terminating blank line never dispatched, and flush must not invent one.
+    expect(frames.map((f) => f.event.type)).toEqual(["run-start"]);
+  });
+
+  test("an unparseable frame is skipped without taking the stream with it", () => {
+    const frames = collect(new SSEFrameDecoder(), [
+      'id: 0\ndata: {"type":"run-start","runId":"run_1"}\n\n',
+      "id: 1\ndata: {not json}\n\n",
+      'id: 2\ndata: {"type":"run-end","runId":"run_1","finishReason":"stop"}\n\n',
+    ]);
+
+    expect(frames.map((f) => f.seq)).toEqual([0, 2]);
+  });
+
+  test("CRLF line endings, including a CR left at a chunk boundary", () => {
+    const crlf = WIRE.replace(/\n/g, "\r\n");
+    const cut = crlf.indexOf("\r\n") + 1; // between the CR and the LF
+    const frames = collect(new SSEFrameDecoder(), [crlf.slice(0, cut), crlf.slice(cut)]);
+
+    expect(frames.map((f) => f.seq)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("a frame with no id continues the count rather than restarting it", () => {
+    // Seq is the replay guard downstream, so an id-less frame that resolved to
+    // 0 would read as already-applied for the rest of the run.
+    const frames = collect(new SSEFrameDecoder(), [
+      'id: 7\ndata: {"type":"tool-search","loaded":["a"]}\n\n',
+      'data: {"type":"tool-search","loaded":["b"]}\n\n',
+      'data: {"type":"tool-search","loaded":["c"]}\n\n',
+    ]);
+
+    expect(frames.map((f) => f.seq)).toEqual([7, 8, 9]);
+  });
+
+  test("cursor tracks the highest id seen", () => {
+    const decoder = new SSEFrameDecoder();
+    expect(decoder.cursor).toBe(-1);
+    decoder.push(WIRE);
+    expect(decoder.cursor).toBe(4);
+  });
+});
+
+describe("decodeSSE", () => {
+  test("reads a ReadableStream to the end", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(WIRE.slice(0, 40)));
+        controller.enqueue(encoder.encode(WIRE.slice(40)));
+        controller.close();
+      },
+    });
+
+    const frames = [];
+    for await (const frame of decodeSSE(stream)) frames.push(frame);
+
+    expect(frames.map((f) => f.seq)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("a missing body is an empty stream, not a crash", async () => {
+    const frames = [];
+    for await (const frame of decodeSSE(null)) frames.push(frame);
+
+    expect(frames).toEqual([]);
+  });
+
+  test("breaking out of the loop cancels the stream", async () => {
+    let cancelled = false;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(WIRE));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    for await (const _frame of decodeSSE(stream)) break;
+
+    expect(cancelled).toBe(true);
+  });
+});

--- a/packages/gemi/ai/client/sse.ts
+++ b/packages/gemi/ai/client/sse.ts
@@ -1,0 +1,160 @@
+import type { AgentStreamFrame, ToolShapes } from "../types";
+
+/**
+ * Bytes to frames.
+ *
+ * Split out of the hook because none of it is React: it is a byte-level parser,
+ * and the interesting cases — a chunk boundary landing inside a `data:` line, a
+ * multi-byte character split across two reads, a stream that dies mid-event —
+ * are all reachable from a test with a string and no DOM.
+ *
+ * Deliberately not `EventSource`. The agent routes are POSTs carrying a turn,
+ * `EventSource` can only GET, and reattachment wants the cursor in the request
+ * body next to the thread id rather than in a header the browser owns.
+ */
+
+/**
+ * Feed it chunks, get frames. Holds whatever is left over between calls, which
+ * is the whole point: `push()` is called once per `reader.read()` and those
+ * boundaries have nothing to do with event boundaries.
+ */
+export class SSEFrameDecoder<T extends ToolShapes = ToolShapes, O = unknown> {
+  private buffer = "";
+  private textDecoder = new TextDecoder();
+  /**
+   * A `\r` at the very end of a chunk is ambiguous — the next chunk may open
+   * with the `\n` that completes a CRLF, or with the next line. Holding it back
+   * for one chunk is what keeps a boundary there from being read as a blank
+   * line and cutting an event in half.
+   */
+  private pendingCR = false;
+  private lastSeq = -1;
+
+  /** The cursor to resume from: the highest `id:` seen. */
+  get cursor(): number {
+    return this.lastSeq;
+  }
+
+  push(chunk: Uint8Array | string): AgentStreamFrame<T, O>[] {
+    this.append(
+      typeof chunk === "string" ? chunk : this.textDecoder.decode(chunk, { stream: true }),
+    );
+    return this.drain();
+  }
+
+  /**
+   * End of stream. Anything still buffered is an event with no terminating
+   * blank line, which the SSE spec discards and so does this — a truncated tail
+   * is usually truncated JSON, and half a `text-delta` appended to a message is
+   * worse than a missing one.
+   */
+  flush(): AgentStreamFrame<T, O>[] {
+    this.append(this.textDecoder.decode());
+    const frames = this.drain();
+    this.buffer = "";
+    this.pendingCR = false;
+    return frames;
+  }
+
+  /** Normalises every line ending to `\n` so the rest of the parser only has to
+   *  know about one. */
+  private append(text: string) {
+    if (text === "") return;
+    let rest = text;
+    if (this.pendingCR) {
+      this.buffer += "\n";
+      this.pendingCR = false;
+      if (rest.startsWith("\n")) rest = rest.slice(1);
+    }
+    if (rest.endsWith("\r")) {
+      rest = rest.slice(0, -1);
+      this.pendingCR = true;
+    }
+    this.buffer += rest.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  }
+
+  private drain(): AgentStreamFrame<T, O>[] {
+    const frames: AgentStreamFrame<T, O>[] = [];
+    let boundary = this.buffer.indexOf("\n\n");
+    while (boundary !== -1) {
+      const block = this.buffer.slice(0, boundary);
+      this.buffer = this.buffer.slice(boundary + 2);
+      const frame = this.parse(block);
+      if (frame) frames.push(frame);
+      boundary = this.buffer.indexOf("\n\n");
+    }
+    return frames;
+  }
+
+  private parse(block: string): AgentStreamFrame<T, O> | null {
+    let id: string | undefined;
+    const data: string[] = [];
+
+    for (const line of block.split("\n")) {
+      // A comment. The server sends these as keepalives through a proxy that
+      // would otherwise close an idle connection, and they carry nothing.
+      if (line === "" || line.startsWith(":")) continue;
+      const colon = line.indexOf(":");
+      const field = colon === -1 ? line : line.slice(0, colon);
+      let value = colon === -1 ? "" : line.slice(colon + 1);
+      if (value.startsWith(" ")) value = value.slice(1);
+      if (field === "data") data.push(value);
+      else if (field === "id") id = value;
+      // `event:` and `retry:` are read and dropped: the frame's own `type` is
+      // the discriminator, so a second one on the transport could only disagree
+      // with it.
+    }
+
+    if (data.length === 0) return null;
+
+    let event: AgentStreamFrame<T, O>["event"];
+    try {
+      // Multi-line data rejoins with `\n`, per the spec — which is also what
+      // makes a pretty-printed JSON payload survive the transport.
+      event = JSON.parse(data.join("\n"));
+    } catch {
+      // One unparseable frame must not take the rest of the run with it.
+      return null;
+    }
+
+    const parsed = id === undefined || id === "" ? Number.NaN : Number(id);
+    // A frame with no usable `id` still needs a seq, because seq is what makes
+    // a replayed frame a no-op downstream. Continuing the count is the reading
+    // that keeps the cursor monotone; treating it as 0 would make every such
+    // frame look already-applied.
+    const seq = Number.isFinite(parsed) ? parsed : this.lastSeq + 1;
+    this.lastSeq = seq;
+    return { seq, event };
+  }
+}
+
+/**
+ * The same decoder over a `Response.body`.
+ *
+ * Cancels the reader when the caller stops consuming — a `break` out of the
+ * `for await` is how the hook drops a stream on unmount, and without the cancel
+ * the connection stays open behind it.
+ */
+export async function* decodeSSE<T extends ToolShapes = ToolShapes, O = unknown>(
+  stream: ReadableStream<Uint8Array> | null | undefined,
+): AsyncGenerator<AgentStreamFrame<T, O>, void, void> {
+  if (!stream) return;
+  const reader = stream.getReader();
+  const decoder = new SSEFrameDecoder<T, O>();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        yield* decoder.flush();
+        return;
+      }
+      if (value) yield* decoder.push(value);
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Already errored or already closed; there is nothing left to release.
+    }
+  }
+}

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -108,7 +108,19 @@ function calls() {
   return fetchMock.mock.calls as [string, RequestInit][];
 }
 
+/**
+ * The request body, minus the correlation id.
+ *
+ * `clientRunId` is a fresh uuid on every send, so it cannot appear in an
+ * equality assertion; it has its own tests below, which are the only place it is
+ * interesting.
+ */
 function bodyOf(index: number) {
+  const { clientRunId: _, ...body } = JSON.parse(calls()[index]![1]!.body as string);
+  return body;
+}
+
+function rawBodyOf(index: number) {
   return JSON.parse(calls()[index]![1]!.body as string);
 }
 
@@ -287,10 +299,7 @@ describe("awaiting input", () => {
     });
 
     await act(async () => {
-      await Promise.all([
-        box.api.approve("tc_1", true),
-        box.api.approve("tc_2", false, "too old"),
-      ]);
+      await Promise.all([box.api.approve("tc_1", true), box.api.approve("tc_2", false, "too old")]);
     });
 
     expect(calls()).toHaveLength(2);
@@ -344,6 +353,56 @@ describe("awaiting input", () => {
     expect(calls()).toHaveLength(0);
     expect(box.api.error).toMatchObject({ code: "invalid_tool_result", retryable: false });
   });
+
+  test("a bad toolCallId does not throw away the good ones standing next to it", async () => {
+    fetchMock.mockResolvedValueOnce(streamed(ASKING));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("refund me");
+    });
+
+    await act(async () => {
+      await box.api.approve("tc_nope", true);
+    });
+
+    // The signatures are the only thing that can answer these calls and they are
+    // held nowhere else; dropping them because one report was misaddressed
+    // leaves the user unable to approve anything, with a fresh turn — which the
+    // server reads as refusing everything — the only way out.
+    expect(box.api.pending).toHaveLength(2);
+    expect(box.api.status).toBe("awaiting-input");
+
+    await act(async () => {
+      await box.api.approve("tc_1", true);
+    });
+
+    expect(bodyOf(1).turn.toolResults).toEqual([
+      { toolCallId: "tc_1", signature: "sig_one", approve: true },
+    ]);
+  });
+
+  test("an unrelated failure leaves the standing question alone", async () => {
+    fetchMock.mockResolvedValueOnce(streamed(ASKING));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("refund me");
+    });
+
+    // An upload has nothing to do with the approvals the conversation is
+    // holding, and failing one is no reason to make them unanswerable.
+    fetchMock.mockResolvedValueOnce(new Response("too big", { status: 500 }));
+    await act(async () => {
+      await expect(
+        box.api.attach(new File(["x"], "a.txt", { type: "text/plain" })),
+      ).rejects.toThrow();
+    });
+
+    expect(box.api.pending).toHaveLength(2);
+    expect(box.api.error).toMatchObject({ retryable: true });
+    // With both set, awaiting-input wins: the question is still the thing the UI
+    // has to put in front of the user.
+    expect(box.api.status).toBe("awaiting-input");
+  });
 });
 
 describe("stop", () => {
@@ -385,6 +444,83 @@ describe("stop", () => {
 
     expect(calls()).toHaveLength(0);
   });
+
+  test("a run that has not named itself yet is still stopped", async () => {
+    // Between the send and the first frame — the round trip plus the provider's
+    // time to first token, longer if the agent searches for deferred tools — the
+    // client has no `runId` and, on a stateless first turn, no `threadId`
+    // either. That window is exactly where a user cancels, and a dropped
+    // connection no longer stops the tool loop.
+    const run = controlled();
+    fetchMock.mockImplementation(async (_url: string, init: RequestInit) => {
+      init?.signal?.addEventListener("abort", () => run.abort());
+      return run.response;
+    });
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("write me an essay");
+    });
+    expect(box.api.runId).toBeUndefined();
+
+    await act(async () => {
+      await box.api.stop();
+    });
+
+    expect(calls().map((c) => c[0])).toEqual(["/api/chat", "/api/chat/stop"]);
+    // The correlation id the client minted for the send, so the route has
+    // something to resolve the run by when nothing else exists yet.
+    expect(rawBodyOf(1)).toEqual({ clientRunId: rawBodyOf(0).clientRunId });
+    expect(rawBodyOf(1).clientRunId).toMatch(/^local_/);
+  });
+
+  test("a run attached to, whose tail carried no run-start, is stoppable by thread", async () => {
+    // The other half of the same hole: a tail replayed from a mid-run cursor has
+    // no `run-start` in it, so `runId` never arrives, but the run is visibly
+    // streaming and the thread is the handle the route resolves it by.
+    const run = controlled();
+    fetchMock.mockImplementation(async (_url: string, init: RequestInit) => {
+      init?.signal?.addEventListener("abort", () => run.abort());
+      return run.response;
+    });
+    const { box } = mount({ threadId: "th_9", cursor: { runId: "run_1", seq: 1 } });
+
+    await act(async () => {
+      run.push({ seq: 2, event: { type: "text-delta", messageId: "m1", delta: "…tail" } });
+      await Promise.resolve();
+    });
+    expect(box.api.runId).toBeUndefined();
+
+    await act(async () => {
+      await box.api.stop();
+    });
+
+    expect(calls()[1]![0]).toBe("/api/chat/stop");
+    expect(rawBodyOf(1)).toEqual({ threadId: "th_9" });
+  });
+
+  test("a stop the server refused is reported, not swallowed", async () => {
+    // The transcript says the turn was cut, so the UI looks settled while the
+    // run may still be working through its tool loop and billing for it.
+    const run = controlled();
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      init?.signal?.addEventListener("abort", () => run.abort());
+      return run.response;
+    });
+    fetchMock.mockResolvedValueOnce(new Response("no such run", { status: 500 }));
+    const onError = vi.fn();
+    const { box } = mount({ attach: false, onError });
+
+    await act(async () => {
+      void box.api.sendMessage("hi");
+    });
+    await act(async () => {
+      await box.api.stop();
+    });
+
+    expect(box.api.error).toMatchObject({ retryable: true });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("attach on mount", () => {
@@ -404,18 +540,68 @@ describe("attach on mount", () => {
     expect(box.api.status).toBe("idle");
   });
 
-  test("resumes past what initialMessages already contain", async () => {
+  test("asks for the tail from the cursor restored with the messages", async () => {
     fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
     mount({
       threadId: "th_9",
       initialMessages: [{ id: "m1", role: "user", content: [], createdAt: "" }],
+      cursor: { runId: "run_1", seq: 3 },
     });
 
     await act(async () => {
       await Promise.resolve();
     });
 
-    expect(bodyOf(0).threadId).toBe("th_9");
+    // Both halves, and the run id is not decoration: frames number from zero in
+    // every run, so "I got to 3" says nothing until the server knows which run
+    // reached 3. Given the pair it can resume; given a mismatch it must replay.
+    expect(bodyOf(0)).toEqual({ threadId: "th_9", cursor: 3, runId: "run_1" });
+  });
+
+  test("a full replay onto a restored transcript does not print the answer twice", async () => {
+    // `LiveRuns` keeps a run alive past `run-end` so a refresh a second late
+    // still sees the tail, which means the ordinary refresh right after an
+    // answer gets that answer replayed. With no cursor to hand back — the app
+    // persisted the messages and not the cursor — `seq` cannot recognise a
+    // single frame of it.
+    fetchMock.mockResolvedValueOnce(streamed(ANSWER));
+    const onFinish = vi.fn();
+    const { box } = mount({
+      threadId: "th_9",
+      onFinish,
+      initialMessages: [
+        { id: "u1", role: "user", content: [{ type: "text", text: "hi" }], createdAt: "" },
+        {
+          id: "m1",
+          role: "assistant",
+          content: [{ type: "text", text: "Hi there." }],
+          createdAt: "",
+          finishReason: "stop",
+        },
+      ],
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(box.api.messages).toHaveLength(2);
+    expect(box.api.messages[1]!.content).toEqual([{ type: "text", text: "Hi there." }]);
+    // An app that persists in `onFinish` would otherwise write the message a
+    // second time on every refresh.
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  test("the cursor is handed back, so the next mount can restore it", async () => {
+    const { box } = mount({ threadId: "th_9", attach: false });
+
+    await act(async () => {
+      await box.api.sendMessage("hello");
+    });
+
+    // What an app persists alongside `messages`; restoring one without the other
+    // is what produced the doubled answer above.
+    expect(box.api.cursor).toEqual({ runId: "run_1", seq: 4 });
   });
 
   test("nothing in flight is an ordinary answer, not an error", async () => {
@@ -652,15 +838,47 @@ describe("lifecycle", () => {
     });
 
     // user, the interrupted assistant turn, user, the new answer.
-    expect(box.api.messages.map((m) => m.role)).toEqual([
-      "user",
-      "assistant",
-      "user",
-      "assistant",
-    ]);
+    expect(box.api.messages.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
     // The interrupted turn keeps the text it had produced.
     expect(box.api.messages[1]!.content).toEqual([{ type: "text", text: "Hi there." }]);
     expect(box.api.messages[3]!.content).toEqual([{ type: "text", text: "Second." }]);
+    // And says it was cut off. Left with no finish reason it is indistinguishable
+    // from one still streaming, and run_2's `run-end` would sweep it up and call
+    // it "stop" — telling the user, and in stateless mode the model on every
+    // later turn, that an answer stopped mid-sentence ended cleanly.
+    expect(box.api.messages.map((m) => m.finishReason)).toEqual([
+      undefined,
+      "aborted",
+      undefined,
+      "stop",
+    ]);
     expect(box.api.status).toBe("idle");
+  });
+
+  test("the superseded turn goes back to a stateless server marked aborted", async () => {
+    // The transcript the client carries is what the model is shown next time.
+    const first = controlled();
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      init?.signal?.addEventListener("abort", () => first.abort());
+      return first.response;
+    });
+    const anonymous = ANSWER.map((frame, index) =>
+      index === 0 ? { seq: 0, event: { type: "run-start" as const, runId: "run_1" } } : frame,
+    );
+    fetchMock.mockImplementation(async () => streamed(anonymous));
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("one");
+    });
+    await act(async () => {
+      first.push({ seq: 0, event: { type: "run-start", runId: "run_0" } }, ANSWER[1]!, ANSWER[2]!);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(bodyOf(1).messages[1]).toMatchObject({ role: "assistant", finishReason: "aborted" });
   });
 });

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -1,0 +1,666 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { AgentStreamFrame } from "./types";
+import { useChat, type UseChatResult } from "./useChat";
+
+/**
+ * The hook is thin on purpose — the decoding and the message reducer are tested
+ * on their own, without a DOM — so what is left here is the part that only
+ * exists in React: which URL is called with what body, when the UI is allowed
+ * to say it is idle, and what happens on unmount.
+ *
+ * `useChat`'s path parameter is keyed off the app's `RPC`, which has no agent
+ * routes in the package itself, so the calls below go through `any`. The types
+ * are exercised by `Agent.test-d.ts` and by an application, not from here.
+ */
+
+type Api = UseChatResult<never>;
+
+function encode(frames: AgentStreamFrame[]) {
+  return frames.map((f) => `id: ${f.seq}\ndata: ${JSON.stringify(f.event)}\n\n`).join("");
+}
+
+function streamed(frames: AgentStreamFrame[]) {
+  return new Response(encode(frames), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+/** A stream the test keeps open, so a run can be interrupted halfway. */
+function controlled() {
+  const encoder = new TextEncoder();
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    response: new Response(body, { status: 200 }),
+    push(...frames: AgentStreamFrame[]) {
+      controller.enqueue(encoder.encode(encode(frames)));
+    },
+    close() {
+      controller.close();
+    },
+    // What a real fetch does when its signal fires, and the reason `stop()` can
+    // trust the loop to end.
+    abort() {
+      controller.error(Object.assign(new Error("aborted"), { name: "AbortError" }));
+    },
+  };
+}
+
+const ANSWER: AgentStreamFrame[] = [
+  { seq: 0, event: { type: "run-start", runId: "run_1", threadId: "th_9" } },
+  { seq: 1, event: { type: "message-start", messageId: "m1", role: "assistant" } },
+  { seq: 2, event: { type: "text-delta", messageId: "m1", delta: "Hi there." } },
+  { seq: 3, event: { type: "message-end", messageId: "m1", finishReason: "stop" } },
+  { seq: 4, event: { type: "run-end", runId: "run_1", finishReason: "stop" } },
+];
+
+const ASKING: AgentStreamFrame[] = [
+  { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
+  { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+  { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "I need two things." } },
+  {
+    seq: 3,
+    event: {
+      type: "awaiting-input",
+      runId: "run_2",
+      pending: [
+        {
+          toolCallId: "tc_1",
+          name: "charge",
+          input: { amountCents: 500 },
+          kind: "approval",
+          signature: "sig_one",
+        },
+        {
+          toolCallId: "tc_2",
+          name: "refundOrder",
+          input: { orderId: "o_1" },
+          kind: "approval",
+          signature: "sig_two",
+        },
+      ],
+    },
+  },
+  { seq: 4, event: { type: "message-end", messageId: "m2", finishReason: "awaiting-input" } },
+  { seq: 5, event: { type: "run-end", runId: "run_2", finishReason: "awaiting-input" } },
+];
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function mount(params: Record<string, unknown> = {}) {
+  const box: { api: Api } = { api: null as unknown as Api };
+  function Harness() {
+    box.api = (useChat as any)("/chat", params);
+    return <span data-testid="status">{box.api.status}</span>;
+  }
+  const rendered = render(<Harness />);
+  return { ...rendered, box };
+}
+
+function calls() {
+  return fetchMock.mock.calls as [string, RequestInit][];
+}
+
+function bodyOf(index: number) {
+  return JSON.parse(calls()[index]![1]!.body as string);
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () => streamed(ANSWER));
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("routes", () => {
+  test("every route is derived from the path exactly as mounted", async () => {
+    const run = controlled();
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      init?.signal?.addEventListener("abort", () => run.abort());
+      return run.response;
+    });
+    const { box } = mount({ threadId: "th_9", attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("hello");
+    });
+    await act(async () => {
+      run.push(ANSWER[0]!);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.stop();
+    });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ fileId: "f_1" })));
+    await act(async () => {
+      await box.api.attach(new File(["x"], "a.txt", { type: "text/plain" }));
+    });
+
+    expect(calls().map((c) => c[0])).toEqual(["/api/chat", "/api/chat/stop", "/api/chat/files"]);
+  });
+
+  test("uploading returns the id alongside the file's own name and type", async () => {
+    const { box } = mount({ attach: false });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ fileId: "f_1" })));
+
+    let result: unknown;
+    await act(async () => {
+      result = await box.api.attach(new File(["x"], "invoice.pdf", { type: "application/pdf" }));
+    });
+
+    expect(result).toEqual({ fileId: "f_1", name: "invoice.pdf", mimeType: "application/pdf" });
+    expect(calls()[0]![1]!.body).toBeInstanceOf(FormData);
+  });
+});
+
+describe("sendMessage", () => {
+  test("shows the user's turn before the server has said anything", async () => {
+    // A never-resolving request: the point is what the UI does while it waits.
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("hello");
+    });
+
+    expect(box.api.messages).toHaveLength(1);
+    expect(box.api.messages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    });
+    expect(box.api.status).toBe("submitted");
+  });
+
+  test("streams the answer and lands back on idle", async () => {
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      await box.api.sendMessage("hello");
+    });
+
+    expect(box.api.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(box.api.messages[1]!.content).toEqual([{ type: "text", text: "Hi there." }]);
+    expect(box.api.messages[1]!.finishReason).toBe("stop");
+    expect(box.api.status).toBe("idle");
+    expect(box.api.threadId).toBe("th_9");
+  });
+
+  test("stateless: the client carries the history, and never the new turn twice", async () => {
+    // A server that names no thread. The transcript is the client's to keep,
+    // and it is the transcript *before* this turn — the turn itself travels in
+    // `turn`, so including it would show the model the same message twice.
+    const anonymous = ANSWER.map((frame, index) =>
+      index === 0 ? { seq: 0, event: { type: "run-start" as const, runId: "run_1" } } : frame,
+    );
+    fetchMock.mockImplementation(async () => streamed(anonymous));
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      await box.api.sendMessage("first");
+    });
+    await act(async () => {
+      await box.api.sendMessage("second");
+    });
+
+    expect(bodyOf(0)).toEqual({ turn: { text: "first" }, messages: [] });
+    const second = bodyOf(1);
+    expect(second.turn).toEqual({ text: "second" });
+    expect(second.messages).toHaveLength(2);
+    expect(second.threadId).toBeUndefined();
+  });
+
+  test("once the server names a thread the client stops carrying the history", async () => {
+    // Sending it anyway would be a second copy of a transcript the store
+    // already has, growing every turn.
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      await box.api.sendMessage("first");
+    });
+    await act(async () => {
+      await box.api.sendMessage("second");
+    });
+
+    expect(bodyOf(1)).toEqual({ turn: { text: "second" }, threadId: "th_9" });
+  });
+
+  test("a threadId means the server owns the history", async () => {
+    const { box } = mount({ threadId: "th_1", attach: false });
+
+    await act(async () => {
+      await box.api.sendMessage({ text: "hi", files: [{ fileId: "f_1" }] });
+    });
+
+    expect(bodyOf(0)).toEqual({
+      turn: { text: "hi", files: [{ fileId: "f_1" }] },
+      threadId: "th_1",
+    });
+  });
+
+  test("body and headers ride along", async () => {
+    const { box } = mount({
+      attach: false,
+      body: { locale: "en" },
+      headers: { "X-Tenant": "acme" },
+    });
+
+    await act(async () => {
+      await box.api.sendMessage("hi");
+    });
+
+    expect(bodyOf(0).locale).toBe("en");
+    expect((calls()[0]![1]!.headers as Record<string, string>)["X-Tenant"]).toBe("acme");
+  });
+});
+
+describe("awaiting input", () => {
+  test("a parked run is neither streaming nor idle", async () => {
+    fetchMock.mockResolvedValueOnce(streamed(ASKING));
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      await box.api.sendMessage("refund me");
+    });
+
+    expect(box.api.status).toBe("awaiting-input");
+    expect(box.api.pending).toHaveLength(2);
+  });
+
+  test("approvals answered in one tick become one turn, with the signatures untouched", async () => {
+    // Sent separately, the first turn would deny the second call: a turn that
+    // leaves a pending call unanswered refuses it.
+    fetchMock.mockResolvedValueOnce(streamed(ASKING));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("refund me");
+    });
+
+    await act(async () => {
+      await Promise.all([
+        box.api.approve("tc_1", true),
+        box.api.approve("tc_2", false, "too old"),
+      ]);
+    });
+
+    expect(calls()).toHaveLength(2);
+    expect(bodyOf(1).turn).toEqual({
+      toolResults: [
+        { toolCallId: "tc_1", signature: "sig_one", approve: true },
+        { toolCallId: "tc_2", signature: "sig_two", approve: false, reason: "too old" },
+      ],
+    });
+  });
+
+  test("answer() carries a value under the same signature", async () => {
+    fetchMock.mockResolvedValueOnce(streamed(ASKING));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("refund me");
+    });
+
+    await act(async () => {
+      await box.api.answer("tc_1", { answer: "the March invoice" });
+    });
+
+    expect(bodyOf(1).turn.toolResults).toEqual([
+      { toolCallId: "tc_1", signature: "sig_one", output: { answer: "the March invoice" } },
+    ]);
+  });
+
+  test("pending clears the moment a turn goes out", async () => {
+    fetchMock.mockResolvedValueOnce(streamed(ASKING));
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("refund me");
+    });
+
+    await act(async () => {
+      void box.api.sendMessage("actually, never mind");
+    });
+
+    expect(box.api.pending).toEqual([]);
+    expect(box.api.status).toBe("submitted");
+  });
+
+  test("answering a call this client is not holding is reported, not sent", async () => {
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      await box.api.approve("tc_nope", true);
+    });
+
+    expect(calls()).toHaveLength(0);
+    expect(box.api.error).toMatchObject({ code: "invalid_tool_result", retryable: false });
+  });
+});
+
+describe("stop", () => {
+  test("the UI stops now, the run is ended by the route", async () => {
+    const run = controlled();
+    fetchMock.mockImplementation(async (_url: string, init: RequestInit) => {
+      init?.signal?.addEventListener("abort", () => run.abort());
+      return run.response;
+    });
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("write me an essay");
+    });
+    await act(async () => {
+      run.push(ANSWER[0]!, ANSWER[1]!, ANSWER[2]!);
+      await Promise.resolve();
+    });
+    expect(box.api.messages[1]!.content).toEqual([{ type: "text", text: "Hi there." }]);
+
+    await act(async () => {
+      await box.api.stop();
+    });
+
+    // The text the user already read is still there, marked as cut short.
+    expect(box.api.messages[1]!.content).toEqual([{ type: "text", text: "Hi there." }]);
+    expect(box.api.messages[1]!.finishReason).toBe("aborted");
+    expect(box.api.status).toBe("idle");
+    expect(calls()[1]![0]).toBe("/api/chat/stop");
+    expect(JSON.parse(calls()[1]![1]!.body as string)).toMatchObject({ runId: "run_1" });
+  });
+
+  test("nothing running means nothing to stop", async () => {
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      await box.api.stop();
+    });
+
+    expect(calls()).toHaveLength(0);
+  });
+});
+
+describe("attach on mount", () => {
+  test("asks the attach route, from the cursor this client left off at", async () => {
+    fetchMock.mockResolvedValueOnce(streamed(ANSWER.slice(2)));
+    const { box } = mount({ threadId: "th_9" });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(calls()[0]![0]).toBe("/api/chat/attach");
+    expect(bodyOf(0)).toEqual({ threadId: "th_9", cursor: -1 });
+    // The tail of a message this client never saw start.
+    expect(box.api.messages).toHaveLength(1);
+    expect(box.api.messages[0]!.content).toEqual([{ type: "text", text: "Hi there." }]);
+    expect(box.api.status).toBe("idle");
+  });
+
+  test("resumes past what initialMessages already contain", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    mount({
+      threadId: "th_9",
+      initialMessages: [{ id: "m1", role: "user", content: [], createdAt: "" }],
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(bodyOf(0).threadId).toBe("th_9");
+  });
+
+  test("nothing in flight is an ordinary answer, not an error", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const { box } = mount({ threadId: "th_9" });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(box.api.status).toBe("idle");
+    expect(box.api.error).toBeNull();
+  });
+
+  test("no threadId, no probe: there is no handle to ask about", async () => {
+    mount({});
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(calls()).toHaveLength(0);
+  });
+
+  test("attach: false skips it", async () => {
+    mount({ threadId: "th_9", attach: false });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(calls()).toHaveLength(0);
+  });
+});
+
+describe("regenerate", () => {
+  test("drops the last assistant turn and re-runs from the user turn before it", async () => {
+    const { box } = mount({
+      attach: false,
+      initialMessages: [
+        { id: "u1", role: "user", content: [{ type: "text", text: "say hi" }], createdAt: "" },
+        {
+          id: "a1",
+          role: "assistant",
+          content: [{ type: "text", text: "no" }],
+          createdAt: "",
+          finishReason: "stop",
+        },
+      ],
+    });
+
+    await act(async () => {
+      await box.api.regenerate();
+    });
+
+    expect(bodyOf(0).turn).toEqual({ text: "say hi" });
+    // The user turn is re-sent, not duplicated.
+    expect(box.api.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(box.api.messages[1]!.content).toEqual([{ type: "text", text: "Hi there." }]);
+  });
+
+  test("nothing to regenerate is a no-op", async () => {
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      await box.api.regenerate();
+    });
+
+    expect(calls()).toHaveLength(0);
+  });
+});
+
+describe("errors", () => {
+  test("a pre-flight failure is an HTTP error translated into an AgentError", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { message: "not signed in" } }), { status: 401 }),
+    );
+    const onError = vi.fn();
+    const { box } = mount({ attach: false, onError });
+
+    await act(async () => {
+      await box.api.sendMessage("hi");
+    });
+
+    expect(box.api.status).toBe("error");
+    expect(box.api.error).toEqual({ code: "unknown", message: "not signed in", retryable: false });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  test("429 is retryable and named", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("slow down", { status: 429 }));
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      await box.api.sendMessage("hi");
+    });
+
+    expect(box.api.error).toMatchObject({ code: "rate_limited", retryable: true });
+  });
+
+  test("an error event after the headers flushed reaches error and onError", async () => {
+    const onError = vi.fn();
+    fetchMock.mockResolvedValueOnce(
+      streamed([
+        { seq: 0, event: { type: "run-start", runId: "run_1" } },
+        {
+          seq: 1,
+          event: {
+            type: "error",
+            error: { code: "provider_error", message: "upstream 500", retryable: true },
+          },
+        },
+        { seq: 2, event: { type: "run-end", runId: "run_1", finishReason: "error" } },
+      ]),
+    );
+    const { box } = mount({ attach: false, onError });
+
+    await act(async () => {
+      await box.api.sendMessage("hi");
+    });
+
+    expect(box.api.error).toMatchObject({ code: "provider_error" });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  test("the next send clears it, so a retry does not have to", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("nope", { status: 500 }));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("hi");
+    });
+    expect(box.api.status).toBe("error");
+
+    await act(async () => {
+      await box.api.sendMessage("hi again");
+    });
+
+    expect(box.api.error).toBeNull();
+    expect(box.api.status).toBe("idle");
+  });
+});
+
+describe("lifecycle", () => {
+  test("onFinish fires once per completed message", async () => {
+    const onFinish = vi.fn();
+    const { box } = mount({ attach: false, onFinish });
+
+    await act(async () => {
+      await box.api.sendMessage("hi");
+    });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onFinish.mock.calls[0]![0]).toMatchObject({ id: "m1", finishReason: "stop" });
+  });
+
+  test("onAwaitingInput gets the pending calls", async () => {
+    const onAwaitingInput = vi.fn();
+    fetchMock.mockResolvedValueOnce(streamed(ASKING));
+    const { box } = mount({ attach: false, onAwaitingInput });
+
+    await act(async () => {
+      await box.api.sendMessage("hi");
+    });
+
+    expect(onAwaitingInput.mock.calls[0]![0]).toHaveLength(2);
+  });
+
+  test("unmount aborts the request in flight and sets no state after it", async () => {
+    const run = controlled();
+    let signal: AbortSignal | undefined;
+    fetchMock.mockImplementation(async (_url: string, init: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      init?.signal?.addEventListener("abort", () => run.abort());
+      return run.response;
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { box, unmount } = mount({ attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("hi");
+    });
+    await act(async () => {
+      run.push(ANSWER[0]!, ANSWER[1]!);
+      await Promise.resolve();
+    });
+
+    unmount();
+    expect(signal!.aborted).toBe(true);
+
+    // Frames that were already on the wire when the component went away.
+    await act(async () => {
+      try {
+        run.push(ANSWER[2]!);
+        run.close();
+      } catch {
+        // The stream is already errored by the abort; either way nothing may
+        // reach React.
+      }
+      await Promise.resolve();
+    });
+
+    // React logs "update on an unmounted component" through console.error.
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  test("a second send supersedes the first rather than interleaving two answers", async () => {
+    const first = controlled();
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      init?.signal?.addEventListener("abort", () => first.abort());
+      return first.response;
+    });
+    // A distinct run, whose frames number from zero again — which is exactly
+    // the case the cursor has to be told about.
+    fetchMock.mockImplementationOnce(async () =>
+      streamed([
+        { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
+        { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+        { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
+        { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
+        { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+      ]),
+    );
+    const { box } = mount({ attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("one");
+    });
+    await act(async () => {
+      first.push(ANSWER[0]!, ANSWER[1]!, ANSWER[2]!);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    // user, the interrupted assistant turn, user, the new answer.
+    expect(box.api.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    // The interrupted turn keeps the text it had produced.
+    expect(box.api.messages[1]!.content).toEqual([{ type: "text", text: "Hi there." }]);
+    expect(box.api.messages[3]!.content).toEqual([{ type: "text", text: "Second." }]);
+    expect(box.api.status).toBe("idle");
+  });
+});

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -48,6 +48,23 @@ export interface UseChatParams<P extends keyof AgentRoutes> {
   /** Server-rendered or restored history. */
   initialMessages?: AgentMessage<ToolsOf<P>, OutputOf<P>>[];
   /**
+   * Where the client that produced `initialMessages` left off, so `/attach` can
+   * be asked for the tail rather than the whole run.
+   *
+   * Without it the hook has to say "I have seen nothing", and a run kept alive
+   * past `run-end` — which `LiveRuns` does on purpose, so a refresh a second
+   * late still sees the ending — replays from the top onto a transcript that
+   * already has it. Take it from `cursor` on the previous mount and persist it
+   * beside the messages; the two belong together, and restoring one without the
+   * other is what produces a doubled answer.
+   *
+   * `runId` is half of it rather than decoration: frames number from zero in
+   * every run, so a bare number cannot say whether it describes the run that is
+   * live now. Given both, the server resumes when they match and replays from
+   * the start when they do not.
+   */
+  cursor?: { runId: string; seq: number };
+  /**
    * On mount, ask whether a run is still going on this thread and pick it back
    * up from where this client left off. Needs a `threadId` — that is the handle
    * that survives a refresh, which is why the client is never asked to stash a
@@ -72,6 +89,16 @@ export interface UseChatResult<P extends keyof AgentRoutes> {
   threadId?: string;
   /** The run being streamed or attached to, if any. */
   runId?: string;
+  /**
+   * How far this client has got, to hand back as `cursor` on the next mount.
+   *
+   * Persist it with `messages`: a restored transcript whose cursor was not
+   * restored asks `/attach` for a run it already has, and additive deltas
+   * arriving a second time are how an answer ends up printed twice. `runId` is
+   * undefined until a run has named itself, and the pair is meaningless until
+   * then — there is nothing to resume.
+   */
+  cursor: { runId?: string; seq: number };
 
   /**
    * The one way to advance the conversation. A string is shorthand for
@@ -122,16 +149,45 @@ export type AgentRequestBody = {
   turn: ClientTurn;
   threadId?: string;
   messages?: AgentMessage[];
+  /**
+   * A handle on this run, minted before the run has one.
+   *
+   * `stop` needs something to name, and the server's own `runId` does not reach
+   * the client until `run-start` — a gap covering the network round trip and
+   * the provider's time to first token, which is precisely the window a user
+   * cancels in. A thread id would do it where there is one, but the stateless
+   * first turn has neither. So the client names the run it is starting, and the
+   * server is expected to remember the mapping for as long as the run lives.
+   */
+  clientRunId: string;
 } & Record<string, unknown>;
 
-/** What `POST /api<path>/attach` receives: which thread, and how far this client
- *  already got. */
-export type AgentAttachBody = { threadId: string; cursor: number };
+/**
+ * What `POST /api<path>/attach` receives: which thread, and how far this client
+ * already got.
+ *
+ * `runId` says which run the cursor counts within. Absent, or naming a run that
+ * is not the live one, the cursor cannot be honoured and the run has to be
+ * replayed from the start.
+ */
+export type AgentAttachBody = { threadId: string; cursor: number; runId?: string };
+
+/**
+ * What `POST /api<path>/stop` receives.
+ *
+ * Every field is optional because the client stops runs it cannot always name:
+ * before `run-start` there is no `runId`, and a stateless first turn has no
+ * `threadId` either. Whichever handle is present is enough — resolve by
+ * `runId`, else by `clientRunId`, else the live run on `threadId`.
+ */
+export type AgentStopBody = { runId?: string; threadId?: string; clientRunId?: string };
 
 let localIdCounter = 0;
 
-/** Ids for messages the client authored. Server-assigned ids are what keep a
- *  reattached stream from duplicating a message, so the two must not collide. */
+/** Ids the client mints: messages it authored, and the correlation id it names a
+ *  run by before the server has. Server-assigned ids are what keep a reattached
+ *  stream from duplicating a message, so the two must not collide — hence the
+ *  prefix, which also tells a server log which end invented an id. */
 function localId() {
   const suffix =
     typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
@@ -206,6 +262,7 @@ export function useChat<P extends keyof AgentRoutes>(
   const {
     threadId: initialThreadId,
     initialMessages,
+    cursor: initialCursor,
     attach: attachOnMount = true,
     body: extraBody,
     headers,
@@ -238,13 +295,18 @@ export function useChat<P extends keyof AgentRoutes>(
     stateRef.current = initialChatState<any, any>({
       messages: initialMessages,
       threadId: initialThreadId,
+      seq: initialCursor?.seq,
+      cursorRunId: initialCursor?.runId,
     });
   }
   const [state, setState] = useState<ChatState<any, any>>(stateRef.current);
   const [phase, setPhase] = useState<"idle" | "submitted" | "streaming">("idle");
 
   const mountedRef = useRef(true);
-  const abortRef = useRef<AbortController | null>(null);
+  // The request in flight, carrying the id `stop()` names it by. The two travel
+  // together because a controller with no handle can only close the connection,
+  // and closing the connection is exactly what no longer stops a run.
+  const abortRef = useRef<{ controller: AbortController; clientRunId?: string } | null>(null);
   // The latest callbacks, so a stream started three renders ago still calls the
   // ones the component has now instead of a stale closure.
   const handlers = useRef({ onFinish, onError, onAwaitingInput });
@@ -256,7 +318,7 @@ export function useChat<P extends keyof AgentRoutes>(
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
-      abortRef.current?.abort();
+      abortRef.current?.controller.abort();
       abortRef.current = null;
     };
   }, []);
@@ -272,9 +334,24 @@ export function useChat<P extends keyof AgentRoutes>(
     if (mountedRef.current) setPhase(next);
   }, []);
 
+  /**
+   * Report a failure without touching the conversation.
+   *
+   * `pending` deliberately survives. Most of what fails here has nothing to do
+   * with the question the conversation is holding — an upload that 500s, an
+   * answer aimed at a call this client never had — and the pending calls carry
+   * the only signatures that can answer them, held nowhere else. Dropping them
+   * because an unrelated request failed would leave the user unable to approve
+   * anything at all, with a fresh turn (which the server reads as refusing
+   * everything) the only way out.
+   *
+   * The failures that really do end the turn clear `pending` where they happen:
+   * `send` clears it as the turn goes out, and the stream's own `error` event
+   * clears it in the reducer.
+   */
   const fail = useCallback(
     (error: AgentError) => {
-      commit({ ...stateRef.current!, error, pending: [] });
+      commit({ ...stateRef.current!, error });
       handlers.current.onError?.(error);
     },
     [commit],
@@ -309,8 +386,16 @@ export function useChat<P extends keyof AgentRoutes>(
 
         const event = frame.event;
         if (event.type === "message-end") {
+          // Only for a message that was not already finished. `seq` catches an
+          // ordinary redelivery, but a run replayed from the top onto a restored
+          // transcript is all new to the cursor, and firing `onFinish` again
+          // means an app that persists in it writes the message a second time.
+          // A message-end is terminal, so a second one is replay by definition.
+          const before = previous.messages.find((m: AgentMessage) => m.id === event.messageId);
           const message = next.messages.find((m: AgentMessage) => m.id === event.messageId);
-          if (message) handlers.current.onFinish?.(message);
+          if (message && before?.finishReason === undefined) {
+            handlers.current.onFinish?.(message);
+          }
         } else if (event.type === "awaiting-input") {
           handlers.current.onAwaitingInput?.(event.pending as PendingToolCall<ToolsOf<P>>[]);
         } else if (event.type === "error") {
@@ -327,11 +412,21 @@ export function useChat<P extends keyof AgentRoutes>(
       // One run at a time per hook. A second send while the first is streaming
       // is a user who changed their mind, not a request to interleave two
       // assistants into one transcript.
-      abortRef.current?.abort();
+      //
+      // The superseded turn is marked aborted as it is cut, not left to whatever
+      // stamps it later: a message with no finish reason is indistinguishable
+      // from one still streaming, and the next run's `run-end` would otherwise
+      // find it and label an answer that stopped mid-sentence "stop". In
+      // stateless mode that reason is posted back to the server on every later
+      // turn, so the model would be told the interruption never happened.
+      const superseded = abortRef.current;
+      superseded?.controller.abort();
+      const clientRunId = localId();
       const controller = new AbortController();
-      abortRef.current = controller;
+      abortRef.current = { controller, clientRunId };
 
-      const history = stateRef.current!.messages;
+      const previous = superseded ? markAborted(stateRef.current!) : stateRef.current!;
+      const history = previous.messages;
       const authored: AgentMessage[] =
         turn.text || turn.files?.length
           ? [
@@ -348,7 +443,7 @@ export function useChat<P extends keyof AgentRoutes>(
           : [];
 
       commit({
-        ...stateRef.current!,
+        ...previous,
         messages: [...history, ...authored],
         // The error belonged to the attempt being retried. Leaving it up while
         // the retry streams is a UI that reports a failure and a success at once.
@@ -366,6 +461,7 @@ export function useChat<P extends keyof AgentRoutes>(
       try {
         const payload: AgentRequestBody = {
           turn,
+          clientRunId,
           ...(stateRef.current!.threadId
             ? { threadId: stateRef.current!.threadId }
             : { messages: history }),
@@ -388,7 +484,7 @@ export function useChat<P extends keyof AgentRoutes>(
           });
         }
       } finally {
-        if (abortRef.current === controller) {
+        if (abortRef.current?.controller === controller) {
           abortRef.current = null;
           setPhaseSafe("idle");
         }
@@ -483,18 +579,42 @@ export function useChat<P extends keyof AgentRoutes>(
     // The UI stops now. The POST below is what actually ends the generation and
     // any tool mid-flight, and it may take a moment; a user who clicked stop
     // must not keep watching tokens arrive while it flies.
-    abortRef.current?.abort();
+    const inFlight = abortRef.current;
+    inFlight?.controller.abort();
     abortRef.current = null;
     commit(markAborted(stateRef.current!));
     setPhaseSafe("idle");
-    if (!runId) return;
+    // Whether there is anything to stop is a question about the *request*, not
+    // about `runId`. Gating on `runId` meant the whole time-to-first-token
+    // window — the seconds a user is most likely to cancel in, and longer when
+    // the agent searches for deferred tools first — silently posted nothing,
+    // leaving a tool loop running that a dropped connection does not touch. The
+    // same hole reopened on a correct attach, whose tail carries no `run-start`.
+    if (!inFlight && !runId) return;
+    // Three handles, any of which the route can resolve by; which ones exist
+    // depends on how far the run got. `clientRunId` is the one that is always
+    // there for a turn this client started, which is what closes the window.
+    const body: AgentStopBody = {
+      ...(runId ? { runId } : {}),
+      ...(threadId ? { threadId } : {}),
+      ...(inFlight?.clientRunId ? { clientRunId: inFlight.clientRunId } : {}),
+    };
     try {
-      await post(`${url}/stop`, { runId, threadId });
-    } catch {
-      // The run may still be going server-side, but the transcript already says
-      // it was cut and there is nothing useful to retry from here.
+      const response = await post(`${url}/stop`, body);
+      // A failed stop is not cosmetic. The transcript says the turn was cut, so
+      // the UI looks settled, while the run may still be working through its
+      // tool loop and still billing for it — the one failure here a user would
+      // want to know about, and previously the one that was swallowed.
+      if (!response.ok) fail(await httpError(response));
+    } catch (error) {
+      if (isAbort(error)) return;
+      fail({
+        code: "unknown",
+        message: error instanceof Error ? error.message : String(error),
+        retryable: true,
+      });
     }
-  }, [commit, post, setPhaseSafe]);
+  }, [commit, fail, post, setPhaseSafe]);
 
   const regenerate = useCallback(async () => {
     const messages = stateRef.current!.messages as AgentMessage[];
@@ -568,10 +688,20 @@ export function useChat<P extends keyof AgentRoutes>(
     // already running on it.
     if (attachOnMount === false || !initialThreadId) return;
     const controller = new AbortController();
-    abortRef.current = controller;
+    // No `clientRunId`: this client did not start the run, so the thread is the
+    // only handle it has on it — and `/attach` needs one anyway.
+    abortRef.current = { controller };
     void (async () => {
       try {
-        const body: AgentAttachBody = { threadId: initialThreadId, cursor: stateRef.current!.seq };
+        const body: AgentAttachBody = {
+          threadId: initialThreadId,
+          // The cursor the caller restored alongside `initialMessages`, so the
+          // route can send the tail. Left at -1 it says "I have seen nothing",
+          // and a run still inside its post-`run-end` TTL replays from the top
+          // onto a transcript that already holds it.
+          cursor: stateRef.current!.seq,
+          ...(stateRef.current!.cursorRunId ? { runId: stateRef.current!.cursorRunId } : {}),
+        };
         const response = await post(`${requestRef.current.base}/attach`, body, controller.signal);
         // Nothing running is the ordinary answer, not a failure: the route says
         // so with an empty response and the screen simply stays as it was.
@@ -581,7 +711,7 @@ export function useChat<P extends keyof AgentRoutes>(
         // A probe that could not be made leaves the client exactly where a
         // client without `attach` would be — with its own history and no run.
       } finally {
-        if (abortRef.current === controller) {
+        if (abortRef.current?.controller === controller) {
           abortRef.current = null;
           setPhaseSafe("idle");
         }
@@ -609,6 +739,7 @@ export function useChat<P extends keyof AgentRoutes>(
     error: state.error,
     threadId: state.threadId,
     runId: state.runId,
+    cursor: { runId: state.cursorRunId, seq: state.seq },
     sendMessage,
     stop,
     regenerate,

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -1,6 +1,16 @@
-// @ts-nocheck — the ai rfc is a sketch; see Schema.ts for the full note.
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { RPC } from "../client/rpc";
-import type { AgentError, AgentMessage, ClientTurn, PendingToolCall, ToolShapes } from "./types";
+import { useParams } from "../client/useParams";
+import { applyFrame, initialChatState, markAborted, type ChatState } from "./client/reducer";
+import { decodeSSE } from "./client/sse";
+import type {
+  AgentError,
+  AgentMessage,
+  ClientToolResult,
+  ClientTurn,
+  PendingToolCall,
+  ToolShapes,
+} from "./types";
 
 /**
  * The agent routes, picked out of the same `RPC` interface `useQuery` and
@@ -101,6 +111,85 @@ export interface UseChatResult<P extends keyof AgentRoutes> {
 }
 
 /**
+ * What `POST /api<path>` receives.
+ *
+ * One route for every client turn, so the body has to say which mode it is in:
+ * with a `threadId` the server owns the history, without one the client carries
+ * it and sends the transcript *before* this turn — the turn itself is never in
+ * `messages`, or the server would see it twice.
+ */
+export type AgentRequestBody = {
+  turn: ClientTurn;
+  threadId?: string;
+  messages?: AgentMessage[];
+} & Record<string, unknown>;
+
+/** What `POST /api<path>/attach` receives: which thread, and how far this client
+ *  already got. */
+export type AgentAttachBody = { threadId: string; cursor: number };
+
+let localIdCounter = 0;
+
+/** Ids for messages the client authored. Server-assigned ids are what keep a
+ *  reattached stream from duplicating a message, so the two must not collide. */
+function localId() {
+  const suffix =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${localIdCounter++}`;
+  return `local_${suffix}`;
+}
+
+/** The same substitution `useMutation` does, so a parameterised agent path
+ *  behaves like every other route in the package. */
+function applyRouteParams(url: string, params: Record<string, string>) {
+  let out = url;
+  for (const [key, value] of Object.entries(params)) {
+    out = out.replace(`:${key}?`, value).replace(`:${key}`, value);
+  }
+  return out;
+}
+
+function isAbort(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: string }).name === "AbortError"
+  );
+}
+
+async function httpError(response: Response): Promise<AgentError> {
+  // Anything that fails before the headers flush is an ordinary HTTP error —
+  // auth, validation, an unknown agent — and never reaches the stream's own
+  // error event, so it has to be translated into the same shape here.
+  let message = response.statusText || `Request failed with status ${response.status}`;
+  try {
+    const data = (await response.json()) as { error?: { message?: string }; message?: string };
+    message = data?.error?.message ?? data?.message ?? message;
+  } catch {
+    // Not JSON. The status line is all there is.
+  }
+  return {
+    code: response.status === 429 ? "rate_limited" : "unknown",
+    message,
+    retryable: response.status === 429 || response.status >= 500,
+  };
+}
+
+function turnFrom(message: AgentMessage): ClientTurn {
+  let text = "";
+  const files: NonNullable<ClientTurn["files"]> = [];
+  for (const part of message.content) {
+    if (part.type === "text") text += part.text;
+    if (part.type === "file") {
+      files.push({ fileId: part.fileId, name: part.name, mimeType: part.mimeType });
+    }
+  }
+  return { ...(text ? { text } : {}), ...(files.length > 0 ? { files } : {}) };
+}
+
+/**
  * The path is the agent's route, exactly as mounted:
  *
  *   const { messages, sendMessage } = useChat("/chat")
@@ -110,7 +199,423 @@ export interface UseChatResult<P extends keyof AgentRoutes> {
  * carried through `Agent`, `AgentRoute` and `RPC` instead of being erased at the
  * first boundary.
  */
-export declare function useChat<P extends keyof AgentRoutes>(
+export function useChat<P extends keyof AgentRoutes>(
   path: P,
-  params?: UseChatParams<P>,
-): UseChatResult<P>;
+  params: UseChatParams<P> = {},
+): UseChatResult<P> {
+  const {
+    threadId: initialThreadId,
+    initialMessages,
+    attach: attachOnMount = true,
+    body: extraBody,
+    headers,
+    onFinish,
+    onError,
+    onAwaitingInput,
+  } = params;
+
+  const routeParams = useParams();
+  const base = useMemo(
+    // A route key may or may not carry a method prefix depending on how `RPC`
+    // renders it; stripping one is free and stops `/api/POST:/chat` from being
+    // a possibility.
+    () => `/api${applyRouteParams(String(path).replace(/^[A-Z]+:/, ""), routeParams)}`,
+    [path, routeParams],
+  );
+
+  /**
+   * The state lives in a ref and is mirrored into `useState` for rendering.
+   *
+   * A stream applies frames faster than React commits, and the reducer needs
+   * the result of the previous frame, not the value captured when the loop
+   * started. The ref is the source of truth; `setState` is the notification.
+   *
+   * `any` inside, exact at the boundary: the wire carries erased tool shapes and
+   * the route's real ones are re-asserted once, in the returned object.
+   */
+  const stateRef = useRef<ChatState<any, any> | null>(null);
+  if (stateRef.current === null) {
+    stateRef.current = initialChatState<any, any>({
+      messages: initialMessages,
+      threadId: initialThreadId,
+    });
+  }
+  const [state, setState] = useState<ChatState<any, any>>(stateRef.current);
+  const [phase, setPhase] = useState<"idle" | "submitted" | "streaming">("idle");
+
+  const mountedRef = useRef(true);
+  const abortRef = useRef<AbortController | null>(null);
+  // The latest callbacks, so a stream started three renders ago still calls the
+  // ones the component has now instead of a stale closure.
+  const handlers = useRef({ onFinish, onError, onAwaitingInput });
+  handlers.current = { onFinish, onError, onAwaitingInput };
+  const requestRef = useRef({ base, headers, extraBody });
+  requestRef.current = { base, headers, extraBody };
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortRef.current?.abort();
+      abortRef.current = null;
+    };
+  }, []);
+
+  const commit = useCallback((next: ChatState<any, any>) => {
+    stateRef.current = next;
+    // Nothing after unmount: the stream loop is async and outlives the render
+    // that started it.
+    if (mountedRef.current) setState(next);
+  }, []);
+
+  const setPhaseSafe = useCallback((next: "idle" | "submitted" | "streaming") => {
+    if (mountedRef.current) setPhase(next);
+  }, []);
+
+  const fail = useCallback(
+    (error: AgentError) => {
+      commit({ ...stateRef.current!, error, pending: [] });
+      handlers.current.onError?.(error);
+    },
+    [commit],
+  );
+
+  const post = useCallback((url: string, payload: unknown, signal?: AbortSignal) => {
+    const { headers: extraHeaders } = requestRef.current;
+    return fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...extraHeaders },
+      body: JSON.stringify(payload),
+      signal,
+    });
+  }, []);
+
+  const consume = useCallback(
+    async (response: Response, signal: AbortSignal) => {
+      for await (const frame of decodeSSE(response.body)) {
+        // The signal is checked here as well as by `fetch`, because `stop()`
+        // has to stop the *UI* whether or not the transport under it honours an
+        // abort promptly. A token that lands after the user cancelled is worse
+        // than one that never arrives.
+        if (!mountedRef.current || signal.aborted) return;
+        setPhaseSafe("streaming");
+        const previous = stateRef.current!;
+        const next = applyFrame(previous, frame);
+        // A frame at or below the cursor. Reattachment and retrying proxies both
+        // produce these; applying the deltas again would double the text, and
+        // firing `onFinish` again would double whatever the app does with it.
+        if (next === previous) continue;
+        commit(next);
+
+        const event = frame.event;
+        if (event.type === "message-end") {
+          const message = next.messages.find((m: AgentMessage) => m.id === event.messageId);
+          if (message) handlers.current.onFinish?.(message);
+        } else if (event.type === "awaiting-input") {
+          handlers.current.onAwaitingInput?.(event.pending as PendingToolCall<ToolsOf<P>>[]);
+        } else if (event.type === "error") {
+          handlers.current.onError?.(event.error);
+        }
+      }
+    },
+    [commit, setPhaseSafe],
+  );
+
+  const send = useCallback(
+    async (turn: ClientTurn) => {
+      const { base: url, extraBody: body } = requestRef.current;
+      // One run at a time per hook. A second send while the first is streaming
+      // is a user who changed their mind, not a request to interleave two
+      // assistants into one transcript.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const history = stateRef.current!.messages;
+      const authored: AgentMessage[] =
+        turn.text || turn.files?.length
+          ? [
+              {
+                id: localId(),
+                role: "user",
+                content: [
+                  ...(turn.text ? [{ type: "text" as const, text: turn.text }] : []),
+                  ...(turn.files ?? []).map((file) => ({ type: "file" as const, ...file })),
+                ],
+                createdAt: new Date().toISOString(),
+              },
+            ]
+          : [];
+
+      commit({
+        ...stateRef.current!,
+        messages: [...history, ...authored],
+        // The error belonged to the attempt being retried. Leaving it up while
+        // the retry streams is a UI that reports a failure and a success at once.
+        error: null,
+        // Answered or not, this turn resolves every pending call — the server
+        // denies whatever the turn left out — so holding them would leave the UI
+        // asking a question that is already settled. No local tool-result parts
+        // are fabricated here: the server emits one per call, denials included,
+        // and guessing at the output of a call it has not run yet would be a lie
+        // the stream then contradicts.
+        pending: [],
+      });
+      setPhaseSafe("submitted");
+
+      try {
+        const payload: AgentRequestBody = {
+          turn,
+          ...(stateRef.current!.threadId
+            ? { threadId: stateRef.current!.threadId }
+            : { messages: history }),
+          ...body,
+        };
+        const response = await post(url, payload, controller.signal);
+        if (!response.ok) {
+          fail(await httpError(response));
+          return;
+        }
+        await consume(response, controller.signal);
+      } catch (error) {
+        // An abort is `stop()` or unmount; both already put the UI where it
+        // belongs, and reporting it as a failure would be wrong twice.
+        if (!isAbort(error)) {
+          fail({
+            code: "unknown",
+            message: error instanceof Error ? error.message : String(error),
+            retryable: true,
+          });
+        }
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          setPhaseSafe("idle");
+        }
+      }
+    },
+    [commit, consume, fail, post, setPhaseSafe],
+  );
+
+  const sendMessage = useCallback(
+    (turn: ClientTurn | string) => send(typeof turn === "string" ? { text: turn } : turn),
+    [send],
+  );
+
+  /**
+   * Answers queued within one tick become one turn.
+   *
+   * This is not an optimisation. A turn that leaves a pending call unanswered
+   * denies it, so sending three approvals as three turns would have the first
+   * one refuse the other two — and the natural UI code, a loop over `pending`
+   * calling `approve` for each, is exactly that shape. Coalescing on the
+   * microtask is what makes the declared per-call signature safe to use the way
+   * it reads.
+   */
+  const queued = useRef<{ results: ClientToolResult[]; flushed: Promise<void> } | null>(null);
+
+  const queueResult = useCallback(
+    (result: ClientToolResult) => {
+      if (queued.current) {
+        queued.current.results.push(result);
+        return queued.current.flushed;
+      }
+      const results: ClientToolResult[] = [result];
+      const flushed = Promise.resolve().then(() => {
+        queued.current = null;
+        return send({ toolResults: results });
+      });
+      queued.current = { results, flushed };
+      return flushed;
+    },
+    [send],
+  );
+
+  const resultFor = useCallback(
+    (toolCallId: string, build: (signature: string) => ClientToolResult) => {
+      const call = stateRef.current!.pending.find(
+        (candidate: PendingToolCall) => candidate.toolCallId === toolCallId,
+      );
+      if (!call) {
+        // Not a network failure: the app answered a call this client is not
+        // holding. Surfacing it beats sending a turn the server will reject for
+        // a missing signature, which is where it would otherwise show up.
+        fail({
+          code: "invalid_tool_result",
+          message: `No pending tool call ${toolCallId}`,
+          toolCallId,
+          retryable: false,
+        });
+        return null;
+      }
+      // The signature travels back exactly as it arrived. It signs the input the
+      // server proposed, so an app that never touches it cannot approve one
+      // thing and have another run.
+      return build(call.signature);
+    },
+    [fail],
+  );
+
+  const approve = useCallback(
+    async (toolCallId: string, approved: boolean, reason?: string) => {
+      const result = resultFor(toolCallId, (signature) => ({
+        toolCallId,
+        signature,
+        approve: approved,
+        ...(reason ? { reason } : {}),
+      }));
+      if (result) await queueResult(result);
+    },
+    [queueResult, resultFor],
+  );
+
+  const answer = useCallback(
+    async (toolCallId: string, output: unknown) => {
+      const result = resultFor(toolCallId, (signature) => ({ toolCallId, signature, output }));
+      if (result) await queueResult(result);
+    },
+    [queueResult, resultFor],
+  );
+
+  const stop = useCallback(async () => {
+    const { base: url } = requestRef.current;
+    const { runId, threadId } = stateRef.current!;
+    // The UI stops now. The POST below is what actually ends the generation and
+    // any tool mid-flight, and it may take a moment; a user who clicked stop
+    // must not keep watching tokens arrive while it flies.
+    abortRef.current?.abort();
+    abortRef.current = null;
+    commit(markAborted(stateRef.current!));
+    setPhaseSafe("idle");
+    if (!runId) return;
+    try {
+      await post(`${url}/stop`, { runId, threadId });
+    } catch {
+      // The run may still be going server-side, but the transcript already says
+      // it was cut and there is nothing useful to retry from here.
+    }
+  }, [commit, post, setPhaseSafe]);
+
+  const regenerate = useCallback(async () => {
+    const messages = stateRef.current!.messages as AgentMessage[];
+    let assistantIndex = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === "assistant") {
+        assistantIndex = i;
+        break;
+      }
+    }
+    if (assistantIndex === -1) return;
+    let userIndex = -1;
+    for (let i = assistantIndex - 1; i >= 0; i--) {
+      if (messages[i]!.role === "user") {
+        userIndex = i;
+        break;
+      }
+    }
+    if (userIndex === -1) return;
+
+    const turn = turnFrom(messages[userIndex]!);
+    // The user turn goes too, because `send` re-appends it. Keeping it here and
+    // sending it again would show the question twice.
+    commit({
+      ...stateRef.current!,
+      messages: messages.slice(0, userIndex),
+      pending: [],
+      error: null,
+    });
+    await send(turn);
+  }, [commit, send]);
+
+  const setMessages = useCallback(
+    (messages: AgentMessage<ToolsOf<P>, OutputOf<P>>[]) => {
+      commit({ ...stateRef.current!, messages: messages as AgentMessage<any, any>[] });
+    },
+    [commit],
+  );
+
+  const uploadFile = useCallback(
+    async (file: File) => {
+      const { base: url, headers: extraHeaders } = requestRef.current;
+      const form = new FormData();
+      form.append("file", file);
+      // No Content-Type: the boundary is the browser's to write.
+      const response = await fetch(`${url}/files`, {
+        method: "POST",
+        headers: { ...extraHeaders },
+        body: form,
+      });
+      if (!response.ok) {
+        const error = await httpError(response);
+        fail(error);
+        throw new Error(error.message);
+      }
+      const data = (await response.json()) as { fileId: string; name?: string; mimeType?: string };
+      // The route only has to return the id; the name and type are already here,
+      // so the caller gets something it can hand straight to `sendMessage`.
+      return {
+        fileId: data.fileId,
+        name: data.name ?? file.name,
+        mimeType: data.mimeType ?? file.type,
+      };
+    },
+    [fail],
+  );
+
+  useEffect(() => {
+    // Mount only, deliberately: `threadId` is the handle that survives a
+    // refresh, and re-probing every time it changes would race a stream that is
+    // already running on it.
+    if (attachOnMount === false || !initialThreadId) return;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    void (async () => {
+      try {
+        const body: AgentAttachBody = { threadId: initialThreadId, cursor: stateRef.current!.seq };
+        const response = await post(`${requestRef.current.base}/attach`, body, controller.signal);
+        // Nothing running is the ordinary answer, not a failure: the route says
+        // so with an empty response and the screen simply stays as it was.
+        if (!response.ok || response.status === 204 || !response.body) return;
+        await consume(response, controller.signal);
+      } catch {
+        // A probe that could not be made leaves the client exactly where a
+        // client without `attach` would be — with its own history and no run.
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          setPhaseSafe("idle");
+        }
+      }
+    })();
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const status: ChatStatus =
+    // Ordered so the declared invariant — `pending` non-empty exactly when the
+    // status is `awaiting-input` — is true by construction rather than by
+    // everything downstream remembering to keep it.
+    state.pending.length > 0
+      ? "awaiting-input"
+      : phase !== "idle"
+        ? phase
+        : state.error
+          ? "error"
+          : "idle";
+
+  return {
+    messages: state.messages as AgentMessage<ToolsOf<P>, OutputOf<P>>[],
+    status,
+    error: state.error,
+    threadId: state.threadId,
+    runId: state.runId,
+    sendMessage,
+    stop,
+    regenerate,
+    setMessages,
+    pending: state.pending as PendingToolCall<ToolsOf<P>>[],
+    approve,
+    answer,
+    attach: uploadFile,
+  };
+}


### PR DESCRIPTION
> **Stack**, bottom to top — each PR is based on the one above it:
> 1. `ai/1-schema` — the schema builder runtime
> 2. `ai/2-provider` — the OpenAI and Azure providers
> 3. `ai/3-agent` — the agent run loop and signing
> 4. `ai/4-controller` — controller, stores, `ApiRouter.agent()`
> 5. **`ai/5-client` — you are here** — `useChat` and stream decoding
> 6. `ai/6-exports` — module exports and the example

`useChat`, plus the two pieces of it a DOM cannot help test: a chunk-tolerant SSE decoder and a pure reducer that folds one frame into a `ChatState`.

## The decisions

**`applyFrame` returns the *identical object* when a frame has already been applied,** and the hook reads `next === previous` to know not to re-fire `onFinish`. That is the seam the whole replay story hangs on.

**`seq` counts within one run, not across a thread.** The hook tests found this: a second turn numbers from zero and the first run's cursor swallowed it. A `run-start` naming an unseen run drops the cursor, which meant remembering the run the cursor belongs to (`cursorRunId`) separately from the live `runId` — they diverge at run-end.

**Tool calls and results upsert by `toolCallId` rather than appending,** every id-carrying event creates its message if absent, and `output-delta` takes the snapshot rather than accumulating. Each of those is what mid-run attachment requires: a client that joins at frame 200 must converge on the same state as one that saw frame 0.

**State lives in a ref mirrored into `useState`.** A stream applies frames faster than React commits, and the reducer needs the result of the previous frame, not the value captured when the loop started.

**`approve`/`answer` coalesce on the microtask into one turn.** A turn that leaves a pending call unanswered *denies* it, so a `pending.map(approve)` loop must not become N turns. The signature is handed back untouched.

**The decoder is tested by exhaustive byte-level splitting** — every possible chunk boundary of the same stream must decode identically. That is what catches a CR held across a boundary, which hand-rolled SSE parsers almost always get wrong. A truncated tail is discarded per spec; a single unparseable frame is skipped rather than fatal.

## Contract additions

These are the seam with `ai/4-controller`, and they are now typed and exported rather than implied. The controller half is implemented one PR down.

- **`AgentRequestBody.clientRunId`** — a correlation id the client mints per send. It is the only handle `/stop` has during the window between the POST and `run-start`.
- **`AgentStopBody`** — `{runId?, threadId?, clientRunId?}`, all optional, because which handle exists depends on how far the run got. Resolve by `runId`, else `clientRunId`, else the live run on `threadId`.
- **`AgentAttachBody.runId`** — names the run the `cursor` counts within. Honour the cursor only on a match; a bare cursor across a run boundary silently drops the head of the new run.
- **`UseChatParams.cursor`** and **`UseChatResult.cursor`**, both `{runId, seq}`. An app that persists `messages` across a refresh must persist the cursor with them — restoring one without the other is the doubled-answer bug below.

## What the review round changed

Six findings, one blocking; all six fixed. Each fix was mutation-checked on its own by reverting it against the full suite.

- **Attach-on-mount always sent cursor `-1`, so the replay doubled text the client already had.** `initialChatState` accepted a `seq` and nothing could supply one. `LiveRuns` keeps a run for a short while after run-end, so the ordinary refresh right after an answer replayed from seq 0 on top of the restored transcript: text deltas are additive and the only dedup is `seq`, so the message's own text was appended twice and `onFinish` fired again — an app that persists in `onFinish` wrote every message twice. The reviewer's fix was half of it: a bare cursor is not restorable, because `seq` restarts in every run, so `cursor` is a `{runId, seq}` pair everywhere it appears. Belt-and-braces as suggested, narrowed to the two additive cases (`text-delta`, `reasoning-delta`) since the keyed upserts are already idempotent, and extended to `onFinish`.
- **`run-end` stamped an earlier interrupted turn with the new run's `finishReason`.** A superseded send aborts its controller but never marked the cut-off message, so when the next run finished cleanly its `run-end` labelled the abandoned turn `"stop"` — and in stateless mode that wrong reason was posted back to the server on every later turn. `types.ts` is explicit that an aborted message must stay distinguishable. Both halves fixed: `send()` marks the superseded run aborted, and `run-end` only finishes off the messages this run touched.
- **`stop()` did nothing when the run had not sent `run-start` yet** — the network round trip plus time to first token, which is precisely the window a user cancels in. `AgentController.stop`'s own declaration says a dropped connection no longer stops a run and this route is the only thing that does, so the tool loop kept running and kept charging. Gating on `runId || threadId` still leaves a stateless first turn uncovered, which is why `clientRunId` exists. The same hole reopened on a correct attach, whose replayed tail carries no `run-start`.
- **`fail()` cleared `pending`, so an unrelated error threw away a standing question and its signatures.** A failed file upload wiped the approvals the user still had to answer, and the signatures are the only thing that can answer them — they are held nowhere else. It no longer touches `pending` at all: `send()` already clears it as the turn goes out, and the stream's own `error` event clears it in the reducer, so the two paths that genuinely end a turn were never relying on `fail()`.
- A test named "resumes past what `initialMessages` already contain" asserted only the thread id and would have passed with every line of cursor handling deleted. It now asserts the whole body and is the regression test for the cursor.
- **A `usage` event arriving before any `message-start` attached token counts to the user's own message.** Fixed with a role test, but *not* also narrowed to this run's messages as suggested: that breaks the exhaustive "converges from any mid-run cursor" property, because a client resuming mid-message has touched none of this run's messages yet and would silently drop the usage — making it the one event that fails to converge. The residual case is commented.

## Still open

- **`tool-progress` is decoded and then dropped.** `AgentMessage` has no part type for it and `UseChatResult` exposes nothing to hold it, so surfacing the streaming output the example advertises needs a contract addition this slice deliberately did not make. `tool-search` is likewise consumed for its `seq` only.
- `regenerate()` rebuilds the turn from the user message's text and file parts, so a turn that was purely an answer to a pending call cannot be reconstructed — the signature is gone. Regenerating across one re-runs from the nearest user utterance.
- Attach-on-mount runs with an empty dependency array by design, so a `threadId` supplied late by the app is not probed.
- The hook tests stub `fetch` and construct `Response`s by hand; they never exercise a real fetch's abort-to-stream plumbing. There is a signal check inside the read loop so `stop()` ends the UI even if the transport is slow to abort, but the transport half is untested.

## Verification

At this branch: `bun run typecheck` clean, `bun run test:types` 7 files / 73 tests / no type errors, `bun --bun vitest run` 178 files / 4273 passed / 1 skipped. `oxlint` over `ai/useChat.tsx` and `ai/client/`: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnj9jSx45LoYp5tiv1W8Nw
