### PR TITLE
A message resolved on a later turn replaces its earlier self in the store

### DIFF
--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -2,7 +2,8 @@ process.env.SECRET ??= "agent-test-secret";
 
 import { describe, expect, test, vi } from "vitest";
 import { Agent, AgentTool, Skill, ToolNamespace } from "./Agent";
-import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "./AgentProvider";
+import type { AgentProvider, ProviderEvent } from "./AgentProvider";
+import { fakeProvider } from "./providers/fakeProvider";
 import type { Schema } from "./Schema";
 import { readSignature, verifyPendingCall } from "./signing";
 import type {
@@ -76,53 +77,6 @@ const usage = (inputTokens: number, outputTokens: number): Usage => ({
   outputTokens,
   totalTokens: inputTokens + outputTokens,
 });
-
-/**
- * Scripted `ProviderEvent`s, one script per model call.
- *
- * The real provider is written against the same interface elsewhere; depending
- * on it here would make these tests a test of two things at once, and would
- * need a network.
- */
-class FakeProvider {
-  readonly model = "fake";
-  readonly capabilities = {
-    reasoning: true,
-    structuredOutput: true,
-    fileInput: true,
-    parallelToolCalls: true,
-    toolSearch: true,
-  };
-  readonly calls: ProviderStreamParams[] = [];
-
-  constructor(private scripts: ProviderEvent[][]) {}
-
-  stream(params: ProviderStreamParams) {
-    this.calls.push(params);
-    const script = this.scripts[this.calls.length - 1] ?? [
-      { type: "finish", reason: "stop", usage: usage(0, 0) },
-    ];
-    return (async function* () {
-      for (const event of script) yield event;
-    })();
-  }
-
-  async upload() {
-    return "file_1";
-  }
-
-  normalizeError(error: unknown) {
-    return {
-      code: "provider_error" as const,
-      message: error instanceof Error ? error.message : String(error),
-      retryable: false,
-    };
-  }
-}
-
-function fakeProvider(...scripts: ProviderEvent[][]) {
-  return new FakeProvider(scripts) as unknown as AgentProvider & FakeProvider;
-}
 
 function deferred<T = void>() {
   let resolve!: (value: T) => void;

--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -1,11 +1,12 @@
 process.env.SECRET ??= "agent-test-secret";
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { Agent, AgentTool, Skill, ToolNamespace } from "./Agent";
 import type { AgentProvider, ProviderEvent } from "./AgentProvider";
 import { fakeProvider } from "./providers/fakeProvider";
 import type { Schema } from "./Schema";
 import { readSignature, verifyPendingCall } from "./signing";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS } from "./store/sse";
 import type {
   AgentMessage,
   AgentStreamEvent,
@@ -950,6 +951,91 @@ describe("a run outliving its request", () => {
     expect(body.startsWith("id: 2\ndata: {")).toBe(true);
     expect(body).toContain('"type":"text-delta"');
     expect(body.endsWith("\n\n")).toBe(true);
+  });
+});
+
+describe("toResponse keepalive", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Reads until a read stays pending, and hands that pending read back.
+   *
+   * Boxed rather than returned bare: an async function that returns a promise
+   * adopts it, and the caller would then be waiting for the very chunk the
+   * test has not produced yet.
+   */
+  async function untilSilent(reader: ReadableStreamDefaultReader<Uint8Array>) {
+    while (true) {
+      let settled = false;
+      const next = reader.read().then((chunk) => {
+        settled = true;
+        return chunk;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      if (!settled) return { next };
+    }
+  }
+
+  test("a comment line goes out while a tool is running, and no timer outlives the stream", async () => {
+    vi.useFakeTimers();
+    const started = deferred();
+    const release = deferred<any>();
+    const slow = AgentTool.create({
+      name: "slow",
+      description: "Finishes eventually",
+      inputSchema: anything(),
+      execute: () => {
+        started.resolve();
+        return release.promise;
+      },
+    });
+    const provider = fakeProvider([toolCall("c1", "slow", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "patient", provider, tools: [slow] });
+    const run = agent.stream({ messages: [], req });
+
+    const reader = run.toResponse().body!.getReader();
+    const bytes = new TextDecoder();
+    await started.promise;
+
+    // The tool is running and nothing has been written for a while.
+    const { next } = await untilSilent(reader);
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await next).value)).toBe(SSE_KEEPALIVE);
+
+    release.resolve({ ok: true });
+    let last = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      last = bytes.decode(value);
+    }
+    expect(last).toContain('"type":"run-end"');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a reader that cancels leaves no timer behind either", async () => {
+    vi.useFakeTimers();
+    const release = deferred<any>();
+    const slow = AgentTool.create({
+      name: "slow",
+      description: "Finishes eventually",
+      inputSchema: anything(),
+      execute: () => release.promise,
+    });
+    const provider = fakeProvider([toolCall("c1", "slow", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "patient", provider, tools: [slow] });
+    const run = agent.stream({ messages: [], req });
+
+    const response = run.toResponse();
+    expect(vi.getTimerCount()).toBe(1);
+    await response.body!.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+
+    release.resolve({ ok: true });
+    expect((await run.result()).finishReason).toBe("stop");
   });
 });
 

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -14,6 +14,7 @@ import {
   verifyNestedRun,
   verifyPendingCall,
 } from "./signing";
+import { sseKeepalive } from "./store/sse";
 import type {
   AgentError,
   AgentMessage,
@@ -1284,8 +1285,14 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
     const encoder = new TextEncoder();
     let cancelled = false;
 
+    let keepalive!: ReturnType<typeof sseKeepalive>;
+
     const body = new ReadableStream<Uint8Array>({
       start: async (controller) => {
+        // A slow tool or a thinking sub-agent can leave the connection silent
+        // for longer than a proxy's idle timeout, and a proxy that closes it
+        // looks to the client exactly like a run that finished.
+        keepalive = sseKeepalive(controller);
         try {
           for await (const frame of frames) {
             if (cancelled) break;
@@ -1294,11 +1301,13 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
             controller.enqueue(
               encoder.encode(`id: ${frame.seq}\ndata: ${JSON.stringify(frame.event)}\n\n`),
             );
+            keepalive.touch();
           }
         } catch {
           // A stream that cannot be written to is a dead reader, not a dead
           // run. Nothing to report and nothing to stop.
         }
+        keepalive.stop();
         try {
           controller.close();
         } catch {
@@ -1311,6 +1320,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
         // tool loop is here and a closed tab has not stopped step four from
         // charging a card.
         cancelled = true;
+        keepalive.stop();
       },
     });
 

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -454,6 +454,152 @@ describe("AgentController.stream", () => {
   });
 });
 
