### PR TITLE
A quiet run is not an idle connection

### DIFF
--- a/packages/gemi/ai/Agent.test.ts
+++ b/packages/gemi/ai/Agent.test.ts
@@ -1,11 +1,12 @@
 process.env.SECRET ??= "agent-test-secret";
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { Agent, AgentTool, Skill, ToolNamespace } from "./Agent";
 import type { AgentProvider, ProviderEvent } from "./AgentProvider";
 import { fakeProvider } from "./providers/fakeProvider";
 import type { Schema } from "./Schema";
 import { readSignature, verifyPendingCall } from "./signing";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS } from "./store/sse";
 import type {
   AgentMessage,
   AgentStreamEvent,
@@ -950,6 +951,91 @@ describe("a run outliving its request", () => {
     expect(body.startsWith("id: 2\ndata: {")).toBe(true);
     expect(body).toContain('"type":"text-delta"');
     expect(body.endsWith("\n\n")).toBe(true);
+  });
+});
+
+describe("toResponse keepalive", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * Reads until a read stays pending, and hands that pending read back.
+   *
+   * Boxed rather than returned bare: an async function that returns a promise
+   * adopts it, and the caller would then be waiting for the very chunk the
+   * test has not produced yet.
+   */
+  async function untilSilent(reader: ReadableStreamDefaultReader<Uint8Array>) {
+    while (true) {
+      let settled = false;
+      const next = reader.read().then((chunk) => {
+        settled = true;
+        return chunk;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      if (!settled) return { next };
+    }
+  }
+
+  test("a comment line goes out while a tool is running, and no timer outlives the stream", async () => {
+    vi.useFakeTimers();
+    const started = deferred();
+    const release = deferred<any>();
+    const slow = AgentTool.create({
+      name: "slow",
+      description: "Finishes eventually",
+      inputSchema: anything(),
+      execute: () => {
+        started.resolve();
+        return release.promise;
+      },
+    });
+    const provider = fakeProvider([toolCall("c1", "slow", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "patient", provider, tools: [slow] });
+    const run = agent.stream({ messages: [], req });
+
+    const reader = run.toResponse().body!.getReader();
+    const bytes = new TextDecoder();
+    await started.promise;
+
+    // The tool is running and nothing has been written for a while.
+    const { next } = await untilSilent(reader);
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await next).value)).toBe(SSE_KEEPALIVE);
+
+    release.resolve({ ok: true });
+    let last = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      last = bytes.decode(value);
+    }
+    expect(last).toContain('"type":"run-end"');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a reader that cancels leaves no timer behind either", async () => {
+    vi.useFakeTimers();
+    const release = deferred<any>();
+    const slow = AgentTool.create({
+      name: "slow",
+      description: "Finishes eventually",
+      inputSchema: anything(),
+      execute: () => release.promise,
+    });
+    const provider = fakeProvider([toolCall("c1", "slow", {}), finish()], [finish()]);
+    const agent = Agent.create({ name: "patient", provider, tools: [slow] });
+    const run = agent.stream({ messages: [], req });
+
+    const response = run.toResponse();
+    expect(vi.getTimerCount()).toBe(1);
+    await response.body!.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+
+    release.resolve({ ok: true });
+    expect((await run.result()).finishReason).toBe("stop");
   });
 });
 

--- a/packages/gemi/ai/Agent.ts
+++ b/packages/gemi/ai/Agent.ts
@@ -14,6 +14,7 @@ import {
   verifyNestedRun,
   verifyPendingCall,
 } from "./signing";
