### PR TITLE
A nested transcript is built by the reducer that already builds one

### DIFF
--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -2,7 +2,8 @@ process.env.SECRET ??= "agent-test-secret";
 
 import { describe, expect, test, vi } from "vitest";
 import { Agent, AgentTool, Skill, ToolNamespace } from "./Agent";
-import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "./AgentProvider";
+import type { AgentProvider, ProviderEvent } from "./AgentProvider";
+import { fakeProvider } from "./providers/fakeProvider";
 import type { Schema } from "./Schema";
 import { readSignature, verifyPendingCall } from "./signing";
 import type {
@@ -76,53 +77,6 @@ const usage = (inputTokens: number, outputTokens: number): Usage => ({
   outputTokens,
   totalTokens: inputTokens + outputTokens,
 });
-
-/**
- * Scripted `ProviderEvent`s, one script per model call.
- *
- * The real provider is written against the same interface elsewhere; depending
- * on it here would make these tests a test of two things at once, and would
- * need a network.
- */
-class FakeProvider {
-  readonly model = "fake";
-  readonly capabilities = {
-    reasoning: true,
-    structuredOutput: true,
-    fileInput: true,
-    parallelToolCalls: true,
-    toolSearch: true,
-  };
-  readonly calls: ProviderStreamParams[] = [];
-
-  constructor(private scripts: ProviderEvent[][]) {}
-
-  stream(params: ProviderStreamParams) {
-    this.calls.push(params);
-    const script = this.scripts[this.calls.length - 1] ?? [
-      { type: "finish", reason: "stop", usage: usage(0, 0) },
-    ];
-    return (async function* () {
-      for (const event of script) yield event;
-    })();
-  }
-
-  async upload() {
-    return "file_1";
-  }
-
-  normalizeError(error: unknown) {
-    return {
-      code: "provider_error" as const,
-      message: error instanceof Error ? error.message : String(error),
-      retryable: false,
-    };
-  }
-}
-
-function fakeProvider(...scripts: ProviderEvent[][]) {
-  return new FakeProvider(scripts) as unknown as AgentProvider & FakeProvider;
-}
 
 function deferred<T = void>() {
   let resolve!: (value: T) => void;

--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -1,11 +1,12 @@
 process.env.SECRET ??= "agent-test-secret";
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { Agent, AgentTool, Skill, ToolNamespace } from "./Agent";
 import type { AgentProvider, ProviderEvent } from "./AgentProvider";
 import { fakeProvider } from "./providers/fakeProvider";
 import type { Schema } from "./Schema";
 import { readSignature, verifyPendingCall } from "./signing";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS } from "./store/sse";
 import type {
   AgentMessage,
   AgentStreamEvent,
@@ -950,6 +951,91 @@ describe("a run outliving its request", () => {
     expect(body.startsWith("id: 2\ndata: {")).toBe(true);
     expect(body).toContain('"type":"text-delta"');
     expect(body.endsWith("\n\n")).toBe(true);
+  });
+});
+
+describe("toResponse keepalive", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Reads until a read stays pending, and hands that pending read back.
+   *
+   * Boxed rather than returned bare: an async function that returns a promise
+   * adopts it, and the caller would then be waiting for the very chunk the
+   * test has not produced yet.
+   */
+  async function untilSilent(reader: ReadableStreamDefaultReader<Uint8Array>) {
+    while (true) {
+      let settled = false;
+      const next = reader.read().then((chunk) => {
+        settled = true;
+        return chunk;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      if (!settled) return { next };
+    }
+  }
+
+  test("a comment line goes out while a tool is running, and no timer outlives the stream", async () => {
+    vi.useFakeTimers();
+    const started = deferred();
+    const release = deferred<any>();
+    const slow = AgentTool.create({
+      name: "slow",
+      description: "Finishes eventually",
+      inputSchema: anything(),
+      execute: () => {
+        started.resolve();
+        return release.promise;
+      },
+    });
+    const provider = fakeProvider([toolCall("c1", "slow", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "patient", provider, tools: [slow] });
+    const run = agent.stream({ messages: [], req });
+
+    const reader = run.toResponse().body!.getReader();
+    const bytes = new TextDecoder();
+    await started.promise;
+
+    // The tool is running and nothing has been written for a while.
+    const { next } = await untilSilent(reader);
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await next).value)).toBe(SSE_KEEPALIVE);
+
+    release.resolve({ ok: true });
+    let last = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      last = bytes.decode(value);
+    }
+    expect(last).toContain('"type":"run-end"');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a reader that cancels leaves no timer behind either", async () => {
+    vi.useFakeTimers();
+    const release = deferred<any>();
+    const slow = AgentTool.create({
+      name: "slow",
+      description: "Finishes eventually",
+      inputSchema: anything(),
+      execute: () => release.promise,
+    });
+    const provider = fakeProvider([toolCall("c1", "slow", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "patient", provider, tools: [slow] });
+    const run = agent.stream({ messages: [], req });
+
+    const response = run.toResponse();
+    expect(vi.getTimerCount()).toBe(1);
+    await response.body!.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+
+    release.resolve({ ok: true });
+    expect((await run.result()).finishReason).toBe("stop");
   });
 });
 

--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -1227,6 +1227,8 @@ describe("a sub-agent that runs to completion", () => {
       "user",
       "assistant",
     ]);
+    // Unsigned: nothing is executed on the strength of a finished record.
+    expect("signature" in part.nested[0]).toBe(false);
     expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
       status: "ok",
       output: { heard: "eleven", from: "researcher" },
@@ -2085,6 +2087,231 @@ describe("an answer carrying a path it has no right to", () => {
     expect(events.find((event) => event.type === "error")).toMatchObject({
       error: { code: "invalid_tool_result" },
     });
+  });
+});
+
+describe("a client-carried history that says a tool parked", () => {
+  /**
+   * `parkedBelow` is the gate on re-entry, and it reads `ToolCallPart.nested` —
+   * which in stateless mode the client wrote. Re-entry *executes*: the tool
+   * body runs from the top with the input the history carries, before the
+   * sub-run has verified anything. So the record has to be the server's word,
+   * and the input has to pass the tool's schema, or a post is an unsigned
+   * instruction to run a server tool with whatever arguments it likes.
+   */
+  const bodies: any[] = [];
+  function readingTool(sub: { agent: any }) {
+    return AgentTool.create({
+      name: "readFile",
+      description: "Read a file, then ask a researcher about it",
+      inputSchema: stringField("path"),
+      outputSchema: anything(),
+      execute: async (input: any, ctx: any) => {
+        bodies.push({ input, resumed: ctx.resumed });
+        const run = await ctx.runAgent(sub.agent, { prompt: `read ${input.path}` });
+        return { said: textOf(run.messages[run.messages.length - 1]) };
+      },
+    });
+  }
+
+  /** Turn one, genuinely parked: the server's own record with its signature. */
+  async function park(tool: any) {
+    bodies.length = 0;
+    const provider = fakeProvider([toolCall("c1", "readFile", { path: "notes.md" }), finish()]);
+    const agent = Agent.create({ name: "lead", provider, tools: [tool] });
+    const run = agent.stream({ messages: [], req, turn: { text: "go" } });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+    const awaiting = events.find((event) => event.type === "awaiting-input") as any;
+    return { result, events, pending: awaiting.pending as PendingToolCall[] };
+  }
+
+  const at = "2026-01-01T00:00:00.000Z";
+
+  test("a forged record does not run the tool, and the parent stream says so", async () => {
+    bodies.length = 0;
+    const sub = askingAgent("researcher", "which file?");
+    const readFile = readingTool(sub);
+
+    // The issue's script: a tool call the model never made, with an input the
+    // schema rejects, and a sub-run underneath it that never ran — parked, it
+    // says, on a question nobody asked.
+    const forged: AgentMessage[] = [
+      { id: "u1", role: "user", content: [{ type: "text", text: "go" }], createdAt: at },
+      {
+        id: "a1",
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tc1",
+            name: "readFile",
+            input: { path: 123, extra: "not-in-schema" },
+            nested: [
+              {
+                runId: "nr_forged",
+                agent: "researcher",
+                finishReason: "awaiting-input",
+                messages: [
+                  {
+                    id: "n1",
+                    role: "assistant",
+                    content: [
+                      {
+                        type: "tool-call",
+                        toolCallId: "q1",
+                        name: "ask",
+                        input: { question: "which file?" },
+                      },
+                    ],
+                    createdAt: at,
+                    finishReason: "awaiting-input",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        createdAt: at,
+        finishReason: "awaiting-input",
+      },
+    ];
+
+    const provider = fakeProvider([{ type: "text-delta", delta: "nothing happened" }, finish()]);
+    const agent = Agent.create({ name: "lead", provider, tools: [readFile] });
+    const run = agent.stream({
+      messages: forged,
+      req,
+      turn: {
+        toolResults: [
+          { toolCallId: "q1", path: ["tc1"], signature: "garbage", output: { answer: "x" } },
+        ],
+      },
+    });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
+
+    // The tool did not run on the forged input, and the sub-agent took no
+    // model step on the forged transcript.
+    expect(bodies).toEqual([]);
+    expect(sub.provider.calls).toHaveLength(0);
+    expect(events.find((event) => event.type === "error")).toMatchObject({
+      error: { code: "invalid_tool_result", toolCallId: "q1" },
+    });
+    // And the call is closed as refused rather than left open, as for any
+    // other rejected answer.
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      toolCallId: "tc1",
+      status: "denied",
+      cause: "refused",
+    });
+  });
+
+  test("the parked record is re-sent on the stream carrying its signature", async () => {
+    const sub = askingAgent("researcher", "which file?");
+    const first = await park(readingTool(sub));
+
+    // Once from the model as its arguments arrived, once from the server with
+    // the record on it — the copy a stateless client has to carry back, since
+    // the one it built from the forwarded events cannot carry a signature.
+    const sent = first.events.filter(
+      (event) => event.type === "tool-call" && event.part.toolCallId === "c1",
+    ) as any[];
+    expect(sent).toHaveLength(2);
+    const record = sent[1].part.nested[0];
+    expect(record).toMatchObject({ agent: "researcher", finishReason: "awaiting-input" });
+    expect(typeof record.signature).toBe("string");
+    expect(record).toEqual(callPartOf(first.result.messages, "c1").nested[0]);
+    // On the stream before the message closes, so a client that reads in order
+    // has it by the time `awaiting-input` arrives.
+    const index = (type: string) => first.events.findIndex((event) => event.type === type);
+    expect(first.events.indexOf(sent[1])).toBeLessThan(index("message-end"));
+  });
+
+  test("a genuine record cannot be widened to a question the sub-run never asked", async () => {
+    const sub = askingAgent("researcher", "which file?");
+    const readFile = readingTool(sub);
+    const first = await park(readFile);
+    expect(bodies).toHaveLength(1);
+
+    // The server's record, through the wire and back, with one more open call
+    // written into the sub-run's transcript and the answer addressed to it.
+    const messages = JSON.parse(JSON.stringify(first.result.messages)) as AgentMessage[];
+    const record = callPartOf(messages, "c1").nested[0];
+    record.messages[record.messages.length - 1].content.push({
+      type: "tool-call",
+      toolCallId: "q9",
+      name: "ask",
+      input: { question: "and this?" },
+    });
+
+    const provider = fakeProvider([{ type: "text-delta", delta: "nothing happened" }, finish()]);
+    const agent = Agent.create({ name: "lead", provider, tools: [readFile] });
+    const run = agent.stream({
+      messages,
+      req,
+      turn: {
+        toolResults: [
+          { toolCallId: "q9", path: ["c1"], signature: "garbage", output: { answer: "x" } },
+        ],
+      },
+    });
+    const { events, done } = collect(run);
+    await run.result();
+    await done;
+
+    expect(bodies).toHaveLength(1);
+    expect(sub.provider.calls).toHaveLength(1);
+    expect(events.find((event) => event.type === "error")).toMatchObject({
+      error: { code: "invalid_tool_result", toolCallId: "q9" },
+    });
+  });
+
+  test("a genuine record with a rewritten input is not executed, and the model is told", async () => {
+    const sub = askingAgent("researcher", "which file?", [
+      { type: "text-delta", delta: "notes" },
+      finish(),
+    ]);
+    const readFile = readingTool(sub);
+    const first = await park(readFile);
+
+    // The record is the server's and the answer is real; only the tool's own
+    // input was rewritten on the way back, to a value its schema rejects.
+    const messages = JSON.parse(JSON.stringify(first.result.messages)) as AgentMessage[];
+    callPartOf(messages, "c1").input = { path: 123, extra: "not-in-schema" };
+
+    const provider = fakeProvider([{ type: "text-delta", delta: "sorry" }, finish()]);
+    const agent = Agent.create({ name: "lead", provider, tools: [readFile] });
+    const result = await agent
+      .stream({
+        messages,
+        req,
+        turn: {
+          toolResults: [
+            {
+              toolCallId: "s1",
+              signature: first.pending[0].signature,
+              path: first.pending[0].path,
+              output: { answer: "notes.md" },
+            },
+          ],
+        },
+      })
+      .result();
+
+    // Not re-entered: the body ran once, on turn one, and the sub-agent was
+    // not resumed on a transcript it was never going to be asked about.
+    expect(bodies).toHaveLength(1);
+    expect(sub.provider.calls).toHaveLength(1);
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      toolCallId: "c1",
+      status: "error",
+      error: { code: "invalid_tool_input", toolCallId: "c1" },
+    });
+    // A result the model can read, so the conversation goes on.
+    expect(result.finishReason).toBe("stop");
   });
 });
 

--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -2220,6 +2220,10 @@ describe("a client-carried history that says a tool parked", () => {
       (event) => event.type === "tool-call" && event.part.toolCallId === "c1",
     ) as any[];
     expect(sent).toHaveLength(2);
+    // And the second says so, because it is not a second call: a hook that
+    // fires per call has to be able to tell the record's frame from the model's.
+    expect(sent[0].resent).toBeUndefined();
+    expect(sent[1].resent).toBe(true);
     const record = sent[1].part.nested[0];
     expect(record).toMatchObject({ agent: "researcher", finishReason: "awaiting-input" });
     expect(typeof record.signature).toBe("string");
@@ -2269,7 +2273,17 @@ describe("a client-carried history that says a tool parked", () => {
     });
   });
 
-  test("a genuine record with a rewritten input is not executed, and the model is told", async () => {
+  /** The genuine turn two: the server's own history, the real answer. */
+  function answerOf(first: { pending: PendingToolCall[] }): ClientToolResult {
+    return {
+      toolCallId: "s1",
+      signature: first.pending[0].signature,
+      path: first.pending[0].path,
+      output: { answer: "notes.md" },
+    };
+  }
+
+  test("a genuine record with a rewritten input is not executed, however well-typed", async () => {
     const sub = askingAgent("researcher", "which file?", [
       { type: "text-delta", delta: "notes" },
       finish(),
@@ -2277,32 +2291,67 @@ describe("a client-carried history that says a tool parked", () => {
     const readFile = readingTool(sub);
     const first = await park(readFile);
 
-    // The record is the server's and the answer is real; only the tool's own
-    // input was rewritten on the way back, to a value its schema rejects.
-    const messages = JSON.parse(JSON.stringify(first.result.messages)) as AgentMessage[];
-    callPartOf(messages, "c1").input = { path: 123, extra: "not-in-schema" };
+    // The record is the server's and the answer is real; the tool's input was
+    // rewritten on the way back to a value its schema is happy with, and the
+    // sub-run's seed rewritten to match so nothing about the transcript looks
+    // out of place. Only the signature knows what the tool was parked on.
+    const messages = JSON.parse(
+      JSON.stringify(first.result.messages).replaceAll("notes.md", "/etc/secrets.md"),
+    ) as AgentMessage[];
+    expect(callPartOf(messages, "c1").input).toEqual({ path: "/etc/secrets.md" });
 
-    const provider = fakeProvider([{ type: "text-delta", delta: "sorry" }, finish()]);
+    const provider = fakeProvider([{ type: "text-delta", delta: "nothing happened" }, finish()]);
     const agent = Agent.create({ name: "lead", provider, tools: [readFile] });
-    const result = await agent
-      .stream({
-        messages,
-        req,
-        turn: {
-          toolResults: [
-            {
-              toolCallId: "s1",
-              signature: first.pending[0].signature,
-              path: first.pending[0].path,
-              output: { answer: "notes.md" },
-            },
-          ],
-        },
-      })
-      .result();
+    const run = agent.stream({ messages, req, turn: { toolResults: [answerOf(first)] } });
+    const { events, done } = collect(run);
+    const result = await run.result();
+    await done;
 
     // Not re-entered: the body ran once, on turn one, and the sub-agent was
     // not resumed on a transcript it was never going to be asked about.
+    expect(bodies).toHaveLength(1);
+    expect(sub.provider.calls).toHaveLength(1);
+    expect(events.find((event) => event.type === "error")).toMatchObject({
+      error: {
+        code: "invalid_tool_result",
+        toolCallId: "s1",
+        message: expect.stringContaining("did not sign"),
+      },
+    });
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      toolCallId: "c1",
+      status: "denied",
+      cause: "refused",
+    });
+  });
+
+  test("a tool whose schema changed since it parked is not executed, and the model is told", async () => {
+    const sub = askingAgent("researcher", "which file?", [
+      { type: "text-delta", delta: "notes" },
+      finish(),
+    ]);
+    const first = await park(readingTool(sub));
+
+    // Same history, same answer, same tool name — but the deploy in between
+    // renamed the field, and the input the record vouches for no longer fits
+    // the tool it is about to be handed to.
+    const renamed = AgentTool.create({
+      name: "readFile",
+      description: "Read a file, then ask a researcher about it",
+      inputSchema: stringField("filename"),
+      outputSchema: anything(),
+      execute: async (input: any, ctx: any) => {
+        bodies.push({ input, resumed: ctx.resumed });
+        const run = await ctx.runAgent(sub.agent, { prompt: `read ${input.filename}` });
+        return { said: textOf(run.messages[run.messages.length - 1]) };
+      },
+    });
+    const provider = fakeProvider([{ type: "text-delta", delta: "sorry" }, finish()]);
+    const agent = Agent.create({ name: "lead", provider, tools: [renamed] });
+    const result = await agent
+      .stream({ messages: first.result.messages, req, turn: { toolResults: [answerOf(first)] } })
+      .result();
+
     expect(bodies).toHaveLength(1);
     expect(sub.provider.calls).toHaveLength(1);
     expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
@@ -2312,6 +2361,91 @@ describe("a client-carried history that says a tool parked", () => {
     });
     // A result the model can read, so the conversation goes on.
     expect(result.finishReason).toBe("stop");
+  });
+
+  test("a record re-enters its tool once: the same turn posted again is refused before the body runs", async () => {
+    const sub = askingAgent("researcher", "which file?", [
+      { type: "text-delta", delta: "notes" },
+      finish(),
+    ]);
+    const readFile = readingTool(sub);
+    const first = await park(readFile);
+
+    const provider = fakeProvider(
+      [{ type: "text-delta", delta: "done" }, finish()],
+      [{ type: "text-delta", delta: "nothing happened" }, finish()],
+    );
+    const agent = Agent.create({ name: "lead", provider, tools: [readFile] });
+    const second = await agent
+      .stream({ messages: first.result.messages, req, turn: { toolResults: [answerOf(first)] } })
+      .result();
+    expect(bodies).toHaveLength(2);
+    expect(sub.provider.calls).toHaveLength(2);
+    expect(partsOf(second.messages, "tool-result")[0]).toMatchObject({
+      toolCallId: "c1",
+      status: "ok",
+    });
+
+    // The history from before the result existed, with the same answer. The
+    // answer's own nonce is spent too, but the sub-run is the one that checks
+    // it, and the tool body runs before the sub-run is even started — so the
+    // record has to be what refuses this, or the body runs once per replay.
+    const replay = agent.stream({
+      messages: JSON.parse(JSON.stringify(first.result.messages)),
+      req,
+      turn: { toolResults: [answerOf(first)] },
+    });
+    const { events, done } = collect(replay);
+    const result = await replay.result();
+    await done;
+
+    expect(bodies).toHaveLength(2);
+    expect(sub.provider.calls).toHaveLength(2);
+    expect(events.find((event) => event.type === "error")).toMatchObject({
+      error: {
+        code: "invalid_tool_result",
+        toolCallId: "s1",
+        message: expect.stringContaining("already been re-entered"),
+      },
+    });
+    expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+      toolCallId: "c1",
+      status: "denied",
+      cause: "refused",
+    });
+  });
+
+  test("a record answered after its day is up says it expired, not that the run never parked", async () => {
+    const sub = askingAgent("researcher", "which file?");
+    const readFile = readingTool(sub);
+    const first = await park(readFile);
+
+    // An ordinary outcome in threaded mode — the question sat overnight — and
+    // the message has to send that user back to the model, not to a bug hunt.
+    const now = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 25 * 60 * 60 * 1000);
+    try {
+      const provider = fakeProvider([{ type: "text-delta", delta: "nothing happened" }, finish()]);
+      const agent = Agent.create({ name: "lead", provider, tools: [readFile] });
+      const run = agent.stream({
+        messages: first.result.messages,
+        req,
+        turn: { toolResults: [answerOf(first)] },
+      });
+      const { events, done } = collect(run);
+      await run.result();
+      await done;
+
+      expect(bodies).toHaveLength(1);
+      expect(events.find((event) => event.type === "error")).toMatchObject({
+        error: {
+          code: "invalid_tool_result",
+          toolCallId: "s1",
+          message: expect.stringContaining("expired"),
+        },
+      });
+    } finally {
+      now.mockRestore();
+    }
   });
 });
 

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -14,6 +14,7 @@ import {
   verifyNestedRun,
   verifyPendingCall,
 } from "./signing";
+import { sseKeepalive } from "./store/sse";
 import type {
   AgentError,
   AgentMessage,
@@ -1284,8 +1285,14 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
     const encoder = new TextEncoder();
     let cancelled = false;
 
+    let keepalive!: ReturnType<typeof sseKeepalive>;
+
     const body = new ReadableStream<Uint8Array>({
       start: async (controller) => {
+        // A slow tool or a thinking sub-agent can leave the connection silent
+        // for longer than a proxy's idle timeout, and a proxy that closes it
+        // looks to the client exactly like a run that finished.
+        keepalive = sseKeepalive(controller);
         try {
           for await (const frame of frames) {
             if (cancelled) break;
@@ -1294,11 +1301,13 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
             controller.enqueue(
               encoder.encode(`id: ${frame.seq}\ndata: ${JSON.stringify(frame.event)}\n\n`),
             );
+            keepalive.touch();
           }
         } catch {
           // A stream that cannot be written to is a dead reader, not a dead
           // run. Nothing to report and nothing to stop.
         }
+        keepalive.stop();
         try {
           controller.close();
         } catch {
@@ -1311,6 +1320,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
         // tool loop is here and a closed tab has not stopped step four from
         // charging a card.
         cancelled = true;
+        keepalive.stop();
       },
     });
 

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -6,6 +6,7 @@ import type {
 } from "./AgentProvider";
 import type { Infer, Schema } from "./Schema";
 import {
+  consumeNestedRun,
   consumePendingCall,
   readSignature,
   signNestedRun,
@@ -2043,8 +2044,11 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
         usage: resuming ? addUsage(recorded.usage ?? emptyUsage(), result.usage) : result.usage,
         // A parked record is what the next turn re-enters the tool on, and in
         // stateless mode it comes back from the browser. Signed here, by the
-        // run that knows it is true, over where the sub-run parked and what it
-        // is waiting on — `parkedBelow` will not act on a record without it.
+        // run that knows it is true, over where the sub-run parked, what it is
+        // waiting on and the input the tool was running with — `parkedBelow`
+        // will not act on a record without it. `call.input` is the parsed
+        // value by now, on every path that reaches here, so the transcript
+        // carries exactly what was signed.
         ...(result.finishReason === "awaiting-input"
           ? {
               signature: signNestedRun({
@@ -2052,6 +2056,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
                 path: signingPath,
                 nestedRunId: sub.runId,
                 open: [...openCallIds(messages)],
+                input: call.input,
               }),
             }
           : {}),
@@ -2100,8 +2105,11 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
       // client has built its own from the forwarded events. Re-sending the
       // call is what puts the server's copy in the client's hands to carry
       // back: the reducer takes a re-sent `nested` as authoritative, so this
-      // replaces what the client accumulated rather than adding to it.
-      this.emit({ type: "tool-call", messageId, part: call });
+      // replaces what the client accumulated rather than adding to it. Marked
+      // `resent` because it is not a call: the model made this one earlier —
+      // in this run or, on a re-park, in a previous one — and a hook that
+      // counts calls has already seen it.
+      this.emit({ type: "tool-call", messageId, part: call, resent: true });
       throw new PendingEscalation({ pending: asked, path: signingPath, nested: record });
     }
 
@@ -2208,18 +2216,39 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
           // client-carried history. Content is still checked below, in the
           // sub-run; this is what stops an unsigned request from choosing to
           // execute at all.
-          if (!this.parkedBelow(hosting.call, below, answer.toolCallId)) {
+          const parked = this.parkedBelow(hosting.call, below, answer.toolCallId);
+          if (parked.ok === false) {
+            const under = `The answer for "${answer.toolCallId}" is addressed under "${host}", which`;
             reject(
-              `The answer for "${answer.toolCallId}" is addressed under "${host}", which has no sub-agent run waiting on that question.`,
+              parked.reason === "unparked"
+                ? `${under} has no sub-agent run waiting on that question.`
+                : parked.reason === "expired"
+                  ? `${under} parked a sub-agent run that has since expired. Ask again.`
+                  : `${under} carries a record of a parked sub-agent run the server did not sign.`,
             );
             continue;
           }
-          const group = reentry.get(host) ?? [];
+          let group = reentry.get(host);
+          if (!group) {
+            // Spent here, ahead of the body, for the reason the record is
+            // signed at all: re-entry runs the tool before the sub-run gets to
+            // refuse a spent answer, so a history rewound to before the result
+            // would run it once per replay. Once per record per turn — the
+            // sub-run may have asked two things at once, and every answer to
+            // it re-enters the same tool a single time.
+            if (!consumeNestedRun(parked.signature)) {
+              reject(
+                `The answer for "${answer.toolCallId}" is addressed under "${host}", which has already been re-entered on that record. Ask again.`,
+              );
+              continue;
+            }
+            group = [];
+            reentry.set(host, group);
+            // Marked answered so the refusal pass below leaves it alone: the
+            // tool is about to be re-entered and will produce the real result.
+            answered.add(host);
+          }
           group.push(answer);
-          reentry.set(host, group);
-          // Marked answered so the refusal pass below leaves it alone: the tool
-          // is about to be re-entered and will produce the real result.
-          answered.add(host);
           continue;
         }
 
@@ -2302,23 +2331,42 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
    * input the history carries — before the sub-run gets to verify the answer,
    * so everything the body does ahead of its first `runAgent` happens on the
    * client's say-so. Which is why the record has to carry the server's
-   * signature over the sub-run it parked and the calls it left open, and why
-   * a record without one, or with one that does not match what it now says,
-   * is not a parked run at all.
+   * signature over the sub-run it parked, the calls it left open and the
+   * input the tool was given, and why a record without one, or with one that
+   * does not match what it now says, is not a parked run at all.
+   *
+   * The failure says which of those it was. "Expired" is an ordinary outcome
+   * in threaded mode — a question answered a day late — and telling that
+   * user the run never parked would send them looking for a bug that is not
+   * there; a record that fails its MAC is the other thing entirely, and the
+   * two are kept apart for the same reason `resolveAnswer` keeps them apart.
    *
    * `below` is the answer's path with this run's prefix already removed, so
    * `below[0]` is `call` itself and `below[1]`, when there is one, names the
    * call to re-enter one level further down.
    */
-  private parkedBelow(call: ToolCallPart, below: string[], toolCallId: string): boolean {
+  private parkedBelow(
+    call: ToolCallPart,
+    below: string[],
+    toolCallId: string,
+  ): { ok: true; signature: string } | { ok: false; reason: "unparked" | "unsigned" | "expired" } {
     const wanted = below.length > 1 ? below[1] : toolCallId;
     const path = [...this.pathPrefix, call.toolCallId];
-    return (call.nested ?? []).some((run) => {
-      if (run.finishReason !== "awaiting-input" || typeof run.signature !== "string") return false;
-      const open = openCallIds(run.messages);
-      if (!open.has(wanted)) return false;
-      return verifyNestedRun(run.signature, { path, nestedRunId: run.runId, open: [...open] }).ok;
+    const parked = (call.nested ?? []).find(
+      (run) => run.finishReason === "awaiting-input" && openCallIds(run.messages).has(wanted),
+    );
+    if (!parked) return { ok: false, reason: "unparked" };
+    if (typeof parked.signature !== "string") return { ok: false, reason: "unsigned" };
+    const verified = verifyNestedRun(parked.signature, {
+      path,
+      nestedRunId: parked.runId,
+      open: [...openCallIds(parked.messages)],
+      input: call.input,
     });
+    if (verified.ok === false) {
+      return { ok: false, reason: verified.reason === "expired" ? "expired" : "unsigned" };
+    }
+    return { ok: true, signature: parked.signature };
   }
 
   /**
@@ -2353,15 +2401,13 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
       };
     }
 
-    // Checked the way `runTools` checked the model's arguments, and for the
-    // same reason with a different author: the history this call was read out
-    // of is the client's in stateless mode, and an approval's input is covered
-    // by its signature but a plain server tool's is covered by nothing. The
-    // tool's typed input is a contract with the tool, not with whoever wrote
-    // the transcript, and a value the schema rejects must not reach it — the
-    // failure is a result the model can read, exactly like a mis-typed
-    // argument on the way in. The same result covers a schema that changed
-    // between the turn that parked and the turn that answers.
+    // Checked the way `runTools` checked the model's arguments. The record's
+    // signature has already said this is the input the tool parked on, so what
+    // this catches is the tool itself having moved: a schema that changed
+    // between the turn that parked and the turn that answers. The tool's typed
+    // input is a contract with the tool as it is now, and a value the schema
+    // rejects must not reach it — the failure is a result the model can read,
+    // exactly like a mis-typed argument on the way in.
     const parsed = resolved.tool.inputSchema.safeParse(entry.call.input);
     if (parsed.ok === false) {
       return {

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -8,7 +8,9 @@ import type { Infer, Schema } from "./Schema";
 import {
   consumePendingCall,
   readSignature,
+  signNestedRun,
   signPendingCall,
+  verifyNestedRun,
   verifyPendingCall,
 } from "./signing";
 import type {
@@ -1695,7 +1697,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
       }
 
       running.push(
-        this.executeTool(resolved, call, parsed.value, step)
+        this.executeTool(resolved, message.id, call, parsed.value, step)
           .then((result) => this.addResult(message, result))
           .catch((error) => {
             if (error instanceof PendingEscalation) {
@@ -1768,6 +1770,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
 
   private async executeTool(
     resolved: ResolvedTool,
+    messageId: string,
     call: ToolCallPart,
     input: unknown,
     step: number,
@@ -1782,7 +1785,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
       step,
       depth: this.depth,
       resumed: resume !== undefined,
-      runAgent: this.nestedRunner(call, resume),
+      runAgent: this.nestedRunner(messageId, call, resume),
     };
 
     try {
@@ -1856,6 +1859,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
    * would be invisible.
    */
   private nestedRunner(
+    messageId: string,
     call: ToolCallPart,
     resume?: { answers: ClientToolResult[] },
   ): ToolContext["runAgent"] {
@@ -1900,7 +1904,16 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
         }
       }
 
-      return this.runNested(call, agent, params, at, memo, recorded, resume?.answers ?? []);
+      return this.runNested(
+        messageId,
+        call,
+        agent,
+        params,
+        at,
+        memo,
+        recorded,
+        resume?.answers ?? [],
+      );
     };
   }
 
@@ -1914,6 +1927,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
    * the name chain so a cycle is a sentence rather than a stack overflow.
    */
   private async runNested(
+    messageId: string,
     call: ToolCallPart,
     agent: AnyAgent,
     params: RunAgentParams,
@@ -2010,22 +2024,37 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
     const recording = (async () => {
       const result = await sub.result();
       await forwarding;
+      // The seed leads, because a run only reports the messages it *made* and
+      // `params.messages` is not one of them. Recording the transcript without
+      // its opening is two bugs: a resume re-enters the sub-agent with the
+      // conversation it was started from missing, and the replay check below
+      // has nothing to fingerprint the seed against. Upserted rather than
+      // concatenated because the sub-run may have amended one of these on its
+      // way through.
+      const messages = resuming
+        ? mergeMessages(recorded.messages, result.messages)
+        : mergeMessages(params.messages ?? [], result.messages);
       const record: NestedRun = {
         runId: sub.runId,
         agent: agent.name,
         label,
-        // The seed leads, because a run only reports the messages it *made*
-        // and `params.messages` is not one of them. Recording the transcript
-        // without its opening is two bugs: a resume re-enters the sub-agent
-        // with the conversation it was started from missing, and the replay
-        // check below has nothing to fingerprint the seed against. Upserted
-        // rather than concatenated because the sub-run may have amended one of
-        // these on its way through.
-        messages: resuming
-          ? mergeMessages(recorded.messages, result.messages)
-          : mergeMessages(params.messages ?? [], result.messages),
+        messages,
         finishReason: result.finishReason,
         usage: resuming ? addUsage(recorded.usage ?? emptyUsage(), result.usage) : result.usage,
+        // A parked record is what the next turn re-enters the tool on, and in
+        // stateless mode it comes back from the browser. Signed here, by the
+        // run that knows it is true, over where the sub-run parked and what it
+        // is waiting on — `parkedBelow` will not act on a record without it.
+        ...(result.finishReason === "awaiting-input"
+          ? {
+              signature: signNestedRun({
+                runId: this.signingRunId,
+                path: signingPath,
+                nestedRunId: sub.runId,
+                open: [...openCallIds(messages)],
+              }),
+            }
+          : {}),
       };
       // Written before anything below can throw. An escalation is a pause, not
       // a lost run, and a cancelled sub-run is still work the user should be
@@ -2067,6 +2096,12 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
           `"${agent.name}" ended awaiting input but asked nothing, so there is no question to escalate.`,
         );
       }
+      // The signature is on the server's copy of the record, and a stateless
+      // client has built its own from the forwarded events. Re-sending the
+      // call is what puts the server's copy in the client's hands to carry
+      // back: the reducer takes a re-sent `nested` as authoritative, so this
+      // replaces what the client accumulated rather than adding to it.
+      this.emit({ type: "tool-call", messageId, part: call });
       throw new PendingEscalation({ pending: asked, path: signingPath, nested: record });
     }
 
@@ -2262,10 +2297,14 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
    * `nested` is written from the sub-run's result before the escalation throws,
    * so a call that has never nested has no `nested` at all, and one whose
    * sub-runs all finished has none with `awaiting-input`. In stateless mode
-   * that record arrives from the client and could say anything — but saying it
-   * only buys a re-entry of a tool that really did park, whose answer still has
-   * to carry a MAC the sub-run verifies. What it cannot buy is the execution of
-   * a call that never ran at all.
+   * that record arrives from the client and could say anything, and what
+   * saying it buys is not small: the tool body runs — from the top, with the
+   * input the history carries — before the sub-run gets to verify the answer,
+   * so everything the body does ahead of its first `runAgent` happens on the
+   * client's say-so. Which is why the record has to carry the server's
+   * signature over the sub-run it parked and the calls it left open, and why
+   * a record without one, or with one that does not match what it now says,
+   * is not a parked run at all.
    *
    * `below` is the answer's path with this run's prefix already removed, so
    * `below[0]` is `call` itself and `below[1]`, when there is one, names the
@@ -2273,9 +2312,13 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
    */
   private parkedBelow(call: ToolCallPart, below: string[], toolCallId: string): boolean {
     const wanted = below.length > 1 ? below[1] : toolCallId;
-    return (call.nested ?? []).some(
-      (run) => run.finishReason === "awaiting-input" && openCallIds(run.messages).has(wanted),
-    );
+    const path = [...this.pathPrefix, call.toolCallId];
+    return (call.nested ?? []).some((run) => {
+      if (run.finishReason !== "awaiting-input" || typeof run.signature !== "string") return false;
+      const open = openCallIds(run.messages);
+      if (!open.has(wanted)) return false;
+      return verifyNestedRun(run.signature, { path, nestedRunId: run.runId, open: [...open] }).ok;
+    });
   }
 
   /**
@@ -2310,12 +2353,40 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
       };
     }
 
+    // Checked the way `runTools` checked the model's arguments, and for the
+    // same reason with a different author: the history this call was read out
+    // of is the client's in stateless mode, and an approval's input is covered
+    // by its signature but a plain server tool's is covered by nothing. The
+    // tool's typed input is a contract with the tool, not with whoever wrote
+    // the transcript, and a value the schema rejects must not reach it — the
+    // failure is a result the model can read, exactly like a mis-typed
+    // argument on the way in. The same result covers a schema that changed
+    // between the turn that parked and the turn that answers.
+    const parsed = resolved.tool.inputSchema.safeParse(entry.call.input);
+    if (parsed.ok === false) {
+      return {
+        type: "tool-result",
+        toolCallId: entry.call.toolCallId,
+        name: entry.call.name,
+        status: "error",
+        error: {
+          code: "invalid_tool_input",
+          message: `Invalid arguments for "${name}": ${parsed.errors.join(", ")}`,
+          toolCallId: entry.call.toolCallId,
+          retryable: true,
+        },
+      };
+    }
+
     const call = this.amendCall(entry);
+    // The parsed value is the only input the call has from here on, as in
+    // `runTools` — the clone carries what the tool was actually given.
+    call.input = parsed.value;
     try {
       // Step 0, like an approval executed on the way in: this belongs to the
       // turn, not to a step of the loop that has not started yet.
       return await raceAbort(
-        this.executeTool(resolved, call, call.input, 0, { answers }),
+        this.executeTool(resolved, entry.message.id, call, parsed.value, 0, { answers }),
         this.controller.signal,
       );
     } catch (error) {
@@ -2469,7 +2540,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
         const executing = this.amendCall(entry);
         try {
           return await raceAbort(
-            this.executeTool(resolved, executing, executing.input, 0),
+            this.executeTool(resolved, entry.message.id, executing, executing.input, 0),
             this.controller.signal,
           );
         } catch (error) {

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "vitest";
 
 import { HttpRequest } from "../http/HttpRequest";
 import type { AgentStreamParams } from "./Agent";
-import { AgentController, MemoryAgentStore, MemoryLiveRuns } from "./AgentController";
+import {
+  AgentController,
+  defaultAgentStore,
+  MemoryAgentStore,
+  MemoryLiveRuns,
+} from "./AgentController";
 import { StubAgentRun } from "./store/stubAgentRun";
 import type { AgentMessage, AgentStreamEvent, PendingToolCall } from "./types";
 
@@ -99,14 +104,15 @@ describe("AgentController.stream", () => {
     // happens when no threadId arrives.
     run.finish({ messages: [message("u1", "user", "and now this")] });
     await settle();
-    expect(await controller.store.loadThread("anything")).toEqual([]);
+    expect(await controller.store.loadThread("anything")).toBeNull();
   });
 
   test("reads history from the store and appends the run to it when threaded", async () => {
     const run = new StubAgentRun("run_2");
     const { agent, calls } = stubAgent(run);
     const store = new MemoryAgentStore();
-    await store.appendMessages("t1", [message("u0", "user", "earlier")]);
+    const { threadId } = await store.createThread({});
+    await store.appendMessages(threadId, [message("u0", "user", "earlier")]);
 
     class Chat extends AgentController {
       agent = agent;
@@ -115,10 +121,10 @@ describe("AgentController.stream", () => {
     }
 
     const controller = new Chat();
-    await controller.stream(jsonRequest({ threadId: "t1", text: "next" }));
+    await controller.stream(jsonRequest({ threadId, text: "next" }));
 
     expect(calls[0]!.messages.map((m) => m.id)).toEqual(["u0"]);
-    expect(calls[0]!.threadId).toBe("t1");
+    expect(calls[0]!.threadId).toBe(threadId);
     // The client's own `messages` are ignored once a thread owns the history —
     // otherwise a client could rewrite what the server already believes.
     expect(calls[0]!.messages).toHaveLength(1);
@@ -128,7 +134,7 @@ describe("AgentController.stream", () => {
     });
     await settle();
 
-    expect((await store.loadThread("t1")).map((m) => m.id)).toEqual(["u0", "u1", "a1"]);
+    expect((await store.loadThread(threadId))!.map((m) => m.id)).toEqual(["u0", "u1", "a1"]);
   });
 
   /**
@@ -153,7 +159,7 @@ describe("AgentController.stream", () => {
       liveRuns = new MemoryLiveRuns();
     }
 
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { threadId } = await defaultAgentStore.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, text: "one" }));
     first.finish({ messages: [message("u1", "user", "one")] });
@@ -164,6 +170,80 @@ describe("AgentController.stream", () => {
     await settle();
 
     expect(seen[1]!.messages.map((m) => m.id)).toEqual(["u1"]);
+  });
+
+  test("answers 404 for a thread the store does not have, before anything runs", async () => {
+    const run = new StubAgentRun("run_404");
+    const { agent, calls } = stubAgent(run);
+    let instructed = false;
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      store = new MemoryAgentStore();
+      instructions() {
+        instructed = true;
+      }
+    }
+
+    const controller = new Chat();
+    const response = await controller.stream(jsonRequest({ threadId: "mistyped", text: "hi" }));
+
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("thread_not_found");
+    // Not an empty conversation: no run was started, no app code ran, and
+    // nothing was registered for a client to attach to.
+    expect(calls).toHaveLength(0);
+    expect(instructed).toBe(false);
+    expect(await controller.liveRuns.find({ threadId: "mistyped" })).toBeNull();
+    run.finish();
+  });
+
+  test("a thread that expired is the same 404, not a fresh conversation under its id", async () => {
+    const run = new StubAgentRun("run_ttl");
+    const { agent, calls } = stubAgent(run);
+    const store = new MemoryAgentStore({ ttlMs: 10 });
+    const { threadId } = await store.createThread({});
+    await store.appendMessages(threadId, [message("u0", "user", "a day ago")]);
+    store.sweep(Date.now() + 90_000);
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      store = store;
+    }
+
+    const response = await new Chat().stream(jsonRequest({ threadId, text: "still there?" }));
+
+    expect(response.status).toBe(404);
+    expect(calls).toHaveLength(0);
+    // The id was not quietly re-minted by the miss.
+    expect(await store.loadThread(threadId)).toBeNull();
+    run.finish();
+  });
+
+  test("a store whose ids are the client's takes a first turn on a new id", async () => {
+    const run = new StubAgentRun("run_own");
+    const { agent, calls } = stubAgent(run);
+    const store = new MemoryAgentStore({ clientOwnedIds: true });
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      store = store;
+    }
+
+    const response = await new Chat().stream(
+      jsonRequest({ threadId: "client-minted", text: "hi" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls[0]!.messages).toEqual([]);
+    run.finish({ messages: [message("u1", "user", "hi"), message("a1", "assistant", "hello")] });
+    await settle();
+
+    expect((await store.loadThread("client-minted"))!.map((m) => m.id)).toEqual(["u1", "a1"]);
   });
 
   test("fires onMessage for user and assistant messages alike", async () => {
@@ -267,7 +347,8 @@ describe("AgentController.stream", () => {
     }
 
     const controller = new Chat();
-    await controller.stream(jsonRequest({ threadId: "t9", text: "hi" }));
+    const { threadId } = await controller.store.createThread({});
+    await controller.stream(jsonRequest({ threadId, text: "hi" }));
     run.finish({
       messages: [message("u1", "user", "hi"), message("a1", "assistant", "hello")],
     });
@@ -276,7 +357,7 @@ describe("AgentController.stream", () => {
     expect(reported).toHaveLength(2);
     // The run still finished and the framework store still has the turn: the
     // app's failure cost the app's row, not the answer.
-    expect((await controller.store.loadThread("t9")).map((m) => m.id)).toEqual(["u1", "a1"]);
+    expect((await controller.store.loadThread(threadId))!.map((m) => m.id)).toEqual(["u1", "a1"]);
   });
 });
 
@@ -287,6 +368,10 @@ describe("AgentController.attach", () => {
     class Chat extends AgentController {
       agent = agent;
       liveRuns = new MemoryLiveRuns();
+      // These tests are about the live-run map and name their threads by hand;
+      // a store whose ids are the client's is the one that takes a hand-picked
+      // id as a conversation rather than a 404.
+      store = new MemoryAgentStore({ clientOwnedIds: true });
     }
     return { run, controller: new Chat() };
   }
@@ -449,6 +534,7 @@ describe("AgentController.attach", () => {
     class Chat extends AgentController {
       agent = agent;
       liveRuns = new MemoryLiveRuns({ maxFrames: 4 });
+      store = new MemoryAgentStore({ clientOwnedIds: true });
     }
     const controller = new Chat();
     await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
@@ -489,6 +575,7 @@ describe("AgentController.attach", () => {
     class Chat extends AgentController {
       agent = agent;
       liveRuns = new MemoryLiveRuns({ maxFrames: 4 });
+      store = new MemoryAgentStore({ clientOwnedIds: true });
     }
     const controller = new Chat();
     await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
@@ -519,6 +606,7 @@ describe("AgentController.stop", () => {
     class Chat extends AgentController {
       agent = agent;
       liveRuns = new MemoryLiveRuns();
+      store = new MemoryAgentStore({ clientOwnedIds: true });
     }
     const controller = new Chat();
     await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
@@ -819,6 +907,7 @@ describe("the request body", () => {
     class Chat extends AgentController {
       agent = agent;
       liveRuns = new MemoryLiveRuns();
+      store = new MemoryAgentStore({ clientOwnedIds: true });
     }
     const controller = new Chat();
     await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -454,6 +454,152 @@ describe("AgentController.stream", () => {
   });
 });
 
+describe("one live run per thread", () => {
+  /** A controller whose agent hands out the given runs, in order. */
+  function threaded(runs: StubAgentRun[], store = new MemoryAgentStore()) {
+    const queue = runs.slice();
+    const seen: AgentStreamParams[] = [];
+    const liveRuns = new MemoryLiveRuns();
+    class Chat extends AgentController {
+      agent = {
+        provider: {},
+        stream: (params: AgentStreamParams) => {
+          seen.push(params);
+          return queue.shift()!;
+        },
+      } as any;
+      liveRuns = liveRuns;
+      store = store;
+    }
+    return { Chat, seen, store, liveRuns };
+  }
+
+  /**
+   * The issue's interleaving. A send while the first answer is streaming used
+   * to abort only the connection, which no longer stops a run: the first kept
+   * going, blind to the second turn; the second loaded a history without the
+   * first's answer; and both appended when they finished, in whichever order
+   * the model returned them. With the first slower, the thread read
+   * `user2, assistant2, user1, assistant1`.
+   */
+  test("a second turn stops the first run and waits for its transcript to land", async () => {
+    const first = new StubAgentRun("run_1");
+    const second = new StubAgentRun("run_2");
+    const { Chat, seen, store } = threaded([first, second]);
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, text: "first" }));
+    expect(first.stopped).toBe(false);
+
+    // Held, not refused: this resolves only once the first run is in the store.
+    let started = false;
+    const pending = new Chat()
+      .stream(jsonRequest({ threadId, text: "second" }))
+      .then((response) => {
+        started = true;
+        return response;
+      });
+    await settle();
+
+    expect(first.stopped).toBe(true);
+    expect(started).toBe(false);
+    // The second run has not been asked for, so nothing has loaded the thread
+    // without the first answer in it.
+    expect(seen).toHaveLength(1);
+
+    // The provider answering in reverse order: the first run finishes last from
+    // the client's point of view, but the second cannot start before it.
+    first.finish({
+      messages: [message("u1", "user", "first"), message("a1", "assistant", "one…")],
+    });
+    const response = await pending;
+    expect(response.headers.get("X-Stub-Run")).toBe("run_2");
+    expect(seen[1]!.messages.map((m) => m.id)).toEqual(["u1", "a1"]);
+
+    second.finish({
+      messages: [message("u2", "user", "second"), message("a2", "assistant", "two")],
+    });
+    await settle();
+
+    expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
+  });
+
+  /**
+   * Two turns arriving together both see the same live run, both stop it and
+   * both wait for it; without the lock both then start, and the third answer
+   * never sees the second turn — the same race, one message later.
+   */
+  test("a third turn waits for the second, not just for the first", async () => {
+    const runs = [new StubAgentRun("run_1"), new StubAgentRun("run_2"), new StubAgentRun("run_3")];
+    const { Chat, seen, store } = threaded(runs);
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, text: "first" }));
+    const second = new Chat().stream(jsonRequest({ threadId, text: "second" }));
+    const third = new Chat().stream(jsonRequest({ threadId, text: "third" }));
+    await settle();
+    expect(seen).toHaveLength(1);
+
+    runs[0]!.finish({
+      messages: [message("u1", "user", "first"), message("a1", "assistant", "one")],
+    });
+    await second;
+    await settle();
+    // The third found the second registered and stopped that, rather than
+    // starting alongside it.
+    expect(seen).toHaveLength(2);
+    expect(runs[1]!.stopped).toBe(true);
+
+    runs[1]!.finish({
+      messages: [message("u2", "user", "second"), message("a2", "assistant", "two")],
+    });
+    await third;
+    expect(seen[2]!.messages.map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
+
+    runs[2]!.finish({
+      messages: [message("u3", "user", "third"), message("a3", "assistant", "three")],
+    });
+    await settle();
+    expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "u2",
+      "a2",
+      "u3",
+      "a3",
+    ]);
+  });
+
+  test("a finished run still within its ttl holds nothing up", async () => {
+    const first = new StubAgentRun("run_1");
+    const second = new StubAgentRun("run_2");
+    const { Chat, seen } = threaded([first, second]);
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, text: "first" }));
+    first.finish({ messages: [message("u1", "user", "first")] });
+    await settle();
+
+    await new Chat().stream(jsonRequest({ threadId, text: "second" }));
+    expect(seen).toHaveLength(2);
+    second.finish();
+  });
+
+  test("stateless turns are not serialized: there is no thread to hold", async () => {
+    const first = new StubAgentRun("run_1");
+    const second = new StubAgentRun("run_2");
+    const { Chat, seen } = threaded([first, second]);
+
+    await new Chat().stream(jsonRequest({ text: "first" }));
+    await new Chat().stream(jsonRequest({ text: "second" }));
+
+    expect(seen).toHaveLength(2);
+    expect(first.stopped).toBe(false);
+    first.finish();
+    second.finish();
+  });
+});
+
 describe("AgentController.attach", () => {
   function attachable(runId = "run_a") {
     const run = new StubAgentRun(runId);

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -715,7 +715,12 @@ describe("the request body", () => {
     // No run was started for it.
     expect(calls).toHaveLength(0);
 
-    for (const contentType of ["application/x-www-form-urlencoded", "multipart/form-data"]) {
+    // The last one begins with the accepted bytes and is still another type.
+    for (const contentType of [
+      "application/x-www-form-urlencoded",
+      "multipart/form-data",
+      "application/json-seq",
+    ]) {
       expect((await new Chat().stream(rawRequest("text=hi", contentType))).status).toBe(415);
     }
     expect(calls).toHaveLength(0);

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -1,13 +1,17 @@
+process.env.SECRET ??= "agent-controller-test-secret";
+
 import { describe, expect, test } from "vitest";
 
 import { HttpRequest } from "../http/HttpRequest";
-import type { AgentStreamParams } from "./Agent";
+import { Agent, AgentTool, type AgentStreamParams } from "./Agent";
 import {
   AgentController,
   defaultAgentStore,
   MemoryAgentStore,
   MemoryLiveRuns,
 } from "./AgentController";
+import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "./AgentProvider";
+import { s } from "./Schema";
 import { StubAgentRun } from "./store/stubAgentRun";
 import type { AgentMessage, AgentStreamEvent, PendingToolCall } from "./types";
 
@@ -77,6 +81,52 @@ async function readSse(response: Response): Promise<string> {
   return await response.text();
 }
 
+/** The events in an SSE body, in order. */
+async function eventsOf(response: Response): Promise<AgentStreamEvent[]> {
+  return (await readSse(response))
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice("data: ".length)));
+}
+
+/**
+ * A provider that plays one script per model call, for the tests that need a
+ * real `Agent` behind the controller rather than a stub run: what the store
+ * ends up holding depends on what the agent reports, and a stub run reports
+ * whatever the test hands it.
+ */
+function scriptedProvider(...scripts: ProviderEvent[][]) {
+  let call = 0;
+  return {
+    model: "fake",
+    capabilities: {
+      reasoning: true,
+      structuredOutput: true,
+      fileInput: true,
+      parallelToolCalls: true,
+      toolSearch: true,
+    },
+    stream(_params: ProviderStreamParams) {
+      const script = scripts[call++] ?? [];
+      return (async function* () {
+        for (const event of script) yield event;
+      })();
+    },
+    upload: async () => "file_1",
+    normalizeError: (error: unknown) => ({
+      code: "provider_error" as const,
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    }),
+  } as unknown as AgentProvider;
+}
+
+const finish = (): ProviderEvent => ({
+  type: "finish",
+  reason: "stop",
+  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+});
+
 describe("AgentController.stream", () => {
   test("runs stateless on the history the client sent", async () => {
     const run = new StubAgentRun("run_1");
@@ -135,6 +185,73 @@ describe("AgentController.stream", () => {
     await settle();
 
     expect((await store.loadThread(threadId))!.map((m) => m.id)).toEqual(["u0", "u1", "a1"]);
+  });
+
+  /**
+   * The message that made the call comes back from the second run under the
+   * id it already had, with the result attached. Persisting that turn must
+   * replace the earlier copy, not sit next to it — otherwise every later turn
+   * sends the model the same call twice.
+   */
+  test("a threaded approval leaves one message per id in the store", async () => {
+    const refunded: string[] = [];
+    const refundOrder = AgentTool.create({
+      name: "refundOrder",
+      description: "Refund an order",
+      inputSchema: s.object({ orderId: s.string() }),
+      outputSchema: s.object({ refundId: s.string() }),
+      requiresApproval: true,
+      execute: async ({ orderId }) => {
+        refunded.push(orderId);
+        return { refundId: `rf_${orderId}` };
+      },
+    });
+    const provider = scriptedProvider(
+      [
+        { type: "tool-call", toolCallId: "c1", name: "refundOrder", args: '{"orderId":"ord_1"}' },
+        finish(),
+      ],
+      [{ type: "text-delta", delta: "refunded" }, finish()],
+    );
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder] });
+    const store = new MemoryAgentStore();
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      store = store;
+    }
+
+    const first = await eventsOf(
+      await new Chat().stream(jsonRequest({ threadId: "t1", text: "refund it" })),
+    );
+    await settle();
+    const awaiting = first.find((event) => event.type === "awaiting-input") as any;
+    expect(awaiting?.pending).toHaveLength(1);
+    expect(refunded).toEqual([]);
+
+    await eventsOf(
+      await new Chat().stream(
+        jsonRequest({
+          threadId: "t1",
+          toolResults: [
+            { toolCallId: "c1", signature: awaiting.pending[0].signature, approve: true },
+          ],
+        }),
+      ),
+    );
+    await settle();
+
+    expect(refunded).toEqual(["ord_1"]);
+    const held = await store.loadThread("t1");
+    const ids = held.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    // The copy that survived is the amended one, in the place the original had.
+    const amended = held.find((m) => m.content.some((part) => part.type === "tool-call"))!;
+    expect(held.indexOf(amended)).toBe(1);
+    expect(amended.content.map((part) => part.type)).toEqual(["tool-call", "tool-result"]);
+    const calls = held.flatMap((m) => m.content).filter((part) => part.type === "tool-call");
+    expect(calls).toHaveLength(1);
   });
 
   /**

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -10,7 +10,8 @@ import {
   MemoryAgentStore,
   MemoryLiveRuns,
 } from "./AgentController";
-import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "./AgentProvider";
+import type { ProviderEvent } from "./AgentProvider";
+import { fakeProvider } from "./providers/fakeProvider";
 import { s } from "./Schema";
 import { StubAgentRun } from "./store/stubAgentRun";
 import type { AgentMessage, AgentStreamEvent, PendingToolCall } from "./types";
@@ -89,38 +90,6 @@ async function eventsOf(response: Response): Promise<AgentStreamEvent[]> {
     .map((line) => JSON.parse(line.slice("data: ".length)));
 }
 
-/**
- * A provider that plays one script per model call, for the tests that need a
- * real `Agent` behind the controller rather than a stub run: what the store
- * ends up holding depends on what the agent reports, and a stub run reports
- * whatever the test hands it.
- */
-function scriptedProvider(...scripts: ProviderEvent[][]) {
-  let call = 0;
-  return {
-    model: "fake",
-    capabilities: {
-      reasoning: true,
-      structuredOutput: true,
-      fileInput: true,
-      parallelToolCalls: true,
-      toolSearch: true,
-    },
-    stream(_params: ProviderStreamParams) {
-      const script = scripts[call++] ?? [];
-      return (async function* () {
-        for (const event of script) yield event;
-      })();
-    },
-    upload: async () => "file_1",
-    normalizeError: (error: unknown) => ({
-      code: "provider_error" as const,
-      message: error instanceof Error ? error.message : String(error),
-      retryable: false,
-    }),
-  } as unknown as AgentProvider;
-}
-
 const finish = (): ProviderEvent => ({
   type: "finish",
   reason: "stop",
@@ -192,6 +161,10 @@ describe("AgentController.stream", () => {
    * id it already had, with the result attached. Persisting that turn must
    * replace the earlier copy, not sit next to it — otherwise every later turn
    * sends the model the same call twice.
+   *
+   * This one runs a real `Agent` over a scripted provider rather than a stub
+   * run: what the store ends up holding depends on what the agent reports,
+   * and a stub run reports whatever the test hands it.
    */
   test("a threaded approval leaves one message per id in the store", async () => {
     const refunded: string[] = [];
@@ -206,7 +179,7 @@ describe("AgentController.stream", () => {
         return { refundId: `rf_${orderId}` };
       },
     });
-    const provider = scriptedProvider(
+    const provider = fakeProvider(
       [
         { type: "tool-call", toolCallId: "c1", name: "refundOrder", args: '{"orderId":"ord_1"}' },
         finish(),

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -188,6 +188,9 @@ describe("AgentController.stream", () => {
     );
     const agent = Agent.create({ name: "support", provider, tools: [refundOrder] });
     const store = new MemoryAgentStore();
+    // Minted by the store: an id it has never seen is a 404 before the run,
+    // and this test is about what the second run leaves behind.
+    const { threadId } = await store.createThread({});
 
     class Chat extends AgentController {
       agent = agent;
@@ -196,7 +199,7 @@ describe("AgentController.stream", () => {
     }
 
     const first = await eventsOf(
-      await new Chat().stream(jsonRequest({ threadId: "t1", text: "refund it" })),
+      await new Chat().stream(jsonRequest({ threadId, text: "refund it" })),
     );
     await settle();
     const awaiting = first.find((event) => event.type === "awaiting-input") as any;
@@ -206,7 +209,7 @@ describe("AgentController.stream", () => {
     await eventsOf(
       await new Chat().stream(
         jsonRequest({
-          threadId: "t1",
+          threadId,
           toolResults: [
             { toolCallId: "c1", signature: awaiting.pending[0].signature, approve: true },
           ],
@@ -216,7 +219,7 @@ describe("AgentController.stream", () => {
     await settle();
 
     expect(refunded).toEqual(["ord_1"]);
-    const held = await store.loadThread("t1");
+    const held = (await store.loadThread(threadId))!;
     const ids = held.map((m) => m.id);
     expect(new Set(ids).size).toBe(ids.length);
     // The copy that survived is the amended one, in the place the original had.

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -486,7 +486,7 @@ describe("one live run per thread", () => {
     const first = new StubAgentRun("run_1");
     const second = new StubAgentRun("run_2");
     const { Chat, seen, store } = threaded([first, second]);
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { threadId } = await store.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, text: "first" }));
     expect(first.stopped).toBe(false);
@@ -532,7 +532,7 @@ describe("one live run per thread", () => {
   test("a third turn waits for the second, not just for the first", async () => {
     const runs = [new StubAgentRun("run_1"), new StubAgentRun("run_2"), new StubAgentRun("run_3")];
     const { Chat, seen, store } = threaded(runs);
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { threadId } = await store.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, text: "first" }));
     const second = new Chat().stream(jsonRequest({ threadId, text: "second" }));
@@ -586,7 +586,7 @@ describe("one live run per thread", () => {
         return new Promise(() => {});
       }
     }
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { threadId } = await store.createThread({});
 
     await new Hanging().stream(jsonRequest({ threadId, text: "first" }));
     const pending = new Hanging().stream(jsonRequest({ threadId, text: "second" }));
@@ -614,8 +614,8 @@ describe("one live run per thread", () => {
    */
   test("a stop that names a turn still waiting its place ends it before it starts", async () => {
     const runs = [new StubAgentRun("run_1"), new StubAgentRun("run_2")];
-    const { Chat, seen } = threaded(runs);
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { Chat, seen, store } = threaded(runs);
+    const { threadId } = await store.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, clientRunId: "c1", text: "first" }));
     const waiting = new Chat().stream(jsonRequest({ threadId, clientRunId: "c2", text: "second" }));
@@ -647,8 +647,8 @@ describe("one live run per thread", () => {
   test("a finished run still within its ttl holds nothing up", async () => {
     const first = new StubAgentRun("run_1");
     const second = new StubAgentRun("run_2");
-    const { Chat, seen } = threaded([first, second]);
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { Chat, seen, store } = threaded([first, second]);
+    const { threadId } = await store.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, text: "first" }));
     first.finish({ messages: [message("u1", "user", "first")] });

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -570,6 +570,80 @@ describe("one live run per thread", () => {
     ]);
   });
 
+  /**
+   * What the next turn waits for is the transcript in the store, not the app's
+   * hooks on it. Those are the app's own: an `onStreamComplete` that writes to
+   * something slow would be paid by every later turn, and one that never
+   * settles would hold the thread and every turn queued on it, each an open
+   * connection.
+   */
+  test("a hook that never settles does not hold the thread", async () => {
+    const first = new StubAgentRun("run_1");
+    const second = new StubAgentRun("run_2");
+    const { Chat, seen, store } = threaded([first, second]);
+    class Hanging extends Chat {
+      protected onStreamComplete(): Promise<void> {
+        return new Promise(() => {});
+      }
+    }
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Hanging().stream(jsonRequest({ threadId, text: "first" }));
+    const pending = new Hanging().stream(jsonRequest({ threadId, text: "second" }));
+    await settle();
+
+    first.finish({
+      messages: [message("u1", "user", "first"), message("a1", "assistant", "one")],
+    });
+    const response = await pending;
+    expect(response.headers.get("X-Stub-Run")).toBe("run_2");
+    // Started on the stored transcript: the wait was for the append, and only
+    // for the append.
+    expect(seen[1]!.messages.map((m) => m.id)).toEqual(["u1", "a1"]);
+    expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual(["u1", "a1"]);
+    second.finish();
+  });
+
+  /**
+   * Send, send again, then stop. The second turn is waiting behind the first
+   * run's unwind, and until it starts there is no run for `/stop` to find by
+   * `clientRunId`. Falling through to `threadId` found the first run, already
+   * stopping, answered `{ stopped: true }`, and the second turn started anyway
+   * once the first unwound — unwatched, billing, and with no handle left on the
+   * client, which had let go of the request and never saw its `run-start`.
+   */
+  test("a stop that names a turn still waiting its place ends it before it starts", async () => {
+    const runs = [new StubAgentRun("run_1"), new StubAgentRun("run_2")];
+    const { Chat, seen } = threaded(runs);
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, clientRunId: "c1", text: "first" }));
+    const waiting = new Chat().stream(jsonRequest({ threadId, clientRunId: "c2", text: "second" }));
+    await settle();
+    expect(seen).toHaveLength(1);
+
+    // What `useChat.stop()` sends for a turn whose `run-start` never came.
+    expect(await new Chat().stop(jsonRequest({ threadId, clientRunId: "c2" }))).toEqual({
+      stopped: true,
+    });
+
+    runs[0]!.finish({
+      messages: [message("u1", "user", "first"), message("a1", "assistant", "one")],
+    });
+    const response = await waiting;
+    expect(response.status).toBe(409);
+    expect(((await response.json()) as any).error.code).toBe("stopped");
+    // The model was never asked, and nothing was registered for `/stop` to
+    // have missed.
+    expect(seen).toHaveLength(1);
+
+    // And the thread is free: the next turn starts as usual.
+    await new Chat().stream(jsonRequest({ threadId, clientRunId: "c3", text: "third" }));
+    expect(seen).toHaveLength(2);
+    expect(seen[1]!.messages.map((m) => m.id)).toEqual(["u1", "a1"]);
+    runs[1]!.finish();
+  });
+
   test("a finished run still within its ttl holds nothing up", async () => {
     const first = new StubAgentRun("run_1");
     const second = new StubAgentRun("run_2");

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -224,6 +224,14 @@ describe("AgentController.stream", () => {
       messageId: "a1",
       part: { type: "tool-call", toolCallId: "c1", name: "bash", input: { command: "ls" } },
     } as AgentStreamEvent);
+    // A re-sent frame is the server's copy of a call the hook has already
+    // seen — a parked sub-run's signed record rides on it — not a second call.
+    run.emit({
+      type: "tool-call",
+      messageId: "a1",
+      part: { type: "tool-call", toolCallId: "c1", name: "bash", input: { command: "ls" } },
+      resent: true,
+    } as AgentStreamEvent);
     run.emit({
       type: "awaiting-input",
       runId: "run_4",

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -668,8 +668,105 @@ describe("the request body", () => {
       headers: { "Content-Type": "application/json; charset=utf-8" },
       body: JSON.stringify({ text: "hi" }),
     });
-    await new Chat().stream(new HttpRequest(raw, {}, "api", "/chat"));
+    const response = await new Chat().stream(new HttpRequest(raw, {}, "api", "/chat"));
+    expect(response.status).toBe(200);
     expect(calls[0]!.turn).toEqual({ text: "hi" });
+    run.finish();
+  });
+
+  /** Media types are case-insensitive, and some proxies rewrite them. */
+  test("matches the content type without regard to case", async () => {
+    const run = new StubAgentRun("run_case");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const response = await new Chat().stream(
+      rawRequest(JSON.stringify({ text: "hi" }), "Application/JSON; charset=UTF-8"),
+    );
+    expect(response.status).toBe(200);
+    expect(calls[0]!.turn).toEqual({ text: "hi" });
+    run.finish();
+  });
+
+  /**
+   * The CSRF shape: a cross-site `<form enctype="text/plain">` whose single
+   * field is named `{"text":"` and valued `"}` posts exactly this body, and the
+   * browser sends it without a preflight. Parsing it would let any page on the
+   * web take a turn on a logged-in user's conversation. The refusal comes
+   * before the body is looked at, so it is the same for one that is valid JSON
+   * as for one that is not.
+   */
+  test("refuses a body that is not application/json with a 415", async () => {
+    const run = new StubAgentRun("run_415");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+
+    const response = await new Chat().stream(rawRequest('{"text":"hi"}', "text/plain"));
+    expect(response.status).toBe(415);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    const body = (await response.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("unsupported_media_type");
+    expect(body.error.message).toContain("application/json");
+    // No run was started for it.
+    expect(calls).toHaveLength(0);
+
+    for (const contentType of ["application/x-www-form-urlencoded", "multipart/form-data"]) {
+      expect((await new Chat().stream(rawRequest("text=hi", contentType))).status).toBe(415);
+    }
+    expect(calls).toHaveLength(0);
+    run.finish();
+  });
+
+  /**
+   * A body with no type at all. Bun's `Request` leaves a string body untyped,
+   * which is what this builds; a browser would have filled in
+   * `text/plain;charset=UTF-8`, which the test above refuses the same way.
+   */
+  test("refuses a body that carries no content type at all", async () => {
+    const run = new StubAgentRun("run_notype");
+    const { agent, calls } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const raw = new Request("http://localhost/api/chat", {
+      method: "POST",
+      body: JSON.stringify({ text: "hi" }),
+    });
+    expect(raw.headers.get("Content-Type")).toBeNull();
+    const response = await new Chat().stream(new HttpRequest(raw, {}, "api", "/chat"));
+    expect(response.status).toBe(415);
+    expect(calls).toHaveLength(0);
+    run.finish();
+  });
+
+  test("attach and stop hold the body to the same type", async () => {
+    const run = new StubAgentRun("run_415b");
+    const { agent } = stubAgent(run);
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+    }
+    const controller = new Chat();
+    await controller.stream(jsonRequest({ threadId: "t1", text: "hi" }));
+
+    const attached = await controller.attach(
+      rawRequest(JSON.stringify({ threadId: "t1" }), "text/plain"),
+    );
+    expect(attached.status).toBe(415);
+
+    const stopped = await controller.stop(
+      rawRequest(JSON.stringify({ runId: "run_415b" }), "text/plain"),
+    );
+    expect(stopped).toBeInstanceOf(Response);
+    expect((stopped as Response).status).toBe(415);
+    expect(run.stopped).toBe(false);
+
     run.finish();
   });
 

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -293,14 +293,14 @@ describe("AgentController.attach", () => {
     run.finish();
     await settle();
 
-    const response = await controller.attach(jsonRequest({ threadId: "t1", from: 2 }));
+    const response = await controller.attach(jsonRequest({ threadId: "t1", from: 3 }));
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/event-stream");
 
     const body = await readSse(response);
-    expect(body).toContain("id: 2");
     expect(body).toContain("id: 3");
-    expect(body).not.toContain("id: 1");
+    expect(body).toContain("id: 4");
+    expect(body).not.toContain("id: 2");
     expect(body).toContain('"delta":"c"');
     expect(body).not.toContain('"delta":"b"');
   });
@@ -340,11 +340,11 @@ describe("AgentController.attach", () => {
     await settle();
 
     const response = await controller.attach(
-      jsonRequest({ threadId: "t1", cursor: 1, runId: "run_cur" }),
+      jsonRequest({ threadId: "t1", cursor: 2, runId: "run_cur" }),
     );
     const body = await readSse(response);
-    expect(body).toContain("id: 2");
-    expect(body).not.toContain("id: 1");
+    expect(body).toContain("id: 3");
+    expect(body).not.toContain("id: 2");
     expect(body).toContain('"delta":"c"');
     expect(body).not.toContain('"delta":"b"');
   });
@@ -369,7 +369,7 @@ describe("AgentController.attach", () => {
     );
     expect(response.status).toBe(200);
     const body = await readSse(response);
-    expect(body).toContain("id: 39");
+    expect(body).toContain("id: 40");
   });
 
   test("forfeits a cursor that counts within a run which is not the live one", async () => {
@@ -382,14 +382,14 @@ describe("AgentController.attach", () => {
     run.finish();
     await settle();
 
-    // The client applied 3 frames of an EARLIER run on this thread. seq starts
-    // at zero in every run, so honouring that 2 here would swallow the head of
-    // a run it has seen nothing of.
+    // The client applied frames of an EARLIER run on this thread. seq restarts
+    // in every run, so honouring that 2 here would swallow the head of a run it
+    // has seen nothing of.
     const response = await controller.attach(
       jsonRequest({ threadId: "t1", cursor: 2, runId: "run_one" }),
     );
     const body = await readSse(response);
-    expect(body).toContain("id: 0");
+    expect(body).toContain("id: 1");
     expect(body).toContain('"delta":"a"');
   });
 
@@ -406,9 +406,9 @@ describe("AgentController.attach", () => {
     // `from` and `Last-Event-ID` predate the cursor/runId pairing and carry no
     // run; an EventSource reconnecting on its own will never grow one. They
     // must keep resuming rather than being read as a mismatch.
-    const body = await readSse(await controller.attach(jsonRequest({ threadId: "t1", from: 2 })));
-    expect(body).toContain("id: 2");
-    expect(body).not.toContain("id: 1");
+    const body = await readSse(await controller.attach(jsonRequest({ threadId: "t1", from: 3 })));
+    expect(body).toContain("id: 3");
+    expect(body).not.toContain("id: 2");
   });
 
   test("misses explicitly when no run is in flight in this process", async () => {
@@ -455,9 +455,9 @@ describe("AgentController.attach", () => {
 
     expect(response.status).toBe(200);
     const body = await readSse(response);
-    expect(body).toContain("id: 6");
-    expect(body).toContain("id: 9");
-    expect(body).not.toContain("id: 5");
+    expect(body).toContain("id: 7");
+    expect(body).toContain("id: 10");
+    expect(body).not.toContain("id: 6");
   });
 
   test("with no cursor and nothing dropped, returns the run from the start", async () => {
@@ -471,8 +471,8 @@ describe("AgentController.attach", () => {
     await settle();
 
     const body = await readSse(await controller.attach(jsonRequest({ threadId: "t1" })));
-    expect(body).toContain("id: 0");
     expect(body).toContain("id: 1");
+    expect(body).toContain("id: 2");
   });
 
   test("answers 410 for a cursor the buffer has dropped", async () => {
@@ -491,14 +491,16 @@ describe("AgentController.attach", () => {
     run.finish();
     await settle();
 
-    // Explicitly `from: 0`: this client says its transcript ends at frame 0, so
-    // handing it frame 6 onwards would leave a hole it cannot see. That is the
-    // 410, and it is exactly the request a client with no cursor is NOT making.
-    const response = await controller.attach(jsonRequest({ threadId: "t1", from: 0 }));
+    // Explicitly `from: 1`: this client says its transcript starts at the run's
+    // first frame, so handing it frame 7 onwards would leave a hole it cannot
+    // see. That is the 410, and it is exactly the request a client with no
+    // cursor is NOT making. `from: 0` is a different question — "everything you
+    // still have" — and on a run that dropped nothing it is answerable.
+    const response = await controller.attach(jsonRequest({ threadId: "t1", from: 1 }));
     expect(response.status).toBe(410);
     const body = (await response.json()) as { error: { code: string; oldestSeq: number } };
     expect(body.error.code).toBe("frame_cursor_evicted");
-    expect(body.error.oldestSeq).toBe(6);
+    expect(body.error.oldestSeq).toBe(7);
   });
 });
 

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -124,6 +124,21 @@ export type AgentHookContext = {
  */
 const ControllerBase = Controller as new () => Controller;
 
+/**
+ * The thread a `stream` is setting up on, to the setup ahead of it. Module
+ * level because the controller is constructed per request, so nothing on it
+ * can be seen by the next request; keyed by thread rather than held on
+ * `liveRuns` because it guards the controller's protocol, not the frames. An
+ * entry is removed once the last setup queued on it releases.
+ */
+const threadLocks = new Map<string, Promise<void>>();
+
+/**
+ * Each run to the promise that its transcript has been stored. Weak, so a run
+ * the map has evicted is not kept alive here for a promise nobody will ask for.
+ */
+const persisted = new WeakMap<AgentRun, Promise<void>>();
+
 export abstract class AgentController<A extends AnyAgent = AnyAgent> extends ControllerBase {
   static kind = "agent-controller" as const;
 
@@ -185,63 +200,135 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     // or a `store` that scopes by `req.user`. The framework's job is to make
     // sure the route is behind the router's middleware in the first place,
     // which `ApiRouter.agent()` now does.
-    let messages: AgentMessage[];
-    if (threadId) {
-      const history = await this.store.loadThread(threadId);
-      if (!history) {
-        // Before `instructions()` and before the run: nothing has been
-        // charged for, and the client has to learn that its thread is gone —
-        // expired, mistyped, or on an instance that no longer exists — rather
-        // than see it answered as an empty conversation and have this turn
-        // persisted under the dead id.
-        //
-        // That ordering is deliberate, and it costs something: the ownership
-        // check the comment above points at `instructions()` for has not run
-        // yet, so a caller holding a uuid learns whether it is live here
-        // without the app's say. `/attach` already answers a question of that
-        // shape to anyone with the id and never calls `instructions()`, and
-        // the id is unguessable — which is why the load stays above
-        // `instructions()`, whose own work (a database read, typically) would
-        // otherwise be spent on a thread that is gone. Move it below and that
-        // work is spent on every dead id instead.
-        return jsonResponse(404, {
-          code: "thread_not_found",
-          message: `Thread ${threadId} does not exist here, or has expired.`,
-        });
+    //
+    // Everything from the load on happens inside `start`, which on a thread
+    // runs under the thread's lock once the previous run's transcript is in the
+    // store — the load has to come after that, or it reads a history the old
+    // answer is missing from. `instructions()` follows the load in there rather
+    // than running ahead of the lock, so that a dead thread is still a 404
+    // before the app's own work is spent on it; the cost is that a turn queued
+    // behind this one waits for `instructions()` as well.
+    const start = async (): Promise<Response> => {
+      let messages: AgentMessage[];
+      if (threadId) {
+        const history = await this.store.loadThread(threadId);
+        if (!history) {
+          // Before `instructions()` and before the run: nothing has been
+          // charged for, and the client has to learn that its thread is gone —
+          // expired, mistyped, or on an instance that no longer exists — rather
+          // than see it answered as an empty conversation and have this turn
+          // persisted under the dead id.
+          //
+          // That ordering is deliberate, and it costs something: the ownership
+          // check the comment above points at `instructions()` for has not run
+          // yet, so a caller holding a uuid learns whether it is live here
+          // without the app's say. `/attach` already answers a question of that
+          // shape to anyone with the id and never calls `instructions()`, and
+          // the id is unguessable — which is why the load stays above
+          // `instructions()`, whose own work (a database read, typically) would
+          // otherwise be spent on a thread that is gone. Move it below and that
+          // work is spent on every dead id instead.
+          return jsonResponse(404, {
+            code: "thread_not_found",
+            message: `Thread ${threadId} does not exist here, or has expired.`,
+          });
+        }
+        messages = history;
+      } else {
+        messages = Array.isArray(body.messages) ? (body.messages as AgentMessage[]) : [];
       }
-      messages = history;
-    } else {
-      messages = Array.isArray(body.messages) ? (body.messages as AgentMessage[]) : [];
-    }
 
-    const instructions = (await this.instructions(req)) || undefined;
+      const instructions = (await this.instructions(req)) || undefined;
 
-    const run = this.agent.stream({
-      messages,
-      turn,
-      req,
-      threadId,
-      instructions,
-    }) as AgentRun;
+      const run = this.agent.stream({
+        messages,
+        turn,
+        req,
+        threadId,
+        instructions,
+      }) as AgentRun;
 
-    const ctx: AgentHookContext = { req, runId: run.runId, threadId };
+      const ctx: AgentHookContext = { req, runId: run.runId, threadId };
 
-    // Registered before the response is built: the run is now owned by the
-    // process rather than by this request, which is the property `/attach`
-    // depends on and the reason a dropped connection no longer cancels
-    // anything.
-    this.liveRuns.register(run, {
-      threadId,
-      // The client's handle on a run it started, which is the only one that
-      // exists before `run-start` reaches it. See `RegisterParams`.
-      clientRunId: typeof body.clientRunId === "string" ? body.clientRunId : undefined,
-      onEvent: (event) => this.dispatchEvent(event, ctx),
-      onInternalError: (err) => this.reportHookFailure(err),
+      // Registered before the response is built: the run is now owned by the
+      // process rather than by this request, which is the property `/attach`
+      // depends on and the reason a dropped connection no longer cancels
+      // anything.
+      this.liveRuns.register(run, {
+        threadId,
+        // The client's handle on a run it started, which is the only one that
+        // exists before `run-start` reaches it. See `RegisterParams`.
+        clientRunId: typeof body.clientRunId === "string" ? body.clientRunId : undefined,
+        onEvent: (event) => this.dispatchEvent(event, ctx),
+        onInternalError: (err) => this.reportHookFailure(err),
+      });
+
+      // Kept, not just fired: the next turn on this thread has to know when
+      // this one's transcript is in the store. See `withThread`.
+      persisted.set(run, this.persistRun(run, ctx));
+
+      return run.toResponse();
+    };
+
+    return threadId ? await this.withThread(threadId, start) : await start();
+  }
+
+  /**
+   * A thread holds one run at a time; a new turn on it ends the old one first.
+   *
+   * Since a dropped connection no longer stops a run, a user who sends again
+   * mid-answer used to leave the first run going. It could not see the new
+   * turn, the new run's `loadThread` could not see its answer, and both
+   * appended when they finished — in whichever order the model returned them,
+   * so the thread read `user2, assistant2, user1, assistant1`. `byThread` then
+   * named the second run while the first was still live and unstoppable by
+   * `threadId`.
+   *
+   * Stopping the old run and waiting for its transcript to land is chosen over
+   * refusing the new turn with a 409, because sending again *is* the stop: it
+   * is what `useChat.send` means, and a client that has to poll `/stop` until
+   * the run is really gone before it may post the turn it has already shown is
+   * a worse client for no better thread. The cost is that the new turn waits
+   * for the old run to unwind, which is as long as its slowest tool in flight —
+   * and that wait is the thing that puts `assistant1` before `user2`.
+   *
+   * The wait is on `persistRun`, not on `run.result()`. `result()` settling is
+   * the transcript being final, not stored: `appendMessages` runs after it, and
+   * a `loadThread` in that gap reads a history the old answer is missing from,
+   * which is the original bug by a shorter route.
+   *
+   * The lock around it is what makes a *third* turn wait for the second rather
+   * than for the first. Two turns arriving together both see the same live
+   * run, both stop it, both wait for it, and both start — the same race, one
+   * message later. Under the lock the later one finds the earlier one
+   * registered and stops that instead. Per process, like `LiveRuns`, and for
+   * the same reason: the run it guards lives here.
+   */
+  private async withThread<T>(threadId: string, fn: () => Promise<T>): Promise<T> {
+    const previous = threadLocks.get(threadId) ?? Promise.resolve();
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
     });
-
-    void this.persistRun(run, ctx);
-
-    return run.toResponse();
+    const tail = previous.then(() => held);
+    threadLocks.set(threadId, tail);
+    await previous;
+    try {
+      const live = await this.liveRuns.find({ threadId });
+      const run = live ? this.liveRuns.get(live.runId) : null;
+      if (run) {
+        // A run that already ended is still `find`-able for `ttlMs`; stopping
+        // it is a no-op and waiting on it is the append it may still be doing.
+        run.stop({ reason: "superseded by a later turn on this thread" });
+        await persisted.get(run);
+      }
+      return await fn();
+    } finally {
+      release();
+      if (threadLocks.get(threadId) === tail) {
+        threadLocks.delete(threadId);
+      }
+    }
   }
 
   /**
@@ -324,9 +411,10 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
 
   /**
    * `POST /<path>/stop` — the explicit cancel. Since a dropped connection no
-   * longer stops a run, this is the only thing that does, and it is why
-   * stopping cannot be a client-side concern: the tool loop is here, and a
-   * client that stops reading has not stopped step four from charging a card.
+   * longer stops a run, this and a later turn on the same thread are the only
+   * things that do, and it is why stopping cannot be a client-side concern:
+   * the tool loop is here, and a client that stops reading has not stopped
+   * step four from charging a card.
    *
    * Returns as soon as the run is aborted, not when it has finished unwinding.
    * The terminal events — the stopped tool results, the aborted message — go

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -396,8 +396,11 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
       case "tool-call":
         // Skipped while the arguments are still streaming: a hook that fires
         // per token would fire with a half-parsed input, which is worse than
-        // firing late.
-        if (!event.part.partial) {
+        // firing late. And skipped for a re-sent frame, which carries a parked
+        // sub-run's record on a call this hook has already seen — once per call
+        // is the contract, and a run that re-parks would otherwise fire it for
+        // a call some earlier run made.
+        if (!event.part.partial && !event.resent) {
           await this.onToolCall(
             {
               toolCallId: event.part.toolCallId,

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -32,7 +32,19 @@ import type {
  */
 export interface AgentStore {
   createThread(params: { userId?: string | number }): Promise<{ threadId: string }>;
-  loadThread(threadId: string): Promise<AgentMessage[]>;
+  /**
+   * The history, or `null` for a thread the store does not have.
+   *
+   * `null` and `[]` are different answers and the controller acts on the
+   * difference: an empty array is a conversation with nothing in it yet, and a
+   * turn on it runs; `null` is a 404 before anything runs. A store that answers
+   * `[]` for an id it has never seen turns an expired or mistyped thread into a
+   * fresh conversation with no signal, and persists the next turn under the
+   * dead id. Only a store whose ids are minted by the client should do that,
+   * and then on purpose — see `MemoryAgentStore`'s `clientOwnedIds`.
+   */
+  loadThread(threadId: string): Promise<AgentMessage[] | null>;
+  /** Called with a thread `loadThread` just found. Must not create one. */
   appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
 }
 
@@ -152,11 +164,24 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     // or a `store` that scopes by `req.user`. The framework's job is to make
     // sure the route is behind the router's middleware in the first place,
     // which `ApiRouter.agent()` now does.
-    const messages = threadId
-      ? await this.store.loadThread(threadId)
-      : Array.isArray(body.messages)
-        ? (body.messages as AgentMessage[])
-        : [];
+    let messages: AgentMessage[];
+    if (threadId) {
+      const history = await this.store.loadThread(threadId);
+      if (!history) {
+        // Before `instructions()` and before the run: nothing has been
+        // charged for, and the client has to learn that its thread is gone —
+        // expired, mistyped, or on an instance that no longer exists — rather
+        // than see it answered as an empty conversation and have this turn
+        // persisted under the dead id.
+        return jsonResponse(404, {
+          code: "thread_not_found",
+          message: `Thread ${threadId} does not exist here, or has expired.`,
+        });
+      }
+      messages = history;
+    } else {
+      messages = Array.isArray(body.messages) ? (body.messages as AgentMessage[]) : [];
+    }
 
     const instructions = (await this.instructions(req)) || undefined;
 
@@ -215,6 +240,12 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
       });
     }
 
+    // The store is not consulted. This route answers whether a run is in
+    // flight here, and a run it finds was started on a thread `stream` had
+    // already loaded; a miss is `no_live_run` whether or not the thread exists,
+    // because a client that gets one re-reads the thread anyway (see
+    // `onAttachMiss`) and learns there. The thread's own 404 is `stream`'s,
+    // where a turn would otherwise be persisted under it.
     const live = await this.liveRuns.find({ threadId });
     if (!live) {
       // An explicit miss, not a 200 with an empty stream. See `MemoryLiveRuns`:

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -134,7 +134,7 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     if (parsed.error) {
       // Before anything is registered or charged for. A run started off a body
       // we could not read would answer nothing, at the user's expense.
-      return invalidRequest(parsed.error);
+      return invalidRequest(parsed);
     }
     const body = parsed.body;
     const threadId = typeof body.threadId === "string" ? body.threadId : undefined;
@@ -202,7 +202,7 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
   async attach(req: HttpRequest<any, any> = new HttpRequest()): Promise<Response> {
     const parsed = await readJsonBody(req);
     if (parsed.error) {
-      return invalidRequest(parsed.error);
+      return invalidRequest(parsed);
     }
     const body = parsed.body;
     const threadId =
@@ -272,7 +272,7 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * and `onMessage` records it whether anyone is watching or not.
    *
    * Answers `{ stopped }` normally, and a `Response` only to reject a request
-   * it could not read — the union is the 400, not a second success shape.
+   * it could not read — the union is the error, not a second success shape.
    */
   async stop(
     req: HttpRequest<any, any> = new HttpRequest(),
@@ -283,7 +283,7 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
       // status: it means "there was nothing to stop", and the truth is that we
       // could not tell what to stop. A client that believes the first one stops
       // asking, and the run keeps going.
-      return invalidRequest(parsed.error);
+      return invalidRequest(parsed);
     }
     const body = parsed.body;
 
@@ -486,7 +486,13 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
  * discriminant — `if (!parsed.ok)` leaves `parsed.message` an error. A field
  * that is either set or not needs no narrowing to read.
  */
-type ParsedBody = { body: Record<string, any>; error?: string };
+type ParsedBody = {
+  body: Record<string, any>;
+  error?: string;
+  /** Which HTTP error the rejection is. A missing one is the 400. */
+  status?: number;
+  code?: string;
+};
 
 /**
  * The body, as JSON — or a reason it is not.
@@ -495,6 +501,17 @@ type ParsedBody = { body: Record<string, any>; error?: string };
  * `Content-Type` exactly, so `application/json; charset=utf-8` — which several
  * HTTP clients send by default — parses as an empty body, and an agent turn
  * that silently loses its text is a bad way to find that out.
+ *
+ * Matching the type by prefix is not the same as ignoring it. A body that
+ * arrives as anything other than `application/json` is a 415, and the reason
+ * is not tidiness: a cross-site `<form enctype="text/plain">` can be made to
+ * concatenate its one field into valid JSON, and a JSON parser that reads
+ * whatever it is handed turns that form into a turn on someone else's
+ * conversation. Insisting on `application/json` is what makes these routes
+ * non-simple requests — the browser will not send one cross-origin without a
+ * preflight — and that holds whether or not the app's cookies are `SameSite`
+ * and whether or not `CSRFMiddleware` is mounted. Only a request that carries a
+ * body is held to this; a bodiless POST has no type to check and stays `{}`.
  *
  * The three cases are kept apart deliberately. NO body is a real request — a
  * reattach, or a turn that just lets the model continue — and reads as `{}`. A
@@ -514,6 +531,17 @@ async function readJsonBody(req: HttpRequest<any, any>): Promise<ParsedBody> {
   const raw = req?.rawRequest;
   if (!raw || raw.method === "GET" || raw.method === "HEAD" || !raw.body) {
     return { body: {} };
+  }
+
+  if (!isJsonContentType(raw.headers.get("Content-Type"))) {
+    // Before the body is read: nothing in a body about to be refused is worth
+    // the bytes, and the refusal must not depend on what they were.
+    return {
+      body: {},
+      status: 415,
+      code: "unsupported_media_type",
+      error: "The request body must be sent as application/json.",
+    };
   }
 
   let text: string;
@@ -543,8 +571,24 @@ async function readJsonBody(req: HttpRequest<any, any>): Promise<ParsedBody> {
   return { body: parsed as Record<string, any> };
 }
 
-function invalidRequest(message: string): Response {
-  return jsonResponse(400, { code: "invalid_request", message });
+/**
+ * Media types compare case-insensitively and may carry parameters, so this is a
+ * prefix match on the lowercased value rather than an equality, and
+ * `Application/JSON; charset=utf-8` passes. None of the three types a browser
+ * will send without a preflight — `text/plain`,
+ * `application/x-www-form-urlencoded`, `multipart/form-data` — does, and
+ * neither does no type at all, which is what a hand-written `fetch` with a
+ * string body and no header ends up sending as `text/plain`.
+ */
+function isJsonContentType(value: string | null): boolean {
+  return typeof value === "string" && value.trim().toLowerCase().startsWith("application/json");
+}
+
+function invalidRequest(parsed: ParsedBody): Response {
+  return jsonResponse(parsed.status ?? 400, {
+    code: parsed.code ?? "invalid_request",
+    message: parsed.error,
+  });
 }
 
 /**

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -31,6 +31,15 @@ import type {
  * still there after a refresh.
  */
 export interface AgentStore {
+  /**
+   * Where a `threadId` comes from. `ApiRouter.agent()` mounts no route for
+   * this: the app writes one, calls it here, and hands the id to `useChat` —
+   * the mount is the app's because it is where ownership gets recorded, and a
+   * store that holds no user cannot do that for it. An id that did not come out
+   * of here is `null` from `loadThread` and a 404 from the controller, unless
+   * the store's ids are the client's by design (`MemoryAgentStore`'s
+   * `clientOwnedIds`).
+   */
   createThread(params: { userId?: string | number }): Promise<{ threadId: string }>;
   /**
    * The history, or `null` for a thread the store does not have.
@@ -173,6 +182,16 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
         // expired, mistyped, or on an instance that no longer exists — rather
         // than see it answered as an empty conversation and have this turn
         // persisted under the dead id.
+        //
+        // That ordering is deliberate, and it costs something: the ownership
+        // check the comment above points at `instructions()` for has not run
+        // yet, so a caller holding a uuid learns whether it is live here
+        // without the app's say. `/attach` already answers a question of that
+        // shape to anyone with the id and never calls `instructions()`, and
+        // the id is unguessable — which is why the load stays above
+        // `instructions()`, whose own work (a database read, typically) would
+        // otherwise be spent on a thread that is gone. Move it below and that
+        // work is spent on every dead id instead.
         return jsonResponse(404, {
           code: "thread_not_found",
           message: `Thread ${threadId} does not exist here, or has expired.`,

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -53,7 +53,17 @@ export interface AgentStore {
    * and then on purpose — see `MemoryAgentStore`'s `clientOwnedIds`.
    */
   loadThread(threadId: string): Promise<AgentMessage[] | null>;
-  /** Called with a thread `loadThread` just found. Must not create one. */
+  /**
+   * Upsert by message id: replace a message the thread already holds, append
+   * one it does not, and keep the order the thread had. Called with a thread
+   * `loadThread` just found; must not create one.
+   *
+   * The name says append because that is what almost every call is, but a
+   * turn that resolves a pending call reports the earlier assistant message
+   * again — same id, now with the result attached — and a store that only
+   * appends ends up with both versions. A table keyed by message id gets this
+   * for free; a store that is a list has to look before it pushes.
+   */
   appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
 }
 

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -61,8 +61,10 @@ export interface AgentStore {
    * The name says append because that is what almost every call is, but a
    * turn that resolves a pending call reports the earlier assistant message
    * again — same id, now with the result attached — and a store that only
-   * appends ends up with both versions. A table keyed by message id gets this
-   * for free; a store that is a list has to look before it pushes.
+   * appends ends up with both versions. A table keyed by message id has the
+   * lookup already but still needs an insert-or-update rather than a plain
+   * insert, which would fail on the key; a store that is a list has to look
+   * before it pushes.
    */
   appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
 }

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -139,6 +139,20 @@ const threadLocks = new Map<string, Promise<void>>();
  */
 const persisted = new WeakMap<AgentRun, Promise<void>>();
 
+/**
+ * Turns read but not yet registered, by the client's name for them.
+ *
+ * A run can be stopped from `register` on, and named from `run-start` on. What
+ * `/stop` could not reach was a turn still waiting its place on the thread —
+ * which is where a user who sent twice and thought better of it presses stop,
+ * and the wait is now as long as the old run's unwind. Falling through to
+ * `threadId` there found the old run, already stopping, said `stopped: true`,
+ * and the queued turn started anyway: unwatched, billing, and with no handle
+ * left on the client that had let go of it. The entry is marked rather than
+ * removed, because the turn itself is what answers once its wait is over.
+ */
+const pendingTurns = new Map<string, { cancelled: boolean }>();
+
 export abstract class AgentController<A extends AnyAgent = AnyAgent> extends ControllerBase {
   static kind = "agent-controller" as const;
 
@@ -187,6 +201,14 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     const body = parsed.body;
     const threadId = typeof body.threadId === "string" ? body.threadId : undefined;
     const turn = toClientTurn(body);
+    const clientRunId = typeof body.clientRunId === "string" ? body.clientRunId : undefined;
+
+    // From here until `register`, the only thing `/stop` can find this turn by.
+    // See `pendingTurns`.
+    const pending = clientRunId ? { cancelled: false } : null;
+    if (pending) {
+      pendingTurns.set(clientRunId, pending);
+    }
 
     // The whole of the stateless/threaded difference, in one expression: with a
     // thread the server owns the history, without one the client carries it.
@@ -240,6 +262,17 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
 
       const instructions = (await this.instructions(req)) || undefined;
 
+      if (pending?.cancelled) {
+        // Stopped while it waited. Nothing has been asked of the model and
+        // nothing registered, so there is no run to end and nothing charged
+        // for. Checked after the last `await` above, so that a stop landing
+        // during it is not missed: from here to `register` nothing yields.
+        return jsonResponse(409, {
+          code: "stopped",
+          message: "The turn was stopped before it started.",
+        });
+      }
+
       const run = this.agent.stream({
         messages,
         turn,
@@ -258,7 +291,7 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
         threadId,
         // The client's handle on a run it started, which is the only one that
         // exists before `run-start` reaches it. See `RegisterParams`.
-        clientRunId: typeof body.clientRunId === "string" ? body.clientRunId : undefined,
+        clientRunId,
         onEvent: (event) => this.dispatchEvent(event, ctx),
         onInternalError: (err) => this.reportHookFailure(err),
       });
@@ -270,7 +303,13 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
       return run.toResponse();
     };
 
-    return threadId ? await this.withThread(threadId, start) : await start();
+    try {
+      return threadId ? await this.withThread(threadId, start) : await start();
+    } finally {
+      if (pending && pendingTurns.get(clientRunId) === pending) {
+        pendingTurns.delete(clientRunId);
+      }
+    }
   }
 
   /**
@@ -295,7 +334,10 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * The wait is on `persistRun`, not on `run.result()`. `result()` settling is
    * the transcript being final, not stored: `appendMessages` runs after it, and
    * a `loadThread` in that gap reads a history the old answer is missing from,
-   * which is the original bug by a shorter route.
+   * which is the original bug by a shorter route. It is also *only* that:
+   * `persistRun` settles once the transcript is stored and lets the app's
+   * hooks run on without it, so a slow `onMessage` is not a slow thread and a
+   * hung one is not a hung thread.
    *
    * The lock around it is what makes a *third* turn wait for the second rather
    * than for the first. Two turns arriving together both see the same live
@@ -440,12 +482,24 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     // Three handles, most specific first, because which ones the client has
     // depends on how far the run got. `runId` is the server's own and settles
     // it. `clientRunId` covers the window before `run-start`, when the client
-    // has nothing else for a stateless first turn. `threadId` is the fallback
-    // for a client that did not start this run at all — one that attached to
-    // it, whose replayed tail carried no `run-start`.
+    // has nothing else for a stateless first turn — and, before that, a turn
+    // that has not become a run yet because it is waiting its place on the
+    // thread, which is ended where it waits. `threadId` is the fallback for a
+    // client that did not start this run at all — one that attached to it,
+    // whose replayed tail carried no `run-start`.
     let runId = typeof body.runId === "string" ? body.runId : undefined;
     if (!runId && typeof body.clientRunId === "string") {
       runId = this.liveRuns.findByClientRunId(body.clientRunId) ?? undefined;
+      if (!runId) {
+        const pending = pendingTurns.get(body.clientRunId);
+        if (pending) {
+          // Not on to `threadId`: that names the run this turn is queued
+          // behind, which is already stopping, and answering for it would
+          // leave this one to start.
+          pending.cancelled = true;
+          return { stopped: true };
+        }
+      }
     }
     if (!runId && typeof body.threadId === "string") {
       runId = (await this.liveRuns.find({ threadId: body.threadId }))?.runId;
@@ -580,13 +634,21 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * how the two copies drift. It also means a stopped run persists the same way
    * a finished one does: `stop()` finalizes the transcript, so by the time this
    * resolves there is a valid history to store.
+   *
+   * Settles when the transcript is in the store, not when the app is done with
+   * it. The next turn on this thread waits on this (see `withThread`), and the
+   * hooks are the app's: an `onMessage` that writes to something slow would
+   * make every later turn wait for it, once per message of the old run, and
+   * one that never settles — which `safely` cannot catch — would hold the
+   * thread, and every turn queued on it, behind an open connection each. So
+   * the hooks run on after this on their own, reported the same way.
    */
   private async persistRun(run: AgentRun, ctx: AgentHookContext): Promise<void> {
     let result: AgentRunResult<ToolShapes, unknown>;
     try {
       result = await run.result();
     } catch (err) {
-      await this.safely(() =>
+      void this.safely(() =>
         this.onError(
           {
             code: "unknown",
@@ -609,6 +671,15 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
       }
     }
 
+    void this.notifyRun(result, messages, ctx);
+  }
+
+  /** The hooks on a finished run, in order. Never rejects: see `safely`. */
+  private async notifyRun(
+    result: AgentRunResult<ToolShapes, unknown>,
+    messages: AgentMessage[],
+    ctx: AgentHookContext,
+  ): Promise<void> {
     for (const message of messages) {
       await this.safely(() => this.onMessage(message, ctx));
     }

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -572,16 +572,20 @@ async function readJsonBody(req: HttpRequest<any, any>): Promise<ParsedBody> {
 }
 
 /**
- * Media types compare case-insensitively and may carry parameters, so this is a
- * prefix match on the lowercased value rather than an equality, and
- * `Application/JSON; charset=utf-8` passes. None of the three types a browser
- * will send without a preflight — `text/plain`,
- * `application/x-www-form-urlencoded`, `multipart/form-data` — does, and
- * neither does no type at all, which is what a hand-written `fetch` with a
- * string body and no header ends up sending as `text/plain`.
+ * Media types compare case-insensitively and may carry parameters, so the
+ * comparison is on the lowercased type with its parameters cut off, and
+ * `Application/JSON; charset=utf-8` passes. It is an equality on that type
+ * rather than a prefix, so `application/json-seq` and the other types that
+ * merely begin with those bytes do not. None of the three types a browser will
+ * send without a preflight — `text/plain`, `application/x-www-form-urlencoded`,
+ * `multipart/form-data` — does either, and neither does no type at all, which
+ * is what a hand-written `fetch` with a string body and no header ends up
+ * sending as `text/plain`.
  */
 function isJsonContentType(value: string | null): boolean {
-  return typeof value === "string" && value.trim().toLowerCase().startsWith("application/json");
+  if (typeof value !== "string") return false;
+  const [type] = value.split(";", 1);
+  return type.trim().toLowerCase() === "application/json";
 }
 
 function invalidRequest(parsed: ParsedBody): Response {

--- a/packages/gemi/ai/client/reducer.test-d.ts
+++ b/packages/gemi/ai/client/reducer.test-d.ts
@@ -1,0 +1,66 @@
+/**
+ * Type-level tests for the browser half.
+ *
+ * `Agent.test-d.ts` pins that a tool's progress type survives `ToolShapesOf`
+ * and lands on `ToolCallPart`. What is left, and what belongs here, is that it
+ * survives the *reducer's* generics — `ChatState<T, O>` carries `T` down
+ * through `AgentMessage` into a content part — because that is the last link
+ * between a tool's `execute` and the component that renders its progress log,
+ * and it is entirely made of mapped types no runtime test touches.
+ *
+ * Run with `bun run test:types`.
+ */
+import { describe, expectTypeOf, test } from "vitest";
+import type { AgentMessage, NestedRun } from "../types";
+import type { ChatState } from "./reducer";
+
+type Shapes = {
+  research: {
+    input: { topic: string };
+    output: { summary: string };
+    progress: { stage: string };
+  };
+  bash: { input: { command: string }; output: { output: string }; progress: never };
+};
+
+type Part = ChatState<Shapes>["messages"][number]["content"][number];
+
+describe("what a component gets out of the reducer's state", () => {
+  test("a tool call's progress log is typed by the tool, not by `unknown`", () => {
+    const part = {} as Part;
+    if (part.type === "tool-call" && part.name === "research") {
+      expectTypeOf(part.progress).toEqualTypeOf<{ stage: string }[] | undefined>();
+      expectTypeOf(part.input).toEqualTypeOf<{ topic: string }>();
+    }
+  });
+
+  test("a tool that cannot yield gets a progress log it cannot fill", () => {
+    // `never[]`, not `unknown[]`: a UI that maps over this has nothing to
+    // narrow, which is the correct amount of work for a tool with no yields.
+    const part = {} as Part;
+    if (part.type === "tool-call" && part.name === "bash") {
+      expectTypeOf(part.progress).toEqualTypeOf<never[] | undefined>();
+    }
+  });
+
+  test("a nested run is a transcript, so it renders with the message renderer", () => {
+    const part = {} as Part;
+    if (part.type === "tool-call") {
+      expectTypeOf(part.nested).toEqualTypeOf<NestedRun[] | undefined>();
+      // The claim that makes the recursion worth anything: what comes out of a
+      // nested run is assignable to the argument of a component written against
+      // the top-level transcript.
+      const render = (_messages: AgentMessage[]) => {};
+      expectTypeOf(render).toBeCallableWith({} as NestedRun["messages"]);
+    }
+  });
+
+  test("a sub-agent's transcript is not typed with the parent's tools", () => {
+    // A parent's tool shapes say nothing about what its children can call, so
+    // `NestedRun.messages` stays at the default shapes. Asserting the negative
+    // because the tempting mistake — threading `T` down into `nested` — would
+    // compile and would name every sub-agent's tools after the parent's.
+    expectTypeOf<NestedRun["messages"]>().toEqualTypeOf<AgentMessage[]>();
+    expectTypeOf<NestedRun["messages"]>().not.toEqualTypeOf<AgentMessage<Shapes>[]>();
+  });
+});

--- a/packages/gemi/ai/client/reducer.test.ts
+++ b/packages/gemi/ai/client/reducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import type { AgentMessage, AgentStreamFrame } from "../types";
+import type { AgentMessage, AgentStreamFrame, NestedRun } from "../types";
 import { applyFrame, initialChatState, markAborted, type ChatState } from "./reducer";
 
 const NOW = "2026-09-02T00:00:00.000Z";
@@ -429,15 +429,28 @@ describe("the rest of the event union", () => {
     expect(state.messages[0]!.usage).toBeUndefined();
   });
 
-  test("tool-search and tool-progress advance the cursor and nothing else", () => {
+  test("tool-search names the tools in play without touching the transcript", () => {
     const before = at(6);
     const after = fold(before, [
       { seq: 7, event: { type: "tool-search", loaded: ["refundOrder"] } },
-      { seq: 8, event: { type: "tool-progress", toolCallId: "tc_1", data: { line: "$ ls" } } },
+      { seq: 8, event: { type: "tool-search", loaded: ["refundOrder", "listOrders"] } },
     ]);
 
+    // A set, so the second search — which reports everything loaded so far, and
+    // which a reattached client may be handed twice — adds one name, not three.
+    expect(after.loadedTools).toEqual(["refundOrder", "listOrders"]);
     expect(after.messages).toEqual(before.messages);
     expect(after.seq).toBe(8);
+  });
+
+  test("tool-search is run-scoped, so the next turn does not inherit it", () => {
+    const state = fold(at(6), [
+      { seq: 7, event: { type: "tool-search", loaded: ["refundOrder"] } },
+      { seq: 8, event: { type: "run-end", runId: "run_1", finishReason: "stop" } },
+      { seq: 0, event: { type: "run-start", runId: "run_2" } },
+    ]);
+
+    expect(state.loadedTools).toEqual([]);
   });
 });
 
@@ -495,5 +508,473 @@ describe("markAborted", () => {
     const state = markAborted(initialChatState({ messages: [user] }));
 
     expect(state.messages[0]!.finishReason).toBeUndefined();
+  });
+});
+
+/**
+ * One tool that runs a sub-agent, on the wire.
+ *
+ * `tc_1` is the parent's tool call; `nr_1` is the sub-run it drove. Every
+ * sub-run frame is a `nested-event` on the *parent's* stream, numbered in the
+ * parent's `seq` — which is what lets `/attach` and the cursor keep working
+ * through the nesting, and what means nothing below needs a second cursor.
+ */
+const NESTED: AgentStreamFrame[] = [
+  { seq: 0, event: { type: "run-start", runId: "run_1", threadId: "th_1" } },
+  { seq: 1, event: { type: "message-start", messageId: "m1", role: "assistant" } },
+  { seq: 2, event: { type: "text-delta", messageId: "m1", delta: "Looking into it." } },
+  {
+    seq: 3,
+    event: {
+      type: "tool-call",
+      messageId: "m1",
+      part: {
+        type: "tool-call",
+        toolCallId: "tc_1",
+        name: "research",
+        input: { topic: "pricing" },
+      },
+    },
+  },
+  { seq: 4, event: { type: "tool-progress", toolCallId: "tc_1", data: { stage: "starting" } } },
+  { seq: 5, event: nested({ type: "run-start", runId: "nr_1" }) },
+  { seq: 6, event: nested({ type: "message-start", messageId: "n1", role: "assistant" }) },
+  { seq: 7, event: nested({ type: "text-delta", messageId: "n1", delta: "The list price is " }) },
+  { seq: 8, event: nested({ type: "text-delta", messageId: "n1", delta: "$40." }) },
+  { seq: 9, event: nested({ type: "message-end", messageId: "n1", finishReason: "stop" }) },
+  {
+    seq: 10,
+    event: nested({
+      type: "usage",
+      usage: { inputTokens: 30, outputTokens: 8, totalTokens: 38 },
+    }),
+  },
+  { seq: 11, event: nested({ type: "run-end", runId: "nr_1", finishReason: "stop" }) },
+  { seq: 12, event: { type: "tool-progress", toolCallId: "tc_1", data: { stage: "summarising" } } },
+  {
+    seq: 13,
+    event: {
+      type: "tool-result",
+      messageId: "m1",
+      part: {
+        type: "tool-result",
+        toolCallId: "tc_1",
+        name: "research",
+        status: "ok",
+        output: { summary: "$40" },
+      },
+    },
+  },
+  { seq: 14, event: { type: "text-delta", messageId: "m1", delta: " It is $40." } },
+  { seq: 15, event: { type: "message-end", messageId: "m1", finishReason: "stop" } },
+  { seq: 16, event: { type: "run-end", runId: "run_1", finishReason: "stop" } },
+];
+
+/** The wrapper every sub-run frame arrives in, so the fixture reads as a run. */
+function nested(
+  event: AgentStreamFrame["event"],
+  wrap: { toolCallId?: string; runId?: string; agent?: string; label?: string } = {},
+): AgentStreamFrame["event"] {
+  return {
+    type: "nested-event",
+    toolCallId: wrap.toolCallId ?? "tc_1",
+    runId: wrap.runId ?? "nr_1",
+    agent: wrap.agent ?? "pricing",
+    label: wrap.label ?? "researching pricing",
+    event,
+  };
+}
+
+function runOf(state: ChatState, toolCallId = "tc_1", index = 0) {
+  for (const message of state.messages) {
+    for (const part of message.content) {
+      if (part.type === "tool-call" && part.toolCallId === toolCallId) {
+        return part.nested?.[index];
+      }
+    }
+  }
+  return undefined;
+}
+
+function callOf(state: ChatState, toolCallId = "tc_1") {
+  for (const message of state.messages) {
+    for (const part of message.content) {
+      if (part.type === "tool-call" && part.toolCallId === toolCallId) return part;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The two ways nesting can violate the reducer's contract, first.
+ *
+ * Both are shapes of the same thing — a client handed the middle of a run —
+ * and both are the reason the happy-path tests below are not enough on their
+ * own.
+ */
+describe("nesting tolerates a stream it joined late", () => {
+  test("a nested-event for a tool call this client never saw is dropped, not crashed", () => {
+    // The mid-run `/attach` with nothing kept: the `tool-call` frame that would
+    // have created `tc_1` is at seq 3, below where this client joined, and it is
+    // never re-sent. There is no honest place to put the sub-run — a
+    // `ToolCallPart` invented here would need a tool name and an input that no
+    // nested frame carries — so the run is lost and the transcript stays true.
+    const state = fold(initialChatState(), NESTED.slice(5, 12));
+
+    expect(state.messages).toEqual([]);
+    expect(state.error).toBeNull();
+    // The cursor still advances, which is the part that must not break: the
+    // frames after these describe messages this client *can* build.
+    expect(state.seq).toBe(11);
+  });
+
+  test("the run continues normally after the orphaned nested frames", () => {
+    const state = fold(initialChatState(), NESTED.slice(5));
+
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]!.content.map((part) => part.type)).toEqual([
+      "tool-result",
+      "text",
+    ]);
+    expect(state.finishReason).toBe("stop");
+  });
+
+  test("a nested run whose own message-start never arrived builds the message anyway", () => {
+    // The sub-run joined halfway too. The recursion means this needs no code of
+    // its own — `withMessage` creates a message it never saw start, and it does
+    // that inside a nested transcript for the same reason it does it outside.
+    const state = fold(at3(), [
+      { seq: 4, event: nested({ type: "text-delta", messageId: "n1", delta: "half a thought" }) },
+    ]);
+
+    expect(runOf(state)!.messages).toEqual([
+      {
+        id: "n1",
+        role: "assistant",
+        content: [{ type: "text", text: "half a thought" }],
+        createdAt: NOW,
+      },
+    ]);
+  });
+
+  test("a nested run whose run-start never arrived is still labelled", () => {
+    // `agent` and `label` ride on every nested frame, not just the first, so a
+    // sub-run created from its tail still has something to render as a heading.
+    const state = fold(at3(), [
+      { seq: 4, event: nested({ type: "text-delta", messageId: "n1", delta: "…" }) },
+    ]);
+
+    expect(runOf(state)).toMatchObject({
+      runId: "nr_1",
+      agent: "pricing",
+      label: "researching pricing",
+    });
+  });
+});
+
+/** The parent up to and including the tool call, which is all nesting needs. */
+function at3() {
+  return fold(initialChatState(), NESTED.slice(0, 4));
+}
+
+describe("a tool that runs a sub-agent", () => {
+  test("the sub-run's transcript lands on the tool call that drove it", () => {
+    const state = fold(initialChatState(), NESTED);
+
+    expect(runOf(state)).toEqual({
+      runId: "nr_1",
+      agent: "pricing",
+      label: "researching pricing",
+      finishReason: "stop",
+      usage: { inputTokens: 30, outputTokens: 8, totalTokens: 38 },
+      messages: [
+        {
+          id: "n1",
+          role: "assistant",
+          content: [{ type: "text", text: "The list price is $40." }],
+          createdAt: NOW,
+          finishReason: "stop",
+          usage: { inputTokens: 30, outputTokens: 8, totalTokens: 38 },
+        },
+      ],
+    });
+  });
+
+  test("a nested message is the shape of a top-level one, so one renderer does both", () => {
+    // The claim the whole design rests on. `render` below stands in for a
+    // component: it is written once, against `AgentMessage[]`, and it is handed
+    // the outer transcript and then the inner one with no second code path and
+    // nothing that knows a sub-agent exists.
+    const state = fold(initialChatState(), NESTED);
+    const render = (messages: AgentMessage[]) =>
+      messages.map(
+        (message) =>
+          `${message.role}: ${message.content
+            .map((part) => (part.type === "text" ? part.text : `[${part.type}]`))
+            .join("")}`,
+      );
+
+    expect(render(state.messages)).toEqual([
+      "assistant: Looking into it.[tool-call][tool-result] It is $40.",
+    ]);
+    expect(render(runOf(state)!.messages)).toEqual(["assistant: The list price is $40."]);
+  });
+
+  test("the tool's own yields accumulate in order beside the sub-run", () => {
+    const state = fold(initialChatState(), NESTED);
+
+    expect(callOf(state)!.progress).toEqual([{ stage: "starting" }, { stage: "summarising" }]);
+  });
+
+  test("a tool call with no sub-agent and no yields grows no fields", () => {
+    const state = fold(initialChatState(), RUN);
+
+    expect(callOf(state, "tc_1")).toEqual({
+      type: "tool-call",
+      toolCallId: "tc_1",
+      name: "grep",
+      input: { pattern: "TODO", filePath: "a.ts" },
+    });
+  });
+
+  test("the parent transcript is unchanged by the nesting", () => {
+    const state = fold(initialChatState(), NESTED);
+
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]!.content.map((part) => part.type)).toEqual([
+      "text",
+      "tool-call",
+      "tool-result",
+      "text",
+    ]);
+    expect(state.messages[0]!.finishReason).toBe("stop");
+  });
+
+  test("two sub-runs under one tool call stay separate, in the order they started", () => {
+    const state = fold(at3(), [
+      { seq: 4, event: nested({ type: "text-delta", messageId: "n1", delta: "one" }) },
+      {
+        seq: 5,
+        event: nested({ type: "text-delta", messageId: "n2", delta: "two" }, {
+          runId: "nr_2",
+          agent: "legal",
+          label: "checking terms",
+        }),
+      },
+      { seq: 6, event: nested({ type: "text-delta", messageId: "n1", delta: "!" }) },
+    ]);
+
+    const runs = callOf(state)!.nested!;
+    expect(runs.map((run) => run.runId)).toEqual(["nr_1", "nr_2"]);
+    expect(runs[0]!.messages[0]!.content).toEqual([{ type: "text", text: "one!" }]);
+    expect(runs[1]!.agent).toBe("legal");
+  });
+});
+
+describe("nesting keeps the reducer's contract", () => {
+  test("applying the whole nested run twice changes nothing", () => {
+    const once = fold(initialChatState(), NESTED);
+    const twice = fold(once, NESTED);
+
+    expect(twice).toBe(once);
+  });
+
+  test("a redelivered nested text-delta does not append its text twice", () => {
+    const state = fold(initialChatState(), NESTED.slice(0, 8));
+    const again = applyFrame(state, NESTED[7]!, NOW);
+
+    expect(again).toBe(state);
+    expect(runOf(state)!.messages[0]!.content).toEqual([
+      { type: "text", text: "The list price is " },
+    ]);
+  });
+
+  test("a redelivered tool-progress does not log the same yield twice", () => {
+    const state = fold(initialChatState(), NESTED.slice(0, 5));
+    const again = applyFrame(state, NESTED[4]!, NOW);
+
+    expect(again).toBe(state);
+    expect(callOf(state)!.progress).toEqual([{ stage: "starting" }]);
+  });
+
+  test("a whole run replayed onto a transcript that already holds it doubles nothing", () => {
+    // The case `seq` cannot catch: the cursor was lost, so every frame is new to
+    // it. The finished parent message is the only evidence this is replay, and
+    // it has to protect the nested transcript and the progress log as well as
+    // the text.
+    const done = fold(initialChatState(), NESTED);
+    const restored = initialChatState({ messages: done.messages });
+
+    const replayed = fold(restored, NESTED);
+
+    expect(callOf(replayed)!.progress).toEqual([{ stage: "starting" }, { stage: "summarising" }]);
+    expect(callOf(replayed)!.nested).toHaveLength(1);
+    expect(runOf(replayed)!.messages[0]!.content).toEqual([
+      { type: "text", text: "The list price is $40." },
+    ]);
+  });
+
+  test("a re-sent tool-call frame does not wipe what execution put on the part", () => {
+    // The bug this file's upsert had until nesting made it visible: a
+    // `tool-call` is the model's half of the part, and replacing the whole part
+    // with it throws away the sub-run and the progress log — which arrive on
+    // events that name no message and so can never be re-derived.
+    const state = fold(initialChatState(), NESTED.slice(0, 12));
+    const resent = applyFrame(state, { seq: 99, event: NESTED[3]!.event }, NOW);
+
+    expect(callOf(resent)!.progress).toEqual([{ stage: "starting" }]);
+    expect(runOf(resent)!.messages[0]!.content).toEqual([
+      { type: "text", text: "The list price is $40." },
+    ]);
+  });
+
+  test("a sub-run's own pending call does not become the parent's", () => {
+    // An escalated question reaches the user on the parent's `awaiting-input`,
+    // carrying the path that says which tool to re-enter. The copy inside the
+    // sub-run's stream carries no path, so surfacing it here would show the
+    // question twice and make one of the two unanswerable.
+    const state = fold(at3(), [
+      {
+        seq: 4,
+        event: nested({
+          type: "awaiting-input",
+          runId: "nr_1",
+          pending: [
+            {
+              toolCallId: "tc_inner",
+              name: "ask",
+              input: { question: "Which tier?" },
+              kind: "question",
+              signature: "sig_inner",
+            },
+          ],
+        }),
+      },
+    ]);
+
+    expect(state.pending).toEqual([]);
+  });
+
+  test("resuming from any mid-run cursor converges on the same conversation", () => {
+    const full = fold(initialChatState(), NESTED);
+
+    for (let cursor = 0; cursor < NESTED.length - 1; cursor++) {
+      const dropped = fold(initialChatState(), NESTED.slice(0, cursor + 1));
+      const resumed = initialChatState({
+        messages: dropped.messages,
+        pending: dropped.pending,
+        threadId: dropped.threadId,
+        seq: dropped.seq,
+      });
+
+      const caughtUp = fold(resumed, NESTED.slice(cursor + 1));
+
+      expect(caughtUp.messages, `resumed at ${cursor}`).toEqual(full.messages);
+      expect(caughtUp.seq, `resumed at ${cursor}`).toBe(full.seq);
+    }
+  });
+});
+
+describe("nesting two levels deep", () => {
+  /**
+   * `tc_1` runs the pricing agent, whose own tool `tc_9` runs a web agent. The
+   * inner frames are a `nested-event` wrapped in a `nested-event`, which is the
+   * whole of what depth costs: the second one lands back in the same branch of
+   * the same switch, one message list further down.
+   */
+  const DEEP: AgentStreamFrame[] = [
+    ...NESTED.slice(0, 4),
+    { seq: 4, event: nested({ type: "message-start", messageId: "n1", role: "assistant" }) },
+    {
+      seq: 5,
+      event: nested({
+        type: "tool-call",
+        messageId: "n1",
+        part: {
+          type: "tool-call",
+          toolCallId: "tc_9",
+          name: "browse",
+          input: { url: "https://example.com/pricing" },
+        },
+      }),
+    },
+    {
+      seq: 6,
+      event: nested(
+        nested({ type: "message-start", messageId: "d1", role: "assistant" }, {
+          toolCallId: "tc_9",
+          runId: "nr_2",
+          agent: "web",
+          label: "reading the pricing page",
+        }),
+      ),
+    },
+    {
+      seq: 7,
+      event: nested(
+        nested({ type: "text-delta", messageId: "d1", delta: "$40 a seat." }, {
+          toolCallId: "tc_9",
+          runId: "nr_2",
+          agent: "web",
+          label: "reading the pricing page",
+        }),
+      ),
+    },
+    {
+      seq: 8,
+      event: nested(
+        nested({ type: "run-end", runId: "nr_2", finishReason: "stop" }, {
+          toolCallId: "tc_9",
+          runId: "nr_2",
+          agent: "web",
+          label: "reading the pricing page",
+        }),
+      ),
+    },
+  ];
+
+  function inner(state: ChatState) {
+    const outer = runOf(state)!;
+    const call = outer.messages
+      .flatMap((message) => message.content)
+      .find((part) => part.type === "tool-call" && part.toolCallId === "tc_9");
+    return (call as { nested?: NestedRun[] }).nested![0]!;
+  }
+
+  test("the sub-sub-run lands on the sub-run's own tool call", () => {
+    const state = fold(initialChatState(), DEEP);
+
+    expect(inner(state)).toEqual({
+      runId: "nr_2",
+      agent: "web",
+      label: "reading the pricing page",
+      finishReason: "stop",
+      messages: [
+        {
+          id: "d1",
+          role: "assistant",
+          content: [{ type: "text", text: "$40 a seat." }],
+          createdAt: NOW,
+          // The nested `run-end` closed off a message whose `message-end` never
+          // came, two levels down, with no code that knows about depth.
+          finishReason: "stop",
+        },
+      ],
+    });
+  });
+
+  test("depth costs the contract nothing: replay and a mid-run cursor still converge", () => {
+    const full = fold(initialChatState(), DEEP);
+
+    expect(fold(full, DEEP)).toBe(full);
+
+    for (let cursor = 0; cursor < DEEP.length - 1; cursor++) {
+      const dropped = fold(initialChatState(), DEEP.slice(0, cursor + 1));
+      const resumed = initialChatState({ messages: dropped.messages, seq: dropped.seq });
+
+      expect(fold(resumed, DEEP.slice(cursor + 1)).messages, `resumed at ${cursor}`).toEqual(
+        full.messages,
+      );
+    }
   });
 });

--- a/packages/gemi/ai/client/reducer.test.ts
+++ b/packages/gemi/ai/client/reducer.test.ts
@@ -978,3 +978,273 @@ describe("nesting two levels deep", () => {
     }
   });
 });
+
+/**
+ * The resume turn, which is the reason nesting exists and the one shape no
+ * single-turn fixture can produce.
+ *
+ * `Agent.loop` finalises the message **before** the run parks — `finalizeMessage
+ * ("awaiting-input")` then `emit({ type: "awaiting-input" })` — so by the time
+ * the user answers, the message holding the escalating tool call already carries
+ * a finish reason. The next turn re-enters that same call (`resolveAnswer` runs
+ * `executeTool` against the call it found in the history) and its progress and
+ * sub-run frames arrive against that finished message.
+ */
+const PARKED: AgentStreamFrame[] = [
+  { seq: 0, event: { type: "run-start", runId: "run_1", threadId: "th_1" } },
+  { seq: 1, event: { type: "message-start", messageId: "m1", role: "assistant" } },
+  {
+    seq: 2,
+    event: {
+      type: "tool-call",
+      messageId: "m1",
+      part: {
+        type: "tool-call",
+        toolCallId: "tc_1",
+        name: "research",
+        input: { topic: "pricing" },
+      },
+    },
+  },
+  { seq: 3, event: { type: "message-end", messageId: "m1", finishReason: "awaiting-input" } },
+  {
+    seq: 4,
+    event: {
+      type: "awaiting-input",
+      runId: "run_1",
+      pending: [
+        {
+          toolCallId: "tc_inner",
+          name: "ask",
+          input: { question: "Which tier?" },
+          kind: "question",
+          signature: "sig_inner",
+          path: ["tc_1"],
+        },
+      ],
+    },
+  },
+  { seq: 5, event: { type: "run-end", runId: "run_1", finishReason: "awaiting-input" } },
+];
+
+/** The turn that answers it: the tool runs again, this time to completion. */
+const RESUMED: AgentStreamFrame[] = [
+  { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_1" } },
+  { seq: 1, event: { type: "tool-progress", toolCallId: "tc_1", data: { stage: "resuming" } } },
+  { seq: 2, event: nested({ type: "message-start", messageId: "n1", role: "assistant" }) },
+  { seq: 3, event: nested({ type: "text-delta", messageId: "n1", delta: "The pro tier is $80." }) },
+  { seq: 4, event: nested({ type: "message-end", messageId: "n1", finishReason: "stop" }) },
+  { seq: 5, event: nested({ type: "run-end", runId: "nr_1", finishReason: "stop" }) },
+  {
+    seq: 6,
+    event: {
+      type: "tool-result",
+      messageId: "m1",
+      part: {
+        type: "tool-result",
+        toolCallId: "tc_1",
+        name: "research",
+        status: "ok",
+        output: { summary: "$80" },
+      },
+    },
+  },
+  { seq: 7, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+  { seq: 8, event: { type: "text-delta", messageId: "m2", delta: "It is $80." } },
+  { seq: 9, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
+  { seq: 10, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+];
+
+describe("the turn that answers a sub-agent's question", () => {
+  test("the re-entered tool still reports, though its message closed last turn", () => {
+    // The bug: the finished-message replay guard fired on every resume, so the
+    // whole second execution was dropped while its `tool-result` — which goes
+    // through `withMessage`, unguarded — still landed. The user watched the call
+    // go silent and then produce an answer, which is the exact failure nesting
+    // was built to fix.
+    const state = fold(fold(initialChatState(), PARKED), RESUMED);
+
+    expect(callOf(state)!.progress).toEqual([{ stage: "resuming" }]);
+    expect(runOf(state)!.messages[0]!.content).toEqual([
+      { type: "text", text: "The pro tier is $80." },
+    ]);
+    expect(runOf(state)!.finishReason).toBe("stop");
+  });
+
+  test("the sub-run is recorded, which is what the next turn replays it from", () => {
+    // Not cosmetic. `useChat.send` posts `messages` verbatim in stateless mode
+    // and section D resumes a sub-agent from `ToolCallPart.nested`, so a
+    // continuation the client never recorded is a sub-run that, to the next
+    // turn, never finished.
+    const state = fold(fold(initialChatState(), PARKED), RESUMED);
+    const posted = fold(initialChatState({ messages: state.messages }), []);
+
+    expect(runOf(posted)).toMatchObject({ runId: "nr_1", finishReason: "stop" });
+  });
+
+  test("a second parked call reports too, after the first one's result has landed", () => {
+    // `ingestTurn` resolves the answers one at a time, attaching each result
+    // before it starts the next tool — so the second call's progress arrives
+    // once the message has already been written to by this run. Anything that
+    // decided "replay" from the run having touched the message would drop it.
+    const twoCalls = fold(initialChatState(), [
+      ...PARKED.slice(0, 3),
+      {
+        seq: 3,
+        event: {
+          type: "tool-call",
+          messageId: "m1",
+          part: { type: "tool-call", toolCallId: "tc_2", name: "book", input: { seats: 2 } },
+        },
+      },
+      { seq: 4, event: { type: "message-end", messageId: "m1", finishReason: "awaiting-input" } },
+      { seq: 5, event: { type: "run-end", runId: "run_1", finishReason: "awaiting-input" } },
+    ]);
+
+    const state = fold(twoCalls, [
+      { seq: 0, event: { type: "run-start", runId: "run_2" } },
+      { seq: 1, event: { type: "tool-progress", toolCallId: "tc_1", data: { stage: "a" } } },
+      {
+        seq: 2,
+        event: {
+          type: "tool-result",
+          messageId: "m1",
+          part: { type: "tool-result", toolCallId: "tc_1", name: "research", status: "ok" },
+        },
+      },
+      { seq: 3, event: { type: "tool-progress", toolCallId: "tc_2", data: { stage: "b" } } },
+    ]);
+
+    expect(callOf(state, "tc_2")!.progress).toEqual([{ stage: "b" }]);
+  });
+
+  test("once the result lands the call is closed again, so a replay adds nothing", () => {
+    // The carve-out is exactly as wide as the case: parked *and* unanswered. A
+    // whole conversation replayed onto a client that already holds it must not
+    // log the resumed execution twice.
+    const done = fold(fold(initialChatState(), PARKED), RESUMED);
+    const restored = initialChatState({ messages: done.messages });
+
+    const replayed = fold(fold(restored, PARKED), RESUMED);
+
+    expect(callOf(replayed)!.progress).toEqual([{ stage: "resuming" }]);
+    expect(callOf(replayed)!.nested).toHaveLength(1);
+    expect(runOf(replayed)!.messages[0]!.content).toEqual([
+      { type: "text", text: "The pro tier is $80." },
+    ]);
+  });
+});
+
+/**
+ * A run cut short while a sub-agent two levels down is still talking.
+ *
+ * Nothing here ever ends: no `message-end`, no nested `run-end`, no parent
+ * `run-end` — which is what the transcript looks like the instant `stop()` is
+ * pressed.
+ */
+/** The wrap the innermost frames of `LIVE_DEEP` arrive in: `tc_9`'s own sub-run. */
+const INNER = { toolCallId: "tc_9", runId: "nr_2", agent: "web" };
+
+const LIVE_DEEP: AgentStreamFrame[] = [
+  ...NESTED.slice(0, 4),
+  { seq: 4, event: nested({ type: "message-start", messageId: "n1", role: "assistant" }) },
+  {
+    seq: 5,
+    event: nested({
+      type: "tool-call",
+      messageId: "n1",
+      part: { type: "tool-call", toolCallId: "tc_9", name: "browse", input: { url: "x" } },
+    }),
+  },
+  {
+    seq: 6,
+    event: nested(nested({ type: "message-start", messageId: "d1", role: "assistant" }, INNER)),
+  },
+  {
+    seq: 7,
+    event: nested(nested({ type: "text-delta", messageId: "d1", delta: "half a thou" }, INNER)),
+  },
+];
+
+/** Every message in the tree, at any depth, that no reason was ever put on. */
+function unfinished(messages: AgentMessage[], trail = "", found: string[] = []): string[] {
+  for (const message of messages) {
+    if (message.role === "assistant" && message.finishReason === undefined) {
+      found.push(`${trail}${message.id}`);
+    }
+    for (const part of message.content) {
+      if (part.type !== "tool-call" || !part.nested) continue;
+      for (const run of part.nested) unfinished(run.messages, `${trail}${run.runId}/`, found);
+    }
+  }
+  return found;
+}
+
+/** Every nested run in the tree that no reason was ever put on. */
+function unfinishedRuns(messages: AgentMessage[], found: string[] = []): string[] {
+  for (const message of messages) {
+    for (const part of message.content) {
+      if (part.type !== "tool-call" || !part.nested) continue;
+      for (const run of part.nested) {
+        if (run.finishReason === undefined) found.push(run.runId);
+        unfinishedRuns(run.messages, found);
+      }
+    }
+  }
+  return found;
+}
+
+describe("ending a run ends the sub-runs it was holding", () => {
+  test("stopping closes every message in the tree, not just the parent's", () => {
+    // A `NestedRun` renders with the component that renders `messages`, so a
+    // nested message with no finish reason draws a live cursor inside a block
+    // that will never receive another frame. `markAborted` is the case no
+    // forwarded nested `run-end` can rescue: `stop()` marks the transcript
+    // before the server has said anything at all.
+    const live = fold(initialChatState(), LIVE_DEEP);
+
+    expect(unfinished(live.messages)).toEqual(["m1", "nr_1/n1", "nr_1/nr_2/d1"]);
+
+    const stopped = markAborted(live);
+
+    expect(unfinished(stopped.messages)).toEqual([]);
+    expect(unfinishedRuns(stopped.messages)).toEqual([]);
+    expect(runOf(stopped)!.finishReason).toBe("aborted");
+  });
+
+  test("run-end closes them the same way, so a label is there either way", () => {
+    const state = fold(fold(initialChatState(), LIVE_DEEP), [
+      { seq: 8, event: { type: "run-end", runId: "run_1", finishReason: "error" } },
+    ]);
+
+    expect(unfinished(state.messages)).toEqual([]);
+    expect(runOf(state)!.finishReason).toBe("error");
+  });
+
+  test("a sub-run that finished on its own keeps the reason it finished with", () => {
+    // The parent being cut short says nothing about a sub-run that already
+    // ended cleanly — relabelling it "aborted" would report a result the user
+    // was given as one they never got.
+    const stopped = markAborted(fold(initialChatState(), NESTED.slice(0, 12)));
+
+    expect(runOf(stopped)!.finishReason).toBe("stop");
+    expect(stopped.messages[0]!.finishReason).toBe("aborted");
+  });
+
+  test("stopping the turn that answers a question closes the sub-run under it", () => {
+    // The two fixes meeting: the parked message is finished, so `run-end` and
+    // `markAborted` used to skip straight past it — and the sub-run the resumed
+    // tool started is hanging off a tool call inside it.
+    const resuming = fold(fold(initialChatState(), PARKED), RESUMED.slice(0, 4));
+
+    expect(runOf(resuming)!.finishReason).toBeUndefined();
+
+    const stopped = markAborted(resuming);
+
+    expect(unfinished(stopped.messages)).toEqual([]);
+    expect(runOf(stopped)!.finishReason).toBe("aborted");
+    // The parent's own reason is the one it parked with, not the one the stop
+    // brought: that message did finish, last turn, awaiting this answer.
+    expect(stopped.messages[0]!.finishReason).toBe("awaiting-input");
+  });
+});

--- a/packages/gemi/ai/client/reducer.test.ts
+++ b/packages/gemi/ai/client/reducer.test.ts
@@ -314,6 +314,32 @@ describe("the rest of the event union", () => {
     ]);
   });
 
+  test("a reasoning part keeps the provider's item id, so a stateless turn can echo it back", () => {
+    const state = fold(initialChatState(), [
+      { seq: 0, event: { type: "reasoning-delta", messageId: "m1", delta: "hm", id: "rs_1" } },
+      { seq: 1, event: { type: "reasoning-delta", messageId: "m1", delta: "mm", id: "rs_1" } },
+    ]);
+
+    // Without the id, `providers/request.ts` drops the item when the client
+    // posts its history back, and the model re-derives its reasoning every
+    // step while the prompt cache misses on every one.
+    expect(state.messages[0]!.content).toEqual([{ type: "reasoning", id: "rs_1", text: "hmmm" }]);
+  });
+
+  test("two reasoning items stay two parts rather than flattening under one id", () => {
+    const state = fold(initialChatState(), [
+      { seq: 0, event: { type: "reasoning-delta", messageId: "m1", delta: "first", id: "rs_1" } },
+      { seq: 1, event: { type: "reasoning-delta", messageId: "m1", delta: "second", id: "rs_2" } },
+    ]);
+
+    // Merging these would post back one item claiming to be `rs_1` and holding
+    // text the provider never wrote under that id.
+    expect(state.messages[0]!.content).toEqual([
+      { type: "reasoning", id: "rs_1", text: "first" },
+      { type: "reasoning", id: "rs_2", text: "second" },
+    ]);
+  });
+
   test("output snapshots replace rather than accumulate, so a late client is right", () => {
     const late = fold(initialChatState(), [
       {

--- a/packages/gemi/ai/client/reducer.ts
+++ b/packages/gemi/ai/client/reducer.ts
@@ -195,7 +195,7 @@ function reduce<T extends ToolShapes, O>(
       if (isFinished(state, event.messageId)) return state;
       return withMessage(state, event.messageId, now, (message) => ({
         ...message,
-        content: appendReasoning(message.content, event.delta),
+        content: appendReasoning(message.content, event.delta, event.id),
       }));
 
     case "output-delta":
@@ -691,15 +691,23 @@ function appendText<T extends ToolShapes, O>(
   return [...content, { type: "text", text: delta }];
 }
 
+/**
+ * Mirrors `appendReasoning` in Agent.ts, including its merge rule: deltas join
+ * the last part only when the reasoning-item id matches, so a step that
+ * produced two items stays two parts instead of flattening into one under the
+ * wrong id. The two implementations have to agree, because a stateless client
+ * posts this content straight back and the provider matches on that id.
+ */
 function appendReasoning<T extends ToolShapes, O>(
   content: AgentContentPart<T, O>[],
   delta: string,
+  id?: string,
 ): AgentContentPart<T, O>[] {
   const last = content[content.length - 1];
-  if (last && last.type === "reasoning") {
+  if (last && last.type === "reasoning" && last.id === id) {
     return [...content.slice(0, -1), { ...last, text: (last.text ?? "") + delta }];
   }
-  return [...content, { type: "reasoning", text: delta }];
+  return [...content, id ? { type: "reasoning", id, text: delta } : { type: "reasoning", text: delta }];
 }
 
 function upsert<T extends ToolShapes, O>(

--- a/packages/gemi/ai/client/reducer.ts
+++ b/packages/gemi/ai/client/reducer.ts
@@ -2,9 +2,12 @@ import type {
   AgentContentPart,
   AgentError,
   AgentMessage,
+  AgentStreamEvent,
   AgentStreamFrame,
   FinishReason,
+  NestedRun,
   PendingToolCall,
+  ToolCallPart,
   ToolShapes,
 } from "../types";
 
@@ -33,6 +36,15 @@ import type {
  *     or an upsert keyed by an id. Tool calls and tool results arrive more than
  *     once (a call re-streams as its arguments grow), so those are keyed by
  *     `toolCallId`, never pushed blindly.
+ *
+ * A sub-agent's transcript is built by this same function calling itself. A
+ * `nested-event` is unwrapped onto the `NestedRun` hanging off its parent's
+ * tool-call part and handed to `reduce` again, so every rule above holds inside
+ * a nested run for free — a nested `message-start` that never arrived, a
+ * nested delta after a nested `message-end`, a nested `run-end` closing off a
+ * message that never ended. Two levels of nesting cost this file nothing over
+ * one, which is the whole reason the wire has a `nested-event` rather than a
+ * second reducer.
  */
 
 export type ChatState<T extends ToolShapes = ToolShapes, O = unknown> = {
@@ -71,6 +83,23 @@ export type ChatState<T extends ToolShapes = ToolShapes, O = unknown> = {
    * up from the first frame that names a message, which is the same set.
    */
   runMessageIds: string[];
+  /**
+   * The deferred tools the model has pulled in during this run, as a set.
+   *
+   * Not a message part, because a `tool-search` names no tool call and no
+   * message — it happens *before* any call, which is exactly what makes it
+   * worth showing ("looking for the right tool" instead of an unexplained
+   * pause). So unlike `tool-progress` and `nested-event`, which now have a home
+   * on the tool-call part, this one had nowhere in `AgentMessage` to go that
+   * would not have meant inventing a content part in a frozen contract.
+   *
+   * A set, not a log: union is the only accumulation that survives redelivery
+   * without a guard, and a client attached mid-run and handed a `tool-search`
+   * it has already applied must not show the same tool twice. Run-scoped and
+   * reset by `run-start` — it describes a run in progress, so it is deliberately
+   * not something `initialChatState` restores.
+   */
+  loadedTools: string[];
   finishReason?: FinishReason;
 };
 
@@ -97,6 +126,7 @@ export function initialChatState<T extends ToolShapes = ToolShapes, O = unknown>
     seq: init.seq ?? -1,
     cursorRunId: init.cursorRunId,
     runMessageIds: [],
+    loadedTools: [],
   };
 }
 
@@ -137,6 +167,7 @@ function reduce<T extends ToolShapes, O>(
         cursorRunId: event.runId,
         threadId: event.threadId ?? state.threadId,
         runMessageIds: [],
+        loadedTools: [],
         finishReason: undefined,
       };
 
@@ -181,15 +212,85 @@ function reduce<T extends ToolShapes, O>(
       }));
 
     case "tool-call":
-      // Keyed, because the same call re-streams as its arguments fill in.
-      return withMessage(state, event.messageId, now, (message) => ({
-        ...message,
-        content: upsert(
-          message.content,
-          event.part,
+      // Keyed, because the same call re-streams as its arguments fill in — and
+      // *merged* rather than replaced, which the plain upsert below cannot do.
+      //
+      // A `tool-call` frame is the model's half of the part. `progress` and
+      // `nested` are the execution's half, and they arrive on events that name
+      // no message, so a part that loses them cannot rebuild them from anything
+      // later in the stream. Replacing wholesale is exactly how a run replayed
+      // onto a transcript that already holds it drops a sub-agent's entire
+      // transcript while appearing to converge.
+      return withMessage(state, event.messageId, now, (message) => {
+        const index = message.content.findIndex(
           (part) => part.type === "tool-call" && part.toolCallId === event.part.toolCallId,
-        ),
+        );
+        const existing = index === -1 ? undefined : (message.content[index] as ToolCallPart<T>);
+        // The frame wins where it says anything — a server that persists the
+        // nested transcript and re-sends it is more authoritative than what this
+        // client accumulated — and the part is kept where it does not.
+        const progress = event.part.progress ?? existing?.progress;
+        const nested = event.part.nested ?? existing?.nested;
+        const part = {
+          ...event.part,
+          ...(progress ? { progress } : {}),
+          ...(nested ? { nested } : {}),
+        };
+        const content = message.content.slice();
+        if (index === -1) content.push(part);
+        else content[index] = part;
+        return { ...message, content };
+      });
+
+    case "tool-search": {
+      // Accumulated as a set. Every other additive event in this file leans on
+      // `seq` to survive redelivery; this one cannot, because a `tool-search`
+      // carries no id at all — there is nothing to key an upsert on and nothing
+      // to tell a second delivery from a second search. Union is what makes the
+      // question moot: applying the same frame again is the same set, and two
+      // genuinely different searches that both loaded `refundOrder` are, for a
+      // UI naming the tools in play, the same fact twice.
+      const loaded = event.loaded.filter((name) => !state.loadedTools.includes(name));
+      if (loaded.length === 0) return state;
+      return { ...state, loadedTools: [...state.loadedTools, ...loaded] };
+    }
+
+    case "tool-progress":
+      // Append-only, exactly like a text delta, and protected the same two
+      // ways: `seq` for redelivery within a run, and the finished-message check
+      // inside `withToolCall` for a run replayed onto a transcript that already
+      // holds it. The tool loop emits every yield before the message it belongs
+      // to is finalised, so a progress datum for a finished message is replay
+      // by definition — the same argument `text-delta` makes.
+      return withToolCall(state, event.toolCallId, (part) => ({
+        ...part,
+        progress: [...(part.progress ?? []), event.data],
       }));
+
+    case "nested-event": {
+      // The recursion. The sub-run's transcript is an ordinary message list, so
+      // it is reduced by this function rather than by a parallel one — which is
+      // why an arbitrarily deep nesting is not a case handled here at all: an
+      // inner `nested-event` simply lands back in this branch, one message list
+      // further down.
+      const nestedEvent = event as NestedEvent;
+      return withToolCall(state, event.toolCallId, (part) => {
+        const runs = part.nested ?? [];
+        const index = runs.findIndex((run) => run.runId === nestedEvent.runId);
+        // Created on the spot when unknown, for the same reason `withMessage`
+        // creates a message it never saw start: a client attached mid-run gets
+        // the sub-run's tail and no `run-start`, and dropping it would leave a
+        // tool call that visibly does something looking like one that hangs.
+        const run: NestedRun = runs[index] ?? {
+          runId: nestedEvent.runId,
+          agent: nestedEvent.agent,
+          messages: [],
+        };
+        const next = applyNested(run, nestedEvent, now);
+        const nested = index === -1 ? [...runs, next] : runs.map((r, i) => (i === index ? next : r));
+        return { ...part, nested };
+      });
+    }
 
     case "tool-result": {
       const next = withMessage(state, event.messageId, now, (message) => ({
@@ -266,10 +367,11 @@ function reduce<T extends ToolShapes, O>(
         messages: finishUnended(state, event.finishReason),
       };
 
-    // `tool-search` and `tool-progress` are consumed and not stored: neither has
-    // a place in `AgentMessage`, and inventing one would change a contract four
-    // other slices compile against. The seq still advances, so the cursor stays
-    // right.
+    // Every event in the union is handled above, so this is reached only by a
+    // server that speaks a newer protocol than this client. Kept as a silent
+    // no-op rather than an exhaustiveness assertion for that reason: an old tab
+    // meeting a new event must keep rendering the rest of the stream, and the
+    // seq still advances so its cursor stays right.
     default:
       return state;
   }
@@ -316,6 +418,113 @@ function finishUnended<T extends ToolShapes, O>(
       ? { ...message, finishReason: reason }
       : message,
   );
+}
+
+type NestedEvent = Extract<AgentStreamEvent, { type: "nested-event" }>;
+
+/**
+ * Run one update over the tool-call part with this id, wherever it lives.
+ *
+ * `tool-progress` and `nested-event` are the only events that name a tool call
+ * without naming a message, so the message has to be found rather than told —
+ * a scan from the newest end, because the call being worked on is the one that
+ * just arrived.
+ *
+ * **A frame for a tool call this transcript does not have is dropped.** That is
+ * the mid-run `/attach` case the whole file is written for, and it is the one
+ * place the usual answer — create it on the spot — is the wrong one: a
+ * `ToolCallPart` needs a tool `name` and an `input`, and neither is on these
+ * events. Inventing them would put a tool call the model never made into the
+ * transcript, under a name that is not a key of the agent's tools, which breaks
+ * the narrowing that is the reason the shapes are carried into the browser at
+ * all. So the progress is lost and the transcript stays true, rather than the
+ * other way round.
+ *
+ * In practice a client that has the cursor has the part: `useChat` documents
+ * `cursor` and `initialMessages` as things to persist together, and a client
+ * that persisted one without the other is already the case that doubles text.
+ * Parking the orphans until their tool call shows up was considered and is not
+ * worth it — the call is *earlier* in the stream, never later, so nothing would
+ * ever drain the parking lot.
+ */
+function withToolCall<T extends ToolShapes, O>(
+  state: ChatState<T, O>,
+  toolCallId: string,
+  update: (part: ToolCallPart<T>) => ToolCallPart<T>,
+): ChatState<T, O> {
+  for (let i = state.messages.length - 1; i >= 0; i--) {
+    const message = state.messages[i]!;
+    const index = message.content.findIndex(
+      (part) => part.type === "tool-call" && part.toolCallId === toolCallId,
+    );
+    if (index === -1) continue;
+    // The replay guard, and the same one the deltas use. The tool loop runs
+    // every tool before it finalises the message the calls sit in, so nothing
+    // legitimately appends to a call inside a finished message; a frame that
+    // does is a run being replayed onto a transcript that already has it, and
+    // appending would show the progress log twice.
+    if (message.finishReason !== undefined) return state;
+    const content = message.content.slice();
+    content[index] = update(content[index] as ToolCallPart<T>);
+    const messages = state.messages.slice();
+    messages[i] = { ...message, content };
+    // Counted as a message this run touched, like every event that names one
+    // directly — a client whose only frames for this message were nested ones
+    // still needs `run-end` to close it, or it shows a cursor forever.
+    const runMessageIds = state.runMessageIds.includes(message.id)
+      ? state.runMessageIds
+      : [...state.runMessageIds, message.id];
+    return { ...state, runMessageIds, messages };
+  }
+  return state;
+}
+
+/**
+ * One sub-run event, applied to the sub-run's own transcript.
+ *
+ * The sub-state is built and thrown away per event rather than kept, because
+ * there is nowhere to keep it: `NestedRun` is a wire type and holds a
+ * transcript, not a reducer state. Everything the inner `reduce` needs is
+ * derivable from it.
+ *
+ *   - `seq` is `-1` and this calls `reduce`, not `applyFrame`. A nested event
+ *     has no sequence of its own; it is numbered in the *parent's* stream, and
+ *     the parent's cursor has already refused the duplicates.
+ *   - `runMessageIds` is every message in the transcript, which for a nested
+ *     run is exactly right and needs none of the parent's care. The parent
+ *     scopes it because its list mixes runs; a `NestedRun` is keyed by `runId`
+ *     and only ever written by events carrying that id, so every message in it
+ *     belongs to the run that is ending.
+ *   - `pending` is dropped. An escalated question reaches the user on the
+ *     *parent's* `awaiting-input`, carrying the path that says which tool to
+ *     re-enter; the copy inside the sub-run's own stream carries no path, so
+ *     surfacing it would show the question twice and make one of them
+ *     unanswerable.
+ */
+function applyNested(run: NestedRun, event: NestedEvent, now: string): NestedRun {
+  const sub: ChatState = {
+    messages: run.messages,
+    pending: [],
+    error: null,
+    seq: -1,
+    runMessageIds: run.messages.map((message) => message.id),
+    loadedTools: [],
+    finishReason: run.finishReason,
+  };
+  const next = reduce(sub, event.event, now);
+  return {
+    ...run,
+    // A late label is still a label: `/attach` may deliver the sub-run's tail,
+    // and every nested frame carries it.
+    ...(event.label !== undefined ? { label: event.label } : {}),
+    messages: next.messages,
+    ...(next.finishReason !== undefined ? { finishReason: next.finishReason } : {}),
+    // The sub-run's own total, lifted so a UI can price the block it is
+    // rendering without walking its messages. An assignment, so redelivery is
+    // harmless — the inner `reduce` has already put the same number on the
+    // sub-run's last assistant message.
+    ...(event.event.type === "usage" ? { usage: event.event.usage } : {}),
+  };
 }
 
 function isFinished<T extends ToolShapes, O>(state: ChatState<T, O>, messageId: string) {

--- a/packages/gemi/ai/client/reducer.ts
+++ b/packages/gemi/ai/client/reducer.ts
@@ -261,7 +261,14 @@ function reduce<T extends ToolShapes, O>(
       // inside `withToolCall` for a run replayed onto a transcript that already
       // holds it. The tool loop emits every yield before the message it belongs
       // to is finalised, so a progress datum for a finished message is replay
-      // by definition — the same argument `text-delta` makes.
+      // by definition — the same argument `text-delta` makes, and with the same
+      // carve-out for a message the run parked on.
+      //
+      // Unbounded on purpose: a tool decides how often it yields, and truncating
+      // its log here would lose data the UI asked for. What is bounded is the
+      // *wire* — `useChat.send` strips `progress` from the history it posts, so
+      // a tool that yields ten thousand times costs ten thousand entries in this
+      // tab and nothing at all on every later turn. See `forWire`.
       return withToolCall(state, event.toolCallId, (part) => ({
         ...part,
         progress: [...(part.progress ?? []), event.data],
@@ -406,18 +413,76 @@ export function markAborted<T extends ToolShapes = ToolShapes, O = unknown>(
 
 // --- helpers -------------------------------------------------------------
 
-/** The messages this run wrote, finished off with `reason` if they never ended. */
+/**
+ * The messages this run wrote, finished off with `reason` if they never ended —
+ * and, inside them, the sub-runs this run left mid-sentence.
+ *
+ * The nesting descent is not an extra: a `NestedRun` renders with the component
+ * that renders `messages`, so a nested message with no `finishReason` draws a
+ * live cursor inside a block that will never receive another frame. The parent
+ * ending is the last word anything will say about it, and for `markAborted`
+ * there is no other word available at all — `stop()` marks the transcript
+ * optimistically, before the server has answered, so no forwarded nested
+ * `run-end` can arrive in time.
+ *
+ * It recurses through `closeRun`, which builds a `ChatState` around the sub-run
+ * and calls back here, so a sub-sub-run is closed by the same three lines that
+ * close the top level — the same trick `applyNested` plays on the way in.
+ */
 function finishUnended<T extends ToolShapes, O>(
   state: ChatState<T, O>,
   reason: FinishReason,
 ): AgentMessage<T, O>[] {
   return state.messages.map((message) =>
-    message.role === "assistant" &&
-    message.finishReason === undefined &&
-    state.runMessageIds.includes(message.id)
-      ? { ...message, finishReason: reason }
+    message.role === "assistant" && state.runMessageIds.includes(message.id)
+      ? closeMessage(message, reason)
       : message,
   );
+}
+
+/**
+ * One message of this run, and the sub-runs hanging off its tool calls.
+ *
+ * The message's own finish reason is only filled in when it is missing, but the
+ * descent happens either way: the message a run parks on is *finished* while the
+ * sub-run underneath it is still live, and that is the case where the block
+ * stuck streaming is easiest to hit.
+ */
+function closeMessage<T extends ToolShapes, O>(
+  message: AgentMessage<T, O>,
+  reason: FinishReason,
+): AgentMessage<T, O> {
+  const content = message.content.map((part) =>
+    part.type === "tool-call" && part.nested?.some((run) => run.finishReason === undefined)
+      ? {
+          ...part,
+          nested: part.nested.map((run) =>
+            run.finishReason === undefined ? closeRun(run, reason) : run,
+          ),
+        }
+      : part,
+  );
+  if (message.finishReason === undefined) return { ...message, finishReason: reason, content };
+  // Identity where nothing changed, so `run-end` on a settled transcript keeps
+  // the parts a UI may be memoising on.
+  const changed = content.some((part, index) => part !== message.content[index]);
+  return changed ? { ...message, content } : message;
+}
+
+/** A sub-run the parent outlived, stamped with the parent's reason, recursively. */
+function closeRun(run: NestedRun, reason: FinishReason): NestedRun {
+  const sub: ChatState = {
+    messages: run.messages,
+    pending: [],
+    error: null,
+    seq: -1,
+    // Every message in the transcript, for the reason `applyNested` gives: a
+    // `NestedRun` is keyed by `runId` and only ever written by events carrying
+    // it, so there is no other run's work in here to protect.
+    runMessageIds: run.messages.map((message) => message.id),
+    loadedTools: [],
+  };
+  return { ...run, finishReason: reason, messages: finishUnended(sub, reason) };
 }
 
 type NestedEvent = Extract<AgentStreamEvent, { type: "nested-event" }>;
@@ -458,12 +523,32 @@ function withToolCall<T extends ToolShapes, O>(
       (part) => part.type === "tool-call" && part.toolCallId === toolCallId,
     );
     if (index === -1) continue;
-    // The replay guard, and the same one the deltas use. The tool loop runs
-    // every tool before it finalises the message the calls sit in, so nothing
-    // legitimately appends to a call inside a finished message; a frame that
-    // does is a run being replayed onto a transcript that already has it, and
-    // appending would show the progress log twice.
-    if (message.finishReason !== undefined) return state;
+    // The replay guard, and the same one the deltas use — with the one carve-out
+    // a delta does not need.
+    //
+    // Within a run the tool loop runs every tool before it finalises the message
+    // the calls sit in, so a frame for a call inside a finished message is that
+    // run being replayed onto a transcript that already has it, and appending
+    // would show the progress log twice.
+    //
+    // But a message the run *parked* on is not a closed message. `Agent.loop`
+    // finalises it with `"awaiting-input"` **before** emitting `awaiting-input`,
+    // and the very next turn re-enters that same tool call — `resolveAnswer`
+    // calls `executeTool` against the call it found in the history — so its
+    // `tool-progress` and `nested-event` frames arrive after their message
+    // carries a finish reason. Treating those as replay dropped every frame of
+    // the resumed execution while the `tool-result` (which goes through
+    // `withMessage`, unguarded) still landed: the call went silent and then
+    // produced an answer, which is the bug nesting exists to fix. Worse, in
+    // stateless mode the nested transcript is what the next turn replays the
+    // sub-run from, so the client posted back a sub-run frozen at the question.
+    //
+    // The carve-out is as narrow as the case: parked, *and* the call still open.
+    // Once its result has landed nothing legitimately appends to it again, so a
+    // replay of a parked run is still refused for every call it answered.
+    if (message.finishReason !== undefined && !isReenterable(state, message, toolCallId)) {
+      return state;
+    }
     const content = message.content.slice();
     content[index] = update(content[index] as ToolCallPart<T>);
     const messages = state.messages.slice();
@@ -525,6 +610,30 @@ function applyNested(run: NestedRun, event: NestedEvent, now: string): NestedRun
     // sub-run's last assistant message.
     ...(event.event.type === "usage" ? { usage: event.event.usage } : {}),
   };
+}
+
+/**
+ * Whether a finished message's tool call can still be written to.
+ *
+ * Exactly one message can say yes: the one a run parked on, holding a call
+ * nobody has answered yet. That is the resume turn — the tool is re-entered
+ * from the top and streams progress and sub-run events against a message that
+ * closed on the previous turn.
+ *
+ * "Open" is the server's own test, `Agent.openCalls`: a tool call with no
+ * `tool-result` for it anywhere in the transcript. The result is the thing that
+ * says the re-entry finished, and it always arrives *after* the frames this
+ * guards — `attachToHistory` emits it once `executeTool` returns.
+ */
+function isReenterable<T extends ToolShapes, O>(
+  state: ChatState<T, O>,
+  message: AgentMessage<T, O>,
+  toolCallId: string,
+) {
+  if (message.finishReason !== "awaiting-input") return false;
+  return !state.messages.some((candidate) =>
+    candidate.content.some((part) => part.type === "tool-result" && part.toolCallId === toolCallId),
+  );
 }
 
 function isFinished<T extends ToolShapes, O>(state: ChatState<T, O>, messageId: string) {

--- a/packages/gemi/ai/example.ts
+++ b/packages/gemi/ai/example.ts
@@ -242,6 +242,15 @@ class Api extends ApiRouter {
       stop: "auth",
       upload: "auth",
     }),
+    // Where the `threadId` that `Chat` below is handed comes from. `agent()`
+    // does not mount this, because minting a thread is where an app records
+    // who owns it, and the store cannot — so the route is the app's, and it is
+    // the only source of an id the default store will take: one the client
+    // made up is a `thread_not_found` on its first turn.
+    "/support/threads": this.post(async () => {
+      const user = await Auth.user();
+      return supportStore.createThread({ userId: user.id });
+    }).middleware("auth"),
   };
 }
 

--- a/packages/gemi/ai/example.ts
+++ b/packages/gemi/ai/example.ts
@@ -265,16 +265,49 @@ declare module "../client/rpc" {
   interface RPC extends CreateRPC<Api> {}
 }
 
+// The app's own transcript component, stubbed. The point of the signature is
+// that the nested walk below hands it `run.messages` and it compiles: a sub-run
+// is rendered by whatever already renders a run.
+declare function renderTranscript(messages: AgentMessage[]): null;
+
 function Chat({ threadId }: { threadId: string }) {
   // Reattaches on mount if a run is still going on this thread.
-  const { messages, sendMessage, status, pending, approve, answer } = useChat("/support", {
-    threadId,
-  });
+  const { messages, sendMessage, status, pending, approve, answer, loadedTools } = useChat(
+    "/support",
+    { threadId },
+  );
+
+  // What the model has pulled out of a deferred namespace so far this run —
+  // somewhere to put "…looking for the right tool" instead of an unexplained
+  // pause. Run-scoped, not transcript: empty again on the next run, so it is
+  // not something to persist beside `messages`.
+  loadedTools.join(", ");
 
   for (const message of messages) {
     for (const part of message.content) {
       if (part.type === "tool-result" && part.name === "grep" && part.status === "ok") {
         part.output.matches; // string[]
+      }
+
+      // A generator tool's yields, typed by what its `execute` actually yields
+      // rather than as `unknown`. `bash` yields `{ line: string }`, so this is
+      // `{ line: string }[] | undefined` — and a tool that never yields gets
+      // `never[]`, which is what stops a UI writing a progress renderer for a
+      // tool that can have none.
+      if (part.type === "tool-call" && part.name === "bash") {
+        part.progress?.map((entry) => entry.line); // string[]
+      }
+
+      // The sub-agent runs this tool drove. Each is an ordinary
+      // `AgentMessage[]` with a name and a label, so the component that renders
+      // `messages` renders this too — which is the whole reason nesting reuses
+      // the transcript shape instead of inventing a second one.
+      if (part.type === "tool-call" && part.name === "research") {
+        for (const run of part.nested ?? []) {
+          run.label ?? run.agent; // what to title the block with
+          run.finishReason; // undefined while it is still going
+          renderTranscript(run.messages);
+        }
       }
     }
   }
@@ -286,7 +319,13 @@ function Chat({ threadId }: { threadId: string }) {
         approve(call.toolCallId, true);
       }
       if (call.kind === "question") {
-        answer(call.toolCallId, { answer: "the invoice from March" });
+        // A question the RESEARCH agent asked arrives in this same list, with
+        // `path` naming the chain of tool calls it is nested under. Answering
+        // it is the identical call — the hook carries the signature and the
+        // path back untouched — so a UI reads `path` only to say who is asking,
+        // never to route the answer.
+        const asker = call.path?.length ? "the research agent" : "support";
+        answer(call.toolCallId, { answer: `the invoice from March (for ${asker})` });
       }
     }
   }

--- a/packages/gemi/ai/live/harness.ts
+++ b/packages/gemi/ai/live/harness.ts
@@ -1,0 +1,233 @@
+/**
+ * The plumbing the live suite needs, kept out of the suite so the tests read as
+ * claims about the API rather than as setup.
+ *
+ * NOTHING IN THIS DIRECTORY READS A KEY BY VALUE. The providers pull
+ * `OPENAI_API_KEY` / `AZURE_OPENAI_API_KEY` out of `process.env` themselves —
+ * see `AgentProvider.endpoint()` — so the only thing this file does with a
+ * credential is ask whether one is set. That is deliberate: a harness that
+ * carried the key around would eventually put it in a failure message, and a
+ * failure message is the one place a secret is guaranteed to be printed.
+ */
+import type {
+  AgentProvider,
+  ProviderEvent,
+  ProviderStream,
+  ProviderStreamParams,
+} from "../AgentProvider";
+import { AzureOpenAIProvider, OpenAIProvider } from "../AgentProvider";
+import type { AgentMessage, AgentStreamFrame, Usage } from "../types";
+
+/**
+ * The model the suite is written against. `gpt-5.4` is not incidental: it is
+ * the generation where tool search exists (see `providers/capabilities.ts`),
+ * and the deferred-namespace test is the whole reason this suite exists.
+ *
+ * Overridable so a resource whose deployment is called something else can still
+ * run — Azure lets whoever ran the template name it anything.
+ */
+export const LIVE_MODEL = process.env.AI_LIVE_MODEL ?? "gpt-5.4";
+export const LIVE_AZURE_DEPLOYMENT =
+  process.env.AI_LIVE_AZURE_DEPLOYMENT ?? process.env.AI_LIVE_MODEL ?? "gpt-5.4";
+
+/**
+ * A key alone is not enough for Azure: the provider also needs to know which
+ * resource, and there are three spellings of that. Checking for all three is
+ * what stops the suite from running and failing with a 404 for a contributor
+ * who exported the key and nothing else.
+ */
+export const AZURE_RESOURCE_VARS = [
+  "AZURE_OPENAI_ENDPOINT",
+  "AZURE_OPENAI_RESOURCE_NAME",
+  "AZURE_RESOURCE_NAME",
+] as const;
+
+export const openaiConfigured = Boolean(process.env.OPENAI_API_KEY);
+export const azureConfigured =
+  Boolean(process.env.AZURE_OPENAI_API_KEY) &&
+  AZURE_RESOURCE_VARS.some((name) => Boolean(process.env[name]));
+
+/**
+ * A provider that records what went through it and caps what it costs.
+ *
+ * Two jobs, and both are load-bearing rather than convenience:
+ *
+ * `calls` is evidence. The memoization claim in the escalation test — that a
+ * sub-run which finished on turn one is replayed from the transcript rather
+ * than run again — is not observable from the transcript, because a replayed
+ * run and a re-run one produce the same messages. The only difference is
+ * whether a request was made, so the test counts requests.
+ *
+ * `maxOutputTokens` is a cap `Agent` has no way to set: `AgentStreamParams`
+ * carries no token budget, deliberately, and `ProviderStreamParams` does. So
+ * the cap goes on the seam between them. Without it a reasoning model asked a
+ * puzzle can spend thousands of tokens deciding how to say "nine".
+ */
+export class RecordingProvider implements AgentProvider {
+  readonly model: string;
+  readonly capabilities: AgentProvider["capabilities"];
+  /** One entry per model call, in order. */
+  readonly requests: ProviderStreamParams[] = [];
+  /** Every `ProviderEvent` the parser produced, flattened across calls — this
+   *  is where the tool-search and namespace assertions read from, because
+   *  `AgentStreamEvent` carries only half of what the parser knows. */
+  readonly events: ProviderEvent[] = [];
+
+  constructor(
+    private readonly inner: AgentProvider,
+    private readonly maxOutputTokens: number,
+  ) {
+    this.model = inner.model;
+    this.capabilities = inner.capabilities;
+  }
+
+  get calls(): number {
+    return this.requests.length;
+  }
+
+  /**
+   * What the provider itself reported spending, summed over every call.
+   *
+   * Deliberately a second implementation of `Agent`'s `addUsage` rather than a
+   * call to it: the claim being checked is that the run's total is the sum of
+   * what the provider billed, and asking the accumulator whether it accumulated
+   * would check nothing. The optional members follow the same rule the real one
+   * does — present as soon as any call reported them, so a run whose provider
+   * never mentions reasoning tokens keeps the smaller shape.
+   */
+  spent(): Usage {
+    const total: Usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    for (const event of this.events) {
+      if (event.type !== "finish") continue;
+      total.inputTokens += event.usage.inputTokens ?? 0;
+      total.outputTokens += event.usage.outputTokens ?? 0;
+      total.totalTokens += event.usage.totalTokens ?? 0;
+      if (event.usage.reasoningTokens !== undefined || total.reasoningTokens !== undefined) {
+        total.reasoningTokens = (total.reasoningTokens ?? 0) + (event.usage.reasoningTokens ?? 0);
+      }
+      if (event.usage.cachedInputTokens !== undefined || total.cachedInputTokens !== undefined) {
+        total.cachedInputTokens =
+          (total.cachedInputTokens ?? 0) + (event.usage.cachedInputTokens ?? 0);
+      }
+    }
+    return total;
+  }
+
+  stream(params: ProviderStreamParams): ProviderStream {
+    this.requests.push(params);
+    const events = this.events;
+    const inner = this.inner.stream({ ...params, maxOutputTokens: this.maxOutputTokens });
+    return (async function* () {
+      for await (const event of inner) {
+        events.push(event);
+        yield event;
+      }
+    })();
+  }
+
+  upload(file: File): Promise<string> {
+    return this.inner.upload(file);
+  }
+
+  normalizeError(error: unknown) {
+    return this.inner.normalizeError(error);
+  }
+}
+
+/** Long enough for `reasoning: "high"` to think and still answer; short enough
+ *  that a runaway generation is a cent rather than a dollar. */
+const DEFAULT_MAX_OUTPUT_TOKENS = 2_000;
+
+export type LiveTarget = {
+  /** Appears in every suite name, so `vitest -t openai` selects one provider. */
+  label: "openai" | "azure";
+  provider: (maxOutputTokens?: number) => RecordingProvider;
+};
+
+export const TARGETS: LiveTarget[] = [
+  {
+    label: "openai",
+    provider: (max = DEFAULT_MAX_OUTPUT_TOKENS) =>
+      new RecordingProvider(OpenAIProvider.model(LIVE_MODEL), max),
+  },
+  {
+    label: "azure",
+    provider: (max = DEFAULT_MAX_OUTPUT_TOKENS) =>
+      new RecordingProvider(AzureOpenAIProvider.model(LIVE_AZURE_DEPLOYMENT), max),
+  },
+];
+
+export const configuredFor = (label: LiveTarget["label"]) =>
+  label === "openai" ? openaiConfigured : azureConfigured;
+
+// --- reading a transcript -------------------------------------------------
+
+export const textOf = (message: AgentMessage | undefined): string =>
+  (message?.content ?? [])
+    .filter((part) => part.type === "text")
+    .map((part: any) => part.text as string)
+    .join("");
+
+export const partsOf = (messages: AgentMessage[], type: string): any[] =>
+  messages.flatMap((message) => message.content.filter((part) => part.type === type)) as any[];
+
+export const lastOf = <T>(items: T[]): T => items[items.length - 1];
+
+/** Every text part in the run, joined — what the user ends up reading. */
+export const transcriptText = (messages: AgentMessage[]) => messages.map(textOf).join("\n");
+
+/**
+ * The same text with digit grouping removed, for the assertions that look for a
+ * number the tool produced.
+ *
+ * A model writes 7413 as "7,413" about half the time, and on a French system
+ * prompt it would write "7 413". Stripping the separators is not a weaker
+ * assertion — it is the same number — and the alternative, telling the model
+ * how to format its digits, would make the test pass by changing what is being
+ * measured.
+ */
+export const withoutDigitGrouping = (text: string) =>
+  text.replace(/(?<=\d)[,\u202f\u00a0 ](?=\d)/g, "");
+
+/**
+ * Drains a run's numbered frames while it is still going, twice over.
+ *
+ * `frames()` rather than the plain async iterator because half the claims in
+ * this suite are about `seq` — that nested events are numbered in the parent's
+ * sequence, and that a client replaying them lands on the same transcript.
+ *
+ * WHY TWO ARRAYS, AND WHY THIS IS NOT PEDANTRY. A `tool-call` frame carries the
+ * `ToolCallPart` BY REFERENCE, and the part goes on being written to after the
+ * frame is emitted: `nestedRunner` hangs `nested` on it, and the sub-run's
+ * transcript grows there for the rest of the call. In process, that means a
+ * frame collected at the top of a run has a *different* value by the end of it.
+ *
+ * `AgentRunImpl.toResponse` does `JSON.stringify(frame.event)` at yield time,
+ * so a browser watching live receives the part as it was when the frame went
+ * out — which is what `wire` is: a clone taken the instant the frame arrived.
+ * That is the only honest input for a test of the client reducer. Feeding the
+ * live objects instead would hand the reducer a nested transcript it never had
+ * to build, and a reducer that dropped `nested-event` entirely would still
+ * pass. (It did. That is how this was found.)
+ *
+ * `live` is kept because the other shape is real too: a client that calls
+ * `/attach?from=0` after the run has finished gets the buffered frames
+ * serialized *then*, nested transcript already on the part, and then every
+ * `nested-event` again on top of it. Converging from there is a claim worth
+ * making rather than an accident worth relying on.
+ */
+export function collectFrames(run: { frames(from?: number): AsyncIterable<AgentStreamFrame> }) {
+  const wire: AgentStreamFrame[] = [];
+  const live: AgentStreamFrame[] = [];
+  const done = (async () => {
+    for await (const frame of run.frames()) {
+      live.push(frame);
+      wire.push(JSON.parse(JSON.stringify(frame)) as AgentStreamFrame);
+    }
+  })();
+  return { wire, live, done };
+}
+
+/** The request that has no user in it: these tests call `Agent.stream` directly
+ *  rather than through the controller, and no tool here reads the request. */
+export const req = {} as any;

--- a/packages/gemi/ai/live/live.test.ts
+++ b/packages/gemi/ai/live/live.test.ts
@@ -1,0 +1,939 @@
+/**
+ * The suite that talks to a real model.
+ *
+ * WHY THIS EXISTS. Every other test in `ai/` drives a scripted provider or a
+ * recorded stream, which is the right default — they are fast, offline and
+ * deterministic. What they cannot do is notice that the thing being scripted is
+ * not what the API sends. The deferred-tool test below is the case in point:
+ * `tool_search_output.tools` is an array of *namespaces* containing functions,
+ * the parser used to read the top-level `name` off it and report `["crm"]`, and
+ * every fixture in the repo agreed with the parser because the fixtures were
+ * written from the same misreading. Only the API disagrees.
+ *
+ * HOW IT IS GATED, and why it is gated this way. The repository already has an
+ * answer for environment-dependent suites — `POSTGRES_URL ? describe :
+ * describe.skip` plus a *passing* test that warns — and the reasoning is
+ * written up in `orm/postgres-suite-selection.test.ts`: three suites once ran
+ * in neither CI job and nothing said so. `describe.skip` is silent, and a
+ * silently skipped suite reads exactly like a passing one. So the same idiom is
+ * used here, and the announcement below is not decoration: it is the only thing
+ * standing between "the live tests are green" and "the live tests did not run".
+ *
+ * A contributor with no key gets two passing announcements and no failures.
+ * `bun run test:live` runs it deliberately, and `vitest -t openai` / `-t azure`
+ * runs one provider — every suite name carries its provider for that reason.
+ *
+ * NO KEY MATERIAL, ANYWHERE. Nothing here reads a credential by value; the
+ * providers pick their own out of the environment. Load them however you like —
+ * `set -a && . packages/.env && set +a` is the usual one — and note that the
+ * fixtures this suite would otherwise tempt you to record belong in
+ * `providers/__fixtures__`, which has a test asserting no file in it carries a
+ * key.
+ *
+ * COST. Prompts are short, `max_output_tokens` is capped at 2000 by
+ * `RecordingProvider`, and every agent has a low `maxSteps`. A full run of both
+ * providers is a few cents.
+ */
+process.env.SECRET ??= "ai-live-test-secret";
+
+import { describe, expect, test } from "vitest";
+import { Agent, AgentTool, ToolNamespace } from "../Agent";
+import { applyFrame, initialChatState } from "../client/reducer";
+import { toResponsesInput } from "../providers/request";
+import { s } from "../Schema";
+import type { AgentMessage, AgentStreamEvent, PendingToolCall } from "../types";
+import {
+  AZURE_RESOURCE_VARS,
+  azureConfigured,
+  collectFrames,
+  configuredFor,
+  lastOf,
+  LIVE_AZURE_DEPLOYMENT,
+  LIVE_MODEL,
+  openaiConfigured,
+  partsOf,
+  req,
+  TARGETS,
+  textOf,
+  transcriptText,
+  withoutDigitGrouping,
+  type LiveTarget,
+} from "./harness";
+
+/** A model call can take a while at `reasoning: "high"`, and a nested run is
+ *  several of them in series. */
+const TIMEOUT = 240_000;
+
+// --- the announcement -----------------------------------------------------
+//
+// Deliberately a passing test rather than `test.skip`, and deliberately loud:
+// see the header. The wording matches the four Postgres suites that already do
+// this, because a second dialect of the same message is a second thing to
+// recognize.
+
+if (!openaiConfigured) {
+  describe("live openai (skipped)", () => {
+    test("SKIPPED — set OPENAI_API_KEY to run the live OpenAI suite", () => {
+      console.warn(
+        "\n  ⚠  Live OpenAI agent tests did NOT run.\n" +
+          "     Set OPENAI_API_KEY to exercise the module against the real\n" +
+          "     Responses API. Everything else in ai/ runs offline.\n",
+      );
+      expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    });
+  });
+}
+
+if (!azureConfigured) {
+  describe("live azure (skipped)", () => {
+    test("SKIPPED — set AZURE_OPENAI_API_KEY and a resource to run the live Azure suite", () => {
+      console.warn(
+        "\n  ⚠  Live Azure agent tests did NOT run.\n" +
+          `     Set AZURE_OPENAI_API_KEY and one of ${AZURE_RESOURCE_VARS.join(", ")}.\n` +
+          "     Azure is not a formality here: it sends content_filters OpenAI\n" +
+          "     does not, and its Responses path differs — see AgentProvider.\n",
+      );
+      // One of the two halves is missing; saying which would mean printing an
+      // env var this file has no business reading.
+      expect(azureConfigured).toBe(false);
+    });
+  });
+}
+
+// --- fixtures the battery builds per provider ----------------------------
+
+/** A number no model will produce on its own, so "the tool's answer reached the
+ *  final message" is checkable by looking for it. */
+const POPULATION = 7413;
+const STOCK = 9182;
+
+function inventoryTool(log: string[]) {
+  return AgentTool.create({
+    name: "checkStock",
+    description: "How many units of one SKU are in the warehouse",
+    inputSchema: s.object({ sku: s.string().describe("A SKU like AB-1") }),
+    outputSchema: s.object({ units: s.number() }),
+    execute: async (input) => {
+      log.push(input.sku);
+      return { units: input.sku === "AB-1" ? STOCK : STOCK + 1 };
+    },
+  });
+}
+
+function populationTool(log: string[]) {
+  return AgentTool.create({
+    name: "lookupPopulation",
+    description: "The population of a town in the company's private records",
+    inputSchema: s.object({ town: s.string() }),
+    outputSchema: s.object({ people: s.number() }),
+    execute: async (input) => {
+      log.push(input.town);
+      return { people: POPULATION };
+    },
+  });
+}
+
+function refundTool(log: string[]) {
+  return AgentTool.create({
+    name: "issueRefund",
+    description: "Refund one order in full",
+    inputSchema: s.object({ orderId: s.string() }),
+    outputSchema: s.object({ refundId: s.string() }),
+    requiresApproval: true,
+    execute: async (input) => {
+      log.push(input.orderId);
+      return { refundId: `rf_${input.orderId}` };
+    },
+  });
+}
+
+// --- the battery ----------------------------------------------------------
+
+function battery(target: LiveTarget) {
+  const RUN = configuredFor(target.label) ? describe : describe.skip;
+  const model = target.label === "openai" ? LIVE_MODEL : LIVE_AZURE_DEPLOYMENT;
+
+  RUN(`live ${target.label} — ${model}`, () => {
+    test(
+      "a plain text run",
+      async () => {
+        const provider = target.provider();
+        const agent = Agent.create({
+          name: "greeter",
+          instructions: "Answer with a single word and no punctuation.",
+          provider,
+        });
+        const run = agent.stream({
+          messages: [],
+          req,
+          turn: { text: "What is the capital of France?" },
+        });
+        const events: AgentStreamEvent[] = [];
+        for await (const event of run) events.push(event);
+        const result = await run.result();
+
+        expect(result.finishReason).toBe("stop");
+        expect(result.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+        expect(textOf(lastOf(result.messages))).toMatch(/paris/i);
+        // A run that reported no tokens has not talked to anything.
+        expect(result.usage.totalTokens).toBeGreaterThan(0);
+        expect(result.usage).toEqual(provider.spent());
+        expect(events[0]).toMatchObject({ type: "run-start" });
+        expect(lastOf(events)).toMatchObject({ type: "run-end", finishReason: "stop" });
+        expect(events.some((event) => event.type === "text-delta")).toBe(true);
+      },
+      TIMEOUT,
+    );
+
+    test(
+      "a tool call, and its result feeding the final answer",
+      async () => {
+        const called: string[] = [];
+        const provider = target.provider();
+        const agent = Agent.create({
+          name: "warehouse",
+          instructions:
+            "You have no stock figures of your own. Use checkStock, then state the number.",
+          provider,
+          tools: [inventoryTool(called)],
+          maxSteps: 4,
+        });
+        const result = await agent
+          .stream({
+            messages: [],
+            req,
+            turn: { text: "How many units of AB-1 are in stock?" },
+          })
+          .result();
+
+        expect(called).toEqual(["AB-1"]);
+        const calls = partsOf(result.messages, "tool-call");
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({ name: "checkStock", input: { sku: "AB-1" } });
+        expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({
+          status: "ok",
+          output: { units: STOCK },
+        });
+        // The claim that matters: the tool's answer, not the model's guess,
+        // is what the user reads. `9182` is not a number a model invents.
+        expect(withoutDigitGrouping(textOf(lastOf(result.messages)))).toContain(String(STOCK));
+        expect(result.finishReason).toBe("stop");
+        // Two model calls: one to ask for the tool, one to answer with it.
+        expect(provider.calls).toBe(2);
+      },
+      TIMEOUT,
+    );
+
+    test(
+      "parallel tool calls in one step",
+      async () => {
+        const called: string[] = [];
+        const provider = target.provider();
+        const agent = Agent.create({
+          name: "warehouse",
+          instructions:
+            "You have no stock figures of your own. When asked about several SKUs, call " +
+            "checkStock once for each of them in the SAME turn, never one turn at a time.",
+          provider,
+          tools: [inventoryTool(called)],
+          maxSteps: 4,
+        });
+        const result = await agent
+          .stream({
+            messages: [],
+            req,
+            turn: { text: "Stock for AB-1 and for CD-2?" },
+          })
+          .result();
+
+        expect(called.sort()).toEqual(["AB-1", "CD-2"]);
+        const calls = partsOf(result.messages, "tool-call");
+        expect(calls).toHaveLength(2);
+        // Parallel means one assistant message holding both, which is also what
+        // makes it one model call rather than two.
+        const messagesWithCalls = result.messages.filter((message) =>
+          message.content.some((part) => part.type === "tool-call"),
+        );
+        expect(messagesWithCalls).toHaveLength(1);
+        expect(provider.calls).toBe(2);
+        expect(partsOf(result.messages, "tool-result")).toHaveLength(2);
+      },
+      TIMEOUT,
+    );
+
+    test(
+      "structured output against a schema built with `s`",
+      async () => {
+        const schema = s.object({
+          sentiment: s.enum(["positive", "neutral", "negative"]),
+          topics: s.array(s.string()),
+        });
+        const provider = target.provider();
+        const agent = Agent.create({
+          name: "classifier",
+          instructions: "Classify the message.",
+          provider,
+          output: schema,
+        });
+        const run = agent.stream({
+          messages: [],
+          req,
+          turn: { text: "The invoice arrived late again and support never replied." },
+        });
+        const events: AgentStreamEvent[] = [];
+        for await (const event of run) events.push(event);
+        const result = await run.result();
+
+        expect(result.finishReason).toBe("stop");
+        // The point of the assertion: the schema that built the request is the
+        // one that reads the answer, and it accepts it.
+        const parsed = schema.safeParse(result.output);
+        expect(parsed.ok === true ? [] : parsed.errors).toEqual([]);
+        expect(result.output).toMatchObject({ sentiment: "negative" });
+        expect(Array.isArray((result.output as any).topics)).toBe(true);
+        // Strict mode: nothing outside the schema comes back.
+        expect(Object.keys(result.output as any).sort()).toEqual(["sentiment", "topics"]);
+
+        const output = partsOf(result.messages, "output");
+        expect(output).toHaveLength(1);
+        expect(output[0].value).toEqual(result.output);
+        // The JSON arrived as a stream, which is what `output-delta` is for.
+        expect(events.filter((event) => event.type === "output-delta").length).toBeGreaterThan(0);
+      },
+      TIMEOUT,
+    );
+
+    test(
+      "a deferred tool behind a namespace, and what tool search reports",
+      async () => {
+        const provider = target.provider();
+        const listOrders = AgentTool.create({
+          name: "listOrders",
+          description: "List a customer's recent order ids",
+          inputSchema: s.object({ customerId: s.string() }),
+          outputSchema: s.object({ orderIds: s.array(s.string()) }),
+          execute: async () => ({ orderIds: ["ord_1"] }),
+        });
+        const getOrder = AgentTool.create({
+          name: "getOrder",
+          description: "Read one order's total, in cents",
+          inputSchema: s.object({ orderId: s.string() }),
+          outputSchema: s.object({ totalCents: s.number() }),
+          execute: async () => ({ totalCents: 4200 }),
+        });
+        const crm = ToolNamespace.create({
+          name: "crm",
+          description: "Customer records, orders and refunds",
+          deferred: true,
+          tools: [listOrders, getOrder],
+        });
+        const agent = Agent.create({
+          name: "support",
+          instructions: "Use the crm tools. Answer with the number of cents only.",
+          provider,
+          tools: [crm],
+          maxSteps: 4,
+        });
+        const run = agent.stream({
+          messages: [],
+          req,
+          turn: { text: "What is the total on order ord_1?" },
+        });
+        const events: AgentStreamEvent[] = [];
+        for await (const event of run) events.push(event);
+        const result = await run.result();
+
+        // THE BUG THIS SUITE WAS WRITTEN FOR. The search results are a tree of
+        // namespaces holding functions; reading `name` off the top level yields
+        // the namespace, so this used to report `loaded: ["crm"]` — the one
+        // thing the user already knew. Every offline fixture agreed with it,
+        // because the fixtures were written from the same misreading.
+        const searches = events.filter((event) => event.type === "tool-search") as any[];
+        expect(searches.length).toBeGreaterThan(0);
+        const loaded = searches.flatMap((event) => event.loaded);
+        expect(loaded).toContain("getOrder");
+        expect(loaded).not.toContain("crm");
+
+        // The parser knows both levels; `AgentStreamEvent` only carries one, so
+        // the group is checked where it exists.
+        const parsed = provider.events.filter((event) => event.type === "tool-search") as any[];
+        expect(parsed.length).toBeGreaterThan(0);
+        expect(parsed.flatMap((event) => event.namespaces)).toEqual(["crm"]);
+
+        // The RFC's open question, answered by the API rather than by us: a
+        // namespaced call comes back with a FLAT name and the namespace beside
+        // it, which is why `name` is still the registry key.
+        const providerCalls = provider.events.filter(
+          (event) => event.type === "tool-call",
+        ) as any[];
+        expect(providerCalls.length).toBeGreaterThan(0);
+        expect(providerCalls[0].namespace).toBe("crm");
+        expect(providerCalls[0].name).not.toContain(".");
+        expect(["listOrders", "getOrder"]).toContain(providerCalls[0].name);
+
+        expect(result.finishReason).toBe("stop");
+        expect(transcriptText(result.messages)).toContain("4200");
+      },
+      TIMEOUT,
+    );
+
+    /**
+     * WHETHER A MODEL REASONS IS THE MODEL'S BUSINESS, and it is the one thing
+     * in this file that is genuinely nondeterministic: at `effort: "high"` on a
+     * puzzle whose answer the tool call depends on, both providers emitted a
+     * reasoning item on the first step five times out of six, and the sixth run
+     * emitted none at all.
+     *
+     * So the RUN is retried until the model reasons before its last step. The
+     * ASSERTIONS are not retried and are not relaxed — the loop below stops at
+     * the first run that gives the round trip something to be about, and then
+     * checks it. A run that never reasons in three attempts fails, loudly,
+     * rather than passing vacuously.
+     */
+    async function reasoningRun() {
+      const recorded: number[] = [];
+      const provider = target.provider();
+      const record = AgentTool.create({
+        name: "recordAnswer",
+        description: "Record how many dollars are genuinely unaccounted for",
+        inputSchema: s.object({ dollars: s.number() }),
+        outputSchema: s.object({ saved: s.boolean() }),
+        execute: async (input) => {
+          recorded.push(input.dollars);
+          return { saved: true };
+        },
+      });
+      const agent = Agent.create({
+        name: "thinker",
+        instructions: "Think it through before you answer.",
+        provider,
+        tools: [record],
+        reasoning: "high",
+        maxSteps: 4,
+      });
+      const result = await agent
+        .stream({
+          messages: [],
+          req,
+          turn: {
+            text:
+              "Three people pay 30 for a room; the clerk refunds 5, the bellhop keeps 2 and " +
+              "returns 1 each. Work out where the missing dollar goes, call recordAnswer with " +
+              "how many dollars are genuinely unaccounted for, then explain in one sentence.",
+          },
+        })
+        .result();
+
+      // What each model call after the first actually put on the wire, beside
+      // the reasoning it was handed. This pair is the round trip.
+      const steps = provider.requests.slice(1).map((request) => ({
+        held: partsOf(request.messages, "reasoning").filter((part: any) => part.id),
+        sent: toResponsesInput(request.messages, provider.capabilities).filter(
+          (item) => item.type === "reasoning",
+        ),
+      }));
+      return { provider, result, recorded, steps };
+    }
+
+    test(
+      "reasoning survives a round trip across two steps",
+      async () => {
+        let run = await reasoningRun();
+        for (
+          let attempt = 1;
+          attempt < 3 && run.steps.every((step) => step.held.length === 0);
+          attempt++
+        ) {
+          run = await reasoningRun();
+        }
+
+        expect(run.provider.calls).toBeGreaterThanOrEqual(2);
+        expect(run.recorded).toHaveLength(1);
+
+        const reasoning = partsOf(run.result.messages, "reasoning");
+        expect(
+          reasoning.length,
+          "the model produced no reasoning in three attempts, so there was no round trip to check",
+        ).toBeGreaterThan(0);
+        // An id, because that is the API's handle on the stored reasoning and
+        // `request.ts` drops an item without one rather than fabricating a
+        // reference. Losing it is invisible in the transcript and shows up as a
+        // cold prompt cache and a model that has forgotten its own argument —
+        // which is exactly what this suite found the first time it ran.
+        expect(reasoning[0].id).toMatch(/^rs_/);
+        expect(reasoning[0].text.length).toBeGreaterThan(0);
+
+        // THE ROUND TRIP. Every reasoning item a later step was handed is a
+        // reasoning item that step sent, under the same id.
+        expect(run.steps.some((step) => step.held.length > 0)).toBe(true);
+        for (const step of run.steps) {
+          expect(step.sent.map((item) => item.id).sort()).toEqual(
+            step.held.map((part: any) => part.id).sort(),
+          );
+        }
+      },
+      TIMEOUT,
+    );
+
+    test(
+      "an approval parks the run, and a second turn releases it",
+      async () => {
+        const refunded: string[] = [];
+        const refund = refundTool(refunded);
+        const first = target.provider();
+        const agent = Agent.create({
+          name: "billing",
+          instructions: "Use issueRefund. Confirm with the refund id when it comes back.",
+          provider: first,
+          tools: [refund],
+          maxSteps: 4,
+        });
+        const run = agent.stream({
+          messages: [],
+          req,
+          turn: { text: "Refund order ord_7 in full." },
+        });
+        const events: AgentStreamEvent[] = [];
+        for await (const event of run) events.push(event);
+        const parked = await run.result();
+
+        expect(parked.finishReason).toBe("awaiting-input");
+        // Not run, and not run yet — the whole point of an approval.
+        expect(refunded).toEqual([]);
+        const awaiting = events.find((event) => event.type === "awaiting-input") as any;
+        const pending = awaiting.pending as PendingToolCall[];
+        expect(pending).toHaveLength(1);
+        expect(pending[0]).toMatchObject({
+          name: "issueRefund",
+          kind: "approval",
+          input: { orderId: "ord_7" },
+        });
+        expect(pending[0].signature.length).toBeGreaterThan(0);
+        // Top level: no path. The nested test below is where a path appears.
+        expect(pending[0].path).toBeUndefined();
+        expect(partsOf(parked.messages, "tool-result")).toHaveLength(0);
+
+        const second = target.provider();
+        const resumed = await agent
+          .stream({
+            messages: parked.messages,
+            req,
+            provider: second,
+            turn: {
+              toolResults: [
+                {
+                  toolCallId: pending[0].toolCallId,
+                  signature: pending[0].signature,
+                  approve: true,
+                },
+              ],
+            },
+          })
+          .result();
+
+        expect(refunded).toEqual(["ord_7"]);
+        expect(resumed.finishReason).toBe("stop");
+        const results = partsOf(resumed.messages, "tool-result");
+        expect(results).toHaveLength(1);
+        expect(results[0]).toMatchObject({
+          toolCallId: pending[0].toolCallId,
+          status: "ok",
+          output: { refundId: "rf_ord_7" },
+        });
+        expect(transcriptText(resumed.messages)).toContain("rf_ord_7");
+      },
+      TIMEOUT,
+    );
+
+    // --- the headline: a tool that runs another agent ----------------------
+
+    /**
+     * Built once and shared by the nesting test and the client-reducer test.
+     *
+     * Lazily rather than in a `beforeAll` so that skipping the reducer test
+     * skips the model calls too, and so the two tests are not ordered against
+     * each other — either one alone builds it.
+     */
+    let nested: Promise<Awaited<ReturnType<typeof buildNested>>> | undefined;
+    const nestedFixture = () => (nested ??= buildNested());
+
+    async function buildNested() {
+      const towns: string[] = [];
+      const subProvider = target.provider();
+      const researcher = Agent.create({
+        name: "researcher",
+        instructions: "Use lookupPopulation. Answer with the number and nothing else.",
+        provider: subProvider,
+        tools: [populationTool(towns)],
+        maxSteps: 4,
+      });
+
+      const delegate = AgentTool.create({
+        name: "delegate",
+        description: "Ask the research sub-agent one question",
+        inputSchema: s.object({ question: s.string() }),
+        outputSchema: s.object({ answer: s.string() }),
+        execute: async (input, ctx) => {
+          const sub = await ctx.runAgent(researcher, {
+            prompt: input.question,
+            label: "researching the town",
+          });
+          return { answer: textOf(lastOf(sub.messages)) };
+        },
+      });
+
+      const parentProvider = target.provider();
+      const lead = Agent.create({
+        name: "lead",
+        instructions:
+          "You cannot look anything up. Use delegate for any question of fact, then " +
+          "report what it said.",
+        provider: parentProvider,
+        tools: [delegate],
+        maxSteps: 4,
+      });
+
+      const userText = "What is the population of Ashgrove Hollow?";
+      const run = lead.stream({ messages: [], req, turn: { text: userText } });
+      const { wire, live, done } = collectFrames(run);
+      const result = await run.result();
+      await done;
+      return { result, wire, live, parentProvider, subProvider, towns, userText };
+    }
+
+    test(
+      "a tool whose execute runs a sub-agent that calls a tool of its own",
+      async () => {
+        const { result, wire: frames, parentProvider, subProvider, towns } = await nestedFixture();
+
+        expect(result.finishReason).toBe("stop");
+        expect(towns.length).toBe(1);
+
+        const call = partsOf(result.messages, "tool-call").find((part) => part.name === "delegate");
+        expect(call).toBeDefined();
+        expect(partsOf(result.messages, "tool-result")[0]).toMatchObject({ status: "ok" });
+        // The sub-agent's tool's answer reached the parent's final message,
+        // through the sub-agent's own answer and the parent tool's return.
+        expect(withoutDigitGrouping(transcriptText(result.messages))).toContain(String(POPULATION));
+
+        // THE NESTED TRANSCRIPT, on the parent's tool call.
+        expect(call.nested).toHaveLength(1);
+        const sub = call.nested[0];
+        expect(sub).toMatchObject({
+          agent: "researcher",
+          label: "researching the town",
+          finishReason: "stop",
+        });
+        expect(sub.usage.totalTokens).toBeGreaterThan(0);
+        // It is an ordinary transcript, which is the entire design: the same
+        // reducer and the same components render it.
+        const subCalls = partsOf(sub.messages, "tool-call");
+        expect(subCalls.map((part: any) => part.name)).toEqual(["lookupPopulation"]);
+        expect(partsOf(sub.messages, "tool-result")[0]).toMatchObject({
+          status: "ok",
+          output: { people: POPULATION },
+        });
+
+        // NESTED EVENTS, IN THE PARENT'S SEQ. `/attach` replay and the frame
+        // buffer both count in this sequence, so a nested event numbered
+        // outside it would be a hole a reattaching client falls into.
+        expect(frames.map((frame) => frame.seq)).toEqual(frames.map((_, at) => at + 1));
+        const nestedFrames = frames.filter((frame) => frame.event.type === "nested-event");
+        expect(nestedFrames.length).toBeGreaterThan(0);
+        for (const frame of nestedFrames) {
+          expect(frame.event).toMatchObject({
+            toolCallId: call.toolCallId,
+            runId: sub.runId,
+            agent: "researcher",
+            label: "researching the town",
+          });
+        }
+        const inner = nestedFrames.map((frame) => (frame.event as any).event.type);
+        expect(inner).toContain("run-start");
+        expect(inner).toContain("tool-call");
+        expect(inner).toContain("tool-result");
+        expect(inner).toContain("run-end");
+
+        const indexOf = (match: (event: any) => boolean) =>
+          frames.findIndex((frame) => match(frame.event));
+        const parentCall = indexOf(
+          (event) => event.type === "tool-call" && event.part.toolCallId === call.toolCallId,
+        );
+        const parentResult = indexOf(
+          (event) => event.type === "tool-result" && event.part.toolCallId === call.toolCallId,
+        );
+        const nestedPositions = frames
+          .map((frame, at) => (frame.event.type === "nested-event" ? at : -1))
+          .filter((at) => at >= 0);
+        expect(Math.min(...nestedPositions)).toBeGreaterThan(parentCall);
+        expect(Math.max(...nestedPositions)).toBeLessThan(parentResult);
+
+        // USAGE ROLLED UP: the parent's total is every token both runs spent,
+        // checked against what the two providers themselves reported.
+        const spent = {
+          inputTokens: parentProvider.spent().inputTokens + subProvider.spent().inputTokens,
+          outputTokens: parentProvider.spent().outputTokens + subProvider.spent().outputTokens,
+          totalTokens: parentProvider.spent().totalTokens + subProvider.spent().totalTokens,
+        };
+        expect(result.usage.inputTokens).toBe(spent.inputTokens);
+        expect(result.usage.outputTokens).toBe(spent.outputTokens);
+        expect(result.usage.totalTokens).toBe(spent.totalTokens);
+        expect(subProvider.calls).toBeGreaterThanOrEqual(2);
+      },
+      TIMEOUT,
+    );
+
+    test(
+      "a sub-agent's approval reaches the user, and the resumed tool does not redo its work",
+      async () => {
+        const towns: string[] = [];
+        const refunded: string[] = [];
+        const resumedFlags: boolean[] = [];
+
+        const researchProvider = target.provider();
+        const researcher = Agent.create({
+          name: "researcher",
+          instructions: "Use lookupPopulation. Answer with the number and nothing else.",
+          provider: researchProvider,
+          tools: [populationTool(towns)],
+          maxSteps: 4,
+        });
+
+        const financeProvider = target.provider();
+        const finance = Agent.create({
+          name: "finance",
+          instructions: "Use issueRefund for the order you are given, then confirm the refund id.",
+          provider: financeProvider,
+          tools: [refundTool(refunded)],
+          maxSteps: 4,
+        });
+
+        const settle = AgentTool.create({
+          name: "settle",
+          description: "Look the town up and refund the order, using the two sub-agents",
+          inputSchema: s.object({ orderId: s.string() }),
+          outputSchema: s.object({ town: s.string(), refund: s.string() }),
+          execute: async (input, ctx) => {
+            resumedFlags.push(ctx.resumed);
+            // Runs on turn one, and must be REPLAYED on turn two rather than
+            // run again — the claim the call counts below exist to check.
+            const looked = await ctx.runAgent(researcher, {
+              prompt: "What is the population of Ashgrove Hollow?",
+              label: "population",
+            });
+            // Escalates: its tool needs an approval only the user can give.
+            const settled = await ctx.runAgent(finance, {
+              prompt: `Refund order ${input.orderId}.`,
+              label: "refund",
+            });
+            return {
+              town: textOf(lastOf(looked.messages)),
+              refund: textOf(lastOf(settled.messages)),
+            };
+          },
+        });
+
+        const parentProvider = target.provider();
+        const lead = Agent.create({
+          name: "lead",
+          instructions: "Use settle for the order you are given, then report both answers.",
+          provider: parentProvider,
+          tools: [settle],
+          maxSteps: 4,
+        });
+
+        const run = lead.stream({
+          messages: [],
+          req,
+          turn: { text: "Settle order ord_7." },
+        });
+        const events: AgentStreamEvent[] = [];
+        for await (const event of run) events.push(event);
+        const parked = await run.result();
+
+        // TURN ONE: the parent parks, holding the SUB-agent's question.
+        expect(parked.finishReason).toBe("awaiting-input");
+        const awaiting = events.find((event) => event.type === "awaiting-input") as any;
+        const pending = awaiting.pending as PendingToolCall[];
+        expect(pending).toHaveLength(1);
+        const parentCall = partsOf(parked.messages, "tool-call").find(
+          (part) => part.name === "settle",
+        );
+        expect(pending[0]).toMatchObject({
+          name: "issueRefund",
+          kind: "approval",
+          input: { orderId: "ord_7" },
+          // The address. The parent never made a call with this id, so the id
+          // alone cannot say which tool to re-enter.
+          path: [parentCall.toolCallId],
+        });
+        expect(refunded).toEqual([]);
+
+        const researchCallsAfterTurnOne = researchProvider.calls;
+        const financeCallsAfterTurnOne = financeProvider.calls;
+        expect(researchCallsAfterTurnOne).toBeGreaterThanOrEqual(2);
+        expect(towns).toHaveLength(1);
+        expect(resumedFlags).toEqual([false]);
+        // Both sub-runs are on the parent's tool call: one finished, one parked.
+        expect(parentCall.nested).toHaveLength(2);
+        expect(parentCall.nested[0]).toMatchObject({ agent: "researcher", finishReason: "stop" });
+        expect(parentCall.nested[1]).toMatchObject({
+          agent: "finance",
+          finishReason: "awaiting-input",
+        });
+
+        // TURN TWO: the user approves, and the tool is re-entered from the top.
+        const resumeProvider = target.provider();
+        const resumed = await lead
+          .stream({
+            messages: parked.messages,
+            req,
+            provider: resumeProvider,
+            turn: {
+              toolResults: [
+                {
+                  toolCallId: pending[0].toolCallId,
+                  signature: pending[0].signature,
+                  path: pending[0].path,
+                  approve: true,
+                },
+              ],
+            },
+          })
+          .result();
+
+        // THE PART THAT MATTERS. The tool body ran again — there is no way to
+        // suspend an async generator across a turn — but the sub-run that had
+        // already finished was replayed out of the transcript: no request, no
+        // tool call, no second bill.
+        expect(resumedFlags).toEqual([false, true]);
+        expect(researchProvider.calls).toBe(researchCallsAfterTurnOne);
+        expect(towns).toHaveLength(1);
+        // The one that parked continued instead of restarting: it took further
+        // steps, and its approval tool ran exactly once.
+        expect(financeProvider.calls).toBeGreaterThan(financeCallsAfterTurnOne);
+        expect(refunded).toEqual(["ord_7"]);
+
+        expect(resumed.finishReason).toBe("stop");
+        const result = partsOf(resumed.messages, "tool-result").find(
+          (part) => part.toolCallId === parentCall.toolCallId,
+        );
+        expect(result).toMatchObject({ status: "ok" });
+        expect(withoutDigitGrouping(result.output.town)).toContain(String(POPULATION));
+        expect(result.output.refund).toContain("rf_ord_7");
+      },
+      TIMEOUT,
+    );
+
+    // --- the client half, against frames a model produced -------------------
+
+    test(
+      "the client reducer rebuilds the transcript a UI would render, nesting included",
+      async () => {
+        const { result, wire, live, userText } = await nestedFixture();
+
+        // Seeded the way `useChat` seeds it: the user's own turn is authored in
+        // the browser and never comes back on the stream.
+        const seed: AgentMessage[] = [
+          {
+            id: "local_1",
+            role: "user",
+            content: [{ type: "text", text: userText }],
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        ];
+        const now = "2026-01-01T00:00:00.000Z";
+        const replay = (frames = wire, initial = initialChatState({ messages: seed })) =>
+          frames.reduce((state, frame) => applyFrame(state, frame, now), initial);
+
+        // `wire`, not the live frame objects: a `tool-call` frame carries its
+        // part by reference and the part keeps being written to afterwards, so
+        // the in-process objects arrive at the reducer with the nested
+        // transcript already built. See `collectFrames`.
+        const state = replay();
+
+        expect(state.error).toBeNull();
+        expect(state.pending).toEqual([]);
+        expect(state.finishReason).toBe("stop");
+        expect(state.messages.map((message) => message.role)).toEqual([
+          "user",
+          ...result.messages.slice(1).map((message) => message.role),
+        ]);
+        // The same ids and the same text the server produced — the client's
+        // transcript is not a paraphrase of the run, it is the run.
+        expect(state.messages.slice(1).map((message) => message.id)).toEqual(
+          result.messages.slice(1).map((message) => message.id),
+        );
+        expect(transcriptText(state.messages.slice(1))).toBe(
+          transcriptText(result.messages.slice(1)),
+        );
+
+        const call = partsOf(state.messages, "tool-call").find((part) => part.name === "delegate");
+        expect(call).toBeDefined();
+        expect(partsOf(state.messages, "tool-result")[0]).toMatchObject({ status: "ok" });
+
+        // THE NESTED TRANSCRIPT, REBUILT BY THE SAME REDUCER RECURSING. The
+        // client has never met these frames before: every earlier test of this
+        // path fed it frames the client half wrote itself.
+        expect(call.nested).toHaveLength(1);
+        const sub = call.nested[0];
+        expect(sub).toMatchObject({
+          agent: "researcher",
+          label: "researching the town",
+          finishReason: "stop",
+        });
+        expect(partsOf(sub.messages, "tool-call").map((part: any) => part.name)).toEqual([
+          "lookupPopulation",
+        ]);
+        expect(partsOf(sub.messages, "tool-result")[0]).toMatchObject({
+          status: "ok",
+          output: { people: POPULATION },
+        });
+        // No message anywhere in the tree is left looking like it is still
+        // streaming, at either level.
+        expect(state.messages.slice(1).every((message) => Boolean(message.finishReason))).toBe(
+          true,
+        );
+        expect(sub.messages.every((message: AgentMessage) => Boolean(message.finishReason))).toBe(
+          true,
+        );
+
+        // The reducer's own contract, checked against real frames rather than
+        // hand-written ones: redelivery converges. A reattaching client is
+        // handed frames it already has.
+        expect(replay(wire, state)).toEqual(state);
+        expect(replay()).toEqual(state);
+
+        // And the other shape a real client meets: `/attach?from=0` after the
+        // run has finished serializes the buffered frames as they are NOW, so
+        // the tool-call part already carries the whole nested transcript and
+        // every `nested-event` then arrives on top of it. Nothing may be
+        // applied twice, or a late attach renders the sub-agent's answer twice.
+        const settled = replay(JSON.parse(JSON.stringify(live)));
+        expect(settled.messages.map((message) => message.id)).toEqual(
+          state.messages.map((message) => message.id),
+        );
+        expect(transcriptText(settled.messages)).toBe(transcriptText(state.messages));
+        const settledSub = partsOf(settled.messages, "tool-call").find(
+          (part) => part.name === "delegate",
+        ).nested[0];
+        // Compared over the sub-run's ASSISTANT turns, because the two clients
+        // legitimately see different amounts here: the recorded `NestedRun`
+        // opens with the sub-agent's own user turn, and the live stream never
+        // carried it (a run emits no `message-start` for the turn it was given,
+        // at any depth). More, not doubled — which is what this checks.
+        const assistants = (messages: AgentMessage[]) =>
+          messages.filter((message) => message.role === "assistant");
+        expect(assistants(settledSub.messages).map((message) => message.id)).toEqual(
+          assistants(sub.messages).map((message) => message.id),
+        );
+        expect(transcriptText(assistants(settledSub.messages))).toBe(
+          transcriptText(assistants(sub.messages)),
+        );
+      },
+      TIMEOUT,
+    );
+  });
+}
+
+for (const target of TARGETS) battery(target);

--- a/packages/gemi/ai/providers/fakeProvider.ts
+++ b/packages/gemi/ai/providers/fakeProvider.ts
@@ -1,0 +1,57 @@
+import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "../AgentProvider";
+
+/**
+ * Scripted `ProviderEvent`s, one script per model call.
+ *
+ * The real provider is written against the same interface elsewhere; depending
+ * on it in a test would make that test a test of two things at once, and would
+ * need a network.
+ *
+ * It lives in source rather than in a test file for the same reason
+ * `store/stubAgentRun.ts` does: both the `Agent` tests and the controller tests
+ * need it, and a test file that imports another test file gets that file's
+ * suites collected twice.
+ */
+export class FakeProvider {
+  readonly model = "fake";
+  readonly capabilities = {
+    reasoning: true,
+    structuredOutput: true,
+    fileInput: true,
+    parallelToolCalls: true,
+    toolSearch: true,
+  };
+  readonly calls: ProviderStreamParams[] = [];
+
+  constructor(private scripts: ProviderEvent[][]) {}
+
+  stream(params: ProviderStreamParams) {
+    this.calls.push(params);
+    const script = this.scripts[this.calls.length - 1] ?? [
+      {
+        type: "finish",
+        reason: "stop",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      },
+    ];
+    return (async function* () {
+      for (const event of script) yield event;
+    })();
+  }
+
+  async upload() {
+    return "file_1";
+  }
+
+  normalizeError(error: unknown) {
+    return {
+      code: "provider_error" as const,
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+}
+
+export function fakeProvider(...scripts: ProviderEvent[][]) {
+  return new FakeProvider(scripts) as unknown as AgentProvider & FakeProvider;
+}

--- a/packages/gemi/ai/providers/request.test.ts
+++ b/packages/gemi/ai/providers/request.test.ts
@@ -223,6 +223,35 @@ describe("toResponsesInput()", () => {
     expect(items[1]!.output).toBe("a");
   });
 
+  test("a duplicated call is sent once — the model would otherwise read it twice", () => {
+    // The shape a store that appends rather than upserts produces after a
+    // threaded approval: the assistant message that made the call, then the
+    // amended copy of it carrying the result, both under the same call id.
+    const items = toResponsesInput(
+      [
+        message({
+          id: "a1",
+          role: "assistant",
+          content: [{ type: "tool-call", toolCallId: "call_1", name: "grep", input: {} }],
+        }),
+        message({
+          id: "a1",
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolCallId: "call_1", name: "grep", input: {} },
+            { type: "tool-result", toolCallId: "call_1", name: "grep", status: "ok", output: "a" },
+          ],
+        }),
+      ],
+      FULL,
+    );
+
+    expect(items).toEqual([
+      { type: "function_call", call_id: "call_1", name: "grep", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_1", output: "a" },
+    ]);
+  });
+
   /**
    * The mirror image, and the same consequence: a crash between the call and
    * its result leaves a `function_call` the API will reject forever. Saying

--- a/packages/gemi/ai/providers/request.ts
+++ b/packages/gemi/ai/providers/request.ts
@@ -201,6 +201,13 @@ const NO_RESULT_RECORDED = "No result was recorded for this tool call. Assume it
  * saying so. Fabricating that line is the lesser evil — it is true, the model
  * can read it, and the alternative is a conversation that can never be
  * continued.
+ *
+ * A repeated *call* is dropped for the same reason in the other direction. The
+ * API happens to accept two `function_call`s under one id, so this is not a
+ * 400 — it is the model reading the same call twice, on every turn, for the
+ * rest of the conversation. The way it arises is a store that appended the
+ * amended copy of a message instead of replacing it; the store contract now
+ * says upsert, and this is the guard for a store that did not read it.
  */
 function reconcileToolPairs(items: ResponsesInputItem[]): ResponsesInputItem[] {
   const called = new Set<string>();
@@ -209,7 +216,9 @@ function reconcileToolPairs(items: ResponsesInputItem[]): ResponsesInputItem[] {
 
   for (const item of items) {
     if (item.type === "function_call") {
-      called.add(String(item.call_id));
+      const callId = String(item.call_id);
+      if (called.has(callId)) continue;
+      called.add(callId);
     } else if (item.type === "function_call_output") {
       const callId = String(item.call_id);
       // Positional: the output has to come *after* its call, which is what the

--- a/packages/gemi/ai/signing.test.ts
+++ b/packages/gemi/ai/signing.test.ts
@@ -4,8 +4,11 @@ import {
   canonicalize,
   consumePendingCall,
   readSignature,
+  signNestedRun,
   signPendingCall,
+  verifyNestedRun,
   verifyPendingCall,
+  type NestedRunClaims,
   type PendingCallClaims,
 } from "./signing";
 
@@ -254,6 +257,75 @@ describe("a path on a pending call", () => {
     expect(verifyPendingCall(signature, claims({ path: ["b", "a"] }), { secret })).toEqual({
       ok: false,
       reason: "forged",
+    });
+  });
+});
+
+describe("a signed parked-run record", () => {
+  const record = (overrides: Partial<NestedRunClaims> = {}): NestedRunClaims => ({
+    runId: "run_1",
+    path: ["call_outer"],
+    nestedRunId: "run_sub",
+    open: ["q1", "q2"],
+    ...overrides,
+  });
+  /** What the verifying run has in front of it: everything but the minting run's id. */
+  const presented = ({ runId: _runId, ...rest }: NestedRunClaims) => rest;
+
+  test("verifies against what was recorded, and carries the recording run in the clear", () => {
+    const signature = signNestedRun(record(), { secret });
+    const result = verifyNestedRun(signature, presented(record()), { secret });
+    expect(result.ok).toBe(true);
+    if (result.ok === true) {
+      expect(result.runId).toBe("run_1");
+    }
+  });
+
+  test("reads the open calls as a set, because they come back out of a re-serialized transcript", () => {
+    const signature = signNestedRun(record(), { secret });
+    expect(
+      verifyNestedRun(signature, presented(record({ open: ["q2", "q1"] })), { secret }).ok,
+    ).toBe(true);
+  });
+
+  test("rejects a record widened to a question the sub-run never asked", () => {
+    const signature = signNestedRun(record(), { secret });
+    expect(
+      verifyNestedRun(signature, presented(record({ open: ["q1", "q2", "q9"] })), { secret }),
+    ).toEqual({ ok: false, reason: "forged" });
+  });
+
+  test("cannot be moved under another tool call, or onto another sub-run", () => {
+    const signature = signNestedRun(record(), { secret });
+    expect(
+      verifyNestedRun(signature, presented(record({ path: ["call_other"] })), { secret }),
+    ).toEqual({ ok: false, reason: "forged" });
+    expect(
+      verifyNestedRun(signature, presented(record({ nestedRunId: "run_other" })), { secret }),
+    ).toEqual({ ok: false, reason: "forged" });
+  });
+
+  test("is not a pending call's signature, in either direction", () => {
+    // One tag per token kind: a record presented as an answer, or an answer
+    // presented as a record, is malformed before its MAC is even compared.
+    expect(verifyPendingCall(signNestedRun(record(), { secret }), claims(), { secret })).toEqual({
+      ok: false,
+      reason: "malformed",
+    });
+    expect(
+      verifyNestedRun(signPendingCall(claims(), { secret }), presented(record()), { secret }),
+    ).toEqual({ ok: false, reason: "malformed" });
+  });
+
+  test("expires with the answers it exists to route", () => {
+    const now = Date.now();
+    const signature = signNestedRun(record(), { secret, ttlMs: 1000, now });
+    expect(verifyNestedRun(signature, presented(record()), { secret, now: now + 500 }).ok).toBe(
+      true,
+    );
+    expect(verifyNestedRun(signature, presented(record()), { secret, now: now + 1001 })).toEqual({
+      ok: false,
+      reason: "expired",
     });
   });
 });

--- a/packages/gemi/ai/signing.test.ts
+++ b/packages/gemi/ai/signing.test.ts
@@ -2,6 +2,7 @@ import { createHmac } from "crypto";
 import { describe, expect, test } from "vitest";
 import {
   canonicalize,
+  consumeNestedRun,
   consumePendingCall,
   readSignature,
   signNestedRun,
@@ -267,6 +268,7 @@ describe("a signed parked-run record", () => {
     path: ["call_outer"],
     nestedRunId: "run_sub",
     open: ["q1", "q2"],
+    input: { path: "notes.md" },
     ...overrides,
   });
   /** What the verifying run has in front of it: everything but the minting run's id. */
@@ -293,6 +295,38 @@ describe("a signed parked-run record", () => {
     expect(
       verifyNestedRun(signature, presented(record({ open: ["q1", "q2", "q9"] })), { secret }),
     ).toEqual({ ok: false, reason: "forged" });
+  });
+
+  test("rejects a record whose tool input was rewritten, however well-typed", () => {
+    // The record is what re-enters the tool, and the tool runs on the input
+    // the transcript carries — so a record that verified against any input
+    // would be a signed permission to run the tool with arguments of the
+    // client's choosing.
+    const signature = signNestedRun(record(), { secret });
+    expect(
+      verifyNestedRun(signature, presented(record({ input: { path: "/etc/secrets.md" } })), {
+        secret,
+      }),
+    ).toEqual({ ok: false, reason: "forged" });
+    // Key order is not part of the input: it comes back out of a client's
+    // serializer, as an approval's does.
+    expect(
+      verifyNestedRun(
+        signNestedRun(record({ input: { b: 1, a: 2 } }), { secret }),
+        presented(record({ input: { a: 2, b: 1 } })),
+        { secret },
+      ).ok,
+    ).toBe(true);
+  });
+
+  test("is spent by the re-entry it permits, and a second presentation is a replay", () => {
+    const signature = signNestedRun(record(), { secret });
+    expect(consumeNestedRun(signature)).toBe(true);
+    // Still authentic — what has changed is that the tool has run on it.
+    expect(verifyNestedRun(signature, presented(record()), { secret }).ok).toBe(true);
+    expect(consumeNestedRun(signature)).toBe(false);
+    // A pending call's token is not a record, and spends nothing here.
+    expect(consumeNestedRun(signPendingCall(claims(), { secret }))).toBe(false);
   });
 
   test("cannot be moved under another tool call, or onto another sub-run", () => {

--- a/packages/gemi/ai/signing.ts
+++ b/packages/gemi/ai/signing.ts
@@ -276,7 +276,8 @@ export function verifyPendingCall(
  * Deliberately not signed: the transcript. The sub-run resumes from messages
  * the client carried, exactly as the parent does in stateless mode, and the
  * same argument applies — what the signature pins is that the server parked
- * *here*, on *these* calls, and not what was said on the way.
+ * *here*, on *these* calls, with *this* input, and not what was said on the
+ * way.
  */
 export type NestedRunClaims = {
   /** The root run's id, the one every pending call of the tree is minted under. */
@@ -292,6 +293,15 @@ export type NestedRunClaims = {
   nestedRunId: string;
   /** The tool calls the sub-run is waiting on: every call left open in its transcript. */
   open: string[];
+  /**
+   * The input the tool that parked was running on, as the transcript carries
+   * it. Re-entry runs the tool body with the input the history holds, and the
+   * history is the client's — so a record that pinned where the sub-run parked
+   * but not what its tool was given would let the client keep the run and
+   * rewrite the arguments to anything the schema accepts. The same bargain a
+   * pending call makes: the input executed is the input signed.
+   */
+  input: unknown;
 };
 
 const NESTED_VERSION = "agn1";
@@ -307,14 +317,18 @@ function nestedFields(claims: NestedRunClaims, nonce: string, expiresAt: number)
     // A set, so it is sorted: the ids are read back out of a transcript the
     // client re-serialized, and message order is not part of the claim.
     canonicalize([...claims.open].sort()),
+    canonicalize(claims.input),
   ];
 }
 
 /**
- * Same shape as a pending call's token, so the same reader serves both. The
- * nonce is entropy and nothing more: a record is a fact about the transcript,
- * not a permission that is used up, and a second re-entry on the same record
- * is stopped by the nonce on the *answer* it is delivering.
+ * Same shape as a pending call's token, so the same reader serves both — nonce
+ * included, and the nonce is spent, by `consumeNestedRun` below. A verified
+ * record is permission to run the tool it hangs off, and the tool body runs
+ * before the sub-run gets to look at the answer's own nonce; a record that
+ * could be presented twice would run the body twice before anything refused
+ * the replay. Every park mints a fresh record, so spending one costs a
+ * legitimate re-park nothing.
  */
 export function signNestedRun(claims: NestedRunClaims, options: SignOptions = {}): string {
   const secret = secretKey(options.secret);
@@ -412,7 +426,23 @@ function sweep(now: number) {
  * and this one is a state change that must happen exactly once per answer.
  */
 export function consumePendingCall(signature: string, options: VerifyOptions = {}): boolean {
-  const parsed = readSignature(signature);
+  return spend(readSignature(signature), options);
+}
+
+/**
+ * Spends a parked-run record's nonce, on the same registry and the same terms.
+ * `false` means the record has already re-entered its tool once — the turn is
+ * a replay of a history from before the answer was delivered, and the body
+ * must not run again on it.
+ */
+export function consumeNestedRun(signature: string, options: VerifyOptions = {}): boolean {
+  return spend(readToken(signature, NESTED_VERSION), options);
+}
+
+function spend(
+  parsed: { nonce: string; expiresAt: number } | null,
+  options: VerifyOptions,
+): boolean {
   if (!parsed) return false;
   const now = options.now ?? Date.now();
   if (spent.size >= sweepAt) sweep(now);

--- a/packages/gemi/ai/signing.ts
+++ b/packages/gemi/ai/signing.ts
@@ -195,8 +195,23 @@ export function signPendingCall(claims: PendingCallClaims, options: SignOptions 
 export function readSignature(
   signature: string,
 ): { runId: string; nonce: string; expiresAt: number } | null {
+  return readToken(signature, VERSION);
+}
+
+/**
+ * The version tag is checked here and nowhere else, which is what keeps the
+ * two token kinds apart: a parked-run record presented where a pending call's
+ * signature is expected fails as malformed before its MAC is even looked at,
+ * and the other way round. Their claim sets are different lengths and would
+ * not collide anyway, but a tag makes that a rule rather than an accident of
+ * the field count.
+ */
+function readToken(
+  signature: string,
+  version: string,
+): { runId: string; nonce: string; expiresAt: number } | null {
   const parts = signature.split(".");
-  if (parts.length !== 5 || parts[0] !== VERSION) {
+  if (parts.length !== 5 || parts[0] !== version) {
     return null;
   }
   const expiresAt = Number.parseInt(parts[3], 36);
@@ -233,6 +248,113 @@ export function verifyPendingCall(
   // Expiry is checked *after* the MAC on purpose: only a genuine token can be
   // "expired". Reporting a forgery as expired would tell the UI to say "your
   // approval timed out" to someone who was tampering.
+  if ((options.now ?? Date.now()) > parsed.expiresAt) {
+    return { ok: false, reason: "expired" };
+  }
+
+  return { ok: true, runId: parsed.runId, nonce: parsed.nonce, expiresAt: parsed.expiresAt };
+}
+
+// --- parked sub-runs -----------------------------------------------------
+
+/**
+ * What a parked sub-run's record is signed over.
+ *
+ * `ToolCallPart.nested` is the parent's own record of where a sub-run stopped,
+ * and in stateless mode it makes the same trip through the browser a pending
+ * call does. The next turn *runs a tool* on the strength of that record — the
+ * tool is re-entered because the record says a sub-run under it is waiting on
+ * the question being answered — so an unsigned record lets the client choose
+ * which tools run, with what input, before any answer is verified. A MAC over
+ * what the server actually recorded is what makes the record safe to carry.
+ *
+ * Only a parked record is signed, because only a parked record executes
+ * anything: a finished sub-run is replayed out of its transcript and spends
+ * nothing, and a client that forges one has fed its own tool a made-up answer,
+ * which a client-carried history already allows everywhere.
+ *
+ * Deliberately not signed: the transcript. The sub-run resumes from messages
+ * the client carried, exactly as the parent does in stateless mode, and the
+ * same argument applies — what the signature pins is that the server parked
+ * *here*, on *these* calls, and not what was said on the way.
+ */
+export type NestedRunClaims = {
+  /** The root run's id, the one every pending call of the tree is minted under. */
+  runId: string;
+  /**
+   * Tool-call ids from the root down to and including the call the record
+   * hangs off. A sub-run's id is not an address on its own for the same reason
+   * a nested call's is not: two sub-runs under two different tools can carry
+   * the same one.
+   */
+  path: string[];
+  /** The sub-run's own id, so a record cannot be moved between sub-runs. */
+  nestedRunId: string;
+  /** The tool calls the sub-run is waiting on: every call left open in its transcript. */
+  open: string[];
+};
+
+const NESTED_VERSION = "agn1";
+
+function nestedFields(claims: NestedRunClaims, nonce: string, expiresAt: number): string[] {
+  return [
+    NESTED_VERSION,
+    claims.runId,
+    canonicalize(claims.path),
+    claims.nestedRunId,
+    nonce,
+    String(expiresAt),
+    // A set, so it is sorted: the ids are read back out of a transcript the
+    // client re-serialized, and message order is not part of the claim.
+    canonicalize([...claims.open].sort()),
+  ];
+}
+
+/**
+ * Same shape as a pending call's token, so the same reader serves both. The
+ * nonce is entropy and nothing more: a record is a fact about the transcript,
+ * not a permission that is used up, and a second re-entry on the same record
+ * is stopped by the nonce on the *answer* it is delivering.
+ */
+export function signNestedRun(claims: NestedRunClaims, options: SignOptions = {}): string {
+  const secret = secretKey(options.secret);
+  const now = options.now ?? Date.now();
+  const expiresAt = now + (options.ttlMs ?? DEFAULT_TTL_MS);
+  const nonce = randomBytes(12).toString("base64url");
+  const signature = mac(secret, nestedFields(claims, nonce, expiresAt)).toString("base64url");
+  return [NESTED_VERSION, encode(claims.runId), nonce, expiresAt.toString(36), signature].join(".");
+}
+
+/**
+ * The run that verifies a record is never the run that minted it — the turn
+ * answering a question is a new run with a new id — so the minting run's id is
+ * read out of the token rather than asked of the caller, which has no other
+ * source for it. The MAC covers it, so a client that edits the id in the clear
+ * fails here rather than being believed.
+ */
+export function verifyNestedRun(
+  signature: string,
+  claims: Omit<NestedRunClaims, "runId">,
+  options: VerifyOptions = {},
+): VerifyResult {
+  const secret = secretKey(options.secret);
+  const parsed = readToken(signature, NESTED_VERSION);
+  if (!parsed) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  const presented = Buffer.from(signature.split(".")[4], "base64url");
+  const expected = mac(
+    secret,
+    nestedFields({ ...claims, runId: parsed.runId }, parsed.nonce, parsed.expiresAt),
+  );
+  if (presented.length !== expected.length || !timingSafeEqual(presented, expected)) {
+    return { ok: false, reason: "forged" };
+  }
+
+  // A parked record outlives its usefulness with the answers it exists to
+  // deliver: those expire on the pending call's TTL, and a record older than
+  // that can route nothing that would still verify.
   if ((options.now ?? Date.now()) > parsed.expiresAt) {
     return { ok: false, reason: "expired" };
   }

--- a/packages/gemi/ai/store/LiveRuns.test.ts
+++ b/packages/gemi/ai/store/LiveRuns.test.ts
@@ -279,6 +279,72 @@ describe("MemoryLiveRuns", () => {
     runs.clear();
   });
 })
+describe("a reader whose position is arithmetic, not a scan", () => {
+  test("gets every frame exactly once while the pump keeps pushing behind it", async () => {
+    // `drain` derives its index from the cursor and the window's first seq, and
+    // re-derives it after every yield — the window can have grown and rolled
+    // while this reader was suspended in its consumer. A stale index would
+    // either skip frames or repeat them, and neither shows up in a test that
+    // consumes as fast as the pump produces.
+    const runs = new MemoryLiveRuns({ maxFrames: 64 });
+    const run = new StubAgentRun("run_slow");
+    runs.register(run, { threadId: "t1" });
+    run.emit(textDelta("0"));
+    await settle();
+
+    const seen: number[] = [];
+    const reading = (async () => {
+      for await (const frame of runs.replay("run_slow")) {
+        seen.push(frame.seq);
+        // Suspend between frames, which is when the window moves.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+    })();
+
+    for (let i = 1; i < 40; i++) {
+      run.emit(textDelta(String(i)));
+      await settle();
+    }
+    run.finish();
+    await reading;
+
+    // Contiguous from the first frame, no gaps and no repeats.
+    expect(seen).toEqual(Array.from({ length: 40 }, (_, i) => i + 1));
+    runs.clear();
+  });
+
+  test("a reader that falls further behind than the window is cut, not silently skipped", async () => {
+    const runs = new MemoryLiveRuns({ maxFrames: 4 });
+    const run = new StubAgentRun("run_left");
+    runs.register(run, { threadId: "t1" });
+    run.emit(textDelta("0"));
+    await settle();
+
+    const seen: number[] = [];
+    let error: unknown;
+    const reading = (async () => {
+      try {
+        for await (const frame of runs.replay("run_left")) {
+          seen.push(frame.seq);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+      } catch (err) {
+        error = err;
+      }
+    })();
+
+    for (let i = 1; i < 40; i++) run.emit(textDelta(String(i)));
+    run.finish();
+    await reading;
+
+    // A hole the client cannot see is worse than a stream that stops and says
+    // why — so this is the 410, and what it did deliver stayed contiguous.
+    expect(error).toBeInstanceOf(FrameCursorEvictedError);
+    expect(seen).toEqual(Array.from({ length: seen.length }, (_, i) => seen[0]! + i));
+    runs.clear();
+  });
+});
+
 describe("a cursor older than the buffer, and one only older than seq 1", () => {
   test("a short run replays from the beginning instead of claiming eviction", async () => {
     // Regression. This compared the cursor against `frames[0].seq`, which is 1

--- a/packages/gemi/ai/store/LiveRuns.test.ts
+++ b/packages/gemi/ai/store/LiveRuns.test.ts
@@ -36,7 +36,7 @@ describe("MemoryLiveRuns", () => {
     await settle();
 
     const found = await runs.find({ threadId: "t1" });
-    expect(found).toEqual({ runId: "run_a", seq: 0 });
+    expect(found).toEqual({ runId: "run_a", seq: 1 });
     expect(runs.get("run_a")).toBe(run);
 
     run.finish();
@@ -62,7 +62,7 @@ describe("MemoryLiveRuns", () => {
     run.finish();
 
     const frames = await collect(runs.replay("run_b", 0));
-    expect(frames.map((f) => f.seq)).toEqual([0, 1]);
+    expect(frames.map((f) => f.seq)).toEqual([1, 2]);
     runs.clear();
   });
 
@@ -76,8 +76,8 @@ describe("MemoryLiveRuns", () => {
     }
     run.finish();
 
-    const frames = await collect(runs.replay("run_c", 2));
-    expect(frames.map((f) => f.seq)).toEqual([2, 3]);
+    const frames = await collect(runs.replay("run_c", 3));
+    expect(frames.map((f) => f.seq)).toEqual([3, 4]);
     expect(frames.map((f) => (f.event as { delta: string }).delta)).toEqual(["c", "d"]);
     runs.clear();
   });
@@ -94,7 +94,7 @@ describe("MemoryLiveRuns", () => {
     run.emit(textDelta("b"));
     run.finish();
 
-    expect((await collected).map((f) => f.seq)).toEqual([0, 1]);
+    expect((await collected).map((f) => f.seq)).toEqual([1, 2]);
     runs.clear();
   });
 
@@ -109,8 +109,8 @@ describe("MemoryLiveRuns", () => {
     run.finish();
     await settle();
 
-    const frames = await collect(runs.replay("run_e", 6));
-    expect(frames.map((f) => f.seq)).toEqual([6, 7, 8, 9]);
+    const frames = await collect(runs.replay("run_e", 7));
+    expect(frames.map((f) => f.seq)).toEqual([7, 8, 9, 10]);
     runs.clear();
   });
 
@@ -135,7 +135,8 @@ describe("MemoryLiveRuns", () => {
     }
     expect(thrown).toBeInstanceOf(FrameCursorEvictedError);
     expect((thrown as FrameCursorEvictedError).requested).toBe(0);
-    expect((thrown as FrameCursorEvictedError).oldest).toBe(6);
+    // The lowest seq still obtainable, which is one past the last one dropped.
+    expect((thrown as FrameCursorEvictedError).oldest).toBe(7);
     runs.clear();
   });
 
@@ -155,7 +156,7 @@ describe("MemoryLiveRuns", () => {
     await settle();
 
     const frames = await collect(runs.replay("run_k"));
-    expect(frames.map((f) => f.seq)).toEqual([6, 7, 8, 9]);
+    expect(frames.map((f) => f.seq)).toEqual([7, 8, 9, 10]);
     runs.clear();
   });
 
@@ -170,7 +171,7 @@ describe("MemoryLiveRuns", () => {
     await settle();
 
     const frames = await collect(runs.replay("run_l"));
-    expect(frames.map((f) => f.seq)).toEqual([0, 1]);
+    expect(frames.map((f) => f.seq)).toEqual([1, 2]);
     runs.clear();
   });
 
@@ -185,7 +186,7 @@ describe("MemoryLiveRuns", () => {
     run.emit(textDelta("a"));
     run.finish();
 
-    expect((await collected).map((f) => f.seq)).toEqual([0]);
+    expect((await collected).map((f) => f.seq)).toEqual([1]);
     runs.clear();
   });
 
@@ -226,7 +227,7 @@ describe("MemoryLiveRuns", () => {
     // Still there right after the end — that is the "refresh a second late"
     // case the ttl exists for.
     await new Promise((resolve) => setTimeout(resolve, 1));
-    expect(await runs.find({ threadId: "t1" })).toEqual({ runId: "run_g", seq: 0 });
+    expect(await runs.find({ threadId: "t1" })).toEqual({ runId: "run_g", seq: 1 });
 
     await new Promise((resolve) => setTimeout(resolve, 40));
     expect(await runs.find({ threadId: "t1" })).toBeNull();
@@ -272,9 +273,56 @@ describe("MemoryLiveRuns", () => {
     run.finish();
 
     const frames = await collect(runs.replay("run_i", 0));
-    expect(frames.map((f) => f.seq)).toEqual([0, 1]);
+    expect(frames.map((f) => f.seq)).toEqual([1, 2]);
     await new Promise((resolve) => setTimeout(resolve, 5));
     expect(failures).toHaveLength(2);
+    runs.clear();
+  });
+})
+describe("a cursor older than the buffer, and one only older than seq 1", () => {
+  test("a short run replays from the beginning instead of claiming eviction", async () => {
+    // Regression. This compared the cursor against `frames[0].seq`, which is 1
+    // on a run that has evicted nothing, so a cursor of 0 read as evicted and a
+    // ten-frame run in a five-hundred-frame window answered 410.
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_short");
+    runs.register(run, { threadId: "t1" });
+    for (let i = 0; i < 10; i++) run.emit(textDelta("x"));
+    run.finish();
+    await settle();
+
+    const frames = await collect(runs.replay("run_short", 0));
+    expect(frames[0]!.seq).toBe(1);
+    expect(frames).toHaveLength(10);
+    runs.clear();
+  });
+
+  test("no cursor works on a run that has not produced a frame yet", async () => {
+    // `replay` picks `lastSeq + 1` = 0 for a run registered but not yet pumped:
+    // the refresh-immediately-after-sending race.
+    const runs = new MemoryLiveRuns();
+    const run = new StubAgentRun("run_empty");
+    runs.register(run, { threadId: "t1" });
+
+    const collected = collect(runs.replay("run_empty"));
+    await settle();
+    run.emit(textDelta("first"));
+    await settle();
+    run.finish();
+
+    const frames = await collected;
+    expect(frames[0]!.seq).toBe(1);
+    runs.clear();
+  });
+
+  test("a frame that really was dropped is still a 410 naming what survives", async () => {
+    const runs = new MemoryLiveRuns({ maxFrames: 4 });
+    const run = new StubAgentRun("run_rolled");
+    runs.register(run, { threadId: "t1" });
+    for (let i = 0; i < 20; i++) run.emit(textDelta("x"));
+    await settle();
+
+    expect(() => runs.replay("run_rolled", 1)).toThrow(FrameCursorEvictedError);
     runs.clear();
   });
 });

--- a/packages/gemi/ai/store/LiveRuns.ts
+++ b/packages/gemi/ai/store/LiveRuns.ts
@@ -10,14 +10,32 @@ const DEFAULT_TTL_MS = 60 * 1000;
 /**
  * How many frames are kept per run.
  *
- * The buffer has to be bounded or it is a memory leak with a long fuse: a
+ * The window has to be bounded or it is a memory leak with a long fuse: a
  * server that never restarts holding every token of every conversation it ever
- * streamed. 512 frames is a couple of hundred tokens of prose plus its tool
- * calls — comfortably more than the seconds of catch-up a reattaching client
- * actually needs, and small enough that a thousand concurrent runs is megabytes
- * rather than gigabytes.
+ * streamed.
+ *
+ * It was 512 on the reasoning that a reattaching client only needs seconds of
+ * catch-up. That is true of the *reattaching* client and false of the one that
+ * never left: a frame is roughly a token, so 512 is a four-hundred-word answer,
+ * and a reader that falls behind a longer one by more than that is cut off with
+ * a 410 mid-stream. On a slow connection — the case reattachment exists for —
+ * that is not exotic.
+ *
+ * 4096 covers essentially any single answer. It is affordable because of two
+ * measured facts, and it would not have been before either:
+ *
+ *   - `drain` no longer copies the window per wake, so a reader costs the same
+ *     whatever the window's size. Measured at 64 readers on a 2000-frame run:
+ *     1106 ms of CPU at 4096 before, 425 ms after, and 468 ms at 512 — i.e. the
+ *     size stopped being a term in the cost.
+ *   - the entries are pointers to frames the run is holding anyway, so the
+ *     window costs 8 bytes each, not the frame. Eight times more of them is
+ *     ~28 KB per run, and a thousand concurrent runs is tens of megabytes.
+ *
+ * Both would change if the run's own buffer ever became bounded — then this
+ * window owns the frames, and its size is their size.
  */
-const DEFAULT_MAX_FRAMES = 512;
+const DEFAULT_MAX_FRAMES = 4096;
 
 /**
  * A cursor older than anything still buffered.
@@ -316,18 +334,34 @@ export class MemoryLiveRuns implements LiveRuns {
     let cursor = from;
     while (true) {
       const seen = entry.version;
-      const buffered = entry.frames.slice();
-      if (cursor < entry.lostBefore) {
-        // The buffer rolled past this reader mid-stream. Same reasoning as the
-        // pre-flight check: a gap the client cannot see is worse than a stream
-        // that stops and says why.
-        throw new FrameCursorEvictedError(runId, cursor, entry.lostBefore);
-      }
-      for (const frame of buffered) {
-        if (frame.seq >= cursor) {
-          yield frame;
-          cursor = frame.seq + 1;
+      // The window is contiguous and ordered, so a reader's position in it is
+      // arithmetic, not a search. This used to copy the whole window on every
+      // wake and scan it for frames past the cursor, which is O(window) per
+      // frame per reader — invisible at a 512-frame cap and the reason the cap
+      // could not be raised. Indexing makes the window's size stop mattering.
+      for (;;) {
+        if (cursor < entry.lostBefore) {
+          // The window rolled past this reader mid-stream. Same reasoning as
+          // the pre-flight check: a gap the client cannot see is worse than a
+          // stream that stops and says why. Re-checked inside the loop rather
+          // than once per wake, because a yield suspends this reader for as
+          // long as its consumer takes and the pump keeps running.
+          throw new FrameCursorEvictedError(runId, cursor, entry.lostBefore);
         }
+        const frames = entry.frames;
+        const oldest = frames[0]?.seq;
+        if (oldest === undefined) {
+          break;
+        }
+        // Clamped rather than treated as a gap: a cursor below the first seq
+        // that ever existed is "from the beginning", not a lost position.
+        const index = Math.max(0, cursor - oldest);
+        if (index >= frames.length) {
+          break;
+        }
+        const frame = frames[index]!;
+        yield frame;
+        cursor = frame.seq + 1;
       }
       if (entry.ended && cursor > entry.lastSeq) {
         return;

--- a/packages/gemi/ai/store/LiveRuns.ts
+++ b/packages/gemi/ai/store/LiveRuns.ts
@@ -94,6 +94,18 @@ type Entry = {
   /** A contiguous window of the run's frames, oldest first. */
   frames: AgentStreamFrame[];
   lastSeq: number;
+  /**
+   * The lowest `seq` still obtainable, or 0 while nothing has been dropped.
+   *
+   * Not derivable from `frames[0].seq`, which is what this used to compare
+   * against. `seq` starts at 1, so a run that has evicted nothing still has an
+   * oldest frame of 1, and a cursor of 0 — the "I have no transcript yet"
+   * cursor that `replay` itself picks for a run registered but not yet pumped —
+   * read as older than the buffer. A ten-frame run in a five-hundred-frame
+   * window answered a refresh with 410, which is both false and unactionable:
+   * refreshing right after sending is the case `/attach` exists to serve.
+   */
+  lostBefore: number;
   ended: boolean;
   evictAt: ReturnType<typeof setTimeout> | null;
   wake: Set<() => void>;
@@ -152,6 +164,7 @@ export class MemoryLiveRuns implements LiveRuns {
       clientRunId: params.clientRunId,
       frames: [],
       lastSeq: -1,
+      lostBefore: 0,
       ended: false,
       evictAt: null,
       wake: new Set(),
@@ -222,10 +235,10 @@ export class MemoryLiveRuns implements LiveRuns {
     if (!entry) {
       throw new LiveRunNotFoundError(runId);
     }
-    const oldest = entry.frames[0]?.seq;
-    if (from !== undefined && oldest !== undefined && from < oldest) {
-      throw new FrameCursorEvictedError(runId, from, oldest);
+    if (from !== undefined && from < entry.lostBefore) {
+      throw new FrameCursorEvictedError(runId, from, entry.lostBefore);
     }
+    const oldest = entry.frames[0]?.seq;
     // With nothing buffered — a run registered but not yet pumped — `lastSeq`
     // is -1 and this is 0, which is the same answer by another route.
     return this.drain(entry, runId, from ?? oldest ?? entry.lastSeq + 1);
@@ -260,7 +273,8 @@ export class MemoryLiveRuns implements LiveRuns {
         entry.frames.push(frame);
         entry.lastSeq = frame.seq;
         if (entry.frames.length > this.maxFrames) {
-          entry.frames.shift();
+          const dropped = entry.frames.shift();
+          if (dropped) entry.lostBefore = dropped.seq + 1;
         }
         this.notify(entry);
         const onEvent = params.onEvent;
@@ -303,12 +317,11 @@ export class MemoryLiveRuns implements LiveRuns {
     while (true) {
       const seen = entry.version;
       const buffered = entry.frames.slice();
-      const oldest = buffered[0]?.seq;
-      if (oldest !== undefined && cursor < oldest) {
+      if (cursor < entry.lostBefore) {
         // The buffer rolled past this reader mid-stream. Same reasoning as the
         // pre-flight check: a gap the client cannot see is worse than a stream
         // that stops and says why.
-        throw new FrameCursorEvictedError(runId, cursor, oldest);
+        throw new FrameCursorEvictedError(runId, cursor, entry.lostBefore);
       }
       for (const frame of buffered) {
         if (frame.seq >= cursor) {

--- a/packages/gemi/ai/store/MemoryAgentStore.test.ts
+++ b/packages/gemi/ai/store/MemoryAgentStore.test.ts
@@ -38,15 +38,28 @@ describe("MemoryAgentStore", () => {
     expect(await store.loadThread(threadId)).toHaveLength(1);
   });
 
-  test("reads an unknown thread as empty rather than throwing", async () => {
+  test("answers null for a thread it does not have, which is not an empty one", async () => {
     const store = new MemoryAgentStore();
-    expect(await store.loadThread("never-existed")).toEqual([]);
+    // `[]` here was the bug: an expired or mistyped id read as a conversation
+    // with nothing in it yet, and the controller ran the turn on that.
+    expect(await store.loadThread("never-existed")).toBeNull();
   });
 
-  test("creates a thread on append, so a client-owned id cannot lose a turn", async () => {
+  test("refuses to append to a thread it does not have", async () => {
     const store = new MemoryAgentStore();
+    await expect(
+      store.appendMessages("never-existed", [message("1", "user", "hi")]),
+    ).rejects.toThrow(/never-existed/);
+    expect(store.size).toBe(0);
+  });
+
+  test("with client-owned ids, an id it has not seen is a conversation starting", async () => {
+    // The one setup where unknown is not lost: the client minted the id, so
+    // the first turn arrives before anything is stored under it.
+    const store = new MemoryAgentStore({ clientOwnedIds: true });
+    expect(await store.loadThread("client-chose-this")).toEqual([]);
     await store.appendMessages("client-chose-this", [message("1", "user", "hi")]);
-    expect((await store.loadThread("client-chose-this")).map((m) => m.id)).toEqual(["1"]);
+    expect((await store.loadThread("client-chose-this"))!.map((m) => m.id)).toEqual(["1"]);
   });
 
   test("drops a thread nobody has touched for ttlMs", async () => {
@@ -59,7 +72,9 @@ describe("MemoryAgentStore", () => {
     store.sweep(Date.now() + 90_000);
 
     expect(store.size).toBe(0);
-    expect(await store.loadThread(threadId)).toEqual([]);
+    // Gone, not empty: the client holding this id has a history the store no
+    // longer does, and has to be told.
+    expect(await store.loadThread(threadId)).toBeNull();
   });
 
   test("keeps a thread whose ttl has not run out", async () => {

--- a/packages/gemi/ai/store/MemoryAgentStore.test.ts
+++ b/packages/gemi/ai/store/MemoryAgentStore.test.ts
@@ -28,6 +28,27 @@ describe("MemoryAgentStore", () => {
     expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual(["1", "2"]);
   });
 
+  test("replaces a message it already holds instead of holding it twice", async () => {
+    const store = new MemoryAgentStore();
+    const { threadId } = await store.createThread({});
+    await store.appendMessages(threadId, [
+      message("1", "user", "hi"),
+      message("2", "assistant", "one sec"),
+      message("3", "user", "ok"),
+    ]);
+
+    // What a turn that resolves a pending call reports: the earlier assistant
+    // message again, under its own id, plus the new tail.
+    await store.appendMessages(threadId, [
+      message("2", "assistant", "done"),
+      message("4", "assistant", "anything else?"),
+    ]);
+
+    const held = await store.loadThread(threadId);
+    expect(held.map((m) => m.id)).toEqual(["1", "2", "3", "4"]);
+    expect(held[1]!.content).toEqual([{ type: "text", text: "done" }]);
+  });
+
   test("hands out a copy, so a caller cannot edit history in place", async () => {
     const store = new MemoryAgentStore();
     const { threadId } = await store.createThread({});

--- a/packages/gemi/ai/store/MemoryAgentStore.ts
+++ b/packages/gemi/ai/store/MemoryAgentStore.ts
@@ -82,22 +82,35 @@ export class MemoryAgentStore implements AgentStore {
 
   async appendMessages(threadId: string, messages: AgentMessage[]): Promise<void> {
     this.sweep();
-    const thread = this.threads.get(threadId);
-    if (thread) {
-      thread.messages.push(...messages);
-      thread.touchedAt = Date.now();
-      return;
+    let thread = this.threads.get(threadId);
+    if (!thread) {
+      if (!this.clientOwnedIds) {
+        // Creating the thread here would persist a turn under an id the client
+        // believes holds a longer conversation, and hide from the app that the
+        // conversation is gone. The controller checks before the run and never
+        // reaches this; a store-level caller that does gets told.
+        throw new Error(`Thread ${threadId} does not exist here, or has expired.`);
+      }
+      // The client owns the id, so an append to one the store has never seen is
+      // the first turn, and refusing it would lose a turn that already happened.
+      thread = { messages: [], touchedAt: Date.now() };
+      this.threads.set(threadId, thread);
     }
-    if (!this.clientOwnedIds) {
-      // Creating the thread here would persist a turn under an id the client
-      // believes holds a longer conversation, and hide from the app that the
-      // conversation is gone. The controller checks before the run and never
-      // reaches this; a store-level caller that does gets told.
-      throw new Error(`Thread ${threadId} does not exist here, or has expired.`);
+    // Upsert, not push. A turn that resolves a pending call hands back the
+    // assistant message that made the call under the id it already had, now
+    // with the result attached; pushing it would leave the thread holding both
+    // versions, and the model would read the same call twice on every turn
+    // that follows. Replacing in place keeps the message where the
+    // conversation put it.
+    for (const message of messages) {
+      const at = thread.messages.findIndex((held) => held.id === message.id);
+      if (at === -1) {
+        thread.messages.push(message);
+      } else {
+        thread.messages[at] = message;
+      }
     }
-    // The client owns the id, so an append to one the store has never seen is
-    // the first turn, and refusing it would lose a turn that already happened.
-    this.threads.set(threadId, { messages: messages.slice(), touchedAt: Date.now() });
+    thread.touchedAt = Date.now();
   }
 
   /** Test seam, and a way for an app to drop a conversation on request. */

--- a/packages/gemi/ai/store/MemoryAgentStore.ts
+++ b/packages/gemi/ai/store/MemoryAgentStore.ts
@@ -29,15 +29,27 @@ type Thread = {
  * running forever keeps a process alive that has nothing else to do — so the
  * sweep happens on access, at most once a minute, and an untouched process
  * simply stops sweeping.
+ *
+ * A thread the store does not have is `null` from `loadThread` and an error
+ * from `appendMessages`, never an empty conversation. It used to be the other
+ * way, and the three ways a thread goes missing — it expired, the id was
+ * mistyped, it lived on an instance that was scaled in — all read as a fresh
+ * chat: the history was gone with no signal, and the next turn was persisted
+ * under the dead id as though it were the first. `clientOwnedIds` is the one
+ * setup where an unknown id is not a lost thread, because the client minted it.
  */
 export class MemoryAgentStore implements AgentStore {
   readonly ttlMs: number;
+  /** The ids come from the client, not from `createThread`, so an id this
+   *  store has never seen is a conversation starting rather than one lost. */
+  readonly clientOwnedIds: boolean;
 
   private threads = new Map<string, Thread>();
   private lastSweep = 0;
 
-  constructor(params: { ttlMs?: number } = {}) {
+  constructor(params: { ttlMs?: number; clientOwnedIds?: boolean } = {}) {
     this.ttlMs = params.ttlMs ?? DEFAULT_TTL_MS;
+    this.clientOwnedIds = params.clientOwnedIds ?? false;
   }
 
   async createThread(params: { userId?: string | number }): Promise<{ threadId: string }> {
@@ -51,14 +63,16 @@ export class MemoryAgentStore implements AgentStore {
     return { threadId };
   }
 
-  async loadThread(threadId: string): Promise<AgentMessage[]> {
+  async loadThread(threadId: string): Promise<AgentMessage[] | null> {
     this.sweep();
     const thread = this.threads.get(threadId);
     if (!thread) {
-      // An unknown thread reads as empty rather than throwing: a thread that
-      // expired, and one the client invented, are the same situation to a
-      // conversation that has to keep working.
-      return [];
+      // With client-owned ids the first turn arrives before anything has been
+      // written under it, so unknown is empty. Otherwise unknown is a thread
+      // that expired or never existed, and the controller has to be able to
+      // tell: `[]` here is the silent fresh conversation this store used to
+      // hand out in place of the user's history.
+      return this.clientOwnedIds ? [] : null;
     }
     thread.touchedAt = Date.now();
     // Copied, so a caller that sorts or splices the result does not edit the
@@ -74,9 +88,15 @@ export class MemoryAgentStore implements AgentStore {
       thread.touchedAt = Date.now();
       return;
     }
-    // Appending to a thread the store has never seen creates it. The client
-    // owns the id in stateless-with-a-thread-id setups, so refusing here would
-    // mean losing a turn that already happened.
+    if (!this.clientOwnedIds) {
+      // Creating the thread here would persist a turn under an id the client
+      // believes holds a longer conversation, and hide from the app that the
+      // conversation is gone. The controller checks before the run and never
+      // reaches this; a store-level caller that does gets told.
+      throw new Error(`Thread ${threadId} does not exist here, or has expired.`);
+    }
+    // The client owns the id, so an append to one the store has never seen is
+    // the first turn, and refusing it would lose a turn that already happened.
     this.threads.set(threadId, { messages: messages.slice(), touchedAt: Date.now() });
   }
 

--- a/packages/gemi/ai/store/sse.test.ts
+++ b/packages/gemi/ai/store/sse.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { AgentStreamFrame } from "../types";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseResponse } from "./sse";
+
+const bytes = new TextDecoder();
+
+const frame = (seq: number): AgentStreamFrame => ({
+  seq,
+  event: { type: "text-delta", messageId: "m1", delta: String(seq) },
+});
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** A run that writes one frame, goes quiet until released, writes one more,
+ *  and goes quiet again until it is told to end. */
+function slowRun() {
+  const release = deferred();
+  const end = deferred();
+  async function* frames() {
+    yield frame(1);
+    await release.promise;
+    yield frame(2);
+    await end.promise;
+  }
+  return { frames: frames(), release, end };
+}
+
+describe("sseResponse keepalive", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("a comment line goes out for every interval of silence, and a frame resets the clock", async () => {
+    vi.useFakeTimers();
+    const { frames, release, end } = slowRun();
+    const reader = sseResponse(frames).body!.getReader();
+    const read = async () => bytes.decode((await reader.read()).value);
+
+    expect(await read()).toContain("id: 1\n");
+
+    // The consumer is waiting and the run has nothing to say.
+    let pending = reader.read();
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    // Silence that goes on gets another one, on the same clock.
+    pending = reader.read();
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    // A frame arriving just before the next tick pushes the tick back.
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS - 1);
+    release.resolve();
+    expect(await read()).toContain("id: 2\n");
+    let settled = false;
+    pending = reader.read().then((chunk) => {
+      settled = true;
+      return chunk;
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS - 1);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    end.resolve();
+    expect((await reader.read()).done).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a consumer that cancels leaves no timer behind", async () => {
+    vi.useFakeTimers();
+    const { frames } = slowRun();
+    const body = sseResponse(frames).body!;
+    expect(vi.getTimerCount()).toBe(1);
+    await body.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/gemi/ai/store/sse.test.ts
+++ b/packages/gemi/ai/store/sse.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { AgentStreamFrame } from "../types";
-import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseResponse } from "./sse";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseKeepalive, sseResponse } from "./sse";
 
 const bytes = new TextDecoder();
 
@@ -80,5 +80,18 @@ describe("sseResponse keepalive", () => {
     expect(vi.getTimerCount()).toBe(1);
     await body.cancel();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a touch after stop does not arm a timer", () => {
+    vi.useFakeTimers();
+    const enqueue = vi.fn();
+    const keepalive = sseKeepalive({
+      enqueue,
+    } as unknown as ReadableStreamDefaultController<Uint8Array>);
+    keepalive.stop();
+    keepalive.touch();
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(enqueue).not.toHaveBeenCalled();
   });
 });

--- a/packages/gemi/ai/store/sse.ts
+++ b/packages/gemi/ai/store/sse.ts
@@ -17,13 +17,17 @@ export function encodeFrame(frame: AgentStreamFrame): string {
 /**
  * How long a connection may sit idle before a comment line goes out.
  *
- * Azure App Service's front end drops a connection that has carried nothing
- * for about 230 seconds, and a slow tool or a thinking sub-agent can be silent
- * for longer than that. 25 seconds sits well inside every proxy timeout we
- * know of, and far enough apart that the comment lines cost nothing. Both
- * encoders read this one value, so the two cannot drift apart.
+ * The nearest ceiling is not a proxy but our own server: Bun's `idleTimeout`
+ * counts socket silence, a streaming body included, and gemi runs at its
+ * 10-second default unless `SERVER_IDLE_TIMEOUT` says otherwise. A comment
+ * line every 25 seconds was measured to lose the connection at 12; every 5
+ * keeps it open, with room for a write that lands late. Azure App Service's
+ * front end, at about 230 seconds, is the far ceiling, and 5 clears it by the
+ * same margin. A thousand quiet streams cost two hundred thirteen-byte writes
+ * a second, which is nothing. Both encoders read this one value, so the two
+ * cannot drift apart.
  */
-export const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
+export const SSE_KEEPALIVE_INTERVAL_MS = 5_000;
 
 /**
  * The comment line itself. A line starting with `:` is a comment under the SSE
@@ -42,7 +46,8 @@ export const SSE_KEEPALIVE = ": keepalive\n\n";
  *
  * The write is guarded because a cancel can land between the timer firing and
  * the enqueue, and a closed controller throws. There is nothing to do about
- * that except stop.
+ * that except stop. `arm` checks `stopped` too, so a `touch()` that arrives
+ * after `stop()` cannot hand a finished stream a timer for one more interval.
  */
 export function sseKeepalive(
   controller: ReadableStreamDefaultController<Uint8Array>,
@@ -52,6 +57,7 @@ export function sseKeepalive(
   let stopped = false;
 
   const arm = () => {
+    if (stopped) return;
     if (timer !== null) clearTimeout(timer);
     timer = setTimeout(() => {
       timer = null;

--- a/packages/gemi/ai/store/sse.ts
+++ b/packages/gemi/ai/store/sse.ts
@@ -14,6 +14,68 @@ export function encodeFrame(frame: AgentStreamFrame): string {
   return `id: ${frame.seq}\ndata: ${JSON.stringify(frame.event)}\n\n`;
 }
 
+/**
+ * How long a connection may sit idle before a comment line goes out.
+ *
+ * Azure App Service's front end drops a connection that has carried nothing
+ * for about 230 seconds, and a slow tool or a thinking sub-agent can be silent
+ * for longer than that. 25 seconds sits well inside every proxy timeout we
+ * know of, and far enough apart that the comment lines cost nothing. Both
+ * encoders read this one value, so the two cannot drift apart.
+ */
+export const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
+
+/**
+ * The comment line itself. A line starting with `:` is a comment under the SSE
+ * spec: every parser on our side skips it, and so does the browser's own
+ * `EventSource`.
+ */
+export const SSE_KEEPALIVE = ": keepalive\n\n";
+
+/**
+ * Writes a keepalive whenever the stream has been silent for the interval.
+ *
+ * Armed on creation because the silence before the first frame is real
+ * silence too — a model thinking is the common case. `touch()` after every
+ * frame is what makes it measure silence rather than elapsed time; `stop()`
+ * on close or cancel is what keeps a finished stream from holding a timer.
+ *
+ * The write is guarded because a cancel can land between the timer firing and
+ * the enqueue, and a closed controller throws. There is nothing to do about
+ * that except stop.
+ */
+export function sseKeepalive(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  intervalMs = SSE_KEEPALIVE_INTERVAL_MS,
+): { touch(): void; stop(): void } {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const arm = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      if (stopped) return;
+      try {
+        controller.enqueue(encoder.encode(SSE_KEEPALIVE));
+      } catch {
+        stop();
+        return;
+      }
+      arm();
+    }, intervalMs);
+  };
+
+  const stop = () => {
+    stopped = true;
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+  };
+
+  arm();
+  return { touch: arm, stop };
+}
+
 export function sseHeaders(): Record<string, string> {
   return {
     "Content-Type": "text/event-stream",
@@ -38,23 +100,30 @@ export function sseHeaders(): Record<string, string> {
 export function sseResponse(frames: AsyncIterable<AgentStreamFrame>, status = 200): Response {
   const iterator = frames[Symbol.asyncIterator]();
   let lastSeq = -1;
+  let keepalive!: ReturnType<typeof sseKeepalive>;
 
   const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      keepalive = sseKeepalive(controller);
+    },
     async pull(controller) {
       try {
         const next = await iterator.next();
         if (next.done) {
+          keepalive.stop();
           controller.close();
           return;
         }
         lastSeq = next.value.seq;
         controller.enqueue(encoder.encode(encodeFrame(next.value)));
+        keepalive.touch();
       } catch (err) {
         // Past the headers there is no status left to fail with, so the reason
         // goes out as the last event. Closing silently would be
         // indistinguishable from a run that finished, which is the one thing a
         // reattaching client must not be told by mistake.
         const event = { type: "error", error: toAgentError(err) } as const;
+        keepalive.stop();
         controller.enqueue(encoder.encode(encodeFrame({ seq: lastSeq + 1, event })));
         controller.close();
       }
@@ -62,6 +131,7 @@ export function sseResponse(frames: AsyncIterable<AgentStreamFrame>, status = 20
     cancel(reason) {
       // The client went away. Let the generator unwind so its `finally` runs
       // and it stops waiting on frames nobody will read.
+      keepalive.stop();
       void iterator.return?.(reason);
     },
   });

--- a/packages/gemi/ai/store/stubAgentRun.ts
+++ b/packages/gemi/ai/store/stubAgentRun.ts
@@ -21,7 +21,16 @@ export class StubAgentRun implements AgentRun<ToolShapes, unknown> {
   subscriptions = 0;
 
   private buffer: AgentStreamFrame[] = [];
-  private nextSeq = 0;
+  /**
+   * Frames are numbered from 1, because `AgentRunImpl` numbers them from 1.
+   *
+   * This used to start at 0, and the difference was not cosmetic: `LiveRuns`
+   * decided whether a cursor had been evicted by comparing it against the
+   * oldest buffered `seq`, which is 1 on a real run that has evicted nothing
+   * and 0 on this one. Every test here passed against a stub that could not
+   * express the case, and a ten-frame run answered a refresh with 410.
+   */
+  private nextSeq = 1;
   private done = false;
   private wake = new Set<() => void>();
   /** See the note on `Entry.version` in `LiveRuns`: same missed-wakeup window,

--- a/packages/gemi/ai/types.ts
+++ b/packages/gemi/ai/types.ts
@@ -339,7 +339,20 @@ export type AgentStreamEvent<T extends ToolShapes = ToolShapes, O = unknown> =
    *  text, `snapshot` the best-effort parse so far, so a UI can bind fields
    *  before the object closes. */
   | { type: "output-delta"; messageId: string; delta: string; snapshot: Partial<O> }
-  | { type: "tool-call"; messageId: string; part: ToolCallPart<T> }
+  | {
+      type: "tool-call";
+      messageId: string;
+      part: ToolCallPart<T>;
+      /**
+       * The server sending a call the client already holds, to put its own
+       * copy of the part in the client's hands — a parked sub-run's signed
+       * record, which the client cannot build from the forwarded events. Not
+       * a new call: the reducer merges it like any other frame, and a hook
+       * that fires per call skips it, because on a re-park the call it names
+       * was made by a previous run altogether.
+       */
+      resent?: true;
+    }
   /** The model searched for deferred tools and loaded these. A UI can say "…
    *  looking for the right tool" instead of showing an unexplained pause. */
   | { type: "tool-search"; loaded: string[] }

--- a/packages/gemi/ai/types.ts
+++ b/packages/gemi/ai/types.ts
@@ -60,6 +60,10 @@ export type AgentErrorCode =
   /** A tool result came back for a call the server never made, or with a
    *  signature that does not verify. */
   | "invalid_tool_result"
+  /** The `threadId` names a thread the server's store does not have: expired,
+   *  mistyped, or on an instance that is gone. Answered before anything runs;
+   *  the app starts a new thread or continues stateless. */
+  | "thread_not_found"
   | "aborted"
   | "unknown";
 

--- a/packages/gemi/ai/types.ts
+++ b/packages/gemi/ai/types.ts
@@ -114,6 +114,18 @@ export type NestedRun = {
   messages: AgentMessage[];
   finishReason?: FinishReason;
   usage?: Usage;
+  /**
+   * Present on a record whose sub-run is parked `awaiting-input`, and handed
+   * back untouched like a pending call's.
+   *
+   * The next turn re-enters — runs — the tool this record hangs off because
+   * the record says a sub-run under it is waiting on the question being
+   * answered. In stateless mode the record arrives from the browser, so
+   * without this it is the client deciding which tools run. Signed by the
+   * server over where the sub-run parked and which calls it left open; see
+   * `signing.ts`.
+   */
+  signature?: string;
 };
 
 export type ToolCallPart<T extends ToolShapes = ToolShapes> = {

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -874,21 +874,26 @@ describe("lifecycle", () => {
 
   test("a second send supersedes the first rather than interleaving two answers", async () => {
     const first = controlled();
-    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
-      init?.signal?.addEventListener("abort", () => first.abort());
-      return first.response;
-    });
     // A distinct run, whose frames number from zero again — which is exactly
     // the case the cursor has to be told about.
-    fetchMock.mockImplementationOnce(async () =>
-      streamed([
-        { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
-        { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
-        { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
-        { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
-        { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
-      ]),
-    );
+    const second = streamed([
+      { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
+      { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+      { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
+      { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
+      { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+    ]);
+    // Routed by URL rather than by call order: the second send posts `/stop`
+    // for the first run on its way out, and that call must not eat the answer.
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) return new Response(JSON.stringify({ stopped: true }));
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return second;
+    });
     const { box } = mount({ attach: false });
 
     await act(async () => {
@@ -920,17 +925,98 @@ describe("lifecycle", () => {
     expect(box.api.status).toBe("idle");
   });
 
+  test("the superseded run is stopped on the server, not just disconnected from", async () => {
+    // Aborting the fetch closes the connection, and a closed connection no
+    // longer stops a run. Left alone the first run keeps going, blind to the
+    // second turn, and appends its answer whenever it finishes — after the
+    // second one's, if the model is slower the first time.
+    const first = controlled();
+    const second = streamed([
+      { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
+      { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+      { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
+      { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
+      { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+    ]);
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) return new Response(JSON.stringify({ stopped: true }));
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return second;
+    });
+    const { box } = mount({ threadId: "th_9", attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("one");
+    });
+    await act(async () => {
+      first.push(
+        { seq: 0, event: { type: "run-start", runId: "run_0", threadId: "th_9" } },
+        ANSWER[1]!,
+        ANSWER[2]!,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(calls().map((c) => c[0])).toEqual(["/api/chat", "/api/chat/stop", "/api/chat"]);
+    // Named by the handles that mean exactly the first run. Not by `threadId`:
+    // the stop is not awaited, so by the time it lands the thread's live run
+    // may be the one the second turn just started.
+    expect(rawBodyOf(1)).toEqual({ runId: "run_0", clientRunId: rawBodyOf(0).clientRunId });
+    expect(rawBodyOf(1).clientRunId).not.toBe(rawBodyOf(2).clientRunId);
+    expect(box.api.messages.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
+    expect(box.api.status).toBe("idle");
+  });
+
+  test("a run this client neither started nor saw start is left to the server", async () => {
+    // Attached mid-run, from a cursor past `run-start`: no `clientRunId`, no
+    // `runId`. The only handle is the thread, and a stop by thread that lands
+    // late would stop the turn being sent. The server ends the old run when
+    // the new turn reaches the thread, so nothing is posted here.
+    const run = controlled();
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/attach")) {
+        init?.signal?.addEventListener("abort", () => run.abort());
+        return run.response;
+      }
+      return streamed(ANSWER);
+    });
+    const { box } = mount({ threadId: "th_9", cursor: { runId: "run_1", seq: 1 } });
+
+    await act(async () => {
+      run.push({ seq: 2, event: { type: "text-delta", messageId: "m1", delta: "…tail" } });
+      await Promise.resolve();
+    });
+    expect(box.api.runId).toBeUndefined();
+
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(calls().map((c) => c[0])).toEqual(["/api/chat/attach", "/api/chat"]);
+  });
+
   test("the superseded turn goes back to a stateless server marked aborted", async () => {
     // The transcript the client carries is what the model is shown next time.
     const first = controlled();
-    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
-      init?.signal?.addEventListener("abort", () => first.abort());
-      return first.response;
-    });
     const anonymous = ANSWER.map((frame, index) =>
       index === 0 ? { seq: 0, event: { type: "run-start" as const, runId: "run_1" } } : frame,
     );
-    fetchMock.mockImplementation(async () => streamed(anonymous));
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) return new Response(JSON.stringify({ stopped: true }));
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return streamed(anonymous);
+    });
     const { box } = mount({ attach: false });
 
     await act(async () => {
@@ -944,7 +1030,8 @@ describe("lifecycle", () => {
       await box.api.sendMessage("two");
     });
 
-    expect(bodyOf(1).messages[1]).toMatchObject({ role: "assistant", finishReason: "aborted" });
+    // Call 1 is the `/stop` for run_0; the second turn is call 2.
+    expect(bodyOf(2).messages[1]).toMatchObject({ role: "assistant", finishReason: "aborted" });
   });
 });
 

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -735,6 +735,38 @@ describe("errors", () => {
     expect(box.api.error).toMatchObject({ code: "rate_limited", retryable: true });
   });
 
+  test("a thread the server no longer has is named, so the app can start another", async () => {
+    // The route answers this before anything runs — the thread expired, or
+    // never existed here — and "unknown" would hide the one thing the app can
+    // do about it, which is drop the id and continue on a new thread or
+    // stateless.
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "thread_not_found", message: "Thread th_9 does not exist here." },
+        }),
+        { status: 404 },
+      ),
+    );
+    const onError = vi.fn();
+    const { box } = mount({ threadId: "th_9", attach: false, onError });
+
+    await act(async () => {
+      await box.api.sendMessage("hi");
+    });
+
+    expect(box.api.status).toBe("error");
+    expect(box.api.error).toEqual({
+      code: "thread_not_found",
+      message: "Thread th_9 does not exist here.",
+      retryable: false,
+    });
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: "thread_not_found" }));
+    // The turn that failed is still on screen, so an app that remounts without
+    // the thread has the message to resend.
+    expect(box.api.messages.map((m) => m.role)).toEqual(["user"]);
+  });
+
   test("an error event after the headers flushed reaches error and onError", async () => {
     const onError = vi.fn();
     fetchMock.mockResolvedValueOnce(

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -882,3 +882,223 @@ describe("lifecycle", () => {
     expect(bodyOf(1).messages[1]).toMatchObject({ role: "assistant", finishReason: "aborted" });
   });
 });
+
+/**
+ * A tool that ran a sub-agent, which asked a question of its own.
+ *
+ * The question reaches the user on the *parent's* `awaiting-input`, carrying
+ * the path that says which tool call to re-enter. Everything below is about one
+ * claim: an app cannot tell from its own code that this happened.
+ */
+const NESTED_ASK: AgentStreamFrame[] = [
+  { seq: 0, event: { type: "run-start", runId: "run_3", threadId: "th_9" } },
+  { seq: 1, event: { type: "message-start", messageId: "m3", role: "assistant" } },
+  {
+    seq: 2,
+    event: {
+      type: "tool-call",
+      messageId: "m3",
+      part: {
+        type: "tool-call",
+        toolCallId: "tc_outer",
+        name: "research",
+        input: { topic: "pricing" },
+      },
+    },
+  },
+  { seq: 3, event: { type: "tool-search", loaded: ["browse"] } },
+  { seq: 4, event: { type: "tool-progress", toolCallId: "tc_outer", data: { stage: "starting" } } },
+  {
+    seq: 5,
+    event: {
+      type: "nested-event",
+      toolCallId: "tc_outer",
+      runId: "nr_1",
+      agent: "pricing",
+      label: "researching pricing",
+      event: { type: "text-delta", messageId: "n1", delta: "I need the customer tier." },
+    },
+  },
+  {
+    seq: 6,
+    event: {
+      type: "awaiting-input",
+      runId: "run_3",
+      pending: [
+        {
+          toolCallId: "tc_inner",
+          name: "ask",
+          input: { question: "Which tier?" },
+          kind: "question",
+          signature: "sig_nested",
+          path: ["tc_outer"],
+        },
+      ],
+    },
+  },
+  { seq: 7, event: { type: "message-end", messageId: "m3", finishReason: "awaiting-input" } },
+  { seq: 8, event: { type: "run-end", runId: "run_3", finishReason: "awaiting-input" } },
+];
+
+describe("a question from a sub-agent", () => {
+  async function parked() {
+    fetchMock.mockResolvedValueOnce(streamed(NESTED_ASK));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("what should we charge?");
+    });
+    return box;
+  }
+
+  test("is answered by the same answer() an app already writes", async () => {
+    const box = await parked();
+
+    await act(async () => {
+      await box.api.answer("tc_inner", { answer: "enterprise" });
+    });
+
+    // The path goes back exactly as it arrived, beside the signature that
+    // commits to it — the app wrote a tool call id and a value, and nothing
+    // else, which is the whole point of doing it this way.
+    expect(bodyOf(1).turn.toolResults).toEqual([
+      {
+        toolCallId: "tc_inner",
+        signature: "sig_nested",
+        path: ["tc_outer"],
+        output: { answer: "enterprise" },
+      },
+    ]);
+  });
+
+  test("approve() carries the path too", async () => {
+    const box = await parked();
+
+    await act(async () => {
+      await box.api.approve("tc_inner", false, "wrong customer");
+    });
+
+    expect(bodyOf(1).turn.toolResults).toEqual([
+      {
+        toolCallId: "tc_inner",
+        signature: "sig_nested",
+        path: ["tc_outer"],
+        approve: false,
+        reason: "wrong customer",
+      },
+    ]);
+  });
+
+  test("a top-level call still sends no path at all", async () => {
+    // The absent path has to stay absent: `signing.ts` must produce the same
+    // signature it produced before paths existed, or every open approval breaks.
+    fetchMock.mockResolvedValueOnce(streamed(ASKING));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("refund me");
+    });
+
+    await act(async () => {
+      await box.api.approve("tc_1", true);
+    });
+
+    expect(bodyOf(1).turn.toolResults).toEqual([
+      { toolCallId: "tc_1", signature: "sig_one", approve: true },
+    ]);
+  });
+
+  test("the UI can see where the question came from without needing to", async () => {
+    const box = await parked();
+
+    expect(box.api.status).toBe("awaiting-input");
+    expect(box.api.pending[0]).toMatchObject({ toolCallId: "tc_inner", path: ["tc_outer"] });
+  });
+
+  test("two sub-runs holding the same tool call id are refused, not guessed at", async () => {
+    // Reachable only through nesting: the ids come from whichever provider ran
+    // each sub-run. `approve` is addressed by id alone on purpose, so when the
+    // id stops being an address the honest answer is to say so rather than
+    // approve whichever call sorted first.
+    const collision = NESTED_ASK.map((frame) =>
+      frame.seq === 6
+        ? {
+            seq: 6,
+            event: {
+              type: "awaiting-input" as const,
+              runId: "run_3",
+              pending: [
+                (frame.event as { pending: unknown[] }).pending[0] as never,
+                {
+                  toolCallId: "tc_inner",
+                  name: "ask",
+                  input: { question: "Which region?" },
+                  kind: "question" as const,
+                  signature: "sig_other",
+                  path: ["tc_second"],
+                } as never,
+              ],
+            },
+          }
+        : frame,
+    );
+    fetchMock.mockResolvedValueOnce(streamed(collision));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("what should we charge?");
+    });
+
+    await act(async () => {
+      await box.api.answer("tc_inner", { answer: "enterprise" });
+    });
+
+    expect(calls()).toHaveLength(1);
+    expect(box.api.error).toMatchObject({ code: "invalid_tool_result", retryable: false });
+    // Both are still answerable once the app disambiguates; nothing was thrown
+    // away because one report was ambiguous.
+    expect(box.api.pending).toHaveLength(2);
+  });
+});
+
+describe("what a nested run leaves in the transcript", () => {
+  test("the sub-run and the tool's own yields are on the tool call, ready to render", async () => {
+    fetchMock.mockResolvedValueOnce(streamed(NESTED_ASK));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("what should we charge?");
+    });
+
+    const call = box.api.messages
+      .flatMap((message) => message.content)
+      .find((part) => part.type === "tool-call") as {
+      progress?: unknown[];
+      nested?: { agent: string; label?: string; messages: unknown[] }[];
+    };
+    expect(call.progress).toEqual([{ stage: "starting" }]);
+    expect(call.nested).toHaveLength(1);
+    expect(call.nested![0]).toMatchObject({ agent: "pricing", label: "researching pricing" });
+    expect(call.nested![0]!.messages).toEqual([
+      {
+        id: "n1",
+        role: "assistant",
+        content: [{ type: "text", text: "I need the customer tier." }],
+        createdAt: expect.any(String),
+      },
+    ]);
+  });
+
+  test("loadedTools names the deferred tools in play and empties on the next run", async () => {
+    fetchMock.mockResolvedValueOnce(streamed(NESTED_ASK));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("what should we charge?");
+    });
+
+    expect(box.api.loadedTools).toEqual(["browse"]);
+
+    fetchMock.mockResolvedValueOnce(streamed(ANSWER));
+    await act(async () => {
+      await box.api.sendMessage("never mind");
+    });
+
+    expect(box.api.loadedTools).toEqual([]);
+  });
+});

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -974,6 +974,96 @@ describe("lifecycle", () => {
     expect(box.api.status).toBe("idle");
   });
 
+  test("a supersede stop that fails is not the new turn's error", async () => {
+    // The stop is not awaited, so its failure lands after `send` has cleared
+    // `error` for the turn going out. Through `fail` it would sit on an answer
+    // streaming fine, and the turn would end `error` after succeeding. With a
+    // thread the server ends the old run when the new turn reaches it, so the
+    // failed stop changed nothing and nothing is said.
+    const first = controlled();
+    const onError = vi.fn();
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) {
+        return new Response(JSON.stringify({ error: { message: "upstream gone" } }), {
+          status: 502,
+        });
+      }
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return streamed([
+        { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
+        { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+        { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
+        { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
+        { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+      ]);
+    });
+    const { box } = mount({ threadId: "th_9", attach: false, onError });
+
+    await act(async () => {
+      void box.api.sendMessage("one");
+    });
+    await act(async () => {
+      first.push(
+        { seq: 0, event: { type: "run-start", runId: "run_0", threadId: "th_9" } },
+        ANSWER[1]!,
+        ANSWER[2]!,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(calls().map((c) => c[0])).toEqual(["/api/chat", "/api/chat/stop", "/api/chat"]);
+    expect(box.api.messages[3]!.content).toEqual([{ type: "text", text: "Second." }]);
+    expect(box.api.status).toBe("idle");
+    expect(box.api.error).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test("without a thread, a supersede stop that fails is the app's to hear, not the turn's", async () => {
+    // Stateless, so nothing on the server will end the old run for this
+    // client; a stop that did not land is a run still billing, and this is the
+    // only place that knows. The app is told — and the turn that went out,
+    // which succeeded, still says so.
+    const first = controlled();
+    const onError = vi.fn();
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) return new Response("", { status: 502 });
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return streamed(
+        ANSWER.map((frame, index) =>
+          index === 0 ? { seq: 0, event: { type: "run-start" as const, runId: "run_1" } } : frame,
+        ),
+      );
+    });
+    const { box } = mount({ attach: false, onError });
+
+    await act(async () => {
+      void box.api.sendMessage("one");
+    });
+    await act(async () => {
+      first.push({ seq: 0, event: { type: "run-start", runId: "run_0" } }, ANSWER[1]!, ANSWER[2]!);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0]).toMatchObject({ retryable: true });
+    expect(box.api.status).toBe("idle");
+    expect(box.api.error).toBeNull();
+  });
+
   test("a run this client neither started nor saw start is left to the server", async () => {
     // Attached mid-run, from a cursor past `run-start`: no `clientRunId`, no
     // `runId`. The only handle is the thread, and a stop by thread that lands

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -540,6 +540,39 @@ describe("attach on mount", () => {
     expect(box.api.status).toBe("idle");
   });
 
+  test("reports a miss, because on more than one instance it is not a miss", async () => {
+    // 404 is what the route answers for a thread with nothing running AND for
+    // a refresh routed to an instance that is not the one holding the run.
+    // Neither end can tell them apart, so the client hands the ambiguity to the
+    // app rather than deciding it is nothing.
+    const seen: { threadId: string }[] = [];
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ code: "no_live_run" }), { status: 404 }),
+    );
+    const { box } = mount({ threadId: "th_9", onAttachMiss: (p: { threadId: string }) => seen.push(p) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(seen).toEqual([{ threadId: "th_9" }]);
+    // And it still leaves the client where one without `attach` would be.
+    expect(box.api.messages).toHaveLength(0);
+    expect(box.api.status).toBe("idle");
+  });
+
+  test("does not report a miss when a run was there to attach to", async () => {
+    const seen: unknown[] = [];
+    fetchMock.mockResolvedValueOnce(streamed(ANSWER.slice(2)));
+    mount({ threadId: "th_9", onAttachMiss: () => seen.push(1) });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(seen).toEqual([]);
+  });
+
   test("asks for the tail from the cursor restored with the messages", async () => {
     fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
     mount({

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -1081,6 +1081,13 @@ describe("what a nested run leaves in the transcript", () => {
         role: "assistant",
         content: [{ type: "text", text: "I need the customer tier." }],
         createdAt: expect.any(String),
+        // Put there by the parent's `run-end`. This fixture never sends the
+        // sub-run's own `message-end` — a real runtime would, since the
+        // sub-agent finalises its message before escalating — and the point of
+        // the safety net is that the block stops drawing a live cursor either
+        // way. "awaiting-input" is what it is waiting for, and it is what the
+        // parent message beside it carries.
+        finishReason: "awaiting-input",
       },
     ]);
   });
@@ -1100,5 +1107,146 @@ describe("what a nested run leaves in the transcript", () => {
     });
 
     expect(box.api.loadedTools).toEqual([]);
+  });
+});
+
+/**
+ * A stateless run — no `threadId`, so the client carries the transcript — whose
+ * tool yielded twice and whose sub-agent's own tool yielded once.
+ */
+const STATELESS_NESTED: AgentStreamFrame[] = [
+  { seq: 0, event: { type: "run-start", runId: "run_5" } },
+  { seq: 1, event: { type: "message-start", messageId: "m5", role: "assistant" } },
+  {
+    seq: 2,
+    event: {
+      type: "tool-call",
+      messageId: "m5",
+      part: {
+        type: "tool-call",
+        toolCallId: "tc_outer",
+        name: "research",
+        input: { topic: "pricing" },
+      },
+    },
+  },
+  { seq: 3, event: { type: "tool-progress", toolCallId: "tc_outer", data: { chunk: 1 } } },
+  { seq: 4, event: { type: "tool-progress", toolCallId: "tc_outer", data: { chunk: 2 } } },
+  {
+    seq: 5,
+    event: {
+      type: "nested-event",
+      toolCallId: "tc_outer",
+      runId: "nr_1",
+      agent: "pricing",
+      event: { type: "message-start", messageId: "n1", role: "assistant" },
+    },
+  },
+  {
+    seq: 6,
+    event: {
+      type: "nested-event",
+      toolCallId: "tc_outer",
+      runId: "nr_1",
+      agent: "pricing",
+      event: {
+        type: "tool-call",
+        messageId: "n1",
+        part: {
+          type: "tool-call",
+          toolCallId: "tc_inner",
+          name: "browse",
+          input: { url: "https://example.com" },
+        },
+      },
+    },
+  },
+  {
+    seq: 7,
+    event: {
+      type: "nested-event",
+      toolCallId: "tc_outer",
+      runId: "nr_1",
+      agent: "pricing",
+      event: { type: "tool-progress", toolCallId: "tc_inner", data: { page: 1 } },
+    },
+  },
+  {
+    seq: 8,
+    event: {
+      type: "nested-event",
+      toolCallId: "tc_outer",
+      runId: "nr_1",
+      agent: "pricing",
+      event: { type: "message-end", messageId: "n1", finishReason: "stop" },
+    },
+  },
+  {
+    seq: 9,
+    event: {
+      type: "tool-result",
+      messageId: "m5",
+      part: {
+        type: "tool-result",
+        toolCallId: "tc_outer",
+        name: "research",
+        status: "ok",
+        output: { summary: "$40" },
+      },
+    },
+  },
+  { seq: 10, event: { type: "message-end", messageId: "m5", finishReason: "stop" } },
+  { seq: 11, event: { type: "run-end", runId: "run_5", finishReason: "stop" } },
+];
+
+describe("the history a stateless turn posts back", () => {
+  async function secondTurn() {
+    fetchMock.mockResolvedValueOnce(streamed(STATELESS_NESTED));
+    const { box } = mount({ attach: false });
+    await act(async () => {
+      await box.api.sendMessage("what should we charge?");
+    });
+    fetchMock.mockResolvedValueOnce(streamed(ANSWER));
+    await act(async () => {
+      await box.api.sendMessage("and for teams?");
+    });
+    const posted = bodyOf(1).messages as any[];
+    return { box, call: posted[1].content.find((p: any) => p.type === "tool-call") };
+  }
+
+  test("leaves the progress logs behind, at every depth", async () => {
+    // Every stateless turn re-uploads the whole transcript, and `progress` is
+    // the one thing on it that grows without a bound the model imposes — a tool
+    // yielding per chunk writes an entry per chunk, and turn 2, turn 3 and
+    // every turn after would carry all of them. Nothing server-side reads it:
+    // no provider translates it, `openCalls` matches on `toolCallId`, and the
+    // resume path replays a sub-agent from `nested`.
+    const { call } = await secondTurn();
+
+    expect("progress" in call).toBe(false);
+    const inner = call.nested[0].messages[0].content.find((p: any) => p.type === "tool-call");
+    expect("progress" in inner).toBe(false);
+  });
+
+  test("keeps the nested transcript, which the resume path does read", async () => {
+    // The asymmetry is the point: `nested` is how section D replays a finished
+    // sub-run on the next turn, so stripping it would break resumption to save
+    // the same bytes.
+    const { call } = await secondTurn();
+
+    expect(call.nested).toHaveLength(1);
+    expect(call.nested[0]).toMatchObject({ runId: "nr_1", agent: "pricing" });
+    expect(call.nested[0].messages[0]).toMatchObject({ id: "n1", finishReason: "stop" });
+  });
+
+  test("and the tab still has every yield it was shown", async () => {
+    // The stripping shapes the request body, not the transcript: a UI rendering
+    // the log must not lose it because a later turn was sent.
+    const { box } = await secondTurn();
+    const call = (box.api.messages[1]!.content as any[]).find((p) => p.type === "tool-call");
+
+    expect(call.progress).toEqual([{ chunk: 1 }, { chunk: 2 }]);
+    const inner = call.nested[0].messages[0].content.find((p: any) => p.type === "tool-call");
+    expect(inner.progress).toEqual([{ page: 1 }]);
   });
 });

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -278,14 +278,26 @@ async function httpError(response: Response): Promise<AgentError> {
   // auth, validation, an unknown agent — and never reaches the stream's own
   // error event, so it has to be translated into the same shape here.
   let message = response.statusText || `Request failed with status ${response.status}`;
+  let code: AgentError["code"] = response.status === 429 ? "rate_limited" : "unknown";
   try {
-    const data = (await response.json()) as { error?: { message?: string }; message?: string };
+    const data = (await response.json()) as {
+      error?: { code?: string; message?: string };
+      message?: string;
+    };
     message = data?.error?.message ?? data?.message ?? message;
+    // The one server code an app has something to do about: the thread it
+    // holds is gone, and the fix is a new one or a stateless send, neither of
+    // which "unknown" would suggest. Other codes stay folded into the status,
+    // because the union names what the client can act on, not what the server
+    // can say.
+    if (data?.error?.code === "thread_not_found") {
+      code = "thread_not_found";
+    }
   } catch {
     // Not JSON. The status line is all there is.
   }
   return {
-    code: response.status === 429 ? "rate_limited" : "unknown",
+    code,
     message,
     retryable: response.status === 429 || response.status >= 500,
   };

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -282,6 +282,47 @@ function turnFrom(message: AgentMessage): ClientTurn {
 }
 
 /**
+ * The transcript as the server needs it, without the progress logs.
+ *
+ * In stateless mode `send` posts the whole history on *every* turn, so anything
+ * that accumulates on a message is paid for again on each one. `progress` is
+ * the only part of the transcript that grows without a bound the model imposes:
+ * a generator tool yielding per chunk writes an entry per chunk, and a tool that
+ * yielded five thousand times would put five thousand objects in the body of
+ * turn 2, turn 3, and every turn after, forever.
+ *
+ * Nothing server-side reads it. It is not translated into a provider message,
+ * `openCalls` matches on `toolCallId`, and the resume path replays a sub-agent
+ * from `nested` — which is why `nested` is kept here, recursed into rather than
+ * dropped, while `progress` is not. The client's own copy is untouched: this
+ * shapes the request body only, so a UI still renders every yield it received.
+ */
+function forWire(messages: AgentMessage[]): AgentMessage[] {
+  return messages.map((message) => {
+    // Identity for the overwhelming majority of messages, which have neither —
+    // `nested` counts because a sub-agent's own yields are the same dead weight
+    // one level down.
+    const touched = message.content.some(
+      (part) => part.type === "tool-call" && (part.progress || part.nested),
+    );
+    if (!touched) return message;
+    return {
+      ...message,
+      content: message.content.map((part) => {
+        if (part.type !== "tool-call") return part;
+        const { progress: _progress, ...rest } = part;
+        return rest.nested
+          ? {
+              ...rest,
+              nested: rest.nested.map((run) => ({ ...run, messages: forWire(run.messages) })),
+            }
+          : rest;
+      }),
+    };
+  });
+}
+
+/**
  * The path is the agent's route, exactly as mounted:
  *
  *   const { messages, sendMessage } = useChat("/chat")
@@ -500,7 +541,9 @@ export function useChat<P extends keyof AgentRoutes>(
           clientRunId,
           ...(stateRef.current!.threadId
             ? { threadId: stateRef.current!.threadId }
-            : { messages: history }),
+            : // Stripped of the progress logs, which no part of the server
+              // reads and which every later turn would otherwise re-upload.
+              { messages: forWire(history) }),
           ...body,
         };
         const response = await post(url, payload, controller.signal);

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -78,6 +78,28 @@ export interface UseChatParams<P extends keyof AgentRoutes> {
   onFinish?: (message: AgentMessage<ToolsOf<P>, OutputOf<P>>) => void;
   onError?: (error: AgentError) => void;
   onAwaitingInput?: (pending: PendingToolCall<ToolsOf<P>>[]) => void;
+  /**
+   * The mount probe found no run to attach to.
+   *
+   * On one server this means what it says, and there is nothing to do. On more
+   * than one it is ambiguous in a way neither end can resolve: a run lives in
+   * the process that started it, `find` only ever searches that process, and a
+   * refresh routed to a different instance gets the same answer as a thread
+   * with nothing running. The server cannot tell the two apart, so it does not
+   * pretend to.
+   *
+   * What an app can do is re-read the thread — the run is still going wherever
+   * it is, and its messages land in the store when it finishes, so refetching
+   * shows the answer that the stream would have shown arriving. Without this
+   * the client simply sits on its own history, and the reply appears only when
+   * something else happens to reload it.
+   *
+   * The better fix is upstream: route a session to one instance (on Azure App
+   * Service that is ARR affinity, which is on by default) so the refresh lands
+   * where its run is. This is the fallback for when it does not — a scale-in,
+   * a new device, a cleared cookie.
+   */
+  onAttachMiss?: (params: { threadId: string }) => void;
 }
 
 export interface UseChatResult<P extends keyof AgentRoutes> {
@@ -346,6 +368,7 @@ export function useChat<P extends keyof AgentRoutes>(
     onFinish,
     onError,
     onAwaitingInput,
+    onAttachMiss,
   } = params;
 
   const routeParams = useParams();
@@ -386,8 +409,8 @@ export function useChat<P extends keyof AgentRoutes>(
   const abortRef = useRef<{ controller: AbortController; clientRunId?: string } | null>(null);
   // The latest callbacks, so a stream started three renders ago still calls the
   // ones the component has now instead of a stale closure.
-  const handlers = useRef({ onFinish, onError, onAwaitingInput });
-  handlers.current = { onFinish, onError, onAwaitingInput };
+  const handlers = useRef({ onFinish, onError, onAwaitingInput, onAttachMiss });
+  handlers.current = { onFinish, onError, onAwaitingInput, onAttachMiss };
   const requestRef = useRef({ base, headers, extraBody });
   requestRef.current = { base, headers, extraBody };
 
@@ -818,8 +841,15 @@ export function useChat<P extends keyof AgentRoutes>(
         };
         const response = await post(`${requestRef.current.base}/attach`, body, controller.signal);
         // Nothing running is the ordinary answer, not a failure: the route says
-        // so with an empty response and the screen simply stays as it was.
-        if (!response.ok || response.status === 204 || !response.body) return;
+        // so with an empty response and the screen simply stays as it was —
+        // except that on more than one instance it is also what a refresh
+        // routed away from its run gets, which is not ordinary at all. The
+        // client cannot tell; `onAttachMiss` is how an app that runs more than
+        // one process gets to react.
+        if (!response.ok || response.status === 204 || !response.body) {
+          handlers.current.onAttachMiss?.({ threadId: initialThreadId });
+          return;
+        }
         await consume(response, controller.signal);
       } catch {
         // A probe that could not be made leaves the client exactly where a

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -488,26 +488,27 @@ export function useChat<P extends keyof AgentRoutes>(
 
   /**
    * The server call that ends a run. Shared by `stop()` and by a `send` that
-   * supersedes one, because the failure handling is the point: a stop that did
-   * not land is a run still working through its tool loop and still billing,
-   * behind a transcript that says it was cut.
+   * supersedes one; what each does with a failure is its own, because a stop
+   * that did not land is a run still working through its tool loop and still
+   * billing, behind a transcript that says it was cut — and whose problem that
+   * is depends on who asked.
    */
   const postStop = useCallback(
-    async (body: AgentStopBody) => {
+    async (body: AgentStopBody, report: (error: AgentError) => void) => {
       const { base: url } = requestRef.current;
       try {
         const response = await post(`${url}/stop`, body);
-        if (!response.ok) fail(await httpError(response));
+        if (!response.ok) report(await httpError(response));
       } catch (error) {
         if (isAbort(error)) return;
-        fail({
+        report({
           code: "unknown",
           message: error instanceof Error ? error.message : String(error),
           retryable: true,
         });
       }
     },
-    [fail, post],
+    [post],
   );
 
   const consume = useCallback(
@@ -579,12 +580,22 @@ export function useChat<P extends keyof AgentRoutes>(
         // anyway when the new turn reaches the thread. Not awaited: the server
         // orders the two, and a round trip before every "changed my mind" would
         // be paid for nothing.
-        const { runId } = stateRef.current!;
+        const { runId, threadId } = stateRef.current!;
         const body: AgentStopBody = {
           ...(runId ? { runId } : {}),
           ...(superseded.clientRunId ? { clientRunId: superseded.clientRunId } : {}),
         };
-        if (Object.keys(body).length > 0) void postStop(body);
+        if (Object.keys(body).length > 0) {
+          // A failure here does not go through `fail`. The post is not awaited,
+          // so its answer lands after this send has cleared `error` for the
+          // turn going out, and a 502 from `/stop` would sit on an answer that
+          // is streaming fine — a turn that succeeded, ending `error`. With a
+          // thread the server ends the old run when this turn reaches it, so a
+          // stop that failed changed nothing and there is nothing to say.
+          // Without one this client is the only thing that knows the old run
+          // is still going, so the app is told, and only told.
+          void postStop(body, threadId ? () => {} : (error) => handlers.current.onError?.(error));
+        }
       }
 
       const previous = superseded ? markAborted(stateRef.current!) : stateRef.current!;
@@ -797,8 +808,8 @@ export function useChat<P extends keyof AgentRoutes>(
       ...(threadId ? { threadId } : {}),
       ...(inFlight?.clientRunId ? { clientRunId: inFlight.clientRunId } : {}),
     };
-    await postStop(body);
-  }, [commit, postStop, setPhaseSafe]);
+    await postStop(body, fail);
+  }, [commit, fail, postStop, setPhaseSafe]);
 
   const regenerate = useCallback(async () => {
     const messages = stateRef.current!.messages as AgentMessage[];

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -43,7 +43,14 @@ export type ChatStatus = "idle" | "submitted" | "streaming" | "awaiting-input" |
 
 export interface UseChatParams<P extends keyof AgentRoutes> {
   /** Continues a server-side thread. Omitted, the hook keeps history itself and
-   *  sends it with each request — the stateless default. */
+   *  sends it with each request — the stateless default.
+   *
+   *  The id is the store's, not the client's: an app route calls
+   *  `store.createThread` and hands the result to this hook, and an id the
+   *  store never minted — or has since expired — is a `thread_not_found` error
+   *  on the first turn. Only a store built with client-owned ids
+   *  (`new MemoryAgentStore({ clientOwnedIds: true })`) takes one the client
+   *  made up. */
   threadId?: string;
   /** Server-rendered or restored history. */
   initialMessages?: AgentMessage<ToolsOf<P>, OutputOf<P>>[];

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -81,6 +81,24 @@ export interface UseChatParams<P extends keyof AgentRoutes> {
 }
 
 export interface UseChatResult<P extends keyof AgentRoutes> {
+  /**
+   * The transcript, tools and all.
+   *
+   * A `tool-call` part narrows on `name`, and with it `input`, `output` and
+   * `progress` — the tool's own yields, in order, typed by what its `execute`
+   * yields rather than as `unknown`. `nested` on that same part holds the
+   * sub-agent runs the tool drove, each an ordinary `AgentMessage[]` with a
+   * name and a label, so a component walks into it and renders it with whatever
+   * it already renders `messages` with:
+   *
+   *   {part.type === "tool-call" && part.nested?.map((run) => (
+   *     <Transcript key={run.runId} title={run.label ?? run.agent} messages={run.messages} />
+   *   ))}
+   *
+   * Those inner messages are typed with the default `ToolShapes`, not this
+   * route's: a sub-agent's tools are its own, and typing its transcript with
+   * the parent's tool names would be a lie the compiler tells.
+   */
   messages: AgentMessage<ToolsOf<P>, OutputOf<P>>[];
   status: ChatStatus;
   /** Cleared by the next successful send, so a retry does not have to clear it. */
@@ -119,12 +137,30 @@ export interface UseChatResult<P extends keyof AgentRoutes> {
   regenerate(): Promise<void>;
   setMessages(messages: AgentMessage<ToolsOf<P>, OutputOf<P>>[]): void;
 
-  /** Non-empty exactly when `status === "awaiting-input"`. */
+  /**
+   * Non-empty exactly when `status === "awaiting-input"`.
+   *
+   * A call a *sub*-agent made arrives here too, with `path` naming the chain of
+   * tool calls it is nested under. Nothing else about it is different, and that
+   * is the point: it is answered by `approve`/`answer` like any other, and
+   * `path` is there only so a UI can say which agent is asking.
+   */
   pending: PendingToolCall<ToolsOf<P>>[];
   /**
-   * Sugar over `sendMessage`. The hook carries each pending call's signature and
-   * hands it back untouched, so an app answers with a boolean and never sees the
-   * mechanism that makes answering trustworthy.
+   * The deferred tools the model has pulled in during the run in flight.
+   *
+   * Somewhere for a UI to put "…looking for the right tool" instead of an
+   * unexplained pause. Run-scoped and not part of the transcript: it says what
+   * is happening now, and is empty again on the next `run-start`, so it is not
+   * something to persist beside `messages`.
+   */
+  loadedTools: string[];
+  /**
+   * Sugar over `sendMessage`. The hook carries each pending call's signature —
+   * and its `path`, if the question came from a sub-agent — and hands both back
+   * untouched, so an app answers with a boolean and never sees the mechanism
+   * that makes answering trustworthy. Answering a nested question is the same
+   * call as answering a top-level one.
    */
   approve(toolCallId: string, approve: boolean, reason?: string): Promise<void>;
   /** The same, for a `question` or `client` tool: the value is checked against
@@ -527,11 +563,26 @@ export function useChat<P extends keyof AgentRoutes>(
     [send],
   );
 
+  /**
+   * The half of a `ClientToolResult` the app never writes: the id, the
+   * signature, and the path.
+   *
+   * All three are carried by the hook and handed back untouched, which is what
+   * makes a sub-agent's question answerable with the same two lines as a
+   * top-level one. `path` is absent for a call the parent's own tools made, so
+   * an app cannot tell from its own code where the question came from — the only
+   * difference is that `pending[i].path` is there to render if it wants to say
+   * which agent is asking.
+   */
   const resultFor = useCallback(
-    (toolCallId: string, build: (signature: string) => ClientToolResult) => {
-      const call = stateRef.current!.pending.find(
+    (
+      toolCallId: string,
+      build: (base: { toolCallId: string; signature: string; path?: string[] }) => ClientToolResult,
+    ) => {
+      const matches = stateRef.current!.pending.filter(
         (candidate: PendingToolCall) => candidate.toolCallId === toolCallId,
       );
+      const call = matches[0];
       if (!call) {
         // Not a network failure: the app answered a call this client is not
         // holding. Surfacing it beats sending a turn the server will reject for
@@ -544,19 +595,39 @@ export function useChat<P extends keyof AgentRoutes>(
         });
         return null;
       }
+      if (matches.length > 1) {
+        // Nesting is what makes this reachable: two sub-runs, under two
+        // different tools of the same parent turn, each holding a call. The ids
+        // come from whichever provider ran each sub-run, so nothing guarantees
+        // they differ, and the path is what tells them apart — but `approve` is
+        // deliberately addressed by id alone, because an app must not have to
+        // know a question was nested to answer it. Refusing beats guessing:
+        // picking one would silently approve a tool the user was not looking at.
+        fail({
+          code: "invalid_tool_result",
+          message: `Ambiguous tool call ${toolCallId}: ${matches.length} pending calls share it`,
+          toolCallId,
+          retryable: false,
+        });
+        return null;
+      }
       // The signature travels back exactly as it arrived. It signs the input the
-      // server proposed, so an app that never touches it cannot approve one
-      // thing and have another run.
-      return build(call.signature);
+      // server proposed — and, for a nested call, the path it was proposed at —
+      // so an app that never touches either cannot approve one thing and have
+      // another run, or have the right answer applied to the wrong sub-agent.
+      return build({
+        toolCallId,
+        signature: call.signature,
+        ...(call.path ? { path: call.path } : {}),
+      });
     },
     [fail],
   );
 
   const approve = useCallback(
     async (toolCallId: string, approved: boolean, reason?: string) => {
-      const result = resultFor(toolCallId, (signature) => ({
-        toolCallId,
-        signature,
+      const result = resultFor(toolCallId, (base) => ({
+        ...base,
         approve: approved,
         ...(reason ? { reason } : {}),
       }));
@@ -567,7 +638,7 @@ export function useChat<P extends keyof AgentRoutes>(
 
   const answer = useCallback(
     async (toolCallId: string, output: unknown) => {
-      const result = resultFor(toolCallId, (signature) => ({ toolCallId, signature, output }));
+      const result = resultFor(toolCallId, (base) => ({ ...base, output }));
       if (result) await queueResult(result);
     },
     [queueResult, resultFor],
@@ -745,6 +816,7 @@ export function useChat<P extends keyof AgentRoutes>(
     regenerate,
     setMessages,
     pending: state.pending as PendingToolCall<ToolsOf<P>>[],
+    loadedTools: state.loadedTools,
     approve,
     answer,
     attach: uploadFile,

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -486,6 +486,30 @@ export function useChat<P extends keyof AgentRoutes>(
     });
   }, []);
 
+  /**
+   * The server call that ends a run. Shared by `stop()` and by a `send` that
+   * supersedes one, because the failure handling is the point: a stop that did
+   * not land is a run still working through its tool loop and still billing,
+   * behind a transcript that says it was cut.
+   */
+  const postStop = useCallback(
+    async (body: AgentStopBody) => {
+      const { base: url } = requestRef.current;
+      try {
+        const response = await post(`${url}/stop`, body);
+        if (!response.ok) fail(await httpError(response));
+      } catch (error) {
+        if (isAbort(error)) return;
+        fail({
+          code: "unknown",
+          message: error instanceof Error ? error.message : String(error),
+          retryable: true,
+        });
+      }
+    },
+    [fail, post],
+  );
+
   const consume = useCallback(
     async (response: Response, signal: AbortSignal) => {
       for await (const frame of decodeSSE(response.body)) {
@@ -543,6 +567,25 @@ export function useChat<P extends keyof AgentRoutes>(
       const clientRunId = localId();
       const controller = new AbortController();
       abortRef.current = { controller, clientRunId };
+
+      if (superseded) {
+        // Aborting the fetch only closes the connection, and a closed connection
+        // no longer stops a run: the superseded one would keep going server
+        // side, blind to this turn and still billing. So it is stopped the way
+        // `stop()` stops it, by the handles that name exactly that run — never
+        // by `threadId`, which by the time this lands may name the run this
+        // turn is about to start. A run this client did not start, and whose
+        // `run-start` never arrived, has no such handle; the server ends it
+        // anyway when the new turn reaches the thread. Not awaited: the server
+        // orders the two, and a round trip before every "changed my mind" would
+        // be paid for nothing.
+        const { runId } = stateRef.current!;
+        const body: AgentStopBody = {
+          ...(runId ? { runId } : {}),
+          ...(superseded.clientRunId ? { clientRunId: superseded.clientRunId } : {}),
+        };
+        if (Object.keys(body).length > 0) void postStop(body);
+      }
 
       const previous = superseded ? markAborted(stateRef.current!) : stateRef.current!;
       const history = previous.messages;
@@ -611,7 +654,7 @@ export function useChat<P extends keyof AgentRoutes>(
         }
       }
     },
-    [commit, consume, fail, post, setPhaseSafe],
+    [commit, consume, fail, post, postStop, setPhaseSafe],
   );
 
   const sendMessage = useCallback(
@@ -730,7 +773,6 @@ export function useChat<P extends keyof AgentRoutes>(
   );
 
   const stop = useCallback(async () => {
-    const { base: url } = requestRef.current;
     const { runId, threadId } = stateRef.current!;
     // The UI stops now. The POST below is what actually ends the generation and
     // any tool mid-flight, and it may take a moment; a user who clicked stop
@@ -755,22 +797,8 @@ export function useChat<P extends keyof AgentRoutes>(
       ...(threadId ? { threadId } : {}),
       ...(inFlight?.clientRunId ? { clientRunId: inFlight.clientRunId } : {}),
     };
-    try {
-      const response = await post(`${url}/stop`, body);
-      // A failed stop is not cosmetic. The transcript says the turn was cut, so
-      // the UI looks settled, while the run may still be working through its
-      // tool loop and still billing for it — the one failure here a user would
-      // want to know about, and previously the one that was swallowed.
-      if (!response.ok) fail(await httpError(response));
-    } catch (error) {
-      if (isAbort(error)) return;
-      fail({
-        code: "unknown",
-        message: error instanceof Error ? error.message : String(error),
-        retryable: true,
-      });
-    }
-  }, [commit, fail, post, setPhaseSafe]);
+    await postStop(body);
+  }, [commit, postStop, setPhaseSafe]);
 
   const regenerate = useCallback(async () => {
     const messages = stateRef.current!.messages as AgentMessage[];

--- a/packages/gemi/package.json
+++ b/packages/gemi/package.json
@@ -58,6 +58,7 @@
     "build:client-types": "tsc -p tsconfig.browser.json",
     "test": "bun --bun vitest",
     "test:types": "vitest run --typecheck.only",
+    "test:live": "bun --bun vitest run ai/live",
     "test:packaging": "bun --bun vitest run --config vitest.packaging.config.ts",
     "build:publish": "bun scripts/build-publish.ts",
     "prepublishOnly": "echo 'Do not publish from this directory \u2014 its exports point at TS source. Run: bun run build:publish, then publish from .publish/' && exit 1",


### PR DESCRIPTION
> **Stack**, bottom to top — each PR is based on the one below it:
> 1. `ai/1-schema` — the schema builder runtime
> 2. `ai/2-provider` — the OpenAI and Azure providers
> 3. `ai/3-agent` — the agent run loop and signing
> 4. `ai/4-controller` — controller, stores, `ApiRouter.agent()`
> 5. `ai/5-client` — `useChat` and stream decoding
> 6. `ai/6-exports` — module exports and the example
> 7. `ai/7-progress-contract` — progress and nesting in the wire contract
> 8. `ai/8-provider-live` — providers corrected against the live API
> 9. `ai/9-nested-runs` — `ctx.runAgent`, escalation, replay
> 10. **`ai/10-chat-nested` — you are here** — nested transcripts in `useChat`
> 11. `ai/11-live-tests` — live verification against OpenAI and Azure

The browser half of nesting. A `nested-event` finds the tool-call part by id, finds-or-creates the `NestedRun` on it by `runId`, builds a throwaway `ChatState` around `run.messages`, and calls `reduce` — the same function, not `applyFrame`, because a nested event has no `seq` of its own and the parent's cursor has already refused the duplicates.

**Two levels deep needed zero reducer code.** An inner `nested-event` lands back in the same switch branch one message list down, and the test for it is five extra fixture frames. Everything the outer reducer already does happens inside a nested run for free: `withMessage` builds a nested message whose `message-start` never came, the finished-message guard refuses a nested delta after a nested `message-end`, and a nested `run-end` closes an unended message two levels down.

Three commits: the reducer and hook, the review fixes, and the worked example.

## The decisions

**`runMessageIds` is seeded with *every* message in a nested transcript**, where the parent scopes it carefully. That is correct rather than sloppy: a `NestedRun` is keyed by `runId` and only written by events carrying that id, so every message in it belongs to the run that is ending.

**The nested `pending` is dropped.** An escalation reaches the user on the parent's own `awaiting-input` carrying the `path`; the copy inside the sub-run's stream carries no path, so surfacing it would show the question twice with one of the two unanswerable. This is the direct counterpart of `ai/9`'s note that it forwards a sub-run's `awaiting-input` verbatim — the two branches meet exactly here.

**An orphan is dropped, and this is the one place the file's own "create it on the spot" idiom was not followed.** A `ToolCallPart` needs a tool `name` and an `input`, and neither is on a `tool-progress` or a `nested-event`. A fabricated part would put a call the model never made into the transcript under a name that is not a key of the agent's tools, breaking the narrowing that is the entire reason tool shapes are carried into the browser. A lost progress log was traded for a true transcript. Parking orphans until their tool call arrives was considered and rejected: the `tool-call` frame is always *earlier* in the stream, never later, so nothing would ever drain the lot.

**`tool-search` accumulates as a set, not a log.** It fits nowhere progress and nesting went — it names no tool call and no message, because it happens *before* any call, which is the whole reason it is worth showing. Union is the only accumulation that survives redelivery without a guard, and `tool-search` carries no id to key an upsert on. It is reset by `run-start` and surfaces as `loadedTools`.

**`resultFor` refuses a same-id collision rather than guessing.** Nesting makes one reachable for the first time — two sub-runs under two different tools, ids minted by whichever provider ran each — and picking one would silently approve a tool the user was not looking at.

## A real bug the tolerance tests found

`tool-call` upserted by **replacing** the part. `progress` and `nested` arrive on events that name no message, so a replaced part can never rebuild them from anything later in the stream — a run replayed onto a transcript that already held it silently dropped an entire sub-agent transcript while every existing test still passed. `tool-call` now merges: the frame wins where it says anything, the part is kept where it does not. Found by the replay test, not by reading.

## Contract changes

| symbol | change | why |
|---|---|---|
| `UseChatResult.loadedTools` | new required member | Storing tool-search without exposing it would be pointless; it is the field a UI reads to say "looking for the right tool" instead of showing an unexplained pause. `UseChatResult` is re-exported from `gemi/ai/client`, so this is public API — additive, so no app breaks, but an app structurally implementing the interface would now be missing a member. |
| `ChatState.loadedTools` | new required member | Where it lands. Required rather than optional so `run-start` resetting it and the union append never handle `undefined`. `reducer.ts` is deliberately not exported from `client/index.ts`, so this reaches no other slice. |
| `reduce` (`tool-call` case) | merges `progress`/`nested` forward | **Not in the design, and load-bearing** — see above. Behaviour for a call with neither is byte-identical. |

## What the review round changed

Three findings, one blocking. All three real, all three fixed, all mutation-tested both ways.

- **The finished-message guard dropped all progress and all nested events on the resume turn — the escalation path the feature exists for.** `Agent.loop` finalises the message *before* the run parks, so after turn 1 the client's message carries `finishReason: "awaiting-input"` and holds the tool call. On turn 2 `resolveAnswer` re-enters the same tool against the same call id and emits `tool-progress` and `nested-event` for it; `withToolCall` saw a finish reason and dropped every one. Meanwhile `tool-result` goes through `withMessage`, which has no such guard, so the result *did* land — the user saw the call go silent and then produce an answer, which is exactly the bug the design set out to fix. Worse in stateless mode: `ToolCallPart.nested` is what the next turn replays finished sub-runs from, so the client posted a nested transcript frozen at the escalation point and the sub-run that answered the question looked, to the replay logic, like one that never finished.
  **Fixed with a narrower guard than the one suggested.** The reviewer's `finishReason === "awaiting-input"` carve-out re-opens a parked message to every *replay* of it, and the `runMessageIds` alternative they floated as stricter is actually wrong: `ingestTurn` attaches each result before starting the next tool, so a second parked call's progress arrives after this run has already written to the message and would be dropped. The guard is now **parked *and* the call still open**, open being the server's own `openCalls` definition — no `tool-result` for that id anywhere in the transcript. Once the result lands the call is closed again, so a replay of a parked run still adds nothing. Restoring the old guard fails 5 tests; widening the carve-out to parked-only fails 1.
- **A run that ended while a sub-run was live left the nested message unfinished, so the nested block streamed forever.** `finishUnended` only mapped top-level messages, so `run-end` and `markAborted` left a nested message with no `finishReason` — and the whole premise of the slice is that `run.messages` renders with the component that renders `messages`, so that component reads a missing reason as "still streaming" and draws a live cursor in a block that will never receive another frame. `markAborted` in particular could not be fixed one branch down: `stop()` calls it optimistically before the server has said anything, so no forwarded nested `run-end` can arrive in time. Now `finishUnended → closeMessage → closeRun → finishUnended` recurses, so depth costs nothing, and the descent runs even when the message's own reason is already set — which is exactly the parked-message case, where the two findings meet.
- **`progress` grew without bound and was re-uploaded on every stateless turn, though nothing server-side reads it.** Verified: no provider translates it, `openCalls`/`resolveAnswer` match on `toolCallId`, and the resume path replays a sub-agent from `nested`. A tool yielding 5,000 progress objects on turn 1 made every later turn POST all 5,000. **Fixed on the wire rather than in the reducer** — capping the log would lose data a UI legitimately asked for, and the problem is the wire, not the tab. A new `forWire` strips `progress` from the posted history, recursing into `nested` (a sub-agent's own yields are the same dead weight one level down) while keeping `nested` itself for the replay path. The client's own `state.messages` is untouched, so the UI keeps every yield.

**One existing assertion moved as a consequence**, and it is worth knowing why: `NESTED_ASK`'s nested message now carries `"awaiting-input"` from the parent's `run-end`. That is what a real runtime would have sent — the sub-agent finalises its message before escalating — and the fixture simply never sent it. The safety net converges on the truth. Noted in the test.

## The example

The client half of the worked example, and the place the contract slice's type work either survives the trip into the browser or quietly does not. `Chat` now walks `part.nested` and hands each `run.messages` to an ordinary transcript renderer — the claim nesting is built on, stated as something that compiles — reads `part.progress` off the `bash` call, answers a question carrying a `path` with the same `answer()` a top-level one takes, and reads `loadedTools`.

Five sites, mutation-checked one at a time. **Two of the compiler errors are the interesting part.** Misspelling the yielded field reports `Property 'lines' does not exist on type '{ line: string; }'`, so a generator tool's `Progress` really does reach the browser inferred rather than as `unknown`. And the non-yielding `research` call's part comes back typed `progress?: never[]` — so a tool that cannot yield gives a UI nothing to render instead of an `unknown` to narrow by hand. That is the whole point of `ai/7` defaulting `Progress` to `never`, now checked end to end through `AgentTool.create → ToolShapesOf →` the route `→ useChat` rather than asserted in a type test.

## Verification

At this branch, in a clean worktree: `bun run typecheck` clean (package and `ide/typescript-plugin`); `bun run test:types` 8 files / 84 passed / no type errors; `bun --bun vitest run` **180 files / 4392 passed / 1 skipped**. `templates/saas-starter` not run.

That is 38 tests above the `ai/9-nested-runs` baseline of 4354. `client/reducer.test-d.ts` is new and closes the last link `ai/7` could not: that `T` survives `ChatState<T,O>` down through `AgentMessage` into a content part, and — the negative that matters — that `NestedRun["messages"]` is **not** typed with the parent's shapes. The tempting mistake there would compile, and would name every sub-agent's tools after its parent's.

A first full run during development showed 2 timeouts in `ide/typescript-plugin/plugin.test.ts`, a cold-transform-cache flake in a file this change cannot reach; it passes in isolation with and without these changes, and every run since — including the one above, on a cold worktree — has been green.

## Still open

- **An orphaned `tool-progress` or `nested-event` is dropped**, so that sub-run does not render. This is the `/attach`-with-a-cursor-but-no-messages case `useChat` already documents as the bug that doubles text. Tested and named, not fixed; see the `withToolCall` comment for why materialising a stub part was the wrong answer. Convergence there is unachievable either way — the part itself is below the cursor.
- **`NestedRun.usage` is lifted only when a nested event carries a `usage` event**, and `finishReason` has the same dependency on a forwarded nested `run-end`. A runtime that rolled sub-run usage into the parent total without forwarding the sub-run's own frame would leave a UI pricing a nested block with nothing to show. `ai/9` does forward both, and `ai/11` asserts it live.
- **`loadedTools` is not restorable** — `initialChatState` takes no seed for it — so a refresh during a long tool search shows an empty list until the next frame. Deliberate (it describes a run in progress, not the transcript), but it means the indicator is wrong rather than merely stale on a mid-search reattach.
- **The same-id refusal in `resultFor` gives an app no escape hatch.** If two sub-agents genuinely hold calls with the same id, neither can be answered through `approve`/`answer`, and the only way out is a fresh turn — which the server reads as refusing both. Refusing beats guessing, but an id+path overload would be the honest fix if it ever shows up.
- `path` is sent back on a `ClientToolResult` and is now hashed by `ai/9`'s `claimFields` — but only when non-empty, so an absent path still produces the old eight-field MAC byte-for-byte. Nothing in this slice can affect that either way.
- **Every frame in these tests is hand-constructed**, so an ordering assumption read out of `Agent.ts` — that `runTools` emits every progress and nested event *before* `finalizeMessage` closes the parent message — is not verified here against the real runtime. That assumption is what makes the replay guard safe. `ai/11` drives this reducer over frames from real runs and asserts exactly that, which is the integration check this gap asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnj9jSx45LoYp5tiv1W8Nw