+describe("one live run per thread", () => {
+  /** A controller whose agent hands out the given runs, in order. */
+  function threaded(runs: StubAgentRun[], store = new MemoryAgentStore()) {
+    const queue = runs.slice();
+    const seen: AgentStreamParams[] = [];
+    const liveRuns = new MemoryLiveRuns();
+    class Chat extends AgentController {
+      agent = {
+        provider: {},
+        stream: (params: AgentStreamParams) => {
+          seen.push(params);
+          return queue.shift()!;
+        },
+      } as any;
+      liveRuns = liveRuns;
+      store = store;
+    }
+    return { Chat, seen, store, liveRuns };
+  }
+
+  /**
+   * The issue's interleaving. A send while the first answer is streaming used
+   * to abort only the connection, which no longer stops a run: the first kept
+   * going, blind to the second turn; the second loaded a history without the
+   * first's answer; and both appended when they finished, in whichever order
+   * the model returned them. With the first slower, the thread read
+   * `user2, assistant2, user1, assistant1`.
+   */
+  test("a second turn stops the first run and waits for its transcript to land", async () => {
+    const first = new StubAgentRun("run_1");
+    const second = new StubAgentRun("run_2");
+    const { Chat, seen, store } = threaded([first, second]);
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, text: "first" }));
+    expect(first.stopped).toBe(false);
+
+    // Held, not refused: this resolves only once the first run is in the store.
+    let started = false;
+    const pending = new Chat()
+      .stream(jsonRequest({ threadId, text: "second" }))
+      .then((response) => {
+        started = true;
+        return response;
+      });
+    await settle();
+
+    expect(first.stopped).toBe(true);
+    expect(started).toBe(false);
+    // The second run has not been asked for, so nothing has loaded the thread
+    // without the first answer in it.
+    expect(seen).toHaveLength(1);
+
+    // The provider answering in reverse order: the first run finishes last from
+    // the client's point of view, but the second cannot start before it.
+    first.finish({
+      messages: [message("u1", "user", "first"), message("a1", "assistant", "one…")],
+    });
+    const response = await pending;
+    expect(response.headers.get("X-Stub-Run")).toBe("run_2");
+    expect(seen[1]!.messages.map((m) => m.id)).toEqual(["u1", "a1"]);
+
+    second.finish({
+      messages: [message("u2", "user", "second"), message("a2", "assistant", "two")],
+    });
+    await settle();
+
+    expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
+  });
+
+  /**
+   * Two turns arriving together both see the same live run, both stop it and
+   * both wait for it; without the lock both then start, and the third answer
+   * never sees the second turn — the same race, one message later.
+   */
+  test("a third turn waits for the second, not just for the first", async () => {
+    const runs = [new StubAgentRun("run_1"), new StubAgentRun("run_2"), new StubAgentRun("run_3")];
+    const { Chat, seen, store } = threaded(runs);
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, text: "first" }));
+    const second = new Chat().stream(jsonRequest({ threadId, text: "second" }));
+    const third = new Chat().stream(jsonRequest({ threadId, text: "third" }));
+    await settle();
+    expect(seen).toHaveLength(1);
+
+    runs[0]!.finish({
+      messages: [message("u1", "user", "first"), message("a1", "assistant", "one")],
+    });
+    await second;
+    await settle();
+    // The third found the second registered and stopped that, rather than
+    // starting alongside it.
+    expect(seen).toHaveLength(2);
+    expect(runs[1]!.stopped).toBe(true);
+
+    runs[1]!.finish({
+      messages: [message("u2", "user", "second"), message("a2", "assistant", "two")],
+    });
+    await third;
+    expect(seen[2]!.messages.map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
+
+    runs[2]!.finish({
+      messages: [message("u3", "user", "third"), message("a3", "assistant", "three")],
+    });
+    await settle();
+    expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "u2",
+      "a2",
+      "u3",
+      "a3",
+    ]);
+  });
+
+  test("a finished run still within its ttl holds nothing up", async () => {
+    const first = new StubAgentRun("run_1");
+    const second = new StubAgentRun("run_2");
+    const { Chat, seen } = threaded([first, second]);
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, text: "first" }));
+    first.finish({ messages: [message("u1", "user", "first")] });
+    await settle();
+
+    await new Chat().stream(jsonRequest({ threadId, text: "second" }));
+    expect(seen).toHaveLength(2);
+    second.finish();
+  });
+
+  test("stateless turns are not serialized: there is no thread to hold", async () => {
+    const first = new StubAgentRun("run_1");
+    const second = new StubAgentRun("run_2");
+    const { Chat, seen } = threaded([first, second]);
+
+    await new Chat().stream(jsonRequest({ text: "first" }));
+    await new Chat().stream(jsonRequest({ text: "second" }));
+
+    expect(seen).toHaveLength(2);
+    expect(first.stopped).toBe(false);
+    first.finish();
+    second.finish();
+  });
+});
+
 describe("AgentController.attach", () => {
   function attachable(runId = "run_a") {
     const run = new StubAgentRun(runId);

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -1,13 +1,17 @@
+process.env.SECRET ??= "agent-controller-test-secret";
+
 import { describe, expect, test } from "vitest";
 
 import { HttpRequest } from "../http/HttpRequest";
-import type { AgentStreamParams } from "./Agent";
+import { Agent, AgentTool, type AgentStreamParams } from "./Agent";
 import {
   AgentController,
   defaultAgentStore,
   MemoryAgentStore,
   MemoryLiveRuns,
 } from "./AgentController";
+import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "./AgentProvider";
+import { s } from "./Schema";
 import { StubAgentRun } from "./store/stubAgentRun";
 import type { AgentMessage, AgentStreamEvent, PendingToolCall } from "./types";
 
@@ -77,6 +81,52 @@ async function readSse(response: Response): Promise<string> {
   return await response.text();
 }
 
+/** The events in an SSE body, in order. */
+async function eventsOf(response: Response): Promise<AgentStreamEvent[]> {
+  return (await readSse(response))
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice("data: ".length)));
+}
+
+/**
+ * A provider that plays one script per model call, for the tests that need a
+ * real `Agent` behind the controller rather than a stub run: what the store
+ * ends up holding depends on what the agent reports, and a stub run reports
+ * whatever the test hands it.
+ */
+function scriptedProvider(...scripts: ProviderEvent[][]) {
+  let call = 0;
+  return {
+    model: "fake",
+    capabilities: {
+      reasoning: true,
+      structuredOutput: true,
+      fileInput: true,
+      parallelToolCalls: true,
+      toolSearch: true,
+    },
+    stream(_params: ProviderStreamParams) {
+      const script = scripts[call++] ?? [];
+      return (async function* () {
+        for (const event of script) yield event;
+      })();
+    },
+    upload: async () => "file_1",
+    normalizeError: (error: unknown) => ({
+      code: "provider_error" as const,
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    }),
+  } as unknown as AgentProvider;
+}
+
+const finish = (): ProviderEvent => ({
+  type: "finish",
+  reason: "stop",
+  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+});
+
 describe("AgentController.stream", () => {
   test("runs stateless on the history the client sent", async () => {
     const run = new StubAgentRun("run_1");
@@ -135,6 +185,73 @@ describe("AgentController.stream", () => {
     await settle();
 
     expect((await store.loadThread(threadId))!.map((m) => m.id)).toEqual(["u0", "u1", "a1"]);
+  });
+
+  /**
+   * The message that made the call comes back from the second run under the
+   * id it already had, with the result attached. Persisting that turn must
+   * replace the earlier copy, not sit next to it — otherwise every later turn
+   * sends the model the same call twice.
+   */
+  test("a threaded approval leaves one message per id in the store", async () => {
+    const refunded: string[] = [];
+    const refundOrder = AgentTool.create({
+      name: "refundOrder",
+      description: "Refund an order",
+      inputSchema: s.object({ orderId: s.string() }),
+      outputSchema: s.object({ refundId: s.string() }),
+      requiresApproval: true,
+      execute: async ({ orderId }) => {
+        refunded.push(orderId);
+        return { refundId: `rf_${orderId}` };
+      },
+    });
+    const provider = scriptedProvider(
+      [
+        { type: "tool-call", toolCallId: "c1", name: "refundOrder", args: '{"orderId":"ord_1"}' },
+        finish(),
+      ],
+      [{ type: "text-delta", delta: "refunded" }, finish()],
+    );
+    const agent = Agent.create({ name: "support", provider, tools: [refundOrder] });
+    const store = new MemoryAgentStore();
+
+    class Chat extends AgentController {
+      agent = agent;
+      liveRuns = new MemoryLiveRuns();
+      store = store;
+    }
+
+    const first = await eventsOf(
+      await new Chat().stream(jsonRequest({ threadId: "t1", text: "refund it" })),
+    );
+    await settle();
+    const awaiting = first.find((event) => event.type === "awaiting-input") as any;
+    expect(awaiting?.pending).toHaveLength(1);
+    expect(refunded).toEqual([]);
+
+    await eventsOf(
+      await new Chat().stream(
+        jsonRequest({
+          threadId: "t1",
+          toolResults: [
+            { toolCallId: "c1", signature: awaiting.pending[0].signature, approve: true },
+          ],
+        }),
+      ),
+    );
+    await settle();
+
+    expect(refunded).toEqual(["ord_1"]);
+    const held = await store.loadThread("t1");
+    const ids = held.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    // The copy that survived is the amended one, in the place the original had.
+    const amended = held.find((m) => m.content.some((part) => part.type === "tool-call"))!;
+    expect(held.indexOf(amended)).toBe(1);
+    expect(amended.content.map((part) => part.type)).toEqual(["tool-call", "tool-result"]);
+    const calls = held.flatMap((m) => m.content).filter((part) => part.type === "tool-call");
+    expect(calls).toHaveLength(1);
   });
 
   /**

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -10,7 +10,8 @@ import {
   MemoryAgentStore,
   MemoryLiveRuns,
 } from "./AgentController";
-import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "./AgentProvider";
+import type { ProviderEvent } from "./AgentProvider";
+import { fakeProvider } from "./providers/fakeProvider";
 import { s } from "./Schema";
 import { StubAgentRun } from "./store/stubAgentRun";
 import type { AgentMessage, AgentStreamEvent, PendingToolCall } from "./types";
@@ -89,38 +90,6 @@ async function eventsOf(response: Response): Promise<AgentStreamEvent[]> {
     .map((line) => JSON.parse(line.slice("data: ".length)));
 }
 
-/**
- * A provider that plays one script per model call, for the tests that need a
- * real `Agent` behind the controller rather than a stub run: what the store
- * ends up holding depends on what the agent reports, and a stub run reports
- * whatever the test hands it.
- */
-function scriptedProvider(...scripts: ProviderEvent[][]) {
-  let call = 0;
-  return {
-    model: "fake",
-    capabilities: {
-      reasoning: true,
-      structuredOutput: true,
-      fileInput: true,
-      parallelToolCalls: true,
-      toolSearch: true,
-    },
-    stream(_params: ProviderStreamParams) {
-      const script = scripts[call++] ?? [];
-      return (async function* () {
-        for (const event of script) yield event;
-      })();
-    },
-    upload: async () => "file_1",
-    normalizeError: (error: unknown) => ({
-      code: "provider_error" as const,
-      message: error instanceof Error ? error.message : String(error),
-      retryable: false,
-    }),
-  } as unknown as AgentProvider;
-}
-
 const finish = (): ProviderEvent => ({
   type: "finish",
   reason: "stop",
@@ -192,6 +161,10 @@ describe("AgentController.stream", () => {
    * id it already had, with the result attached. Persisting that turn must
    * replace the earlier copy, not sit next to it — otherwise every later turn
    * sends the model the same call twice.
+   *
+   * This one runs a real `Agent` over a scripted provider rather than a stub
+   * run: what the store ends up holding depends on what the agent reports,
+   * and a stub run reports whatever the test hands it.
    */
   test("a threaded approval leaves one message per id in the store", async () => {
     const refunded: string[] = [];
@@ -206,7 +179,7 @@ describe("AgentController.stream", () => {
         return { refundId: `rf_${orderId}` };
       },
     });
-    const provider = scriptedProvider(
+    const provider = fakeProvider(
       [
         { type: "tool-call", toolCallId: "c1", name: "refundOrder", args: '{"orderId":"ord_1"}' },
         finish(),

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -188,6 +188,9 @@ describe("AgentController.stream", () => {
     );
     const agent = Agent.create({ name: "support", provider, tools: [refundOrder] });
     const store = new MemoryAgentStore();
+    // Minted by the store: an id it has never seen is a 404 before the run,
+    // and this test is about what the second run leaves behind.
+    const { threadId } = await store.createThread({});
 
     class Chat extends AgentController {
       agent = agent;
@@ -196,7 +199,7 @@ describe("AgentController.stream", () => {
     }
 
     const first = await eventsOf(
-      await new Chat().stream(jsonRequest({ threadId: "t1", text: "refund it" })),
+      await new Chat().stream(jsonRequest({ threadId, text: "refund it" })),
     );
     await settle();
     const awaiting = first.find((event) => event.type === "awaiting-input") as any;
@@ -206,7 +209,7 @@ describe("AgentController.stream", () => {
     await eventsOf(
       await new Chat().stream(
         jsonRequest({
-          threadId: "t1",
+          threadId,
           toolResults: [
             { toolCallId: "c1", signature: awaiting.pending[0].signature, approve: true },
           ],
@@ -216,7 +219,7 @@ describe("AgentController.stream", () => {
     await settle();
 
     expect(refunded).toEqual(["ord_1"]);
-    const held = await store.loadThread("t1");
+    const held = (await store.loadThread(threadId))!;
     const ids = held.map((m) => m.id);
     expect(new Set(ids).size).toBe(ids.length);
     // The copy that survived is the amended one, in the place the original had.

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -486,7 +486,7 @@ describe("one live run per thread", () => {
     const first = new StubAgentRun("run_1");
     const second = new StubAgentRun("run_2");
     const { Chat, seen, store } = threaded([first, second]);
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { threadId } = await store.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, text: "first" }));
     expect(first.stopped).toBe(false);
@@ -532,7 +532,7 @@ describe("one live run per thread", () => {
   test("a third turn waits for the second, not just for the first", async () => {
     const runs = [new StubAgentRun("run_1"), new StubAgentRun("run_2"), new StubAgentRun("run_3")];
     const { Chat, seen, store } = threaded(runs);
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { threadId } = await store.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, text: "first" }));
     const second = new Chat().stream(jsonRequest({ threadId, text: "second" }));
@@ -586,7 +586,7 @@ describe("one live run per thread", () => {
         return new Promise(() => {});
       }
     }
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { threadId } = await store.createThread({});
 
     await new Hanging().stream(jsonRequest({ threadId, text: "first" }));
     const pending = new Hanging().stream(jsonRequest({ threadId, text: "second" }));
@@ -614,8 +614,8 @@ describe("one live run per thread", () => {
    */
   test("a stop that names a turn still waiting its place ends it before it starts", async () => {
     const runs = [new StubAgentRun("run_1"), new StubAgentRun("run_2")];
-    const { Chat, seen } = threaded(runs);
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { Chat, seen, store } = threaded(runs);
+    const { threadId } = await store.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, clientRunId: "c1", text: "first" }));
     const waiting = new Chat().stream(jsonRequest({ threadId, clientRunId: "c2", text: "second" }));
@@ -647,8 +647,8 @@ describe("one live run per thread", () => {
   test("a finished run still within its ttl holds nothing up", async () => {
     const first = new StubAgentRun("run_1");
     const second = new StubAgentRun("run_2");
-    const { Chat, seen } = threaded([first, second]);
-    const threadId = `t-${crypto.randomUUID()}`;
+    const { Chat, seen, store } = threaded([first, second]);
+    const { threadId } = await store.createThread({});
 
     await new Chat().stream(jsonRequest({ threadId, text: "first" }));
     first.finish({ messages: [message("u1", "user", "first")] });

--- a/packages/gemi/ai/AgentController.test.ts
+++ b/packages/gemi/ai/AgentController.test.ts
@@ -570,6 +570,80 @@ describe("one live run per thread", () => {
     ]);
   });
 
+  /**
+   * What the next turn waits for is the transcript in the store, not the app's
+   * hooks on it. Those are the app's own: an `onStreamComplete` that writes to
+   * something slow would be paid by every later turn, and one that never
+   * settles would hold the thread and every turn queued on it, each an open
+   * connection.
+   */
+  test("a hook that never settles does not hold the thread", async () => {
+    const first = new StubAgentRun("run_1");
+    const second = new StubAgentRun("run_2");
+    const { Chat, seen, store } = threaded([first, second]);
+    class Hanging extends Chat {
+      protected onStreamComplete(): Promise<void> {
+        return new Promise(() => {});
+      }
+    }
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Hanging().stream(jsonRequest({ threadId, text: "first" }));
+    const pending = new Hanging().stream(jsonRequest({ threadId, text: "second" }));
+    await settle();
+
+    first.finish({
+      messages: [message("u1", "user", "first"), message("a1", "assistant", "one")],
+    });
+    const response = await pending;
+    expect(response.headers.get("X-Stub-Run")).toBe("run_2");
+    // Started on the stored transcript: the wait was for the append, and only
+    // for the append.
+    expect(seen[1]!.messages.map((m) => m.id)).toEqual(["u1", "a1"]);
+    expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual(["u1", "a1"]);
+    second.finish();
+  });
+
+  /**
+   * Send, send again, then stop. The second turn is waiting behind the first
+   * run's unwind, and until it starts there is no run for `/stop` to find by
+   * `clientRunId`. Falling through to `threadId` found the first run, already
+   * stopping, answered `{ stopped: true }`, and the second turn started anyway
+   * once the first unwound — unwatched, billing, and with no handle left on the
+   * client, which had let go of the request and never saw its `run-start`.
+   */
+  test("a stop that names a turn still waiting its place ends it before it starts", async () => {
+    const runs = [new StubAgentRun("run_1"), new StubAgentRun("run_2")];
+    const { Chat, seen } = threaded(runs);
+    const threadId = `t-${crypto.randomUUID()}`;
+
+    await new Chat().stream(jsonRequest({ threadId, clientRunId: "c1", text: "first" }));
+    const waiting = new Chat().stream(jsonRequest({ threadId, clientRunId: "c2", text: "second" }));
+    await settle();
+    expect(seen).toHaveLength(1);
+
+    // What `useChat.stop()` sends for a turn whose `run-start` never came.
+    expect(await new Chat().stop(jsonRequest({ threadId, clientRunId: "c2" }))).toEqual({
+      stopped: true,
+    });
+
+    runs[0]!.finish({
+      messages: [message("u1", "user", "first"), message("a1", "assistant", "one")],
+    });
+    const response = await waiting;
+    expect(response.status).toBe(409);
+    expect(((await response.json()) as any).error.code).toBe("stopped");
+    // The model was never asked, and nothing was registered for `/stop` to
+    // have missed.
+    expect(seen).toHaveLength(1);
+
+    // And the thread is free: the next turn starts as usual.
+    await new Chat().stream(jsonRequest({ threadId, clientRunId: "c3", text: "third" }));
+    expect(seen).toHaveLength(2);
+    expect(seen[1]!.messages.map((m) => m.id)).toEqual(["u1", "a1"]);
+    runs[1]!.finish();
+  });
+
   test("a finished run still within its ttl holds nothing up", async () => {
     const first = new StubAgentRun("run_1");
     const second = new StubAgentRun("run_2");

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -124,6 +124,21 @@ export type AgentHookContext = {
  */
 const ControllerBase = Controller as new () => Controller;
 
+/**
+ * The thread a `stream` is setting up on, to the setup ahead of it. Module
+ * level because the controller is constructed per request, so nothing on it
+ * can be seen by the next request; keyed by thread rather than held on
+ * `liveRuns` because it guards the controller's protocol, not the frames. An
+ * entry is removed once the last setup queued on it releases.
+ */
+const threadLocks = new Map<string, Promise<void>>();
+
+/**
+ * Each run to the promise that its transcript has been stored. Weak, so a run
+ * the map has evicted is not kept alive here for a promise nobody will ask for.
+ */
+const persisted = new WeakMap<AgentRun, Promise<void>>();
+
 export abstract class AgentController<A extends AnyAgent = AnyAgent> extends ControllerBase {
   static kind = "agent-controller" as const;
 
@@ -185,63 +200,135 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     // or a `store` that scopes by `req.user`. The framework's job is to make
     // sure the route is behind the router's middleware in the first place,
     // which `ApiRouter.agent()` now does.
-    let messages: AgentMessage[];
-    if (threadId) {
-      const history = await this.store.loadThread(threadId);
-      if (!history) {
-        // Before `instructions()` and before the run: nothing has been
-        // charged for, and the client has to learn that its thread is gone —
-        // expired, mistyped, or on an instance that no longer exists — rather
-        // than see it answered as an empty conversation and have this turn
-        // persisted under the dead id.
-        //
-        // That ordering is deliberate, and it costs something: the ownership
-        // check the comment above points at `instructions()` for has not run
-        // yet, so a caller holding a uuid learns whether it is live here
-        // without the app's say. `/attach` already answers a question of that
-        // shape to anyone with the id and never calls `instructions()`, and
-        // the id is unguessable — which is why the load stays above
-        // `instructions()`, whose own work (a database read, typically) would
-        // otherwise be spent on a thread that is gone. Move it below and that
-        // work is spent on every dead id instead.
-        return jsonResponse(404, {
-          code: "thread_not_found",
-          message: `Thread ${threadId} does not exist here, or has expired.`,
-        });
+    //
+    // Everything from the load on happens inside `start`, which on a thread
+    // runs under the thread's lock once the previous run's transcript is in the
+    // store — the load has to come after that, or it reads a history the old
+    // answer is missing from. `instructions()` follows the load in there rather
+    // than running ahead of the lock, so that a dead thread is still a 404
+    // before the app's own work is spent on it; the cost is that a turn queued
+    // behind this one waits for `instructions()` as well.
+    const start = async (): Promise<Response> => {
+      let messages: AgentMessage[];
+      if (threadId) {
+        const history = await this.store.loadThread(threadId);
+        if (!history) {
+          // Before `instructions()` and before the run: nothing has been
+          // charged for, and the client has to learn that its thread is gone —
+          // expired, mistyped, or on an instance that no longer exists — rather
+          // than see it answered as an empty conversation and have this turn
+          // persisted under the dead id.
+          //
+          // That ordering is deliberate, and it costs something: the ownership
+          // check the comment above points at `instructions()` for has not run
+          // yet, so a caller holding a uuid learns whether it is live here
+          // without the app's say. `/attach` already answers a question of that
+          // shape to anyone with the id and never calls `instructions()`, and
+          // the id is unguessable — which is why the load stays above
+          // `instructions()`, whose own work (a database read, typically) would
+          // otherwise be spent on a thread that is gone. Move it below and that
+          // work is spent on every dead id instead.
+          return jsonResponse(404, {
+            code: "thread_not_found",
+            message: `Thread ${threadId} does not exist here, or has expired.`,
+          });
+        }
+        messages = history;
+      } else {
+        messages = Array.isArray(body.messages) ? (body.messages as AgentMessage[]) : [];
       }
-      messages = history;
-    } else {
-      messages = Array.isArray(body.messages) ? (body.messages as AgentMessage[]) : [];
-    }
 
-    const instructions = (await this.instructions(req)) || undefined;
+      const instructions = (await this.instructions(req)) || undefined;
 
-    const run = this.agent.stream({
-      messages,
-      turn,
-      req,
-      threadId,
-      instructions,
-    }) as AgentRun;
+      const run = this.agent.stream({
+        messages,
+        turn,
+        req,
+        threadId,
+        instructions,
+      }) as AgentRun;
 
-    const ctx: AgentHookContext = { req, runId: run.runId, threadId };
+      const ctx: AgentHookContext = { req, runId: run.runId, threadId };
 
-    // Registered before the response is built: the run is now owned by the
-    // process rather than by this request, which is the property `/attach`
-    // depends on and the reason a dropped connection no longer cancels
-    // anything.
-    this.liveRuns.register(run, {
-      threadId,
-      // The client's handle on a run it started, which is the only one that
-      // exists before `run-start` reaches it. See `RegisterParams`.
-      clientRunId: typeof body.clientRunId === "string" ? body.clientRunId : undefined,
-      onEvent: (event) => this.dispatchEvent(event, ctx),
-      onInternalError: (err) => this.reportHookFailure(err),
+      // Registered before the response is built: the run is now owned by the
+      // process rather than by this request, which is the property `/attach`
+      // depends on and the reason a dropped connection no longer cancels
+      // anything.
+      this.liveRuns.register(run, {
+        threadId,
+        // The client's handle on a run it started, which is the only one that
+        // exists before `run-start` reaches it. See `RegisterParams`.
+        clientRunId: typeof body.clientRunId === "string" ? body.clientRunId : undefined,
+        onEvent: (event) => this.dispatchEvent(event, ctx),
+        onInternalError: (err) => this.reportHookFailure(err),
+      });
+
+      // Kept, not just fired: the next turn on this thread has to know when
+      // this one's transcript is in the store. See `withThread`.
+      persisted.set(run, this.persistRun(run, ctx));
+
+      return run.toResponse();
+    };
+
+    return threadId ? await this.withThread(threadId, start) : await start();
+  }
+
+  /**
+   * A thread holds one run at a time; a new turn on it ends the old one first.
+   *
+   * Since a dropped connection no longer stops a run, a user who sends again
+   * mid-answer used to leave the first run going. It could not see the new
+   * turn, the new run's `loadThread` could not see its answer, and both
+   * appended when they finished — in whichever order the model returned them,
+   * so the thread read `user2, assistant2, user1, assistant1`. `byThread` then
+   * named the second run while the first was still live and unstoppable by
+   * `threadId`.
+   *
+   * Stopping the old run and waiting for its transcript to land is chosen over
+   * refusing the new turn with a 409, because sending again *is* the stop: it
+   * is what `useChat.send` means, and a client that has to poll `/stop` until
+   * the run is really gone before it may post the turn it has already shown is
+   * a worse client for no better thread. The cost is that the new turn waits
+   * for the old run to unwind, which is as long as its slowest tool in flight —
+   * and that wait is the thing that puts `assistant1` before `user2`.
+   *
+   * The wait is on `persistRun`, not on `run.result()`. `result()` settling is
+   * the transcript being final, not stored: `appendMessages` runs after it, and
+   * a `loadThread` in that gap reads a history the old answer is missing from,
+   * which is the original bug by a shorter route.
+   *
+   * The lock around it is what makes a *third* turn wait for the second rather
+   * than for the first. Two turns arriving together both see the same live
+   * run, both stop it, both wait for it, and both start — the same race, one
+   * message later. Under the lock the later one finds the earlier one
+   * registered and stops that instead. Per process, like `LiveRuns`, and for
+   * the same reason: the run it guards lives here.
+   */
+  private async withThread<T>(threadId: string, fn: () => Promise<T>): Promise<T> {
+    const previous = threadLocks.get(threadId) ?? Promise.resolve();
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
     });
-
-    void this.persistRun(run, ctx);
-
-    return run.toResponse();
+    const tail = previous.then(() => held);
+    threadLocks.set(threadId, tail);
+    await previous;
+    try {
+      const live = await this.liveRuns.find({ threadId });
+      const run = live ? this.liveRuns.get(live.runId) : null;
+      if (run) {
+        // A run that already ended is still `find`-able for `ttlMs`; stopping
+        // it is a no-op and waiting on it is the append it may still be doing.
+        run.stop({ reason: "superseded by a later turn on this thread" });
+        await persisted.get(run);
+      }
+      return await fn();
+    } finally {
+      release();
+      if (threadLocks.get(threadId) === tail) {
+        threadLocks.delete(threadId);
+      }
+    }
   }
 
   /**
@@ -324,9 +411,10 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
 
   /**
    * `POST /<path>/stop` — the explicit cancel. Since a dropped connection no
-   * longer stops a run, this is the only thing that does, and it is why
-   * stopping cannot be a client-side concern: the tool loop is here, and a
-   * client that stops reading has not stopped step four from charging a card.
+   * longer stops a run, this and a later turn on the same thread are the only
+   * things that do, and it is why stopping cannot be a client-side concern:
+   * the tool loop is here, and a client that stops reading has not stopped
+   * step four from charging a card.
    *
    * Returns as soon as the run is aborted, not when it has finished unwinding.
    * The terminal events — the stopped tool results, the aborted message — go

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -53,7 +53,17 @@ export interface AgentStore {
    * and then on purpose — see `MemoryAgentStore`'s `clientOwnedIds`.
    */
   loadThread(threadId: string): Promise<AgentMessage[] | null>;
-  /** Called with a thread `loadThread` just found. Must not create one. */
+  /**
+   * Upsert by message id: replace a message the thread already holds, append
+   * one it does not, and keep the order the thread had. Called with a thread
+   * `loadThread` just found; must not create one.
+   *
+   * The name says append because that is what almost every call is, but a
+   * turn that resolves a pending call reports the earlier assistant message
+   * again — same id, now with the result attached — and a store that only
+   * appends ends up with both versions. A table keyed by message id gets this
+   * for free; a store that is a list has to look before it pushes.
+   */
   appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
 }
 

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -61,8 +61,10 @@ export interface AgentStore {
    * The name says append because that is what almost every call is, but a
    * turn that resolves a pending call reports the earlier assistant message
    * again — same id, now with the result attached — and a store that only
-   * appends ends up with both versions. A table keyed by message id gets this
-   * for free; a store that is a list has to look before it pushes.
+   * appends ends up with both versions. A table keyed by message id has the
+   * lookup already but still needs an insert-or-update rather than a plain
+   * insert, which would fail on the key; a store that is a list has to look
+   * before it pushes.
    */
   appendMessages(threadId: string, messages: AgentMessage[]): Promise<void>;
 }

--- a/packages/gemi/ai/AgentController.ts
+++ b/packages/gemi/ai/AgentController.ts
@@ -139,6 +139,20 @@ const threadLocks = new Map<string, Promise<void>>();
  */
 const persisted = new WeakMap<AgentRun, Promise<void>>();
 
+/**
+ * Turns read but not yet registered, by the client's name for them.
+ *
+ * A run can be stopped from `register` on, and named from `run-start` on. What
+ * `/stop` could not reach was a turn still waiting its place on the thread —
+ * which is where a user who sent twice and thought better of it presses stop,
+ * and the wait is now as long as the old run's unwind. Falling through to
+ * `threadId` there found the old run, already stopping, said `stopped: true`,
+ * and the queued turn started anyway: unwatched, billing, and with no handle
+ * left on the client that had let go of it. The entry is marked rather than
+ * removed, because the turn itself is what answers once its wait is over.
+ */
+const pendingTurns = new Map<string, { cancelled: boolean }>();
+
 export abstract class AgentController<A extends AnyAgent = AnyAgent> extends ControllerBase {
   static kind = "agent-controller" as const;
 
@@ -187,6 +201,14 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     const body = parsed.body;
     const threadId = typeof body.threadId === "string" ? body.threadId : undefined;
     const turn = toClientTurn(body);
+    const clientRunId = typeof body.clientRunId === "string" ? body.clientRunId : undefined;
+
+    // From here until `register`, the only thing `/stop` can find this turn by.
+    // See `pendingTurns`.
+    const pending = clientRunId ? { cancelled: false } : null;
+    if (pending) {
+      pendingTurns.set(clientRunId, pending);
+    }
 
     // The whole of the stateless/threaded difference, in one expression: with a
     // thread the server owns the history, without one the client carries it.
@@ -240,6 +262,17 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
 
       const instructions = (await this.instructions(req)) || undefined;
 
+      if (pending?.cancelled) {
+        // Stopped while it waited. Nothing has been asked of the model and
+        // nothing registered, so there is no run to end and nothing charged
+        // for. Checked after the last `await` above, so that a stop landing
+        // during it is not missed: from here to `register` nothing yields.
+        return jsonResponse(409, {
+          code: "stopped",
+          message: "The turn was stopped before it started.",
+        });
+      }
+
       const run = this.agent.stream({
         messages,
         turn,
@@ -258,7 +291,7 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
         threadId,
         // The client's handle on a run it started, which is the only one that
         // exists before `run-start` reaches it. See `RegisterParams`.
-        clientRunId: typeof body.clientRunId === "string" ? body.clientRunId : undefined,
+        clientRunId,
         onEvent: (event) => this.dispatchEvent(event, ctx),
         onInternalError: (err) => this.reportHookFailure(err),
       });
@@ -270,7 +303,13 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
       return run.toResponse();
     };
 
-    return threadId ? await this.withThread(threadId, start) : await start();
+    try {
+      return threadId ? await this.withThread(threadId, start) : await start();
+    } finally {
+      if (pending && pendingTurns.get(clientRunId) === pending) {
+        pendingTurns.delete(clientRunId);
+      }
+    }
   }
 
   /**
@@ -295,7 +334,10 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * The wait is on `persistRun`, not on `run.result()`. `result()` settling is
    * the transcript being final, not stored: `appendMessages` runs after it, and
    * a `loadThread` in that gap reads a history the old answer is missing from,
-   * which is the original bug by a shorter route.
+   * which is the original bug by a shorter route. It is also *only* that:
+   * `persistRun` settles once the transcript is stored and lets the app's
+   * hooks run on without it, so a slow `onMessage` is not a slow thread and a
+   * hung one is not a hung thread.
    *
    * The lock around it is what makes a *third* turn wait for the second rather
    * than for the first. Two turns arriving together both see the same live
@@ -440,12 +482,24 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
     // Three handles, most specific first, because which ones the client has
     // depends on how far the run got. `runId` is the server's own and settles
     // it. `clientRunId` covers the window before `run-start`, when the client
-    // has nothing else for a stateless first turn. `threadId` is the fallback
-    // for a client that did not start this run at all — one that attached to
-    // it, whose replayed tail carried no `run-start`.
+    // has nothing else for a stateless first turn — and, before that, a turn
+    // that has not become a run yet because it is waiting its place on the
+    // thread, which is ended where it waits. `threadId` is the fallback for a
+    // client that did not start this run at all — one that attached to it,
+    // whose replayed tail carried no `run-start`.
     let runId = typeof body.runId === "string" ? body.runId : undefined;
     if (!runId && typeof body.clientRunId === "string") {
       runId = this.liveRuns.findByClientRunId(body.clientRunId) ?? undefined;
+      if (!runId) {
+        const pending = pendingTurns.get(body.clientRunId);
+        if (pending) {
+          // Not on to `threadId`: that names the run this turn is queued
+          // behind, which is already stopping, and answering for it would
+          // leave this one to start.
+          pending.cancelled = true;
+          return { stopped: true };
+        }
+      }
     }
     if (!runId && typeof body.threadId === "string") {
       runId = (await this.liveRuns.find({ threadId: body.threadId }))?.runId;
@@ -580,13 +634,21 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
    * how the two copies drift. It also means a stopped run persists the same way
    * a finished one does: `stop()` finalizes the transcript, so by the time this
    * resolves there is a valid history to store.
+   *
+   * Settles when the transcript is in the store, not when the app is done with
+   * it. The next turn on this thread waits on this (see `withThread`), and the
+   * hooks are the app's: an `onMessage` that writes to something slow would
+   * make every later turn wait for it, once per message of the old run, and
+   * one that never settles — which `safely` cannot catch — would hold the
+   * thread, and every turn queued on it, behind an open connection each. So
+   * the hooks run on after this on their own, reported the same way.
    */
   private async persistRun(run: AgentRun, ctx: AgentHookContext): Promise<void> {
     let result: AgentRunResult<ToolShapes, unknown>;
     try {
       result = await run.result();
     } catch (err) {
-      await this.safely(() =>
+      void this.safely(() =>
         this.onError(
           {
             code: "unknown",
@@ -609,6 +671,15 @@ export abstract class AgentController<A extends AnyAgent = AnyAgent> extends Con
       }
     }
 
+    void this.notifyRun(result, messages, ctx);
+  }
+
+  /** The hooks on a finished run, in order. Never rejects: see `safely`. */
+  private async notifyRun(
+    result: AgentRunResult<ToolShapes, unknown>,
+    messages: AgentMessage[],
+    ctx: AgentHookContext,
+  ): Promise<void> {
     for (const message of messages) {
       await this.safely(() => this.onMessage(message, ctx));
     }

--- a/packages/gemi/ai/providers/fakeProvider.ts
+++ b/packages/gemi/ai/providers/fakeProvider.ts
@@ -1,0 +1,57 @@
+import type { AgentProvider, ProviderEvent, ProviderStreamParams } from "../AgentProvider";
+
+/**
+ * Scripted `ProviderEvent`s, one script per model call.
+ *
+ * The real provider is written against the same interface elsewhere; depending
+ * on it in a test would make that test a test of two things at once, and would
+ * need a network.
+ *
+ * It lives in source rather than in a test file for the same reason
+ * `store/stubAgentRun.ts` does: both the `Agent` tests and the controller tests
+ * need it, and a test file that imports another test file gets that file's
+ * suites collected twice.
+ */
+export class FakeProvider {
+  readonly model = "fake";
+  readonly capabilities = {
+    reasoning: true,
+    structuredOutput: true,
+    fileInput: true,
+    parallelToolCalls: true,
+    toolSearch: true,
+  };
+  readonly calls: ProviderStreamParams[] = [];
+
+  constructor(private scripts: ProviderEvent[][]) {}
+
+  stream(params: ProviderStreamParams) {
+    this.calls.push(params);
+    const script = this.scripts[this.calls.length - 1] ?? [
+      {
+        type: "finish",
+        reason: "stop",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      },
+    ];
+    return (async function* () {
+      for (const event of script) yield event;
+    })();
+  }
+
+  async upload() {
+    return "file_1";
+  }
+
+  normalizeError(error: unknown) {
+    return {
+      code: "provider_error" as const,
+      message: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    };
+  }
+}
+
+export function fakeProvider(...scripts: ProviderEvent[][]) {
+  return new FakeProvider(scripts) as unknown as AgentProvider & FakeProvider;
+}

--- a/packages/gemi/ai/providers/request.test.ts
+++ b/packages/gemi/ai/providers/request.test.ts
@@ -223,6 +223,35 @@ describe("toResponsesInput()", () => {
     expect(items[1]!.output).toBe("a");
   });
 
+  test("a duplicated call is sent once — the model would otherwise read it twice", () => {
+    // The shape a store that appends rather than upserts produces after a
+    // threaded approval: the assistant message that made the call, then the
+    // amended copy of it carrying the result, both under the same call id.
+    const items = toResponsesInput(
+      [
+        message({
+          id: "a1",
+          role: "assistant",
+          content: [{ type: "tool-call", toolCallId: "call_1", name: "grep", input: {} }],
+        }),
+        message({
+          id: "a1",
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolCallId: "call_1", name: "grep", input: {} },
+            { type: "tool-result", toolCallId: "call_1", name: "grep", status: "ok", output: "a" },
+          ],
+        }),
+      ],
+      FULL,
+    );
+
+    expect(items).toEqual([
+      { type: "function_call", call_id: "call_1", name: "grep", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_1", output: "a" },
+    ]);
+  });
+
   /**
    * The mirror image, and the same consequence: a crash between the call and
    * its result leaves a `function_call` the API will reject forever. Saying

--- a/packages/gemi/ai/providers/request.ts
+++ b/packages/gemi/ai/providers/request.ts
@@ -201,6 +201,13 @@ const NO_RESULT_RECORDED = "No result was recorded for this tool call. Assume it
  * saying so. Fabricating that line is the lesser evil — it is true, the model
  * can read it, and the alternative is a conversation that can never be
  * continued.
+ *
+ * A repeated *call* is dropped for the same reason in the other direction. The
+ * API happens to accept two `function_call`s under one id, so this is not a
+ * 400 — it is the model reading the same call twice, on every turn, for the
+ * rest of the conversation. The way it arises is a store that appended the
+ * amended copy of a message instead of replacing it; the store contract now
+ * says upsert, and this is the guard for a store that did not read it.
  */
 function reconcileToolPairs(items: ResponsesInputItem[]): ResponsesInputItem[] {
   const called = new Set<string>();
@@ -209,7 +216,9 @@ function reconcileToolPairs(items: ResponsesInputItem[]): ResponsesInputItem[] {
 
   for (const item of items) {
     if (item.type === "function_call") {
-      called.add(String(item.call_id));
+      const callId = String(item.call_id);
+      if (called.has(callId)) continue;
+      called.add(callId);
     } else if (item.type === "function_call_output") {
       const callId = String(item.call_id);
       // Positional: the output has to come *after* its call, which is what the

--- a/packages/gemi/ai/store/MemoryAgentStore.test.ts
+++ b/packages/gemi/ai/store/MemoryAgentStore.test.ts
@@ -28,6 +28,27 @@ describe("MemoryAgentStore", () => {
     expect((await store.loadThread(threadId)).map((m) => m.id)).toEqual(["1", "2"]);
   });
 
+  test("replaces a message it already holds instead of holding it twice", async () => {
+    const store = new MemoryAgentStore();
+    const { threadId } = await store.createThread({});
+    await store.appendMessages(threadId, [
+      message("1", "user", "hi"),
+      message("2", "assistant", "one sec"),
+      message("3", "user", "ok"),
+    ]);
+
+    // What a turn that resolves a pending call reports: the earlier assistant
+    // message again, under its own id, plus the new tail.
+    await store.appendMessages(threadId, [
+      message("2", "assistant", "done"),
+      message("4", "assistant", "anything else?"),
+    ]);
+
+    const held = await store.loadThread(threadId);
+    expect(held.map((m) => m.id)).toEqual(["1", "2", "3", "4"]);
+    expect(held[1]!.content).toEqual([{ type: "text", text: "done" }]);
+  });
+
   test("hands out a copy, so a caller cannot edit history in place", async () => {
     const store = new MemoryAgentStore();
     const { threadId } = await store.createThread({});

--- a/packages/gemi/ai/store/MemoryAgentStore.ts
+++ b/packages/gemi/ai/store/MemoryAgentStore.ts
@@ -82,22 +82,35 @@ export class MemoryAgentStore implements AgentStore {
 
   async appendMessages(threadId: string, messages: AgentMessage[]): Promise<void> {
     this.sweep();
-    const thread = this.threads.get(threadId);
-    if (thread) {
-      thread.messages.push(...messages);
-      thread.touchedAt = Date.now();
-      return;
+    let thread = this.threads.get(threadId);
+    if (!thread) {
+      if (!this.clientOwnedIds) {
+        // Creating the thread here would persist a turn under an id the client
+        // believes holds a longer conversation, and hide from the app that the
+        // conversation is gone. The controller checks before the run and never
+        // reaches this; a store-level caller that does gets told.
+        throw new Error(`Thread ${threadId} does not exist here, or has expired.`);
+      }
+      // The client owns the id, so an append to one the store has never seen is
+      // the first turn, and refusing it would lose a turn that already happened.
+      thread = { messages: [], touchedAt: Date.now() };
+      this.threads.set(threadId, thread);
     }
-    if (!this.clientOwnedIds) {
-      // Creating the thread here would persist a turn under an id the client
-      // believes holds a longer conversation, and hide from the app that the
-      // conversation is gone. The controller checks before the run and never
-      // reaches this; a store-level caller that does gets told.
-      throw new Error(`Thread ${threadId} does not exist here, or has expired.`);
+    // Upsert, not push. A turn that resolves a pending call hands back the
+    // assistant message that made the call under the id it already had, now
+    // with the result attached; pushing it would leave the thread holding both
+    // versions, and the model would read the same call twice on every turn
+    // that follows. Replacing in place keeps the message where the
+    // conversation put it.
+    for (const message of messages) {
+      const at = thread.messages.findIndex((held) => held.id === message.id);
+      if (at === -1) {
+        thread.messages.push(message);
+      } else {
+        thread.messages[at] = message;
+      }
     }
-    // The client owns the id, so an append to one the store has never seen is
-    // the first turn, and refusing it would lose a turn that already happened.
-    this.threads.set(threadId, { messages: messages.slice(), touchedAt: Date.now() });
+    thread.touchedAt = Date.now();
   }
 
   /** Test seam, and a way for an app to drop a conversation on request. */

--- a/packages/gemi/ai/store/sse.test.ts
+++ b/packages/gemi/ai/store/sse.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { AgentStreamFrame } from "../types";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseResponse } from "./sse";
+
+const bytes = new TextDecoder();
+
+const frame = (seq: number): AgentStreamFrame => ({
+  seq,
+  event: { type: "text-delta", messageId: "m1", delta: String(seq) },
+});
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** A run that writes one frame, goes quiet until released, writes one more,
+ *  and goes quiet again until it is told to end. */
+function slowRun() {
+  const release = deferred();
+  const end = deferred();
+  async function* frames() {
+    yield frame(1);
+    await release.promise;
+    yield frame(2);
+    await end.promise;
+  }
+  return { frames: frames(), release, end };
+}
+
+describe("sseResponse keepalive", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("a comment line goes out for every interval of silence, and a frame resets the clock", async () => {
+    vi.useFakeTimers();
+    const { frames, release, end } = slowRun();
+    const reader = sseResponse(frames).body!.getReader();
+    const read = async () => bytes.decode((await reader.read()).value);
+
+    expect(await read()).toContain("id: 1\n");
+
+    // The consumer is waiting and the run has nothing to say.
+    let pending = reader.read();
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    // Silence that goes on gets another one, on the same clock.
+    pending = reader.read();
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    // A frame arriving just before the next tick pushes the tick back.
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS - 1);
+    release.resolve();
+    expect(await read()).toContain("id: 2\n");
+    let settled = false;
+    pending = reader.read().then((chunk) => {
+      settled = true;
+      return chunk;
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS - 1);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    end.resolve();
+    expect((await reader.read()).done).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a consumer that cancels leaves no timer behind", async () => {
+    vi.useFakeTimers();
+    const { frames } = slowRun();
+    const body = sseResponse(frames).body!;
+    expect(vi.getTimerCount()).toBe(1);
+    await body.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/gemi/ai/store/sse.test.ts
+++ b/packages/gemi/ai/store/sse.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { AgentStreamFrame } from "../types";
-import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseResponse } from "./sse";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseKeepalive, sseResponse } from "./sse";
 
 const bytes = new TextDecoder();
 
@@ -80,5 +80,18 @@ describe("sseResponse keepalive", () => {
     expect(vi.getTimerCount()).toBe(1);
     await body.cancel();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a touch after stop does not arm a timer", () => {
+    vi.useFakeTimers();
+    const enqueue = vi.fn();
+    const keepalive = sseKeepalive({
+      enqueue,
+    } as unknown as ReadableStreamDefaultController<Uint8Array>);
+    keepalive.stop();
+    keepalive.touch();
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(enqueue).not.toHaveBeenCalled();
   });
 });

--- a/packages/gemi/ai/store/sse.ts
+++ b/packages/gemi/ai/store/sse.ts
@@ -17,13 +17,17 @@ export function encodeFrame(frame: AgentStreamFrame): string {
 /**
  * How long a connection may sit idle before a comment line goes out.
  *
- * Azure App Service's front end drops a connection that has carried nothing
- * for about 230 seconds, and a slow tool or a thinking sub-agent can be silent
- * for longer than that. 25 seconds sits well inside every proxy timeout we
- * know of, and far enough apart that the comment lines cost nothing. Both
- * encoders read this one value, so the two cannot drift apart.
+ * The nearest ceiling is not a proxy but our own server: Bun's `idleTimeout`
+ * counts socket silence, a streaming body included, and gemi runs at its
+ * 10-second default unless `SERVER_IDLE_TIMEOUT` says otherwise. A comment
+ * line every 25 seconds was measured to lose the connection at 12; every 5
+ * keeps it open, with room for a write that lands late. Azure App Service's
+ * front end, at about 230 seconds, is the far ceiling, and 5 clears it by the
+ * same margin. A thousand quiet streams cost two hundred thirteen-byte writes
+ * a second, which is nothing. Both encoders read this one value, so the two
+ * cannot drift apart.
  */
-export const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
+export const SSE_KEEPALIVE_INTERVAL_MS = 5_000;
 
 /**
  * The comment line itself. A line starting with `:` is a comment under the SSE
@@ -42,7 +46,8 @@ export const SSE_KEEPALIVE = ": keepalive\n\n";
  *
  * The write is guarded because a cancel can land between the timer firing and
  * the enqueue, and a closed controller throws. There is nothing to do about
- * that except stop.
+ * that except stop. `arm` checks `stopped` too, so a `touch()` that arrives
+ * after `stop()` cannot hand a finished stream a timer for one more interval.
  */
 export function sseKeepalive(
   controller: ReadableStreamDefaultController<Uint8Array>,
@@ -52,6 +57,7 @@ export function sseKeepalive(
   let stopped = false;
 
   const arm = () => {
+    if (stopped) return;
     if (timer !== null) clearTimeout(timer);
     timer = setTimeout(() => {
       timer = null;

--- a/packages/gemi/ai/store/sse.ts
+++ b/packages/gemi/ai/store/sse.ts
@@ -14,6 +14,68 @@ export function encodeFrame(frame: AgentStreamFrame): string {
   return `id: ${frame.seq}\ndata: ${JSON.stringify(frame.event)}\n\n`;
 }
 
+/**
+ * How long a connection may sit idle before a comment line goes out.
+ *
+ * Azure App Service's front end drops a connection that has carried nothing
+ * for about 230 seconds, and a slow tool or a thinking sub-agent can be silent
+ * for longer than that. 25 seconds sits well inside every proxy timeout we
+ * know of, and far enough apart that the comment lines cost nothing. Both
+ * encoders read this one value, so the two cannot drift apart.
+ */
+export const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
+
+/**
+ * The comment line itself. A line starting with `:` is a comment under the SSE
+ * spec: every parser on our side skips it, and so does the browser's own
+ * `EventSource`.
+ */
+export const SSE_KEEPALIVE = ": keepalive\n\n";
+
+/**
+ * Writes a keepalive whenever the stream has been silent for the interval.
+ *
+ * Armed on creation because the silence before the first frame is real
+ * silence too — a model thinking is the common case. `touch()` after every
+ * frame is what makes it measure silence rather than elapsed time; `stop()`
+ * on close or cancel is what keeps a finished stream from holding a timer.
+ *
+ * The write is guarded because a cancel can land between the timer firing and
+ * the enqueue, and a closed controller throws. There is nothing to do about
+ * that except stop.
+ */
+export function sseKeepalive(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  intervalMs = SSE_KEEPALIVE_INTERVAL_MS,
+): { touch(): void; stop(): void } {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const arm = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      if (stopped) return;
+      try {
+        controller.enqueue(encoder.encode(SSE_KEEPALIVE));
+      } catch {
+        stop();
+        return;
+      }
+      arm();
+    }, intervalMs);
+  };
+
+  const stop = () => {
+    stopped = true;
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+  };
+
+  arm();
+  return { touch: arm, stop };
+}
+
 export function sseHeaders(): Record<string, string> {
   return {
     "Content-Type": "text/event-stream",
@@ -38,23 +100,30 @@ export function sseHeaders(): Record<string, string> {
 export function sseResponse(frames: AsyncIterable<AgentStreamFrame>, status = 200): Response {
   const iterator = frames[Symbol.asyncIterator]();
   let lastSeq = -1;
+  let keepalive!: ReturnType<typeof sseKeepalive>;
 
   const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      keepalive = sseKeepalive(controller);
+    },
     async pull(controller) {
       try {
         const next = await iterator.next();
         if (next.done) {
+          keepalive.stop();
           controller.close();
           return;
         }
         lastSeq = next.value.seq;
         controller.enqueue(encoder.encode(encodeFrame(next.value)));
+        keepalive.touch();
       } catch (err) {
         // Past the headers there is no status left to fail with, so the reason
         // goes out as the last event. Closing silently would be
         // indistinguishable from a run that finished, which is the one thing a
         // reattaching client must not be told by mistake.
         const event = { type: "error", error: toAgentError(err) } as const;
+        keepalive.stop();
         controller.enqueue(encoder.encode(encodeFrame({ seq: lastSeq + 1, event })));
         controller.close();
       }
@@ -62,6 +131,7 @@ export function sseResponse(frames: AsyncIterable<AgentStreamFrame>, status = 20
     cancel(reason) {
       // The client went away. Let the generator unwind so its `finally` runs
       // and it stops waiting on frames nobody will read.
+      keepalive.stop();
       void iterator.return?.(reason);
     },
   });

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -874,21 +874,26 @@ describe("lifecycle", () => {
 
   test("a second send supersedes the first rather than interleaving two answers", async () => {
     const first = controlled();
-    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
-      init?.signal?.addEventListener("abort", () => first.abort());
-      return first.response;
-    });
     // A distinct run, whose frames number from zero again — which is exactly
     // the case the cursor has to be told about.
-    fetchMock.mockImplementationOnce(async () =>
-      streamed([
-        { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
-        { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
-        { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
-        { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
-        { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
-      ]),
-    );
+    const second = streamed([
+      { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
+      { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+      { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
+      { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
+      { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+    ]);
+    // Routed by URL rather than by call order: the second send posts `/stop`
+    // for the first run on its way out, and that call must not eat the answer.
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) return new Response(JSON.stringify({ stopped: true }));
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return second;
+    });
     const { box } = mount({ attach: false });
 
     await act(async () => {
@@ -920,17 +925,98 @@ describe("lifecycle", () => {
     expect(box.api.status).toBe("idle");
   });
 
+  test("the superseded run is stopped on the server, not just disconnected from", async () => {
+    // Aborting the fetch closes the connection, and a closed connection no
+    // longer stops a run. Left alone the first run keeps going, blind to the
+    // second turn, and appends its answer whenever it finishes — after the
+    // second one's, if the model is slower the first time.
+    const first = controlled();
+    const second = streamed([
+      { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
+      { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+      { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
+      { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
+      { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+    ]);
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) return new Response(JSON.stringify({ stopped: true }));
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return second;
+    });
+    const { box } = mount({ threadId: "th_9", attach: false });
+
+    await act(async () => {
+      void box.api.sendMessage("one");
+    });
+    await act(async () => {
+      first.push(
+        { seq: 0, event: { type: "run-start", runId: "run_0", threadId: "th_9" } },
+        ANSWER[1]!,
+        ANSWER[2]!,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(calls().map((c) => c[0])).toEqual(["/api/chat", "/api/chat/stop", "/api/chat"]);
+    // Named by the handles that mean exactly the first run. Not by `threadId`:
+    // the stop is not awaited, so by the time it lands the thread's live run
+    // may be the one the second turn just started.
+    expect(rawBodyOf(1)).toEqual({ runId: "run_0", clientRunId: rawBodyOf(0).clientRunId });
+    expect(rawBodyOf(1).clientRunId).not.toBe(rawBodyOf(2).clientRunId);
+    expect(box.api.messages.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
+    expect(box.api.status).toBe("idle");
+  });
+
+  test("a run this client neither started nor saw start is left to the server", async () => {
+    // Attached mid-run, from a cursor past `run-start`: no `clientRunId`, no
+    // `runId`. The only handle is the thread, and a stop by thread that lands
+    // late would stop the turn being sent. The server ends the old run when
+    // the new turn reaches the thread, so nothing is posted here.
+    const run = controlled();
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/attach")) {
+        init?.signal?.addEventListener("abort", () => run.abort());
+        return run.response;
+      }
+      return streamed(ANSWER);
+    });
+    const { box } = mount({ threadId: "th_9", cursor: { runId: "run_1", seq: 1 } });
+
+    await act(async () => {
+      run.push({ seq: 2, event: { type: "text-delta", messageId: "m1", delta: "…tail" } });
+      await Promise.resolve();
+    });
+    expect(box.api.runId).toBeUndefined();
+
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(calls().map((c) => c[0])).toEqual(["/api/chat/attach", "/api/chat"]);
+  });
+
   test("the superseded turn goes back to a stateless server marked aborted", async () => {
     // The transcript the client carries is what the model is shown next time.
     const first = controlled();
-    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
-      init?.signal?.addEventListener("abort", () => first.abort());
-      return first.response;
-    });
     const anonymous = ANSWER.map((frame, index) =>
       index === 0 ? { seq: 0, event: { type: "run-start" as const, runId: "run_1" } } : frame,
     );
-    fetchMock.mockImplementation(async () => streamed(anonymous));
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) return new Response(JSON.stringify({ stopped: true }));
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return streamed(anonymous);
+    });
     const { box } = mount({ attach: false });
 
     await act(async () => {
@@ -944,7 +1030,8 @@ describe("lifecycle", () => {
       await box.api.sendMessage("two");
     });
 
-    expect(bodyOf(1).messages[1]).toMatchObject({ role: "assistant", finishReason: "aborted" });
+    // Call 1 is the `/stop` for run_0; the second turn is call 2.
+    expect(bodyOf(2).messages[1]).toMatchObject({ role: "assistant", finishReason: "aborted" });
   });
 });
 

--- a/packages/gemi/ai/useChat.test.tsx
+++ b/packages/gemi/ai/useChat.test.tsx
@@ -974,6 +974,96 @@ describe("lifecycle", () => {
     expect(box.api.status).toBe("idle");
   });
 
+  test("a supersede stop that fails is not the new turn's error", async () => {
+    // The stop is not awaited, so its failure lands after `send` has cleared
+    // `error` for the turn going out. Through `fail` it would sit on an answer
+    // streaming fine, and the turn would end `error` after succeeding. With a
+    // thread the server ends the old run when the new turn reaches it, so the
+    // failed stop changed nothing and nothing is said.
+    const first = controlled();
+    const onError = vi.fn();
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) {
+        return new Response(JSON.stringify({ error: { message: "upstream gone" } }), {
+          status: 502,
+        });
+      }
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return streamed([
+        { seq: 0, event: { type: "run-start", runId: "run_2", threadId: "th_9" } },
+        { seq: 1, event: { type: "message-start", messageId: "m2", role: "assistant" } },
+        { seq: 2, event: { type: "text-delta", messageId: "m2", delta: "Second." } },
+        { seq: 3, event: { type: "message-end", messageId: "m2", finishReason: "stop" } },
+        { seq: 4, event: { type: "run-end", runId: "run_2", finishReason: "stop" } },
+      ]);
+    });
+    const { box } = mount({ threadId: "th_9", attach: false, onError });
+
+    await act(async () => {
+      void box.api.sendMessage("one");
+    });
+    await act(async () => {
+      first.push(
+        { seq: 0, event: { type: "run-start", runId: "run_0", threadId: "th_9" } },
+        ANSWER[1]!,
+        ANSWER[2]!,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(calls().map((c) => c[0])).toEqual(["/api/chat", "/api/chat/stop", "/api/chat"]);
+    expect(box.api.messages[3]!.content).toEqual([{ type: "text", text: "Second." }]);
+    expect(box.api.status).toBe("idle");
+    expect(box.api.error).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test("without a thread, a supersede stop that fails is the app's to hear, not the turn's", async () => {
+    // Stateless, so nothing on the server will end the old run for this
+    // client; a stop that did not land is a run still billing, and this is the
+    // only place that knows. The app is told — and the turn that went out,
+    // which succeeded, still says so.
+    const first = controlled();
+    const onError = vi.fn();
+    let turns = 0;
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      if (url.endsWith("/stop")) return new Response("", { status: 502 });
+      if (turns++ === 0) {
+        init?.signal?.addEventListener("abort", () => first.abort());
+        return first.response;
+      }
+      return streamed(
+        ANSWER.map((frame, index) =>
+          index === 0 ? { seq: 0, event: { type: "run-start" as const, runId: "run_1" } } : frame,
+        ),
+      );
+    });
+    const { box } = mount({ attach: false, onError });
+
+    await act(async () => {
+      void box.api.sendMessage("one");
+    });
+    await act(async () => {
+      first.push({ seq: 0, event: { type: "run-start", runId: "run_0" } }, ANSWER[1]!, ANSWER[2]!);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await box.api.sendMessage("two");
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0]).toMatchObject({ retryable: true });
+    expect(box.api.status).toBe("idle");
+    expect(box.api.error).toBeNull();
+  });
+
   test("a run this client neither started nor saw start is left to the server", async () => {
     // Attached mid-run, from a cursor past `run-start`: no `clientRunId`, no
     // `runId`. The only handle is the thread, and a stop by thread that lands

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -488,26 +488,27 @@ export function useChat<P extends keyof AgentRoutes>(
 
   /**
    * The server call that ends a run. Shared by `stop()` and by a `send` that
-   * supersedes one, because the failure handling is the point: a stop that did
-   * not land is a run still working through its tool loop and still billing,
-   * behind a transcript that says it was cut.
+   * supersedes one; what each does with a failure is its own, because a stop
+   * that did not land is a run still working through its tool loop and still
+   * billing, behind a transcript that says it was cut — and whose problem that
+   * is depends on who asked.
    */
   const postStop = useCallback(
-    async (body: AgentStopBody) => {
+    async (body: AgentStopBody, report: (error: AgentError) => void) => {
       const { base: url } = requestRef.current;
       try {
         const response = await post(`${url}/stop`, body);
-        if (!response.ok) fail(await httpError(response));
+        if (!response.ok) report(await httpError(response));
       } catch (error) {
         if (isAbort(error)) return;
-        fail({
+        report({
           code: "unknown",
           message: error instanceof Error ? error.message : String(error),
           retryable: true,
         });
       }
     },
-    [fail, post],
+    [post],
   );
 
   const consume = useCallback(
@@ -579,12 +580,22 @@ export function useChat<P extends keyof AgentRoutes>(
         // anyway when the new turn reaches the thread. Not awaited: the server
         // orders the two, and a round trip before every "changed my mind" would
         // be paid for nothing.
-        const { runId } = stateRef.current!;
+        const { runId, threadId } = stateRef.current!;
         const body: AgentStopBody = {
           ...(runId ? { runId } : {}),
           ...(superseded.clientRunId ? { clientRunId: superseded.clientRunId } : {}),
         };
-        if (Object.keys(body).length > 0) void postStop(body);
+        if (Object.keys(body).length > 0) {
+          // A failure here does not go through `fail`. The post is not awaited,
+          // so its answer lands after this send has cleared `error` for the
+          // turn going out, and a 502 from `/stop` would sit on an answer that
+          // is streaming fine — a turn that succeeded, ending `error`. With a
+          // thread the server ends the old run when this turn reaches it, so a
+          // stop that failed changed nothing and there is nothing to say.
+          // Without one this client is the only thing that knows the old run
+          // is still going, so the app is told, and only told.
+          void postStop(body, threadId ? () => {} : (error) => handlers.current.onError?.(error));
+        }
       }
 
       const previous = superseded ? markAborted(stateRef.current!) : stateRef.current!;
@@ -797,8 +808,8 @@ export function useChat<P extends keyof AgentRoutes>(
       ...(threadId ? { threadId } : {}),
       ...(inFlight?.clientRunId ? { clientRunId: inFlight.clientRunId } : {}),
     };
-    await postStop(body);
-  }, [commit, postStop, setPhaseSafe]);
+    await postStop(body, fail);
+  }, [commit, fail, postStop, setPhaseSafe]);
 
   const regenerate = useCallback(async () => {
     const messages = stateRef.current!.messages as AgentMessage[];

--- a/packages/gemi/ai/useChat.tsx
+++ b/packages/gemi/ai/useChat.tsx
@@ -486,6 +486,30 @@ export function useChat<P extends keyof AgentRoutes>(
     });
   }, []);
 
+  /**
+   * The server call that ends a run. Shared by `stop()` and by a `send` that
+   * supersedes one, because the failure handling is the point: a stop that did
+   * not land is a run still working through its tool loop and still billing,
+   * behind a transcript that says it was cut.
+   */
+  const postStop = useCallback(
+    async (body: AgentStopBody) => {
+      const { base: url } = requestRef.current;
+      try {
+        const response = await post(`${url}/stop`, body);
+        if (!response.ok) fail(await httpError(response));
+      } catch (error) {
+        if (isAbort(error)) return;
+        fail({
+          code: "unknown",
+          message: error instanceof Error ? error.message : String(error),
+          retryable: true,
+        });
+      }
+    },
+    [fail, post],
+  );
+
   const consume = useCallback(
     async (response: Response, signal: AbortSignal) => {
       for await (const frame of decodeSSE(response.body)) {
@@ -543,6 +567,25 @@ export function useChat<P extends keyof AgentRoutes>(
       const clientRunId = localId();
       const controller = new AbortController();
       abortRef.current = { controller, clientRunId };
+
+      if (superseded) {
+        // Aborting the fetch only closes the connection, and a closed connection
+        // no longer stops a run: the superseded one would keep going server
+        // side, blind to this turn and still billing. So it is stopped the way
+        // `stop()` stops it, by the handles that name exactly that run — never
+        // by `threadId`, which by the time this lands may name the run this
+        // turn is about to start. A run this client did not start, and whose
+        // `run-start` never arrived, has no such handle; the server ends it
+        // anyway when the new turn reaches the thread. Not awaited: the server
+        // orders the two, and a round trip before every "changed my mind" would
+        // be paid for nothing.
+        const { runId } = stateRef.current!;
+        const body: AgentStopBody = {
+          ...(runId ? { runId } : {}),
+          ...(superseded.clientRunId ? { clientRunId: superseded.clientRunId } : {}),
+        };
+        if (Object.keys(body).length > 0) void postStop(body);
+      }
 
       const previous = superseded ? markAborted(stateRef.current!) : stateRef.current!;
       const history = previous.messages;
@@ -611,7 +654,7 @@ export function useChat<P extends keyof AgentRoutes>(
         }
       }
     },
-    [commit, consume, fail, post, setPhaseSafe],
+    [commit, consume, fail, post, postStop, setPhaseSafe],
   );
 
   const sendMessage = useCallback(
@@ -730,7 +773,6 @@ export function useChat<P extends keyof AgentRoutes>(
   );
 
   const stop = useCallback(async () => {
-    const { base: url } = requestRef.current;
     const { runId, threadId } = stateRef.current!;
     // The UI stops now. The POST below is what actually ends the generation and
     // any tool mid-flight, and it may take a moment; a user who clicked stop
@@ -755,22 +797,8 @@ export function useChat<P extends keyof AgentRoutes>(
       ...(threadId ? { threadId } : {}),
       ...(inFlight?.clientRunId ? { clientRunId: inFlight.clientRunId } : {}),
     };
-    try {
-      const response = await post(`${url}/stop`, body);
-      // A failed stop is not cosmetic. The transcript says the turn was cut, so
-      // the UI looks settled, while the run may still be working through its
-      // tool loop and still billing for it — the one failure here a user would
-      // want to know about, and previously the one that was swallowed.
-      if (!response.ok) fail(await httpError(response));
-    } catch (error) {
-      if (isAbort(error)) return;
-      fail({
-        code: "unknown",
-        message: error instanceof Error ? error.message : String(error),
-        retryable: true,
-      });
-    }
-  }, [commit, fail, post, setPhaseSafe]);
+    await postStop(body);
+  }, [commit, postStop, setPhaseSafe]);
 
   const regenerate = useCallback(async () => {
     const messages = stateRef.current!.messages as AgentMessage[];


### PR DESCRIPTION
## Problem

When a turn resolves a pending call, `Agent.amend` clones the earlier assistant message, attaches the result, and pushes the clone onto `produced` under the id the message already had. `AgentController.persistRun` hands `result.messages` to `store.appendMessages`, and `MemoryAgentStore.appendMessages` pushed. After a threaded approval the thread held the same message id twice — the original without the result and the clone with it — and every following request carried `function_call:call_1 | function_call:call_1 | function_call_output:call_1`.

OpenAI accepts the duplicate, so on the default store the cost was tokens and a transcript the model reads twice rather than a 400. A store backed by a table keyed on message id would have thrown on the primary key instead. `AgentStreamParams.onMessage` already documented that a store keyed by id should upsert; the built-in store did not, and the interface did not say so.

## Fix

- `MemoryAgentStore.appendMessages` upserts by message `id`: replace in place when the id is held, append otherwise. The amended message keeps the position the conversation gave it, which is what the next request needs.
- `AgentStore.appendMessages` on the interface now documents upsert semantics, since the name suggests plain append and an app writing its own store reads the interface rather than the memory implementation.
- `reconcileToolPairs` in `providers/request.ts` drops a second `function_call` with an already-seen `call_id`, mirroring the existing guard for a second output. Belt and braces for a store that did not follow the contract.

`Agent.amend` is untouched: the store contract is the fix, per the issue.

## Decisions

- **Upsert lives in the store, not in `persistRun`.** The controller could dedupe before calling the store, but then a custom store would still see duplicates through `onMessage`, and the interface would still be lying about append. Putting it on the contract means every store gets it, and a table keyed by id gets it for free.
- **In-place replacement rather than delete-and-append.** The amended message is the one holding the tool call; if it moved to the end of the thread, the next request would place the call after messages that came later in the conversation. The controller test checks the index.
- **The call guard is silent, like the output guard.** Dropping the second call is not a lossy operation — it is the same call — so there is nothing to warn about, and the comment on `reconcileToolPairs` says where duplicates come from.
- **The controller test uses a real `Agent` behind the controller** rather than `StubAgentRun`. What the store ends up holding depends on what `Agent.amend` reports, and a stub run reports whatever the test hands it, so a stub-based test would only have asserted the store's own behaviour, which the store unit test already does. The test sets `process.env.SECRET` the way `Agent.test.ts` does, because a pending call has to be signed. The scripted `FakeProvider` that `Agent.test.ts` used to define locally now lives in `providers/fakeProvider.ts`, shared by both test files (source tree rather than a test file, following `store/stubAgentRun.ts`), and `Agent.test.ts` drops its own copy.
- **The upsert test mints its thread with `store.createThread`** rather than a hand-picked id, because the PR below this one in the stack answers 404 for a thread the store never created.

## Verification

From `packages/gemi`:

- `bun --bun vitest run ai` — 19 files, 457 passed, 20 skipped
- `bunx tsc --noEmit -p tsconfig.json` — clean
- `bun run test:types` — 8 files, 84 passed, no type errors

Each of the three new tests was also run with its fix temporarily reverted and failed as expected.

## Adjacent, not changed here

`persistRun` calls `store.appendMessages` once per run with every message the run produced; a store whose `appendMessages` is not atomic could persist the user turn and not the assistant turn if it throws halfway. That is a store-implementation concern and out of scope for this issue.

Fixes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnj9jSx45LoYp5tiv1W8Nw