+import { sseKeepalive } from "./store/sse";
 import type {
   AgentError,
   AgentMessage,
@@ -1284,8 +1285,14 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
     const encoder = new TextEncoder();
     let cancelled = false;
 
+    let keepalive!: ReturnType<typeof sseKeepalive>;
+
     const body = new ReadableStream<Uint8Array>({
       start: async (controller) => {
+        // A slow tool or a thinking sub-agent can leave the connection silent
+        // for longer than a proxy's idle timeout, and a proxy that closes it
+        // looks to the client exactly like a run that finished.
+        keepalive = sseKeepalive(controller);
         try {
           for await (const frame of frames) {
             if (cancelled) break;
@@ -1294,11 +1301,13 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
             controller.enqueue(
               encoder.encode(`id: ${frame.seq}\ndata: ${JSON.stringify(frame.event)}\n\n`),
             );
+            keepalive.touch();
           }
         } catch {
           // A stream that cannot be written to is a dead reader, not a dead
           // run. Nothing to report and nothing to stop.
         }
+        keepalive.stop();
         try {
           controller.close();
         } catch {
@@ -1311,6 +1320,7 @@ class AgentRunImpl implements AgentRun<ToolShapes, unknown> {
         // tool loop is here and a closed tab has not stopped step four from
         // charging a card.
         cancelled = true;
+        keepalive.stop();
       },
     });
 

--- a/packages/gemi/ai/store/sse.test.ts
+++ b/packages/gemi/ai/store/sse.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { AgentStreamFrame } from "../types";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseResponse } from "./sse";
+
+const bytes = new TextDecoder();
+
+const frame = (seq: number): AgentStreamFrame => ({
+  seq,
+  event: { type: "text-delta", messageId: "m1", delta: String(seq) },
+});
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** A run that writes one frame, goes quiet until released, writes one more,
+ *  and goes quiet again until it is told to end. */
+function slowRun() {
+  const release = deferred();
+  const end = deferred();
+  async function* frames() {
+    yield frame(1);
+    await release.promise;
+    yield frame(2);
+    await end.promise;
+  }
+  return { frames: frames(), release, end };
+}
+
+describe("sseResponse keepalive", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("a comment line goes out for every interval of silence, and a frame resets the clock", async () => {
+    vi.useFakeTimers();
+    const { frames, release, end } = slowRun();
+    const reader = sseResponse(frames).body!.getReader();
+    const read = async () => bytes.decode((await reader.read()).value);
+
+    expect(await read()).toContain("id: 1\n");
+
+    // The consumer is waiting and the run has nothing to say.
+    let pending = reader.read();
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    // Silence that goes on gets another one, on the same clock.
+    pending = reader.read();
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    // A frame arriving just before the next tick pushes the tick back.
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS - 1);
+    release.resolve();
+    expect(await read()).toContain("id: 2\n");
+    let settled = false;
+    pending = reader.read().then((chunk) => {
+      settled = true;
+      return chunk;
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(SSE_KEEPALIVE_INTERVAL_MS - 1);
+    expect(bytes.decode((await pending).value)).toBe(SSE_KEEPALIVE);
+
+    end.resolve();
+    expect((await reader.read()).done).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a consumer that cancels leaves no timer behind", async () => {
+    vi.useFakeTimers();
+    const { frames } = slowRun();
+    const body = sseResponse(frames).body!;
+    expect(vi.getTimerCount()).toBe(1);
+    await body.cancel();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/gemi/ai/store/sse.test.ts
+++ b/packages/gemi/ai/store/sse.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { AgentStreamFrame } from "../types";
-import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseResponse } from "./sse";
+import { SSE_KEEPALIVE, SSE_KEEPALIVE_INTERVAL_MS, sseKeepalive, sseResponse } from "./sse";
 
 const bytes = new TextDecoder();
 
@@ -80,5 +80,18 @@ describe("sseResponse keepalive", () => {
     expect(vi.getTimerCount()).toBe(1);
     await body.cancel();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("a touch after stop does not arm a timer", () => {
+    vi.useFakeTimers();
+    const enqueue = vi.fn();
+    const keepalive = sseKeepalive({
+      enqueue,
+    } as unknown as ReadableStreamDefaultController<Uint8Array>);
+    keepalive.stop();
+    keepalive.touch();
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(SSE_KEEPALIVE_INTERVAL_MS);
+    expect(enqueue).not.toHaveBeenCalled();
   });
 });

--- a/packages/gemi/ai/store/sse.ts
+++ b/packages/gemi/ai/store/sse.ts
@@ -17,13 +17,17 @@ export function encodeFrame(frame: AgentStreamFrame): string {
 /**
  * How long a connection may sit idle before a comment line goes out.
  *
- * Azure App Service's front end drops a connection that has carried nothing
- * for about 230 seconds, and a slow tool or a thinking sub-agent can be silent
- * for longer than that. 25 seconds sits well inside every proxy timeout we
- * know of, and far enough apart that the comment lines cost nothing. Both
- * encoders read this one value, so the two cannot drift apart.
+ * The nearest ceiling is not a proxy but our own server: Bun's `idleTimeout`
+ * counts socket silence, a streaming body included, and gemi runs at its
+ * 10-second default unless `SERVER_IDLE_TIMEOUT` says otherwise. A comment
+ * line every 25 seconds was measured to lose the connection at 12; every 5
+ * keeps it open, with room for a write that lands late. Azure App Service's
+ * front end, at about 230 seconds, is the far ceiling, and 5 clears it by the
+ * same margin. A thousand quiet streams cost two hundred thirteen-byte writes
+ * a second, which is nothing. Both encoders read this one value, so the two
+ * cannot drift apart.
  */
-export const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
+export const SSE_KEEPALIVE_INTERVAL_MS = 5_000;
 
 /**
  * The comment line itself. A line starting with `:` is a comment under the SSE
@@ -42,7 +46,8 @@ export const SSE_KEEPALIVE = ": keepalive\n\n";
  *
  * The write is guarded because a cancel can land between the timer firing and
  * the enqueue, and a closed controller throws. There is nothing to do about
- * that except stop.
+ * that except stop. `arm` checks `stopped` too, so a `touch()` that arrives
+ * after `stop()` cannot hand a finished stream a timer for one more interval.
  */
 export function sseKeepalive(
   controller: ReadableStreamDefaultController<Uint8Array>,
@@ -52,6 +57,7 @@ export function sseKeepalive(
   let stopped = false;
 
   const arm = () => {
+    if (stopped) return;
     if (timer !== null) clearTimeout(timer);
     timer = setTimeout(() => {
       timer = null;

--- a/packages/gemi/ai/store/sse.ts
+++ b/packages/gemi/ai/store/sse.ts
@@ -14,6 +14,68 @@ export function encodeFrame(frame: AgentStreamFrame): string {
   return `id: ${frame.seq}\ndata: ${JSON.stringify(frame.event)}\n\n`;
 }
 
+/**
+ * How long a connection may sit idle before a comment line goes out.
+ *
+ * Azure App Service's front end drops a connection that has carried nothing
+ * for about 230 seconds, and a slow tool or a thinking sub-agent can be silent
+ * for longer than that. 25 seconds sits well inside every proxy timeout we
+ * know of, and far enough apart that the comment lines cost nothing. Both
+ * encoders read this one value, so the two cannot drift apart.
+ */
+export const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
+
+/**
+ * The comment line itself. A line starting with `:` is a comment under the SSE
+ * spec: every parser on our side skips it, and so does the browser's own
+ * `EventSource`.
+ */
+export const SSE_KEEPALIVE = ": keepalive\n\n";
+
+/**
+ * Writes a keepalive whenever the stream has been silent for the interval.
+ *
+ * Armed on creation because the silence before the first frame is real
+ * silence too — a model thinking is the common case. `touch()` after every
+ * frame is what makes it measure silence rather than elapsed time; `stop()`
+ * on close or cancel is what keeps a finished stream from holding a timer.
+ *
+ * The write is guarded because a cancel can land between the timer firing and
+ * the enqueue, and a closed controller throws. There is nothing to do about
+ * that except stop.
+ */
+export function sseKeepalive(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  intervalMs = SSE_KEEPALIVE_INTERVAL_MS,
+): { touch(): void; stop(): void } {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const arm = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      if (stopped) return;
+      try {
+        controller.enqueue(encoder.encode(SSE_KEEPALIVE));
+      } catch {
+        stop();
+        return;
+      }
+      arm();
+    }, intervalMs);
+  };
+
+  const stop = () => {
+    stopped = true;
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+  };
+
+  arm();
+  return { touch: arm, stop };
+}
+
 export function sseHeaders(): Record<string, string> {
   return {
     "Content-Type": "text/event-stream",
@@ -38,23 +100,30 @@ export function sseHeaders(): Record<string, string> {
 export function sseResponse(frames: AsyncIterable<AgentStreamFrame>, status = 200): Response {
   const iterator = frames[Symbol.asyncIterator]();
   let lastSeq = -1;
+  let keepalive!: ReturnType<typeof sseKeepalive>;
 
   const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      keepalive = sseKeepalive(controller);
+    },
     async pull(controller) {
       try {
         const next = await iterator.next();
         if (next.done) {
+          keepalive.stop();
           controller.close();
           return;
         }
         lastSeq = next.value.seq;
         controller.enqueue(encoder.encode(encodeFrame(next.value)));
+        keepalive.touch();
       } catch (err) {
         // Past the headers there is no status left to fail with, so the reason
         // goes out as the last event. Closing silently would be
         // indistinguishable from a run that finished, which is the one thing a
         // reattaching client must not be told by mistake.
         const event = { type: "error", error: toAgentError(err) } as const;
+        keepalive.stop();
         controller.enqueue(encoder.encode(encodeFrame({ seq: lastSeq + 1, event })));
         controller.close();
       }
@@ -62,6 +131,7 @@ export function sseResponse(frames: AsyncIterable<AgentStreamFrame>, status = 20
     cancel(reason) {
       // The client went away. Let the generator unwind so its `finally` runs
       // and it stops waiting on frames nobody will read.
+      keepalive.stop();
       void iterator.return?.(reason);
     },
   });


### PR DESCRIPTION
## Problem

Neither SSE encoder — `AgentRunImpl.toResponse` in `ai/Agent.ts` or `sseResponse` in `ai/store/sse.ts` — ever wrote anything between frames. While a slow tool runs, a sub-agent thinks, or a model takes its time before its first token, the connection carries nothing, and a proxy that drops idle connections closes it (Azure App Service's front end does, at about 230 seconds). The client then sees the stream end with no `error` frame, which is indistinguishable from a run that finished.

## Fix

Both encoders write `: keepalive\n\n` every 5 seconds of silence. The timer is:

- armed when the stream is created, because the wait for the first frame is silence too;
- reset on every frame, so it measures silence rather than elapsed time;
- cleared when the stream closes, errors, or the reader cancels, so a finished response holds no timer.

The interval (`SSE_KEEPALIVE_INTERVAL_MS`) and the comment text (`SSE_KEEPALIVE`) are one constant in `ai/store/sse.ts`, and a small `sseKeepalive(controller)` helper next to them owns the arm/reset/clear logic. Both encoders import it, so the two paths cannot drift.

Both parsers on our side already skip comment lines: `ai/client/sse.ts` (`parse` drops any line starting with `:`) and `ai/providers/stream.ts` (`handleLine` does the same). Nothing on the receiving end changes.

The interval is 5 seconds because the nearest ceiling is gemi's own server, not a proxy: Bun's `idleTimeout` counts socket silence, a streaming body included, and `server/httpProd.ts` runs at the 10-second default unless `SERVER_IDLE_TIMEOUT` is set. Measured on Bun 1.3.14, a comment every 25 seconds loses the connection at 12 s (`ECONNRESET`); every 5 seconds keeps it open. Azure's 230 s is the far ceiling. A thousand quiet streams cost 200 thirteen-byte writes a second.

## Decisions

- **A shared helper rather than only a shared constant.** The issue asks for the interval to live in one place. Sharing only the number would still have left the reset-on-enqueue / clear-on-close logic written twice, and that logic is where the two paths would actually diverge. The helper is ~30 lines and does not merge the encoders — that is #454.
- **`setTimeout` re-armed after each fire, not `setInterval`.** "Reset on every enqueue" is a single `clearTimeout` + `setTimeout`; a re-armed timeout also makes "no timer outlives the stream" a one-line invariant (`timer === null` after `stop()`), which the tests check with `vi.getTimerCount()`.
- **The keepalive write is guarded.** A cancel can land between the timer firing and the enqueue, and a closed controller throws. The catch stops the timer and does nothing else: there is no reader to tell. `arm` also refuses after `stop()`, so a late `touch()` cannot leave a finished stream holding a timer.
- **No option on `sseResponse`/`toResponse` for the interval.** Nothing needs to vary it; the tests use the exported constant with fake timers.

## Adjacent, not fixed here

- A `Response` body that is created and never read or cancelled keeps its keepalive timer ticking and enqueues a 13-byte comment every 5 s into a queue nobody drains. That stream was already holding a parked frame generator before this change, so it is the same abandoned-response leak with one more thing attached, and a caller-side bug rather than something the encoder can detect. Noting it so the #454 encoder can decide whether to stop the timer when `desiredSize` drops.

## Verification

From `packages/gemi`:

- `bun --bun vitest run ai` — 20 files passed, 459 tests passed, 20 skipped. New: `ai/store/sse.test.ts` (3 tests) and a `toResponse keepalive` describe in `ai/Agent.test.ts` (2 tests), all with `vi.useFakeTimers()`: a keepalive goes out after `SSE_KEEPALIVE_INTERVAL_MS` of silence, a second one after continued silence, a frame pushes the next tick back, `vi.getTimerCount()` is 0 after both close and cancel, and a `touch()` after `stop()` arms nothing.
- `bunx tsc --noEmit -p tsconfig.json` — clean.
- `bun run test:types` — 8 files, 84 tests passed, no type errors.

Fixes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnj9jSx45LoYp5tiv1W8Nw

